### PR TITLE
Ensure we use the owner url when deleting initiative items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### [Unreleased][HEAD]
 
+* Changes
+  * Use the owner's item url when deleting an initiative item
+
 ## [1.5.1] - November 21st 2018
 
 ### @esri/hub-annotations

--- a/packages/initiatives/src/remove.ts
+++ b/packages/initiatives/src/remove.ts
@@ -74,6 +74,7 @@ export function removeInitiative(
       const portal = results[1];
       state.hasSite = !!model.item.properties.siteId;
       state.siteId = model.item.properties.siteId;
+      state.initiativeOwner = model.item.owner;
       state.collaborationGroupId = getProp(
         portal,
         "properties.openData.settings.groupId"
@@ -106,6 +107,7 @@ export function removeInitiative(
       const prms = [];
       const opts = {
         id,
+        owner: state.initiativeOwner,
         ...requestOptions
       } as IItemIdRequestOptions;
       prms.push(removeItem(opts));


### PR DESCRIPTION
Updated the removeInitiative function to always construct the url using the item owner's username. This allows an admin to delete an initiative they don't own