### PR TITLE
Added examples for simple Annotation CRUD

### DIFF
--- a/packages/annotations/README.md
+++ b/packages/annotations/README.md
@@ -17,24 +17,29 @@
 npm install @esri/hub-annotations
 ```
 ```js
-import { searchAnnotations } from "@esri/hub-annotations";
+import { getAnnotationServiceUrl, searchAnnotations } from "@esri/hub-annotations";
 
-searchAnnotations({
-  url: annotationsUrl + "/0"
-})
-  .then( response => {
-        // {
-        //   data: [{
-        //     id: "User1",
-        //     type: "annotations",
-        //     attributes: {description: "Great place!", ...}
-        //   }],
-        //   included: [{
-        //     id: "User1",
-        //     type: "users",
-        //     attributes: { firstName: "User", lastName: "Name", ...}
-        //   }]
-        // }
+ // pass in an organization id
+getAnnotationServiceUrl("abc123")
+    .then(annotationsUrl => {
+      // https://services.arcgis.com/abc123/arcgis/rest/services/Hub Annotations/FeatureServer
+      searchAnnotations({
+        url: annotationsUrl + "/0"
+      })
+        .then( response => {
+              // {
+              //   data: [{
+              //     id: "User1",
+              //     type: "annotations",
+              //     attributes: {description: "Great place!", ...}
+              //   }],
+              //   included: [{
+              //     id: "User1",
+              //     type: "users",
+              //     attributes: { firstName: "User", lastName: "Name", ...}
+              //   }]
+              // }
+          });
     });
 ```
 

--- a/packages/annotations/README.md
+++ b/packages/annotations/README.md
@@ -27,6 +27,59 @@ getAnnotationServiceUrl("abc123")
     );
 ```
 
+```js
+import { searchAnnotations  } from '@esri/hub-annotations';
+
+// pass in an organization id
+searchAnnotations({url: annotationsUrl + "/0"})
+    .then( response => {
+        {
+          data: [{
+            id: "User1",
+            type: "annotations",
+            attributes: {description: "Great place!", ...}
+          }],
+          included: [{
+            id: "User1",
+            type: "users",
+            attributes: { firstName: "User", lastName: "Name", ...}
+          }]
+        }
+    });
+```
+
+```js
+import { addAnnotations } from '@esri/hub-annotations';
+
+// pass in an organization id
+addAnnotations({url: annotationsUrl + "/0", adds: [
+        {attributes: {author: "User1", target: "http://...", description: "A grand idea!"}}
+    ]}).then( response => {
+        console.log("addAnnotations", response);
+    });
+```
+
+```js
+import { updateAnnotations } from '@esri/hub-annotations';
+
+// pass in an organization id
+updateAnnotations({url: annotationsUrl + "/0", updates: [
+        {attributes: {OBJECTID: 1, description: "A grander idea!!!!"}}
+    ]}).then( response => {
+        console.log("updateAnnotations", response);
+    });
+```
+
+```js
+import { deleteAnnotations  } from '@esri/hub-annotations';
+
+// pass in an organization id
+deleteAnnotations({url: annotationsUrl + "/0", deletes: [ 1 ] })
+    .then( response => {
+        console.log("deleteAnnotations", response);
+    });
+```
+
 ### Issues
 
 If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/hub.js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/hub.js/issues/new) to hear from you.

--- a/packages/annotations/README.md
+++ b/packages/annotations/README.md
@@ -16,69 +16,29 @@
 ```bash
 npm install @esri/hub-annotations
 ```
-
 ```js
-import { getAnnotationServiceUrl  } from '@esri/hub-annotations';
+import { searchAnnotations } from "@esri/hub-annotations";
 
-// pass in an organization id
-getAnnotationServiceUrl("abc123")
-    .then(
-        response => // https://services.arcgis.com/abc123/arcgis/rest/services/Hub Annotations/FeatureServer
-    );
-```
-
-```js
-import { searchAnnotations  } from '@esri/hub-annotations';
-
-// pass in an organization id
-searchAnnotations({url: annotationsUrl + "/0"})
-    .then( response => {
-        {
-          data: [{
-            id: "User1",
-            type: "annotations",
-            attributes: {description: "Great place!", ...}
-          }],
-          included: [{
-            id: "User1",
-            type: "users",
-            attributes: { firstName: "User", lastName: "Name", ...}
-          }]
-        }
+searchAnnotations({
+  url: annotationsUrl + "/0"
+})
+  .then( response => {
+        // {
+        //   data: [{
+        //     id: "User1",
+        //     type: "annotations",
+        //     attributes: {description: "Great place!", ...}
+        //   }],
+        //   included: [{
+        //     id: "User1",
+        //     type: "users",
+        //     attributes: { firstName: "User", lastName: "Name", ...}
+        //   }]
+        // }
     });
 ```
 
-```js
-import { addAnnotations } from '@esri/hub-annotations';
-
-// pass in an organization id
-addAnnotations({url: annotationsUrl + "/0", adds: [
-        {attributes: {author: "User1", target: "http://...", description: "A grand idea!"}}
-    ]}).then( response => {
-        console.log("addAnnotations", response);
-    });
-```
-
-```js
-import { updateAnnotations } from '@esri/hub-annotations';
-
-// pass in an organization id
-updateAnnotations({url: annotationsUrl + "/0", updates: [
-        {attributes: {OBJECTID: 1, description: "A grander idea!!!!"}}
-    ]}).then( response => {
-        console.log("updateAnnotations", response);
-    });
-```
-
-```js
-import { deleteAnnotations  } from '@esri/hub-annotations';
-
-// pass in an organization id
-deleteAnnotations({url: annotationsUrl + "/0", deletes: [ 1 ] })
-    .then( response => {
-        console.log("deleteAnnotations", response);
-    });
-```
+## [API Reference](https://esri.github.io/hub.js/api/annotations/)
 
 ### Issues
 

--- a/packages/annotations/package-lock.json
+++ b/packages/annotations/package-lock.json
@@ -3,46 +3,46 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.9.0.tgz",
-			"integrity": "sha512-Q7dvrxfj5FZ7z61xRRrBJ6NO41ad9Olt7+4kfedI5fN6sBfPcqMexpSRdcgHopClYU+aGb4netPotoMWk1ySOQ==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.11.0.tgz",
+			"integrity": "sha512-pwgn76O/sVbJ70sRy8oQAIKwCl5P4vxBjM5IWmg3eeJJNKzgNAI8Ty3aoV9nHDtRZ80M7kDk0jqi1NGLMndFtQ==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-common-types": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.9.0.tgz",
-			"integrity": "sha512-cuEc7zwTVl4JE/A7Tt0OWrHnYE6XgSMNZo4M1vjxZBtlFDG+z08u3L3ZeGoQN3A1i+SmBUFWaxyccMq4q3QqdA=="
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.11.0.tgz",
+			"integrity": "sha512-uHgrSWZ1CWGVxUBkrHh8Mb2UBnaFADZCg4KMSBuaAy+P1FoCf0aLY2pxfhH2c7JevTiOVrY5Hx9oqdtw/QJvtw=="
 		},
 		"@esri/arcgis-rest-feature-service": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-1.9.0.tgz",
-			"integrity": "sha512-39iXjJElGs8FXQNrpTglMSNvvIAXovVdXK/wc5lfCpbQSoOHmRZQDCCBLXmM7mTCaAncY5VRcMjTX4zVZxGjcg==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-1.11.0.tgz",
+			"integrity": "sha512-HuW0y3aweJqH/IEczo7WPwOPc2FJEYP3xORGomT2ABit9juROs0dH8zyBJoiQ0O7SGkG4CJmFb5gWT1mJ6UIjQ==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-items": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-items/-/arcgis-rest-items-1.9.0.tgz",
-			"integrity": "sha512-glhZFvlQxsDtRVvX/btyyFV7SW064NOtoXMRguEQ+5VBzG2WqmoZt6nfFaT+fcrY+pK26nVRIQbloMf3U/Qfdw==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-items/-/arcgis-rest-items-1.11.0.tgz",
+			"integrity": "sha512-Gl1PJBj8Ak9oGrzkk6UCDwgGA2KtewmnZO7LZ0irpkHPMHS5CeGvOhMnCL+6Vwg4+pi1XuJYa1+5vyWruGoJ4g==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.9.0.tgz",
-			"integrity": "sha512-tUq1YN7qppwaTfp5tx79zm1ELhQaNVsm3zdyYaPQ5M3Ni/GaM9YZm7WAgFb8QWBglyRHkOPdmaMZzBktFvi4xA==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.11.0.tgz",
+			"integrity": "sha512-vKuVayN5NPd3wVvC0YSpG1zFigVSBbUghOPM7kOVV8uDfrBQ5sIImIYfShNWSAgJhkgIreYbA7KV36mo0MRvgg==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-users": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-users/-/arcgis-rest-users-1.9.0.tgz",
-			"integrity": "sha512-fCstdU3ulpsZEVe8eaK1Gxix19qVCagPdKzjBxZpcMC514c74EeTeEHy3lYZvTFdYND8pYo79ayYy34yZqZi5Q==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-users/-/arcgis-rest-users-1.11.0.tgz",
+			"integrity": "sha512-Kvycf5yS+dpMdYZwZhl117DHLefj0lMv7FAnCgRzoNub++f3nnPMkDJULudi7zuR7KCCAZ/ibexB/bvDimO0jw==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}

--- a/packages/annotations/src/add.ts
+++ b/packages/annotations/src/add.ts
@@ -22,7 +22,22 @@ export interface IAddAnnotationsRequestOptions
   extends IAddFeaturesRequestOptions {
   adds: IAnnoFeature[];
 }
+
 /**
+ * ```js
+ * import { addAnnotations } from "@esri/hub-annotations";
+ * addAnnotations({
+ *   url: annotationsUrl + "/0",
+ *   adds: [{
+ *     attributes: {
+ *       author: "User1",
+ *       target: "http://...",
+ *       description: "A grand idea!"
+ *     }
+ *   }]
+ * })
+ *   .then(response);
+ * ```
  * Add an annotation to ArcGIS Hub. Uses authentication to derive authorship, appends a timestamp and sets a default status of "pending" to new comments by default.
  * @param requestOptions - request options that may include authentication
  * @returns A Promise that will resolve with response from the service after attempting to add one or more new annotations.

--- a/packages/annotations/src/delete.ts
+++ b/packages/annotations/src/delete.ts
@@ -8,6 +8,16 @@ import {
 } from "@esri/arcgis-rest-feature-service";
 
 /**
+ * ```js
+ * import { deleteAnnotations } from "@esri/hub-annotations";
+ * deleteAnnotations({
+ *   url: annotationsUrl + "/0",
+ *   // an array of featureIds
+ *   deletes: [1]
+ * })
+ *   .then(response);
+ * ```
+ *
  * Delete an annotation from ArcGIS Hub.
  * @param requestOptions - request options that may include authentication
  * @returns A Promise that will resolve with response from the service after attempting to delete annotations.

--- a/packages/annotations/src/search.ts
+++ b/packages/annotations/src/search.ts
@@ -18,6 +18,26 @@ export interface IResourceObject {
 }
 
 /**
+ * ````js
+ * import { searchAnnotations } from "@esri/hub-annotations";
+ *
+ * // by default, all annotations will be retrieved
+ * searchAnnotations({ url: annotationsUrl + "/0" })
+ *   .then(response => {
+ *     // {
+ *     //   data: [{
+ *     //     id: "User1",
+ *     //     type: "annotations",
+ *     //     attributes: {description: "Great place!", ...}
+ *     //   }],
+ *     //   included: [{
+ *     //     id: "User1",
+ *     //     type: "users",
+ *     //     attributes: { firstName: "User", lastName: "Name", ...}
+ *     //   }]
+ *     // }
+ *   });
+ * ```
  * Query for annotations from ArcGIS Hub.
  * @param requestOptions - request options that may include authentication
  * @returns A Promise that will resolve with decorated features from the annotation service for a Hub enabled ArcGIS Online organization.

--- a/packages/annotations/src/update.ts
+++ b/packages/annotations/src/update.ts
@@ -8,6 +8,20 @@ import {
 } from "@esri/arcgis-rest-feature-service";
 
 /**
+ * ```js
+ * import { updateAnnotations } from "@esri/hub-annotations";
+ * updateAnnotations({
+ *   url: annotationsUrl + "/0",
+ *   updates: [{
+ *     attributes: {
+ *       // an ID is necessary to determine which feature to update
+ *       OBJECTID: 1,
+ *       description: "An even grander idea!"
+ *     }
+ *   }]
+ * })
+ *   .then(response);
+ * ```
  * Update an annotation in ArcGIS Hub, appending a `created_at` timestamp internally.
  * @param requestOptions - request options that may include authentication
  * @returns A Promise that will resolve with response from the service after attempting to update one or more annotations.

--- a/packages/auth/package-lock.json
+++ b/packages/auth/package-lock.json
@@ -3,22 +3,22 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@esri/arcgis-rest-auth": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.9.0.tgz",
-      "integrity": "sha512-Q7dvrxfj5FZ7z61xRRrBJ6NO41ad9Olt7+4kfedI5fN6sBfPcqMexpSRdcgHopClYU+aGb4netPotoMWk1ySOQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.11.0.tgz",
+      "integrity": "sha512-pwgn76O/sVbJ70sRy8oQAIKwCl5P4vxBjM5IWmg3eeJJNKzgNAI8Ty3aoV9nHDtRZ80M7kDk0jqi1NGLMndFtQ==",
       "requires": {
         "tslib": "^1.7.1"
       }
     },
     "@esri/arcgis-rest-common-types": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.9.0.tgz",
-      "integrity": "sha512-cuEc7zwTVl4JE/A7Tt0OWrHnYE6XgSMNZo4M1vjxZBtlFDG+z08u3L3ZeGoQN3A1i+SmBUFWaxyccMq4q3QqdA=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.11.0.tgz",
+      "integrity": "sha512-uHgrSWZ1CWGVxUBkrHh8Mb2UBnaFADZCg4KMSBuaAy+P1FoCf0aLY2pxfhH2c7JevTiOVrY5Hx9oqdtw/QJvtw=="
     },
     "@esri/arcgis-rest-request": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.9.0.tgz",
-      "integrity": "sha512-tUq1YN7qppwaTfp5tx79zm1ELhQaNVsm3zdyYaPQ5M3Ni/GaM9YZm7WAgFb8QWBglyRHkOPdmaMZzBktFvi4xA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.11.0.tgz",
+      "integrity": "sha512-vKuVayN5NPd3wVvC0YSpG1zFigVSBbUghOPM7kOVV8uDfrBQ5sIImIYfShNWSAgJhkgIreYbA7KV36mo0MRvgg==",
       "requires": {
         "tslib": "^1.7.1"
       }

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-common-types": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.9.0.tgz",
-			"integrity": "sha512-cuEc7zwTVl4JE/A7Tt0OWrHnYE6XgSMNZo4M1vjxZBtlFDG+z08u3L3ZeGoQN3A1i+SmBUFWaxyccMq4q3QqdA=="
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.11.0.tgz",
+			"integrity": "sha512-uHgrSWZ1CWGVxUBkrHh8Mb2UBnaFADZCg4KMSBuaAy+P1FoCf0aLY2pxfhH2c7JevTiOVrY5Hx9oqdtw/QJvtw=="
 		}
 	}
 }

--- a/packages/initiatives/package-lock.json
+++ b/packages/initiatives/package-lock.json
@@ -3,38 +3,30 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.9.0.tgz",
-			"integrity": "sha512-Q7dvrxfj5FZ7z61xRRrBJ6NO41ad9Olt7+4kfedI5fN6sBfPcqMexpSRdcgHopClYU+aGb4netPotoMWk1ySOQ==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.11.0.tgz",
+			"integrity": "sha512-pwgn76O/sVbJ70sRy8oQAIKwCl5P4vxBjM5IWmg3eeJJNKzgNAI8Ty3aoV9nHDtRZ80M7kDk0jqi1NGLMndFtQ==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-common-types": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.9.0.tgz",
-			"integrity": "sha512-cuEc7zwTVl4JE/A7Tt0OWrHnYE6XgSMNZo4M1vjxZBtlFDG+z08u3L3ZeGoQN3A1i+SmBUFWaxyccMq4q3QqdA=="
-		},
-		"@esri/arcgis-rest-groups": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-groups/-/arcgis-rest-groups-1.9.0.tgz",
-			"integrity": "sha512-L/14rUGI+Udly41M6xPjfOPazyfCkJuAIpNOsgK8ALsX2vKCX9sQd6fSB7gQyVrwX/GdpI9qEGpf+qbe/N1rZw==",
-			"requires": {
-				"tslib": "^1.7.1"
-			}
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.11.0.tgz",
+			"integrity": "sha512-uHgrSWZ1CWGVxUBkrHh8Mb2UBnaFADZCg4KMSBuaAy+P1FoCf0aLY2pxfhH2c7JevTiOVrY5Hx9oqdtw/QJvtw=="
 		},
 		"@esri/arcgis-rest-items": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-items/-/arcgis-rest-items-1.9.0.tgz",
-			"integrity": "sha512-glhZFvlQxsDtRVvX/btyyFV7SW064NOtoXMRguEQ+5VBzG2WqmoZt6nfFaT+fcrY+pK26nVRIQbloMf3U/Qfdw==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-items/-/arcgis-rest-items-1.11.0.tgz",
+			"integrity": "sha512-Gl1PJBj8Ak9oGrzkk6UCDwgGA2KtewmnZO7LZ0irpkHPMHS5CeGvOhMnCL+6Vwg4+pi1XuJYa1+5vyWruGoJ4g==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.9.0.tgz",
-			"integrity": "sha512-tUq1YN7qppwaTfp5tx79zm1ELhQaNVsm3zdyYaPQ5M3Ni/GaM9YZm7WAgFb8QWBglyRHkOPdmaMZzBktFvi4xA==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.11.0.tgz",
+			"integrity": "sha512-vKuVayN5NPd3wVvC0YSpG1zFigVSBbUghOPM7kOVV8uDfrBQ5sIImIYfShNWSAgJhkgIreYbA7KV36mo0MRvgg==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}

--- a/packages/sites/package-lock.json
+++ b/packages/sites/package-lock.json
@@ -3,30 +3,30 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.9.0.tgz",
-			"integrity": "sha512-Q7dvrxfj5FZ7z61xRRrBJ6NO41ad9Olt7+4kfedI5fN6sBfPcqMexpSRdcgHopClYU+aGb4netPotoMWk1ySOQ==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.11.0.tgz",
+			"integrity": "sha512-pwgn76O/sVbJ70sRy8oQAIKwCl5P4vxBjM5IWmg3eeJJNKzgNAI8Ty3aoV9nHDtRZ80M7kDk0jqi1NGLMndFtQ==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-common-types": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.9.0.tgz",
-			"integrity": "sha512-cuEc7zwTVl4JE/A7Tt0OWrHnYE6XgSMNZo4M1vjxZBtlFDG+z08u3L3ZeGoQN3A1i+SmBUFWaxyccMq4q3QqdA=="
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.11.0.tgz",
+			"integrity": "sha512-uHgrSWZ1CWGVxUBkrHh8Mb2UBnaFADZCg4KMSBuaAy+P1FoCf0aLY2pxfhH2c7JevTiOVrY5Hx9oqdtw/QJvtw=="
 		},
 		"@esri/arcgis-rest-items": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-items/-/arcgis-rest-items-1.9.0.tgz",
-			"integrity": "sha512-glhZFvlQxsDtRVvX/btyyFV7SW064NOtoXMRguEQ+5VBzG2WqmoZt6nfFaT+fcrY+pK26nVRIQbloMf3U/Qfdw==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-items/-/arcgis-rest-items-1.11.0.tgz",
+			"integrity": "sha512-Gl1PJBj8Ak9oGrzkk6UCDwgGA2KtewmnZO7LZ0irpkHPMHS5CeGvOhMnCL+6Vwg4+pi1XuJYa1+5vyWruGoJ4g==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.9.0.tgz",
-			"integrity": "sha512-tUq1YN7qppwaTfp5tx79zm1ELhQaNVsm3zdyYaPQ5M3Ni/GaM9YZm7WAgFb8QWBglyRHkOPdmaMZzBktFvi4xA==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.11.0.tgz",
+			"integrity": "sha512-vKuVayN5NPd3wVvC0YSpG1zFigVSBbUghOPM7kOVV8uDfrBQ5sIImIYfShNWSAgJhkgIreYbA7KV36mo0MRvgg==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}

--- a/packages/solutions/package-lock.json
+++ b/packages/solutions/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-request": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.9.0.tgz",
-			"integrity": "sha512-tUq1YN7qppwaTfp5tx79zm1ELhQaNVsm3zdyYaPQ5M3Ni/GaM9YZm7WAgFb8QWBglyRHkOPdmaMZzBktFvi4xA==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.11.0.tgz",
+			"integrity": "sha512-vKuVayN5NPd3wVvC0YSpG1zFigVSBbUghOPM7kOVV8uDfrBQ5sIImIYfShNWSAgJhkgIreYbA7KV36mo0MRvgg==",
 			"requires": {
 				"tslib": "^1.7.1"
 			}


### PR DESCRIPTION
Added examples - but before merging I would like to discuss simple improvements to the method signatures that exposes less of the implementation.

- Directly use the `annotationsUrl` without requiring adding a layer index `+ '/0'`
- Remove redundant parameter names `addAnnotations({adds: [...]})`
- Make Delete consistent with updates and add 
  - `addAnnotations({annotations: [{attributes: {description: "Kinda Awesome!"}]})`
  - `updateAnnotations({annotations: [{attributes: {OBJECTID: 1, description: "More Awesomer!"}]})`
  - `deleteAnnotations({annotations: [{attributes: {OBJECTID: 1}]})`