### PR TITLE
Add maybeAdd util fn

### DIFF
--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+/* Copyright (c) 2018-2019 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
 /**
@@ -117,7 +117,7 @@ export function createId(prefix: string = "i"): string {
 
 /**
  * If value is not null, push it into an array, or append as a property of an object.
- * This is a very useful companion to the getProp utility. Note: the array or object
+ * This is a very useful companion to [getProp()](../getProp/). Note: the array or object
  * that is passed in is cloned before being appended to.
  *
  * Allows for code like:
@@ -141,13 +141,13 @@ export function createId(prefix: string = "i"): string {
  *  }
  * };
  *
- * // lets pluck some id's into an array...
+ * // lets pluck some values and place them in an array...
  * let vals = maybeAdd([], getProp(obj, 'item.properties.sourceId'));
  * // vals => ['3ef]
  *
- * // now try to get a value from a property that is missing...
+ * // try to get a value from a property that is missing...
  * vals = maybeAdd(vals, getProp(obj, 'item.properties.childId'));
- * // vals => ['3ef]
+ * // vals => []
  *
  * // Let's pluck some details into an object. This time we'll use an array
  * // of properties to pluck out of the source
@@ -170,7 +170,7 @@ export function createId(prefix: string = "i"): string {
  * ```
  * @param objectOrArray - the object (or array) to update
  * @param val - the possibly null value
- * @param key - optional key (used when appending to an objeect)
+ * @param key - optional key (used when appending to an object)
  */
 export function maybeAdd(
   objectOrArray: any,

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -116,15 +116,15 @@ export function createId(prefix: string = "i"): string {
 }
 
 /**
- * If value is not null, push it into an array, or append as a property of an object.
- * This is a very useful companion to [getProp()](../getProp/). Note: the array or object
- * that is passed in is cloned before being appended to.
+ * Append or replace a value on an object, using a specified key, if the value is not null.
+ * This is a very useful companion to the [getProp()](../getProp/) utility.
+ *
+ * Note: object that is passed in is cloned before the property is appended.
  *
  * Allows for code like:
  *
  * ```js
- * // example object
- * let obj = {
+ * let model = {
  *  item: {
  *    title: 'some example object',
  *    description: 'this is some longer text',
@@ -141,16 +141,7 @@ export function createId(prefix: string = "i"): string {
  *  }
  * };
  *
- * // lets pluck some values and place them in an array...
- * let vals = maybeAdd([], getProp(obj, 'item.properties.sourceId'));
- * // vals => ['3ef]
- *
- * // try to get a value from a property that is missing...
- * vals = maybeAdd(vals, getProp(obj, 'item.properties.childId'));
- * // vals => []
- *
- * // Let's pluck some details into an object. This time we'll use an array
- * // of properties to pluck out of the source
+ * // Let's extract some details into an object.
  * const summary = [
  *  'item.title',
  *  'item.description',
@@ -158,7 +149,7 @@ export function createId(prefix: string = "i"): string {
  *  'data.parcelLayer.primaryField'].reduce((acc, prop) => {
  *   // create the property name... you could do this however...
  *   let propName = prop.split('.').reverse()[0];
- *   return maybeAdd(acc, getProp(obj, key), propName);
+ *   return maybeAdd(propName, getProp(model, key), acc);
  * }, {});
  *
  * // summary =>
@@ -168,27 +159,76 @@ export function createId(prefix: string = "i"): string {
  * //   primaryField: 'PIN'
  * // }
  * ```
- * @param objectOrArray - the object (or array) to update
+ * @param key - key to use when appending to the object
  * @param val - the possibly null value
- * @param key - optional key (used when appending to an object)
+ * @param target - the object to update
  */
-export function maybeAdd(
-  objectOrArray: any,
-  val: any,
-  key: string = null
-): any {
-  // create a clone because mutation makes us sad...
-  const target = cloneObject(objectOrArray);
+export function maybeAdd(key: string, val: any, target: any): any {
   // see if we got something...
   if (val !== null && val !== undefined) {
-    // is target an array?
-    if (Array.isArray(target)) {
-      // push it...
-      target.push(val);
-    } else {
-      // attach using the key
-      target[key] = val;
-    }
+    target = cloneObject(target);
+    // attach using the key
+    target[key] = val;
+  }
+  return target;
+}
+
+/**
+ * Append a value to an array, if the value is not null.
+ * This is a very useful companion to the [getProp()](../getProp/) utility.
+ *
+ * Note: the array that is passed in is cloned before being appended to.
+ *
+ * Allows for code like:
+ * ```js
+ *  // example object
+ * let model = {
+ *  item: {
+ *    id: 'c00',
+ *    title: 'some example object',
+ *    description: 'this is some longer text',
+ *    type: 'Web Map',
+ *    properties: {
+ *      sourceId: '3ef'
+ *    }
+ *  },
+ *  data: {
+ *    theme: 'orange',
+ *    parcelLayer: {
+ *      itemId: '7ca',
+ *      primaryField: 'PIN'
+ *    }
+ *  }
+ * };
+ * // lets pluck some id's into an array...
+ * let vals = maybeAdd(getProp(model, 'item.properties.sourceId'), []);
+ * // vals => ['3ef]
+ *
+ * // now try to get a value from a property that is missing...
+ * vals = maybeAdd(getProp(obj, 'item.properties.childId'), vals);
+ * // vals => ['3ef]
+ *
+ * // easily pluck values via property paths
+ * const summary = [
+ *  'item.id',
+ *  'item.properties.sourceId',
+ *  'item.properties.childId',
+ *  'data.parcelLayer.itemId'].reduce((acc, prop) => {
+ *   return maybeAdd(getProp(model, key), acc);
+ * }, []);
+ *
+ * // summary => ['c00', '3ef', '7ca']
+ *
+ * ```
+ *
+ * @param val - the possibly null value
+ * @param target - the array to add the value to
+ */
+export function maybePush(val: any, target: any[]): any[] {
+  if (val !== null && val !== undefined) {
+    // create a clone because mutation makes us sad...
+    target = cloneObject(target) as any[];
+    target.push(val);
   }
   return target;
 }

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -116,23 +116,61 @@ export function createId(prefix: string = "i"): string {
 }
 
 /**
- * If value is not null, push it into an array, or append as a property of an object
+ * If value is not null, push it into an array, or append as a property of an object.
+ * This is a very useful companion to the getProp utility. Note: the array or object
+ * that is passed in is cloned before being appended to.
+ *
  * Allows for code like:
- * ```js
- * const vals = maybeAdd([], getProp(obj, 'some.deep.path.thatMayBe.undefined'));
- * ```
- *
- * or
  *
  * ```js
- * let summary = {}
- * ['item.title', 'item.description', 'item.snippet'].forEach((k) => {
- *   summary = maybeAdd(summary, getProp(model, k));
- * })
+ * // example object
+ * let obj = {
+ *  item: {
+ *    title: 'some example object',
+ *    description: 'this is some longer text',
+ *    type: 'Web Map',
+ *    properties: {
+ *      sourceId: '3ef'
+ *    }
+ *  },
+ *  data: {
+ *    theme: 'orange',
+ *    parcelLayer: {
+ *      primaryField: 'PIN'
+ *    }
+ *  }
+ * };
+ *
+ * // lets pluck some id's into an array...
+ * let vals = maybeAdd([], getProp(obj, 'item.properties.sourceId'));
+ * // vals => ['3ef]
+ *
+ * // now try to get a value from a property that is missing...
+ * vals = maybeAdd(vals, getProp(obj, 'item.properties.childId'));
+ * // vals => ['3ef]
+ *
+ * // Let's pluck some details into an object. This time we'll use an array
+ * // of properties to pluck out of the source
+ * const summary = [
+ *  'item.title',
+ *  'item.description',
+ *  'item.missingProp',
+ *  'data.parcelLayer.primaryField'].reduce((acc, prop) => {
+ *   // create the property name... you could do this however...
+ *   let propName = prop.split('.').reverse()[0];
+ *   return maybeAdd(acc, getProp(obj, key), propName);
+ * }, {});
+ *
+ * // summary =>
+ * // {
+ * //   title: 'some example object',
+ * //   description: 'this is some longer text',
+ * //   primaryField: 'PIN'
+ * // }
  * ```
- * @param objectOrArray
- * @param val
- * @param key
+ * @param objectOrArray - the object (or array) to update
+ * @param val - the possibly null value
+ * @param key - optional key (used when appending to an objeect)
  */
 export function maybeAdd(
   objectOrArray: any,

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -34,7 +34,7 @@ export function cloneObject(obj: { [index: string]: any }) {
  * Get a property out of a deeply nested object
  * Does not handle anything but nested object graph
  */
-export function getProp(obj: { [index: string]: any }, path: string) {
+export function getProp(obj: { [index: string]: any }, path: string): any {
   return path.split(".").reduce(function(prev, curr) {
     /* istanbul ignore next no need to test undefined scenario */
     return prev ? prev[curr] : undefined;
@@ -45,7 +45,7 @@ export function getProp(obj: { [index: string]: any }, path: string) {
  * Given an array of objects, convert into an object, with each
  * entry assigned the key via the keyprop
  */
-export function arrayToObject(arr: any[], key: string) {
+export function arrayToObject(arr: any[], key: string): any {
   return arr.reduce((hash, entry) => {
     hash[getProp(entry, key)] = entry;
     return hash;
@@ -113,6 +113,46 @@ export function createId(prefix: string = "i"): string {
   return `${prefix}${Math.random()
     .toString(36)
     .substr(2, 8)}`;
+}
+
+/**
+ * If value is not null, push it into an array, or append as a property of an object
+ * Allows for code like:
+ * ```js
+ * const vals = maybeAdd([], getProp(obj, 'some.deep.path.thatMayBe.undefined'));
+ * ```
+ *
+ * or
+ *
+ * ```js
+ * let summary = {}
+ * ['item.title', 'item.description', 'item.snippet'].forEach((k) => {
+ *   summary = maybeAdd(summary, getProp(model, k));
+ * })
+ * ```
+ * @param objectOrArray
+ * @param val
+ * @param key
+ */
+export function maybeAdd(
+  objectOrArray: any,
+  val: any,
+  key: string = null
+): any {
+  // create a clone because mutation makes us sad...
+  const target = cloneObject(objectOrArray);
+  // see if we got something...
+  if (val !== null && val !== undefined) {
+    // is target an array?
+    if (Array.isArray(target)) {
+      // push it...
+      target.push(val);
+    } else {
+      // attach using the key
+      target[key] = val;
+    }
+  }
+  return target;
 }
 
 /**

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -426,5 +426,40 @@ describe("util functions", () => {
       expect(chk.prop).toBe("val", "should keep existing prop");
       expect(chk.arr).toBe(a, "should append in array");
     });
+
+    it("deep object test", () => {
+      const m = {
+        item: {
+          id: "bc3",
+          properties: {
+            source: {
+              itemId: "3ef"
+            },
+            fieldworker: {
+              itemId: "7fe"
+            }
+          }
+        },
+        data: {
+          values: {
+            webmap: "3c4"
+          }
+        }
+      };
+      const props = [
+        "item.id",
+        "item.properties.source.itemId",
+        "item.properties.fieldworker.itemId",
+        "item.properties.stakeholder.itemId",
+        "data.values.webmap"
+      ];
+      const ids = props.reduce((acc, key) => {
+        return maybeAdd(acc, getProp(m, key));
+      }, []);
+      expect(ids.length).toBe(4, "should have 4 entries");
+      ["bc3", "3ef", "7fe", "3c4"].forEach(k => {
+        expect(ids.indexOf(k)).toBeGreaterThan(-1, `should include ${k}`);
+      });
+    });
   });
 });

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -8,7 +8,8 @@ import {
   compose,
   camelize,
   createId,
-  maybeAdd
+  maybeAdd,
+  maybePush
 } from "../src/util";
 
 describe("util functions", () => {
@@ -346,9 +347,9 @@ describe("util functions", () => {
     });
   });
 
-  describe("maybeAdd utility", () => {
+  describe("maybePush utility", () => {
     it("should push a value into an array", () => {
-      const chk = maybeAdd(["one"], "two");
+      const chk = maybePush("two", ["one"]);
       expect(chk.length).toBe(2, "should add the value");
       expect(chk[0]).toBe("one", "should have the original value");
       expect(chk[1]).toBe("two", "should have the new value");
@@ -358,75 +359,23 @@ describe("util functions", () => {
       const o = {
         color: "red"
       };
-      const chk = maybeAdd([], o);
+      const chk = maybePush(o, []);
       expect(chk.length).toBe(1, "should add the value");
       expect(chk[0].color).toBe("red", "should add the value");
       expect(chk[0]).toBe(o, "should push the actual value in");
     });
 
     it("should not push null", () => {
-      const chk = maybeAdd(["one"], null);
+      const chk = maybePush(null, ["one"]);
       expect(chk.length).toBe(1, "should add the value");
       expect(chk[0]).toBe("one", "should have the original value");
     });
 
     it("should not push undefined", () => {
-      const chk = maybeAdd(["one"], undefined);
+      const chk = maybePush(undefined, ["one"]);
       expect(chk.length).toBe(1, "should add the value");
       expect(chk[0]).toBe("one", "should have the original value");
     });
-
-    it("should append key w value", () => {
-      const m = {
-        prop: "val"
-      };
-      const chk = maybeAdd(m, "skywalker", "lastName");
-      expect(chk.prop).toBe("val", "should have existing vals");
-      expect(chk.lastName).toBe("skywalker", "should add the new one");
-    });
-
-    it("should not append null or undefined key", () => {
-      const m = {
-        prop: "val"
-      };
-      const chk = maybeAdd(m, null, "lastName");
-      expect(chk.prop).toBe("val", "should have existing vals");
-      expect(chk.lastName).toBeUndefined("should not add");
-      const chk2 = maybeAdd(m, undefined, "lastName");
-      expect(chk2.prop).toBe("val", "should have existing vals");
-      expect(chk2.lastName).toBeUndefined("should not add");
-    });
-
-    it("should replace key w value", () => {
-      const m = {
-        prop: "val"
-      };
-      const chk = maybeAdd(m, "skywalker", "prop");
-      expect(chk.prop).toBe("skywalker", "should add the new one");
-    });
-
-    it("should replace key w obj", () => {
-      const m = {
-        prop: "val"
-      };
-      const o = {
-        color: "red"
-      };
-      const chk = maybeAdd(m, o, "properties");
-      expect(chk.prop).toBe("val", "should keep existing prop");
-      expect(chk.properties).toBe(o, "should append in object");
-    });
-
-    it("should attach array as prop", () => {
-      const m = {
-        prop: "val"
-      };
-      const a = ["this", "is", "arry"];
-      const chk = maybeAdd(m, a, "arr");
-      expect(chk.prop).toBe("val", "should keep existing prop");
-      expect(chk.arr).toBe(a, "should append in array");
-    });
-
     it("deep object test", () => {
       const m = {
         item: {
@@ -454,12 +403,65 @@ describe("util functions", () => {
         "data.values.webmap"
       ];
       const ids = props.reduce((acc, key) => {
-        return maybeAdd(acc, getProp(m, key));
+        return maybePush(getProp(m, key), acc);
       }, []);
       expect(ids.length).toBe(4, "should have 4 entries");
       ["bc3", "3ef", "7fe", "3c4"].forEach(k => {
         expect(ids.indexOf(k)).toBeGreaterThan(-1, `should include ${k}`);
       });
+    });
+  });
+
+  describe("maybeAdd utility", () => {
+    it("should append key w value", () => {
+      const m = {
+        prop: "val"
+      };
+      const chk = maybeAdd("lastName", "skywalker", m);
+      expect(chk.prop).toBe("val", "should have existing vals");
+      expect(chk.lastName).toBe("skywalker", "should add the new one");
+    });
+
+    it("should not append null or undefined key", () => {
+      const m = {
+        prop: "val"
+      };
+      const chk = maybeAdd("lastName", null, m);
+      expect(chk.prop).toBe("val", "should have existing vals");
+      expect(chk.lastName).toBeUndefined("should not add");
+      const chk2 = maybeAdd("lastName", undefined, m);
+      expect(chk2.prop).toBe("val", "should have existing vals");
+      expect(chk2.lastName).toBeUndefined("should not add");
+    });
+
+    it("should replace key w value", () => {
+      const m = {
+        prop: "val"
+      };
+      const chk = maybeAdd("prop", "skywalker", m);
+      expect(chk.prop).toBe("skywalker", "should add the new one");
+    });
+
+    it("should replace key w obj", () => {
+      const m = {
+        prop: "val"
+      };
+      const o = {
+        color: "red"
+      };
+      const chk = maybeAdd("properties", o, m);
+      expect(chk.prop).toBe("val", "should keep existing prop");
+      expect(chk.properties).toBe(o, "should append in object");
+    });
+
+    it("should attach array as prop", () => {
+      const m = {
+        prop: "val"
+      };
+      const a = ["this", "is", "arry"];
+      const chk = maybeAdd("arr", a, m);
+      expect(chk.prop).toBe("val", "should keep existing prop");
+      expect(chk.arr).toBe(a, "should append in array");
     });
 
     it("deep object into object test", () => {
@@ -487,7 +489,7 @@ describe("util functions", () => {
       ];
       const chk = props.reduce((acc, key) => {
         const propName = key.split(".").reverse()[0];
-        return maybeAdd(acc, getProp(m, key), propName);
+        return maybeAdd(propName, getProp(m, key), acc);
       }, {}) as any;
 
       expect(chk.title).toBe(m.item.title, "should have title");

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -417,7 +417,7 @@ describe("util functions", () => {
       expect(chk.properties).toBe(o, "should append in object");
     });
 
-    it("should replace key w obj", () => {
+    it("should attach array as prop", () => {
       const m = {
         prop: "val"
       };
@@ -460,6 +460,48 @@ describe("util functions", () => {
       ["bc3", "3ef", "7fe", "3c4"].forEach(k => {
         expect(ids.indexOf(k)).toBeGreaterThan(-1, `should include ${k}`);
       });
+    });
+
+    it("deep object into object test", () => {
+      const m = {
+        item: {
+          title: "some example object",
+          description: "this is some longer text",
+          type: "Web Map",
+          properties: {
+            sourceId: "3ef"
+          }
+        },
+        data: {
+          theme: "orange",
+          parcelLayer: {
+            primaryField: "PIN"
+          }
+        }
+      };
+      const props = [
+        "item.title",
+        "item.description",
+        "item.missingProp",
+        "data.parcelLayer.primaryField"
+      ];
+      const chk = props.reduce((acc, key) => {
+        const propName = key.split(".").reverse()[0];
+        return maybeAdd(acc, getProp(m, key), propName);
+      }, {}) as any;
+
+      expect(chk.title).toBe(m.item.title, "should have title");
+      expect(chk.description).toBe(
+        m.item.description,
+        "should have description"
+      );
+      expect(chk.primaryField).toBe(
+        m.data.parcelLayer.primaryField,
+        "should have primaryField"
+      );
+      expect(chk.missingProp).not.toBeDefined(
+        "missing prop should not be defined"
+      );
     });
   });
 });

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -7,7 +7,8 @@ import {
   without,
   compose,
   camelize,
-  createId
+  createId,
+  maybeAdd
 } from "../src/util";
 
 describe("util functions", () => {
@@ -293,7 +294,12 @@ describe("util functions", () => {
     const inc = (x: number) => x + 1;
 
     expect(typeof compose).toEqual("function");
-    expect(compose(sqr, inc)(2)).toEqual(sqr(inc(2)));
+    expect(
+      compose(
+        sqr,
+        inc
+      )(2)
+    ).toEqual(sqr(inc(2)));
     expect(null).toBeNull();
   });
   describe("without ::", () => {
@@ -337,6 +343,88 @@ describe("util functions", () => {
         "other",
         "should append a prefix"
       );
+    });
+  });
+
+  describe("maybeAdd utility", () => {
+    it("should push a value into an array", () => {
+      const chk = maybeAdd(["one"], "two");
+      expect(chk.length).toBe(2, "should add the value");
+      expect(chk[0]).toBe("one", "should have the original value");
+      expect(chk[1]).toBe("two", "should have the new value");
+    });
+
+    it("should push an object into an array", () => {
+      const o = {
+        color: "red"
+      };
+      const chk = maybeAdd([], o);
+      expect(chk.length).toBe(1, "should add the value");
+      expect(chk[0].color).toBe("red", "should add the value");
+      expect(chk[0]).toBe(o, "should push the actual value in");
+    });
+
+    it("should not push null", () => {
+      const chk = maybeAdd(["one"], null);
+      expect(chk.length).toBe(1, "should add the value");
+      expect(chk[0]).toBe("one", "should have the original value");
+    });
+
+    it("should not push undefined", () => {
+      const chk = maybeAdd(["one"], undefined);
+      expect(chk.length).toBe(1, "should add the value");
+      expect(chk[0]).toBe("one", "should have the original value");
+    });
+
+    it("should append key w value", () => {
+      const m = {
+        prop: "val"
+      };
+      const chk = maybeAdd(m, "skywalker", "lastName");
+      expect(chk.prop).toBe("val", "should have existing vals");
+      expect(chk.lastName).toBe("skywalker", "should add the new one");
+    });
+
+    it("should not append null or undefined key", () => {
+      const m = {
+        prop: "val"
+      };
+      const chk = maybeAdd(m, null, "lastName");
+      expect(chk.prop).toBe("val", "should have existing vals");
+      expect(chk.lastName).toBeUndefined("should not add");
+      const chk2 = maybeAdd(m, undefined, "lastName");
+      expect(chk2.prop).toBe("val", "should have existing vals");
+      expect(chk2.lastName).toBeUndefined("should not add");
+    });
+
+    it("should replace key w value", () => {
+      const m = {
+        prop: "val"
+      };
+      const chk = maybeAdd(m, "skywalker", "prop");
+      expect(chk.prop).toBe("skywalker", "should add the new one");
+    });
+
+    it("should replace key w obj", () => {
+      const m = {
+        prop: "val"
+      };
+      const o = {
+        color: "red"
+      };
+      const chk = maybeAdd(m, o, "properties");
+      expect(chk.prop).toBe("val", "should keep existing prop");
+      expect(chk.properties).toBe(o, "should append in object");
+    });
+
+    it("should replace key w obj", () => {
+      const m = {
+        prop: "val"
+      };
+      const a = ["this", "is", "arry"];
+      const chk = maybeAdd(m, a, "arr");
+      expect(chk.prop).toBe("val", "should keep existing prop");
+      expect(chk.arr).toBe(a, "should append in array");
     });
   });
 });


### PR DESCRIPTION
Once you see how this works, you will ask yourself... "Self, how have I lived without this?"

Ok, maybe it's not that awesome, but in Hub-land we do a LOT of data manipulation, and that involves a lot of checking if some deep-nested-property exists, and if to, grabbing it's value and pushing it into another object, or into an array.

`maybeAdd` allows us to drop a lot of the `if(valueExists) { pushValueIntoArray }` code.

Instead we can just 
```js
let ids =[];
ids = maybeAdd(ids, getProp(model, 'item.id'));
ids = maybeAdd(ids, getProp(model, 'item.properties.serviceId'));
ids = maybeAdd(ids, getProp(model, 'item.data.values.webmap'));
```
or get super cool and use it in a reduce...

```js
const ids = ['item.id', 'item.properties.sourceServiceId', 'data.values.webmap'].reduce((acc, key) => {
  return maybeAdd(acc, getProp(model, key));
}, []);
```

And if you wanted to do this with an object?

```js
const idHash = ['item.id', 'item.properties.serviceId', 'data.values.webmap'].reduce((acc, key) => {
  let prop = key.split('.').reverse()[0];
  return maybeAdd(acc, getProp(model, key, prop));
}, {});
```

As good functional citizens, we clone the `arrayOrObject` because mutation makes us sad. The value itself is appended by-ref if an object or array, and by-val if it's a simple type.