### PR TITLE
refactor(anno): improve updateAnno signature

### DIFF
--- a/packages/annotations/src/update.ts
+++ b/packages/annotations/src/update.ts
@@ -1,21 +1,58 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { IFeature } from "@esri/arcgis-rest-common-types";
+
 import {
   updateFeatures,
   IUpdateFeaturesRequestOptions,
   IUpdateFeaturesResult
 } from "@esri/arcgis-rest-feature-service";
 
+export interface IUpdateAnnotationsRequestOptions extends IRequestOptions {
+  /**
+   * Feature service url.
+   */
+  url: string;
+  /**
+   * Array of JSON features to update.
+   */
+  annotations: IFeature[];
+}
+
 /**
  * Update an annotation in ArcGIS Hub, appending a `created_at` timestamp internally.
+ *
+ * ````js
+ *
+ * updateAnnotations({
+ *   url,
+ *   annotations: [{
+ *     attributes: {
+ *       OBJECTID: 1,
+ *       description: "A grander idea!!!!"
+ *     }
+ *   }]
+ * }).then(response)
+ * ```
+ *
  * @param requestOptions - request options that may include authentication
  * @returns A Promise that will resolve with response from the service after attempting to update one or more annotations.
  */
 
 export function updateAnnotations(
-  requestOptions: IUpdateFeaturesRequestOptions
+  requestOptions:
+    | IUpdateAnnotationsRequestOptions
+    | IUpdateFeaturesRequestOptions
 ): Promise<IUpdateFeaturesResult> {
+  if (isUpdateAnno(requestOptions)) {
+    requestOptions = {
+      updates: requestOptions.annotations,
+      ...requestOptions
+    } as IUpdateFeaturesRequestOptions;
+  }
+
   requestOptions.updates.forEach(function(anno) {
     const defaults = {
       updated_at: new Date().getTime()
@@ -29,4 +66,12 @@ export function updateAnnotations(
   });
 
   return updateFeatures(requestOptions);
+}
+
+function isUpdateAnno(
+  options: IUpdateAnnotationsRequestOptions | IUpdateFeaturesRequestOptions
+): options is IUpdateAnnotationsRequestOptions {
+  return (
+    (options as IUpdateAnnotationsRequestOptions).annotations !== undefined
+  );
 }

--- a/packages/annotations/test/crud.test.ts
+++ b/packages/annotations/test/crud.test.ts
@@ -229,6 +229,41 @@ describe("add/update/deleteAnnotations", () => {
 
     updateAnnotations({
       url: annoUrl,
+      annotations: [
+        {
+          attributes: {
+            OBJECTID: 1001,
+            description: "i changed my mind, we can wait a lil while."
+          }
+        }
+      ]
+    }).then(() => {
+      expect(paramsSpy.calls.count()).toEqual(1);
+      const opts = paramsSpy.calls.argsFor(
+        0
+      )[0] as IUpdateFeaturesRequestOptions;
+
+      expect(opts.url).toEqual(annoUrl);
+      const anno = opts.updates[0] as IFeature;
+      expect(anno.attributes.description).toEqual(
+        "i changed my mind, we can wait a lil while."
+      );
+      // flexible ~100ms
+      expect(anno.attributes.updated_at).toBeCloseTo(new Date().getTime(), -1);
+      done();
+    });
+  });
+
+  it("should update an annotation the old way", done => {
+    // stub add features
+    const paramsSpy = spyOn(featureService, "updateFeatures").and.returnValue(
+      new Promise(resolve => {
+        resolve(updateFeaturesResponse);
+      })
+    );
+
+    updateAnnotations({
+      url: annoUrl,
       updates: [
         {
           attributes: {


### PR DESCRIPTION
addresses #58 

this is the least amount of TypeScript gymnastics/[type guarding](https://www.typescriptlang.org/docs/handbook/advanced-types.html) i could figure out to support the signature for crud operations that @ajturner suggested.

if everyone is happy with this approach, i'll do the same for add/delete in the same PR.

AFFECTS PACKAGES:
@esri/hub-annotations