### PR TITLE
Create blank initiative

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5062,7 +5062,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5083,12 +5084,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5103,17 +5106,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5230,7 +5236,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5242,6 +5249,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5256,6 +5264,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5263,12 +5272,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5287,6 +5298,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5367,7 +5379,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5379,6 +5392,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5464,7 +5478,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5500,6 +5515,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5519,6 +5535,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5562,12 +5579,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/initiatives/package-lock.json
+++ b/packages/initiatives/package-lock.json
@@ -1,4 +1,10 @@
 {
+<<<<<<< HEAD
+=======
+	"name": "@esri/hub-initiatives",
+	"version": "2.4.0",
+	"lockfileVersion": 1,
+>>>>>>> refactor(change activate initiative flow to handle missing group create privs and embedded resources
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
@@ -7,8 +13,8 @@
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.0.1.tgz",
 			"integrity": "sha512-88SVnEpX/JpnLqeWxyf07c+dXEDfibKol7bZIRrrbBuw28dsRiwQqlMqI+bF0Vbyj0zTid/zvBLn74DNovKkFg==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.0.1",
-				"tslib": "^1.9.3"
+				"@esri/arcgis-rest-types": "2.0.1",
+				"tslib": "1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-portal": {
@@ -16,8 +22,8 @@
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.0.1.tgz",
 			"integrity": "sha512-KlSvvojy6NKR2TXgNJq+w/jwhpIouiNihtnv8v2o2XKt6pRrMgL7qIzZssQbB6UZ1FD8gxbdXe6xdwRgW+yaiQ==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.0.1",
-				"tslib": "^1.9.3"
+				"@esri/arcgis-rest-types": "2.0.1",
+				"tslib": "1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-request": {
@@ -25,13 +31,36 @@
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.0.1.tgz",
 			"integrity": "sha512-lAhX15VI306bzzMH6xWCSSg1GHZxa5eWLb0r5M94Uet/Z0mMTXXTtIMQWYO0WQ05jEpLnZ5UKvNR0v9aKyFNkw==",
 			"requires": {
-				"tslib": "^1.9.3"
+				"tslib": "1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-types": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.0.1.tgz",
+<<<<<<< HEAD
 			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig=="
+=======
+			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig==",
+			"dev": true
+		},
+		"@esri/hub-common": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-2.4.0.tgz",
+			"integrity": "sha512-EtMzb3VVx/ihxekwxsOdGyfQ2VTtTYg2JN08thSVZl2BlzXdTt60rtSW7PPGiNoQVTc1Jj8I0Cy9Axyjh3iXfA==",
+			"dev": true,
+			"requires": {
+				"tslib": "1.9.3"
+			}
+		},
+		"@esri/hub-sites": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-2.4.0.tgz",
+			"integrity": "sha512-r1CRJCFMNloBoHbyk7A802+QGo5xTtND35E7Esu1h+dNsymnbkq1LyOBqO2boSHVEThbFaCukiGI93+2gFXDuA==",
+			"dev": true,
+			"requires": {
+				"tslib": "1.9.3"
+			}
+>>>>>>> refactor(change activate initiative flow to handle missing group create privs and embedded resources
 		},
 		"blob": {
 			"version": "0.0.4",

--- a/packages/initiatives/src/activate.ts
+++ b/packages/initiatives/src/activate.ts
@@ -92,7 +92,7 @@ export function activateInitiative(
       state.template = templateItemModel;
       return createInitiativeGroups(collaborationGroupName, dataGroupName, ro);
     })
-    .then((groupIds: any) => {
+    .then(groupIds => {
       progressCallback({
         processId,
         status: "working",

--- a/packages/initiatives/src/groups.ts
+++ b/packages/initiatives/src/groups.ts
@@ -13,7 +13,17 @@ import {
 } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 
-// doc
+/**
+ * Create all of the groups needed for activating an initiative, provided the user has the
+ * correct privs; simply does not create a group if the proper priv not present (rather than
+ * throwing an error)
+ *
+ * @export
+ * @param {string} collaborationGroupName name of the collaboration group to be created
+ * @param {string} dataGroupName name of the content group to be created
+ * @param {IRequestOptions} ro
+ * @returns {Promise<any>} object containing the groupIds
+ */
 export function createInitiativeGroups(
   collaborationGroupName: string,
   dataGroupName: string,
@@ -27,7 +37,7 @@ export function createInitiativeGroups(
       );
       state.canCreateContentGroup = portal.user.privileges.includes(
         "opendata:user:designateGroup"
-      ); // TODO remove this guard when hyu fixes things
+      ); // TODO remove this guard when no longer creating open data groups
       const namePromises: any[] = [];
       if (state.canCreateCollabGroup) {
         namePromises.push(

--- a/packages/initiatives/src/groups.ts
+++ b/packages/initiatives/src/groups.ts
@@ -7,9 +7,80 @@ import {
   searchGroups,
   removeGroup,
   unprotectGroup,
-  IUserGroupOptions
+  getSelf,
+  IUserGroupOptions,
+  IPortal
 } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
+
+// doc
+export function createInitiativeGroups(
+  collaborationGroupName: string,
+  dataGroupName: string,
+  ro: IRequestOptions
+): Promise<any> {
+  const state = {} as any;
+  return getSelf(ro)
+    .then((portal: IPortal) => {
+      state.canCreateCollabGroup = portal.user.privileges.includes(
+        "portal:admin:createUpdateCapableGroup"
+      );
+      state.canCreateContentGroup = portal.user.privileges.includes(
+        "opendata:user:designateGroup"
+      ); // TODO remove this guard when hyu fixes things
+      const namePromises: any[] = [];
+      if (state.canCreateCollabGroup) {
+        namePromises.push(
+          getUniqueGroupName(collaborationGroupName, portal.id, 0, ro).then(
+            name => {
+              state.collabGroupName = name;
+            }
+          )
+        );
+      }
+      if (state.canCreateContentGroup) {
+        namePromises.push(
+          getUniqueGroupName(dataGroupName, portal.id, 0, ro).then(name => {
+            state.dataGroupName = name;
+          })
+        );
+      }
+      return Promise.all(namePromises).then(() => {
+        return true;
+      });
+    })
+    .then(() => {
+      const createPromises = [];
+      const result: any = {};
+      if (state.collabGroupName) {
+        createPromises.push(
+          createInitiativeGroup(
+            state.collabGroupName,
+            state.collabGroupName,
+            { isSharedEditing: true },
+            ro
+          ).then(groupId => {
+            result.collabGroupId = groupId;
+          })
+        );
+      }
+      if (state.dataGroupName) {
+        createPromises.push(
+          createInitiativeGroup(
+            state.dataGroupName,
+            state.dataGroupName,
+            { isOpenData: true }, // TODO remove this
+            ro
+          ).then(groupId => {
+            result.dataGroupId = groupId;
+          })
+        );
+      }
+      return Promise.all(createPromises).then(() => {
+        return result;
+      });
+    });
+}
 
 /**
  * Create an initiative collaboration or open data group

--- a/packages/initiatives/src/templates.ts
+++ b/packages/initiatives/src/templates.ts
@@ -14,8 +14,8 @@ import { INITIATIVE_TYPE_NAME } from "./add";
  */
 export interface IInitiativeTemplateOptions {
   title: string;
-  collaborationGroupId: string;
-  openDataGroupId: string;
+  collaborationGroupId?: string;
+  dataGroupId?: string;
   initiativeKey: string;
 }
 
@@ -51,19 +51,22 @@ export function createInitiativeModelFromTemplate(
   );
   model.item.typeKeywords.push("hubInitiative");
 
-  // remove things that are irrelvant or are set server-side
+  // remove things that are irrelevant or are set server-side
   ["id", "owner", "created_at", "modified_at"].forEach(
     prop => delete model.item[prop]
   );
-
   // we store a bunch of Ids in here so we can avoid fetching /data for common interactions
   model.item.properties = {
     source: template.item.id,
-    groupId: options.collaborationGroupId,
-    openDataGroupId: options.openDataGroupId,
     schemaVersion: CURRENT_SCHEMA_VERSION,
     initialParent: template.item.id
   };
+  if (options.collaborationGroupId) {
+    model.item.properties.groupId = options.collaborationGroupId;
+  }
+  if (options.dataGroupId) {
+    model.item.properties.openDataGroupId = options.dataGroupId;
+  }
   // we create a new .data node so we're cleaning rogue properties as we go
   model.data = {
     assets: cloneObject(template.data.assets),
@@ -71,14 +74,17 @@ export function createInitiativeModelFromTemplate(
     indicators: [],
     source: template.item.id,
     values: {
-      collaborationGroupId: options.collaborationGroupId,
-      openDataGroupId: options.openDataGroupId,
       followerGroups: [],
       initiativeKey: options.initiativeKey,
       bannerImage: cloneObject(template.data.values.bannerImage)
     }
   };
-
+  if (options.collaborationGroupId) {
+    model.data.values.collaborationGroupId = options.collaborationGroupId;
+  }
+  if (options.dataGroupId) {
+    model.data.values.openDataGroupId = options.dataGroupId;
+  }
   // just in case the template does not have a banner image defined...
   if (!model.data.values.bannerImage) {
     model.data.values.bannerImage = {
@@ -88,6 +94,5 @@ export function createInitiativeModelFromTemplate(
       }
     };
   }
-
   return model;
 }

--- a/packages/initiatives/src/util.ts
+++ b/packages/initiatives/src/util.ts
@@ -52,6 +52,47 @@ export function copyImageResources(
 }
 
 /**
+ *  Copy an set of embedded resources to an item
+ *
+ * @export
+ * @param {string} id destination item id
+ * @param {string} owner destination item owner
+ * @param {any[]} assets list of assets to copy
+ * @param {IRequestOptions} requestOptions
+ * @returns {Promise<boolean>}
+ */
+export function copyEmbeddedImageResources(
+  targetItemId: string,
+  owner: string,
+  assets: any[],
+  requestOptions: IRequestOptions
+): Promise<boolean> {
+  // need to move resources from embedded template into AGO
+  const promises = assets.map((asset: any) => {
+    // // first, generate a URL to each asset in the model
+    // const entry = newModel.data.assets.findBy('id', asset.id);
+    // entry.url = `${ro.authentication.portal}/content/items/${newModel.item.id}/resources/${asset.name}`;
+    // then, upload the actual asset
+    return addImageAsResource(
+      targetItemId,
+      owner,
+      asset.name,
+      asset.url,
+      requestOptions as IUserRequestOptions
+    )
+      .then(() => {
+        return true;
+      })
+      .catch(() => {
+        return true; // swallow the error
+      });
+  });
+  return Promise.all(promises).then(() => {
+    return true;
+  });
+}
+
+/**
  * Load an image from a url, and store it as a resource on an existing item
  *
  * @export

--- a/packages/initiatives/src/util.ts
+++ b/packages/initiatives/src/util.ts
@@ -55,7 +55,7 @@ export function copyImageResources(
  *  Copy an set of embedded resources to an item
  *
  * @export
- * @param {string} id destination item id
+ * @param {string} targetItemId destination item id
  * @param {string} owner destination item owner
  * @param {any[]} assets list of assets to copy
  * @param {IRequestOptions} requestOptions
@@ -69,10 +69,6 @@ export function copyEmbeddedImageResources(
 ): Promise<boolean> {
   // need to move resources from embedded template into AGO
   const promises = assets.map((asset: any) => {
-    // // first, generate a URL to each asset in the model
-    // const entry = newModel.data.assets.findBy('id', asset.id);
-    // entry.url = `${ro.authentication.portal}/content/items/${newModel.item.id}/resources/${asset.name}`;
-    // then, upload the actual asset
     return addImageAsResource(
       targetItemId,
       owner,

--- a/packages/initiatives/test/activate.test.ts
+++ b/packages/initiatives/test/activate.test.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { cloneObject, createId } from "@esri/hub-common";
+import { cloneObject } from "@esri/hub-common";
 import { activateInitiative } from "../src/activate";
 import * as portal from "@esri/arcgis-rest-portal";
 import * as InitiativeFetchAPI from "../src/get";
@@ -202,7 +202,22 @@ describe("Initiative Activation :: ", () => {
         expect(progressCallbackSpy.calls.argsFor(0)[0].steps).toEqual(
           ActivateInitiativeAPI.steps
         );
-
+        expect(response.item.properties.groupId).toEqual(
+          "3ef",
+          "has collab group"
+        );
+        expect(response.data.values.collaborationGroupId).toEqual(
+          "3ef",
+          "has collab group"
+        );
+        expect(response.item.properties.openDataGroupId).toEqual(
+          "2ef",
+          "has data group"
+        );
+        expect(response.data.values.openDataGroupId).toEqual(
+          "2ef",
+          "has data group"
+        );
         done();
       });
     });

--- a/packages/initiatives/test/templates.test.ts
+++ b/packages/initiatives/test/templates.test.ts
@@ -36,7 +36,7 @@ describe("Initiative Templates ::", () => {
       const opts = {
         title: "Death Star Initiative",
         collaborationGroupId: "bc45251",
-        openDataGroupId: "bc45251",
+        dataGroupId: "bc45251",
         initiativeKey: "deathStarInitiative"
       };
       const chk = createInitiativeModelFromTemplate(tmpl, opts);
@@ -52,7 +52,7 @@ describe("Initiative Templates ::", () => {
         "templateId should be source"
       );
       expect(chk.item.properties.groupId).toBe(opts.collaborationGroupId);
-      expect(chk.item.properties.openDataGroupId).toBe(opts.openDataGroupId);
+      expect(chk.item.properties.openDataGroupId).toBe(opts.dataGroupId);
       expect(chk.item.properties.initialParent).toBe(defaultTemplate.item.id);
 
       expect(chk.item.tags).toContain("Hub Initiative");
@@ -67,8 +67,21 @@ describe("Initiative Templates ::", () => {
       expect(chk.data.values.collaborationGroupId).toBe(
         opts.collaborationGroupId
       );
-      expect(chk.data.values.openDataGroupId).toBe(opts.openDataGroupId);
+      expect(chk.data.values.openDataGroupId).toBe(opts.dataGroupId);
       expect(chk.data.values.initiativeKey).toBe(opts.initiativeKey);
+    });
+    it("should return a new model with groupIds excluded", () => {
+      const tmpl = cloneObject(defaultTemplate) as IInitiativeModel;
+      const opts = {
+        title: "Death Star Initiative",
+        initiativeKey: "deathStarInitiative"
+      };
+      const chk = createInitiativeModelFromTemplate(tmpl, opts);
+
+      expect(chk.item.properties.groupId).toBeUndefined();
+      expect(chk.item.properties.openDataGroupId).toBeUndefined();
+      expect(chk.data.values.collaborationGroupId).toBeUndefined();
+      expect(chk.data.values.openDataGroupId).toBeUndefined();
     });
     it("should inject a default banner image", () => {
       const tmpl = cloneObject(defaultTemplate) as IInitiativeModel;
@@ -76,7 +89,7 @@ describe("Initiative Templates ::", () => {
       const opts = {
         title: "Death Star Initiative",
         collaborationGroupId: "bc45251",
-        openDataGroupId: "bc45251",
+        dataGroupId: "bc45251",
         initiativeKey: "deathStarInitiative"
       };
       const chk = createInitiativeModelFromTemplate(tmpl, opts);


### PR DESCRIPTION
This refactor creates a new orchestration method for creating the two groups required for activating an initiative so that it can handle users who do not have all the privs necessary to create
groups. It also allows activateInitiative to activate an embedded initiative by adding support for copying embedded image resources to AGO.

AFFECTS PACKAGES:
@esri/hub-initiatives

ISSUES CLOSED: #145