### PR TITLE
add dev scripts to watch a specific package and run a specific build

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Some useful commands include:
 * There is also a `Debug Node Tests` configuration in the `.vscode/launch.json` which will run the Node tests in the VS Code debugger.
 * `npm run docs:serve` will run the documentation site locally at http://localhost:3000
 * `npm run build` will created UMD bundles for _all_ the packages
-* `npm run watch -- <glob> <esm|node|umd>` will re-run the specified build type any time the source code changes in the matched package(s). Example: `npm run watch -- @esri/* umd`
+* `npm run dev -- <glob> <esm|node|umd>` will re-run the specified build type any time the source code changes in the matched package(s). Example: `npm run dev -- @esri/* umd`
 
 ### Packages
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Some useful commands include:
 * There is also a `Debug Node Tests` configuration in the `.vscode/launch.json` which will run the Node tests in the VS Code debugger.
 * `npm run docs:serve` will run the documentation site locally at http://localhost:3000
 * `npm run build` will created UMD bundles for _all_ the packages
-* `npm run dev -- --scope <glob> dev:<esm|node|umd> --parallel` will re-run the specified build type any time the source code changes in the matched package(s). Example: `npm run dev -- --scope @esri/* dev:umd --parallel`
+* `npm run watch -- <glob> <esm|node|umd>` will re-run the specified build type any time the source code changes in the matched package(s). Example: `npm run watch -- @esri/* umd`
 
 ### Packages
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Some useful commands include:
 * There is also a `Debug Node Tests` configuration in the `.vscode/launch.json` which will run the Node tests in the VS Code debugger.
 * `npm run docs:serve` will run the documentation site locally at http://localhost:3000
 * `npm run build` will created UMD bundles for _all_ the packages
+* `support/dev.sh <esm|node|umd> <glob>` will re-run the specified build type any time the source code changes in the matched package(s). Example: `support/dev.sh umd @esri/hub-initiatives`
 
 ### Packages
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Some useful commands include:
 * There is also a `Debug Node Tests` configuration in the `.vscode/launch.json` which will run the Node tests in the VS Code debugger.
 * `npm run docs:serve` will run the documentation site locally at http://localhost:3000
 * `npm run build` will created UMD bundles for _all_ the packages
-* `npm run dev -- <glob> <esm|node|umd>` will re-run the specified build type any time the source code changes in the matched package(s). Example: `npm run dev -- @esri/* umd`
+* `npm run dev -- <esm|node|umd> <glob>` will re-run the specified build type any time the source code changes in the matched package(s). Example: `npm run dev -- umd @esri/*`
 
 ### Packages
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Some useful commands include:
 * There is also a `Debug Node Tests` configuration in the `.vscode/launch.json` which will run the Node tests in the VS Code debugger.
 * `npm run docs:serve` will run the documentation site locally at http://localhost:3000
 * `npm run build` will created UMD bundles for _all_ the packages
-* `npm run watch -- <glob> <esm|node|umd>` will re-run the specified build type any time the source code changes in the matched package(s). Example: `npm run watch -- @esri/* umd`
+* `npm run dev -- --scope <glob> dev:<esm|node|umd> --parallel` will re-run the specified build type any time the source code changes in the matched package(s). Example: `npm run dev -- --scope @esri/* dev:umd --parallel`
 
 ### Packages
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Some useful commands include:
 * There is also a `Debug Node Tests` configuration in the `.vscode/launch.json` which will run the Node tests in the VS Code debugger.
 * `npm run docs:serve` will run the documentation site locally at http://localhost:3000
 * `npm run build` will created UMD bundles for _all_ the packages
-* `support/dev.sh <esm|node|umd> <glob>` will re-run the specified build type any time the source code changes in the matched package(s). Example: `support/dev.sh umd @esri/hub-initiatives`
+* `npm run watch -- <glob> <esm|node|umd>` will re-run the specified build type any time the source code changes in the matched package(s). Example: `npm run watch -- @esri/* umd`
 
 ### Packages
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "scripts": {
     "build": "lerna run build",
+    "watch": "support/dev.sh",
     "test": "npm run test:node && npm run test:chrome",
     "test:chrome:debug": "karma start --auto-watch --no-single-run --browsers=Chrome",
     "test:chrome": "karma start --single-run --browsers=Chrome",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
   },
   "scripts": {
     "build": "lerna run build",
-    "dev": "lerna run",
     "watch": "support/dev.sh",
     "test": "npm run test:node && npm run test:chrome",
     "test:chrome:debug": "karma start --auto-watch --no-single-run --browsers=Chrome",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "scripts": {
     "build": "lerna run build",
+    "dev": "lerna run",
     "watch": "support/dev.sh",
     "test": "npm run test:node && npm run test:chrome",
     "test:chrome:debug": "karma start --auto-watch --no-single-run --browsers=Chrome",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "scripts": {
     "build": "lerna run build",
-    "watch": "support/dev.sh",
+    "dev": "support/dev.sh",
     "test": "npm run test:node && npm run test:chrome",
     "test:chrome:debug": "karma start --auto-watch --no-single-run --browsers=Chrome",
     "test:chrome": "karma start --single-run --browsers=Chrome",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -25,7 +25,11 @@
     "build": "npm run build:node && npm run build:umd && npm run build:esm",
     "build:esm": "tsc --module es2015 --outDir ./dist/esm --declaration",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
-    "build:node": "tsc --module commonjs --outDir ./dist/node"
+    "build:node": "tsc --module commonjs --outDir ./dist/node",
+    "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
+    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
+    "rollup:dev": "rollup -c ../../umd-base-profile.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -22,7 +22,11 @@
     "build": "npm run build:node && npm run build:umd && npm run build:esm",
     "build:esm": "tsc --module es2015 --outDir ./dist/esm --declaration",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
-    "build:node": "tsc --module commonjs --outDir ./dist/node"
+    "build:node": "tsc --module commonjs --outDir ./dist/node",
+    "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
+    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
+    "rollup:dev": "rollup -c ../../umd-base-profile.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,7 +20,11 @@
     "build": "npm run build:node && npm run build:umd && npm run build:esm",
     "build:esm": "tsc --module es2015 --outDir ./dist/esm --declaration",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
-    "build:node": "tsc --module commonjs --outDir ./dist/node"
+    "build:node": "tsc --module commonjs --outDir ./dist/node",
+    "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
+    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
+    "rollup:dev": "rollup -c ../../umd-base-profile.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/domains/package.json
+++ b/packages/domains/package.json
@@ -26,7 +26,11 @@
     "build": "npm run build:node && npm run build:umd && npm run build:esm",
     "build:esm": "tsc --module es2015 --outDir ./dist/esm --declaration",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
-    "build:node": "tsc --module commonjs --outDir ./dist/node"
+    "build:node": "tsc --module commonjs --outDir ./dist/node",
+    "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
+    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
+    "rollup:dev": "rollup -c ../../umd-base-profile.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/initiatives/package.json
+++ b/packages/initiatives/package.json
@@ -38,8 +38,9 @@
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
-    "dev:umd": "rollup -w -c ../../umd-base-profile.js",
-    "dev:node": "tsc -w --module commonjs --outDir ./dist/node"
+    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
+    "rollup:dev": "rollup -c ../../umd-base-profile.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/initiatives/package.json
+++ b/packages/initiatives/package.json
@@ -36,7 +36,10 @@
     "build": "npm run build:node && npm run build:umd && npm run build:esm",
     "build:esm": "tsc --module es2015 --outDir ./dist/esm --declaration",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
-    "build:node": "tsc --module commonjs --outDir ./dist/node"
+    "build:node": "tsc --module commonjs --outDir ./dist/node",
+    "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
+    "dev:umd": "rollup -w -c ../../umd-base-profile.js",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -31,7 +31,11 @@
     "build": "npm run build:node && npm run build:umd && npm run build:esm",
     "build:esm": "tsc --module es2015 --outDir ./dist/esm --declaration",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
-    "build:node": "tsc --module commonjs --outDir ./dist/node"
+    "build:node": "tsc --module commonjs --outDir ./dist/node",
+    "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
+    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
+    "rollup:dev": "rollup -c ../../umd-base-profile.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/solutions/package.json
+++ b/packages/solutions/package.json
@@ -28,7 +28,11 @@
     "build": "npm run build:node && npm run build:umd && npm run build:esm",
     "build:esm": "tsc --module es2015 --outDir ./dist/esm --declaration",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
-    "build:node": "tsc --module commonjs --outDir ./dist/node"
+    "build:node": "tsc --module commonjs --outDir ./dist/node",
+    "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
+    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
+    "rollup:dev": "rollup -c ../../umd-base-profile.js"
   },
   "publishConfig": {
     "access": "public"

--- a/support/dev.sh
+++ b/support/dev.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# extract scope and build type from the command line args
-SCOPE=$1
-BUILD_TYPE=$2
+# extract build type and scope from the command line args
+BUILD_TYPE=$1
+SCOPE=$2
 
 # run the dev script for that build type in the scoped packages
-  lerna run --scope "$SCOPE" dev:$BUILD_TYPE --parallel
+lerna run --scope "$SCOPE" dev:$BUILD_TYPE --parallel

--- a/support/dev.sh
+++ b/support/dev.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# extract scope and build type from the command line args
-SCOPE=$1
-BUILD_TYPE=$2
-
-# run the dev script for that build type in the scoped packages
-  lerna run --scope "$SCOPE" dev:$BUILD_TYPE --parallel

--- a/support/dev.sh
+++ b/support/dev.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-# extract build type and scope from the command line args
-BUILD_TYPE=$1
-SCOPE=$2
-# echo $BUILD_TYPE $SCOPE
+# extract scope and build type from the command line args
+SCOPE=$1
+BUILD_TYPE=$2
 
 # run the dev script for that build type in the scoped packages
   lerna run --scope "$SCOPE" dev:$BUILD_TYPE --parallel

--- a/support/dev.sh
+++ b/support/dev.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# extract build type and scope from the command line args
+BUILD_TYPE=$1
+SCOPE=$2
+# echo $BUILD_TYPE $SCOPE
+
+# run the dev script for that build type in the scoped packages
+  lerna run --scope "$SCOPE" dev:$BUILD_TYPE --parallel

--- a/support/dev.sh
+++ b/support/dev.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# extract scope and build type from the command line args
+SCOPE=$1
+BUILD_TYPE=$2
+
+# run the dev script for that build type in the scoped packages
+  lerna run --scope "$SCOPE" dev:$BUILD_TYPE --parallel


### PR DESCRIPTION
added `dev:esm`, `dev:umd`, and `dev:node` scripts for initiative package (only, so far).

You can run `lerna run dev:esm --parallel` and `tsc` will launch in watch mode and recompile the ESM output instantly whenver you change the TS source for the initiatives package. 🎉 

But of course, the one we care about, `lerna run dev:umd --parallel`, does not work. I get this output:

```bash
➜  hub.js git:(chore/dist-scripts) lerna run dev:umd --parallel
lerna info version 2.8.0
lerna info run in 1 package(s): npm run dev:umd
@esri/hub-initiatives: > @esri/hub-initiatives@1.3.0 dev:umd /Users/tom/code/hub.js/packages/initiatives
@esri/hub-initiatives: > rollup -w -c ../../umd-base-profile.js
@esri/hub-initiatives: rollup v0.53.4
@esri/hub-initiatives: bundles ./src/index.ts → dist/umd/initiatives.umd.js...
lerna success run Ran npm script 'dev:umd' in packages:
lerna success - @esri/hub-initiatives

```

The command that I used in the `dev:umd` script _does_ launch rollup in watch mode by `cd`ing into the `packages/initiatives` folder and running `../../node_modules/.bin/rollup -w -c ../../umd-base-profile.js`, which outputs:

```bash
rollup v0.53.4
bundles ./src/index.ts → dist/umd/initiatives.umd.js...
created dist/umd/initiatives.umd.js in 246ms

[2018-10-04 15:18:32] waiting for changes...
```

It's almost like lerna interprets the rollup output as being done.
