### PR TITLE
[DNM] Get Initiative and Apply Migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "scripts": {
     "build": "lerna run build",
     "test": "npm run test:node && npm run test:chrome",
+    "test:headless": "nodemon --exec jasmine --config=jasmine.json",
     "test:chrome:debug": "karma start --auto-watch --no-single-run --browsers=Chrome",
     "test:chrome": "karma start --single-run --browsers=Chrome",
     "test:chrome:ci": "karma start --single-run --browsers ChromeHeadlessCI karma.conf.js",

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,18 +1,31 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IItem } from "@esri/arcgis-rest-common-types";
+import { IItemAdd } from "@esri/arcgis-rest-common-types";
+
+/**
+ * Generic Model, will be used for all type-specific api wrappers
+ */
+export interface IModel {
+  item: {
+    [propName: string]: any;
+  };
+  data?: {
+    [propName: string]: any;
+  };
+}
 
 /**
  * One small step for Hub, one large leap for hubkind
  */
-export interface IInitiative {
+export interface IInitiativeModel extends IModel {
   item: IInitiativeItem;
   data?: {
     [propName: string]: any;
   };
 }
 
-export interface IInitiativeItem extends IItem {
+export interface IInitiativeItem extends IItemAdd {
+  id?: string;
   type: "Hub Initiative";
 }

--- a/packages/initiatives/src/initiatives.ts
+++ b/packages/initiatives/src/initiatives.ts
@@ -31,13 +31,8 @@ export function fetchInitiative(
   id: string,
   requestOptions?: IInitiativeRequestOptions
 ): Promise<IInitiativeModel> {
-  if (requestOptions && !requestOptions.data) {
-    return getItem(id, requestOptions).then(result => {
-      return {
-        item: result as IInitiativeItem
-      };
-    });
-  } else {
+  // if we have specifically requested the data...
+  if (requestOptions && requestOptions.data === true) {
     return Promise.all([
       getItem(id, requestOptions),
       getItemData(id, requestOptions)
@@ -52,6 +47,13 @@ export function fetchInitiative(
       .then(model => {
         return migrateSchema(model, getPortalUrl(requestOptions));
       });
+  } else {
+    // otherwise, just get the item
+    return getItem(id, requestOptions).then(result => {
+      return {
+        item: result as IInitiativeItem
+      };
+    });
   }
 }
 

--- a/packages/initiatives/src/migrations/apply-schema.ts
+++ b/packages/initiatives/src/migrations/apply-schema.ts
@@ -1,0 +1,83 @@
+import { IInitiativeModel } from "@esri/hub-common";
+import { getProp, cloneObject } from "@esri/hub-common";
+
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+export function applyInitialSchema(
+  model: IInitiativeModel,
+  portalUrl?: string
+): IInitiativeModel {
+  const curVersion = getProp(model, "item.properties.schemaVersion");
+  // if no current version or it's below 1
+  if (!curVersion || curVersion < 1) {
+    // clone the model because we play by immutable rules
+    const clone = cloneObject(model) as IInitiativeModel;
+    // console.debug(`------- CLONE ---------`);
+    // console.debug(JSON.stringify(clone, null, 2));
+    // console.debug(`------- CLONE ---------`);
+    // ensure some properties exist...
+    if (!clone.data.values) {
+      clone.data.values = {};
+    }
+    if (!clone.item.properties) {
+      clone.item.properties = {};
+    }
+
+    // set the schema version...
+    clone.item.properties.schemaVersion = 1.0;
+
+    let isTemplate = false;
+    if (clone.item.typeKeywords) {
+      isTemplate =
+        clone.item.typeKeywords.indexOf("hubInitiativeTemplate") >= 0;
+    }
+
+    // ensure source is in item.properties if it has a parent...
+    const hasParent = !!clone.data.source;
+    if (hasParent && clone.item.properties.source !== clone.data.source) {
+      clone.item.properties.source = clone.data.source;
+    }
+    // convert configuratinSettings to steps array...
+    // this is only for 'templates', or Custom Initiatives
+    if (clone.data.configurationSettings) {
+      const config = clone.data.configurationSettings;
+      delete clone.data.configurationSettings;
+      // get the steps entry...
+      const stepCategory = config.find((el: any) => {
+        return el.category === "Steps";
+      });
+      // hoist step names into an array
+      clone.data.values.steps = stepCategory.fields.map((entry: any) => {
+        return entry.fieldName;
+      });
+      // move the label and tooltip to title and description, in the values.<fieldName> prop
+      stepCategory.fields.forEach((entry: any) => {
+        // ensure values prop exists...
+        if (!clone.data.values[entry.fieldName]) {
+          clone.data.values[entry.fieldName] = {};
+        }
+        // assign in values
+        clone.data.values[entry.fieldName].title = entry.label;
+        clone.data.values[entry.fieldName].description = entry.tooltip;
+        clone.data.values[entry.fieldName].id = entry.fieldName;
+        // if a .items array exists, rename that to .templates
+        if (clone.data.values[entry.fieldName].items) {
+          // if this is a template, then move items to templates...
+          if (isTemplate) {
+            clone.data.values[entry.fieldName].templates =
+              clone.data.values[entry.fieldName].items;
+            delete clone.data.values[entry.fieldName].items;
+          }
+        } else {
+          // ensure empty arrays
+          clone.data.values[entry.fieldName].items = [];
+          clone.data.values[entry.fieldName].templates = [];
+        }
+      });
+    }
+    return clone;
+  } else {
+    return model;
+  }
+}

--- a/packages/initiatives/src/migrations/apply-schema.ts
+++ b/packages/initiatives/src/migrations/apply-schema.ts
@@ -39,18 +39,20 @@ export function applyInitialSchema(
       clone.item.properties.source = clone.data.source;
     }
     // convert configuratinSettings to steps array...
-    // this is only for 'templates', or Custom Initiatives
+    // NOTE: this is only for 'templates', or Custom Initiatives
     if (clone.data.configurationSettings) {
-      const config = clone.data.configurationSettings;
+      const config = cloneObject(clone.data.configurationSettings);
       delete clone.data.configurationSettings;
       // get the steps entry...
       const stepCategory = config.find((el: any) => {
         return el.category === "Steps";
       });
+
       // hoist step names into an array
       clone.data.values.steps = stepCategory.fields.map((entry: any) => {
         return entry.fieldName;
       });
+
       // move the label and tooltip to title and description, in the values.<fieldName> prop
       stepCategory.fields.forEach((entry: any) => {
         // ensure values prop exists...

--- a/packages/initiatives/src/migrations/upgrade-one-dot-one.ts
+++ b/packages/initiatives/src/migrations/upgrade-one-dot-one.ts
@@ -7,52 +7,14 @@ export function upgradeToOneDotOne(
   model: IInitiativeModel,
   portalUrl?: string
 ): IInitiativeModel {
-  const curVersion = getProp(model, "item.properties.schemaVersion") || 0;
+  const curVersion = getProp(model, "item.properties.schemaVersion");
   if (curVersion < 1.1) {
     const clone = cloneObject(model) as IInitiativeModel;
     // store the schemaVersion
     clone.item.properties.schemaVersion = 1.1;
     // add the assets...
-    if (!clone.data.assets) {
-      clone.data.assets = [
-        {
-          id: "bannerImage",
-          url: getResourceUrl(model.item.id, "detail-image.jpg", portalUrl),
-          properties: {
-            type: "resource",
-            fileName: "detail-image.jpg",
-            mimeType: "image/jepg"
-          },
-          license: {
-            type: "none"
-          }
-        },
-        {
-          id: "iconDark",
-          url: getResourceUrl(model.item.id, "icon-dark.png", portalUrl),
-          properties: {
-            type: "resource",
-            fileName: "icon-dark.png",
-            mimeType: "image/png"
-          },
-          license: {
-            type: "none"
-          }
-        },
-        {
-          id: "iconLight",
-          url: getResourceUrl(model.item.id, "icon-light.png", portalUrl),
-          properties: {
-            type: "resource",
-            fileName: "icon-light.png",
-            mimeType: "image/png"
-          },
-          license: {
-            type: "none"
-          }
-        }
-      ];
-    }
+    _addDefaultResources(clone, portalUrl);
+
     if (!clone.data.values.bannerImage) {
       clone.data.values.bannerImage = {
         source: "bannerImage",
@@ -66,6 +28,53 @@ export function upgradeToOneDotOne(
     // console.debug(`Not upgrading CurVersion: ${curVersion}`);
     return model;
   }
+}
+
+export function _addDefaultResources(
+  model: IInitiativeModel,
+  portalUrl?: string
+): IInitiativeModel {
+  if (!model.data.assets) {
+    model.data.assets = [
+      {
+        id: "bannerImage",
+        url: getResourceUrl(model.item.id, "detail-image.jpg", portalUrl),
+        properties: {
+          type: "resource",
+          fileName: "detail-image.jpg",
+          mimeType: "image/jepg"
+        },
+        license: {
+          type: "none"
+        }
+      },
+      {
+        id: "iconDark",
+        url: getResourceUrl(model.item.id, "icon-dark.png", portalUrl),
+        properties: {
+          type: "resource",
+          fileName: "icon-dark.png",
+          mimeType: "image/png"
+        },
+        license: {
+          type: "none"
+        }
+      },
+      {
+        id: "iconLight",
+        url: getResourceUrl(model.item.id, "icon-light.png", portalUrl),
+        properties: {
+          type: "resource",
+          fileName: "icon-light.png",
+          mimeType: "image/png"
+        },
+        license: {
+          type: "none"
+        }
+      }
+    ];
+  }
+  return model;
 }
 
 export function getResourceUrl(

--- a/packages/initiatives/src/migrations/upgrade-one-dot-one.ts
+++ b/packages/initiatives/src/migrations/upgrade-one-dot-one.ts
@@ -1,0 +1,86 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { getProp, cloneObject } from "@esri/hub-common";
+import { IInitiativeModel, IInitiativeItem } from "@esri/hub-common";
+
+export function upgradeToOneDotOne(
+  model: IInitiativeModel,
+  portalUrl?: string
+): IInitiativeModel {
+  const curVersion = getProp(model, "item.properties.schemaVersion") || 0;
+  if (curVersion < 1.1) {
+    const clone = cloneObject(model) as IInitiativeModel;
+    // store the schemaVersion
+    clone.item.properties.schemaVersion = 1.1;
+    // add the assets...
+    if (!clone.data.assets) {
+      clone.data.assets = [
+        {
+          id: "bannerImage",
+          url: getResourceUrl(model.item.id, "detail-image.jpg", portalUrl),
+          properties: {
+            type: "resource",
+            fileName: "detail-image.jpg",
+            mimeType: "image/jepg"
+          },
+          license: {
+            type: "none"
+          }
+        },
+        {
+          id: "iconDark",
+          url: getResourceUrl(model.item.id, "icon-dark.png", portalUrl),
+          properties: {
+            type: "resource",
+            fileName: "icon-dark.png",
+            mimeType: "image/png"
+          },
+          license: {
+            type: "none"
+          }
+        },
+        {
+          id: "iconLight",
+          url: getResourceUrl(model.item.id, "icon-light.png", portalUrl),
+          properties: {
+            type: "resource",
+            fileName: "icon-light.png",
+            mimeType: "image/png"
+          },
+          license: {
+            type: "none"
+          }
+        }
+      ];
+    }
+    if (!clone.data.values.bannerImage) {
+      clone.data.values.bannerImage = {
+        source: "bannerImage",
+        display: {
+          position: { x: "50%", y: "10%" }
+        }
+      };
+    }
+    return clone;
+  } else {
+    // console.debug(`Not upgrading CurVersion: ${curVersion}`);
+    return model;
+  }
+}
+
+export function getResourceUrl(
+  itemId: string,
+  resourceName: string,
+  portal?: string,
+  folder?: string
+): string {
+  // default to www.arcgis.com
+  const portalUrl = portal || "https://www.arcgis.com/sharing/rest";
+  let url = `${portalUrl}/content/items/${itemId}/resources`;
+  if (folder) {
+    url = `${url}/${folder}/${resourceName}`;
+  } else {
+    url = `${url}/${resourceName}`;
+  }
+  return url;
+}

--- a/packages/initiatives/src/migrations/upgrade-two-dot-zero.ts
+++ b/packages/initiatives/src/migrations/upgrade-two-dot-zero.ts
@@ -23,10 +23,7 @@ export function upgradeToTwoDotZero(
     }
     // convert the indicators
     clone.data.indicators = convertInitiativeIndicators(clone.data.values);
-    // remove data.values.<indicator> properties
-    Object.keys(clone.data.indicators).forEach(propName => {
-      delete clone.data.values[propName];
-    });
+    return clone;
   } else {
     return model;
   }
@@ -53,10 +50,10 @@ export const convertIndicatorToDefinition = function(ind: any) {
   const def = {
     id: ind.fieldName,
     type: "Data",
-    name: ind.label,
+    name: ind.label || ind.fieldName,
     optional: ind.optional || false,
     definition: {
-      description: ind.label || ind.name || "",
+      description: ind.label || ind.fieldName,
       supportedTypes: [...ind.layerOptions.supportedTypes],
       geometryTypes: [...ind.layerOptions.geometryTypes],
       fields: ind.fields.map(convertIndicatorField)
@@ -93,9 +90,9 @@ export const convertIndicator = function(indicator: any) {
   const result = {
     id: indicator.id,
     type: "Data",
-    name: indicator.name,
+    name: indicator.name || indicator.id,
     definition: {
-      description: indicator.label || indicator.name || ""
+      description: indicator.name || indicator.id
     },
     source: convertIndicatorValueToSource(indicator)
   };
@@ -139,7 +136,7 @@ export const convertIndicatorValueToSource = function(indicator: any) {
     url: indicator.url,
     itemId: indicator.itemId,
     layerId: indicator.layerId,
-    name: indicator.name || "",
+    name: indicator.name || indicator.id,
     mappings: indicator.fields.map(flattenField)
   };
 };

--- a/packages/initiatives/src/migrations/upgrade-two-dot-zero.ts
+++ b/packages/initiatives/src/migrations/upgrade-two-dot-zero.ts
@@ -1,0 +1,193 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { getProp, cloneObject } from "@esri/hub-common";
+import { IInitiativeModel } from "@esri/hub-common";
+
+export function upgradeToTwoDotZero(
+  model: IInitiativeModel,
+  portalUrl?: string
+): IInitiativeModel {
+  const curVersion = getProp(model, "item.properties.schemaVersion");
+  if (curVersion < 2) {
+    const clone = cloneObject(model) as IInitiativeModel;
+    // store the schemaVersion
+    clone.item.properties.schemaVersion = 2.0;
+    // convert the values and values.steps into data.steps
+    clone.data.steps = convertSteps(clone.data.values.steps, clone.data.values);
+    if (clone.data.values.steps) {
+      // remove the data.values.steps properties
+      clone.data.values.steps.forEach((propName: string) => {
+        delete clone.data.values[propName];
+      });
+      delete clone.data.values.steps;
+    }
+    // convert the indicators
+    clone.data.indicators = convertInitiativeIndicators(clone.data.values);
+    // remove data.values.<indicator> properties
+    Object.keys(clone.data.indicators).forEach(propName => {
+      delete clone.data.values[propName];
+    });
+  } else {
+    return model;
+  }
+}
+
+/**
+ * Given the Indicators entry from a CAS configurationSettings array,
+ * convert to an indicators object in the new schema
+ */
+export const convertIndicatorsToDefinitions = function(indicatorsHash: any) {
+  // the incoming structure should have a .fields property, and what we want will be in there...
+  if (!indicatorsHash.fields || !Array.isArray(indicatorsHash.fields)) {
+    indicatorsHash.fields = [];
+  }
+  const defs = indicatorsHash.fields.map(convertIndicatorToDefinition);
+  // now we need to create an object which has props for each def
+  return defs;
+};
+
+/**
+ * Convert a CAS formatted indicator to the .definition in the new schama
+ */
+export const convertIndicatorToDefinition = function(ind: any) {
+  const def = {
+    id: ind.fieldName,
+    type: "Data",
+    name: ind.label,
+    optional: ind.optional || false,
+    definition: {
+      description: ind.label || ind.name || "",
+      supportedTypes: [...ind.layerOptions.supportedTypes],
+      geometryTypes: [...ind.layerOptions.geometryTypes],
+      fields: ind.fields.map(convertIndicatorField)
+    }
+  };
+  return def;
+};
+
+/**
+ * Convert the CAS formatted "field" into the new schema
+ */
+export const convertIndicatorField = function(field: any) {
+  return {
+    id: field.fieldName,
+    name: field.label,
+    optional: field.optional || false,
+    description: field.tooltip,
+    supportedTypes: [...field.supportedTypes]
+  };
+};
+
+/**
+ * Given the values hash that contains indicators, extract them
+ * convert them, and return the indicators hash
+ */
+export const convertInitiativeIndicators = function(values: any) {
+  return extractIndicators(values).map(convertIndicator);
+};
+
+/**
+ * Convert the "source" information
+ */
+export const convertIndicator = function(indicator: any) {
+  const result = {
+    id: indicator.id,
+    type: "Data",
+    name: indicator.name,
+    definition: {
+      description: indicator.label || indicator.name || ""
+    },
+    source: convertIndicatorValueToSource(indicator)
+  };
+  return result;
+};
+/**
+ * Given the values hash, locate the properties that are Indicators
+ * and return an array of cloned objects
+ */
+export const extractIndicators = function(values: any) {
+  return Object.keys(values).reduce((acc, prop) => {
+    const obj = values[prop];
+    if (isIndicator(obj)) {
+      const clone = cloneObject(obj);
+      // we want to keep the prop name as the id
+      clone.id = prop;
+      acc.push(clone);
+    }
+    return acc;
+  }, []);
+};
+
+/**
+ * Given an object, conduct checks to see if it is an indicator
+ */
+export const isIndicator = function(obj: any) {
+  let result = false;
+  if (Array.isArray(obj.fields) && obj.fields.length > 0) {
+    result = true;
+  }
+  return result;
+};
+
+/**
+ * Given the indicator value object (from the Initiative), extract
+ * the properties to create the .source hash
+ */
+export const convertIndicatorValueToSource = function(indicator: any) {
+  return {
+    type: "Feature Layer",
+    url: indicator.url,
+    itemId: indicator.itemId,
+    layerId: indicator.layerId,
+    name: indicator.name || "",
+    mappings: indicator.fields.map(flattenField)
+  };
+};
+
+/**
+ * CAS format had the field properties nested but
+ * the new format is flattened
+ */
+export const flattenField = function(field: any) {
+  return {
+    id: field.id,
+    name: field.field.name,
+    alias: field.field.alias,
+    type: field.field.type
+  };
+};
+/**
+ * given the array of steps (prop names), construct an array
+ * of the actual step objects while also falttening templates
+ * and items arrays to just ids
+ */
+export const convertSteps = function(steps: any, values: any) {
+  if (steps && Array.isArray(steps)) {
+    return steps.map(stepName => {
+      return convertStep(values[stepName]);
+    });
+  } else {
+    return [];
+  }
+};
+
+/**
+ * Given a Step object, return a new object with the
+ * updated schema
+ */
+export const convertStep = function(step: any) {
+  // can't use object spread b/c there are props we don't want to carry forward
+  const templates = step.templates || [];
+  const items = step.items || [];
+  return {
+    title: step.title,
+    description: step.description,
+    id: step.id, // needed so we can later flatten out of the array into an object graph. This will be the key in the graph
+    templateIds: templates.map(byId),
+    itemIds: items.map(byId)
+  };
+};
+
+export const byId = function(entry: any) {
+  return entry.id;
+};

--- a/packages/initiatives/src/migrator.ts
+++ b/packages/initiatives/src/migrator.ts
@@ -1,0 +1,34 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { getProp, cloneObject } from "@esri/hub-common";
+import { IInitiativeModel, IInitiativeItem } from "@esri/hub-common";
+import { applyInitialSchema } from "./migrations/apply-schema";
+import { upgradeToOneDotOne } from "./migrations/upgrade-one-dot-one";
+import { upgradeToTwoDotZero } from "./migrations/upgrade-two-dot-zero";
+
+/**
+ * Current Schema Version
+ */
+export const CURRENT_SCHEMA_VERSION = 2;
+
+export function migrateSchema(
+  model: IInitiativeModel,
+  portalUrl: string
+): IInitiativeModel {
+  // if the model is not on the current schema, we apply all of them
+  // the individual migrations will early-exit if the item version
+  // is at or above the migration
+  if (
+    getProp(model, "item.properties.schemaVersion") === CURRENT_SCHEMA_VERSION
+  ) {
+    return model;
+  } else {
+    // apply upgrade functions in order...
+    model = applyInitialSchema(model, portalUrl);
+    model = upgradeToOneDotOne(model, portalUrl);
+    model = upgradeToTwoDotZero(model, portalUrl);
+    // model = this._upgradeToTwoDotZero(model);
+    // etc
+    return model;
+  }
+}

--- a/packages/initiatives/src/migrator.ts
+++ b/packages/initiatives/src/migrator.ts
@@ -27,7 +27,6 @@ export function migrateSchema(
     model = applyInitialSchema(model, portalUrl);
     model = upgradeToOneDotOne(model, portalUrl);
     model = upgradeToTwoDotZero(model, portalUrl);
-    // model = this._upgradeToTwoDotZero(model);
     // etc
     return model;
   }

--- a/packages/initiatives/test/initiatives.test.ts
+++ b/packages/initiatives/test/initiatives.test.ts
@@ -1,16 +1,18 @@
-import { fetchInitiative, lookupSiteUrlByInitiative } from "../src/index";
+import * as Initiative from "../src/index";
 import * as fetchMock from "fetch-mock";
+import { IInitiativeModel, cloneObject } from "@esri/hub-common";
 
 describe("get()", () => {
   const itemBaseUrl = "https://www.arcgis.com/sharing/rest/content/items";
   afterEach(fetchMock.restore);
+
   it("should make an item request w/o fetching data", done => {
     fetchMock.once(`${itemBaseUrl}/5cd?f=json`, {
       id: "5cd",
       title: "Fake initiative",
       type: "Hub Initiative"
     });
-    fetchInitiative("5cd", {
+    Initiative.fetchInitiative("5cd", {
       data: false
     })
       .then(initiative => {
@@ -27,21 +29,80 @@ describe("get()", () => {
       });
   });
 
-  it("should make an item and data request", done => {
-    fetchMock.once(`${itemBaseUrl}/3ef?f=json`, {
-      id: "3ef",
-      title: "Fake initiative",
-      type: "Hub Initiative"
-    });
-    fetchMock.once(`${itemBaseUrl}/3ef/data?f=json`, {
-      source: "bc3",
-      values: {}
-    });
+  // it('should spy on a method', done => {
+  //   let m = {} as IInitiativeModel;
+  //   let chk = Initiative.upgradeSchema(m, 'https://foo.com');
+  //   expect(upgradeSchemaSpy.calls.count()).toEqual(1);
+  //   done();
+  // })
 
-    fetchInitiative("3ef")
+  it("should make an item and data request", done => {
+    const m = {
+      item: {
+        id: "3ef",
+        title: "Fake initiative",
+        type: "Hub Initiative",
+        properties: {}
+      },
+      data: {
+        source: "bc3",
+        values: {}
+      }
+    };
+
+    fetchMock.once(`${itemBaseUrl}/3ef?f=json`, m.item);
+    fetchMock.once(`${itemBaseUrl}/3ef/data?f=json`, m.data);
+
+    Initiative.fetchInitiative("3ef")
+      .then(model => {
+        expect(model.item).toBeDefined();
+        expect(model.item.properties.schemaVersion).toEqual(2);
+        expect(model.data).toBeDefined();
+        expect(fetchMock.done()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          `${itemBaseUrl}/3ef?f=json`
+        );
+        expect(url).toContain("f=json");
+        expect(url).toContain("items/3ef");
+        const [dataUrl, dataOptions]: [
+          string,
+          RequestInit
+        ] = fetchMock.lastCall(`${itemBaseUrl}/3ef/data?f=json`);
+        expect(dataUrl).toContain("f=json");
+        expect(dataUrl).toContain("3ef/data");
+        // expect(upgradeSchemaSpy.calls.count()).toEqual(1);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+  it("should skip schema upgrade if on current version", done => {
+    const m = {
+      item: {
+        id: "3ef",
+        title: "Fake initiative",
+        type: "Hub Initiative",
+        properties: {
+          schemaVersion: 2
+        }
+      },
+      data: {
+        source: "bc3",
+        values: {}
+      }
+    };
+    fetchMock.once(`${itemBaseUrl}/3ef?f=json`, m.item);
+    fetchMock.once(`${itemBaseUrl}/3ef/data?f=json`, m.data);
+    Initiative.fetchInitiative("3ef")
       .then(model => {
         expect(model.item).toBeDefined();
         expect(model.data).toBeDefined();
+        // this test is really checking that the schema upgrade
+        // was NOT run... spyOn was not working reliably
+        expect(model.data.assets).not.toBeDefined(
+          "schemaUpgrade should not be run"
+        );
         expect(fetchMock.done()).toBeTruthy();
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(
           `${itemBaseUrl}/3ef?f=json`
@@ -73,7 +134,7 @@ describe("lookupSiteUrlByInitiative", () => {
       properties: {}
     });
 
-    lookupSiteUrlByInitiative("3ef").catch(ex => {
+    Initiative.lookupSiteUrlByInitiative("3ef").catch(ex => {
       expect(ex.message).toBe("Initiative does not have an associated site");
       done();
     });
@@ -92,7 +153,7 @@ describe("lookupSiteUrlByInitiative", () => {
       `https://hub.arcgis.com/utilities/domains?f=json&siteId=5bc`,
       [{ domain: "data.foo.com" }, { domain: "org.hub.arcgis.com" }]
     );
-    lookupSiteUrlByInitiative("3ef").then(domain => {
+    Initiative.lookupSiteUrlByInitiative("3ef").then(domain => {
       expect(domain).toBe("data.foo.com");
       // ensure all mocks were used
       expect(fetchMock.done()).toBeTruthy();
@@ -124,7 +185,7 @@ describe("lookupSiteUrlByInitiative", () => {
       `https://hub.arcgis.com/utilities/domains?f=json&siteId=5bc`,
       [{ domain: "org-beta.hub.arcgis.com" }, { domain: "org.hub.arcgis.com" }]
     );
-    lookupSiteUrlByInitiative("3ef").then(domain => {
+    Initiative.lookupSiteUrlByInitiative("3ef").then(domain => {
       expect(domain).toBe("org-beta.hub.arcgis.com");
       // ensure all mocks were used
       expect(fetchMock.done()).toBeTruthy();

--- a/packages/initiatives/test/initiatives.test.ts
+++ b/packages/initiatives/test/initiatives.test.ts
@@ -2,206 +2,211 @@ import * as Initiative from "../src/index";
 import * as fetchMock from "fetch-mock";
 import { IInitiativeModel, cloneObject } from "@esri/hub-common";
 
-describe("get()", () => {
-  const itemBaseUrl = "https://www.arcgis.com/sharing/rest/content/items";
-  afterEach(fetchMock.restore);
+describe("Initiatives :: ", () => {
+  describe("fetchInitiative :: ", () => {
+    const itemBaseUrl = "https://www.arcgis.com/sharing/rest/content/items";
+    afterEach(fetchMock.restore);
 
-  it("should make an item request w/o fetching data", done => {
-    fetchMock.once(`${itemBaseUrl}/5cd?f=json`, {
-      id: "5cd",
-      title: "Fake initiative",
-      type: "Hub Initiative"
-    });
-    Initiative.fetchInitiative("5cd", {
-      data: false
-    })
-      .then(initiative => {
-        expect(initiative.item.id).toBe("5cd");
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
-          `${itemBaseUrl}/5cd?f=json`
-        );
-        expect(url).toContain("f=json");
-        expect(url).toContain("items/5cd");
-        done();
-      })
-      .catch(e => {
-        fail(e);
+    it("should make an item request w/o fetching data", done => {
+      fetchMock.once(`${itemBaseUrl}/5cd?f=json`, {
+        id: "5cd",
+        title: "Fake initiative 0",
+        type: "Hub Initiative"
       });
+      Initiative.fetchInitiative("5cd")
+        .then(model => {
+          expect(model.item.id).toBe("5cd");
+          expect(model.data).not.toBeDefined("Should not return the model");
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+            `${itemBaseUrl}/5cd?f=json`
+          );
+          expect(url).toContain("f=json");
+          expect(url).toContain("items/5cd");
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    // it('should spy on a method', done => {
+    //   let m = {} as IInitiativeModel;
+    //   let chk = Initiative.upgradeSchema(m, 'https://foo.com');
+    //   expect(upgradeSchemaSpy.calls.count()).toEqual(1);
+    //   done();
+    // })
+
+    it("should make an item and data request", done => {
+      const m = {
+        item: {
+          id: "3ef",
+          title: "Fake initiative 1",
+          type: "Hub Initiative",
+          properties: {}
+        },
+        data: {
+          source: "bc3",
+          values: {}
+        }
+      };
+
+      fetchMock.once(`${itemBaseUrl}/3ef?f=json`, m.item);
+      fetchMock.once(`${itemBaseUrl}/3ef/data?f=json`, m.data);
+
+      Initiative.fetchInitiative("3ef", { data: true })
+        .then(model => {
+          expect(model.item).toBeDefined();
+          expect(model.item.properties.schemaVersion).toEqual(2);
+          expect(model.data).toBeDefined();
+          expect(fetchMock.done()).toBeTruthy();
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+            `${itemBaseUrl}/3ef?f=json`
+          );
+          expect(url).toContain("f=json");
+          expect(url).toContain("items/3ef");
+          const [dataUrl, dataOptions]: [
+            string,
+            RequestInit
+          ] = fetchMock.lastCall(`${itemBaseUrl}/3ef/data?f=json`);
+          expect(dataUrl).toContain("f=json");
+          expect(dataUrl).toContain("3ef/data");
+          // expect(upgradeSchemaSpy.calls.count()).toEqual(1);
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should skip schema upgrade if on current version", done => {
+      const m = {
+        item: {
+          id: "3ef",
+          title: "Fake initiative 2",
+          type: "Hub Initiative",
+          properties: {
+            schemaVersion: 2
+          }
+        },
+        data: {
+          source: "bc3",
+          values: {}
+        }
+      };
+      fetchMock.once(`${itemBaseUrl}/3ef?f=json`, m.item);
+      fetchMock.once(`${itemBaseUrl}/3ef/data?f=json`, m.data);
+      Initiative.fetchInitiative("3ef", { data: true })
+        .then(model => {
+          expect(model.item).toBeDefined("model.item should be defined");
+          expect(model.data).toBeDefined("model.data should be defined");
+          // this test is really checking that the schema upgrade
+          // was NOT run... spyOn was not working reliably
+          expect(model.data.assets).not.toBeDefined(
+            "schemaUpgrade should not be run"
+          );
+          expect(fetchMock.done()).toBeTruthy();
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+            `${itemBaseUrl}/3ef?f=json`
+          );
+          expect(url).toContain("f=json");
+          expect(url).toContain("items/3ef");
+          const [dataUrl, dataOptions]: [
+            string,
+            RequestInit
+          ] = fetchMock.lastCall(`${itemBaseUrl}/3ef/data?f=json`);
+          expect(dataUrl).toContain("f=json");
+          expect(dataUrl).toContain("3ef/data");
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
   });
 
-  // it('should spy on a method', done => {
-  //   let m = {} as IInitiativeModel;
-  //   let chk = Initiative.upgradeSchema(m, 'https://foo.com');
-  //   expect(upgradeSchemaSpy.calls.count()).toEqual(1);
-  //   done();
-  // })
-
-  it("should make an item and data request", done => {
-    const m = {
-      item: {
+  describe("lookupSiteUrlByInitiative :: ", () => {
+    const itemBaseUrl = "https://www.arcgis.com/sharing/rest/content/items";
+    afterEach(fetchMock.restore);
+    it("should reject if initiative does not have a siteId", done => {
+      fetchMock.once(`${itemBaseUrl}/3ef?f=json`, {
         id: "3ef",
         title: "Fake initiative",
         type: "Hub Initiative",
         properties: {}
-      },
-      data: {
-        source: "bc3",
-        values: {}
-      }
-    };
-
-    fetchMock.once(`${itemBaseUrl}/3ef?f=json`, m.item);
-    fetchMock.once(`${itemBaseUrl}/3ef/data?f=json`, m.data);
-
-    Initiative.fetchInitiative("3ef")
-      .then(model => {
-        expect(model.item).toBeDefined();
-        expect(model.item.properties.schemaVersion).toEqual(2);
-        expect(model.data).toBeDefined();
-        expect(fetchMock.done()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
-          `${itemBaseUrl}/3ef?f=json`
-        );
-        expect(url).toContain("f=json");
-        expect(url).toContain("items/3ef");
-        const [dataUrl, dataOptions]: [
-          string,
-          RequestInit
-        ] = fetchMock.lastCall(`${itemBaseUrl}/3ef/data?f=json`);
-        expect(dataUrl).toContain("f=json");
-        expect(dataUrl).toContain("3ef/data");
-        // expect(upgradeSchemaSpy.calls.count()).toEqual(1);
-        done();
-      })
-      .catch(e => {
-        fail(e);
       });
-  });
-  it("should skip schema upgrade if on current version", done => {
-    const m = {
-      item: {
+
+      Initiative.lookupSiteUrlByInitiative("3ef").catch(ex => {
+        expect(ex.message).toBe("Initiative does not have an associated site");
+        done();
+      });
+    });
+
+    it("should return custom domain if multiple entries exist", done => {
+      fetchMock.once(`${itemBaseUrl}/3ef?f=json`, {
         id: "3ef",
         title: "Fake initiative",
         type: "Hub Initiative",
         properties: {
-          schemaVersion: 2
+          siteId: "5bc"
         }
-      },
-      data: {
-        source: "bc3",
-        values: {}
-      }
-    };
-    fetchMock.once(`${itemBaseUrl}/3ef?f=json`, m.item);
-    fetchMock.once(`${itemBaseUrl}/3ef/data?f=json`, m.data);
-    Initiative.fetchInitiative("3ef")
-      .then(model => {
-        expect(model.item).toBeDefined();
-        expect(model.data).toBeDefined();
-        // this test is really checking that the schema upgrade
-        // was NOT run... spyOn was not working reliably
-        expect(model.data.assets).not.toBeDefined(
-          "schemaUpgrade should not be run"
-        );
+      });
+      fetchMock.once(
+        `https://hub.arcgis.com/utilities/domains?f=json&siteId=5bc`,
+        [{ domain: "data.foo.com" }, { domain: "org.hub.arcgis.com" }]
+      );
+      Initiative.lookupSiteUrlByInitiative("3ef").then(domain => {
+        expect(domain).toBe("data.foo.com");
+        // ensure all mocks were used
         expect(fetchMock.done()).toBeTruthy();
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(
           `${itemBaseUrl}/3ef?f=json`
         );
         expect(url).toContain("f=json");
         expect(url).toContain("items/3ef");
-        const [dataUrl, dataOptions]: [
+        const [domainUrl, domainOptions]: [
           string,
           RequestInit
-        ] = fetchMock.lastCall(`${itemBaseUrl}/3ef/data?f=json`);
-        expect(dataUrl).toContain("f=json");
-        expect(dataUrl).toContain("3ef/data");
+        ] = fetchMock.lastCall(
+          "https://hub.arcgis.com/utilities/domains?f=json&siteId=5bc"
+        );
+        expect(domainUrl).toContain("siteId=5bc");
         done();
-      })
-      .catch(e => {
-        fail(e);
       });
-  });
-});
-
-describe("lookupSiteUrlByInitiative", () => {
-  const itemBaseUrl = "https://www.arcgis.com/sharing/rest/content/items";
-  afterEach(fetchMock.restore);
-  it("should reject if initiative does not have a siteId", done => {
-    fetchMock.once(`${itemBaseUrl}/3ef?f=json`, {
-      id: "3ef",
-      title: "Fake initiative",
-      type: "Hub Initiative",
-      properties: {}
     });
-
-    Initiative.lookupSiteUrlByInitiative("3ef").catch(ex => {
-      expect(ex.message).toBe("Initiative does not have an associated site");
-      done();
-    });
-  });
-
-  it("should return custom domain if multiple entries exist", done => {
-    fetchMock.once(`${itemBaseUrl}/3ef?f=json`, {
-      id: "3ef",
-      title: "Fake initiative",
-      type: "Hub Initiative",
-      properties: {
-        siteId: "5bc"
-      }
-    });
-    fetchMock.once(
-      `https://hub.arcgis.com/utilities/domains?f=json&siteId=5bc`,
-      [{ domain: "data.foo.com" }, { domain: "org.hub.arcgis.com" }]
-    );
-    Initiative.lookupSiteUrlByInitiative("3ef").then(domain => {
-      expect(domain).toBe("data.foo.com");
-      // ensure all mocks were used
-      expect(fetchMock.done()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall(
-        `${itemBaseUrl}/3ef?f=json`
+    it("should return first if multiple non-custom entries exist", done => {
+      fetchMock.once(`${itemBaseUrl}/3ef?f=json`, {
+        id: "3ef",
+        title: "Fake initiative",
+        type: "Hub Initiative",
+        properties: {
+          siteId: "5bc"
+        }
+      });
+      fetchMock.once(
+        `https://hub.arcgis.com/utilities/domains?f=json&siteId=5bc`,
+        [
+          { domain: "org-beta.hub.arcgis.com" },
+          { domain: "org.hub.arcgis.com" }
+        ]
       );
-      expect(url).toContain("f=json");
-      expect(url).toContain("items/3ef");
-      const [domainUrl, domainOptions]: [
-        string,
-        RequestInit
-      ] = fetchMock.lastCall(
-        "https://hub.arcgis.com/utilities/domains?f=json&siteId=5bc"
-      );
-      expect(domainUrl).toContain("siteId=5bc");
-      done();
-    });
-  });
-  it("should return first if multiple non-custom entries exist", done => {
-    fetchMock.once(`${itemBaseUrl}/3ef?f=json`, {
-      id: "3ef",
-      title: "Fake initiative",
-      type: "Hub Initiative",
-      properties: {
-        siteId: "5bc"
-      }
-    });
-    fetchMock.once(
-      `https://hub.arcgis.com/utilities/domains?f=json&siteId=5bc`,
-      [{ domain: "org-beta.hub.arcgis.com" }, { domain: "org.hub.arcgis.com" }]
-    );
-    Initiative.lookupSiteUrlByInitiative("3ef").then(domain => {
-      expect(domain).toBe("org-beta.hub.arcgis.com");
-      // ensure all mocks were used
-      expect(fetchMock.done()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall(
-        `${itemBaseUrl}/3ef?f=json`
-      );
-      expect(url).toContain("f=json");
-      expect(url).toContain("items/3ef");
-      const [domainUrl, domainOptions]: [
-        string,
-        RequestInit
-      ] = fetchMock.lastCall(
-        "https://hub.arcgis.com/utilities/domains?f=json&siteId=5bc"
-      );
-      expect(domainUrl).toContain("siteId=5bc");
-      done();
+      Initiative.lookupSiteUrlByInitiative("3ef").then(domain => {
+        expect(domain).toBe("org-beta.hub.arcgis.com");
+        // ensure all mocks were used
+        expect(fetchMock.done()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          `${itemBaseUrl}/3ef?f=json`
+        );
+        expect(url).toContain("f=json");
+        expect(url).toContain("items/3ef");
+        const [domainUrl, domainOptions]: [
+          string,
+          RequestInit
+        ] = fetchMock.lastCall(
+          "https://hub.arcgis.com/utilities/domains?f=json&siteId=5bc"
+        );
+        expect(domainUrl).toContain("siteId=5bc");
+        done();
+      });
     });
   });
 });

--- a/packages/initiatives/test/mocks/initiative-versionOne.ts
+++ b/packages/initiatives/test/mocks/initiative-versionOne.ts
@@ -1,0 +1,157 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { IInitiativeModel, IInitiativeItem } from "@esri/hub-common";
+
+export const initiativeVersionOne: IInitiativeModel = {
+  item: {
+    id: "4b73483961964193a9a4195fc35dd53f",
+    owner: "dbouwman_dc",
+    title: "goldie assets - dbouwman",
+    type: "Hub Initiative",
+    typeKeywords: ["Hub", "hubInitiative", "OpenData"],
+    description:
+      "This initiative is promised to function and contains a template of each type of thing for testing",
+    tags: ["Hub Initiative"],
+    snippet:
+      "This initiative is promised to function and contains a template of each type of thing for testing",
+    extent: [
+      [-77.17599999994654, 38.75499999997309],
+      [-76.89599999994672, 39.034999999972825]
+    ],
+    spatialReference: "null",
+    accessInformation: "Esri",
+    licenseInfo: "null",
+    culture: "en-us",
+    properties: {
+      source: "b746772712ef4c68a53d0e268e3c8f49",
+      groupId: "3172234c50bc4ab9a6a221c4a6ccc743",
+      openDataGroupId: "d364221d37a441ef8c2ce2344ad79e0f",
+      schemaVersion: 1
+    },
+    url:
+      "https://hubqa.arcgis.com/admin/initiatives/4b73483961964193a9a4195fc35dd53f",
+    access: "shared"
+  } as IInitiativeItem,
+  data: {
+    source: "b746772712ef4c68a53d0e268e3c8f49",
+    values: {
+      collaborationGroupId: "3172234c50bc4ab9a6a221c4a6ccc743",
+      openDataGroupId: "d364221d37a441ef8c2ce2344ad79e0f",
+      followerGroups: [],
+      steps: ["monitorTools", "informTools", "listenTools", "pageTesting"],
+      monitorTools: {
+        title: "Website testing here",
+        description:
+          "Establish performance measures that incorporate the publics perspective.",
+        id: "monitorTools",
+        templates: [
+          {
+            title: "Gold Standard Website",
+            id: "236012a5263b4d719d857ae878166a54",
+            type: "hub site application"
+          },
+          {
+            title: "Gold Standard Site with Children",
+            id: "42fb3f80f6f44ee684d90acf66d0adfc",
+            type: "hub site application"
+          }
+        ],
+        templateItemIds: [
+          "236012a5263b4d719d857ae878166a54",
+          "42fb3f80f6f44ee684d90acf66d0adfc"
+        ],
+        configuredItemIds: [
+          "88bbf31694aa473ca5bd87bc42230dcc",
+          "94ea596a16f447e0a935f9d679823d64"
+        ],
+        items: [
+          {
+            id: "88bbf31694aa473ca5bd87bc42230dcc",
+            title: "Gold Standard Site",
+            type: "Hub Site Application"
+          },
+          {
+            id: "94ea596a16f447e0a935f9d679823d64",
+            title: "00 - Initiative: Open Data",
+            type: "Hub Site Application"
+          }
+        ]
+      },
+      informTools: {
+        title: "App testing here",
+        description:
+          "Share your data with the public so people can easily find, download and use your data in different formats.",
+        id: "informTools",
+        templates: [
+          {
+            title: "Gold Standard App",
+            id: "2dc1b35134c1403697d5fc4fe3e6b906",
+            type: "web mapping application"
+          },
+          {
+            title: "Gold Standard Optional App",
+            id: "4ca3c6422eeb40c58494c8678621318c",
+            type: "web mapping application"
+          },
+          {
+            title: "Gold Standard Private Solution",
+            id: "8c4f2be8e417441c8245eb249250a577",
+            type: "web mapping application"
+          }
+        ],
+        templateItemIds: [
+          "2dc1b35134c1403697d5fc4fe3e6b906",
+          "4ca3c6422eeb40c58494c8678621318c",
+          "8c4f2be8e417441c8245eb249250a577"
+        ],
+        configuredItemIds: ["56b546a2e57741e181eb8f65020d4e92"],
+        items: [
+          {
+            id: "56b546a2e57741e181eb8f65020d4e92",
+            title: "Gold Standard Optional App",
+            type: "Web Mapping Application"
+          }
+        ]
+      },
+      listenTools: {
+        title: "Survey testing here",
+        description:
+          "Create ways to gather citizen feedback to help inform your city officials.",
+        id: "listenTools",
+        templates: [
+          {
+            title: "Gold Standard Survey",
+            id: "0585fd3f92534cc1b266de4caec1912a",
+            type: "Form"
+          }
+        ],
+        templateItemIds: ["0585fd3f92534cc1b266de4caec1912a"],
+        configuredItemIds: [],
+        items: []
+      },
+      pageTesting: {
+        title: "Page testing here",
+        description:
+          "Pages should require a site to exist on the initiative before creating",
+        id: "pageTesting",
+        templates: [
+          {
+            title: "Gold Standard Page",
+            id: "2d964e35474c45eb89f84e0252a656f3",
+            type: "hub page"
+          }
+        ],
+        templateItemIds: ["2d964e35474c45eb89f84e0252a656f3"],
+        configuredItemIds: [],
+        items: [
+          {
+            id: "c629886541a84196b93123a37ae86839",
+            title: "non vz event",
+            type: "Hub Page"
+          }
+        ]
+      },
+      initiativeKey: "goldieAssetsDbouwman"
+    }
+  }
+};

--- a/packages/initiatives/test/mocks/initiative-versionOneDotOne.ts
+++ b/packages/initiatives/test/mocks/initiative-versionOneDotOne.ts
@@ -1,0 +1,302 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { IInitiativeModel, IInitiativeItem } from "@esri/hub-common";
+
+export const initiativeVersionOneDotOne: IInitiativeModel = {
+  item: {
+    id: "bf5cc1f0e18f45aa91ecaa6ba004ba7d",
+    owner: "dcadminqa",
+    created: 1511289191000,
+    modified: 1533234144000,
+    guid: null,
+    name: null,
+    title: "A Gold Standard for QA - Inherit Thumbnails Markham",
+    type: "Hub Initiative",
+    typeKeywords: ["Hub", "hubInitiative", "OpenData"],
+    description: "asdasdsdasdasd",
+    tags: ["Hub Initiative"],
+    snippet:
+      "This initiative is promised to function and contains a template of each type of thing for testing",
+    thumbnail: "thumbnail/ago_downloaded.png",
+    documentation: null,
+    extent: [
+      [-77.17599999995046, 38.75499999997506],
+      [-76.89599999995063, 39.03499999997481]
+    ],
+    categories: [],
+    spatialReference: "null",
+    accessInformation: "Esri",
+    licenseInfo: "null",
+    culture: "en-us",
+    properties: {
+      source: "b746772712ef4c68a53d0e268e3c8f49",
+      groupId: "d9b510d8e9a445af999f343928c99180",
+      openDataGroupId: "fffc85c72079400fb551f4e4025e84c2",
+      schemaVersion: 1.1,
+      siteId: "47136fd182cf4f5ca54699f09e058f16"
+    },
+    url:
+      "https://hubqa.arcgis.com/admin/initiatives/bf5cc1f0e18f45aa91ecaa6ba004ba7d",
+    access: "shared"
+  } as IInitiativeItem,
+  data: {
+    source: "b746772712ef4c68a53d0e268e3c8f49",
+    values: {
+      collaborationGroupId: "d9b510d8e9a445af999f343928c99180",
+      openDataGroupId: "fffc85c72079400fb551f4e4025e84c2",
+      followerGroups: [],
+      initiativeKey: "aGoldStandardForQAInheritThumbnailsMarkham",
+      collisionLayer: {},
+      informTools: {
+        items: [
+          {
+            id: "a9d20dd182224fe88a82b942ff09bbc4",
+            title: "Gold Standard Optional App",
+            type: "Web Mapping Application"
+          },
+          {
+            id: "99961b3a89424680b329760caacf3c64",
+            title: "Gold Standard App",
+            type: "Web Mapping Application"
+          },
+          {
+            id: "90b69ecf1ab945faab0824c30d4af748",
+            title: "Default Story Map Template",
+            type: "Web Mapping Application"
+          },
+          {
+            id: "b83f836ca8644ab597e9588fc6a487d5",
+            title: "Gold Standard Defaulting App",
+            type: "Web Mapping Application"
+          }
+        ],
+        title: "App testing here",
+        description:
+          "Share your data with the public so people can easily find, download and use your data in different formats.",
+        id: "informTools",
+        templates: [
+          {
+            title: "Gold Standard App",
+            id: "2dc1b35134c1403697d5fc4fe3e6b906",
+            type: "web mapping application"
+          },
+          {
+            title: "Gold Standard Optional App",
+            id: "4ca3c6422eeb40c58494c8678621318c",
+            type: "web mapping application"
+          },
+          {
+            title: "Gold Standard Private Solution",
+            id: "8c4f2be8e417441c8245eb249250a577",
+            type: "web mapping application"
+          },
+          {
+            title: "Gold Standard Optional Defaulting App",
+            id: "b19646d59698485da418e5cf44456a0d",
+            type: "web mapping application"
+          },
+          {
+            title: "Gold Standard Webmap",
+            id: "efd37089716a4647aab12e83f2f79fc3",
+            type: "webmap"
+          }
+        ],
+        templateItemIds: [
+          "2dc1b35134c1403697d5fc4fe3e6b906",
+          "4ca3c6422eeb40c58494c8678621318c",
+          "8c4f2be8e417441c8245eb249250a577",
+          "b19646d59698485da418e5cf44456a0d",
+          "efd37089716a4647aab12e83f2f79fc3"
+        ],
+        configuredItemIds: [
+          "a9d20dd182224fe88a82b942ff09bbc4",
+          "99961b3a89424680b329760caacf3c64",
+          "90b69ecf1ab945faab0824c30d4af748",
+          "b83f836ca8644ab597e9588fc6a487d5"
+        ]
+      },
+      monitorTools: {
+        items: [
+          {
+            id: "47136fd182cf4f5ca54699f09e058f16",
+            title: "00 - Initiative: Open Data",
+            type: "Hub Site Application"
+          }
+        ],
+        title: "Website testing here",
+        description:
+          "Establish performance measures that incorporate the publics perspective.",
+        id: "monitorTools",
+        templates: [
+          {
+            title: "Gold Standard Website",
+            id: "236012a5263b4d719d857ae878166a54",
+            type: "hub site application"
+          },
+          {
+            title: "Gold Standard Site with Children",
+            id: "42fb3f80f6f44ee684d90acf66d0adfc",
+            type: "hub site application"
+          }
+        ],
+        templateItemIds: [
+          "236012a5263b4d719d857ae878166a54",
+          "42fb3f80f6f44ee684d90acf66d0adfc"
+        ],
+        configuredItemIds: ["47136fd182cf4f5ca54699f09e058f16"]
+      },
+      listenTools: {
+        items: [
+          {
+            id: "d7f669a6a1a942e4a1620ea40bd61e1c",
+            title: "Newer Survey Test",
+            type: "Form"
+          }
+        ],
+        title: "Survey testing here",
+        description:
+          "Create ways to gather citizen feedback to help inform your city officials.",
+        id: "listenTools",
+        templates: [
+          {
+            title: "Gold Standard Survey",
+            id: "0585fd3f92534cc1b266de4caec1912a",
+            type: "Form"
+          }
+        ],
+        templateItemIds: ["0585fd3f92534cc1b266de4caec1912a"],
+        configuredItemIds: ["d7f669a6a1a942e4a1620ea40bd61e1c"]
+      },
+      pageTesting: {
+        items: [],
+        title: "Page testing here",
+        description:
+          "Pages should require a site to exist on the initiative before creating",
+        id: "pageTesting",
+        templates: [
+          {
+            title: "Gold Standard Page",
+            id: "2d964e35474c45eb89f84e0252a656f3",
+            type: "hub page"
+          }
+        ],
+        templateItemIds: ["2d964e35474c45eb89f84e0252a656f3"],
+        configuredItemIds: []
+      },
+      bannerImage: {
+        source: "bannerImage",
+        display: {
+          position: {
+            x: "77.41228070175438%",
+            y: "91.81818181818183%"
+          }
+        }
+      },
+      steps: [
+        "monitorTools",
+        "informTools",
+        "listenTools",
+        "pageTesting",
+        "dashboardTesting"
+      ],
+      dashboardTesting: {
+        title: "Dashboard Testing Here",
+        description: "Test your Ops Dashboard templates here",
+        id: "dashboardTesting",
+        templates: [
+          {
+            title: "Gold Standard Ops Dashboard",
+            id: "e84590e7e6974e83892126e437f13029",
+            type: "dashboard"
+          }
+        ],
+        templateItemIds: ["e84590e7e6974e83892126e437f13029"],
+        configuredItemIds: [
+          "4e82186c0759421dbffdbbbbf25a048b",
+          "a6081cc3887142f2b5665d0807b54661"
+        ],
+        items: [
+          {
+            id: "4e82186c0759421dbffdbbbbf25a048b",
+            title: "Gold Standard Ops Dashboard",
+            type: "Web Mapping Application"
+          },
+          {
+            id: "a6081cc3887142f2b5665d0807b54661",
+            title: "Gold Standard Ops Dashboard",
+            type: "Web Mapping Application"
+          }
+        ]
+      },
+      optionalData: {
+        url:
+          "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/survey123_7d7a9fabcb0c44bcaf1d6473cd088a07/FeatureServer/1",
+        layerId: 1,
+        itemId: "a5b15fe368684a66b8c85a6cadaef9e5",
+        name: "metadata",
+        fields: [
+          {
+            id: "optionalField",
+            field: {
+              name: "value",
+              alias: "value",
+              type: "esriFieldTypeString"
+            }
+          }
+        ]
+      }
+    },
+    assets: [
+      {
+        id: "bannerImage",
+        url:
+          "https://dc.mapsqa.arcgis.com/sharing/rest/content/items/bf5cc1f0e18f45aa91ecaa6ba004ba7d/resources/detail-image.jpg",
+        properties: {
+          type: "resource",
+          fileName: "detail-image.jpg",
+          mimeType: "image/jepg"
+        },
+        license: {
+          type: "none"
+        },
+        display: {
+          position: {
+            x: "77.41228070175438%",
+            y: "91.81818181818183%"
+          }
+        }
+      },
+      {
+        id: "iconDark",
+        url:
+          "https://dc.mapsqa.arcgis.com/sharing/rest/content/items/bf5cc1f0e18f45aa91ecaa6ba004ba7d/resources/icon-dark.png",
+        properties: {
+          type: "resource",
+          fileName: "icon-dark.png",
+          mimeType: "image/png"
+        },
+        license: {
+          type: "none"
+        }
+      },
+      {
+        id: "iconLight",
+        url:
+          "https://dc.mapsqa.arcgis.com/sharing/rest/content/items/bf5cc1f0e18f45aa91ecaa6ba004ba7d/resources/icon-light.png",
+        properties: {
+          type: "resource",
+          fileName: "icon-light.png",
+          mimeType: "image/png"
+        },
+        license: {
+          type: "none"
+        }
+      }
+    ]
+  }
+};
+
+export const initiativeVersionOneTemplate: IInitiativeModel = {
+  item: {} as IInitiativeItem,
+  data: {}
+};

--- a/packages/initiatives/test/mocks/initiative-versionTwo.ts
+++ b/packages/initiatives/test/mocks/initiative-versionTwo.ts
@@ -1,0 +1,8 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { IInitiativeModel, IInitiativeItem } from "@esri/hub-common";
+
+export const initiativeVersionZero: IInitiativeModel = {
+  item: {} as IInitiativeItem,
+  data: {}
+};

--- a/packages/initiatives/test/mocks/initiative-versionZero.ts
+++ b/packages/initiatives/test/mocks/initiative-versionZero.ts
@@ -1,0 +1,264 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { IInitiativeModel, IInitiativeItem } from "@esri/hub-common";
+
+export const initiativeVersionZero: IInitiativeModel = {
+  item: {
+    id: "c5963a6bb6244eb8b8fb4f56cb0bef4c",
+    owner: "cclaessens_dcqa",
+    created: 1507920879000,
+    modified: 1532444916000,
+    guid: null,
+    name: null,
+    title: "!Vision Zero ",
+    type: "Hub Initiative",
+    typeKeywords: [
+      "Hub",
+      "hubIndicatorName|nhtsa_wat",
+      "hubInitiative",
+      "OpenData"
+    ],
+    description:
+      "Share your VisionZero strategy. Schedule events on pedestrian & bicycle safety. Gather reports of dangerous intersections. Explore collision trends and areas to improve. -- Vision Zero is a worldwide safety project that aims to achieve a highway system with no traffic fatalities and severe injuries caused by road traffic. Communities around the world have launched Vision Zero initiatives with the goal of reducing and ultimately eliminating traffic-related fatalities and injuries while increasing safe, healthy, equitable mobility for all.\n\n",
+    tags: ["Hub Initiative"],
+    snippet: "Eliminate all traffic fatalities and severe injuries.",
+    thumbnail: "thumbnail/ago_downloaded.png",
+    documentation: null,
+    extent: [],
+    categories: [],
+    spatialReference: "null",
+    accessInformation: "Esri",
+    licenseInfo: "CC-BY",
+    culture: "en-us",
+    properties: {
+      source: "e3f65f7cb7ef4dbca590498b035fd6b3",
+      groupId: "4aa2a5215c884814b51a532d18fb7953",
+      openDataGroupId: "4cfba68ecefe41c1b61524d74f0bbccf"
+    },
+    url: "https://-vision-zero--dc.hubqa.arcgis.com",
+    proxyFilter: null,
+    access: "shared",
+    size: -1,
+    appCategories: [],
+    industries: [],
+    languages: [],
+    largeThumbnail: null,
+    banner: null,
+    screenshots: [],
+    listed: false,
+    numComments: 0,
+    numRatings: 0,
+    avgRating: 0,
+    numViews: 69,
+    scoreCompleteness: 76,
+    groupDesignations: null
+  } as IInitiativeItem,
+  data: {
+    source: "e3f65f7cb7ef4dbca590498b035fd6b3",
+    values: {
+      collaborationGroupId: "4aa2a5215c884814b51a532d18fb7953",
+      openDataGroupId: "4cfba68ecefe41c1b61524d74f0bbccf",
+      followerGroups: [],
+      initiativeKey: "testThisCocoVisionZero",
+      informTools: {
+        items: [
+          {
+            id: "d51f963282204fcebdcfecdf881e6556",
+            title: "[test this coco] Vision Zero Site",
+            type: "Hub Site Application"
+          },
+          {
+            id: "441c87fd97994df48fc8bc6b0d65d776",
+            title: "Blank Site Template",
+            type: "Hub Site Application"
+          },
+          {
+            id: "302beec950964c41abc833da48c5c11e",
+            title: "Blank Site Template",
+            type: "Hub Site Application"
+          }
+        ]
+      }
+    }
+  }
+};
+
+export const initiativeVersionZeroTemplate: IInitiativeModel = {
+  item: {
+    id: "5f49a84495844c3e9c4ab6836e6c16a9",
+    owner: "dcadminqa",
+    created: 1498673136000,
+    modified: 1499092291000,
+    guid: null,
+    name: null,
+    title: "WHAT IS THIS ONE",
+    type: "Hub Initiative",
+    typeKeywords: ["Hub", "hubInitiativeTemplate", "OpenData"],
+    description: "Change this",
+    tags: [],
+    snippet: "Change this",
+    thumbnail: null,
+    documentation: null,
+    extent: [],
+    categories: [],
+    licenseInfo: "null",
+    culture: "en-us",
+    properties: {},
+    access: "private"
+  } as IInitiativeItem,
+  data: {
+    configurationSettings: [
+      {
+        category: "Steps",
+        fields: [
+          {
+            type: "item",
+            multipleSelection: true,
+            fieldName: "informTools",
+            label: "Inform the Public",
+            tooltip:
+              "Share your data with the public so people can easily find, download and use your data in different formats.",
+            supportedTypes: [
+              "Web Mapping Application",
+              "Mobile Application",
+              "Form"
+            ]
+          },
+          {
+            type: "item",
+            multipleSelection: true,
+            fieldName: "listenTools",
+            label: "Listen to the Public",
+            tooltip:
+              "Create ways to gather citizen feedback to help inform your city officials.",
+            supportedTypes: [
+              "Web Mapping Application",
+              "Mobile Application",
+              "Form"
+            ]
+          },
+          {
+            type: "item",
+            multipleSelection: true,
+            fieldName: "monitorTools",
+            label: "Monitor Progress",
+            tooltip:
+              "Establish performance measures that incorporate the publics perspective.",
+            supportedTypes: [
+              "Web Mapping Application",
+              "Mobile Application",
+              "Form"
+            ]
+          }
+        ]
+      }
+    ],
+    values: {
+      informTools: {
+        items: []
+      },
+      listenTools: {
+        items: [
+          {
+            id: "e748dbcedbb14f998c006d93028fd58f",
+            title: "Missing Data Request",
+            type: "Form"
+          }
+        ]
+      },
+      monitorTools: {
+        items: []
+      }
+    }
+  }
+};
+
+export const customInitiative: IInitiativeModel = {
+  item: {
+    id: "6f49a84495844c3e9c4ab6836e6c16a9",
+    owner: "dcadminqa",
+    created: 1498673136000,
+    modified: 1499092291000,
+    guid: null,
+    name: null,
+    title: "Custom Initiative",
+    type: "Hub Initiative",
+    typeKeywords: ["Hub", "OpenData"],
+    description: "Change this",
+    tags: [],
+    snippet: "Change this",
+    thumbnail: null,
+    documentation: null,
+    extent: [],
+    categories: [],
+    licenseInfo: "null",
+    culture: "en-us",
+    properties: {},
+    access: "private"
+  } as IInitiativeItem,
+  data: {
+    configurationSettings: [
+      {
+        category: "Steps",
+        fields: [
+          {
+            type: "item",
+            multipleSelection: true,
+            fieldName: "informTools",
+            label: "Inform the Public",
+            tooltip:
+              "Share your data with the public so people can easily find, download and use your data in different formats.",
+            supportedTypes: [
+              "Web Mapping Application",
+              "Mobile Application",
+              "Form"
+            ]
+          },
+          {
+            type: "item",
+            multipleSelection: true,
+            fieldName: "listenTools",
+            label: "Listen to the Public",
+            tooltip:
+              "Create ways to gather citizen feedback to help inform your city officials.",
+            supportedTypes: [
+              "Web Mapping Application",
+              "Mobile Application",
+              "Form"
+            ]
+          },
+          {
+            type: "item",
+            multipleSelection: true,
+            fieldName: "monitorTools",
+            label: "Monitor Progress",
+            tooltip:
+              "Establish performance measures that incorporate the publics perspective.",
+            supportedTypes: [
+              "Web Mapping Application",
+              "Mobile Application",
+              "Form"
+            ]
+          }
+        ]
+      }
+    ],
+    values: {
+      informTools: {
+        items: []
+      },
+      listenTools: {
+        items: [
+          {
+            id: "e748dbcedbb14f998c006d93028fd58f",
+            title: "Missing Data Request",
+            type: "Form"
+          }
+        ]
+      },
+      monitorTools: {
+        items: []
+      }
+    }
+  }
+};

--- a/packages/initiatives/test/schema-upgrade.test.ts
+++ b/packages/initiatives/test/schema-upgrade.test.ts
@@ -1,0 +1,20 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { IInitiativeModel, cloneObject } from "@esri/hub-common";
+import { migrateSchema, CURRENT_SCHEMA_VERSION } from "../src/migrator";
+
+describe("Initiative Schema Migration", () => {
+  it("should not upgrade if on current version", done => {
+    const m = {
+      item: {
+        properties: {
+          schemaVersion: CURRENT_SCHEMA_VERSION
+        }
+      },
+      data: {}
+    } as IInitiativeModel;
+    const chk = migrateSchema(m, "https://some.portal.com/arcgis/rest");
+    expect(chk).toBe(m, "should return the same object");
+    done();
+  });
+});

--- a/packages/initiatives/test/upgrades/apply-schema.test.ts
+++ b/packages/initiatives/test/upgrades/apply-schema.test.ts
@@ -1,0 +1,151 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { IInitiativeModel, cloneObject } from "@esri/hub-common";
+import { applyInitialSchema } from "../../src/migrations/apply-schema";
+
+describe("Applying Initial Initiative Schema", () => {
+  describe("apply schema", () => {
+    const model: IInitiativeModel = {
+      item: {
+        id: "3ef",
+        title: "fake",
+        owner: "vader",
+        type: "Hub Initiative",
+        typeKeywords: [],
+        properties: {}
+      },
+      data: {
+        source: "bc34",
+        configurationSettings: [
+          {
+            category: "Steps",
+            fields: [
+              {
+                type: "item",
+                multipleSelection: true,
+                fieldName: "listenTools",
+                label: "Listen to the Public",
+                tooltip:
+                  "Create ways to gather citizen feedback to help inform your city officials.",
+                supportedTypes: [
+                  "Web Mapping Application",
+                  "Mobile Application",
+                  "Form"
+                ]
+              }
+            ]
+          }
+        ],
+        values: {
+          listenTools: {
+            items: [
+              {
+                title: "Vision Zero Website",
+                id: "54b",
+                type: "Web Mapping Application"
+              },
+              {
+                title: "Collision Lens",
+                id: "c47",
+                type: "Web Mapping Application"
+              },
+              {
+                title: "Invasive Collisions",
+                id: "776",
+                type: "Web Mapping Application"
+              }
+            ]
+          }
+        }
+      }
+    };
+    it("should return the model if it is already 1 or higher", done => {
+      const instance = cloneObject(model) as IInitiativeModel;
+      instance.item.properties.schemaVersion = 1;
+      const chk = applyInitialSchema(instance);
+      expect(chk).toBe(instance, "should return the same instance");
+      done();
+    });
+    it("should ensure properties", done => {
+      const instance = cloneObject(model) as IInitiativeModel;
+      delete instance.item.properties;
+      delete instance.data.values;
+      // console.debug(`------- INSTANCE ---------`);
+      // console.debug(JSON.stringify(instance, null, 2));
+      // console.debug(`------- INSTANCE ---------`);
+      const chk = applyInitialSchema(instance);
+      expect(chk.item.properties).toBeDefined(
+        "item properties should be defined"
+      );
+      expect(chk.data.values).toBeDefined("data.values should be defined");
+      done();
+    });
+    it("should add the schema to an instance", done => {
+      const instance = cloneObject(model) as IInitiativeModel;
+      const chk = applyInitialSchema(instance);
+      expect(chk.item.properties.schemaVersion).toBeDefined("schema version");
+      expect(chk.data.configurationSettings).not.toBeDefined(
+        "should remove config settings"
+      );
+      expect(chk.data.source).toEqual(
+        chk.item.properties.source,
+        "source should be copied to item props"
+      );
+      expect(chk.data.values.listenTools.title).toEqual(
+        "Listen to the Public",
+        "should move title"
+      );
+      expect(chk.data.values.steps).toBeDefined(
+        "data values steps should be defined"
+      );
+      expect(chk.data.values.listenTools.items).toBeDefined(
+        "step items should be preserved"
+      );
+      expect(chk.data.values.listenTools.items.length).toEqual(
+        3,
+        "should have 3 entries"
+      );
+      done();
+    });
+    it("should add the schema to a template", done => {
+      const tmpl = cloneObject(model) as IInitiativeModel;
+      tmpl.item.typeKeywords.push("hubInitiativeTemplate");
+      const chk = applyInitialSchema(tmpl);
+      expect(chk.item.properties.schemaVersion).toBeDefined("schema version");
+      expect(chk.data.configurationSettings).not.toBeDefined(
+        "should remove config settings"
+      );
+      expect(chk.data.source).toEqual(
+        chk.item.properties.source,
+        "source should be copied to item props"
+      );
+      expect(chk.data.values.listenTools.title).toEqual(
+        "Listen to the Public",
+        "should move title"
+      );
+      expect(chk.data.values.steps).toBeDefined(
+        "data values steps should be defined"
+      );
+      expect(chk.data.values.listenTools.items).not.toBeDefined(
+        "step items should be removed"
+      );
+      expect(chk.data.values.listenTools.templates).toBeDefined(
+        "step templates should be defined"
+      );
+      expect(chk.data.values.listenTools.templates.length).toEqual(
+        3,
+        "should have 3 entries"
+      );
+      done();
+    });
+    it("should create values entry if it does not exist", done => {
+      const m = cloneObject(model) as IInitiativeModel;
+      delete m.data.values.listenTools;
+      const chk = applyInitialSchema(m);
+      expect(chk.data.values.listenTools).toBeDefined(
+        "listenTools should be defined"
+      );
+      done();
+    });
+  });
+});

--- a/packages/initiatives/test/upgrades/apply-schema.test.ts
+++ b/packages/initiatives/test/upgrades/apply-schema.test.ts
@@ -2,63 +2,20 @@
  * Apache-2.0 */
 import { IInitiativeModel, cloneObject } from "@esri/hub-common";
 import { applyInitialSchema } from "../../src/migrations/apply-schema";
+import {
+  initiativeVersionZero,
+  initiativeVersionZeroTemplate,
+  customInitiative
+} from "../mocks/initiative-versionZero";
 
-describe("Applying Initial Initiative Schema", () => {
-  describe("apply schema", () => {
-    const model: IInitiativeModel = {
-      item: {
-        id: "3ef",
-        title: "fake",
-        owner: "vader",
-        type: "Hub Initiative",
-        typeKeywords: [],
-        properties: {}
-      },
-      data: {
-        source: "bc34",
-        configurationSettings: [
-          {
-            category: "Steps",
-            fields: [
-              {
-                type: "item",
-                multipleSelection: true,
-                fieldName: "listenTools",
-                label: "Listen to the Public",
-                tooltip:
-                  "Create ways to gather citizen feedback to help inform your city officials.",
-                supportedTypes: [
-                  "Web Mapping Application",
-                  "Mobile Application",
-                  "Form"
-                ]
-              }
-            ]
-          }
-        ],
-        values: {
-          listenTools: {
-            items: [
-              {
-                title: "Vision Zero Website",
-                id: "54b",
-                type: "Web Mapping Application"
-              },
-              {
-                title: "Collision Lens",
-                id: "c47",
-                type: "Web Mapping Application"
-              },
-              {
-                title: "Invasive Collisions",
-                id: "776",
-                type: "Web Mapping Application"
-              }
-            ]
-          }
-        }
-      }
-    };
+describe("Applying Initial Initiative Schema ::", () => {
+  const model = cloneObject(initiativeVersionZero) as IInitiativeModel;
+  const modelTmpl = cloneObject(
+    initiativeVersionZeroTemplate
+  ) as IInitiativeModel;
+  const custom = cloneObject(customInitiative) as IInitiativeModel;
+
+  describe("Apply schema to an Instance ::", () => {
     it("should return the model if it is already 1 or higher", done => {
       const instance = cloneObject(model) as IInitiativeModel;
       instance.item.properties.schemaVersion = 1;
@@ -66,13 +23,11 @@ describe("Applying Initial Initiative Schema", () => {
       expect(chk).toBe(instance, "should return the same instance");
       done();
     });
+
     it("should ensure properties", done => {
       const instance = cloneObject(model) as IInitiativeModel;
       delete instance.item.properties;
       delete instance.data.values;
-      // console.debug(`------- INSTANCE ---------`);
-      // console.debug(JSON.stringify(instance, null, 2));
-      // console.debug(`------- INSTANCE ---------`);
       const chk = applyInitialSchema(instance);
       expect(chk.item.properties).toBeDefined(
         "item properties should be defined"
@@ -91,25 +46,13 @@ describe("Applying Initial Initiative Schema", () => {
         chk.item.properties.source,
         "source should be copied to item props"
       );
-      expect(chk.data.values.listenTools.title).toEqual(
-        "Listen to the Public",
-        "should move title"
-      );
-      expect(chk.data.values.steps).toBeDefined(
-        "data values steps should be defined"
-      );
-      expect(chk.data.values.listenTools.items).toBeDefined(
-        "step items should be preserved"
-      );
-      expect(chk.data.values.listenTools.items.length).toEqual(
-        3,
-        "should have 3 entries"
-      );
       done();
     });
+  });
+
+  describe("Apply Schema to a Template ::", () => {
     it("should add the schema to a template", done => {
-      const tmpl = cloneObject(model) as IInitiativeModel;
-      tmpl.item.typeKeywords.push("hubInitiativeTemplate");
+      const tmpl = cloneObject(modelTmpl) as IInitiativeModel;
       const chk = applyInitialSchema(tmpl);
       expect(chk.item.properties.schemaVersion).toBeDefined("schema version");
       expect(chk.data.configurationSettings).not.toBeDefined(
@@ -126,6 +69,10 @@ describe("Applying Initial Initiative Schema", () => {
       expect(chk.data.values.steps).toBeDefined(
         "data values steps should be defined"
       );
+      expect(chk.data.values.steps).toEqual(
+        ["informTools", "listenTools", "monitorTools"],
+        "all three steps should be in steps array"
+      );
       expect(chk.data.values.listenTools.items).not.toBeDefined(
         "step items should be removed"
       );
@@ -133,17 +80,54 @@ describe("Applying Initial Initiative Schema", () => {
         "step templates should be defined"
       );
       expect(chk.data.values.listenTools.templates.length).toEqual(
-        3,
-        "should have 3 entries"
+        1,
+        "should have 1 entries"
       );
       done();
     });
     it("should create values entry if it does not exist", done => {
-      const m = cloneObject(model) as IInitiativeModel;
-      delete m.data.values.listenTools;
+      const m = cloneObject(modelTmpl) as IInitiativeModel;
+      delete m.data.values.informTools;
       const chk = applyInitialSchema(m);
-      expect(chk.data.values.listenTools).toBeDefined(
-        "listenTools should be defined"
+      expect(chk.data.values.informTools).toBeDefined(
+        "informTools should be defined"
+      );
+      done();
+    });
+  });
+
+  describe("Apply Schema to a Custom Initiative ::", () => {
+    it("should add the schema to a custom initiative", done => {
+      const customClone = cloneObject(custom) as IInitiativeModel;
+      const chk = applyInitialSchema(customClone);
+      expect(chk.item.properties.schemaVersion).toBeDefined("schema version");
+      expect(chk.data.configurationSettings).not.toBeDefined(
+        "should remove config settings"
+      );
+      expect(chk.data.source).toEqual(
+        chk.item.properties.source,
+        "source should be copied to item props"
+      );
+      expect(chk.data.values.listenTools.title).toEqual(
+        "Listen to the Public",
+        "should move title"
+      );
+      expect(chk.data.values.steps).toBeDefined(
+        "data values steps should be defined"
+      );
+      expect(chk.data.values.steps).toEqual(
+        ["informTools", "listenTools", "monitorTools"],
+        "all three steps should be in steps array"
+      );
+      expect(chk.data.values.listenTools.items).toBeDefined(
+        "step items should remain"
+      );
+      expect(chk.data.values.listenTools.templates).not.toBeDefined(
+        "step templates should not be defined"
+      );
+      expect(chk.data.values.listenTools.items.length).toEqual(
+        1,
+        "should have 1 entries"
       );
       done();
     });

--- a/packages/initiatives/test/upgrades/upgrade-one-dot-one.test.ts
+++ b/packages/initiatives/test/upgrades/upgrade-one-dot-one.test.ts
@@ -5,75 +5,80 @@ import {
   upgradeToOneDotOne,
   getResourceUrl
 } from "../../src/migrations/upgrade-one-dot-one";
+import { initiativeVersionOne } from "../mocks/initiative-versionOne";
 
-describe("upgrade 1.1", () => {
-  it("should return the model if its at 1.1", done => {
-    const m: IInitiativeModel = {
-      item: {
-        id: "3ef",
-        title: "fake",
-        owner: "vader",
-        type: "Hub Initiative",
-        properties: {
-          schemaVersion: 1.1
+describe("Applying v1.1 Initiative Schema ::", () => {
+  const model = cloneObject(initiativeVersionOne) as IInitiativeModel;
+  // There is no template specific logic for this upgrade
+
+  describe("Upgrade Instance ::", () => {
+    it("should return the model if its at 1.1", done => {
+      const instance = cloneObject(model) as IInitiativeModel;
+      instance.item.properties.schemaVersion = 1.1;
+      const chk = upgradeToOneDotOne(instance);
+      expect(chk).toBe(instance, "should return the same object");
+      done();
+    });
+    it("should add the schema version and assets", done => {
+      const instance = cloneObject(model) as IInitiativeModel;
+      const chk = upgradeToOneDotOne(instance);
+      expect(chk).not.toBe(instance, "should return a new object");
+      expect(chk.item.properties.schemaVersion).toBeDefined("schema version");
+      expect(chk.item.properties.schemaVersion).toEqual(
+        1.1,
+        "should set version to 1.1"
+      );
+      expect(chk.data.assets).toBeDefined("assets should be defined");
+      expect(chk.data.assets.length).toBe(3, "should add 3 assets");
+      expect(chk.data.assets[0].url.includes("www.arcgis.com")).toBeTruthy(
+        "should use www.arcgis.com"
+      );
+      expect(chk.data.values.bannerImage).toBeDefined("should add bannerImage");
+      done();
+    });
+    it("should add assets with urls using passed in portalUrl", done => {
+      const instance = cloneObject(model) as IInitiativeModel;
+      const portalUrl = "http://somefoo.com";
+      const chk = upgradeToOneDotOne(instance, portalUrl);
+      expect(chk).not.toBe(instance, "should return a new object");
+      expect(chk.data.assets).toBeDefined("assets should be defined");
+      expect(chk.data.assets.length).toBe(3, "should add 3 assets");
+      expect(chk.data.assets[0].url.includes(portalUrl)).toBeTruthy(
+        "should use passed in url"
+      );
+      done();
+    });
+    it("should not add bannerImage if it exists", done => {
+      const instance = cloneObject(model) as IInitiativeModel;
+      instance.data.values.bannerImage = {
+        source: "bannerImageOther",
+        display: {
+          position: { x: "50%", y: "10%" }
         }
-      },
-      data: {
-        values: {}
-      }
-    };
-    const chk = upgradeToOneDotOne(m);
-    expect(chk).toBe(m, "should return the same object");
-    done();
-  });
-  it("should add the schema version and assets", done => {
-    const m: IInitiativeModel = {
-      item: {
-        id: "3ef",
-        title: "fake",
-        owner: "vader",
-        type: "Hub Initiative",
-        properties: {
-          schemaVersion: 1.0
-        }
-      },
-      data: {
-        values: {}
-      }
-    };
-    const chk = upgradeToOneDotOne(m);
-    expect(chk).not.toBe(m, "should return a new object");
-    expect(chk.item.properties.schemaVersion).toBeDefined("schema version");
-    expect(chk.data.assets).toBeDefined("assets should be defined");
-    expect(chk.data.assets.length).toBe(3, "should add 3 assets");
-    expect(chk.data.values.bannerImage).toBeDefined("should add bannerImage");
-    done();
-  });
-  it("should add assets with urls using passed in portalUrl", done => {
-    const m: IInitiativeModel = {
-      item: {
-        id: "3ef",
-        title: "fake",
-        owner: "vader",
-        type: "Hub Initiative",
-        properties: {
-          schemaVersion: 1.0
-        }
-      },
-      data: {
-        values: {}
-      }
-    };
-    const chk = upgradeToOneDotOne(m);
-    expect(chk).not.toBe(m, "should return a new object");
-    expect(chk.item.properties.schemaVersion).toBeDefined("schema version");
-    expect(chk.data.assets).toBeDefined("assets should be defined");
-    expect(chk.data.assets.length).toBe(3, "should add 3 assets");
-    expect(chk.data.values.bannerImage).toBeDefined("should add bannerImage");
-    done();
+      };
+      const chk = upgradeToOneDotOne(instance);
+      expect(chk).not.toBe(instance, "should return a new object");
+      expect(chk.data.values.bannerImage).toBeDefined(
+        "bannerImage should be defined"
+      );
+      expect(chk.data.values.bannerImage.source).toEqual(
+        "bannerImageOther",
+        "should keep existing bannerImage"
+      );
+      done();
+    });
+    it("should not add assets if it exists", done => {
+      const instance = cloneObject(model) as IInitiativeModel;
+      instance.data.assets = [];
+      const chk = upgradeToOneDotOne(instance);
+      expect(chk).not.toBe(instance, "should return a new object");
+      expect(chk.data.assets).toBeDefined("assets should be defined");
+      expect(chk.data.assets.length).toBe(0, "should add 0 assets");
+      done();
+    });
   });
 
-  describe("getResourceUrl", () => {
+  describe("utils :: getResourceUrl", () => {
     it("should constuct resource url and default to arcgis.com", done => {
       const url = getResourceUrl("3ef", "test.png");
       expect(url).toEqual(

--- a/packages/initiatives/test/upgrades/upgrade-one-dot-one.test.ts
+++ b/packages/initiatives/test/upgrades/upgrade-one-dot-one.test.ts
@@ -1,0 +1,110 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { IInitiativeModel, cloneObject } from "@esri/hub-common";
+import {
+  upgradeToOneDotOne,
+  getResourceUrl
+} from "../../src/migrations/upgrade-one-dot-one";
+
+describe("upgrade 1.1", () => {
+  it("should return the model if its at 1.1", done => {
+    const m: IInitiativeModel = {
+      item: {
+        id: "3ef",
+        title: "fake",
+        owner: "vader",
+        type: "Hub Initiative",
+        properties: {
+          schemaVersion: 1.1
+        }
+      },
+      data: {
+        values: {}
+      }
+    };
+    const chk = upgradeToOneDotOne(m);
+    expect(chk).toBe(m, "should return the same object");
+    done();
+  });
+  it("should add the schema version and assets", done => {
+    const m: IInitiativeModel = {
+      item: {
+        id: "3ef",
+        title: "fake",
+        owner: "vader",
+        type: "Hub Initiative",
+        properties: {
+          schemaVersion: 1.0
+        }
+      },
+      data: {
+        values: {}
+      }
+    };
+    const chk = upgradeToOneDotOne(m);
+    expect(chk).not.toBe(m, "should return a new object");
+    expect(chk.item.properties.schemaVersion).toBeDefined("schema version");
+    expect(chk.data.assets).toBeDefined("assets should be defined");
+    expect(chk.data.assets.length).toBe(3, "should add 3 assets");
+    expect(chk.data.values.bannerImage).toBeDefined("should add bannerImage");
+    done();
+  });
+  it("should add assets with urls using passed in portalUrl", done => {
+    const m: IInitiativeModel = {
+      item: {
+        id: "3ef",
+        title: "fake",
+        owner: "vader",
+        type: "Hub Initiative",
+        properties: {
+          schemaVersion: 1.0
+        }
+      },
+      data: {
+        values: {}
+      }
+    };
+    const chk = upgradeToOneDotOne(m);
+    expect(chk).not.toBe(m, "should return a new object");
+    expect(chk.item.properties.schemaVersion).toBeDefined("schema version");
+    expect(chk.data.assets).toBeDefined("assets should be defined");
+    expect(chk.data.assets.length).toBe(3, "should add 3 assets");
+    expect(chk.data.values.bannerImage).toBeDefined("should add bannerImage");
+    done();
+  });
+
+  describe("getResourceUrl", () => {
+    it("should constuct resource url and default to arcgis.com", done => {
+      const url = getResourceUrl("3ef", "test.png");
+      expect(url).toEqual(
+        "https://www.arcgis.com/sharing/rest/content/items/3ef/resources/test.png"
+      );
+      done();
+    });
+
+    it("should constuct resource url using passed portalUrl", done => {
+      const url = getResourceUrl(
+        "3ef",
+        "test.png",
+        "https://someportal.com/arcgis/rest"
+      );
+      expect(url).toEqual(
+        "https://someportal.com/arcgis/rest/content/items/3ef/resources/test.png"
+      );
+      done();
+    });
+
+    it("should constuct resource url using passed folder", done => {
+      const url = getResourceUrl(
+        "3ef",
+        "test.png",
+        "https://someportal.com/arcgis/rest",
+        "fakefolder"
+      );
+      expect(url).toEqual(
+        "https://someportal.com/arcgis/rest/content/items/3ef/resources/fakefolder/test.png"
+      );
+      done();
+    });
+  });
+});

--- a/packages/initiatives/test/upgrades/upgrade-two-dot-zero.test.ts
+++ b/packages/initiatives/test/upgrades/upgrade-two-dot-zero.test.ts
@@ -14,8 +14,70 @@ import {
   convertInitiativeIndicators
 } from "../../src/migrations/upgrade-two-dot-zero";
 
-describe("upgrade 2.0", () => {
+import { initiativeVersionOneDotOne } from "../mocks/initiative-versionOneDotOne";
+
+describe("Apply upgrade 2.0 ::", () => {
+  const model = cloneObject(initiativeVersionOneDotOne) as IInitiativeModel;
+  describe("Upgrade Instance ::", () => {
+    it("returns a model", done => {
+      const chk = upgradeToTwoDotZero(model);
+      expect(chk.item).toBeDefined("Should return the item");
+      expect(chk.data).toBeDefined("Should return the data");
+      done();
+    });
+    it("removes old data.values props", done => {
+      const chk = upgradeToTwoDotZero(model);
+      expect(chk.item).toBeDefined("Should return the item");
+      expect(chk.data).toBeDefined("Should return the data");
+      expect(chk.data.values.steps).not.toBeDefined(
+        "Should remove the data.values.steps"
+      );
+      expect(chk.data.values.informTools).not.toBeDefined(
+        "Should remove the data.values.informTools"
+      );
+      done();
+    });
+    it("adds data.indicators prop", done => {
+      const chk = upgradeToTwoDotZero(model);
+      expect(chk.item).toBeDefined("Should return the item");
+      expect(chk.data.indicators).toBeDefined(
+        "Should return the data.indicators"
+      );
+      expect(chk.data.steps).toBeDefined("Should return the data.steps");
+      expect(chk.data.steps.length).toEqual(5, "Should have 5 steps");
+      done();
+    });
+    it("returns the model if it is already 2.0", done => {
+      const m = cloneObject(model) as IInitiativeModel;
+      m.item.properties.schemaVersion = 2;
+      const chk = upgradeToTwoDotZero(m);
+
+      expect(chk.item).toBeDefined("Should return the item");
+      expect(chk.data).toBeDefined("Should return the data");
+      expect(chk).toBe(m, "should return the same instance");
+      done();
+    });
+  });
   describe("helper functions", () => {
+    it("can convert a step without templates or items", done => {
+      const step = {
+        title: "App testing here",
+        description:
+          "Share your data with the public so people can easily find, download and use your data in different formats.",
+        id: "informTools"
+      } as any;
+      const chk = convertStep(step);
+      expect(chk).not.toBe(step, "should return a different object");
+      expect(chk.title).toEqual(step.title, "title should match");
+      expect(chk.description).toEqual(
+        step.description,
+        "description should match"
+      );
+      expect(chk.id).toEqual(step.id, "id should match");
+      expect(chk.templateIds.length).toEqual(0, "should have 0 templates");
+      expect(chk.itemIds.length).toEqual(0, "should have 0 items");
+      done();
+    });
     it("can convert a step", done => {
       const step = {
         title: "App testing here",
@@ -127,70 +189,9 @@ describe("upgrade 2.0", () => {
       expect(s[0].id).toEqual("one", "should preserve steps array order");
       done();
     });
-  });
-  it("isIndicator returns true for obj with fields array", done => {
-    const obj = {
-      url:
-        "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
-      layerId: 0,
-      itemId: "e05e89d83552497bba267a20ca4cea74",
-      name: "Collisions_Indicator",
-      fields: [
-        {
-          id: "numInjuries",
-          field: {
-            name: "MAJORINJURIES",
-            alias: "MAJORINJURIES",
-            type: "esriFieldTypeInteger"
-          }
-        }
-      ]
-    } as any;
-    const s = isIndicator(obj);
-    expect(s).toBeTruthy("should return true");
-    done();
-  });
-  it("isIndicator returns false for obj with empty fields array", done => {
-    const obj = {
-      url:
-        "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
-      layerId: 0,
-      itemId: "e05e89d83552497bba267a20ca4cea74",
-      name: "Collisions_Indicator",
-      fields: []
-    } as any;
-    const s = isIndicator(obj);
-    expect(s).toBeFalsy("should return false if fields array is empty");
-    done();
-  });
-  it("isIndicator returns false for obj with fields obj", done => {
-    const obj = {
-      url:
-        "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
-      layerId: 0,
-      itemId: "e05e89d83552497bba267a20ca4cea74",
-      name: "Collisions_Indicator",
-      fields: {
-        foo: {
-          id: "numInjuries",
-          field: {
-            name: "MAJORINJURIES",
-            alias: "MAJORINJURIES",
-            type: "esriFieldTypeInteger"
-          }
-        }
-      }
-    };
-    const s = isIndicator(obj);
-    expect(s).toBeFalsy("should return false");
-    done();
-  });
-  it("can extract indicators from values hash", done => {
-    const values = {
-      notIndicator: {
-        key: "some value"
-      },
-      collisionLayer: {
+
+    it("isIndicator returns true for obj with fields array", done => {
+      const obj = {
         url:
           "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
         layerId: 0,
@@ -206,197 +207,280 @@ describe("upgrade 2.0", () => {
             }
           }
         ]
-      }
-    } as any;
-    const c = extractIndicators(values);
-    expect(Array.isArray(c)).toBeTruthy("Should return an array");
-    expect(c.length).toEqual(1, "Should have one entry");
-    const entry = c[0];
-    const orig = values.collisionLayer;
-    expect(entry.id).toEqual("collisionLayer", "prop should become the id");
-    ["url", "layerId", "itemId", "name"].map((prop: string) => {
-      expect(entry[prop] as any).toEqual(
-        orig[prop] as any,
-        `clone should have same ${prop}`
-      );
+      } as any;
+      const s = isIndicator(obj);
+      expect(s).toBeTruthy("should return true");
+      done();
     });
-    // make sure the fields entry is a clone
-    expect(entry.fields[0]).not.toBe(
-      orig.fields[0],
-      "field entries should not be same ref"
-    );
-    done();
-  });
-  it("can convert cas indicator to definition", done => {
-    const ind = {
-      label: "Collision Data",
-      type: "layerAndFieldSelector",
-      fieldName: "collisionLayer",
-      layerOptions: {
-        geometryTypes: [
-          "esriGeometryPoint",
-          "esriGeometryLine",
-          "esriGeometryPolygon"
-        ],
-        supportedTypes: ["FeatureLayer", "FeatureCollection"]
-      },
-      fields: [
-        {
-          tooltip: "Count of people…",
-          label: "Number of Injuries",
-          fieldName: "numInjuries",
-          supportedTypes: ["esriFieldTypeInteger"]
-        },
-        {
-          tooltip: "Count of deaths…",
-          label: "Number of Fatalities",
-          fieldName: "numFatalities",
-          supportedTypes: ["esriFieldTypeInteger"]
+    it("isIndicator returns false for obj with empty fields array", done => {
+      const obj = {
+        url:
+          "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
+        layerId: 0,
+        itemId: "e05e89d83552497bba267a20ca4cea74",
+        name: "Collisions_Indicator",
+        fields: []
+      } as any;
+      const s = isIndicator(obj);
+      expect(s).toBeFalsy("should return false if fields array is empty");
+      done();
+    });
+    it("isIndicator returns false for obj with fields obj", done => {
+      const obj = {
+        url:
+          "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
+        layerId: 0,
+        itemId: "e05e89d83552497bba267a20ca4cea74",
+        name: "Collisions_Indicator",
+        fields: {
+          foo: {
+            id: "numInjuries",
+            field: {
+              name: "MAJORINJURIES",
+              alias: "MAJORINJURIES",
+              type: "esriFieldTypeInteger"
+            }
+          }
         }
-      ]
-    } as any;
-    const c = convertIndicatorToDefinition(ind);
-    expect(c).not.toBe(ind, "returned field should not be the same object");
-    expect(c.id).toEqual(ind.fieldName, "fieldName becomes id");
-    expect(c.name).toEqual(ind.label, "label becomes name");
-    expect(c.definition.description).toEqual(
-      ind.label,
-      "label becomes description"
-    );
-    expect(c.definition.supportedTypes.length).toEqual(
-      ind.layerOptions.supportedTypes.length,
-      "supported types have same contents"
-    );
-    expect(c.definition.geometryTypes).not.toBe(
-      ind.layerOptions.geometryTypes,
-      "geometryTypes should not be same instance"
-    );
-    expect(c.definition.geometryTypes.length).toEqual(
-      ind.layerOptions.geometryTypes.length,
-      "geometryTypes have same contents"
-    );
-    expect(c.definition.fields.length).toEqual(
-      ind.fields.length,
-      "fields have same contents"
-    );
-    done();
-  });
-  it("can convert cas field to definition field", done => {
-    const fld = {
-      tooltip: "Count of people…",
-      label: "Number of Injuries",
-      fieldName: "numInjuries",
-      supportedTypes: ["esriFieldTypeInteger"]
-    } as any;
-    const c = convertIndicatorField(fld);
-    expect(c).not.toEqual(fld, "returned field should not be the same object");
-    expect(c.id).toEqual(fld.fieldName, "fieldName becomes id");
-    expect(c.name).toEqual(fld.label, "label becomes name");
-    expect(c.supportedTypes).not.toBe(
-      fld.supportedTypes,
-      "supported types should not be same instance"
-    );
-    expect(c.supportedTypes.length).toEqual(
-      fld.supportedTypes.length,
-      "supported types have same contents"
-    );
-    done();
-  });
-  it("can convert configSettings indicator structure to indicators hash", done => {
-    const cs = {
-      category: "Indicators",
-      fields: [
-        {
-          fieldName: "collisionLayer",
-          label: "Collision Data",
-          type: "layerAndFieldSelector",
-          layerOptions: {
-            geometryTypes: [
-              "esriGeometryPoint",
-              "esriGeometryLine",
-              "esriGeometryPolygon"
-            ],
-            supportedTypes: ["FeatureLayer", "FeatureCollection"]
-          },
+      };
+      const s = isIndicator(obj);
+      expect(s).toBeFalsy("should return false");
+      done();
+    });
+    it("can extract indicators from values hash", done => {
+      const values = {
+        notIndicator: {
+          key: "some value"
+        },
+        collisionLayer: {
+          url:
+            "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
+          layerId: 0,
+          itemId: "e05e89d83552497bba267a20ca4cea74",
+          name: "Collisions_Indicator",
           fields: [
             {
-              tooltip: "Count of people…",
-              label: "Number of Injuries",
-              fieldName: "numInjuries",
-              supportedTypes: ["esriFieldTypeInteger"]
-            },
-            {
-              tooltip: "Count of deaths…",
-              label: "Number of Fatalities",
-              fieldName: "numFatalities",
-              supportedTypes: ["esriFieldTypeInteger"]
+              id: "numInjuries",
+              field: {
+                name: "MAJORINJURIES",
+                alias: "MAJORINJURIES",
+                type: "esriFieldTypeInteger"
+              }
             }
           ]
         }
-      ]
-    } as any;
-
-    // now pass this into the converter...
-    const c = convertIndicatorsToDefinitions(cs);
-    expect(Array.isArray(c)).toBeTruthy("should return an array");
-    expect(c[0].id).toEqual(
-      "collisionLayer",
-      "collisionLayer should be the id of the first entry"
-    );
-    done();
-  });
-  it("can convert indicator entry into definition and source", done => {
-    const v = {
-      id: "collisionLayer",
-      url:
-        "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
-      layerId: 0,
-      itemId: "e05e89d83552497bba267a20ca4cea74",
-      name: "Collisions_Indicator",
-      fields: [
-        {
-          id: "numInjuries",
-          field: {
-            name: "MAJORINJURIES",
-            alias: "MAJORINJURIES",
-            type: "esriFieldTypeInteger"
-          }
-        }
-      ]
-    } as any;
-    const c = convertIndicator(v) as any;
-    expect(c).not.toBe(v, "should return a new object");
-    expect(c.definition).toBeTruthy("should return a definiton property");
-    expect(c.id).toEqual(v.id, "object should have id");
-    expect(c.name).toEqual(v.name, "object should have name");
-    expect(c.definition.description).toEqual(
-      v.name,
-      "definition should have description, filled with name"
-    );
-    expect(c.source).toBeTruthy("should return a source property");
-    ["url", "layerId", "itemId", "name"].map((prop: string) => {
-      expect(c.source[prop] as any).toEqual(
-        v[prop] as any,
-        `clone should have same ${prop}`
+      } as any;
+      const c = extractIndicators(values);
+      expect(Array.isArray(c)).toBeTruthy("Should return an array");
+      expect(c.length).toEqual(1, "Should have one entry");
+      const entry = c[0];
+      const orig = values.collisionLayer;
+      expect(entry.id).toEqual("collisionLayer", "prop should become the id");
+      ["url", "layerId", "itemId", "name"].map((prop: string) => {
+        expect(entry[prop] as any).toEqual(
+          orig[prop] as any,
+          `clone should have same ${prop}`
+        );
+      });
+      // make sure the fields entry is a clone
+      expect(entry.fields[0]).not.toBe(
+        orig.fields[0],
+        "field entries should not be same ref"
       );
+      done();
     });
-    expect(Array.isArray(c.source.mappings)).toBeTruthy(
-      "mappings should be an array"
-    );
-    const fld = c.source.mappings[0];
-    const orig = v.fields[0].field;
-    expect(fld.id).toEqual(v.fields[0].id, "field should have same id");
-    ["name", "alias", "type"].map((prop: string) => {
-      expect(fld[prop]).toEqual(orig[prop], `field should have same ${prop}`);
+    it("can convert cas indicator to definition", done => {
+      const ind = {
+        label: "Collision Data",
+        type: "layerAndFieldSelector",
+        fieldName: "collisionLayer",
+        layerOptions: {
+          geometryTypes: [
+            "esriGeometryPoint",
+            "esriGeometryLine",
+            "esriGeometryPolygon"
+          ],
+          supportedTypes: ["FeatureLayer", "FeatureCollection"]
+        },
+        fields: [
+          {
+            tooltip: "Count of people…",
+            label: "Number of Injuries",
+            fieldName: "numInjuries",
+            supportedTypes: ["esriFieldTypeInteger"]
+          },
+          {
+            tooltip: "Count of deaths…",
+            label: "Number of Fatalities",
+            fieldName: "numFatalities",
+            supportedTypes: ["esriFieldTypeInteger"]
+          }
+        ]
+      } as any;
+      const c = convertIndicatorToDefinition(ind);
+      expect(c).not.toBe(ind, "returned field should not be the same object");
+      expect(c.id).toEqual(ind.fieldName, "fieldName becomes id");
+      expect(c.name).toEqual(ind.label, "label becomes name");
+      expect(c.definition.description).toEqual(
+        ind.label,
+        "label becomes description"
+      );
+      expect(c.definition.supportedTypes.length).toEqual(
+        ind.layerOptions.supportedTypes.length,
+        "supported types have same contents"
+      );
+      expect(c.definition.geometryTypes).not.toBe(
+        ind.layerOptions.geometryTypes,
+        "geometryTypes should not be same instance"
+      );
+      expect(c.definition.geometryTypes.length).toEqual(
+        ind.layerOptions.geometryTypes.length,
+        "geometryTypes have same contents"
+      );
+      expect(c.definition.fields.length).toEqual(
+        ind.fields.length,
+        "fields have same contents"
+      );
+      done();
     });
-    done();
-  });
-  it("can extract and convert indicators from an initiative values hash", done => {
-    const v = {
-      notIndicator: {
-        foo: "prop"
-      },
-      collisionLayer: {
+    it("can convert cas indicator without label to definition", done => {
+      const ind = {
+        // label: "Collision Data",
+        type: "layerAndFieldSelector",
+        fieldName: "collisionLayer",
+        layerOptions: {
+          geometryTypes: [
+            "esriGeometryPoint",
+            "esriGeometryLine",
+            "esriGeometryPolygon"
+          ],
+          supportedTypes: ["FeatureLayer", "FeatureCollection"]
+        },
+        fields: [
+          {
+            tooltip: "Count of people…",
+            label: "Number of Injuries",
+            fieldName: "numInjuries",
+            supportedTypes: ["esriFieldTypeInteger"]
+          },
+          {
+            tooltip: "Count of deaths…",
+            label: "Number of Fatalities",
+            fieldName: "numFatalities",
+            supportedTypes: ["esriFieldTypeInteger"]
+          }
+        ]
+      } as any;
+      const c = convertIndicatorToDefinition(ind);
+      expect(c).not.toBe(ind, "returned field should not be the same object");
+      expect(c.id).toEqual(ind.fieldName, "fieldName becomes id");
+      expect(c.name).toEqual(
+        ind.fieldName,
+        "fieldName becomes name if not label"
+      );
+      expect(c.definition.description).toEqual(
+        ind.fieldName,
+        "field becomes description if no label"
+      );
+      expect(c.definition.supportedTypes.length).toEqual(
+        ind.layerOptions.supportedTypes.length,
+        "supported types have same contents"
+      );
+      expect(c.definition.geometryTypes).not.toBe(
+        ind.layerOptions.geometryTypes,
+        "geometryTypes should not be same instance"
+      );
+      expect(c.definition.geometryTypes.length).toEqual(
+        ind.layerOptions.geometryTypes.length,
+        "geometryTypes have same contents"
+      );
+      expect(c.definition.fields.length).toEqual(
+        ind.fields.length,
+        "fields have same contents"
+      );
+      done();
+    });
+    it("can convert cas field to definition field", done => {
+      const fld = {
+        tooltip: "Count of people…",
+        label: "Number of Injuries",
+        fieldName: "numInjuries",
+        supportedTypes: ["esriFieldTypeInteger"]
+      } as any;
+      const c = convertIndicatorField(fld);
+      expect(c).not.toEqual(
+        fld,
+        "returned field should not be the same object"
+      );
+      expect(c.id).toEqual(fld.fieldName, "fieldName becomes id");
+      expect(c.name).toEqual(fld.label, "label becomes name");
+      expect(c.supportedTypes).not.toBe(
+        fld.supportedTypes,
+        "supported types should not be same instance"
+      );
+      expect(c.supportedTypes.length).toEqual(
+        fld.supportedTypes.length,
+        "supported types have same contents"
+      );
+      done();
+    });
+    it("can convert configSettings indicator structure to indicators hash", done => {
+      const cs = {
+        category: "Indicators",
+        fields: [
+          {
+            fieldName: "collisionLayer",
+            label: "Collision Data",
+            type: "layerAndFieldSelector",
+            layerOptions: {
+              geometryTypes: [
+                "esriGeometryPoint",
+                "esriGeometryLine",
+                "esriGeometryPolygon"
+              ],
+              supportedTypes: ["FeatureLayer", "FeatureCollection"]
+            },
+            fields: [
+              {
+                tooltip: "Count of people…",
+                label: "Number of Injuries",
+                fieldName: "numInjuries",
+                supportedTypes: ["esriFieldTypeInteger"]
+              },
+              {
+                tooltip: "Count of deaths…",
+                label: "Number of Fatalities",
+                fieldName: "numFatalities",
+                supportedTypes: ["esriFieldTypeInteger"]
+              }
+            ]
+          }
+        ]
+      } as any;
+
+      // now pass this into the converter...
+      const c = convertIndicatorsToDefinitions(cs);
+      expect(Array.isArray(c)).toBeTruthy("should return an array");
+      expect(c[0].id).toEqual(
+        "collisionLayer",
+        "collisionLayer should be the id of the first entry"
+      );
+      done();
+    });
+    it("handles configSettings with no fields", done => {
+      const cs = {
+        category: "Indicators"
+      } as any;
+
+      // now pass this into the converter...
+      const c = convertIndicatorsToDefinitions(cs);
+      expect(Array.isArray(c)).toBeTruthy("should return an array");
+      expect(c.length).toEqual(0, "should have no entries");
+      done();
+    });
+    it("can convert indicator entry into definition and source", done => {
+      const v = {
+        id: "collisionLayer",
         url:
           "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
         layerId: 0,
@@ -412,55 +496,134 @@ describe("upgrade 2.0", () => {
             }
           }
         ]
-      },
-      alsoNotIndicator: {
-        stuff: [1, 2, 4]
-      },
-      maleOverdoses: {
-        url:
-          "https://services6.arcgis.com/7THfVfoNJu2Ftu4Q/arcgis/rest/services/Male_Overdoses/FeatureServer/0",
-        layerId: 0,
-        itemId: "8d601537e61c4f0cb3ac3826241a66fb",
-        name: "Male_Overdoses_M",
-        fields: [
-          {
-            id: "count",
-            field: {
-              name: "Point_Count",
-              alias: "Count of Points",
-              type: "esriFieldTypeInteger"
-            }
-          }
-        ]
-      },
-      femaleOverdoses: {
-        url:
-          "https://services6.arcgis.com/7THfVfoNJu2Ftu4Q/arcgis/rest/services/Male_Overdoses/FeatureServer/0",
-        layerId: 0,
-        itemId: "8d601537e61c4f0cb3ac3826241a66fb",
-        name: "Male_Overdoses_M",
-        fields: [
-          {
-            id: "count",
-            field: {
-              name: "Point_Count",
-              alias: "Count of Points",
-              type: "esriFieldTypeInteger"
-            }
-          }
-        ]
-      }
-    } as any;
-    const result = convertInitiativeIndicators(v);
-    expect(Array.isArray(result)).toBeTruthy("should return an array");
-    ["collisionLayer", "maleOverdoses", "femaleOverdoses"].map(prop => {
-      const entry = findBy(result, "id", prop);
-      expect(entry.id).toEqual(prop, `should have ${prop} as ${prop}.id`);
-      expect(entry.definition).toBeTruthy(
-        `should have prop ${prop}.definition`
+      } as any;
+      const c = convertIndicator(v) as any;
+      expect(c).not.toBe(v, "should return a new object");
+      expect(c.definition).toBeTruthy("should return a definiton property");
+      expect(c.id).toEqual(v.id, "object should have id");
+      expect(c.name).toEqual(v.name, "object should have name");
+      expect(c.definition.description).toEqual(
+        v.name,
+        "definition should have description, filled with name"
       );
-      expect(entry.source).toBeTruthy(`should have prop ${prop}.source`);
+      expect(c.source).toBeTruthy("should return a source property");
+      ["url", "layerId", "itemId", "name"].map((prop: string) => {
+        expect(c.source[prop] as any).toEqual(
+          v[prop] as any,
+          `clone should have same ${prop}`
+        );
+      });
+      expect(Array.isArray(c.source.mappings)).toBeTruthy(
+        "mappings should be an array"
+      );
+      const fld = c.source.mappings[0];
+      const orig = v.fields[0].field;
+      expect(fld.id).toEqual(v.fields[0].id, "field should have same id");
+      ["name", "alias", "type"].map((prop: string) => {
+        expect(fld[prop]).toEqual(orig[prop], `field should have same ${prop}`);
+      });
+      done();
     });
-    done();
+    it("can convert indicator entry with no name", done => {
+      const v = {
+        id: "collisionLayer",
+        url: "https://servicesqa.arcgis.com/Collisions_Indicator",
+        layerId: 0,
+        itemId: "e05e89d83552497bba267a20ca4cea74",
+        fields: [
+          {
+            id: "numInjuries",
+            field: {
+              name: "MAJORINJURIES",
+              alias: "MAJORINJURIES",
+              type: "esriFieldTypeInteger"
+            }
+          }
+        ]
+      } as any;
+      const c = convertIndicator(v) as any;
+      expect(c).not.toBe(v, "should return a new object");
+      expect(c.id).toEqual(v.id, "object should have id");
+      expect(c.name).toEqual(v.id, "name is id if no name present");
+      expect(c.definition).toBeDefined("should return a definiton property");
+      expect(c.definition.description).toEqual(
+        v.id,
+        "definition should be the id if no name present"
+      );
+      done();
+    });
+
+    it("can extract and convert indicators from an initiative values hash", done => {
+      const v = {
+        notIndicator: {
+          foo: "prop"
+        },
+        collisionLayer: {
+          url:
+            "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
+          layerId: 0,
+          itemId: "e05e89d83552497bba267a20ca4cea74",
+          name: "Collisions_Indicator",
+          fields: [
+            {
+              id: "numInjuries",
+              field: {
+                name: "MAJORINJURIES",
+                alias: "MAJORINJURIES",
+                type: "esriFieldTypeInteger"
+              }
+            }
+          ]
+        },
+        alsoNotIndicator: {
+          stuff: [1, 2, 4]
+        },
+        maleOverdoses: {
+          url:
+            "https://services6.arcgis.com/7THfVfoNJu2Ftu4Q/arcgis/rest/services/Male_Overdoses/FeatureServer/0",
+          layerId: 0,
+          itemId: "8d601537e61c4f0cb3ac3826241a66fb",
+          name: "Male_Overdoses_M",
+          fields: [
+            {
+              id: "count",
+              field: {
+                name: "Point_Count",
+                alias: "Count of Points",
+                type: "esriFieldTypeInteger"
+              }
+            }
+          ]
+        },
+        femaleOverdoses: {
+          url:
+            "https://services6.arcgis.com/7THfVfoNJu2Ftu4Q/arcgis/rest/services/Male_Overdoses/FeatureServer/0",
+          layerId: 0,
+          itemId: "8d601537e61c4f0cb3ac3826241a66fb",
+          name: "Male_Overdoses_M",
+          fields: [
+            {
+              id: "count",
+              field: {
+                name: "Point_Count",
+                alias: "Count of Points",
+                type: "esriFieldTypeInteger"
+              }
+            }
+          ]
+        }
+      } as any;
+      const result = convertInitiativeIndicators(v);
+      expect(Array.isArray(result)).toBeTruthy("should return an array");
+      ["collisionLayer", "maleOverdoses", "femaleOverdoses"].map(prop => {
+        const entry = findBy(result, "id", prop);
+        expect(entry.id).toEqual(prop, `should have ${prop} as ${prop}.id`);
+        expect(entry.definition).toBeTruthy(
+          `should have prop ${prop}.definition`
+        );
+        expect(entry.source).toBeTruthy(`should have prop ${prop}.source`);
+      });
+      done();
+    });
   });
 });

--- a/packages/initiatives/test/upgrades/upgrade-two-dot-zero.test.ts
+++ b/packages/initiatives/test/upgrades/upgrade-two-dot-zero.test.ts
@@ -1,0 +1,466 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { IInitiativeModel, cloneObject, findBy } from "@esri/hub-common";
+import {
+  upgradeToTwoDotZero,
+  convertStep,
+  convertSteps,
+  isIndicator,
+  extractIndicators,
+  convertIndicator,
+  convertIndicatorToDefinition,
+  convertIndicatorField,
+  convertIndicatorsToDefinitions,
+  convertInitiativeIndicators
+} from "../../src/migrations/upgrade-two-dot-zero";
+
+describe("upgrade 2.0", () => {
+  describe("helper functions", () => {
+    it("can convert a step", done => {
+      const step = {
+        title: "App testing here",
+        description:
+          "Share your data with the public so people can easily find, download and use your data in different formats.",
+        id: "informTools",
+        templates: [
+          {
+            title: "Gold Standard App",
+            id: "2dc1b35134c1403697d5fc4fe3e6b906",
+            type: "web mapping application"
+          },
+          {
+            title: "Gold Standard Optional App",
+            id: "4ca3c6422eeb40c58494c8678621318c",
+            type: "web mapping application"
+          },
+          {
+            title: "Gold Standard Private Solution",
+            id: "8c4f2be8e417441c8245eb249250a577",
+            type: "web mapping application"
+          },
+          {
+            title: "Gold Standard Optional Defaulting App",
+            id: "b19646d59698485da418e5cf44456a0d",
+            type: "web mapping application"
+          },
+          {
+            title: "Gold Standard Webmap",
+            id: "efd37089716a4647aab12e83f2f79fc3",
+            type: "webmap"
+          }
+        ],
+        templateItemIds: [
+          "2dc1b35134c1403697d5fc4fe3e6b906",
+          "4ca3c6422eeb40c58494c8678621318c",
+          "8c4f2be8e417441c8245eb249250a577",
+          "b19646d59698485da418e5cf44456a0d"
+        ],
+        configuredItemIds: [],
+        items: [
+          {
+            title: "Gold Standard Webmap",
+            id: "b19646d59698485da418e5cf44456a0d",
+            type: "webmap"
+          }
+        ] as any[]
+      } as any;
+      const chk = convertStep(step);
+      expect(chk).not.toBe(step, "should return a different object");
+      expect(chk.title).toEqual(step.title, "title should match");
+      expect(chk.description).toEqual(
+        step.description,
+        "description should match"
+      );
+      expect(chk.id).toEqual(step.id, "id should match");
+      expect(chk.templateIds.length).toEqual(5, "should have 5 templates");
+      expect(typeof chk.templateIds[0]).toEqual(
+        "string",
+        "templateIds array should contain strings"
+      );
+      expect(typeof chk.itemIds[0]).toEqual(
+        "string",
+        "itemIds array should contain strings"
+      );
+      done();
+    });
+    it("can convert steps", done => {
+      const values = {
+        steps: ["one", "two"],
+        two: {
+          title: "Survey Testing One",
+          description: "Just for a test",
+          id: "one",
+          templates: [
+            {
+              title: "Gold Standard Survey",
+              id: "0585fd3f92534cc1b266de4caec1912a",
+              type: "Form"
+            }
+          ],
+          items: [] as any
+        },
+        notStep: {
+          foo: 23
+        },
+        one: {
+          title: "App Testing One",
+          description: "Just for a test",
+          id: "one",
+          templates: [
+            {
+              title: "Gold Standard Optional Defaulting App",
+              id: "b19646d59698485da418e5cf44456a0d",
+              type: "web mapping application"
+            }
+          ],
+          items: [
+            {
+              title: "Gold Standard Webmap",
+              id: "b19646d59698485da418e5cf44456a0d",
+              type: "webmap"
+            }
+          ]
+        }
+      };
+      const s = convertSteps(values.steps, values);
+      expect(s.length).toEqual(2, "should have two steps");
+      expect(s[0].id).toEqual("one", "should preserve steps array order");
+      done();
+    });
+  });
+  it("isIndicator returns true for obj with fields array", done => {
+    const obj = {
+      url:
+        "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
+      layerId: 0,
+      itemId: "e05e89d83552497bba267a20ca4cea74",
+      name: "Collisions_Indicator",
+      fields: [
+        {
+          id: "numInjuries",
+          field: {
+            name: "MAJORINJURIES",
+            alias: "MAJORINJURIES",
+            type: "esriFieldTypeInteger"
+          }
+        }
+      ]
+    } as any;
+    const s = isIndicator(obj);
+    expect(s).toBeTruthy("should return true");
+    done();
+  });
+  it("isIndicator returns false for obj with empty fields array", done => {
+    const obj = {
+      url:
+        "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
+      layerId: 0,
+      itemId: "e05e89d83552497bba267a20ca4cea74",
+      name: "Collisions_Indicator",
+      fields: []
+    } as any;
+    const s = isIndicator(obj);
+    expect(s).toBeFalsy("should return false if fields array is empty");
+    done();
+  });
+  it("isIndicator returns false for obj with fields obj", done => {
+    const obj = {
+      url:
+        "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
+      layerId: 0,
+      itemId: "e05e89d83552497bba267a20ca4cea74",
+      name: "Collisions_Indicator",
+      fields: {
+        foo: {
+          id: "numInjuries",
+          field: {
+            name: "MAJORINJURIES",
+            alias: "MAJORINJURIES",
+            type: "esriFieldTypeInteger"
+          }
+        }
+      }
+    };
+    const s = isIndicator(obj);
+    expect(s).toBeFalsy("should return false");
+    done();
+  });
+  it("can extract indicators from values hash", done => {
+    const values = {
+      notIndicator: {
+        key: "some value"
+      },
+      collisionLayer: {
+        url:
+          "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
+        layerId: 0,
+        itemId: "e05e89d83552497bba267a20ca4cea74",
+        name: "Collisions_Indicator",
+        fields: [
+          {
+            id: "numInjuries",
+            field: {
+              name: "MAJORINJURIES",
+              alias: "MAJORINJURIES",
+              type: "esriFieldTypeInteger"
+            }
+          }
+        ]
+      }
+    } as any;
+    const c = extractIndicators(values);
+    expect(Array.isArray(c)).toBeTruthy("Should return an array");
+    expect(c.length).toEqual(1, "Should have one entry");
+    const entry = c[0];
+    const orig = values.collisionLayer;
+    expect(entry.id).toEqual("collisionLayer", "prop should become the id");
+    ["url", "layerId", "itemId", "name"].map((prop: string) => {
+      expect(entry[prop] as any).toEqual(
+        orig[prop] as any,
+        `clone should have same ${prop}`
+      );
+    });
+    // make sure the fields entry is a clone
+    expect(entry.fields[0]).not.toBe(
+      orig.fields[0],
+      "field entries should not be same ref"
+    );
+    done();
+  });
+  it("can convert cas indicator to definition", done => {
+    const ind = {
+      label: "Collision Data",
+      type: "layerAndFieldSelector",
+      fieldName: "collisionLayer",
+      layerOptions: {
+        geometryTypes: [
+          "esriGeometryPoint",
+          "esriGeometryLine",
+          "esriGeometryPolygon"
+        ],
+        supportedTypes: ["FeatureLayer", "FeatureCollection"]
+      },
+      fields: [
+        {
+          tooltip: "Count of people…",
+          label: "Number of Injuries",
+          fieldName: "numInjuries",
+          supportedTypes: ["esriFieldTypeInteger"]
+        },
+        {
+          tooltip: "Count of deaths…",
+          label: "Number of Fatalities",
+          fieldName: "numFatalities",
+          supportedTypes: ["esriFieldTypeInteger"]
+        }
+      ]
+    } as any;
+    const c = convertIndicatorToDefinition(ind);
+    expect(c).not.toBe(ind, "returned field should not be the same object");
+    expect(c.id).toEqual(ind.fieldName, "fieldName becomes id");
+    expect(c.name).toEqual(ind.label, "label becomes name");
+    expect(c.definition.description).toEqual(
+      ind.label,
+      "label becomes description"
+    );
+    expect(c.definition.supportedTypes.length).toEqual(
+      ind.layerOptions.supportedTypes.length,
+      "supported types have same contents"
+    );
+    expect(c.definition.geometryTypes).not.toBe(
+      ind.layerOptions.geometryTypes,
+      "geometryTypes should not be same instance"
+    );
+    expect(c.definition.geometryTypes.length).toEqual(
+      ind.layerOptions.geometryTypes.length,
+      "geometryTypes have same contents"
+    );
+    expect(c.definition.fields.length).toEqual(
+      ind.fields.length,
+      "fields have same contents"
+    );
+    done();
+  });
+  it("can convert cas field to definition field", done => {
+    const fld = {
+      tooltip: "Count of people…",
+      label: "Number of Injuries",
+      fieldName: "numInjuries",
+      supportedTypes: ["esriFieldTypeInteger"]
+    } as any;
+    const c = convertIndicatorField(fld);
+    expect(c).not.toEqual(fld, "returned field should not be the same object");
+    expect(c.id).toEqual(fld.fieldName, "fieldName becomes id");
+    expect(c.name).toEqual(fld.label, "label becomes name");
+    expect(c.supportedTypes).not.toBe(
+      fld.supportedTypes,
+      "supported types should not be same instance"
+    );
+    expect(c.supportedTypes.length).toEqual(
+      fld.supportedTypes.length,
+      "supported types have same contents"
+    );
+    done();
+  });
+  it("can convert configSettings indicator structure to indicators hash", done => {
+    const cs = {
+      category: "Indicators",
+      fields: [
+        {
+          fieldName: "collisionLayer",
+          label: "Collision Data",
+          type: "layerAndFieldSelector",
+          layerOptions: {
+            geometryTypes: [
+              "esriGeometryPoint",
+              "esriGeometryLine",
+              "esriGeometryPolygon"
+            ],
+            supportedTypes: ["FeatureLayer", "FeatureCollection"]
+          },
+          fields: [
+            {
+              tooltip: "Count of people…",
+              label: "Number of Injuries",
+              fieldName: "numInjuries",
+              supportedTypes: ["esriFieldTypeInteger"]
+            },
+            {
+              tooltip: "Count of deaths…",
+              label: "Number of Fatalities",
+              fieldName: "numFatalities",
+              supportedTypes: ["esriFieldTypeInteger"]
+            }
+          ]
+        }
+      ]
+    } as any;
+
+    // now pass this into the converter...
+    const c = convertIndicatorsToDefinitions(cs);
+    expect(Array.isArray(c)).toBeTruthy("should return an array");
+    expect(c[0].id).toEqual(
+      "collisionLayer",
+      "collisionLayer should be the id of the first entry"
+    );
+    done();
+  });
+  it("can convert indicator entry into definition and source", done => {
+    const v = {
+      id: "collisionLayer",
+      url:
+        "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
+      layerId: 0,
+      itemId: "e05e89d83552497bba267a20ca4cea74",
+      name: "Collisions_Indicator",
+      fields: [
+        {
+          id: "numInjuries",
+          field: {
+            name: "MAJORINJURIES",
+            alias: "MAJORINJURIES",
+            type: "esriFieldTypeInteger"
+          }
+        }
+      ]
+    } as any;
+    const c = convertIndicator(v) as any;
+    expect(c).not.toBe(v, "should return a new object");
+    expect(c.definition).toBeTruthy("should return a definiton property");
+    expect(c.id).toEqual(v.id, "object should have id");
+    expect(c.name).toEqual(v.name, "object should have name");
+    expect(c.definition.description).toEqual(
+      v.name,
+      "definition should have description, filled with name"
+    );
+    expect(c.source).toBeTruthy("should return a source property");
+    ["url", "layerId", "itemId", "name"].map((prop: string) => {
+      expect(c.source[prop] as any).toEqual(
+        v[prop] as any,
+        `clone should have same ${prop}`
+      );
+    });
+    expect(Array.isArray(c.source.mappings)).toBeTruthy(
+      "mappings should be an array"
+    );
+    const fld = c.source.mappings[0];
+    const orig = v.fields[0].field;
+    expect(fld.id).toEqual(v.fields[0].id, "field should have same id");
+    ["name", "alias", "type"].map((prop: string) => {
+      expect(fld[prop]).toEqual(orig[prop], `field should have same ${prop}`);
+    });
+    done();
+  });
+  it("can extract and convert indicators from an initiative values hash", done => {
+    const v = {
+      notIndicator: {
+        foo: "prop"
+      },
+      collisionLayer: {
+        url:
+          "https://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/Collisions_Indicator",
+        layerId: 0,
+        itemId: "e05e89d83552497bba267a20ca4cea74",
+        name: "Collisions_Indicator",
+        fields: [
+          {
+            id: "numInjuries",
+            field: {
+              name: "MAJORINJURIES",
+              alias: "MAJORINJURIES",
+              type: "esriFieldTypeInteger"
+            }
+          }
+        ]
+      },
+      alsoNotIndicator: {
+        stuff: [1, 2, 4]
+      },
+      maleOverdoses: {
+        url:
+          "https://services6.arcgis.com/7THfVfoNJu2Ftu4Q/arcgis/rest/services/Male_Overdoses/FeatureServer/0",
+        layerId: 0,
+        itemId: "8d601537e61c4f0cb3ac3826241a66fb",
+        name: "Male_Overdoses_M",
+        fields: [
+          {
+            id: "count",
+            field: {
+              name: "Point_Count",
+              alias: "Count of Points",
+              type: "esriFieldTypeInteger"
+            }
+          }
+        ]
+      },
+      femaleOverdoses: {
+        url:
+          "https://services6.arcgis.com/7THfVfoNJu2Ftu4Q/arcgis/rest/services/Male_Overdoses/FeatureServer/0",
+        layerId: 0,
+        itemId: "8d601537e61c4f0cb3ac3826241a66fb",
+        name: "Male_Overdoses_M",
+        fields: [
+          {
+            id: "count",
+            field: {
+              name: "Point_Count",
+              alias: "Count of Points",
+              type: "esriFieldTypeInteger"
+            }
+          }
+        ]
+      }
+    } as any;
+    const result = convertInitiativeIndicators(v);
+    expect(Array.isArray(result)).toBeTruthy("should return an array");
+    ["collisionLayer", "maleOverdoses", "femaleOverdoses"].map(prop => {
+      const entry = findBy(result, "id", prop);
+      expect(entry.id).toEqual(prop, `should have ${prop} as ${prop}.id`);
+      expect(entry.definition).toBeTruthy(
+        `should have prop ${prop}.definition`
+      );
+      expect(entry.source).toBeTruthy(`should have prop ${prop}.source`);
+    });
+    done();
+  });
+});

--- a/packages/sites/src/sites.ts
+++ b/packages/sites/src/sites.ts
@@ -4,7 +4,6 @@
 import { request, IRequestOptions } from "@esri/arcgis-rest-request";
 import { IItem } from "@esri/arcgis-rest-common-types";
 import { getItem, getItemData } from "@esri/arcgis-rest-items";
-import { IInitiative, IInitiativeItem } from "@esri/hub-common";
 
 /**
  * Fetch the domains associated with a Hub Site.


### PR DESCRIPTION
**This still requires doc-comments** thus the DNM

Adds schema migration logic to the `fetchInitiative` function.

Applies 3 current migrations, which are stored in `packages/initiatives/src/migrations`

