### PR TITLE
feat(search) support filters specified implicitly

### DIFF
--- a/packages/search/src/ago/encode-ago-query.ts
+++ b/packages/search/src/ago/encode-ago-query.ts
@@ -26,12 +26,16 @@ export function encodeAgoQuery(queryParams: any = {}) {
     const filter = createFilters(queryParams.catalog);
     queryParts.push(handleFilter(filter));
   }
-  if (queryParams.filter) {
-    // queryParams filter is an obj with key<string>: value<string> where value is serialized as 'all(a,b)'
-    // so parse each filter string into fn and terms
-    const filter = createFilters(queryParams.filter);
+
+  const implicitFilters = createFilters(queryParams);
+  // queryParams filter is an obj with key<string>: value<string> where value is serialized as 'all(a,b)'
+  // so parse each filter string into fn and terms
+  const explicitFilters = createFilters(queryParams.filter);
+  const filters = { ...implicitFilters, ...explicitFilters };
+
+  if (Object.keys(filters).length) {
     // add each parsed filter object into ago query
-    queryParts.push(handleFilter(filter));
+    queryParts.push(handleFilter(filters));
   }
   // cleanse queryParts by removing blank strings
   queryParts = queryParts.filter(qp => !!qp);

--- a/packages/search/src/ago/helpers/filters/create-filters.ts
+++ b/packages/search/src/ago/helpers/filters/create-filters.ts
@@ -27,6 +27,9 @@ import { filterSchema } from "./filter-schema";
 //   }
 // }
 export function createFilters(params: ISearchParams): any {
+  if (!params) {
+    return {};
+  }
   const filter = Object.keys(params).reduce((filters: any, key) => {
     const filterDefinition = filterSchema[key] || {};
     if (

--- a/packages/search/test/ago/encode-ago-query.test.ts
+++ b/packages/search/test/ago/encode-ago-query.test.ts
@@ -1,5 +1,4 @@
 import { encodeAgoQuery } from "../../src/ago/encode-ago-query";
-import { encode } from "punycode";
 
 describe("encodeAgoQuery test", () => {
   it("encodes ago query for all fields defined in params", () => {
@@ -19,6 +18,35 @@ describe("encodeAgoQuery test", () => {
     const expected = {
       q:
         '-type:"code attachment" AND crime AND ((group:"1ef")) AND (tags:"test")',
+      start: 1,
+      num: 10,
+      sortField: "title",
+      sortOrder: "asc",
+      countFields: "tags,type",
+      countSize: 200,
+      bbox: "1,2,3,4"
+    };
+    expect(actual).toEqual(expected);
+  });
+
+  it("encodes ago query when a filterable field is passed in at the top level ", () => {
+    const params: any = {
+      q: "crime",
+      catalog: {
+        groupIds: "any(1ef)"
+      },
+      collection: "Map",
+      filter: {
+        tags: "all(test)"
+      },
+      sort: "name",
+      agg: { fields: "tags,type" },
+      bbox: "1,2,3,4"
+    };
+    const actual = encodeAgoQuery(params);
+    const expected = {
+      q:
+        '-type:"code attachment" AND crime AND ((group:"1ef")) AND (type:"City Engine Web Scene" OR type:"CityEngine Web Scene" OR type:"Image Collection" OR type:"Image Service" OR type:"Map Service Layer" OR type:"Map Service" OR type:"Scene Service" OR type:"Vector Tile Service" OR type:"Web Map Service" OR type:"Web Map Tile Service" OR type:"Web Map" OR type:"Web Scene" OR type:"WFS" OR type:"WMS") AND (tags:"test")',
       start: 1,
       num: 10,
       sortField: "title",


### PR DESCRIPTION
support generating a correct filter from any key in ISearchParams
```
e.g. 
{
tags: 'water',
q: 'air'
}

-> q="air AND tags:water"
```