### PR TITLE
Exactly matching group titles for existance check

### DIFF
--- a/packages/initiatives/package-lock.json
+++ b/packages/initiatives/package-lock.json
@@ -1,10 +1,4 @@
 {
-<<<<<<< HEAD
-=======
-	"name": "@esri/hub-initiatives",
-	"version": "2.4.0",
-	"lockfileVersion": 1,
->>>>>>> refactor(change activate initiative flow to handle missing group create privs and embedded resources
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
@@ -13,8 +7,8 @@
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.0.1.tgz",
 			"integrity": "sha512-88SVnEpX/JpnLqeWxyf07c+dXEDfibKol7bZIRrrbBuw28dsRiwQqlMqI+bF0Vbyj0zTid/zvBLn74DNovKkFg==",
 			"requires": {
-				"@esri/arcgis-rest-types": "2.0.1",
-				"tslib": "1.9.3"
+				"@esri/arcgis-rest-types": "^2.0.1",
+				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-portal": {
@@ -22,8 +16,8 @@
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.0.1.tgz",
 			"integrity": "sha512-KlSvvojy6NKR2TXgNJq+w/jwhpIouiNihtnv8v2o2XKt6pRrMgL7qIzZssQbB6UZ1FD8gxbdXe6xdwRgW+yaiQ==",
 			"requires": {
-				"@esri/arcgis-rest-types": "2.0.1",
-				"tslib": "1.9.3"
+				"@esri/arcgis-rest-types": "^2.0.1",
+				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-request": {
@@ -31,36 +25,13 @@
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.0.1.tgz",
 			"integrity": "sha512-lAhX15VI306bzzMH6xWCSSg1GHZxa5eWLb0r5M94Uet/Z0mMTXXTtIMQWYO0WQ05jEpLnZ5UKvNR0v9aKyFNkw==",
 			"requires": {
-				"tslib": "1.9.3"
+				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-types": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.0.1.tgz",
-<<<<<<< HEAD
 			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig=="
-=======
-			"integrity": "sha512-3bsrqespqnjAkT+fdnEOfyX57cjnijEWegnXngeD6QlBohTtIys0bhw5bKySOkq4Jnv3JZzmiPYqVZCuJcDKig==",
-			"dev": true
-		},
-		"@esri/hub-common": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-2.4.0.tgz",
-			"integrity": "sha512-EtMzb3VVx/ihxekwxsOdGyfQ2VTtTYg2JN08thSVZl2BlzXdTt60rtSW7PPGiNoQVTc1Jj8I0Cy9Axyjh3iXfA==",
-			"dev": true,
-			"requires": {
-				"tslib": "1.9.3"
-			}
-		},
-		"@esri/hub-sites": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-2.4.0.tgz",
-			"integrity": "sha512-r1CRJCFMNloBoHbyk7A802+QGo5xTtND35E7Esu1h+dNsymnbkq1LyOBqO2boSHVEThbFaCukiGI93+2gFXDuA==",
-			"dev": true,
-			"requires": {
-				"tslib": "1.9.3"
-			}
->>>>>>> refactor(change activate initiative flow to handle missing group create privs and embedded resources
 		},
 		"blob": {
 			"version": "0.0.4",

--- a/packages/initiatives/src/groups.ts
+++ b/packages/initiatives/src/groups.ts
@@ -122,7 +122,7 @@ export function checkGroupExists(
   requestOptions: IRequestOptions
 ): Promise<any> {
   const options = {
-    q: `${title} AND orgid: ${orgId}`,
+    q: `("${title}") AND orgid: ${orgId}`,
     ...requestOptions
   };
 

--- a/packages/initiatives/test/groups.test.ts
+++ b/packages/initiatives/test/groups.test.ts
@@ -291,7 +291,7 @@ describe("Initiative Groups ::", () => {
         done();
       });
     });
-    it("append a number to original name of group exists", done => {
+    it("append a number to original name if group exists", done => {
       const searchSpy = spyOn(portal, "searchGroups").and.callFake(
         (opts: ISearchOptions) => {
           const res = {
@@ -305,7 +305,7 @@ describe("Initiative Groups ::", () => {
           // if this is the first call w/ a specific name
           // we want to fake the response to show the group
           // does exist
-          if (opts.q === "foo bar baz AND orgid: BZ7426") {
+          if (opts.q === '("foo bar baz") AND orgid: BZ7426') {
             res.total = 1;
             res.results.push({} as IGroup);
           }


### PR DESCRIPTION
[bug](https://esriarlington.tpondemand.com/entity/104035-bug-000126797-unique-initiative-name-detection)

The `checkGroupExists` function is used by Hub to check for initiatiative existance by searching for stuff like "My Initiative Name Core Team." But the way `checkGroupExists` is currently set up, it will match the group name fuzzily. This PR forces it to match group names exactly.