### PR TITLE
chore(ci): retry tests on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 before_script:
 - npm run bootstrap
 script:
-- npm run test:ci
+- travis_retry npm run test:ci
 deploy:
   provider: pages
   skip_cleanup: true


### PR DESCRIPTION
`travis_retry` allegedly retries a failed command 3 times:
https://docs.travis-ci.com/user/common-build-problems/#travis_retry