### PR TITLE
handle case where query cannot be parsed as a regexp

### DIFF
--- a/packages/search/src/ago/helpers/format/highlights.ts
+++ b/packages/search/src/ago/helpers/format/highlights.ts
@@ -5,12 +5,26 @@ export function calcHighlights(input: string, query: string, property: string) {
   // E.g. input string: `Capital bike share... blah blah capital.... CAPITAL`
   // We would like to highlight: `Capital`, `capital`, `CAPITAL`
   if (!input) return undefined;
-  const matches = input.match(new RegExp(query, "ig")); // search globally and case insensitively
-  if (!matches) return undefined;
-  return matches.reduce((highlights, match) => {
+
+  try {
+    const matches = input.match(new RegExp(query, "ig")); // search globally and case insensitively
+
+    if (!matches) return undefined;
+
+    return matches.reduce(injectHighlightMarkdown(property), input);
+  } catch (err) {
+    // the most likely error is that the RegExp could not be compiled, eg: query=*
+    // this is not catastrophic failure
+    return undefined;
+  }
+}
+
+function injectHighlightMarkdown(property: string) {
+  return (highlights: string, match: string) => {
     // match is what appears as is in the input string
     const replacement = `<mark class="hub-search-highlight ${property}-highlight">${match}</mark>`;
+
     // replace the case sensitive match with mark tags
     return highlights.replace(new RegExp(match, "g"), replacement);
-  }, input);
+  };
 }

--- a/packages/search/test/ago/helpers/format/highlights.test.ts
+++ b/packages/search/test/ago/helpers/format/highlights.test.ts
@@ -30,4 +30,23 @@ describe("highlights test", () => {
     const actual = calcHighlights(input, query, property);
     expect(actual).toBe(expected);
   });
+
+  it("query not parseable as RegExp should return undefined", () => {
+    const input = "input value";
+    const query = "[";
+    const property = "name";
+
+    const actual = calcHighlights(input, query, property);
+    expect(actual).toBeUndefined();
+  });
+
+  it("wildcard should return undefined", () => {
+    // this is redundant but useful for the general case
+    const input = "input value";
+    const query = "*";
+    const property = "name";
+
+    const actual = calcHighlights(input, query, property);
+    expect(actual).toBeUndefined();
+  });
 });


### PR DESCRIPTION
This PR fixes the case where the query parameter passed to the highlighting function cannot be parsed a regular expression.  This happens when the query parameter is `*`, resulting in:

```
> new RegExp('*', 'ig')
SyntaxError: Invalid regular expression: /*/: Nothing to repeat
```

Here's the kibana log where this emerges in production:

https://ingress.prod.hub.geocloud.com/kibana/app/kibana#/doc/AWtbfdKt275U86vEW3Rl/logstash-2020.01.23/fluentd?id=AW_UJLyUqLTHbvUsMs2E&_g=()

When the query parameter cannot be parsed as a regexp, the logic treats the highlights as if no matches were found.  

TP issue: https://esriarlington.tpondemand.com/restui/board.aspx?#page=userstory/110728