### PR TITLE
fix: ensure editor tracking is wired up correctly in new anno services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3770,7 +3770,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },

--- a/packages/annotations/src/create.ts
+++ b/packages/annotations/src/create.ts
@@ -73,7 +73,7 @@ export function createAnnotationService(
             description,
             serviceDescription: description,
             copyrightText: "",
-            capabilities: "Create,Delete,Query,Update,Editing",
+            capabilities: clonedServiceDefinition.capabilities,
             spatialReference: defaultExtent.spatialReference,
             xssPreventionInfo: {
               xssPreventionEnabled: true,

--- a/packages/annotations/src/layer-definition.ts
+++ b/packages/annotations/src/layer-definition.ts
@@ -19,9 +19,10 @@ export const defaultExtent: IExtent = {
 export const editorTrackingInfo = {
   enableEditorTracking: true,
   enableOwnershipAccessControl: true,
+  allowOthersToQuery: true,
   allowOthersToUpdate: false,
   allowOthersToDelete: false,
-  allowOthersToQuery: true,
+  allowAnonymousToQuery: true,
   allowAnonymousToUpdate: false,
   allowAnonymousToDelete: false
 };
@@ -31,7 +32,7 @@ export const editorTrackingInfo = {
  */
 export const annotationServiceDefinition: ILayerDefinition = {
   allowGeometryUpdates: true,
-  capabilities: "Create,Delete,Query,Update,Editing",
+  capabilities: "Query,Editing,Create,Update",
   copyrightText: "",
   defaultVisibility: true,
   description: "",
@@ -65,12 +66,42 @@ export const annotationServiceDefinition: ILayerDefinition = {
       defaultValue: null
     },
     {
+      name: "created_at",
+      type: "esriFieldTypeDate",
+      alias: "created_at",
+      length: 8,
+      nullable: true,
+      editable: false,
+      domain: null,
+      defaultValue: null
+    },
+    {
       name: "author",
       type: "esriFieldTypeString",
       alias: "author",
-      length: 256,
-      nullable: false,
-      editable: true,
+      length: 128,
+      nullable: true,
+      editable: false,
+      domain: null,
+      defaultValue: null
+    },
+    {
+      name: "updated_at",
+      type: "esriFieldTypeDate",
+      alias: "updated_at",
+      length: 8,
+      nullable: true,
+      editable: false,
+      domain: null,
+      defaultValue: null
+    },
+    {
+      name: "updater",
+      type: "esriFieldTypeString",
+      alias: "updater",
+      length: 128,
+      nullable: true,
+      editable: false,
       domain: null,
       defaultValue: null
     },
@@ -120,26 +151,6 @@ export const annotationServiceDefinition: ILayerDefinition = {
       alias: "target",
       length: 2000,
       nullable: false,
-      editable: true,
-      domain: null,
-      defaultValue: null
-    },
-    {
-      name: "created_at",
-      type: "esriFieldTypeDate",
-      alias: "created_at",
-      length: 0,
-      nullable: false,
-      editable: true,
-      domain: null,
-      defaultValue: null
-    },
-    {
-      name: "updated_at",
-      type: "esriFieldTypeDate",
-      alias: "updated_at",
-      length: 0,
-      nullable: true,
       editable: true,
       domain: null,
       defaultValue: null
@@ -212,19 +223,9 @@ export const annotationServiceDefinition: ILayerDefinition = {
       drawingTool: "esriFeatureEditToolPolygon",
       prototype: {
         attributes: {
-          author: "",
-          data: null,
           description: "",
           status: "",
-          source: null,
-          target: "",
-          created_at: null,
-          updated_at: null,
-          edits: null,
-          parent_id: null,
-          dataset_id: null,
-          feature_id: null,
-          attribute: null
+          target: ""
         }
       }
     }
@@ -234,9 +235,9 @@ export const annotationServiceDefinition: ILayerDefinition = {
   types: [],
   timeInfo: {},
   editFieldsInfo: {
-    creationDateField: "",
-    creatorField: "",
-    editDateField: "",
-    editorField: ""
+    creationDateField: "created_at",
+    creatorField: "author",
+    editDateField: "updated_at",
+    editorField: "updater"
   }
 };

--- a/packages/annotations/src/search.ts
+++ b/packages/annotations/src/search.ts
@@ -48,13 +48,14 @@ export function searchAnnotations(
     requestOptions.outFields = [
       "OBJECTID",
       "author",
+      "updater",
+      "created_at",
+      "updated_at",
       "description",
       "source",
       "status",
       "target",
-      "dataset_id",
-      "created_at",
-      "updated_at"
+      "dataset_id"
     ];
   }
 

--- a/packages/annotations/test/create.test.ts
+++ b/packages/annotations/test/create.test.ts
@@ -142,7 +142,7 @@ describe("createAnnotationService", () => {
       )[0] as ICreateServiceRequestOptions;
       expect(createOpts.item.name).toEqual("hub_annotations");
       expect(createOpts.item.capabilities).toEqual(
-        "Create,Delete,Query,Update,Editing"
+        annotationServiceDefinition.capabilities
       );
       expect(createOpts.item.maxRecordCount).toEqual(2000);
       expect(createOpts.item.hasStaticData).toEqual(false);

--- a/packages/annotations/test/search.ts
+++ b/packages/annotations/test/search.ts
@@ -15,6 +15,19 @@ import * as featureService from "@esri/arcgis-rest-feature-service";
 import * as user from "@esri/arcgis-rest-users";
 import { IQueryFeaturesRequestOptions } from "@esri/arcgis-rest-feature-service";
 
+const mockOutFields = [
+  "OBJECTID",
+  "author",
+  "updater",
+  "created_at",
+  "updated_at",
+  "description",
+  "source",
+  "status",
+  "target",
+  "dataset_id"
+];
+
 describe("searchAnnotations", () => {
   it("should query for annotations when no parameters are passed", done => {
     const queryParamsSpy = spyOn(
@@ -47,17 +60,7 @@ describe("searchAnnotations", () => {
       const jonesOpts = userParamsSpy.calls.argsFor(1)[0] as string;
 
       expect(queryOpts.url).toBe(annoSearchResponse.results[0].url + "/0");
-      expect(queryOpts.outFields).toEqual([
-        "OBJECTID",
-        "author",
-        "description",
-        "source",
-        "status",
-        "target",
-        "dataset_id",
-        "created_at",
-        "updated_at"
-      ]);
+      expect(queryOpts.outFields).toEqual(mockOutFields);
       expect(caseyOpts).toBe("casey");
       expect(jonesOpts).toBe("jones");
       expect(response).toEqual(annoResponse);
@@ -90,17 +93,7 @@ describe("searchAnnotations", () => {
 
       expect(opts.url).toBe(annoSearchResponse.results[0].url + "/0");
       expect(opts.where).toBe("1=0");
-      expect(opts.outFields).toEqual([
-        "OBJECTID",
-        "author",
-        "description",
-        "source",
-        "status",
-        "target",
-        "dataset_id",
-        "created_at",
-        "updated_at"
-      ]);
+      expect(opts.outFields).toEqual(mockOutFields);
       expect(response).toEqual(annoResponseEmpty);
       done();
     });


### PR DESCRIPTION
the tweaks above ensure the following capabilities are set on new hosted annotation services:

- [X] Enable editing.
- [ ] ~~Keep track of created and updated features.~~
- [X] Keep track of who created and last updated features.
- [X] Editing: Add, update, ~~and delete~~ features
- [X] Visible: Editors can see all features
- [X] Editors can only edit their own features (requires tracking)
- [X] Anonymous access: Only add new features, if allowed above (requires tracking)
- [X] service cant be deleted

i dont know what this one even means, and whats more, i just wasted 4 hours of my life unintentionally confirming that setting it breaks _everything_:

- [ ] Keep track of created and updated features.

to put it another way, i have confirmed manually that the settings here ensure the following


1. anonymous users can **only add** new features
2. named users can add new features **and** update their own features
3. organization administrators (and i assume those with special privileges) **can update** comments from other named users
3. **no one** can delete features
4. the service is appropriately protected from accidental deletion