### PR TITLE
F/add "Site Page" type

### DIFF
--- a/packages/common/src/categories.ts
+++ b/packages/common/src/categories.ts
@@ -32,6 +32,7 @@ const document: string[] = [
   "CAD Drawing",
   "Document Link",
   "Hub Page",
+  "Site Page",
   "Image",
   "iWork Keynote",
   "iWork Numbers",


### PR DESCRIPTION
Update the type list for the `Document` category so that it can recognize pages from Enterprise Sites