### PR TITLE
initialize aggregations on first result when it doesn't exist

### DIFF
--- a/packages/search/src/ago/get-items.ts
+++ b/packages/search/src/ago/get-items.ts
@@ -39,13 +39,17 @@ export async function getItems(
         count: number;
       }>;
     }> = [];
+
     for (const response of responses) {
       const counts = getProp(response, "aggregations.counts") || [];
       allCounts = allCounts.concat(counts);
     }
-    const results = responses[0]; // the results are the same for all requests except the counts
-    results.aggregations.counts = allCounts;
-    return results;
+
+    responses[0].aggregations = {
+      counts: allCounts
+    };
+
+    return responses[0];
   } else {
     return searchItems({
       ...agoParams,


### PR DESCRIPTION
This PR addresses the issue where the first AGO response doesn't have an `aggregations` element, manifesting in the following hub-indexer error:

```
Cannot set property 'counts' of undefined","stack":"at Object.<anonymous> (/opt/hub-indexer/packages/api/node_modules/@esri/hub-search/dist/node/ago/get-items.js:36:49)
```

A test has been added to demonstrate the fix.  I'm not one with the TypeScript so hopefully this passes muster.  