### PR TITLE
fix for borked live site in production

### DIFF
--- a/docs/acetate.config.js
+++ b/docs/acetate.config.js
@@ -5,7 +5,7 @@ const _ = require("lodash");
 const slug = require("slug");
 
 const IS_DEV = process.env.ENV !== "prod";
-const BASE_URL = process.env.ENV === "prod" ? "/arcgis-rest-js" : "";
+const BASE_URL = process.env.ENV === "prod" ? "/hub.js" : "";
 
 module.exports = function(acetate) {
   /**


### PR DESCRIPTION
somehow i forgot that we wrote special logic into the "acetate.config" to modify the `base_url` of the site on the fly in production only.

![screenshot 2018-05-02 11 59 03](https://user-images.githubusercontent.com/3011734/39543459-208f054a-4e00-11e8-8203-3ab7432ff76c.png)