### PR TITLE
fix(all): treat arcigs-rest-js packages as external and bump to latest

### DIFF
--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -10,12 +10,12 @@
   "license": "Apache-2.0",
   "dependencies": {
     "tslib": "^1.7.1",
-    "@esri/arcgis-rest-request": "^1.4.0",
-    "@esri/arcgis-rest-items": "^1.4.0",
-    "@esri/arcgis-rest-auth": "^1.4.0",
-    "@esri/arcgis-rest-common-types": "^1.4.0",
-    "@esri/arcgis-rest-feature-service": "^1.4.0",
-    "@esri/arcgis-rest-users": "^1.4.0"
+    "@esri/arcgis-rest-request": "^1.5.1",
+    "@esri/arcgis-rest-items": "^1.5.1",
+    "@esri/arcgis-rest-auth": "^1.5.1",
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-feature-service": "^1.5.1",
+    "@esri/arcgis-rest-users": "^1.5.1"
   },
   "peerDependencies": {},
   "devDependencies": {},

--- a/packages/common-types/package.json
+++ b/packages/common-types/package.json
@@ -9,7 +9,7 @@
     "dist/types/index.d.ts"
   ],
   "dependencies": {
-    "@esri/arcgis-rest-common-types": "^1.2.1"
+    "@esri/arcgis-rest-common-types": "^1.5.1"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/initiatives/package.json
+++ b/packages/initiatives/package.json
@@ -10,10 +10,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "tslib": "^1.7.1",
-    "@esri/arcgis-rest-request": "^1.2.1",
-    "@esri/arcgis-rest-auth": "^1.2.1",
-    "@esri/arcgis-rest-items": "^1.2.1",
-    "@esri/arcgis-rest-common-types": "^1.2.1"
+    "@esri/arcgis-rest-request": "^1.5.1",
+    "@esri/arcgis-rest-auth": "^1.5.1",
+    "@esri/arcgis-rest-items": "^1.5.1",
+    "@esri/arcgis-rest-common-types": "^1.5.1"
   },
   "peerDependencies": {
     "@esri/hub-common-types": "^1.0.0",

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -10,10 +10,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "tslib": "^1.7.1",
-    "@esri/arcgis-rest-request": "^1.2.1",
-    "@esri/arcgis-rest-auth": "^1.2.1",
-    "@esri/arcgis-rest-items": "^1.2.1",
-    "@esri/arcgis-rest-common-types": "^1.2.1"
+    "@esri/arcgis-rest-request": "^1.5.1",
+    "@esri/arcgis-rest-auth": "^1.5.1",
+    "@esri/arcgis-rest-items": "^1.5.1",
+    "@esri/arcgis-rest-common-types": "^1.5.1"
   },
   "peerDependencies": {
     "@esri/hub-common-types": "^1.0.0"

--- a/umd-base-profile.js
+++ b/umd-base-profile.js
@@ -33,6 +33,7 @@ const copyright = `/* @preserve
  * All exported members of each package will be attached to this global.
  */
 const moduleName = "arcgisHub";
+const arcgisRestModuleName = 'arcgisRest'
 
 /**
  * Now we need to discover all the `@esri/hub-*` package names so we can create
@@ -46,15 +47,30 @@ const packageNames = fs
   }, {});
 
 /**
+ * Now we need to discover all the `@esri/arcgis-rest-*` package names so we can create
+ * the `globals` and `externals` to pass to Rollup.
+ */
+const arcgisRestJsPackageNames = Object.keys(pkg.dependencies)
+  .filter(key => /@esri\/arcgis-rest/.test(key));
+
+/**
  * Rollup will use this map to determine where to lookup modules on the global
  * window object when neither AMD or CommonJS is being used. This configuration
  * will cause Rollup to lookup all imports from our packages on a single global
- * `arcgisRest` object.
+ * `arcgisHub` object.
  */
 const globals = packageNames.reduce((globals, p) => {
   globals[p] = moduleName;
   return globals;
 }, {});
+/**
+* now we tell Rollup to lookup all imports from arcgis-rest-js on a single global
+* `arcgisRest` object.
+*/
+arcgisRestJsPackageNames.reduce((globals, p) => {
+  globals[p] = arcgisRestModuleName;
+  return globals;
+}, globals);
 
 /**
  * Now we can export the Rollup config!
@@ -71,7 +87,7 @@ export default {
     extend: true // causes this module to extend the global specified by `moduleName`
   },
   context: "window",
-  external: packageNames,
+  external: packageNames.concat(arcgisRestJsPackageNames),
   plugins: [
     typescript(),
     json(),


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/hub-annotations
@esri/hub-common-types
@esri/hub-initiatives
@esri/hub-sites