### PR TITLE
fix bad links in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Documentation
    * **README**: replace package name/descriptoin of hub-common-types w/… [`4e21d75`](https://github.com/Esri/hub.js/commit/4e21d75be238d7a5c42e208e3f4acf4329a7e7ba)
 * Chore
-   * **all**: bump ArcGIS Rest Js [#66](https://github.com/Esri/hub.js/pull/66)
+   * **all**: bump ArcGIS REST JS [#66](https://github.com/Esri/hub.js/pull/66)
 
 ## [1.2.0] - September 17th 2018
 
@@ -102,5 +102,5 @@ Initial Release
 [1.1.0]: https://github.com/Esri/hub.js/compare/v1.0.1...v1.1.0 "v1.1.0"
 [1.1.1]: https://github.com/Esri/hub.js/compare/v1.1.0...v1.1.1 "v1.1.1"
 [1.2.0]: https://github.com/Esri/hub.js/compare/v1.1.1...v1.2.0 "v1.2.0"
-[1.3.0]: https://github.com/Esri/hub.js/compare/v1.2.0...1.3.0 "1.3.0"
-[HEAD]: https://github.com/Esri/hub.js/compare/1.3.0...HEAD "Unreleased Changes"
+[1.3.0]: https://github.com/Esri/hub.js/compare/v1.2.0...v1.3.0 "v1.3.0"
+[HEAD]: https://github.com/Esri/hub.js/compare/v1.3.0...HEAD "Unreleased Changes"


### PR DESCRIPTION
doesn't _look_ like a problem in `support/changelog.js`. i _think_ it was a one-off thing.