### PR TITLE
feat(search): use restricted option to scope search

### DIFF
--- a/packages/search/src/ago/encode-ago-query.ts
+++ b/packages/search/src/ago/encode-ago-query.ts
@@ -14,7 +14,10 @@ export function encodeAgoQuery(queryParams: any = {}) {
     num: getProp(queryParams, "page.size") || 10
   };
   // start with 'implicit' query filters
-  let queryParts = ["-access:public", '-type:"code attachment"'];
+  let queryParts = ['-type:"code attachment"'];
+  if (queryParams.restricted) {
+    queryParts.push("-access:public");
+  }
   // Build the potentially enourmous 'q' parameter. In future use SearchQueryBuilder from arcgis-rest-js
   if (queryParams.q) {
     queryParts.push(queryParams.q);

--- a/packages/search/test/ago/encode-ago-query.test.ts
+++ b/packages/search/test/ago/encode-ago-query.test.ts
@@ -18,7 +18,7 @@ describe("encodeAgoQuery test", () => {
     const actual = encodeAgoQuery(params);
     const expected = {
       q:
-        '-access:public AND -type:"code attachment" AND crime AND ((group:"1ef")) AND (tags:"test")',
+        '-type:"code attachment" AND crime AND ((group:"1ef")) AND (tags:"test")',
       start: 1,
       num: 10,
       sortField: "title",
@@ -33,7 +33,17 @@ describe("encodeAgoQuery test", () => {
   it("encodes ago query undefined query params", () => {
     const actual = encodeAgoQuery();
     const expected = {
-      q: '-access:public AND -type:"code attachment"',
+      q: '-type:"code attachment"',
+      start: 1,
+      num: 10
+    };
+    expect(actual).toEqual(expected);
+  });
+
+  it("encodes ago query with correct access if restricted is set query params", () => {
+    const actual = encodeAgoQuery({ restricted: true });
+    const expected = {
+      q: '-type:"code attachment" AND -access:public',
       start: 1,
       num: 10
     };
@@ -43,7 +53,7 @@ describe("encodeAgoQuery test", () => {
   it("encodes ago query in desc if sorting on a field in desc", () => {
     const actual = encodeAgoQuery({ sort: "-name" });
     const expected = {
-      q: '-access:public AND -type:"code attachment"',
+      q: '-type:"code attachment"',
       start: 1,
       num: 10,
       sortField: "title",
@@ -55,7 +65,7 @@ describe("encodeAgoQuery test", () => {
   it("ignores sort if the sort field is illegal", () => {
     const actual = encodeAgoQuery({ sort: "-xyz" });
     const expected = {
-      q: '-access:public AND -type:"code attachment"',
+      q: '-type:"code attachment"',
       start: 1,
       num: 10
     };


### PR DESCRIPTION
Give the ability to search for public content by removing the default -access public.

pass {restricted: true} to add it back