### PR TITLE
feat(support-more-than-3-countFields): support-more-than-3-countFields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5062,8 +5062,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5084,14 +5083,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5106,20 +5103,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5236,8 +5230,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5249,7 +5242,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5264,7 +5256,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5272,14 +5263,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5298,7 +5287,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5379,8 +5367,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5392,7 +5379,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5478,8 +5464,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5515,7 +5500,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5535,7 +5519,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5579,14 +5562,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -338,8 +338,10 @@ export function addDays(date: string, numOfDays: number): string {
  */
 export function chunkArray(arr: any[], size: number) {
   const results = [];
-  while (arr.length) {
-    results.push(arr.splice(0, size));
+  let index = 0;
+  while (index < arr.length) {
+    results.push(arr.slice(index, index + size));
+    index += size;
   }
   return results;
 }

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -329,3 +329,17 @@ export function addDays(date: string, numOfDays: number): string {
     throw new Error("Invalid Date");
   }
 }
+
+/**
+ * Returns an array with arrays of the given size.
+ *
+ * @param arr Array to split
+ * @param size Size of every group
+ */
+export function chunkArray(arr: any[], size: number) {
+  const results = [];
+  while (arr.length) {
+    results.push(arr.splice(0, size));
+  }
+  return results;
+}

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -12,7 +12,8 @@ import {
   maybePush,
   unique,
   extend,
-  addDays
+  addDays,
+  chunkArray
 } from "../src/util";
 
 describe("util functions", () => {
@@ -675,6 +676,13 @@ describe("util functions", () => {
       } catch (e) {
         expect(e.message).toBe("Invalid Date");
       }
+    });
+  });
+
+  describe("chunkArray", () => {
+    it("should chunk array based on size", () => {
+      expect(chunkArray([1, 2, 3, 4, 5], 3)).toEqual([[1, 2, 3], [4, 5]]);
+      expect(chunkArray([], 3)).toEqual([]);
     });
   });
 });

--- a/packages/search/package-lock.json
+++ b/packages/search/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@esri/hub-search",
-	"version": "2.4.0",
+	"version": "3.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -25,13 +25,21 @@
 			}
 		},
 		"@esri/arcgis-rest-portal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.0.1.tgz",
-			"integrity": "sha512-KlSvvojy6NKR2TXgNJq+w/jwhpIouiNihtnv8v2o2XKt6pRrMgL7qIzZssQbB6UZ1FD8gxbdXe6xdwRgW+yaiQ==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.6.1.tgz",
+			"integrity": "sha512-1v1+gtiNhHaYDgwDvm4aLjXeu4+V/+uG7upMk2DPRPd/ZV6ZywkzgA/dTQPffLz6detke9+m/YO/L0m5KRP27g==",
 			"dev": true,
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.0.1",
+				"@esri/arcgis-rest-types": "^2.6.1",
 				"tslib": "^1.9.3"
+			},
+			"dependencies": {
+				"@esri/arcgis-rest-types": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.6.1.tgz",
+					"integrity": "sha512-iBdin1odDUieRUkCjcZZ2zbQDaB+6dzMFBHozeLIC78J7OnZnhLcpyZ8LpwxP4p9ooXRbNFiqTAPR7QMHQH47Q==",
+					"dev": true
+				}
 			}
 		},
 		"@esri/arcgis-rest-request": {
@@ -50,9 +58,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-2.4.0.tgz",
-			"integrity": "sha512-EtMzb3VVx/ihxekwxsOdGyfQ2VTtTYg2JN08thSVZl2BlzXdTt60rtSW7PPGiNoQVTc1Jj8I0Cy9Axyjh3iXfA==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-3.5.0.tgz",
+			"integrity": "sha512-8vzlmECXvOZbaOivrvTjRa0hxl8vdx0U0xrQCyxCLKWG4Ab4avbp3JQnyOzSq2P4H1R8MA1ypsNGI5g2QEepBg==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.3"

--- a/packages/search/package-lock.json
+++ b/packages/search/package-lock.json
@@ -1,14 +1,11 @@
 {
-	"name": "@esri/hub-search",
-	"version": "3.5.0",
-	"lockfileVersion": 1,
 	"requires": true,
+	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.0.1.tgz",
 			"integrity": "sha512-88SVnEpX/JpnLqeWxyf07c+dXEDfibKol7bZIRrrbBuw28dsRiwQqlMqI+bF0Vbyj0zTid/zvBLn74DNovKkFg==",
-			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^2.0.1",
 				"tslib": "^1.9.3"
@@ -18,7 +15,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.0.1.tgz",
 			"integrity": "sha512-X6NS9kKKUVJMR4lSkNiklRrt4Lg+mAPsY1SGNGZZRRqmJ8P5xzV8yabEACcPzxZvySoZLLf84vY8hIAPPv+7Zg==",
-			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^2.0.1",
 				"tslib": "^1.9.3"
@@ -28,7 +24,6 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.6.1.tgz",
 			"integrity": "sha512-1v1+gtiNhHaYDgwDvm4aLjXeu4+V/+uG7upMk2DPRPd/ZV6ZywkzgA/dTQPffLz6detke9+m/YO/L0m5KRP27g==",
-			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^2.6.1",
 				"tslib": "^1.9.3"
@@ -37,8 +32,7 @@
 				"@esri/arcgis-rest-types": {
 					"version": "2.6.1",
 					"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.6.1.tgz",
-					"integrity": "sha512-iBdin1odDUieRUkCjcZZ2zbQDaB+6dzMFBHozeLIC78J7OnZnhLcpyZ8LpwxP4p9ooXRbNFiqTAPR7QMHQH47Q==",
-					"dev": true
+					"integrity": "sha512-iBdin1odDUieRUkCjcZZ2zbQDaB+6dzMFBHozeLIC78J7OnZnhLcpyZ8LpwxP4p9ooXRbNFiqTAPR7QMHQH47Q=="
 				}
 			}
 		},
@@ -46,7 +40,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.0.1.tgz",
 			"integrity": "sha512-lAhX15VI306bzzMH6xWCSSg1GHZxa5eWLb0r5M94Uet/Z0mMTXXTtIMQWYO0WQ05jEpLnZ5UKvNR0v9aKyFNkw==",
-			"dev": true,
 			"requires": {
 				"tslib": "^1.9.3"
 			}
@@ -54,17 +47,7 @@
 		"@esri/arcgis-rest-types": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.0.1.tgz",
-			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig==",
-			"dev": true
-		},
-		"@esri/hub-common": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-3.5.0.tgz",
-			"integrity": "sha512-8vzlmECXvOZbaOivrvTjRa0hxl8vdx0U0xrQCyxCLKWG4Ab4avbp3JQnyOzSq2P4H1R8MA1ypsNGI5g2QEepBg==",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.9.3"
-			}
+			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig=="
 		},
 		"tslib": {
 			"version": "1.9.3",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -15,15 +15,15 @@
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.0.0",
     "@esri/arcgis-rest-feature-layer": "^2.0.0",
-    "@esri/arcgis-rest-portal": "^2.0.1",
+    "@esri/arcgis-rest-portal": "^2.6.1",
     "@esri/arcgis-rest-request": "^2.0.0",
     "@esri/arcgis-rest-types": "^2.0.0",
-    "@esri/hub-common": "^3.4.0"
+    "@esri/hub-common": "^3.5.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^2.0.0",
     "@esri/arcgis-rest-feature-layer": "^2.0.0",
-    "@esri/arcgis-rest-portal": "^2.0.1",
+    "@esri/arcgis-rest-portal": "^2.6.1",
     "@esri/arcgis-rest-request": "^2.0.0",
     "@esri/arcgis-rest-types": "^2.0.0",
     "@esri/hub-common": "^3.5.0"

--- a/packages/search/src/ago/get-items.ts
+++ b/packages/search/src/ago/get-items.ts
@@ -2,6 +2,7 @@ import { ISearchParams } from "./params";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { ISearchResult, IItem, searchItems } from "@esri/arcgis-rest-portal";
 import { encodeAgoQuery } from "./encode-ago-query";
+import { getProp, chunkArray } from "@esri/hub-common";
 
 // Search for Items in ArcGIS and return raw ago response
 export async function getItems(
@@ -11,14 +12,47 @@ export async function getItems(
   authentication?: UserSession
 ): Promise<ISearchResult<IItem>> {
   const agoParams = encodeAgoQuery(params);
-  return searchItems({
-    ...agoParams,
-    params: {
-      token,
-      countFields: agoParams.countFields,
-      countSize: agoParams.countSize
-    },
-    portal,
-    authentication
-  });
+  if (agoParams.countFields) {
+    // if countFields are defined
+    // AGO allows only 3 countFields at max
+    const chunkedCountFields = chunkArray(
+      agoParams.countFields.split(","),
+      3
+    ).map(fieldArrayChunk => fieldArrayChunk.join(","));
+    let allCounts: Array<{
+      fieldName: string;
+      fieldValues: Array<{
+        value: any;
+        count: number;
+      }>;
+    }> = [];
+    let results;
+    for (const chunk of chunkedCountFields) {
+      results = await searchItems({
+        ...agoParams,
+        params: {
+          token,
+          countFields: chunk,
+          countSize: agoParams.countSize
+        },
+        portal,
+        authentication
+      });
+      const counts = getProp(results, "aggregations.counts") || [];
+      allCounts = allCounts.concat(counts);
+    }
+    results.aggregations.counts = allCounts;
+    return results;
+  } else {
+    return searchItems({
+      ...agoParams,
+      params: {
+        token,
+        countFields: agoParams.countFields,
+        countSize: agoParams.countSize
+      },
+      portal,
+      authentication
+    });
+  }
 }

--- a/packages/search/test/ago/get-items.test.ts
+++ b/packages/search/test/ago/get-items.test.ts
@@ -4,7 +4,7 @@ import { ISearchParams } from "../../src/ago/params";
 import * as EncodeAgoQuery from "../../src/ago/encode-ago-query";
 
 describe("getItems test", () => {
-  it("encodes params into ago query and calls portal's searchItems", async done => {
+  it("gets items when there are no count fields i.e. aggs", async done => {
     const rawAgoResults = {
       results: [],
       total: 0,
@@ -23,7 +23,6 @@ describe("getItems test", () => {
       q: "land",
       sort: "name",
       groupIds: "1ef",
-      agg: { fields: "tags,collection,owner,source,hasApi,downloadable" },
       start: 1,
       num: 10
     };
@@ -49,6 +48,179 @@ describe("getItems test", () => {
       }
     ];
     expect(expectedArgsForSearchItems).toEqual(searchItemsSpy.calls.argsFor(0));
+    done();
+  });
+
+  it("gets items when there are <= 3 count fields and searchItems is called once", async done => {
+    const rawAgoResults = {
+      results: [],
+      total: 0,
+      aggregations: { counts: {} }
+    } as any;
+    const encodeAgoQuerySpy = spyOn(
+      EncodeAgoQuery,
+      "encodeAgoQuery"
+    ).and.callFake(() => {
+      return {
+        q: "long ago query",
+        start: 1,
+        num: 10,
+        countFields: "a,b,c",
+        countSize: 10
+      };
+    });
+    const searchItemsSpy = spyOn(Portal, "searchItems").and.callFake(() => {
+      return rawAgoResults;
+    });
+    const params: ISearchParams = {
+      q: "land",
+      sort: "name",
+      groupIds: "1ef",
+      start: 1,
+      num: 10,
+      agg: { fields: "a,b,c" }
+    };
+    const token = "token";
+    const portal = "https://test.com";
+
+    await getItems(params, token, portal);
+
+    // step 1: encode ago query
+    expect(encodeAgoQuerySpy.calls.count()).toEqual(1);
+    const [expectedParams] = encodeAgoQuerySpy.calls.argsFor(0);
+    expect(expectedParams).toEqual(params);
+
+    // step 2: search items
+    expect(searchItemsSpy.calls.count()).toEqual(1);
+    const expectedArgsForSearchItems: any = [
+      {
+        q: "long ago query",
+        start: 1,
+        num: 10,
+        params: { token, countFields: "a,b,c", countSize: 10 },
+        portal,
+        authentication: undefined,
+        countFields: "a,b,c",
+        countSize: 10
+      }
+    ];
+    expect(expectedArgsForSearchItems).toEqual(searchItemsSpy.calls.argsFor(0));
+    done();
+  });
+
+  it("gets items when there are > 3 count fields and searchItems is called multiple times", async done => {
+    const rawAgoResults1 = {
+      results: [],
+      total: 0,
+      aggregations: {
+        counts: [
+          { fieldName: "a", fieldValues: [{ value: "dc", count: 12 }] },
+          { fieldName: "b", fieldValues: [{ value: "crime", count: 3 }] },
+          { fieldName: "c", fieldValues: [{ value: "pdf", count: 5 }] }
+        ]
+      }
+    } as any;
+    const rawAgoResults2 = {
+      results: [],
+      total: 0,
+      aggregations: {
+        counts: [
+          {
+            fieldName: "d",
+            fieldValues: [{ value: "business/store", count: 5 }]
+          }
+        ]
+      }
+    } as any;
+    const rawAgoResults3 = {
+      results: [],
+      total: 0,
+      aggregations: {}
+    } as any;
+    const rawAgoResults = [rawAgoResults1, rawAgoResults2, rawAgoResults3];
+    const encodeAgoQuerySpy = spyOn(
+      EncodeAgoQuery,
+      "encodeAgoQuery"
+    ).and.callFake(() => {
+      return {
+        q: "long ago query",
+        start: 1,
+        num: 10,
+        countFields: "a,b,c,d,e,f,g",
+        countSize: 10
+      };
+    });
+    const searchItemsSpy = spyOn(Portal, "searchItems").and.callFake(() => {
+      return rawAgoResults.shift();
+    });
+    const params: ISearchParams = {
+      q: "land",
+      sort: "name",
+      groupIds: "1ef",
+      start: 1,
+      num: 10,
+      agg: { fields: "a,b,c,d,e,f,g" }
+    };
+    const token = "token";
+    const portal = "https://test.com";
+
+    const results = await getItems(params, token, portal);
+
+    // step 1: encode ago query
+    expect(encodeAgoQuerySpy.calls.count()).toEqual(1);
+    const [expectedParams] = encodeAgoQuerySpy.calls.argsFor(0);
+    expect(expectedParams).toEqual(params);
+
+    // step 2: verify how searchItems gets called
+    expect(searchItemsSpy.calls.count()).toEqual(3);
+    const expectedArgsForSearchItems1: any = [
+      {
+        q: "long ago query",
+        start: 1,
+        num: 10,
+        params: { token, countFields: "a,b,c", countSize: 10 },
+        portal,
+        authentication: undefined,
+        countFields: "a,b,c,d,e,f,g",
+        countSize: 10
+      }
+    ];
+    expect(expectedArgsForSearchItems1).toEqual(
+      searchItemsSpy.calls.argsFor(0)
+    );
+    const expectedArgsForSearchItems2: any = [
+      {
+        q: "long ago query",
+        start: 1,
+        num: 10,
+        params: { token, countFields: "d,e,f", countSize: 10 },
+        portal,
+        authentication: undefined,
+        countFields: "a,b,c,d,e,f,g",
+        countSize: 10
+      }
+    ];
+    expect(expectedArgsForSearchItems2).toEqual(
+      searchItemsSpy.calls.argsFor(1)
+    );
+    const expectedArgsForSearchItems3: any = [
+      {
+        q: "long ago query",
+        start: 1,
+        num: 10,
+        params: { token, countFields: "g", countSize: 10 },
+        portal,
+        authentication: undefined,
+        countFields: "a,b,c,d,e,f,g",
+        countSize: 10
+      }
+    ];
+    expect(expectedArgsForSearchItems3).toEqual(
+      searchItemsSpy.calls.argsFor(2)
+    );
+
+    // step 3. verify actual results' aggregations
+    expect(results.aggregations.counts.length).toEqual(4);
     done();
   });
 });


### PR DESCRIPTION
AGO supports max 3 countFields in a request. Hub search should send multiple requests for countFields > 3, collect responses and return

AFFECTS PACKAGES:
@esri/hub-common
@esri/hub-search