### PR TITLE
filter out falsey type arrays

### DIFF
--- a/packages/search/src/ago/helpers/filters/collection.ts
+++ b/packages/search/src/ago/helpers/filters/collection.ts
@@ -5,6 +5,7 @@ export function collectionFilter(queryFilters: any) {
   const typesArr = categories.map((c: string) => getTypes(c));
   // flatten typesArr
   const filter = typesArr
+    .filter((types: string[]) => !!types)
     .reduce((singleArr: string[], types: string[]) => {
       types.forEach(type => {
         singleArr.push(`type:"${type}"`);

--- a/packages/search/test/ago/helpers/filters/collection.test.ts
+++ b/packages/search/test/ago/helpers/filters/collection.test.ts
@@ -18,4 +18,27 @@ describe("collection test", () => {
     const expected = "()";
     expect(collectionFilter(queryFilters)).toBe(expected);
   });
+
+  it("unsupported collections should not expand to anything or throw errors", () => {
+    const queryFilters = {
+      collection: {
+        terms: ["Dataset", "This is not a valid collection", "Document"],
+        fn: "any"
+      }
+    };
+    const expected =
+      '(type:"CSV Collection" OR type:"CSV" OR type:"Feature Collection Template" OR type:"Feature Collection" OR type:"Feature Layer" OR type:"Feature Service" OR type:"File Geodatabase" OR type:"GeoJSON" OR type:"GeoJson" OR type:"KML Collection" OR type:"KML" OR type:"Microsoft Excel" OR type:"Raster Layer" OR type:"Shapefile" OR type:"Stream Service" OR type:"Table" OR type:"CAD Drawing" OR type:"Document Link" OR type:"Hub Page" OR type:"Site Page" OR type:"Image" OR type:"iWork Keynote" OR type:"iWork Numbers" OR type:"iWork Pages" OR type:"Microsoft Powerpoint" OR type:"Microsoft Visio" OR type:"Microsoft Word" OR type:"PDF" OR type:"Pro Map" OR type:"Report Template")';
+    expect(collectionFilter(queryFilters)).toBe(expected);
+  });
+
+  it("only unsupported collections should result in any empty filter", () => {
+    const queryFilters = {
+      collection: {
+        terms: ["This is not a valid collection", "Another invalid collection"],
+        fn: "any"
+      }
+    };
+    const expected = "()";
+    expect(collectionFilter(queryFilters)).toBe(expected);
+  });
 });


### PR DESCRIPTION
This PR fixes an issue where an unsupported collection is filtered on, resulting in an `undefined` array of types to iterate over.  For example, `filter[collection]=any(Sites)`, where `Sites` is not a supported collection wrapper.  The solution proposed in this PR is to remove falsey `types` arrays before reducing to expanded form.  

An example log from kibana showing the production error is:

```
level="error" timestamp="2020-01-27T14:41:27.272Z" status="itemsSearch-failed" reason={"errorMessage":"Cannot read property 'forEach' of undefined","stack":"at /opt/hub-indexer/packages/api/node_modules/@esri/hub-search/dist/node/ago/helpers/filters/collection.js:10:15"} reqDetails={"query":{"includeFailures":"true","agg":{"fields":"downloadable,hasApi,source,tags,type,access"},"fields":{"datasets":"id,name,modified,modifiedProvenance,searchDescription,recordCount,source,extent,owner,thumbnailUrl,type,url,xFrameOptions,contentSecurityPolicy,siteUrl,tags,collection,size,initiativeCategories,slug,startDate,venue,initiativeId,initiativeTitle,organizers,isAllDay,onlineLocation,timeZone"},"catalog":{"id":"any(22b0181df5b743efac9dce3a63da0cef)","groupIds":"any(22b0181df5b743efac9dce3a63da0cef)"},"filter":{"collection":"any(Sites)","isCancelled":"eventsEq(false)","status":"not(private,draft,planned)","endDate":"eventsBefore(1580136087207)"}},"headers":{"origin":"https://monroe-county-business-development-corporation-2-monroemi.hub.arcgis.com"}}
```