### PR TITLE
add orgId and initiativeId in filterSchema to add them to catalog

### DIFF
--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -35,7 +35,8 @@ const params = {
   start: 1,
   num: 10,
   groupIds: '1ef,2ef',
-  orgId: '3ef'
+  orgId: '3ef',
+  initiativeId: '4ef'
 }
 const token = 'xxxYYY' // AGO token
 const portal = 'https://qaext.arcgis.com/sharing/rest'

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -33,7 +33,9 @@ const params = {
   sort: 'name',
   agg: { fields: 'tags,collection,owner,source,hasApi,downloadable' },
   start: 1,
-  num: 10
+  num: 10,
+  groupIds: '1ef,2ef',
+  orgId: '3ef'
 }
 const token = 'xxxYYY' // AGO token
 const portal = 'https://qaext.arcgis.com/sharing/rest'

--- a/packages/search/src/ago/helpers/filters/filter-schema.ts
+++ b/packages/search/src/ago/helpers/filters/filter-schema.ts
@@ -1,4 +1,9 @@
 const filterSchema: any = {
+  orgId: {
+    type: "filter",
+    dataType: "string",
+    catalogDefinition: true
+  },
   q: { type: "simple" },
   page: { type: "simple" },
   tags: {
@@ -73,6 +78,12 @@ const filterSchema: any = {
     type: "filter",
     dataType: "string",
     defaultOp: "any"
+  },
+  initiativeId: {
+    type: "filter",
+    dataType: "string",
+    defaultOp: "any",
+    catalogDefinition: true
   }
 };
 

--- a/packages/search/test/ago/serialize.test.ts
+++ b/packages/search/test/ago/serialize.test.ts
@@ -2,11 +2,13 @@ import { serialize } from "../../src/ago/serialize";
 import { ISearchParams } from "../../src/ago/params";
 
 describe("serialize test", () => {
-  it("serializes q, tags, aggs, sort correctly", () => {
+  it("serializes q, tags, aggs, sort, groupIds, orgId, initiativeId correctly", () => {
     const input: ISearchParams = {
       q: "crime",
       sort: "name",
       groupIds: "1ef,2ab",
+      orgId: "2ef",
+      initiativeId: "3ef",
       id: "1qw",
       agg: {
         fields: "tags,collection,owner,source,hasApi,downloadable",
@@ -26,7 +28,7 @@ describe("serialize test", () => {
     };
     const actual = serialize(input);
     const expected =
-      "q=crime&sort=name&agg%5Bfields%5D=tags%2Ccollection%2Cowner%2Csource%2ChasApi%2Cdownloadable&agg%5Bsize%5D=10&agg%5Bmode%5D=uniqueCount&page%5Bhub%5D%5Bstart%5D=1&page%5Bhub%5D%5Bsize%5D=10&page%5Bago%5D%5Bstart%5D=1&page%5Bago%5D%5Bsize%5D=10&catalog%5BgroupIds%5D=any(1ef,2ab)&catalog%5Bid%5D=any(1qw)";
+      "q=crime&sort=name&agg%5Bfields%5D=tags%2Ccollection%2Cowner%2Csource%2ChasApi%2Cdownloadable&agg%5Bsize%5D=10&agg%5Bmode%5D=uniqueCount&page%5Bhub%5D%5Bstart%5D=1&page%5Bhub%5D%5Bsize%5D=10&page%5Bago%5D%5Bstart%5D=1&page%5Bago%5D%5Bsize%5D=10&catalog%5BgroupIds%5D=any(1ef,2ab)&catalog%5BorgId%5D=2ef&catalog%5BinitiativeId%5D=any(3ef)&catalog%5Bid%5D=any(1qw)";
     expect(actual).toBe(expected);
   });
 


### PR DESCRIPTION
Recently orgId and initiativeId were added to catalog param schema in the opendata-ui legacy search (https://github.com/ArcGIS/opendata-ui/blob/master/packages/opendata-ui/app/utils/search/create-filters.js#L106). With unified search, that logic needs to be added in hub.js.

Sites with orgId and initiativeId work with this new change --

<img width="1425" alt="Screen Shot 2019-07-24 at 1 08 35 PM" src="https://user-images.githubusercontent.com/16601898/61815105-7ca24180-ae17-11e9-8be7-befb28d10c8b.png">

<img width="1413" alt="Screen Shot 2019-07-24 at 1 20 29 PM" src="https://user-images.githubusercontent.com/16601898/61815112-8035c880-ae17-11e9-9b96-d6a72305bf2e.png">

