### PR TITLE
fix(annotations): fix type errors that prevent running bootstrap and …

### DIFF
--- a/packages/annotations/package-lock.json
+++ b/packages/annotations/package-lock.json
@@ -3,54 +3,54 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.5.1.tgz",
-			"integrity": "sha1-hDMt+Xe17fLne3xQLmC7e3lq0lc=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.6.0.tgz",
+			"integrity": "sha512-8HDm6dEYYTFps/WA0B67wjmkSkFDjIz2VveOdKRzaltzRB3WvRIewVFB4+gPN7Dd5jXlUPCJ7MStZhtzEJm77Q==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-common-types": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.5.1.tgz",
-			"integrity": "sha1-l4YXwq2tsWw2Aib6OMm7iTlzEH0="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.6.0.tgz",
+			"integrity": "sha512-e22oCLT+lXAyhpRRU8yL4xVBDWHHWkxcX0MnNbatUJ5lu4wG+sXw+P42y0dQxDJym97s//NGduriX8SgjAS9OQ=="
 		},
 		"@esri/arcgis-rest-feature-service": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-1.5.1.tgz",
-			"integrity": "sha1-UHcRzNbH12qWAiGrt1NftGZqlEE=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-1.6.0.tgz",
+			"integrity": "sha512-GSGGN2TqSu3+N6IqM9x8XcDhPUNRhI12G4IF6l09D87Cf0vv+jz8OjdA0m3r5+7fieH09xy0JyL38K6KlOWjZw==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-items": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-items/-/arcgis-rest-items-1.5.1.tgz",
-			"integrity": "sha1-RUKnZP+Vy/vxtmr/DObPbfFCcnQ=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-items/-/arcgis-rest-items-1.6.0.tgz",
+			"integrity": "sha512-LHRoEDgTuCDTQ1riueQWOeOvQ6fUOO27g8+xo4kH9zJunALNU+AviXCl5t47CdqqvcRoFMOtQDEM6Yw52OrDRA==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.5.1.tgz",
-			"integrity": "sha1-FkpHBgWJL9D03rQihJMj/pNId4w=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.6.0.tgz",
+			"integrity": "sha512-A1gIS5+UW1ZfF/5bt0hQMWm9HxZycE0al0UM0RXGrW+4w2J1Mwl/8acXg8WHIlFd2RTasmyZprlDPfJ+D5Df7Q==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-users": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-users/-/arcgis-rest-users-1.5.1.tgz",
-			"integrity": "sha1-LeuKlUw6AmAjzocB/1Ku3nwsx5g=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-users/-/arcgis-rest-users-1.6.0.tgz",
+			"integrity": "sha512-/6RUbJ6TQLPL1y4hIZbccFhOasIBdxtpr1USWKtjArF8pJQe6pqOBmUD+l/SfhT5jvn63HRvDG0nBXfuIpOj1g==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
 		}
 	}
 }

--- a/packages/annotations/src/search.ts
+++ b/packages/annotations/src/search.ts
@@ -3,7 +3,8 @@
 
 import {
   IQueryFeaturesRequestOptions,
-  queryFeatures
+  queryFeatures,
+  IQueryFeaturesResponse
 } from "@esri/arcgis-rest-feature-service";
 
 import { getUser } from "@esri/arcgis-rest-users";
@@ -43,7 +44,7 @@ export function searchAnnotations(
     const data: IResourceObject[] = [];
 
     // use .reduce()?
-    response.features.forEach(function(comment) {
+    (response as IQueryFeaturesResponse).features.forEach(function(comment) {
       const attributes = comment.attributes;
       data.push({
         id: attributes.author,

--- a/packages/annotations/test/mocks/ago_search.ts
+++ b/packages/annotations/test/mocks/ago_search.ts
@@ -1,6 +1,6 @@
 import { ISearchResult } from "@esri/arcgis-rest-items";
 
-export const annoSearchResponse: ISearchResult = {
+export const annoSearchResponse: any = {
   query: "hubAnnotationLayer AND orgid:5bc",
   total: 1,
   start: 1,

--- a/packages/annotations/test/mocks/ago_search.ts
+++ b/packages/annotations/test/mocks/ago_search.ts
@@ -1,6 +1,6 @@
 import { ISearchResult } from "@esri/arcgis-rest-items";
 
-export const annoSearchResponse: any = {
+export const annoSearchResponse: ISearchResult = {
   query: "hubAnnotationLayer AND orgid:5bc",
   total: 1,
   start: 1,
@@ -59,7 +59,8 @@ export const annoSearchResponse: any = {
       avgRating: 0,
       numViews: 2,
       scoreCompleteness: 51,
-      groupDesignations: null
+      groupDesignations: null,
+      protected: false
     }
   ]
 };

--- a/packages/common-types/package-lock.json
+++ b/packages/common-types/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-common-types": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.5.1.tgz",
-			"integrity": "sha1-l4YXwq2tsWw2Aib6OMm7iTlzEH0="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.6.0.tgz",
+			"integrity": "sha512-e22oCLT+lXAyhpRRU8yL4xVBDWHHWkxcX0MnNbatUJ5lu4wG+sXw+P42y0dQxDJym97s//NGduriX8SgjAS9OQ=="
 		}
 	}
 }

--- a/packages/initiatives/package-lock.json
+++ b/packages/initiatives/package-lock.json
@@ -3,38 +3,38 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.5.1.tgz",
-			"integrity": "sha1-hDMt+Xe17fLne3xQLmC7e3lq0lc=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.6.0.tgz",
+			"integrity": "sha512-8HDm6dEYYTFps/WA0B67wjmkSkFDjIz2VveOdKRzaltzRB3WvRIewVFB4+gPN7Dd5jXlUPCJ7MStZhtzEJm77Q==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-common-types": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.5.1.tgz",
-			"integrity": "sha1-l4YXwq2tsWw2Aib6OMm7iTlzEH0="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.6.0.tgz",
+			"integrity": "sha512-e22oCLT+lXAyhpRRU8yL4xVBDWHHWkxcX0MnNbatUJ5lu4wG+sXw+P42y0dQxDJym97s//NGduriX8SgjAS9OQ=="
 		},
 		"@esri/arcgis-rest-items": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-items/-/arcgis-rest-items-1.5.1.tgz",
-			"integrity": "sha1-RUKnZP+Vy/vxtmr/DObPbfFCcnQ=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-items/-/arcgis-rest-items-1.6.0.tgz",
+			"integrity": "sha512-LHRoEDgTuCDTQ1riueQWOeOvQ6fUOO27g8+xo4kH9zJunALNU+AviXCl5t47CdqqvcRoFMOtQDEM6Yw52OrDRA==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.5.1.tgz",
-			"integrity": "sha1-FkpHBgWJL9D03rQihJMj/pNId4w=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.6.0.tgz",
+			"integrity": "sha512-A1gIS5+UW1ZfF/5bt0hQMWm9HxZycE0al0UM0RXGrW+4w2J1Mwl/8acXg8WHIlFd2RTasmyZprlDPfJ+D5Df7Q==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
 		}
 	}
 }

--- a/packages/sites/package-lock.json
+++ b/packages/sites/package-lock.json
@@ -3,38 +3,38 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.5.1.tgz",
-			"integrity": "sha1-hDMt+Xe17fLne3xQLmC7e3lq0lc=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.6.0.tgz",
+			"integrity": "sha512-8HDm6dEYYTFps/WA0B67wjmkSkFDjIz2VveOdKRzaltzRB3WvRIewVFB4+gPN7Dd5jXlUPCJ7MStZhtzEJm77Q==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-common-types": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.5.1.tgz",
-			"integrity": "sha1-l4YXwq2tsWw2Aib6OMm7iTlzEH0="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.6.0.tgz",
+			"integrity": "sha512-e22oCLT+lXAyhpRRU8yL4xVBDWHHWkxcX0MnNbatUJ5lu4wG+sXw+P42y0dQxDJym97s//NGduriX8SgjAS9OQ=="
 		},
 		"@esri/arcgis-rest-items": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-items/-/arcgis-rest-items-1.5.1.tgz",
-			"integrity": "sha1-RUKnZP+Vy/vxtmr/DObPbfFCcnQ=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-items/-/arcgis-rest-items-1.6.0.tgz",
+			"integrity": "sha512-LHRoEDgTuCDTQ1riueQWOeOvQ6fUOO27g8+xo4kH9zJunALNU+AviXCl5t47CdqqvcRoFMOtQDEM6Yw52OrDRA==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.5.1.tgz",
-			"integrity": "sha1-FkpHBgWJL9D03rQihJMj/pNId4w=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.6.0.tgz",
+			"integrity": "sha512-A1gIS5+UW1ZfF/5bt0hQMWm9HxZycE0al0UM0RXGrW+4w2J1Mwl/8acXg8WHIlFd2RTasmyZprlDPfJ+D5Df7Q==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
 		}
 	}
 }


### PR DESCRIPTION
…tests

after updating to rest-js v1.6.0, a few types had changed causing TS compile errors

AFFECTS PACKAGES:
@esri/hub-annotations

ISSUES CLOSED: #47