### PR TITLE
fix: fix auth filename in pkg to ensure the umd can be retrieved in observable etc.

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -3,7 +3,7 @@
   "version": "1.8.0",
   "description": "Module to help the community authenticate and interact with ArcGIS Hub.",
   "main": "dist/node/index.js",
-  "unpkg": "dist/umd/hub-auth.umd.js",
+  "unpkg": "dist/umd/auth.umd.js",
   "module": "dist/esm/index.js",
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION

AFFECTS PACKAGES:
@esri/hub-auth