### PR TITLE
add new dependencies to guide and use search to return an id

### DIFF
--- a/docs/acetate.config.js
+++ b/docs/acetate.config.js
@@ -210,7 +210,7 @@ module.exports = function(acetate) {
   acetate.helper("cdnUrl", function(context, package) {
     return `https://unpkg.com/${
       package.name
-    }@${package.version}/dist/umd/${package.name.split("/")[1]}.umd.js`;
+    }@${package.version}/dist/umd/${package.name.replace("@esri/hub-", "")}.umd.js`;
   });
 
   acetate.helper("npmInstallCmd", function(context, package) {

--- a/docs/src/guides/from-a-cdn.md
+++ b/docs/src/guides/from-a-cdn.md
@@ -26,15 +26,25 @@ group: 1-get-started
 
   <!-- hub.js has external dependencies on @esri/arcgis-rest-js packages -->
   <script src="https://unpkg.com/@esri/arcgis-rest-request"></script>
+  <script src="https://unpkg.com/@esri/arcgis-rest-auth"></script>
   <script src="https://unpkg.com/@esri/arcgis-rest-items"></script>
+  <script src="https://unpkg.com/@esri/arcgis-rest-sharing"></script>
 
-  <!-- require @esri/hub.js libraries from https://unpkg.com -->
+  <!-- require @esri/hub.js libraries from https://unpkg.com too -->
+  <script src="{% cdnUrl data.typedoc | findPackage('@esri/hub-common') %}"></script>
+  <script src="{% cdnUrl data.typedoc | findPackage('@esri/hub-domains') %}"></script>
+  <script src="{% cdnUrl data.typedoc | findPackage('@esri/hub-sites') %}"></script>
   <script src="{% cdnUrl data.typedoc | findPackage('@esri/hub-initiatives') %}"></script>
 
   <script>
-    // when including @esri/hub.js all exports are available from an esriHub global
-    arcgisHub.getInitiative("acb123").then(response => {
-      console.log(response);
-    });
+    // all exports are available from an arcgisHub global
+    arcgisHub.searchInitiatives({
+      searchForm: { q: "Share Open Data" }
+    })
+      .then(response => {
+        arcgisHub.getInitiative(response.results[0].id).then(response => {
+          console.log(response);
+        });
+      });
   </script>
 </html>


### PR DESCRIPTION
resolves #87, #88, #89

@lisastaehli i've updated the getting started guide to use searchInitiatives() to get a reference to an `id` instead of going into a deeper explanation.

hopefully this makes things a little more approachable. in the medium-term we'll work on  writing additional demo apps and a 'What is an initiative' guide topic to cover what they are and how they are created.

