### PR TITLE
Invalid `where` parameter fix

### DIFF
--- a/packages/annotations/src/search.ts
+++ b/packages/annotations/src/search.ts
@@ -224,7 +224,7 @@ export function searchAllAnnotationVotes(
   requestOptions.outStatistics = [votesStat];
   // filtering for up votes
   const upVoteClause = "value>0";
-  requestOptions.where += requestOptions.where ? "+AND+" : "";
+  requestOptions.where += requestOptions.where ? " AND " : "";
   requestOptions.where += upVoteClause;
 
   return queryFeatures(requestOptions).then(upVotesResponse => {

--- a/packages/annotations/test/search.test.ts
+++ b/packages/annotations/test/search.test.ts
@@ -287,15 +287,17 @@ describe("searchAllAnnotationVotes", () => {
       })
     );
 
+    const initiativeWhereClause = "dataset_id=initiative123";
     searchAllAnnotationVotes({
       url: annoSearchResponse.results[0].url + "/0",
-      where: "dataset_id=initiative123"
+      where: initiativeWhereClause
     }).then(response => {
       expect(queryParamsSpy.calls.count()).toEqual(2);
       const queryOpts = queryParamsSpy.calls.argsFor(
         0
       )[0] as IQueryFeaturesRequestOptions;
       expect(queryOpts.url).toBe(annoSearchResponse.results[0].url + "/0");
+      expect(queryOpts.where).toContain(initiativeWhereClause + " AND value");
       expect(response).toEqual(allAnnoVoteResponse);
       done();
     });


### PR DESCRIPTION
fixing incorrect where clause construction in `searchAllAnnotationVotes`. 

This is the fix for issue [122](https://github.com/Esri/hub.js/issues/122) 