### PR TITLE
add exb apps to apps category

### DIFF
--- a/packages/common/src/categories.ts
+++ b/packages/common/src/categories.ts
@@ -6,7 +6,8 @@ const app: string[] = [
   "Insights Workbook",
   "Operation View",
   "Web Mapping Application",
-  "StoryMap"
+  "StoryMap",
+  "Web Experience"
 ];
 
 const dataset: string[] = [


### PR DESCRIPTION
Catching something we missed when adding support for exb apps in Hub, adding exb apps to the Apps category. Just a string change.