### PR TITLE
Changing tags filter to default to any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.6.5] - January 28th 2020
 
 ## [Unreleased][HEAD]
-
+* Bug Fixes
+   * **search**: all filters should be consistent and default to "any"
 
 
 ## [3.6.4] - January 28th 2020

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/hub.js",
-  "version": "3.6.5",
+  "version": "3.6.6",
   "description": "compact, modular JavaScript wrappers for ArcGIS Hub that run in Node.js and modern browsers.",
   "devDependencies": {
     "@types/es6-promise": "0.0.32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/hub.js",
-  "version": "3.6.6",
+  "version": "3.6.5",
   "description": "compact, modular JavaScript wrappers for ArcGIS Hub that run in Node.js and modern browsers.",
   "devDependencies": {
     "@types/es6-promise": "0.0.32",

--- a/packages/search/src/ago/helpers/filters/filter-schema.ts
+++ b/packages/search/src/ago/helpers/filters/filter-schema.ts
@@ -10,7 +10,7 @@ const filterSchema: any = {
   tags: {
     type: "filter",
     dataType: "string",
-    defaultOp: "all"
+    defaultOp: "any"
   },
   source: {
     type: "filter",

--- a/packages/search/test/ago/helpers/filters/create-filters.test.ts
+++ b/packages/search/test/ago/helpers/filters/create-filters.test.ts
@@ -50,7 +50,7 @@ describe("createFilters test", () => {
     const actual = createFilters(params);
     const expected: any = {
       tags: {
-        fn: "all",
+        fn: "any",
         terms: ["a", "b", "c"],
         catalogDefinition: undefined
       },


### PR DESCRIPTION
Filters should be consistent and all use the same default values. This PR updates the `tags` filter to `any` to be consistent with the others.