### PR TITLE
Rob/new

### DIFF
--- a/packages/initiatives/src/activate.ts
+++ b/packages/initiatives/src/activate.ts
@@ -6,6 +6,7 @@ import { IInitiativeModel, camelize } from "@esri/hub-common";
 import { getInitiative } from "./get";
 import {
   createInitiativeModelFromTemplate,
+  IInitiativeGroupIds,
   IInitiativeTemplateOptions
 } from "./templates";
 import { addInitiative } from "./add";
@@ -30,7 +31,7 @@ import { getProp } from "@esri/hub-common";
 export function activateInitiative(
   template: string | any,
   title: string,
-  groupIds: any,
+  groupIds: IInitiativeGroupIds,
   requestOptions: IRequestOptions
 ): Promise<IInitiativeModel> {
   // make a copy of the request options so we can mutate things if needed...
@@ -92,11 +93,15 @@ export function activateInitiative(
     })
     .then(
       (): Promise<any> => {
-        if (groupIds.collaborationGroupId) {
+        const collaborationGroupId = getProp(
+          state,
+          "initiativeModel.item.properties.collaborationGroupId"
+        );
+        if (collaborationGroupId) {
           // create sharing options and share to the core team
           const shareOptions = {
             id: state.initiativeModel.item.id,
-            groupId: groupIds.collaborationGroupId,
+            groupId: collaborationGroupId,
             confirmItemControl: true,
             ...requestOptions
           } as IGroupSharingOptions;

--- a/packages/initiatives/src/migrations/upgrade-two-dot-one.ts
+++ b/packages/initiatives/src/migrations/upgrade-two-dot-one.ts
@@ -1,0 +1,27 @@
+/* Copyright (c) 2019 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { getProp, cloneObject } from "@esri/hub-common";
+import { IInitiativeModel } from "@esri/hub-common";
+
+/**
+ * Apply the 2.0 --> 2.1 Migration to an Initiative Model
+ *
+ * @param model
+ * @protected
+ */
+export function upgradeToTwoDotOne(model: IInitiativeModel): IInitiativeModel {
+  const currVersion = getProp(model, "item.properties.schemaVersion");
+  if (currVersion < 2.1) {
+    const clone = cloneObject(model) as IInitiativeModel;
+    // store the schemaVersion
+    clone.item.properties.schemaVersion = 2.1;
+    const collaborationGroupId = getProp(model, "item.properties.groupId");
+    if (collaborationGroupId) {
+      clone.item.properties.collaborationGroupId = collaborationGroupId;
+      delete clone.item.properties.groupId;
+    }
+    return clone;
+  } else {
+    return model;
+  }
+}

--- a/packages/initiatives/src/migrator.ts
+++ b/packages/initiatives/src/migrator.ts
@@ -5,6 +5,7 @@ import { IInitiativeModel } from "@esri/hub-common";
 import { applyInitialSchema } from "./migrations/apply-schema";
 import { upgradeToOneDotOne } from "./migrations/upgrade-one-dot-one";
 import { upgradeToTwoDotZero } from "./migrations/upgrade-two-dot-zero";
+import { upgradeToTwoDotOne } from "./migrations/upgrade-two-dot-one";
 
 /**
  * Current Schema Version
@@ -38,6 +39,7 @@ export function migrateSchema(
     model = applyInitialSchema(model, portalUrl);
     model = upgradeToOneDotOne(model, portalUrl);
     model = upgradeToTwoDotZero(model, portalUrl);
+    model = upgradeToTwoDotOne(model);
     // etc
     return model;
   }

--- a/packages/initiatives/src/templates.ts
+++ b/packages/initiatives/src/templates.ts
@@ -14,9 +14,8 @@ import { INITIATIVE_TYPE_NAME } from "./add";
  */
 export interface IInitiativeTemplateOptions {
   title: string;
-  collaborationGroupId?: string;
-  dataGroupId?: string;
   initiativeKey: string;
+  groupIds?: any;
 }
 
 /**
@@ -61,12 +60,7 @@ export function createInitiativeModelFromTemplate(
     schemaVersion: CURRENT_SCHEMA_VERSION,
     initialParent: template.item.id
   };
-  if (options.collaborationGroupId) {
-    model.item.properties.groupId = options.collaborationGroupId;
-  }
-  if (options.dataGroupId) {
-    model.item.properties.openDataGroupId = options.dataGroupId;
-  }
+  Object.assign(model.item.properties, options.groupIds); // add the groupIds
   // we create a new .data node so we're cleaning rogue properties as we go
   model.data = {
     assets: cloneObject(template.data.assets),
@@ -74,17 +68,11 @@ export function createInitiativeModelFromTemplate(
     indicators: [],
     source: template.item.id,
     values: {
-      followerGroups: [],
       initiativeKey: options.initiativeKey,
       bannerImage: cloneObject(template.data.values.bannerImage)
     }
   };
-  if (options.collaborationGroupId) {
-    model.data.values.collaborationGroupId = options.collaborationGroupId;
-  }
-  if (options.dataGroupId) {
-    model.data.values.openDataGroupId = options.dataGroupId;
-  }
+  Object.assign(model.data.values, options.groupIds); // add the groupIds, TODO stop storing groupIds in data.values
   // just in case the template does not have a banner image defined...
   if (!model.data.values.bannerImage) {
     model.data.values.bannerImage = {

--- a/packages/initiatives/src/templates.ts
+++ b/packages/initiatives/src/templates.ts
@@ -15,7 +15,18 @@ import { INITIATIVE_TYPE_NAME } from "./add";
 export interface IInitiativeTemplateOptions {
   title: string;
   initiativeKey: string;
-  groupIds?: any;
+  groupIds?: IInitiativeGroupIds;
+}
+
+/**
+ * Hash for passing groupIds corresponding to newly created initiative
+ * groups into the new initiative model
+ *
+ * @export
+ * @interface IInitiativeGroupIds
+ */
+export interface IInitiativeGroupIds {
+  [s: string]: string;
 }
 
 /**

--- a/packages/initiatives/test/activate.test.ts
+++ b/packages/initiatives/test/activate.test.ts
@@ -6,17 +6,9 @@ import { activateInitiative } from "../src/activate";
 import * as portal from "@esri/arcgis-rest-portal";
 import * as InitiativeFetchAPI from "../src/get";
 import * as AddInitiativeAPI from "../src/add";
-import * as ActivateInitiativeAPI from "../src/activate";
-import * as InitiativeGroupsAPI from "../src/groups";
 import * as UtilAPI from "../src/util";
 import { InitiativeTemplate } from "./mocks/initiative-template";
 import { MOCK_REQUEST_OPTIONS } from "./mocks/fake-session";
-
-const CBWrapper = {
-  updateProgress(options: any): any {
-    return;
-  }
-};
 
 describe("Initiative Activation :: ", () => {
   let addInitiativeSpy: any;

--- a/packages/initiatives/test/activate.test.ts
+++ b/packages/initiatives/test/activate.test.ts
@@ -19,36 +19,12 @@ const CBWrapper = {
 };
 
 describe("Initiative Activation :: ", () => {
-  let progressCallbackSpy: any;
-  let createGroupsSpy: any;
   let addInitiativeSpy: any;
   let shareInitiativeSpy: any;
   let copyResourcesSpy: any;
   let copyEmbeddedResourcesSpy: any;
 
   beforeEach(function() {
-    progressCallbackSpy = spyOn(CBWrapper, "updateProgress").and.callFake(
-      (options: any): any => {
-        return;
-      }
-    );
-
-    createGroupsSpy = spyOn(
-      InitiativeGroupsAPI,
-      "createInitiativeGroups"
-    ).and.callFake(
-      (
-        collaborationGroupName: string,
-        dataGroupName: string,
-        ro: any
-      ): Promise<any> => {
-        return Promise.resolve({
-          collabGroupId: "3ef",
-          dataGroupId: "2ef"
-        });
-      }
-    );
-
     addInitiativeSpy = spyOn(AddInitiativeAPI, "addInitiative").and.callFake(
       (model: any, ro: any): Promise<any> => {
         const res = cloneObject(model);
@@ -93,17 +69,15 @@ describe("Initiative Activation :: ", () => {
       return activateInitiative(
         InitiativeTemplate,
         "Test Initiative",
-        "Test Initiative Collaboration Group",
-        "Test Initiative Open Data Group",
-        CBWrapper.updateProgress,
+        {
+          contentGroupId: "3ef",
+          collaborationGroupId: "2ef",
+          followersGroupId: "1ef"
+        },
         MOCK_REQUEST_OPTIONS
       ).then(response => {
         expect(response.item.id).toBe("3ef-NEW-INITIATIVE");
         // validate the call counts
-        expect(createGroupsSpy.calls.count()).toEqual(
-          1,
-          "should make 1 calls to create initiative groups"
-        );
         expect(addInitiativeSpy.calls.count()).toEqual(
           1,
           "should make 1 calls to create initiative item"
@@ -120,29 +94,17 @@ describe("Initiative Activation :: ", () => {
           1,
           "should make 1 calls to share initiative"
         );
-        expect(progressCallbackSpy.calls.count()).toEqual(
-          6,
-          "should make 6 calls to callback"
-        );
-        // check the content of the first callback
-        expect(progressCallbackSpy.calls.argsFor(0)[0].steps).toEqual(
-          ActivateInitiativeAPI.steps
-        );
-        expect(response.item.properties.groupId).toEqual(
+        expect(response.item.properties.contentGroupId).toEqual(
           "3ef",
-          "has collab group"
+          "has content group"
         );
-        expect(response.data.values.collaborationGroupId).toEqual(
-          "3ef",
-          "has collab group"
-        );
-        expect(response.item.properties.openDataGroupId).toEqual(
+        expect(response.item.properties.collaborationGroupId).toEqual(
           "2ef",
-          "has data group"
+          "has core team"
         );
-        expect(response.data.values.openDataGroupId).toEqual(
-          "2ef",
-          "has data group"
+        expect(response.item.properties.followersGroupId).toEqual(
+          "1ef",
+          "has followers group"
         );
         done();
       });
@@ -163,9 +125,11 @@ describe("Initiative Activation :: ", () => {
       return activateInitiative(
         InitiativeTemplate.item.id,
         "Test Initiative",
-        "Test Initiative Collaboration Group",
-        "Test Initiative Open Data Group",
-        CBWrapper.updateProgress,
+        {
+          contentGroupId: "3ef",
+          collaborationGroupId: "2ef",
+          followersGroupId: "1ef"
+        },
         MOCK_REQUEST_OPTIONS
       ).then(response => {
         expect(response.item.id).toBe("3ef-NEW-INITIATIVE");
@@ -173,10 +137,6 @@ describe("Initiative Activation :: ", () => {
         expect(getInitiativeSpy.calls.count()).toEqual(
           1,
           "should make one call to fetch the template"
-        );
-        expect(createGroupsSpy.calls.count()).toEqual(
-          1,
-          "should make 1 calls to create initiative groups"
         );
         expect(addInitiativeSpy.calls.count()).toEqual(
           1,
@@ -194,60 +154,43 @@ describe("Initiative Activation :: ", () => {
           1,
           "should make 1 calls to share initiative"
         );
-        expect(progressCallbackSpy.calls.count()).toEqual(
-          6,
-          "should make 6 calls to callback"
-        );
-        // check the content of the first callback
-        expect(progressCallbackSpy.calls.argsFor(0)[0].steps).toEqual(
-          ActivateInitiativeAPI.steps
-        );
-        expect(response.item.properties.groupId).toEqual(
+        expect(response.item.properties.contentGroupId).toEqual(
           "3ef",
-          "has collab group"
+          "has content group"
+        );
+        expect(response.data.values.contentGroupId).toEqual(
+          "3ef",
+          "has content group"
+        ); // TODO remove
+        expect(response.item.properties.collaborationGroupId).toEqual(
+          "2ef",
+          "has core team"
         );
         expect(response.data.values.collaborationGroupId).toEqual(
-          "3ef",
-          "has collab group"
-        );
-        expect(response.item.properties.openDataGroupId).toEqual(
           "2ef",
-          "has data group"
+          "has core team"
+        ); // TODO remove
+        expect(response.item.properties.followersGroupId).toEqual(
+          "1ef",
+          "has followers group"
         );
-        expect(response.data.values.openDataGroupId).toEqual(
-          "2ef",
-          "has data group"
-        );
+        expect(response.data.values.followersGroupId).toEqual(
+          "1ef",
+          "has followers group"
+        ); // TODO remove
         done();
       });
     });
 
     it("should create an initiative without a data or collab group", done => {
-      createGroupsSpy.and.callFake(
-        (
-          collaborationGroupName: string,
-          dataGroupName: string,
-          ro: any
-        ): Promise<any> => {
-          return Promise.resolve({});
-        }
-      );
       return activateInitiative(
         InitiativeTemplate,
         "Test Initiative",
-        "Test Initiative Collaboration Group",
-        "Test Initiative Open Data Group",
-        CBWrapper.updateProgress,
+        {},
         MOCK_REQUEST_OPTIONS
       ).then(response => {
-        expect(shareInitiativeSpy.calls.count()).toEqual(
-          0,
-          "should make 0 calls to share initiative"
-        );
-        expect(response.item.properties.groupId).toBeUndefined();
-        expect(response.data.values.collaborationGroupId).toBeUndefined();
-        expect(response.item.properties.openDataGroupId).toBeUndefined();
-        expect(response.data.values.openDataGroupId).toBeUndefined();
+        expect(response.item.properties.collaborationGroupId).toBeUndefined();
+        expect(response.item.properties.contentGroupId).toBeUndefined();
         done();
       });
     });
@@ -261,9 +204,7 @@ describe("Initiative Activation :: ", () => {
       return activateInitiative(
         InitiativeTemplate,
         "Test Initiative",
-        "Test Initiative Collaboration Group",
-        "Test Initiative Open Data Group",
-        CBWrapper.updateProgress,
+        {},
         MOCK_REQUEST_OPTIONS
       ).then(response => {
         expect(response.item.id).toBe("3ef-NEW-INITIATIVE");

--- a/packages/initiatives/test/get.test.ts
+++ b/packages/initiatives/test/get.test.ts
@@ -28,7 +28,7 @@ describe("Initiatives :: ", () => {
       getInitiative("3ef")
         .then(model => {
           expect(model.item).toBeDefined();
-          expect(model.item.properties.schemaVersion).toEqual(2);
+          expect(model.item.properties.schemaVersion).toEqual(2.1);
           expect(model.data).toBeDefined();
           expect(fetchMock.done()).toBeTruthy();
           const [url]: [string, RequestInit] = fetchMock.lastCall(

--- a/packages/initiatives/test/groups.test.ts
+++ b/packages/initiatives/test/groups.test.ts
@@ -13,7 +13,6 @@ import { MOCK_REQUEST_OPTIONS } from "./mocks/fake-session";
 import {
   checkGroupExists,
   isSharedEditingGroup,
-  createInitiativeGroups,
   createInitiativeGroup,
   getUniqueGroupName,
   removeInitiativeGroup
@@ -50,120 +49,6 @@ describe("Initiative Groups ::", () => {
         return Promise.resolve({ success: true, id: "3ef" });
       }
     );
-  });
-
-  describe("createInitiativeGroups ::", () => {
-    it("should create and protect a data and collab group", done => {
-      const portalSelfSpy = spyOn(portal, "getSelf").and.callFake(() => {
-        return Promise.resolve({
-          id: "FAKEPORTALID",
-          user: {
-            privileges: [
-              "portal:admin:createUpdateCapableGroup",
-              "opendata:user:designateGroup"
-            ]
-          }
-        });
-      });
-      const searchSpy = spyOn(portal, "searchGroups").and.callFake(
-        (opts: ISearchOptions) => {
-          const res = {
-            results: [],
-            query: opts.q,
-            total: 0,
-            start: 0,
-            num: 0,
-            nextStart: -1
-          } as ISearchResult<IGroup>;
-          return Promise.resolve(res);
-        }
-      );
-
-      return createInitiativeGroups(
-        "a collab group",
-        "a data group",
-        MOCK_REQUEST_OPTIONS
-      ).then(groupIds => {
-        expect(portalSelfSpy.calls.count()).toEqual(
-          1,
-          "should make 1 call to getSelf"
-        );
-        expect(searchSpy.calls.count()).toEqual(
-          2,
-          "should make 2 calls to search for getting unique name"
-        );
-        expect(createGroupSpy.calls.count()).toEqual(
-          2,
-          "should make 2 calls to createGroup"
-        );
-        expect(protectGroupSpy.calls.count()).toEqual(
-          2,
-          "should make 2 calls to protectGroup"
-        );
-        const createCollabGroupArgs = createGroupSpy.calls.argsFor(0);
-        expect(createCollabGroupArgs[0].group.capabilities).toEqual(
-          "updateitemcontrol",
-          "isSharedEditing should be true"
-        );
-        const createDataGroupArgs = createGroupSpy.calls.argsFor(1);
-        expect(createDataGroupArgs[0].group.isOpenData).toBeTruthy(
-          "isOpenData should be true"
-        );
-        expect(groupIds.dataGroupId).toBeTruthy();
-        expect(groupIds.collabGroupId).toBeTruthy();
-        done();
-      });
-    });
-
-    it("should not create groups without correct privs", done => {
-      const portalSelfSpy = spyOn(portal, "getSelf").and.callFake(() => {
-        return Promise.resolve({
-          id: "FAKEPORTALID",
-          user: {
-            privileges: []
-          }
-        });
-      });
-      const searchSpy = spyOn(portal, "searchGroups").and.callFake(
-        (opts: ISearchOptions) => {
-          const res = {
-            results: [],
-            query: opts.q,
-            total: 0,
-            start: 0,
-            num: 0,
-            nextStart: -1
-          } as ISearchResult<IGroup>;
-          return Promise.resolve(res);
-        }
-      );
-
-      return createInitiativeGroups(
-        "a collab group",
-        "a data group",
-        MOCK_REQUEST_OPTIONS
-      ).then(groupIds => {
-        expect(portalSelfSpy.calls.count()).toEqual(
-          1,
-          "should make 1 call to getSelf"
-        );
-        expect(searchSpy.calls.count()).toEqual(
-          0,
-          "should make 0 calls to search for getting unique name"
-        );
-        expect(createGroupSpy.calls.count()).toEqual(
-          0,
-          "should make 0 calls to createGroup"
-        );
-        expect(protectGroupSpy.calls.count()).toEqual(
-          0,
-          "should make 0 calls to protectGroup"
-        );
-        expect(groupIds.dataGroupId).toBeUndefined();
-        expect(groupIds.collabGroupId).toBeUndefined();
-        done();
-      });
-    });
   });
 
   describe("createInitiativeGroup ::", () => {

--- a/packages/initiatives/test/mocks/initiative-instance.ts
+++ b/packages/initiatives/test/mocks/initiative-instance.ts
@@ -38,9 +38,10 @@ export const InitiativeInstance: IInitiativeModel = {
     licenseInfo: "null",
     culture: "en-us",
     properties: {
-      groupId: "3dde61efbdcd464eacabe5a7a917c8d4",
-      openDataGroupId: "f6742867e3ee41beb964d9f5d9cec5ae",
-      schemaVersion: 2,
+      collaborationGroupId: "3dde61efbdcd464eacabe5a7a917c8d4",
+      contentGroupId: "f6742867e3ee41beb964d9f5d9cec5ae",
+      followersGroupId: "q736g4f8q76g487f6qg38476gq83746g",
+      schemaVersion: 2.1,
       initialParent: "b746772712ef4c68a53d0e268e3c8f49",
       siteId: "d6f7dcd57d9c4fecb70bbf547ff4613b"
     },
@@ -219,9 +220,6 @@ export const InitiativeInstance: IInitiativeModel = {
       }
     ],
     values: {
-      collaborationGroupId: "3dde61efbdcd464eacabe5a7a917c8d4",
-      openDataGroupId: "f6742867e3ee41beb964d9f5d9cec5ae",
-      followerGroups: [],
       bannerImage: {
         source: "bannerImage",
         display: {

--- a/packages/initiatives/test/mocks/initiative-versionTwo.ts
+++ b/packages/initiatives/test/mocks/initiative-versionTwo.ts
@@ -2,7 +2,12 @@
  * Apache-2.0 */
 import { IInitiativeModel, IInitiativeItem } from "@esri/hub-common";
 
-export const initiativeVersionZero: IInitiativeModel = {
-  item: {} as IInitiativeItem,
+export const initiativeVersionTwo: IInitiativeModel = {
+  item: {
+    properties: {
+      schemaVersion: 2,
+      groupId: "4ef"
+    }
+  } as IInitiativeItem,
   data: {}
 };

--- a/packages/initiatives/test/mocks/search-results.ts
+++ b/packages/initiatives/test/mocks/search-results.ts
@@ -93,8 +93,8 @@ export const InitiativeSearchResults: any = {
       culture: "en-us",
       properties: {
         source: "94bbbf2bf2364e7981d396d2474f4b1c",
-        groupId: "10dcdbf74f314d74b23741e9d790f4ad",
-        openDataGroupId: "b8ce4867a0f94d719cc64514bf4430b4",
+        collaborationGroupId: "10dcdbf74f314d74b23741e9d790f4ad",
+        contentGroupId: "b8ce4867a0f94d719cc64514bf4430b4",
         schemaVersion: 2,
         initialParent: "94bbbf2bf2364e7981d396d2474f4b1c"
       },

--- a/packages/initiatives/test/remove.test.ts
+++ b/packages/initiatives/test/remove.test.ts
@@ -10,16 +10,10 @@ import * as InitiativeFetchAPI from "../src/get";
 import { InitiativeInstance } from "./mocks/initiative-instance";
 import { IInitiativeModel } from "@esri/hub-common";
 
-const CBWrapper = {
-  updateProgress(options: any): any {
-    return;
-  }
-};
 let portalSelfSpy: any;
 let unprotectItemSpy: any;
 let removeItemSpy: any;
 let getItemSpy: any;
-let progressCallbackSpy: any;
 let removeGroupSpy: any;
 let detachSpy: any;
 
@@ -55,12 +49,6 @@ describe("remove Initiative", () => {
       }
     );
 
-    progressCallbackSpy = spyOn(CBWrapper, "updateProgress").and.callFake(
-      (options: any): any => {
-        return;
-      }
-    );
-
     removeGroupSpy = spyOn(GroupAPI, "removeInitiativeGroup").and.callFake(
       (id: string, ro: any): Promise<any> => {
         return Promise.resolve({ success: true });
@@ -85,19 +73,14 @@ describe("remove Initiative", () => {
       }
     );
 
-    return removeInitiative(
-      "bc3",
-      CBWrapper.updateProgress,
-      MOCK_REQUEST_OPTIONS
-    )
+    return removeInitiative("bc3", MOCK_REQUEST_OPTIONS)
       .then(response => {
         expect(portalSelfSpy.calls.count()).toEqual(1);
         expect(getInitiativeSpy.calls.count()).toEqual(1);
         expect(unprotectItemSpy.calls.count()).toEqual(0);
-        expect(removeGroupSpy.calls.count()).toEqual(2);
+        expect(removeGroupSpy.calls.count()).toEqual(3);
         expect(detachSpy.calls.count()).toEqual(1);
         expect(removeItemSpy.calls.count()).toEqual(1);
-        expect(progressCallbackSpy.calls.count()).toEqual(5);
         done();
       })
       .catch(ex => {
@@ -118,20 +101,15 @@ describe("remove Initiative", () => {
       }
     );
 
-    return removeInitiative(
-      "bc3",
-      CBWrapper.updateProgress,
-      MOCK_REQUEST_OPTIONS
-    )
+    return removeInitiative("bc3", MOCK_REQUEST_OPTIONS)
       .then(response => {
         expect(portalSelfSpy.calls.count()).toEqual(1);
         expect(getInitiativeSpy.calls.count()).toEqual(1);
         expect(unprotectItemSpy.calls.count()).toEqual(1);
-        expect(removeGroupSpy.calls.count()).toEqual(2);
+        expect(removeGroupSpy.calls.count()).toEqual(3);
         expect(getItemSpy.calls.count()).toEqual(1);
         expect(detachSpy.calls.count()).toEqual(1);
         expect(removeItemSpy.calls.count()).toEqual(1);
-        expect(progressCallbackSpy.calls.count()).toEqual(5);
         done();
       })
       .catch(ex => {
@@ -149,25 +127,20 @@ describe("remove Initiative", () => {
         clone.item.id = id;
         clone.item.protected = true;
         delete clone.item.properties.siteId;
-        delete clone.item.properties.openDataGroupId;
+        delete clone.item.properties.contentGroupId;
         return Promise.resolve(clone as IInitiativeModel);
       }
     );
 
-    return removeInitiative(
-      "bc3",
-      CBWrapper.updateProgress,
-      MOCK_REQUEST_OPTIONS
-    )
+    return removeInitiative("bc3", MOCK_REQUEST_OPTIONS)
       .then(response => {
         expect(portalSelfSpy.calls.count()).toEqual(1);
         expect(getInitiativeSpy.calls.count()).toEqual(1);
         expect(unprotectItemSpy.calls.count()).toEqual(1);
-        expect(removeGroupSpy.calls.count()).toEqual(1);
+        expect(removeGroupSpy.calls.count()).toEqual(2);
         expect(getItemSpy.calls.count()).toEqual(0);
         expect(detachSpy.calls.count()).toEqual(0);
         expect(removeItemSpy.calls.count()).toEqual(1);
-        expect(progressCallbackSpy.calls.count()).toEqual(5);
         done();
       })
       .catch(ex => {
@@ -192,20 +165,15 @@ describe("remove Initiative", () => {
         return Promise.reject();
       }
     );
-    return removeInitiative(
-      "bc3",
-      CBWrapper.updateProgress,
-      MOCK_REQUEST_OPTIONS
-    )
+    return removeInitiative("bc3", MOCK_REQUEST_OPTIONS)
       .then(response => {
         expect(portalSelfSpy.calls.count()).toEqual(1);
         expect(getInitiativeSpy.calls.count()).toEqual(1);
         expect(unprotectItemSpy.calls.count()).toEqual(1);
-        expect(removeGroupSpy.calls.count()).toEqual(2);
+        expect(removeGroupSpy.calls.count()).toEqual(3);
         expect(getItemSpy.calls.count()).toEqual(1);
         expect(detachSpy.calls.count()).toEqual(0);
         expect(removeItemSpy.calls.count()).toEqual(1);
-        expect(progressCallbackSpy.calls.count()).toEqual(5);
         done();
       })
       .catch(ex => {

--- a/packages/initiatives/test/templates.test.ts
+++ b/packages/initiatives/test/templates.test.ts
@@ -35,9 +35,11 @@ describe("Initiative Templates ::", () => {
       const tmpl = cloneObject(defaultTemplate) as IInitiativeModel;
       const opts = {
         title: "Death Star Initiative",
-        collaborationGroupId: "bc45251",
-        dataGroupId: "bc45251",
-        initiativeKey: "deathStarInitiative"
+        initiativeKey: "deathStarInitiative",
+        groupIds: {
+          collaborationGroupId: "bc45251",
+          contentGroupId: "bc45252"
+        }
       };
       const chk = createInitiativeModelFromTemplate(tmpl, opts);
 
@@ -51,8 +53,16 @@ describe("Initiative Templates ::", () => {
         defaultTemplate.item.id,
         "templateId should be source"
       );
-      expect(chk.item.properties.groupId).toBe(opts.collaborationGroupId);
-      expect(chk.item.properties.openDataGroupId).toBe(opts.dataGroupId);
+      expect(chk.item.properties.collaborationGroupId).toBe(
+        opts.groupIds.collaborationGroupId
+      );
+      expect(chk.item.properties.contentGroupId).toBe(
+        opts.groupIds.contentGroupId
+      );
+      expect(chk.data.values.collaborationGroupId).toBe(
+        opts.groupIds.collaborationGroupId
+      );
+      expect(chk.data.values.contentGroupId).toBe(opts.groupIds.contentGroupId);
       expect(chk.item.properties.initialParent).toBe(defaultTemplate.item.id);
 
       expect(chk.item.tags).toContain("Hub Initiative");
@@ -64,10 +74,6 @@ describe("Initiative Templates ::", () => {
         );
       });
       expect(chk.data.indicators).toBeDefined();
-      expect(chk.data.values.collaborationGroupId).toBe(
-        opts.collaborationGroupId
-      );
-      expect(chk.data.values.openDataGroupId).toBe(opts.dataGroupId);
       expect(chk.data.values.initiativeKey).toBe(opts.initiativeKey);
     });
     it("should return a new model with groupIds excluded", () => {
@@ -78,18 +84,18 @@ describe("Initiative Templates ::", () => {
       };
       const chk = createInitiativeModelFromTemplate(tmpl, opts);
 
-      expect(chk.item.properties.groupId).toBeUndefined();
-      expect(chk.item.properties.openDataGroupId).toBeUndefined();
+      expect(chk.item.properties.collaborationGroupId).toBeUndefined();
+      expect(chk.item.properties.contentGroupId).toBeUndefined();
       expect(chk.data.values.collaborationGroupId).toBeUndefined();
-      expect(chk.data.values.openDataGroupId).toBeUndefined();
+      expect(chk.data.values.contentGroupId).toBeUndefined();
+      expect(chk.data.values.collaborationGroupId).toBeUndefined();
+      expect(chk.data.values.contentGroupId).toBeUndefined();
     });
     it("should inject a default banner image", () => {
       const tmpl = cloneObject(defaultTemplate) as IInitiativeModel;
       delete tmpl.data.values.bannerImage;
       const opts = {
         title: "Death Star Initiative",
-        collaborationGroupId: "bc45251",
-        dataGroupId: "bc45251",
         initiativeKey: "deathStarInitiative"
       };
       const chk = createInitiativeModelFromTemplate(tmpl, opts);

--- a/packages/initiatives/test/templates.test.ts
+++ b/packages/initiatives/test/templates.test.ts
@@ -61,8 +61,8 @@ describe("Initiative Templates ::", () => {
       );
       expect(chk.data.values.collaborationGroupId).toBe(
         opts.groupIds.collaborationGroupId
-      );
-      expect(chk.data.values.contentGroupId).toBe(opts.groupIds.contentGroupId);
+      ); // TODO remove
+      expect(chk.data.values.contentGroupId).toBe(opts.groupIds.contentGroupId); // TODO remove
       expect(chk.item.properties.initialParent).toBe(defaultTemplate.item.id);
 
       expect(chk.item.tags).toContain("Hub Initiative");
@@ -86,7 +86,7 @@ describe("Initiative Templates ::", () => {
 
       expect(chk.item.properties.collaborationGroupId).toBeUndefined();
       expect(chk.item.properties.contentGroupId).toBeUndefined();
-      expect(chk.data.values.collaborationGroupId).toBeUndefined();
+      expect(chk.data.values.collaborationGroupId).toBeUndefined(); // TODO remove this and next 4 lines
       expect(chk.data.values.contentGroupId).toBeUndefined();
       expect(chk.data.values.collaborationGroupId).toBeUndefined();
       expect(chk.data.values.contentGroupId).toBeUndefined();

--- a/packages/initiatives/test/upgrades/upgrade-two-dot-one.test.ts
+++ b/packages/initiatives/test/upgrades/upgrade-two-dot-one.test.ts
@@ -4,7 +4,7 @@ import { IInitiativeModel, cloneObject } from "@esri/hub-common";
 import { upgradeToTwoDotOne } from "../../src/migrations/upgrade-two-dot-one";
 import { initiativeVersionTwo } from "../mocks/initiative-versionTwo";
 
-describe("Applying v1.1 Initiative Schema ::", () => {
+describe("Applying v2.1 Initiative Schema ::", () => {
   const model = cloneObject(initiativeVersionTwo) as IInitiativeModel;
 
   describe("Upgrade Instance ::", () => {
@@ -15,7 +15,7 @@ describe("Applying v1.1 Initiative Schema ::", () => {
       expect(chk).toBe(instance, "should return the same object");
       done();
     });
-    it("should add the schema version and assets", done => {
+    it("should change groupId to collaborationGroupId", done => {
       const instance = cloneObject(model) as IInitiativeModel;
       expect(instance.item.properties.groupId).toBeDefined(
         "groupId is defined"

--- a/packages/initiatives/test/upgrades/upgrade-two-dot-one.test.ts
+++ b/packages/initiatives/test/upgrades/upgrade-two-dot-one.test.ts
@@ -1,0 +1,43 @@
+/* Copyright (c) 2019 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { IInitiativeModel, cloneObject } from "@esri/hub-common";
+import { upgradeToTwoDotOne } from "../../src/migrations/upgrade-two-dot-one";
+import { initiativeVersionTwo } from "../mocks/initiative-versionTwo";
+
+describe("Applying v1.1 Initiative Schema ::", () => {
+  const model = cloneObject(initiativeVersionTwo) as IInitiativeModel;
+
+  describe("Upgrade Instance ::", () => {
+    it("should return the model if it is at 2.1", done => {
+      const instance = cloneObject(model) as IInitiativeModel;
+      instance.item.properties.schemaVersion = 2.1;
+      const chk = upgradeToTwoDotOne(instance);
+      expect(chk).toBe(instance, "should return the same object");
+      done();
+    });
+    it("should add the schema version and assets", done => {
+      const instance = cloneObject(model) as IInitiativeModel;
+      expect(instance.item.properties.groupId).toBeDefined(
+        "groupId is defined"
+      );
+      const chk = upgradeToTwoDotOne(instance);
+      expect(chk).not.toBe(instance, "should return a new object");
+      expect(chk.item.properties.schemaVersion).toBeDefined("schema version");
+      expect(chk.item.properties.schemaVersion).toEqual(
+        2.1,
+        "should set version to 2.1"
+      );
+      expect(chk.item.properties.collaborationGroupId).toBeDefined(
+        "collaborationGroupId should be defined"
+      );
+      expect(chk.item.properties.collaborationGroupId).toEqual(
+        "4ef",
+        "sets correct collaborationGroupId"
+      );
+      expect(chk.item.properties.groupId).toBeUndefined(
+        "groupId no longer defined"
+      );
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Implements the following changes:
* Migrates to new initiative schema where `groupId` is now stored as `collaborationGroupId`
* Removes `progressCallback` from activate and remove initiative processes
* Changes `activateInitiative` and `createInitiativeModelFromTemplate` to expect a hash of groupIds corresponding to _already_ existing groups for the new initiative model