### PR TITLE
remove 'Request' from all extended RequestOption interfaces

### DIFF
--- a/packages/annotations/src/search.ts
+++ b/packages/annotations/src/search.ts
@@ -111,7 +111,7 @@ export function searchAnnotations(
   });
 }
 
-export interface ISearchAnnoRequestOptions extends IQueryFeaturesOptions {
+export interface ISearchAnnoOptions extends IQueryFeaturesOptions {
   url: string;
   annotation: IAnnoFeature;
 }
@@ -151,7 +151,7 @@ export interface IVoteResourceObject {
  * @returns A Promise that will resolve with summary statistics for the specified annotation from the annotation service for a Hub enabled ArcGIS Online organization.
  */
 export function searchSingleAnnotationVotes(
-  requestOptions: ISearchAnnoRequestOptions
+  requestOptions: ISearchAnnoOptions
 ): Promise<{ data: IVoteResourceObject[] }> {
   const data: IVoteResourceObject[] = [];
   const annotationId = requestOptions.annotation.attributes.OBJECTID;

--- a/packages/annotations/src/vote.ts
+++ b/packages/annotations/src/vote.ts
@@ -12,15 +12,14 @@ import {
   deleteFeatures,
   queryFeatures,
   IAddFeaturesOptions,
-  IDeleteFeaturesOptions,
-  IQueryFeaturesResponse
+  IDeleteFeaturesOptions
 } from "@esri/arcgis-rest-feature-layer";
 
 import { IAnnoFeature } from "./add";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { IEditFeatureResult } from "@esri/arcgis-rest-feature-layer/dist/esm/helpers";
 
-export interface IVoteRequestOptions extends IRequestOptions {
+export interface IVoteOptions extends IRequestOptions {
   url: string;
   annotation: IAnnoFeature;
   /**
@@ -46,7 +45,7 @@ export interface IVoteRequestOptions extends IRequestOptions {
  * @returns A Promise that will resolve with the response from the service after attempting to vote on an annotation.
  */
 export function voteOnAnnotation(
-  requestOptions: IVoteRequestOptions
+  requestOptions: IVoteOptions
 ): Promise<
   | { addResults?: IEditFeatureResult[] }
   | { deleteResults?: IEditFeatureResult[] }

--- a/packages/events/src/register.ts
+++ b/packages/events/src/register.ts
@@ -4,7 +4,7 @@
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { joinGroup, leaveGroup } from "@esri/arcgis-rest-portal";
 
-export interface IEventRegisterRequestOptions extends IUserRequestOptions {
+export interface IEventRegisterOptions extends IUserRequestOptions {
   /**
    * Identifier for the group associated with the ArcGIS Hub event.
    */
@@ -25,7 +25,7 @@ export interface IEventRegisterRequestOptions extends IUserRequestOptions {
  * @returns A Promise that will resolve with the response from the service.
  */
 export function registerForEvent(
-  requestOptions: IEventRegisterRequestOptions
+  requestOptions: IEventRegisterOptions
 ): Promise<{ success: boolean; groupId: string }> {
   return joinGroup({
     id: requestOptions.groupId,
@@ -48,7 +48,7 @@ export function registerForEvent(
  * @returns A Promise that will resolve with the response from the service.
  */
 export function unregisterForEvent(
-  requestOptions: IEventRegisterRequestOptions
+  requestOptions: IEventRegisterOptions
 ): Promise<{ success: boolean; groupId: string }> {
   return leaveGroup({
     id: requestOptions.groupId,

--- a/packages/initiatives/src/follow.ts
+++ b/packages/initiatives/src/follow.ts
@@ -2,7 +2,7 @@ import { request, IRequestOptions } from "@esri/arcgis-rest-request";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { IUser, getUserUrl } from "@esri/arcgis-rest-portal";
 
-export interface IFollowInitiativeRequestOptions extends IRequestOptions {
+export interface IFollowInitiativeOptions extends IRequestOptions {
   initiativeId: string;
   authentication: UserSession;
 }
@@ -30,7 +30,7 @@ export const isUserFollowing = (user: IUser, initiativeId: string): boolean =>
  * Follow an initiative.
  */
 export function followInitiative(
-  requestOptions: IFollowInitiativeRequestOptions
+  requestOptions: IFollowInitiativeOptions
 ): Promise<{ success: boolean; username: string }> {
   // we dont call getUser() because the tags are cached and will be mutating
   return request(getUserUrl(requestOptions.authentication), {
@@ -64,7 +64,7 @@ export function followInitiative(
  * Follow an initiative.
  */
 export function unfollowInitiative(
-  requestOptions: IFollowInitiativeRequestOptions
+  requestOptions: IFollowInitiativeOptions
 ): Promise<{ success: boolean; username: string }> {
   // we dont call getUser() because the tags are cached and will be mutating
   return request(getUserUrl(requestOptions.authentication), {


### PR DESCRIPTION
fixing the doc made it clearer that we still needed to rename a couple interfaces.

`ISearchAnnoRequestOptions` > `ISearchAnnoOptions`
`IVoteRequestOptions` > `IVoteOptions`
`IEventRegisterRequestOptions` > `IEventRegisterOptions`
`IFollowInitiativeRequestOptions` > `IFollowInitiativeOptions`

if there is anything else we want to hide/rename, speak now or forever hold your peace.