### PR TITLE
chore(rollup): upgrade to latest rollup & use rollup watch to re-run …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12883,9 +12883,9 @@
       }
     },
     "rollup": {
-      "version": "0.63.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.63.5.tgz",
-      "integrity": "sha512-dFf8LpUNzIj3oE0vCvobX6rqOzHzLBoblyFp+3znPbjiSmSvOoK2kMKx+Fv9jYduG1rvcCfCveSgEaQHjWRF6g==",
+      "version": "0.66.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.66.4.tgz",
+      "integrity": "sha512-oV6dzR2zDYVOMUmrM1XMTW0NlZqKeZANAWH+A7BwCfE+mAfJ6xRkYbrM3qAossgyMxPN9aFBu8kRXf5HYB5gvw==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prettier": "^1.9.2",
     "resolve": "^1.5.0",
     "rimraf": "^2.6.2",
-    "rollup": "^0.63.5",
+    "rollup": "^0.66.4",
     "rollup-plugin-commonjs": "^8.2.6",
     "rollup-plugin-filesize": "^4.0.1",
     "rollup-plugin-json": "^2.3.0",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -27,9 +27,8 @@
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
-    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
-    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
-    "rollup:dev": "rollup -c ../../umd-base-profile.js"
+    "dev:umd": "rollup -w -c ../../umd-base-profile.js",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -24,9 +24,8 @@
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
-    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
-    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
-    "rollup:dev": "rollup -c ../../umd-base-profile.js"
+    "dev:umd": "rollup -w -c ../../umd-base-profile.js",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -22,9 +22,8 @@
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
-    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
-    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
-    "rollup:dev": "rollup -c ../../umd-base-profile.js"
+    "dev:umd": "rollup -w -c ../../umd-base-profile.js",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/domains/package.json
+++ b/packages/domains/package.json
@@ -28,9 +28,8 @@
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
-    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
-    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
-    "rollup:dev": "rollup -c ../../umd-base-profile.js"
+    "dev:umd": "rollup -w -c ../../umd-base-profile.js",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/initiatives/package.json
+++ b/packages/initiatives/package.json
@@ -38,9 +38,8 @@
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
-    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
-    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
-    "rollup:dev": "rollup -c ../../umd-base-profile.js"
+    "dev:umd": "rollup -w -c ../../umd-base-profile.js",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -33,9 +33,8 @@
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
-    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
-    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
-    "rollup:dev": "rollup -c ../../umd-base-profile.js"
+    "dev:umd": "rollup -w -c ../../umd-base-profile.js",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/solutions/package.json
+++ b/packages/solutions/package.json
@@ -30,9 +30,8 @@
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
-    "dev:umd": "onchange 'src/**/*.ts' -- npm run rollup:dev",
-    "dev:node": "tsc -w --module commonjs --outDir ./dist/node",
-    "rollup:dev": "rollup -c ../../umd-base-profile.js"
+    "dev:umd": "rollup -w -c ../../umd-base-profile.js",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
…UMD builds

AFFECTS PACKAGES:
@esri/hub-annotations
@esri/hub-auth
@esri/hub-common
@esri/hub-domains
@esri/hub-initiatives
@esri/hub-sites
@esri/hub-solutions