### PR TITLE
refactor(sites): rename fetchDomain(s) to getDomain(s)

### DIFF
--- a/packages/initiatives/src/get.ts
+++ b/packages/initiatives/src/get.ts
@@ -4,7 +4,7 @@
 import { IRequestOptions, getPortalUrl } from "@esri/arcgis-rest-request";
 import { getItem, getItemData } from "@esri/arcgis-rest-items";
 import { IInitiativeModel, IInitiativeItem } from "@esri/hub-common";
-import { fetchDomain } from "@esri/hub-sites";
+import { getDomain } from "@esri/hub-sites";
 import { migrateSchema } from "./migrator";
 import { convertIndicatorsToDefinitions } from "./migrations/upgrade-two-dot-zero";
 // re-export this one helper function that's needed for solutions
@@ -82,7 +82,7 @@ export function lookupSiteUrlByInitiative(
 ): Promise<string> {
   return getItem(id, requestOptions).then(initiative => {
     if (initiative.properties.siteId) {
-      return fetchDomain(initiative.properties.siteId, requestOptions);
+      return getDomain(initiative.properties.siteId, requestOptions);
     } else {
       // reject
       return Promise.reject(

--- a/packages/sites/README.md
+++ b/packages/sites/README.md
@@ -18,10 +18,10 @@ npm install @esri/hub-sites
 ```
 
 ```js
-import { fetchDomain  } from '@esri/hub-sites';
+import { getDomain  } from '@esri/hub-sites';
 
 // pass in a site id
-fetchDomain("abc123")
+getDomain("abc123")
     .then(
         response => // get back initiative metadata
     );

--- a/packages/sites/src/sites.ts
+++ b/packages/sites/src/sites.ts
@@ -5,12 +5,25 @@ import { request, IRequestOptions } from "@esri/arcgis-rest-request";
 import { getHubUrl } from "@esri/hub-domains";
 
 /**
- * Fetch the domains associated with a Hub Site.
+ * Deprecated. Please use getDomains
+ * @protected
+ */
+/* istanbul ignore next no need to have coverage on deprecated functions */
+export function fetchDomains(siteId: string, requestOptions?: IRequestOptions) {
+  // tslint:disable-next-line
+  console.warn(
+    `fetchDomains has been deprecated. Please use getDomains instead.`
+  );
+  return getDomains(siteId, requestOptions);
+}
+
+/**
+ * Get the domains associated with a Hub Site.
  * @param siteId - Identifier of the Hub Site
  * @param requestOptions - request options that may include authentication
  * @returns A Promise that will resolve with the domains associated with the site.
  */
-export function fetchDomains(
+export function getDomains(
   siteId: string,
   requestOptions?: IRequestOptions
 ): Promise<any> {
@@ -27,7 +40,20 @@ export function fetchDomains(
 }
 
 /**
- * Fetch the domain associated with a Hub Site. Since a site may have a
+ * Deprecated. Please use getDomain
+ * @protected
+ */
+/* istanbul ignore next no need to have coverage on deprecated functions */
+export function fetchDomain(siteId: string, requestOptions?: IRequestOptions) {
+  // tslint:disable-next-line
+  console.warn(
+    `fetchDomain has been deprecated. Please use getDomain instead.`
+  );
+  return getDomain(siteId, requestOptions);
+}
+
+/**
+ * Get the domain associated with a Hub Site. Since a site may have a
  * custom domain, in addition to a default domain, we will return the
  * custom domain over the default domain.
  *
@@ -35,11 +61,11 @@ export function fetchDomains(
  * @param requestOptions - request options that may include authentication
  * @returns A Promise that will resolve with the domains associated with the site.
  */
-export function fetchDomain(
+export function getDomain(
   siteId: string,
   requestOptions?: IRequestOptions
 ): Promise<any> {
-  return fetchDomains(siteId, requestOptions).then(response => {
+  return getDomains(siteId, requestOptions).then(response => {
     if (response.length > 1) {
       // ok - in this case, it's likely that we have a default domain and a custom domain...
       // we want the one that's custom... i.e. does not contain arcgis.com

--- a/packages/sites/test/sites.test.ts
+++ b/packages/sites/test/sites.test.ts
@@ -1,7 +1,7 @@
-import { fetchDomain } from "../src/index";
+import { getDomain } from "../src/index";
 import * as fetchMock from "fetch-mock";
 
-describe("fetchDomain", () => {
+describe("getDomain", () => {
   afterEach(fetchMock.restore);
 
   it("should return a domain", done => {
@@ -10,7 +10,7 @@ describe("fetchDomain", () => {
       [{ domain: "data.foo.com" }]
     );
 
-    fetchDomain("5bc").then(response => {
+    getDomain("5bc").then(response => {
       const [url, options]: [string, RequestInit] = fetchMock.lastCall(
         "https://hub.arcgis.com/utilities/domains?f=json&siteId=5bc"
       );
@@ -26,7 +26,7 @@ describe("fetchDomain", () => {
       `https://hub.arcgis.com/utilities/domains?f=json&siteId=5bc`,
       [{ domain: "data.foo.com" }, { domain: "org.hub.arcgis.com" }]
     );
-    fetchDomain("5bc").then(domain => {
+    getDomain("5bc").then(domain => {
       expect(domain).toBe("data.foo.com");
       const [domainUrl, domainOptions]: [
         string,
@@ -43,7 +43,7 @@ describe("fetchDomain", () => {
       `https://hub.arcgis.com/utilities/domains?f=json&siteId=5bc`,
       [{ domain: "org-beta.hub.arcgis.com" }, { domain: "org.hub.arcgis.com" }]
     );
-    fetchDomain("5bc").then(domain => {
+    getDomain("5bc").then(domain => {
       expect(domain).toBe("org-beta.hub.arcgis.com");
       expect(fetchMock.done()).toBeTruthy();
       const [domainUrl, domainOptions]: [


### PR DESCRIPTION
deprecate old fns and remove from docs

AFFECTS PACKAGES:
@esri/hub-sites

ISSUES CLOSED: #60