### PR TITLE
fix(lowercase ago param keys): lowercase ago param keys

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,14 +1,11 @@
 {
-	"name": "@esri/hub-common",
-	"version": "2.3.0",
-	"lockfileVersion": 1,
 	"requires": true,
+	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.0.1.tgz",
 			"integrity": "sha512-88SVnEpX/JpnLqeWxyf07c+dXEDfibKol7bZIRrrbBuw28dsRiwQqlMqI+bF0Vbyj0zTid/zvBLn74DNovKkFg==",
-			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^2.0.1",
 				"tslib": "^1.9.3"
@@ -18,7 +15,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.0.1.tgz",
 			"integrity": "sha512-KlSvvojy6NKR2TXgNJq+w/jwhpIouiNihtnv8v2o2XKt6pRrMgL7qIzZssQbB6UZ1FD8gxbdXe6xdwRgW+yaiQ==",
-			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^2.0.1",
 				"tslib": "^1.9.3"
@@ -28,7 +24,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.0.1.tgz",
 			"integrity": "sha512-lAhX15VI306bzzMH6xWCSSg1GHZxa5eWLb0r5M94Uet/Z0mMTXXTtIMQWYO0WQ05jEpLnZ5UKvNR0v9aKyFNkw==",
-			"dev": true,
 			"requires": {
 				"tslib": "^1.9.3"
 			}
@@ -36,8 +31,7 @@
 		"@esri/arcgis-rest-types": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.0.1.tgz",
-			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig==",
-			"dev": true
+			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig=="
 		},
 		"tslib": {
 			"version": "1.9.3",

--- a/packages/initiatives/package-lock.json
+++ b/packages/initiatives/package-lock.json
@@ -1,14 +1,11 @@
 {
-	"name": "@esri/hub-initiatives",
-	"version": "2.2.3",
-	"lockfileVersion": 1,
 	"requires": true,
+	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.0.1.tgz",
 			"integrity": "sha512-88SVnEpX/JpnLqeWxyf07c+dXEDfibKol7bZIRrrbBuw28dsRiwQqlMqI+bF0Vbyj0zTid/zvBLn74DNovKkFg==",
-			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^2.0.1",
 				"tslib": "^1.9.3"
@@ -18,7 +15,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.0.1.tgz",
 			"integrity": "sha512-KlSvvojy6NKR2TXgNJq+w/jwhpIouiNihtnv8v2o2XKt6pRrMgL7qIzZssQbB6UZ1FD8gxbdXe6xdwRgW+yaiQ==",
-			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^2.0.1",
 				"tslib": "^1.9.3"
@@ -28,7 +24,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.0.1.tgz",
 			"integrity": "sha512-lAhX15VI306bzzMH6xWCSSg1GHZxa5eWLb0r5M94Uet/Z0mMTXXTtIMQWYO0WQ05jEpLnZ5UKvNR0v9aKyFNkw==",
-			"dev": true,
 			"requires": {
 				"tslib": "^1.9.3"
 			}
@@ -36,32 +31,12 @@
 		"@esri/arcgis-rest-types": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.0.1.tgz",
-			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig==",
-			"dev": true
-		},
-		"@esri/hub-common": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-2.2.3.tgz",
-			"integrity": "sha512-km3TKZROC5/mFE2SxYf7dGyaJqtlflozeC1UrUSewo5F+GkhxPOx1lkevn8VOMjWJCTmtZ1n7vlOUzLEb28aSw==",
-			"dev": true,
-			"requires": {
-				"tslib": "1.9.3"
-			}
-		},
-		"@esri/hub-sites": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-2.2.3.tgz",
-			"integrity": "sha512-I91wUQDRGRiXPnxZDgaYgsn83+/i0ZZtQWSMC/fPh+herw8IUECetFPvKD14XLGLYFiohcREHwOjnvDeNOGgLw==",
-			"dev": true,
-			"requires": {
-				"tslib": "1.9.3"
-			}
+			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig=="
 		},
 		"blob": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-			"integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
-			"dev": true
+			"integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
 		},
 		"tslib": {
 			"version": "1.9.3",

--- a/packages/search/package-lock.json
+++ b/packages/search/package-lock.json
@@ -1,11 +1,14 @@
 {
-	"requires": true,
+	"name": "@esri/hub-search",
+	"version": "2.4.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.0.1.tgz",
 			"integrity": "sha512-88SVnEpX/JpnLqeWxyf07c+dXEDfibKol7bZIRrrbBuw28dsRiwQqlMqI+bF0Vbyj0zTid/zvBLn74DNovKkFg==",
+			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^2.0.1",
 				"tslib": "^1.9.3"
@@ -15,6 +18,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.0.1.tgz",
 			"integrity": "sha512-X6NS9kKKUVJMR4lSkNiklRrt4Lg+mAPsY1SGNGZZRRqmJ8P5xzV8yabEACcPzxZvySoZLLf84vY8hIAPPv+7Zg==",
+			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^2.0.1",
 				"tslib": "^1.9.3"
@@ -24,6 +28,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.0.1.tgz",
 			"integrity": "sha512-KlSvvojy6NKR2TXgNJq+w/jwhpIouiNihtnv8v2o2XKt6pRrMgL7qIzZssQbB6UZ1FD8gxbdXe6xdwRgW+yaiQ==",
+			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^2.0.1",
 				"tslib": "^1.9.3"
@@ -33,6 +38,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.0.1.tgz",
 			"integrity": "sha512-lAhX15VI306bzzMH6xWCSSg1GHZxa5eWLb0r5M94Uet/Z0mMTXXTtIMQWYO0WQ05jEpLnZ5UKvNR0v9aKyFNkw==",
+			"dev": true,
 			"requires": {
 				"tslib": "^1.9.3"
 			}
@@ -40,7 +46,17 @@
 		"@esri/arcgis-rest-types": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.0.1.tgz",
-			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig=="
+			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig==",
+			"dev": true
+		},
+		"@esri/hub-common": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-2.4.0.tgz",
+			"integrity": "sha512-EtMzb3VVx/ihxekwxsOdGyfQ2VTtTYg2JN08thSVZl2BlzXdTt60rtSW7PPGiNoQVTc1Jj8I0Cy9Axyjh3iXfA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.9.3"
+			}
 		},
 		"tslib": {
 			"version": "1.9.3",

--- a/packages/search/src/ago/helpers/filters/build-filter.ts
+++ b/packages/search/src/ago/helpers/filters/build-filter.ts
@@ -3,8 +3,12 @@ import { getProp } from "@esri/hub-common";
 export function buildFilter(queryFilters: any, key: string) {
   const terms = getProp(queryFilters, `${key}.terms`) || [];
   const joinType = getProp(queryFilters, `${key}.fn`);
+  // all params to AGO queries MUST be lower case, so we're going to force
+  // lowerCase here because we use `orgId` for Hub index, and need it as `orgid`
+  // for AGO. This will allow us to use whatever casing for Hub and still
+  // adhere to AGO requirements
   let filter = terms
-    .map((term: string) => `${key}:"${term}"`)
+    .map((term: string) => `${key.toLowerCase()}:"${term}"`)
     .join(agoJoin(joinType));
   if (joinType === "not") {
     // "not" filter means everything but not those given terms

--- a/packages/search/src/ago/helpers/filters/filter-schema.ts
+++ b/packages/search/src/ago/helpers/filters/filter-schema.ts
@@ -2,6 +2,7 @@ const filterSchema: any = {
   orgId: {
     type: "filter",
     dataType: "string",
+    defaultOp: "any",
     catalogDefinition: true
   },
   q: { type: "simple" },

--- a/packages/search/test/ago/helpers/filters/build-filter.test.ts
+++ b/packages/search/test/ago/helpers/filters/build-filter.test.ts
@@ -39,4 +39,17 @@ describe("buildFilter test", () => {
     const queryFilters = {};
     expect(buildFilter(queryFilters, "source")).toBe("()");
   });
+
+  it("builds filter by lowercasing key of AGO params", () => {
+    const queryFilters = {
+      orgId: {
+        fn: "any",
+        terms: ["MNF5ypRINzAAlFbv"],
+        catalogDefinition: true
+      }
+    };
+    expect(buildFilter(queryFilters, "orgId")).toBe(
+      '(orgid:"MNF5ypRINzAAlFbv")'
+    );
+  });
 });

--- a/packages/search/test/ago/serialize.test.ts
+++ b/packages/search/test/ago/serialize.test.ts
@@ -28,7 +28,7 @@ describe("serialize test", () => {
     };
     const actual = serialize(input);
     const expected =
-      "q=crime&sort=name&agg%5Bfields%5D=tags%2Ccollection%2Cowner%2Csource%2ChasApi%2Cdownloadable&agg%5Bsize%5D=10&agg%5Bmode%5D=uniqueCount&page%5Bhub%5D%5Bstart%5D=1&page%5Bhub%5D%5Bsize%5D=10&page%5Bago%5D%5Bstart%5D=1&page%5Bago%5D%5Bsize%5D=10&catalog%5BgroupIds%5D=any(1ef,2ab)&catalog%5BorgId%5D=2ef&catalog%5BinitiativeId%5D=any(3ef)&catalog%5Bid%5D=any(1qw)";
+      "q=crime&sort=name&agg%5Bfields%5D=tags%2Ccollection%2Cowner%2Csource%2ChasApi%2Cdownloadable&agg%5Bsize%5D=10&agg%5Bmode%5D=uniqueCount&page%5Bhub%5D%5Bstart%5D=1&page%5Bhub%5D%5Bsize%5D=10&page%5Bago%5D%5Bstart%5D=1&page%5Bago%5D%5Bsize%5D=10&catalog%5BgroupIds%5D=any(1ef,2ab)&catalog%5BorgId%5D=any(2ef)&catalog%5BinitiativeId%5D=any(3ef)&catalog%5Bid%5D=any(1qw)";
     expect(actual).toBe(expected);
   });
 


### PR DESCRIPTION
Recently some changes were made to legacy search in opendata-ui. They need to be in hub.js because unified search is now generally available. This PR makes the corresponding changes of lowercasing ago param keys to accommodate `search by orgId` for special hub home sites. Reference: https://github.com/ArcGIS/opendata-ui/blob/master/packages/opendata-ui/app/utils/search/encode-ago-query.js#L92

With this change, the below special hub home site returns results based on orgId!

![Screen Shot 2019-08-09 at 9 39 16 AM](https://user-images.githubusercontent.com/16601898/62787976-eb2c0400-ba93-11e9-8b67-5457e3ccd3fe.png)
