### PR TITLE
add support for annotation voting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ notifications:
   slack:
     secure: 4zQtBJ3DuJL3IIbDsq+IR4i2iaL8yYiatECXb4zjcvxoqC7r0QCJ2lkvsyLjJT6vPNGIA3HB3HfV23cH5RxGHuD9ZXfaWo2UhYQ/hq0zhxGdzrujqNYkXEWAKstkpYY2o5Edtfg5rco3NxuEVVgptpptbTW4kM+BrutFltlWkR04056OUozmQnPOJy4hJ084FgR2fsMQdzqd/UmwEYnUt8JvfTC6UQolcyp48+w+0DeS1jyOr5LyttpVg2t+1Ap9QWsf4pR1zOWl8RD+zs9tGgEQIW7NswymxVE6AcTeMOwXN1Nh3NaDoLMsOrGHlcFQRmtPL6QOKctpZUXlKKP+ENpcWOj0sQrHqFe1cPWIZ4OulFJHhW9X3J6anoi9Z1lK1KeeMkw/LFdp745Tm/88ZsJ6uV3gjx9NsespowSK2YU4LOtFGsPp5jceQabl3xgs4FLGH03dnD7dmj+7lSQ6CgsUgjLVHjHCDnTvEVe4+eM3f78eQsjxvl5IP/mNJgcVuRnaL+kor0DV5EoshbzXlP3bqFG3QceUdQj46XIhb0+SCjwoclsJKfl3YsCKukMT5Y+27zJASzOufhWV+yhadOHijwZwwd2GUEU8JwcUmk5EoEcmxB8S3A5guRwY6ok9OTag36q8jAD4RMOJjyddsDVtLKF+KoZG2XFjbV+DnnQ=
 node_js:
-- '8'
 - '10'
+- '11'
 cache:
   directories:
   - node_modules

--- a/docs/src/guides/work-with-annotations.md
+++ b/docs/src/guides/work-with-annotations.md
@@ -6,13 +6,13 @@ order: 40
 group: 1-get-started
 ---
 
-Annotations are geographic comments created by an Author for discussion of an Initiative, about an Events, or feedback of a Dataset. This feedback can also be submitted anonymously.
+Annotations are geographic comments created by an Author to discuss an Initiative or Event or give feedback on a Dataset. Feedback can be submitted by both known and anonymous users.
 
 Under the hood, the information is stored in an ArcGIS hosted feature service.
 
 ## Identify an existing annotation service.
 
-If an organization has already purchased ArcGIS Hub, then it's annotation service can be sniffed out using the technique below.
+If an organization has already purchased ArcGIS Hub, then the url of it's annotation service can be identified using the technique below.
 
 ```js
 import { getPortal } from "@esri/arcgis-rest-request";
@@ -23,12 +23,12 @@ getPortal("http://custom.maps.arcgis.com")
   .then(response => {
     const orgId = response.id;
     getAnnotationServiceUrl(orgId)
-      .then(response => ) // "https://services.arcgis.com/..."
+      .then(response) // "https://services.arcgis.com/..."
 ```
 
 ## Create a brand new annotation service.
 
-@esri/hub.js can be used to _create_ an ArcGIS Hub compatible annotation service in an organization too.
+@esri/hub.js can also be used to _create_ an ArcGIS Hub compatible annotation service in an ArcGIS Online Organization.
 
 ```js
 import { UserSession } from "@esri/arcgis-rest-auth";
@@ -44,7 +44,7 @@ createAnnotationService({
   orgId,
   authentication
 })
-  .then(response => // { success: true, itemId: "fe3" } );
+  .then(response) // { success: true, itemId: "fe3" }
 ```
 
 ## Submit anonymous comments
@@ -56,7 +56,7 @@ import { addAnnotations } from "@esri/hub-annotations";
 
 addAnnotations({
   url: annotationsUrl + "/0",
-  adds: [{
+  features: [{
     attributes: {
       target: "http://...", // the target of the comment
       description: "A grand idea!", // the actual comment

--- a/packages/annotations/src/add.ts
+++ b/packages/annotations/src/add.ts
@@ -16,6 +16,7 @@ export interface IAnnoFeature extends IFeature {
     [key: string]: any;
   };
 }
+
 export interface IAddAnnotationsRequestOptions
   extends IAddFeaturesRequestOptions {
   features: IAnnoFeature[];
@@ -28,6 +29,7 @@ export interface IAddAnnotationsRequestOptions
 /**
  * ```js
  * import { addAnnotations } from "@esri/hub-annotations";
+ * //
  * addAnnotations({
  *   url: annotationsUrl + "/0",
  *   features: [{
@@ -41,7 +43,7 @@ export interface IAddAnnotationsRequestOptions
  * ```
  * Add an annotation to ArcGIS Hub. Uses authentication to derive authorship, appends a timestamp and sets a default status of "pending" to new comments by default.
  * @param requestOptions - request options that may include authentication
- * @returns A Promise that will resolve with response from the service after attempting to add one or more new annotations.
+ * @returns A Promise that will resolve with the response from the service after attempting to add one or more new annotations.
  */
 export function addAnnotations(
   requestOptions: IAddAnnotationsRequestOptions
@@ -49,7 +51,7 @@ export function addAnnotations(
   if (requestOptions.features && requestOptions.features.length) {
     requestOptions.features.forEach(anno => enrichAnnotation(anno));
   }
-  
+
   // in v2 of rest-js 'adds' will be deprecated in favor of 'features'
   if (requestOptions.adds && requestOptions.adds.length) {
     requestOptions.adds.forEach(anno => enrichAnnotation(anno));

--- a/packages/annotations/src/create.ts
+++ b/packages/annotations/src/create.ts
@@ -26,6 +26,7 @@ export interface ICreateAnnoRequestOptions extends IUserRequestOptions {
 /**
  * ```js
  * import { createAnnotationService } from "@esri/hub-annotations";
+ * //
  * createAnnotationService({
  *   orgId: "yb9",
  *   authentication
@@ -35,7 +36,7 @@ export interface ICreateAnnoRequestOptions extends IUserRequestOptions {
  *
  * Create a new hosted annotation feature service for an organization if ArcGIS Hub hasn't already been enabled.
  * @param requestOptions - request options that include authentication
- * @returns A Promise that will resolve with response from the service after attempting to create a new hosted annotation service.
+ * @returns A Promise that will resolve with the response from the service after attempting to create a new hosted annotation service.
  */
 export function createAnnotationService(
   requestOptions: ICreateAnnoRequestOptions
@@ -144,7 +145,7 @@ export function createAnnotationService(
         });
         /*
           firing off all the requests at once would be preferable, but in my own testing,
-          the sharing in particular wasn't updated consistently
+          the sharing wasn't updated consistently
 
           return Promise.all([ ... ])
         */

--- a/packages/annotations/src/delete.ts
+++ b/packages/annotations/src/delete.ts
@@ -10,17 +10,18 @@ import {
 /**
  * ```js
  * import { deleteAnnotations } from "@esri/hub-annotations";
+ * //
  * deleteAnnotations({
  *   url: annotationsUrl + "/0",
  *   // an array of featureIds
- *   objectIds: [1]
+ *   objectIds: [ 1 ]
  * })
  *   .then(response);
  * ```
  *
  * Delete an annotation from ArcGIS Hub.
  * @param requestOptions - request options that may include authentication
- * @returns A Promise that will resolve with response from the service after attempting to delete annotations.
+ * @returns A Promise that will resolve with the response from the service after attempting to delete annotations.
  */
 
 export function deleteAnnotations(

--- a/packages/annotations/src/index.ts
+++ b/packages/annotations/src/index.ts
@@ -7,5 +7,7 @@ export * from "./create";
 export * from "./add";
 export * from "./update";
 export * from "./delete";
+export * from "./vote";
+
 // this is enough for the file to be omitted from the umd and esm, but it will still be in the cjs
 // export * from "./layer-definition";

--- a/packages/annotations/src/layer-definition.ts
+++ b/packages/annotations/src/layer-definition.ts
@@ -202,6 +202,15 @@ export const annotationServiceDefinition: ILayerDefinition = {
       editable: true,
       domain: null,
       defaultValue: null
+    },
+    {
+      name: "value",
+      type: "esriFieldTypeInteger",
+      alias: "value",
+      nullable: true,
+      editable: true,
+      domain: null,
+      defaultValue: null
     }
   ],
   geometryType: "esriGeometryPolygon",

--- a/packages/annotations/src/search.ts
+++ b/packages/annotations/src/search.ts
@@ -22,7 +22,7 @@ export interface IResourceObject {
 /**
  * ```js
  * import { searchAnnotations } from "@esri/hub-annotations";
- *
+ * //
  * searchAnnotations({ url: annotationsUrl + "/0" })
  *   .then(response => {
  *     // {

--- a/packages/annotations/src/update.ts
+++ b/packages/annotations/src/update.ts
@@ -10,6 +10,7 @@ import {
 /**
  * ```js
  * import { updateAnnotations } from "@esri/hub-annotations";
+ * //
  * updateAnnotations({
  *   url: annotationsUrl + "/0",
  *   features: [{
@@ -24,7 +25,7 @@ import {
  * ```
  * Update an annotation in ArcGIS Hub.
  * @param requestOptions - request options that may include authentication
- * @returns A Promise that will resolve with response from the service after attempting to update one or more annotations.
+ * @returns A Promise that will resolve with the response from the service after attempting to update one or more annotations.
  */
 
 export function updateAnnotations(

--- a/packages/annotations/src/vote.ts
+++ b/packages/annotations/src/vote.ts
@@ -1,0 +1,83 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import {
+  addFeatures,
+  IAddFeaturesRequestOptions,
+  IAddFeaturesResult
+} from "@esri/arcgis-rest-feature-service";
+
+import { IAnnoFeature } from "./add";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { searchAnnotations } from "./search";
+
+export interface IVoteRequestOptions extends IRequestOptions {
+  url: string;
+  annotation: IAnnoFeature;
+  /**
+   * Set to 'true' in order to vote another annotation down.
+   */
+  downVote?: boolean;
+}
+
+/**
+ * ```js
+ * import { vote } from "@esri/hub-annotations";
+ * //
+ * voteOnAnnotation({
+ *   url,
+ *   annotation: { attributes: {} },
+ *   authentication
+ * })
+ *   .then(response);
+ * ```
+ * Upvote (or downvote) another annotation.
+ * @param requestOptions - request options that may include authentication
+ * @returns A Promise that will resolve with the response from the service after attempting to vote on an annotation.
+ */
+export function voteOnAnnotation(
+  requestOptions: IVoteRequestOptions
+): Promise<IAddFeaturesResult> {
+  const annotation = requestOptions.annotation;
+  const auth = requestOptions.authentication as UserSession;
+  const url = requestOptions.url;
+
+  if (!auth) {
+    throw Error(`Voting by anonymous users is not supported.`);
+  }
+
+  if (annotation.attributes.author === auth.username) {
+    throw Error(`Users may not vote on their own comment/idea.`);
+  }
+
+  return searchAnnotations({
+    url,
+    where: `parent_id = '${annotation.attributes.OBJECTID}' AND author = '${
+      auth.username
+    }'`
+  }).then(searchResponse => {
+    // dont let folks vote on an idea more than once
+    if (searchResponse.data.length > 0) {
+      throw Error(`Users may only vote on a comment/idea once.`);
+      // to do: allow a vote update
+    }
+    const options: IAddFeaturesRequestOptions = {
+      url,
+      features: [
+        {
+          attributes: {
+            value: requestOptions.downVote ? -1 : 1,
+            parent_id: annotation.attributes.OBJECTID,
+            target: annotation.attributes.target,
+            description: "this is a vote.",
+            status: "approved",
+            source: annotation.attributes.source
+          }
+        }
+      ],
+      authentication: requestOptions.authentication
+    };
+    return addFeatures(options);
+  });
+}

--- a/packages/annotations/test/create.test.ts
+++ b/packages/annotations/test/create.test.ts
@@ -124,6 +124,7 @@ describe("createAnnotationService", () => {
 
     createAnnotationService(options).then(() => {
       expect(searchParamsSpy.calls.count()).toEqual(1);
+      expect(portalParamsSpy.calls.count()).toEqual(1);
       expect(createParamsSpy.calls.count()).toEqual(1);
       expect(shareParamsSpy.calls.count()).toEqual(1);
       expect(updateParamsSpy.calls.count()).toEqual(1);

--- a/packages/annotations/test/mocks/anno_search.ts
+++ b/packages/annotations/test/mocks/anno_search.ts
@@ -90,6 +90,33 @@ export const annoQueryResponse = {
   ]
 };
 
+// search is specifically for previous votes on an annotation by the same user, so only one feature returned
+export const annoQueryVoteResponse = {
+  objectIdFieldName: "OBJECTID",
+  globalIdFieldName: "",
+  geometryType: "esriGeometryPolygon",
+  spatialReference: {
+    wkid: 4326,
+    latestWkid: 4326
+  },
+  features: [
+    {
+      attributes: {
+        OBJECTID: 2,
+        author: "casey",
+        source: "hub.js",
+        status: "approved",
+        target: "something",
+        description: null as string,
+        created_at: 1349395200001,
+        updated_at: 1349395200001,
+        dataset_id: "xds466",
+        value: -1
+      }
+    }
+  ]
+};
+
 export const userResponseCasey = {
   username: "casey",
   fullName: "Casey Shaft",

--- a/packages/annotations/test/vote.test.ts
+++ b/packages/annotations/test/vote.test.ts
@@ -1,0 +1,326 @@
+import { voteOnAnnotation } from "../src/vote";
+import {
+  annoQueryVoteResponse,
+  annoQueryResponseEmpty,
+  userResponseJones
+} from "./mocks/anno_search";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import {
+  IQueryFeaturesRequestOptions,
+  IAddFeaturesRequestOptions,
+  IDeleteFeaturesRequestOptions
+} from "@esri/arcgis-rest-feature-service";
+import * as featureService from "@esri/arcgis-rest-feature-service";
+import * as user from "@esri/arcgis-rest-users";
+
+export const addFeaturesResponse = {
+  addResults: [
+    {
+      objectId: 1001,
+      success: true
+    }
+  ]
+};
+
+export const deleteFeaturesResponse = {
+  deleteResults: [
+    {
+      objectId: 2,
+      success: true
+    }
+  ]
+};
+
+const TOMORROW = (function() {
+  const now = new Date();
+  now.setDate(now.getDate() + 1);
+  return now;
+})();
+
+const MOCK_USER_SESSION = new UserSession({
+  username: "casey",
+  password: "123456",
+  token: "fake-token",
+  tokenExpires: TOMORROW
+});
+
+const annoUrl =
+  "https://services.arcgis.com/xyz/arcgis/rest/services/hub_annotations/FeatureServer/0";
+
+describe("voteOnAnnotation", () => {
+  it("should do upvoting", done => {
+    const queryParamsSpy = spyOn(
+      featureService,
+      "queryFeatures"
+    ).and.returnValue(
+      new Promise(resolve => {
+        resolve(annoQueryResponseEmpty);
+      })
+    );
+
+    // stub add features
+    const addParamsSpy = spyOn(featureService, "addFeatures").and.returnValue(
+      new Promise(resolve => {
+        resolve(addFeaturesResponse);
+      })
+    );
+
+    const options = {
+      url: annoUrl,
+      annotation: {
+        attributes: {
+          OBJECTID: 123,
+          description:
+            "what do we want? bike lanes! when do we want them? now!",
+          target:
+            "https://services.arcgis.com/xyz/arcgis/rest/services/CityX_bikeshare_locations/FeatureServer/0",
+          source: "hub.js",
+          author: "otherguy"
+        }
+      },
+      authentication: MOCK_USER_SESSION
+    };
+
+    voteOnAnnotation(options)
+      .then(() => {
+        expect(queryParamsSpy.calls.count()).toEqual(1);
+        expect(addParamsSpy.calls.count()).toEqual(1);
+        const queryOpts = queryParamsSpy.calls.argsFor(
+          0
+        )[0] as IQueryFeaturesRequestOptions;
+        const addOpts = addParamsSpy.calls.argsFor(
+          0
+        )[0] as IAddFeaturesRequestOptions;
+        expect(queryOpts.url).toBe(annoUrl);
+        expect(queryOpts.where).toBe("parent_id = 123 AND author = 'casey'");
+        expect(addOpts.url).toBe(annoUrl);
+        expect(addOpts.features).toEqual([
+          {
+            attributes: {
+              value: 1,
+              parent_id: 123,
+              target:
+                "https://services.arcgis.com/xyz/arcgis/rest/services/CityX_bikeshare_locations/FeatureServer/0",
+              description: "this is a vote.",
+              status: "approved",
+              source: "hub.js"
+            }
+          }
+        ]);
+        done();
+      })
+      .catch(() => {
+        fail();
+      });
+  });
+
+  it("should do downvoting", done => {
+    const queryParamsSpy = spyOn(
+      featureService,
+      "queryFeatures"
+    ).and.returnValue(
+      new Promise(resolve => {
+        resolve(annoQueryResponseEmpty);
+      })
+    );
+
+    // stub add features
+    const addParamsSpy = spyOn(featureService, "addFeatures").and.returnValue(
+      new Promise(resolve => {
+        resolve(addFeaturesResponse);
+      })
+    );
+
+    const options = {
+      url: annoUrl,
+      downVote: true,
+      annotation: {
+        attributes: {
+          OBJECTID: 123,
+          description:
+            "what do we want? bike lanes! when do we want them? now!",
+          target:
+            "https://services.arcgis.com/xyz/arcgis/rest/services/CityX_bikeshare_locations/FeatureServer/0",
+          source: "hub.js",
+          author: "otherguy"
+        }
+      },
+      authentication: MOCK_USER_SESSION
+    };
+
+    voteOnAnnotation(options)
+      .then(() => {
+        expect(queryParamsSpy.calls.count()).toEqual(1);
+        expect(addParamsSpy.calls.count()).toEqual(1);
+        const queryOpts = queryParamsSpy.calls.argsFor(
+          0
+        )[0] as IQueryFeaturesRequestOptions;
+        const addOpts = addParamsSpy.calls.argsFor(
+          0
+        )[0] as IAddFeaturesRequestOptions;
+        expect(queryOpts.url).toBe(annoUrl);
+        expect(queryOpts.where).toBe("parent_id = 123 AND author = 'casey'");
+        expect(addOpts.url).toBe(annoUrl);
+        expect(addOpts.features).toEqual([
+          {
+            attributes: {
+              value: -1,
+              parent_id: 123,
+              target:
+                "https://services.arcgis.com/xyz/arcgis/rest/services/CityX_bikeshare_locations/FeatureServer/0",
+              description: "this is a vote.",
+              status: "approved",
+              source: "hub.js"
+            }
+          }
+        ]);
+        done();
+      })
+      .catch(() => {
+        fail();
+      });
+  });
+
+  it("should allow a user to switch their vote", done => {
+    const queryParamsSpy = spyOn(
+      featureService,
+      "queryFeatures"
+    ).and.returnValue(
+      new Promise(resolve => {
+        resolve(annoQueryVoteResponse);
+      })
+    );
+
+    // stub add features
+    const deleteParamsSpy = spyOn(
+      featureService,
+      "deleteFeatures"
+    ).and.returnValue(
+      new Promise(resolve => {
+        resolve(deleteFeaturesResponse);
+      })
+    );
+
+    const options = {
+      url: annoUrl,
+      annotation: {
+        attributes: {
+          OBJECTID: 123,
+          description:
+            "what do we want? bike lanes! when do we want them? now!",
+          target:
+            "https://services.arcgis.com/xyz/arcgis/rest/services/CityX_bikeshare_locations/FeatureServer/0",
+          source: "hub.js",
+          author: "otherguy"
+        }
+      },
+      authentication: MOCK_USER_SESSION
+    };
+
+    voteOnAnnotation(options)
+      .then(() => {
+        expect(queryParamsSpy.calls.count()).toEqual(1);
+        expect(deleteParamsSpy.calls.count()).toEqual(1);
+        const queryOpts = queryParamsSpy.calls.argsFor(
+          0
+        )[0] as IQueryFeaturesRequestOptions;
+        const deleteOpts = deleteParamsSpy.calls.argsFor(
+          0
+        )[0] as IDeleteFeaturesRequestOptions;
+        expect(queryOpts.url).toBe(annoUrl);
+        expect(queryOpts.where).toBe("parent_id = 123 AND author = 'casey'");
+        expect(deleteOpts.url).toBe(annoUrl);
+        expect(deleteOpts.objectIds).toEqual([2]);
+        done();
+      })
+      .catch(() => {
+        fail();
+      });
+  });
+
+  it("should throw an error if no auth is passed", done => {
+    const options = {
+      url: annoUrl,
+      annotation: {
+        attributes: {
+          OBJECTID: 123,
+          description:
+            "what do we want? bike lanes! when do we want them? now!",
+          target:
+            "https://services.arcgis.com/xyz/arcgis/rest/services/CityX_bikeshare_locations/FeatureServer/0",
+          source: "hub.js",
+          author: "otherguy"
+        }
+      },
+      authentication: null as any
+    };
+
+    voteOnAnnotation(options).catch(err => {
+      expect(err.message).toEqual(
+        "Voting by anonymous users is not supported."
+      );
+      done();
+    });
+  });
+
+  it("throw an error instead of helping a user upvote their own idea", done => {
+    const options = {
+      url: annoUrl,
+      annotation: {
+        attributes: {
+          OBJECTID: 123,
+          description:
+            "what do we want? bike lanes! when do we want them? now!",
+          target:
+            "https://services.arcgis.com/xyz/arcgis/rest/services/CityX_bikeshare_locations/FeatureServer/0",
+          source: "hub.js",
+          author: "casey"
+        }
+      },
+      authentication: MOCK_USER_SESSION
+    };
+
+    voteOnAnnotation(options).catch(err => {
+      expect(err.message).toEqual(
+        "Users may not vote on their own comment/idea."
+      );
+      done();
+    });
+  });
+
+  it("throw an error instead of logging duplicate votes for a user", done => {
+    const queryParamsSpy = spyOn(
+      featureService,
+      "queryFeatures"
+    ).and.returnValue(
+      new Promise(resolve => {
+        resolve(annoQueryVoteResponse);
+      })
+    );
+
+    const options = {
+      url: annoUrl,
+      downVote: true,
+      annotation: {
+        attributes: {
+          OBJECTID: 123,
+          description:
+            "what do we want? bike lanes! when do we want them? now!",
+          target:
+            "https://services.arcgis.com/xyz/arcgis/rest/services/CityX_bikeshare_locations/FeatureServer/0",
+          source: "hub.js",
+          author: "jones"
+        }
+      },
+      authentication: MOCK_USER_SESSION
+    };
+
+    voteOnAnnotation(options).catch(err => {
+      expect(queryParamsSpy.calls.count()).toEqual(1);
+      expect(err.message).toEqual(
+        "Users may only vote on a comment/idea once."
+      );
+      done();
+    });
+  });
+});


### PR DESCRIPTION
resolves #110 
```js
const orgId = "uCX...";
const authentication = new arcgisRest.UserSession({ username, password })

const serviceUrl = await arcgisHub.getAnnotationServiceUrl(orgId)
const url = `${serviceUrl}/0`;

const searchResponse = await arcgisHub.searchAnnotations({
  url,
  where: "OBJECTID = 1"
});

arcgisHub.voteOnAnnotation({
  url,
  authentication,
  annotation: searchResponse.data[0],
  downVote: true
});
```
to do:
-  [x] tests e5fddb3
