### PR TITLE
add guide for working with annotation services

### DIFF
--- a/docs/src/guides/create-an-initiative.md
+++ b/docs/src/guides/create-an-initiative.md
@@ -8,7 +8,7 @@ group: 1-get-started
 
 ## Create an Initiative
 
-The `@esri/hub-initiatives` exposes both coarse and fine-grained APIs. If your application simply needs to create an Initiative from a template, then the coarse-grained API is for you. If your application is more focused on working with / editing / orchestrating solutions for Initiatives (i.e. the Hub), then the fine-grained api is likely a better fit.
+The `@esri/hub-initiatives` module exposes both coarse and fine-grained APIs. If your application simply needs to create an initiative from a template, then the coarse-grained API is for you. If your application is more focused on working with / editing / orchestrating solutions for Initiatives (i.e. the Hub), then the fine-grained api is likely a better fit.
 
 ### Get an Initiative by Id
 To get an Initiative Model (` {item:{...}, data:{...}}`) you can use this call. If you do not need the `data` you can use the [@esri/arcgis-rest-items::getItem(id)](https://esri.github.io/arcgis-rest-js/api/items/getItem/) call instead.

--- a/docs/src/guides/index.md
+++ b/docs/src/guides/index.md
@@ -10,6 +10,8 @@ description: Get started with @esri/hub.js.
 * [Using a CDN](./from-a-cdn/)
 * [Using Node.js](./node/)
 * [Create an initiative](./create-an-initiative/)
+* [Work with an annotation service](./work-with-annotations/)
+
 <!-- * [Using ES6 modules](./using-es6/) -->
 
 ## Requirements

--- a/docs/src/guides/work-with-annotations.md
+++ b/docs/src/guides/work-with-annotations.md
@@ -34,7 +34,7 @@ getPortal("http://custom.maps.arcgis.com")
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { createAnnotationService } from "@esri/hub-annotations";
 
-// this user will be the owner of the new annotation service
+// user with sufficient privileges to create a new hosted feature service
 const authentication = new UserSession({
   username: "joe",
   password: "shhhh"

--- a/docs/src/guides/work-with-annotations.md
+++ b/docs/src/guides/work-with-annotations.md
@@ -1,0 +1,68 @@
+---
+title: Work with annotations.
+navTitle: Work with annotations
+description: Learn how to work with an annotation service using @esri/hub.js.
+order: 40
+group: 1-get-started
+---
+
+Annotations are geographic comments created by an Author for discussion of an Initiative, about an Events, or feedback of a Dataset. This feedback can also be submitted anonymously.
+
+Under the hood, the information is stored in an ArcGIS hosted feature service.
+
+## Identify an existing annotation service.
+
+If an organization has already purchased ArcGIS Hub, then it's annotation service can be sniffed out using the technique below.
+
+```js
+import { getPortal } from "@esri/arcgis-rest-request";
+import { getAnnotationServiceUrl  } from '@esri/hub-annotations';
+
+// first, use the org url to determine its unique id
+getPortal("http://custom.maps.arcgis.com")
+  .then(response => {
+    const orgId = response.id;
+    getAnnotationServiceUrl(orgId)
+      .then(response => ) // "https://services.arcgis.com/..."
+```
+
+## Create a brand new annotation service.
+
+@esri/hub.js can be used to _create_ an ArcGIS Hub compatible annotation service in an organization too.
+
+```js
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { createAnnotationService } from "@esri/hub-annotations";
+
+// this user will be the owner of the new annotation service
+const authentication = new UserSession({
+  username: "joe",
+  password: "shhhh"
+});
+
+createAnnotationService({
+  orgId,
+  authentication
+})
+  .then(response => // { success: true, itemId: "fe3" } );
+```
+
+## Submit anonymous comments
+
+If you are creating an application for posting anonymous feedback, hub.js has a helper for that as well.
+
+```js
+import { addAnnotations } from "@esri/hub-annotations";
+
+addAnnotations({
+  url: annotationsUrl + "/0",
+  adds: [{
+    attributes: {
+      target: "http://...", // the target of the comment
+      description: "A grand idea!", // the actual comment
+      source: "your cool app"
+    }
+  }]
+})
+  .then(response);
+```

--- a/packages/annotations/src/add.ts
+++ b/packages/annotations/src/add.ts
@@ -45,14 +45,9 @@ export interface IAddAnnotationsRequestOptions
 export function addAnnotations(
   requestOptions: IAddAnnotationsRequestOptions
 ): Promise<IAddFeaturesResult> {
-  const session = requestOptions.authentication as UserSession;
-  const author = session ? session.username : null;
-
   requestOptions.adds.forEach(function(anno) {
     const defaults = {
-      created_at: new Date().getTime(),
       status: "pending",
-      author,
       source: "hub.js"
     };
 

--- a/packages/annotations/src/update.ts
+++ b/packages/annotations/src/update.ts
@@ -30,17 +30,5 @@ import {
 export function updateAnnotations(
   requestOptions: IUpdateFeaturesRequestOptions
 ): Promise<IUpdateFeaturesResult> {
-  requestOptions.updates.forEach(function(anno) {
-    const defaults = {
-      updated_at: new Date().getTime()
-    };
-
-    // mixin, giving precedence to what was passed to the method
-    anno.attributes = {
-      ...defaults,
-      ...anno.attributes
-    };
-  });
-
   return updateFeatures(requestOptions);
 }

--- a/packages/annotations/test/crud.test.ts
+++ b/packages/annotations/test/crud.test.ts
@@ -92,10 +92,7 @@ describe("add/update/deleteAnnotations", () => {
         "what do we want? bike lanes! when do we want them? now!"
       );
       expect(anno.attributes.status).toEqual("pending");
-      expect(anno.attributes.author).toEqual("casey");
       expect(anno.attributes.source).toEqual("hub.js");
-      // flexible ~100ms
-      expect(anno.attributes.created_at).toBeCloseTo(new Date().getTime(), -2);
       done();
     });
   });
@@ -134,8 +131,6 @@ describe("add/update/deleteAnnotations", () => {
       );
       expect(anno.attributes.status).toEqual("pending");
       expect(anno.attributes.source).toEqual("hub.js");
-      // flexible ~100ms
-      expect(anno.attributes.created_at).toBeCloseTo(new Date().getTime(), -1);
       done();
     });
   });
@@ -166,14 +161,11 @@ describe("add/update/deleteAnnotations", () => {
 
       expect(opts.url).toEqual(annoUrl);
       const anno = opts.adds[0] as IFeature;
-      expect(anno.attributes.author).toEqual(null);
       expect(anno.attributes.description).toEqual(
         "what do we want? bike lanes! when do we want them? now!"
       );
       expect(anno.attributes.status).toEqual("pending");
       expect(anno.attributes.source).toEqual("hub.js");
-      // flexible ~100ms
-      expect(anno.attributes.created_at).toBeCloseTo(new Date().getTime(), -2);
       done();
     });
   });
@@ -207,14 +199,11 @@ describe("add/update/deleteAnnotations", () => {
       expect(opts.url).toEqual(annoUrl);
       const anno = opts.adds[0] as IFeature;
 
-      expect(anno.attributes.author).toEqual(null);
       expect(anno.attributes.description).toEqual(
         "what do we want? bike lanes! when do we want them? now!"
       );
       expect(anno.attributes.status).toEqual("URGENT!");
       expect(anno.attributes.source).toEqual("somewhere else");
-      // flexible ~100ms
-      expect(anno.attributes.created_at).toBeCloseTo(new Date().getTime(), -2);
       done();
     });
   });
@@ -248,8 +237,6 @@ describe("add/update/deleteAnnotations", () => {
       expect(anno.attributes.description).toEqual(
         "i changed my mind, we can wait a lil while."
       );
-      // flexible ~100ms
-      expect(anno.attributes.updated_at).toBeCloseTo(new Date().getTime(), -1);
       done();
     });
   });


### PR DESCRIPTION
while i was in there i realized that the code i wrote previously for tacking on the 'author' attribute in annotation CRUD functions needed to be removed.

`created_at`, `updated_at`, `author` and `updater` are all managed by the server when editor tracking is enabled.