### PR TITLE
Bug/get users with portal

### DIFF
--- a/packages/annotations/src/search.ts
+++ b/packages/annotations/src/search.ts
@@ -101,6 +101,7 @@ export function searchAnnotations(
       .map(name => {
         return getUser({
           username: name,
+          portal: requestOptions.portal,
           authentication: requestOptions.authentication as UserSession
         }).catch(() => null);
       });

--- a/packages/annotations/test/search.test.ts
+++ b/packages/annotations/test/search.test.ts
@@ -88,11 +88,13 @@ describe("searchAnnotations", () => {
         expect(queryOpts.outFields).toEqual(mockOutFields);
         expect(caseyOpts).toEqual({
           username: "casey",
-          authentication: undefined
+          authentication: undefined,
+          portal: undefined
         });
         expect(jonesOpts).toEqual({
           username: "jones",
-          authentication: undefined
+          authentication: undefined,
+          portal: undefined
         });
         expect(response).toEqual(annoResponse);
         done();


### PR DESCRIPTION
PR #170 did not solve our issues since the portal has to be passed to `getUser` for anonymous fetching of annotations.

This should solve it.