### PR TITLE
feat(implement extend in hub-common): implement extend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased][HEAD]
+
+* New Features
+   * **extend**: implement extend in `hub-common` [`5e0ff68`](https://github.com/Esri/hub.js/commit/5e0ff68571203ec8460c69f6d57debd2eb3a4fe7)
+
 ## [3.0.1] - September 5th 2019
 
 ### @esri/hub-initiatives
 
 * Bug Fixes
    * **swallow group delete failures on initiative deletion**: swallow group delete failures on initiative deletion [`e11e83d`](https://github.com/Esri/hub.js/commit/e11e83de14a464462bb81ccb9c3de5f1e81be8b1)
-
-## [Unreleased][HEAD]
-
-
 
 ## [3.0.0] - September 4th 2019
 

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -281,7 +281,8 @@ export function unique(value: any, index: number, ary: any[]): boolean {
 
 /**
  * Extends the target object with props from the source object, overwriting identically named
- * props in target with those from source, ignoring null and undefined values; similar to $.extend
+ * props in target with those from source, ignoring null and undefined values; similar to $.extend.
+ * Performs a deep extend by default, unless deep = false is passed as the third arg.
  *
  * @param target - the object that will take props from source
  * @param source - the object from which to take props

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -278,3 +278,33 @@ export function camelize(value: string): string {
 export function unique(value: any, index: number, ary: any[]): boolean {
   return ary.indexOf(value) === index;
 }
+
+/**
+ * Extends the target object with props from the source object, overwriting identically named
+ * props in target with those from source, ignoring null and undefined values; similar to $.extend
+ *
+ * @param target - the object that will take props from source
+ * @param source - the object from which to take props
+ * @param deepExtend - whether or not to perform a deep (recursive( extend of source
+ */
+export function extend(
+  target: { [index: string]: any },
+  source: { [index: string]: any },
+  deepExtend: boolean = false
+): { [index: string]: any } {
+  const extended: { [index: string]: any } = cloneObject(target);
+  return Object.keys(source).reduce((obj, prop) => {
+    if (source[prop] !== null && source[prop] !== undefined) {
+      const value = cloneObject(source[prop]);
+      if (Array.isArray(value)) {
+        // check for arrays, since array is type object
+        obj[prop] = value;
+      } else if (deepExtend && typeof value === "object") {
+        obj[prop] = extend(obj[prop] || {}, value, deepExtend);
+      } else {
+        obj[prop] = value;
+      }
+    }
+    return obj;
+  }, extended);
+}

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -285,12 +285,12 @@ export function unique(value: any, index: number, ary: any[]): boolean {
  *
  * @param target - the object that will take props from source
  * @param source - the object from which to take props
- * @param deepExtend - whether or not to perform a deep (recursive( extend of source
+ * @param deep - whether or not to perform a deep (recursive) extend of source
  */
 export function extend(
   target: { [index: string]: any },
   source: { [index: string]: any },
-  deepExtend: boolean = false
+  deep: boolean = true
 ): { [index: string]: any } {
   const extended: { [index: string]: any } = cloneObject(target);
   return Object.keys(source).reduce((obj, prop) => {
@@ -299,8 +299,8 @@ export function extend(
       if (Array.isArray(value)) {
         // check for arrays, since array is type object
         obj[prop] = value;
-      } else if (deepExtend && typeof value === "object") {
-        obj[prop] = extend(obj[prop] || {}, value, deepExtend);
+      } else if (deep && typeof value === "object") {
+        obj[prop] = extend(obj[prop] || {}, value, deep);
       } else {
         obj[prop] = value;
       }

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -10,7 +10,8 @@ import {
   createId,
   maybeAdd,
   maybePush,
-  unique
+  unique,
+  extend
 } from "../src/util";
 
 describe("util functions", () => {
@@ -516,6 +517,149 @@ describe("util functions", () => {
       expect(["foo"].filter(unique)).toEqual(["foo"]);
       expect(["foo", "bar", "foo"].filter(unique)).toEqual(["foo", "bar"]);
       expect([].filter(unique)).toEqual([]);
+    });
+  });
+
+  /* tslint:disable */
+  describe("extend", () => {
+    it("should extend an object", () => {
+      const target = {
+        a: 1
+      };
+      const source = {
+        a: "foo",
+        b: "bar"
+      };
+      const result = extend(target, source);
+      expect(result).toEqual({ a: "foo", b: "bar" });
+    });
+    it("should ignore null and undefined values", () => {
+      const target = {
+        a: 1,
+        b: 2,
+        c: 3
+      };
+      const source: any = {
+        a: undefined,
+        b: null,
+        c: 58
+      };
+      const result = extend(target, source);
+      expect(result).toEqual({ a: 1, b: 2, c: 58 });
+    });
+    it("should shallow extend a deep object", () => {
+      const target = {
+        a: 1,
+        b: {
+          c: 3
+        }
+      };
+      const source = {
+        a: "foo",
+        b: {
+          d: 5
+        }
+      };
+      const result = extend(target, source);
+      expect(result).toEqual({ a: "foo", b: { d: 5 } });
+    });
+    it("should deep extend a deep object", () => {
+      const target = {
+        a: 1,
+        b: {
+          c: 3
+        }
+      };
+      const source = {
+        a: "foo",
+        b: {
+          d: 5
+        }
+      };
+      const result = extend(target, source, true);
+      expect(result).toEqual({ a: "foo", b: { c: 3, d: 5 } });
+    });
+    it("should shallow extend an object with an array", () => {
+      const target = {
+        a: [1, 2, 3],
+        b: {
+          c: 3
+        }
+      };
+      const source = {
+        a: [4, 5, 6],
+        b: {
+          d: [6, 7, 8]
+        }
+      };
+      const result = extend(target, source);
+      expect(result).toEqual({ a: [4, 5, 6], b: { d: [6, 7, 8] } });
+    });
+    it("should return a new instance", () => {
+      const target = {
+        a: 1
+      };
+      const source = {
+        a: 3
+      };
+      const result = extend(target, source);
+      expect(result == target).toBeFalsy();
+      expect(result == source).toBeFalsy();
+    });
+    it("should deep extend a complex object", () => {
+      const fun = function() {};
+      const target = {
+        a: 1,
+        b: [2, 3],
+        c: {
+          d: 4,
+          e: [5, 6],
+          f: {
+            g: 7,
+            h: function() {},
+            i: [9, 10]
+          }
+        },
+        k: 58
+      };
+      const source: any = {
+        a: "1",
+        c: {
+          d: "4",
+          e: [12, 13],
+          f: {
+            g: ["11", "12"],
+            h: 8,
+            i: [9, 10],
+            j: fun,
+            l: null
+          },
+          r: {
+            o: 3
+          }
+        },
+        k: undefined
+      };
+      const expected = {
+        a: "1",
+        b: [2, 3],
+        c: {
+          d: "4",
+          e: [12, 13],
+          f: {
+            g: ["11", "12"],
+            h: 8,
+            i: [9, 10],
+            j: fun
+          },
+          r: {
+            o: 3
+          }
+        },
+        k: 58
+      };
+      const result = extend(target, source, true);
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -560,7 +560,7 @@ describe("util functions", () => {
           d: 5
         }
       };
-      const result = extend(target, source);
+      const result = extend(target, source, false);
       expect(result).toEqual({ a: "foo", b: { d: 5 } });
     });
     it("should deep extend a deep object", () => {
@@ -576,7 +576,7 @@ describe("util functions", () => {
           d: 5
         }
       };
-      const result = extend(target, source, true);
+      const result = extend(target, source);
       expect(result).toEqual({ a: "foo", b: { c: 3, d: 5 } });
     });
     it("should shallow extend an object with an array", () => {
@@ -592,7 +592,7 @@ describe("util functions", () => {
           d: [6, 7, 8]
         }
       };
-      const result = extend(target, source);
+      const result = extend(target, source, false);
       expect(result).toEqual({ a: [4, 5, 6], b: { d: [6, 7, 8] } });
     });
     it("should return a new instance", () => {
@@ -658,7 +658,7 @@ describe("util functions", () => {
         },
         k: 58
       };
-      const result = extend(target, source, true);
+      const result = extend(target, source);
       expect(result).toEqual(expected);
     });
   });


### PR DESCRIPTION
Implements extend in \`hub-common\`, which extends a target object with props from a source object, overwriting identically named props in target with those from source. Ignores null and undefined
values, similar to $.extend.

AFFECTS PACKAGES:
@esri/hub-common