### PR TITLE
first pass at function to get event service item

### DIFF
--- a/packages/events/src/util.ts
+++ b/packages/events/src/util.ts
@@ -22,7 +22,7 @@ import { IItem } from "@esri/arcgis-rest-common-types";
  * Fetch the events service associated with a Hub Site.
  * @param orgId - Identifier of the ArcGIS Online Organization
  * @param requestOptions - request options that may include authentication
- * @returns A Promise that will resolve with an events url for a Hub enabled ArcGIS Online organization.
+ * @returns A Promise that will resolve with the events API url for a Hub enabled ArcGIS Online organization.
  */
 export function getEventServiceUrl(
   orgId: string,
@@ -40,6 +40,35 @@ export function getEventServiceUrl(
     if (view[1]) {
       return `${host}/api/v3/events/${orgId}/${view[1]}/FeatureServer/0`;
     }
+  });
+}
+
+/**
+ * ```js
+ * import { request } from "@esri/arcgis-rest-request";
+ * import { getEventServiceUrl } from "@esri/hub-events";
+ * // org ids can be retrieved via a call to portals/self
+ * request("http://custom.maps.arcgis.com/sharing/rest/portals/self")
+ *   .then(response => {
+ *     getEventServiceUrl(response.id)
+ *       .then(url)
+ *   })
+ * ```
+ * Fetch the events service associated with a Hub Site.
+ * @param orgId - Identifier of the ArcGIS Online Organization
+ * @param requestOptions - request options that may include authentication
+ * @returns A Promise that will resolve with the events feature service url for a Hub enabled ArcGIS Online organization.
+ */
+export function getEventFeatureServiceUrl(
+  orgId: string,
+  requestOptions?: IRequestOptions
+): Promise<string> {
+  return getEventServiceItem(orgId, requestOptions).then(response => {
+    // single-layer service
+    let url = `${response.url}/0`;
+    // force https
+    url = url.replace(/^http:/gi, "https:");
+    return url;
   });
 }
 

--- a/packages/events/src/util.ts
+++ b/packages/events/src/util.ts
@@ -17,9 +17,10 @@ import { IItem } from "@esri/arcgis-rest-common-types";
  *   .then(response => {
  *     getEventServiceUrl(response.id)
  *       .then(url)
+ *          // "https://hub.arcgis.com/api/v3/events/<orgId>..."
  *   })
  * ```
- * Fetch the events service associated with a Hub Site.
+ * Get the Hub REST API endpoint to use for an organization's events
  * @param orgId - Identifier of the ArcGIS Online Organization
  * @param requestOptions - request options that may include authentication
  * @returns A Promise that will resolve with the events API url for a Hub enabled ArcGIS Online organization.
@@ -46,15 +47,16 @@ export function getEventServiceUrl(
 /**
  * ```js
  * import { request } from "@esri/arcgis-rest-request";
- * import { getEventServiceUrl } from "@esri/hub-events";
+ * import { getEventFeatureServiceUrl } from "@esri/hub-events";
  * // org ids can be retrieved via a call to portals/self
  * request("http://custom.maps.arcgis.com/sharing/rest/portals/self")
  *   .then(response => {
- *     getEventServiceUrl(response.id)
+ *     getEventFeatureServiceUrl(response.id)
  *       .then(url)
+ *         // "https://services.arcgis.com/<orgId>/arcgis/rest/services/..."
  *   })
  * ```
- * Fetch the events service associated with a Hub Site.
+ * Fetch the events feature service/view for the Hub organization and given authorization.
  * @param orgId - Identifier of the ArcGIS Online Organization
  * @param requestOptions - request options that may include authentication
  * @returns A Promise that will resolve with the events feature service url for a Hub enabled ArcGIS Online organization.
@@ -123,7 +125,7 @@ export function getEventQueryFromType(
  * // org ids can be retrieved via a call to portals/self
  * request("http://custom.maps.arcgis.com/sharing/rest/portals/self")
  *   .then(response => {
- *     getEventServiceItems(response.id)
+ *     getEventServiceItem(response.id)
  *       .then(itemResponse)
  *   })
  * ```

--- a/packages/events/src/util.ts
+++ b/packages/events/src/util.ts
@@ -27,11 +27,7 @@ export function getEventServiceUrl(
   orgId: string,
   requestOptions?: IRequestOptions
 ): Promise<string> {
-  return searchItems({
-    searchForm: { q: `typekeywords:hubEventsLayer AND orgid:${orgId}` },
-    // mixin requestOptions (if present)
-    ...requestOptions
-  }).then(response => {
+  return getEventServiceItems(orgId, requestOptions).then(response => {
     const eventResponse = response as ISearchResult;
     if (eventResponse.results && eventResponse.results.length > 0) {
       let result;
@@ -117,4 +113,33 @@ export function getEventQueryFromType(
     newOptions.where = typeWhere;
   }
   return newOptions;
+}
+
+/**
+ * ```js
+ * import { request } from "@esri/arcgis-rest-request";
+ * import { getEventServiceItems } from "@esri/hub-events";
+ * // org ids can be retrieved via a call to portals/self
+ * request("http://custom.maps.arcgis.com/sharing/rest/portals/self")
+ *   .then(response => {
+ *     getEventServiceItems(response.id)
+ *       .then(itemResponse)
+ *   })
+ * ```
+ * Fetch the events service associated with a Hub Site.
+ * @param orgId - Identifier of the ArcGIS Online Organization
+ * @param requestOptions - request options that may include authentication
+ * @returns A Promise that will resolve with an events url for a Hub enabled ArcGIS Online organization.
+ */
+export function getEventServiceItems(
+  orgId: string,
+  requestOptions?: IRequestOptions
+): Promise<ISearchResult> {
+  return searchItems({
+    searchForm: { q: `typekeywords:hubEventsLayer AND orgid:${orgId}` },
+    // mixin requestOptions (if present)
+    ...requestOptions
+  }).then(response => {
+    return response;
+  });
 }

--- a/packages/events/test/util.test.ts
+++ b/packages/events/test/util.test.ts
@@ -1,4 +1,8 @@
-import { getEventServiceUrl, getEventQueryFromType } from "../src/util";
+import {
+  getEventServiceUrl,
+  getEventFeatureServiceUrl,
+  getEventQueryFromType
+} from "../src/util";
 import {
   adminEventSearchResponse,
   orgEventSearchResponse,
@@ -90,6 +94,98 @@ describe("getEventServiceUrl", () => {
     );
 
     getEventServiceUrl("v8b").catch(error => {
+      expect(paramsSpy.calls.count()).toEqual(1);
+      const opts = paramsSpy.calls.argsFor(0)[0] as ISearchRequestOptions;
+      expect(opts.searchForm.q).toContain(
+        "typekeywords:hubEventsLayer AND orgid:v8b"
+      );
+      expect(error.message).toBe(
+        "No events service found. Events are likely not enabled."
+      );
+      done();
+    });
+  });
+});
+
+describe("getEventFeatureServiceUrl", () => {
+  it("should return admin event service url", done => {
+    // stub searchItems
+    const paramsSpy = spyOn(items, "searchItems").and.returnValue(
+      new Promise(resolve => {
+        resolve(adminEventSearchResponse);
+      })
+    );
+
+    getEventFeatureServiceUrl("5bc")
+      .then(result => {
+        expect(paramsSpy.calls.count()).toEqual(1);
+        const opts = paramsSpy.calls.argsFor(0)[0] as ISearchRequestOptions;
+        expect(opts.searchForm.q).toContain(
+          "typekeywords:hubEventsLayer AND orgid:5bc"
+        );
+        expect(result).toBe(
+          "https://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/Hub Events/FeatureServer/0"
+        );
+        done();
+      })
+      .catch(() => fail());
+  });
+
+  it("should return org event service url", done => {
+    // stub searchItems
+    const paramsSpy = spyOn(items, "searchItems").and.returnValue(
+      new Promise(resolve => {
+        resolve(orgEventSearchResponse);
+      })
+    );
+
+    getEventFeatureServiceUrl("5bc")
+      .then(result => {
+        expect(paramsSpy.calls.count()).toEqual(1);
+        const opts = paramsSpy.calls.argsFor(0)[0] as ISearchRequestOptions;
+        expect(opts.searchForm.q).toContain(
+          "typekeywords:hubEventsLayer AND orgid:5bc"
+        );
+        expect(result).toBe(
+          "https://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/Hub Events (org)/FeatureServer/0"
+        );
+        done();
+      })
+      .catch(() => fail());
+  });
+
+  it("should return the public event service url", done => {
+    // stub searchItems
+    const paramsSpy = spyOn(items, "searchItems").and.returnValue(
+      new Promise(resolve => {
+        resolve(publicEventSearchResponse);
+      })
+    );
+
+    getEventFeatureServiceUrl("5bc")
+      .then(result => {
+        expect(paramsSpy.calls.count()).toEqual(1);
+        const opts = paramsSpy.calls.argsFor(0)[0] as ISearchRequestOptions;
+        expect(opts.searchForm.q).toContain(
+          "typekeywords:hubEventsLayer AND orgid:5bc"
+        );
+        expect(result).toBe(
+          "https://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/Hub Events (public)/FeatureServer/0"
+        );
+        done();
+      })
+      .catch(() => fail());
+  });
+
+  it("should throw if no event layer is found", done => {
+    // stub searchItems
+    const paramsSpy = spyOn(items, "searchItems").and.returnValue(
+      new Promise(resolve => {
+        resolve(emptyEventSearchResponse);
+      })
+    );
+
+    getEventFeatureServiceUrl("v8b").catch(error => {
       expect(paramsSpy.calls.count()).toEqual(1);
       const opts = paramsSpy.calls.argsFor(0)[0] as ISearchRequestOptions;
       expect(opts.searchForm.q).toContain(


### PR DESCRIPTION
Refactored `getEventServiceUrl` to add a new function `getEventServiceItems` in order for [hub-indexer](https://github.com/ArcGIS/hub-indexer/blob/9677cf6f94d61cc941bb86425963998f27e13f08/packages/api/middleware/events-fetch-feature-service.js#L18) to be able to get the public feature service url. 