### PR TITLE
fix(search): format item extent properly

### DIFF
--- a/packages/search/src/ago/helpers/format/format-item.ts
+++ b/packages/search/src/ago/helpers/format/format-item.ts
@@ -49,9 +49,19 @@ function formatItemAttributes(item: IItem) {
     name: item.title,
     searchDescription: item.description,
     hubType: hubType || "Other",
-    collection: getTypeCategories(item)
+    collection: getTypeCategories(item),
+    extent: formatExtent(item.extent)
   };
   return { ...item, ...additionalAttrs };
+}
+
+function formatExtent(
+  extent: number[][]
+): { coordinates: number[][]; type: string } {
+  return {
+    coordinates: extent,
+    type: "envelope"
+  };
 }
 
 function highlights(

--- a/packages/search/test/ago/helpers/format/format-item.test.ts
+++ b/packages/search/test/ago/helpers/format/format-item.test.ts
@@ -11,7 +11,8 @@ const itemProps = {
   created: 12345678,
   type: "feature layer",
   numViews: 1000,
-  size: 1
+  size: 1,
+  extent: [[1, 2], [3, 4]]
 };
 
 describe("highlights test", () => {
@@ -27,7 +28,11 @@ describe("highlights test", () => {
         name: "fake item",
         searchDescription: "fake description",
         hubType: "dataset",
-        collection: ["Dataset"]
+        collection: ["Dataset"],
+        extent: {
+          coordinates: [[1, 2], [3, 4]],
+          type: "envelope"
+        }
       },
       meta: {
         highlights: {
@@ -53,7 +58,11 @@ describe("highlights test", () => {
         name: "fake item",
         searchDescription: "fake description",
         hubType: "dataset",
-        collection: ["Dataset"]
+        collection: ["Dataset"],
+        extent: {
+          coordinates: [[1, 2], [3, 4]],
+          type: "envelope"
+        }
       }
     };
     expect(actual).toEqual(expected);
@@ -72,7 +81,11 @@ describe("highlights test", () => {
         name: "fake item",
         searchDescription: "fake description",
         hubType: "Other",
-        collection: ["Other"]
+        collection: ["Other"],
+        extent: {
+          coordinates: [[1, 2], [3, 4]],
+          type: "envelope"
+        }
       }
     };
     expect(actual).toEqual(expected);


### PR DESCRIPTION
item extents are now formatted as from the Hub API
```js
{
 type: 'envelope',
 coordinates: [ [1,2], [3,4] ]
}
```