### PR TITLE
fix(search): multiple filters should be ANDed together

### DIFF
--- a/packages/search/src/ago/helpers/filters/handle-filter.ts
+++ b/packages/search/src/ago/helpers/filters/handle-filter.ts
@@ -39,7 +39,7 @@ export function handleFilter(queryFilters: any) {
   if (catalogDefinition.length) {
     const catalogClause = `(${catalogDefinition.join(" OR ")})`;
     if (otherFilters.length) {
-      return `${catalogClause} AND (${otherFilters.join(" OR ")})`;
+      return `${catalogClause} AND (${otherFilters.join(" AND ")})`;
     } else {
       return catalogClause;
     }

--- a/packages/search/test/ago/encode-ago-query.test.ts
+++ b/packages/search/test/ago/encode-ago-query.test.ts
@@ -58,6 +58,31 @@ describe("encodeAgoQuery test", () => {
     expect(actual).toEqual(expected);
   });
 
+  it("handles a joint collection and type query correctly", () => {
+    const params: any = {
+      q: "",
+      groupIds: "6f063f2d05824bd898ca0d5089d93614",
+      type: "hub page",
+      collection: "Document",
+      sort: "relevance",
+      agg: {
+        fields: "downloadable,hasApi,source,tags,type,access"
+      },
+      id: "4dd789d0c75a4ebb8805b1314c1cc974",
+      initiativeId: ""
+    };
+    const actual = encodeAgoQuery(params);
+    const expected = {
+      q:
+        '-type:"code attachment" AND ((group:"6f063f2d05824bd898ca0d5089d93614") OR (id:"4dd789d0c75a4ebb8805b1314c1cc974")) AND ((type:"hub page") AND (type:"CAD Drawing" OR type:"Document Link" OR type:"Hub Page" OR type:"Image" OR type:"iWork Keynote" OR type:"iWork Numbers" OR type:"iWork Pages" OR type:"Microsoft Powerpoint" OR type:"Microsoft Visio" OR type:"Microsoft Word" OR type:"PDF" OR type:"Pro Map" OR type:"Report Template"))',
+      start: 1,
+      num: 10,
+      countFields: "tags,type,access",
+      countSize: 200
+    };
+    expect(actual).toEqual(expected);
+  });
+
   it("encodes ago query undefined query params", () => {
     const actual = encodeAgoQuery();
     const expected = {

--- a/packages/search/test/ago/helpers/filters/handle-filter.test.ts
+++ b/packages/search/test/ago/helpers/filters/handle-filter.test.ts
@@ -74,7 +74,7 @@ describe("handleFilter test", () => {
       }
     };
     const expected =
-      '((group:"a" OR group:"b") OR (id:"x" OR id:"y")) AND ((tags:"a" AND tags:"b") OR (type:"Feature Service" OR type:"Map Service" OR type:"Image Service"))';
+      '((group:"a" OR group:"b") OR (id:"x" OR id:"y")) AND ((tags:"a" AND tags:"b") AND (type:"Feature Service" OR type:"Map Service" OR type:"Image Service"))';
     const actual = handleFilter(queryFilters);
     expect(actual).toBe(expected);
   });


### PR DESCRIPTION
when searhcing for thigns tagged "tres" and things of type "web map", the generated query should be "type: web map AND tags: trees"

currently they ared ORed together so you get thigns that are web maps or trees