### PR TITLE
fix: value > vote, loosen delete protection, omit votes from search

### DIFF
--- a/docs/src/_layout.html
+++ b/docs/src/_layout.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, user-scalable=no">
     <title>{{title if title}}{{" | " + titleSegments | join(" |") if titleSegments}}{{" | " if title}}@esri/hub.js</title>
     {% if description %}
-    <meta name="description" content="A modular, high quality toolkit for working with <a href='https://hub.arcgis.com/'>ArcGIS Hub</a>">
+    <meta name="description" content="A modular, high quality toolkit for working with ArcGIS Hub">
     {% endif %}
     <link rel="stylesheet" href="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/1.0.0-rc.7/css/calcite-web.min.css">
     <link rel="stylesheet" href="/hub.js/css/style.css">

--- a/docs/src/_layout.html
+++ b/docs/src/_layout.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, user-scalable=no">
     <title>{{title if title}}{{" | " + titleSegments | join(" |") if titleSegments}}{{" | " if title}}@esri/hub.js</title>
     {% if description %}
-    <meta name="description" content="This is an example of a meta description. This will often show up in search results.">
+    <meta name="description" content="A modular, high quality toolkit for working with <a href='https://hub.arcgis.com/'>ArcGIS Hub</a>">
     {% endif %}
     <link rel="stylesheet" href="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/1.0.0-rc.7/css/calcite-web.min.css">
     <link rel="stylesheet" href="/hub.js/css/style.css">

--- a/packages/annotations/src/layer-definition.ts
+++ b/packages/annotations/src/layer-definition.ts
@@ -32,7 +32,7 @@ export const editorTrackingInfo = {
  */
 export const annotationServiceDefinition: ILayerDefinition = {
   allowGeometryUpdates: true,
-  capabilities: "Query,Editing,Create,Update",
+  capabilities: "Query,Editing,Create,Update,Delete",
   copyrightText: "",
   defaultVisibility: true,
   description: "",
@@ -204,9 +204,9 @@ export const annotationServiceDefinition: ILayerDefinition = {
       defaultValue: null
     },
     {
-      name: "value",
+      name: "vote",
       type: "esriFieldTypeInteger",
-      alias: "value",
+      alias: "vote",
       nullable: true,
       editable: true,
       domain: null,

--- a/packages/annotations/src/search.ts
+++ b/packages/annotations/src/search.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+/* Copyright (c) 2018-2019 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
 import {
@@ -60,6 +60,9 @@ export function searchAnnotations(
       "dataset_id"
     ];
   }
+
+  // upvotes and downvotes should not be returned
+  requestOptions.where += " AND parent_id IS NULL";
 
   return queryFeatures(requestOptions).then(response => {
     const users: string[] = [];

--- a/packages/annotations/src/vote.ts
+++ b/packages/annotations/src/vote.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+/* Copyright (c) 2018-2019 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
 import {
@@ -14,8 +14,7 @@ import {
   IAddFeaturesRequestOptions,
   IDeleteFeaturesRequestOptions,
   IAddFeaturesResult,
-  IDeleteFeaturesResult,
-  IQueryFeaturesResponse
+  IDeleteFeaturesResult
 } from "@esri/arcgis-rest-feature-service";
 
 import { IAnnoFeature } from "./add";
@@ -54,19 +53,15 @@ export function voteOnAnnotation(
   const url = requestOptions.url;
 
   if (!auth) {
-    return new Promise((resolve, reject) => {
-      reject(
-        new ArcGISAuthError(`Voting by anonymous users is not supported.`)
-      );
-    });
+    return Promise.reject(
+      new ArcGISAuthError(`Voting by anonymous users is not supported.`)
+    );
   }
 
   if (annotation.attributes.author === auth.username) {
-    return new Promise((resolve, reject) => {
-      reject(
-        new ArcGISRequestError(`Users may not vote on their own comment/idea.`)
-      );
-    });
+    return Promise.reject(
+      new ArcGISRequestError(`Users may not vote on their own comment/idea.`)
+    );
   }
 
   // searchAnnotations() would make more xhrs for user metadata
@@ -82,9 +77,9 @@ export function voteOnAnnotation(
       // if its a switch vote, call deleteFeatures() to remove the original
       if (
         (!requestOptions.downVote &&
-          queryResponse.features[0].attributes.value === -1) ||
+          queryResponse.features[0].attributes.vote === -1) ||
         (requestOptions.downVote &&
-          queryResponse.features[0].attributes.value === 1)
+          queryResponse.features[0].attributes.vote === 1)
       ) {
         const deleteOptions: IDeleteFeaturesRequestOptions = {
           url,
@@ -110,7 +105,7 @@ export function voteOnAnnotation(
       features: [
         {
           attributes: {
-            value: requestOptions.downVote ? -1 : 1,
+            vote: requestOptions.downVote ? -1 : 1,
             parent_id: annotation.attributes.OBJECTID,
             target: annotation.attributes.target,
             description: "this is a vote.",

--- a/packages/annotations/test/mocks/anno_search.ts
+++ b/packages/annotations/test/mocks/anno_search.ts
@@ -111,7 +111,7 @@ export const annoQueryVoteResponse = {
         created_at: 1349395200001,
         updated_at: 1349395200001,
         dataset_id: "xds466",
-        value: -1
+        vote: -1
       }
     }
   ]

--- a/packages/annotations/test/search.test.ts
+++ b/packages/annotations/test/search.test.ts
@@ -92,7 +92,7 @@ describe("searchAnnotations", () => {
       )[0] as IQueryFeaturesRequestOptions;
 
       expect(opts.url).toBe(annoSearchResponse.results[0].url + "/0");
-      expect(opts.where).toBe("1=0");
+      expect(opts.where).toBe("1=0 AND parent_id IS NULL");
       expect(opts.outFields).toEqual(mockOutFields);
       expect(response).toEqual(annoResponseEmpty);
       done();

--- a/packages/annotations/test/vote.test.ts
+++ b/packages/annotations/test/vote.test.ts
@@ -1,8 +1,7 @@
 import { voteOnAnnotation } from "../src/vote";
 import {
   annoQueryVoteResponse,
-  annoQueryResponseEmpty,
-  userResponseJones
+  annoQueryResponseEmpty
 } from "./mocks/anno_search";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import {
@@ -11,7 +10,6 @@ import {
   IDeleteFeaturesRequestOptions
 } from "@esri/arcgis-rest-feature-service";
 import * as featureService from "@esri/arcgis-rest-feature-service";
-import * as user from "@esri/arcgis-rest-users";
 
 export const addFeaturesResponse = {
   addResults: [
@@ -97,7 +95,7 @@ describe("voteOnAnnotation", () => {
         expect(addOpts.features).toEqual([
           {
             attributes: {
-              value: 1,
+              vote: 1,
               parent_id: 123,
               target:
                 "https://services.arcgis.com/xyz/arcgis/rest/services/CityX_bikeshare_locations/FeatureServer/0",
@@ -164,7 +162,7 @@ describe("voteOnAnnotation", () => {
         expect(addOpts.features).toEqual([
           {
             attributes: {
-              value: -1,
+              vote: -1,
               parent_id: 123,
               target:
                 "https://services.arcgis.com/xyz/arcgis/rest/services/CityX_bikeshare_locations/FeatureServer/0",


### PR DESCRIPTION
* ensure that upvotes and downvotes aren't returned by search
* replace fieldname `value` with `vote`
* ensure that users can delete their own vote
* more descriptive `<meta>` tag in docs

@lisastaehli let me know if the second item in the list above is problematic. if you don't want to blow away your existing service entirely you should be able to add `vote` as an additional field in the ArcGIS Online UI. i'm happy to help if you run into any trouble.

AFFECTS PACKAGES:
@esri/hub-annotations

RESOLVES:
#123, #124, #125, #118