### PR TITLE
docs(anno search): fix formatting of code snippet on annotations sear…

### DIFF
--- a/packages/annotations/src/search.ts
+++ b/packages/annotations/src/search.ts
@@ -18,10 +18,9 @@ export interface IResourceObject {
 }
 
 /**
- * ````js
- * import { searchAnnotations } from "@esri/hub-annotations";
- *
+ * ```js
  * // by default, all annotations will be retrieved
+ * import { searchAnnotations } from "@esri/hub-annotations";
  * searchAnnotations({ url: annotationsUrl + "/0" })
  *   .then(response => {
  *     // {

--- a/packages/annotations/src/search.ts
+++ b/packages/annotations/src/search.ts
@@ -19,8 +19,8 @@ export interface IResourceObject {
 
 /**
  * ```js
- * // by default, all annotations will be retrieved
  * import { searchAnnotations } from "@esri/hub-annotations";
+ * // by default, all annotations will be retrieved
  * searchAnnotations({ url: annotationsUrl + "/0" })
  *   .then(response => {
  *     // {


### PR DESCRIPTION
…ch docs

AFFECTS PACKAGES:
@esri/hub-annotations

ISSUES CLOSED: #70 

This fixes the code snippet, but the response is still a bit jacked below:

<img width="1067" alt="image" src="https://user-images.githubusercontent.com/662944/45829471-db56d600-bcaf-11e8-93bb-4f3fe03e0372.png">


