### PR TITLE
findBy supports deep dotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### [Unreleased][HEAD]
 
+### @esri/hub-common
+
+* New Features
+  * `findBy(arr, 'deep.path')` now supports deep-dotting into objects in the array.
+
+
 ## [1.1.0] - August 10th 2018
 
 ### @esri/hub-common

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -13,9 +13,7 @@ export function cloneObject(obj: { [index: string]: any }) {
     for (const i in obj) {
       if (obj[i] != null && typeof obj[i] === "object") {
         clone[i] = cloneObject(obj[i]);
-      } /* else if (Array.isArray(obj[i])) {
-        clone[i] = obj[i].map(cloneObject);
-      }*/ else {
+      } else {
         clone[i] = obj[i];
       }
     }

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -68,7 +68,7 @@ export function findBy(arr: any[], prop: string, value: any) {
     return null;
   }
   const res = arr.reduce((acc, entry) => {
-    if (entry[prop] === value) {
+    if (getProp(entry, prop) === value) {
       acc = entry;
     }
     return acc;

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -235,6 +235,28 @@ describe("util functions", () => {
     expect(c).toBeNull();
   });
 
+  it("findBy can deep-dot into a structure", () => {
+    const data = [
+      {
+        id: "blue",
+        obj2: {
+          obj3: {
+            prop: "value"
+          }
+        }
+      },
+      {
+        id: "red"
+      },
+      {
+        id: "orange"
+      }
+    ];
+    const c = findBy(data, "obj2.obj3.prop", "value");
+    expect(c).toBeDefined();
+    expect(c).toEqual(data[0]); // 'should return the object, not a clone');
+  });
+
   it("compose can run", () => {
     const sqr = (x: number) => x * x;
     const inc = (x: number) => x + 1;

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -51,6 +51,11 @@ describe("util functions", () => {
         type: "string"
       },
       names: ["steve", "james", "bob"],
+      deep: [
+        {
+          things: ["one", "two", "red", "blue"]
+        }
+      ],
       addresses: [
         {
           street: "123 main",
@@ -70,7 +75,8 @@ describe("util functions", () => {
     expect(c.field).not.toBe(obj.field);
     expect(c.names).not.toBe(obj.names);
     expect(c.names.length).toEqual(obj.names.length);
-
+    expect(Array.isArray(c.deep)).toBeTruthy();
+    expect(c.deep[0].things.length).toBe(4);
     ["color", "length"].map(prop => {
       expect(c[prop]).toEqual(obj[prop]);
     });


### PR DESCRIPTION
This is supported `findBy(someArray, 'deep.nested.prop', 'foo');`

Includes a test.

Made with ❤️ in Fort Collins, Colorado