### PR TITLE
search improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### [Unreleased][HEAD]
 
+### @esri/hub-search
+
+* Bug Fixes
+   * Fixed a bug wherein a blank string `""` didn't construct AGO query properly. Added a check in place for that
+   * Removed circular dependency in `computeItemsFacets` function
+* Chores
+   * Developed an algorithm to encode urls cleanly in `serialize` function
+
 ## [2.1.0] - May 14th 2019
 
 ### @esri/hub-search

--- a/docs/build-typedoc.js
+++ b/docs/build-typedoc.js
@@ -139,7 +139,7 @@ const md = new MarkdownIt();
       'collectionFilter', 'createAggs', 'format', 'hasApiAgg', 'buildFilter', 'createFilters', 
       'encodeFilters', 'groupIds', 'handleFilter', 'hasApiFilter', 'computeItemsFacets',
       'formatItem', 'calcHighlights', 'getSortField', 'isFilterable', 'generateFilter',
-      'agoFormatItemCollection'];
+      'agoFormatItemCollection', 'encodeParams', 'getPaths', 'getItems'];
       /**
        * Next we remove any declarations we want to blacklist from the API ref
        */

--- a/packages/search/package-lock.json
+++ b/packages/search/package-lock.json
@@ -1,11 +1,14 @@
 {
-	"requires": true,
+	"name": "@esri/hub-search",
+	"version": "2.1.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.0.1.tgz",
 			"integrity": "sha512-88SVnEpX/JpnLqeWxyf07c+dXEDfibKol7bZIRrrbBuw28dsRiwQqlMqI+bF0Vbyj0zTid/zvBLn74DNovKkFg==",
+			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^2.0.1",
 				"tslib": "^1.9.3"
@@ -15,6 +18,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.0.1.tgz",
 			"integrity": "sha512-X6NS9kKKUVJMR4lSkNiklRrt4Lg+mAPsY1SGNGZZRRqmJ8P5xzV8yabEACcPzxZvySoZLLf84vY8hIAPPv+7Zg==",
+			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^2.0.1",
 				"tslib": "^1.9.3"
@@ -24,6 +28,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.0.1.tgz",
 			"integrity": "sha512-KlSvvojy6NKR2TXgNJq+w/jwhpIouiNihtnv8v2o2XKt6pRrMgL7qIzZssQbB6UZ1FD8gxbdXe6xdwRgW+yaiQ==",
+			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^2.0.1",
 				"tslib": "^1.9.3"
@@ -33,6 +38,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.0.1.tgz",
 			"integrity": "sha512-lAhX15VI306bzzMH6xWCSSg1GHZxa5eWLb0r5M94Uet/Z0mMTXXTtIMQWYO0WQ05jEpLnZ5UKvNR0v9aKyFNkw==",
+			"dev": true,
 			"requires": {
 				"tslib": "^1.9.3"
 			}
@@ -40,7 +46,17 @@
 		"@esri/arcgis-rest-types": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.0.1.tgz",
-			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig=="
+			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig==",
+			"dev": true
+		},
+		"@esri/hub-common": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-2.1.0.tgz",
+			"integrity": "sha512-ALeHZIx5nRO4jZ3GjLHsx1LxWZf/rVqn9fQCbl0jd8FCOUw9bUHSQ11RcBzArurM/b2rwxLVPhnt2wFoV4XF/A==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.9.3"
+			}
 		},
 		"tslib": {
 			"version": "1.9.3",

--- a/packages/search/src/ago/compute-items-facets.ts
+++ b/packages/search/src/ago/compute-items-facets.ts
@@ -1,5 +1,4 @@
 import { UserSession } from "@esri/arcgis-rest-auth";
-import { agoSearch } from "./search";
 import { ISearchParams } from "./params";
 import { getProp } from "@esri/hub-common";
 import {
@@ -8,6 +7,7 @@ import {
   collectionAgg,
   downloadableAgg
 } from "./helpers/aggs";
+import { getItems } from "./get-items";
 
 // these custom aggs are based on a field that are not supported by AGO aggregations
 const customAggsNotSupportedByAgo = ["downloadable"];
@@ -47,7 +47,7 @@ export async function computeItemsFacets(
   if (customAggs.length > 0) {
     const paramsCopy = { ...params, ...{ start: 1, num: 100 } };
     paramsCopy.agg = {};
-    const response = await agoSearch(paramsCopy, token, portal, authentication);
+    const response = await getItems(paramsCopy, token, portal, authentication);
     customAggs.forEach(customAgg => {
       const rawCounts = customAggsFunctions[customAgg](response);
       facets1 = { ...facets1, ...format(rawCounts) };

--- a/packages/search/src/ago/encode-ago-query.ts
+++ b/packages/search/src/ago/encode-ago-query.ts
@@ -14,7 +14,7 @@ export function encodeAgoQuery(queryParams: any = {}) {
     num: getProp(queryParams, "page.size") || 10
   };
   // start with 'implicit' query filters
-  const queryParts = ["-access:public", '-type:"code attachment"'];
+  let queryParts = ["-access:public", '-type:"code attachment"'];
   // Build the potentially enourmous 'q' parameter. In future use SearchQueryBuilder from arcgis-rest-js
   if (queryParams.q) {
     queryParts.push(queryParams.q);
@@ -30,6 +30,8 @@ export function encodeAgoQuery(queryParams: any = {}) {
     // add each parsed filter object into ago query
     queryParts.push(handleFilter(filter));
   }
+  // cleanse queryParts by removing blank strings
+  queryParts = queryParts.filter(qp => !!qp);
   query.q = queryParts.join(" AND ");
   if (queryParams.bbox) {
     query.bbox = queryParams.bbox;

--- a/packages/search/src/ago/get-items.ts
+++ b/packages/search/src/ago/get-items.ts
@@ -1,0 +1,24 @@
+import { ISearchParams } from "./params";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { ISearchResult, IItem, searchItems } from "@esri/arcgis-rest-portal";
+import { encodeAgoQuery } from "./encode-ago-query";
+
+// Search for Items in ArcGIS and return raw ago response
+export async function getItems(
+  params: ISearchParams,
+  token?: string,
+  portal?: string,
+  authentication?: UserSession
+): Promise<ISearchResult<IItem>> {
+  const agoParams = encodeAgoQuery(params);
+  return searchItems({
+    ...agoParams,
+    params: {
+      token,
+      countFields: agoParams.countFields,
+      countSize: agoParams.countSize
+    },
+    portal,
+    authentication
+  });
+}

--- a/packages/search/src/ago/helpers/filters/encode-params.ts
+++ b/packages/search/src/ago/helpers/filters/encode-params.ts
@@ -1,0 +1,77 @@
+import { getProp } from "@esri/hub-common";
+
+/**
+ * Url-encoding of search params. This function is generic enough to encode a deeply nested object
+ * ```
+ * Example:
+ * Input: { a: { b: 2 }, c: 3 }
+ * Output: 'a[b]=2&c=3'
+ * ```
+ * @param {Any} params (query params from hub indexer)
+ * @returns {String}
+ */
+export function encodeParams(params: any = {}): string {
+  // get raw paths
+  const paths = getPaths(params);
+  const flatPaths = paths.filter(path => {
+    return typeof getProp(params, path.join(".")) !== "object";
+  });
+  const parts: string[] = [];
+  // for each nested path, we want to surround it with `[]`
+  // i.e. if a path is like ['a', 'b'], we want encoding as 'a[b]=2' given the input object { a: { b: 2 }, c: 3 }
+  flatPaths.forEach(path => {
+    let str = "";
+    for (let i = 0; i < path.length; i++) {
+      if (i === 0) {
+        str += path[i];
+      } else {
+        str += `[${path[i]}]`;
+      }
+    }
+    const right = encodeURIComponent(getProp(params, path.join(".")));
+    const left = encodeURIComponent(str);
+    if (right) {
+      parts.push(`${left}=${right}`);
+    }
+    return str;
+  });
+  const serialized = parts.join("&");
+  return serialized;
+}
+
+/**
+ * Get all paths to properties of an object as an array of arrays
+ * where each array is a path to a property in the nested object
+ * ```
+ * Example:
+ * Input: { a: { b: 2 }, c: 3 }
+ * Output: [['a'], ['a', 'b'], ['c']]
+ * ```
+ * @param {Any} root the input object
+ * @returns {String}
+ */
+export function getPaths(root: any = {}): string[][] {
+  const paths: string[][] = [];
+  const nodes: any[] = [
+    {
+      obj: root,
+      path: []
+    }
+  ];
+  while (nodes.length > 0) {
+    const n = nodes.pop();
+    Object.keys(n.obj).forEach(k => {
+      if (typeof n.obj[k] === "object") {
+        const path = n.path.concat(k);
+        paths.push(path);
+        nodes.unshift({
+          obj: n.obj[k],
+          path
+        });
+      } else {
+        paths.push(n.path.concat(k));
+      }
+    });
+  }
+  return paths;
+}

--- a/packages/search/src/ago/helpers/filters/encode-params.ts
+++ b/packages/search/src/ago/helpers/filters/encode-params.ts
@@ -28,7 +28,7 @@ export function encodeParams(params: any = {}): string {
         str += `[${path[i]}]`;
       }
     }
-    const right = encodeURIComponent(getProp(params, path.join(".")));
+    const right = encodeURIComponent(getProp(params, path.join(".")) || "");
     const left = encodeURIComponent(str);
     if (right) {
       parts.push(`${left}=${right}`);

--- a/packages/search/src/ago/helpers/filters/index.ts
+++ b/packages/search/src/ago/helpers/filters/index.ts
@@ -2,3 +2,4 @@ export * from "./create-filters";
 export * from "./encode-filters";
 export * from "./handle-filter";
 export * from "./filter-schema";
+export * from "./encode-params";

--- a/packages/search/src/ago/params.ts
+++ b/packages/search/src/ago/params.ts
@@ -17,7 +17,10 @@ export interface ISearchParams extends ISearchOptions {
   isPortal?: string;
   location_name?: string;
   owner?: string;
-  page?: { start?: number; size?: number };
+  page?: {
+    hub?: { start?: number; size?: number };
+    ago?: { start?: number; size?: number };
+  };
   q: string;
   region?: string;
   sector?: string;

--- a/packages/search/src/ago/search.ts
+++ b/packages/search/src/ago/search.ts
@@ -1,15 +1,14 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { searchItems, ISearchResult, IItem } from "@esri/arcgis-rest-portal";
 import { ISearchParams, IHubResults } from "./params";
 import { UserSession } from "@esri/arcgis-rest-auth";
-import { encodeAgoQuery } from "./encode-ago-query";
 import { computeItemsFacets } from "./compute-items-facets";
 import { agoFormatItemCollection } from "./format-item-collection";
+import { getItems } from "./get-items";
 
 /**
- * Search for Items in ArcGIS
+ * Search for Items in ArcGIS, compute facets and format the response into V3 like datasets
  *
  * @export
  * @param {ISearchParams} params (query params from hub indexer)
@@ -22,23 +21,13 @@ export async function agoSearch(
   portal?: string,
   authentication?: UserSession
 ): Promise<IHubResults> {
-  const agoParams = encodeAgoQuery(params);
-  const agoResults: ISearchResult<IItem> = await searchItems({
-    ...agoParams,
-    params: {
-      token,
-      countFields: agoParams.countFields,
-      countSize: agoParams.countSize
-    },
-    portal,
-    authentication
-  });
+  const agoResponse = await getItems(params, token, portal, authentication);
   const facets = await computeItemsFacets(
-    agoResults.aggregations,
+    agoResponse.aggregations,
     params,
     token,
     portal
   );
-  const model = agoFormatItemCollection(agoResults, facets, params);
+  const model = agoFormatItemCollection(agoResponse, facets, params);
   return model;
 }

--- a/packages/search/test/ago/compute-items-facets.test.ts
+++ b/packages/search/test/ago/compute-items-facets.test.ts
@@ -1,5 +1,5 @@
 import { computeItemsFacets } from "../../src/ago/compute-items-facets";
-import * as Search from "../../src/ago/search";
+import * as GetItems from "../../src/ago/get-items";
 import { ISearchResult, IItem } from "@esri/arcgis-rest-portal";
 
 const item: IItem = {
@@ -43,7 +43,7 @@ const aggregations = {
 
 describe("computeItemsFacets test", () => {
   it("it should call ago searchItems if custom aggs are requested", async done => {
-    const agoSearchSpy = spyOn(Search, "agoSearch").and.callFake(() => {
+    const getItemsSpy = spyOn(GetItems, "getItems").and.callFake(() => {
       const response: ISearchResult<IItem> = {
         results: [item],
         query: "blah",
@@ -66,12 +66,12 @@ describe("computeItemsFacets test", () => {
       ]
     };
     expect(facets).toEqual(expected);
-    expect(agoSearchSpy.calls.count()).toEqual(1);
+    expect(getItemsSpy.calls.count()).toEqual(1);
     done();
   });
 
   it("it should compute facets from custom and ago-provided aggs correctly", async done => {
-    const agoSearchSpy = spyOn(Search, "agoSearch").and.callFake(() => {
+    const getItemsSpy = spyOn(GetItems, "getItems").and.callFake(() => {
       const response: ISearchResult<IItem> = {
         results: [item],
         query: "blah",
@@ -107,12 +107,12 @@ describe("computeItemsFacets test", () => {
       hasApi: [{ key: "true", docCount: 22 }, { key: "false", docCount: 0 }]
     };
     expect(facets).toEqual(expected);
-    expect(agoSearchSpy.calls.count()).toEqual(1);
+    expect(getItemsSpy.calls.count()).toEqual(1);
     done();
   });
 
   it("it should handle undefined agoAggregations and undefined agg params correctly", async done => {
-    const agoSearchSpy = spyOn(Search, "agoSearch").and.callFake(() => {
+    const getItemsSpy = spyOn(GetItems, "getItems").and.callFake(() => {
       return Promise.resolve({});
     });
     const params = {
@@ -122,7 +122,7 @@ describe("computeItemsFacets test", () => {
     const portal = "https://qaext.arcgis.com/sharing/rest";
     const facets = await computeItemsFacets(undefined, params, token, portal);
     expect(facets).toEqual({});
-    expect(agoSearchSpy.calls.count()).toEqual(0);
+    expect(getItemsSpy.calls.count()).toEqual(0);
     done();
   });
 });

--- a/packages/search/test/ago/get-items.test.ts
+++ b/packages/search/test/ago/get-items.test.ts
@@ -1,0 +1,54 @@
+import { getItems } from "../../src/ago/get-items";
+import * as Portal from "@esri/arcgis-rest-portal";
+import { ISearchParams } from "../../src/ago/params";
+import * as EncodeAgoQuery from "../../src/ago/encode-ago-query";
+
+describe("getItems test", () => {
+  it("encodes params into ago query and calls portal's searchItems", async done => {
+    const rawAgoResults = {
+      results: [],
+      total: 0,
+      aggregations: { counts: {} }
+    } as any;
+    const encodeAgoQuerySpy = spyOn(
+      EncodeAgoQuery,
+      "encodeAgoQuery"
+    ).and.callFake(() => {
+      return { q: "long ago query", start: 1, num: 10 };
+    });
+    const searchItemsSpy = spyOn(Portal, "searchItems").and.callFake(() => {
+      return rawAgoResults;
+    });
+    const params: ISearchParams = {
+      q: "land",
+      sort: "name",
+      groupIds: "1ef",
+      agg: { fields: "tags,collection,owner,source,hasApi,downloadable" },
+      start: 1,
+      num: 10
+    };
+    const token = "token";
+    const portal = "https://test.com";
+
+    await getItems(params, token, portal);
+    // step 1: encode ago query
+    expect(encodeAgoQuerySpy.calls.count()).toEqual(1);
+    const [expectedParams] = encodeAgoQuerySpy.calls.argsFor(0);
+    expect(expectedParams).toEqual(params);
+
+    // step 2: search items
+    expect(searchItemsSpy.calls.count()).toEqual(1);
+    const expectedArgsForSearchItems: any = [
+      {
+        q: "long ago query",
+        start: 1,
+        num: 10,
+        params: { token, countFields: undefined, countSize: undefined },
+        portal,
+        authentication: undefined
+      }
+    ];
+    expect(expectedArgsForSearchItems).toEqual(searchItemsSpy.calls.argsFor(0));
+    done();
+  });
+});

--- a/packages/search/test/ago/helpers/filters/encode-params.test.ts
+++ b/packages/search/test/ago/helpers/filters/encode-params.test.ts
@@ -1,0 +1,61 @@
+import {
+  encodeParams,
+  getPaths
+} from "../../../../src/ago/helpers/filters/encode-params";
+
+describe("encodeParams test", () => {
+  it("encodes deeply nested object correctly", () => {
+    const input: any = {
+      q: "crime",
+      sort: "name",
+      agg: {
+        fields: "tags,collection,owner,source,hasApi,downloadable",
+        size: 10,
+        mode: "uniqueCount"
+      },
+      page: {
+        hub: {
+          start: 1,
+          size: 10
+        },
+        ago: {
+          start: 1,
+          size: 10
+        }
+      }
+    };
+    const actual = encodeParams(input);
+    const expected =
+      "q=crime&sort=name&agg%5Bfields%5D=tags%2Ccollection%2Cowner%2Csource%2ChasApi%2Cdownloadable&agg%5Bsize%5D=10&agg%5Bmode%5D=uniqueCount&page%5Bhub%5D%5Bstart%5D=1&page%5Bhub%5D%5Bsize%5D=10&page%5Bago%5D%5Bstart%5D=1&page%5Bago%5D%5Bsize%5D=10";
+    expect(actual).toBe(expected);
+  });
+
+  it("encodes blank object correcty", () => {
+    const actual = encodeParams();
+    const expected = "";
+    expect(actual).toBe(expected);
+  });
+});
+
+describe("getPaths test", () => {
+  it("handles blank or undefined obj correctly", () => {
+    expect(getPaths()).toEqual([]);
+  });
+
+  it("gets paths for deeply nested object correctly", () => {
+    const input = {
+      a: { b: { c: 1, d: 2 }, e: [5, 6] }
+    };
+    const actual = getPaths(input);
+    const expected = [
+      ["a"],
+      ["a", "b"],
+      ["a", "e"],
+      ["a", "b", "c"],
+      ["a", "b", "d"],
+      ["a", "e", "0"],
+      ["a", "e", "1"]
+    ];
+    expect(actual).toEqual(actual);
+  });
+});

--- a/packages/search/test/ago/search.test.ts
+++ b/packages/search/test/ago/search.test.ts
@@ -1,8 +1,7 @@
 import { agoSearch } from "../../src/ago/search";
-import * as EncodeAgoQuery from "../../src/ago/encode-ago-query";
+import * as GetItems from "../../src/ago/get-items";
 import * as ComputeItemsFacets from "../../src/ago/compute-items-facets";
 import * as FormatItemCollection from "../../src/ago/format-item-collection";
-import * as Portal from "@esri/arcgis-rest-portal";
 import { ISearchParams } from "../../src/ago/params";
 
 describe("agoSearch test", () => {
@@ -14,13 +13,7 @@ describe("agoSearch test", () => {
     } as any;
     const facets = { facet1: [{ key: "a", docCount: 5 }] };
     const formatted = { data: [], meta: { stats: {} } } as any;
-    const encodeAgoQuerySpy = spyOn(
-      EncodeAgoQuery,
-      "encodeAgoQuery"
-    ).and.callFake(() => {
-      return { q: "long ago query", start: 1, num: 10 };
-    });
-    const searchItemsSpy = spyOn(Portal, "searchItems").and.callFake(() => {
+    const getItemsSpy = spyOn(GetItems, "getItems").and.callFake(() => {
       return rawAgoResults;
     });
     const computeItemsFacetsSpy = spyOn(
@@ -48,14 +41,11 @@ describe("agoSearch test", () => {
     const formattedResults = await agoSearch(params, token, portal);
 
     // step 1: encode ago query
-    expect(encodeAgoQuerySpy.calls.count()).toEqual(1);
-    const actualArgsForEncodeAgoQuery = encodeAgoQuerySpy.calls.argsFor(0)[0];
+    expect(getItemsSpy.calls.count()).toEqual(1);
+    const actualArgsForEncodeAgoQuery = getItemsSpy.calls.argsFor(0)[0];
     expect(actualArgsForEncodeAgoQuery).toEqual(params);
 
-    // step 2: search items
-    expect(searchItemsSpy.calls.count()).toEqual(1);
-
-    // step 3: compute items facets
+    // step 2: compute items facets
     expect(computeItemsFacetsSpy.calls.count()).toBe(1);
     const [
       aggsForComputeFacets,

--- a/packages/search/test/ago/serialize.test.ts
+++ b/packages/search/test/ago/serialize.test.ts
@@ -14,13 +14,19 @@ describe("serialize test", () => {
         mode: "uniqueCount"
       },
       page: {
-        start: 1,
-        size: 10
+        hub: {
+          start: 1,
+          size: 10
+        },
+        ago: {
+          start: 1,
+          size: 10
+        }
       }
     };
     const actual = serialize(input);
     const expected =
-      "q=crime&sort=name&catalog%5BgroupIds%5D=any(1ef,2ab)&catalog%5Bid%5D=any(1qw)&agg%5Bfields%5D=tags%2Ccollection%2Cowner%2Csource%2ChasApi%2Cdownloadable&agg%5Bsize%5D=10&agg%5Bmode%5D=uniqueCount&page%5Bstart%5D=1&page%5Bsize%5D=10";
+      "q=crime&sort=name&agg%5Bfields%5D=tags%2Ccollection%2Cowner%2Csource%2ChasApi%2Cdownloadable&agg%5Bsize%5D=10&agg%5Bmode%5D=uniqueCount&page%5Bhub%5D%5Bstart%5D=1&page%5Bhub%5D%5Bsize%5D=10&page%5Bago%5D%5Bstart%5D=1&page%5Bago%5D%5Bsize%5D=10&catalog%5BgroupIds%5D=any(1ef,2ab)&catalog%5Bid%5D=any(1qw)";
     expect(actual).toBe(expected);
   });
 
@@ -31,11 +37,20 @@ describe("serialize test", () => {
       groupIds: "1ef,2ab",
       id: "1qw"
     };
-    const actual1 = serialize(input);
+    const actual = serialize(input);
     const expected =
-      "q=crime&sort=name&catalog%5BgroupIds%5D=any(1ef,2ab)&catalog%5Bid%5D=any(1qw)&&page%5Bstart%5D=1&page%5Bsize%5D=10";
-    expect(actual1).toBe(expected);
+      "q=crime&sort=name&catalog%5BgroupIds%5D=any(1ef,2ab)&catalog%5Bid%5D=any(1qw)";
+    expect(actual).toBe(expected);
     input.agg = {};
     expect(serialize(input)).toBe(expected);
+  });
+
+  it("serializes without nonFilters and filters", () => {
+    const input: ISearchParams = {
+      q: ""
+    };
+    const actual = serialize(input);
+    const expected = "";
+    expect(actual).toBe(expected);
   });
 });


### PR DESCRIPTION
In this PR --

1. Developed an algorithm to encode urls cleanly in serialize function. The crux of the algorithm is to handle filters and non-filters differently. It can URI encode any nested object like `{ a: { b: 2 }, c: 3 }` as `a[b]=2&c=3`
2. Removed circular dependency in computeItemsFacets function. I have addressed it by creating a `get-items` module shared between `agoSearch` and `computeItemsFacets`.
3. Fixed a bug wherein a blank string `""` didn't construct AGO query properly. So I have added a check in place for that.