### PR TITLE
feat(hub/initiatives): allow recommendedTemplates thru during templating

### DIFF
--- a/packages/initiatives/src/templates.ts
+++ b/packages/initiatives/src/templates.ts
@@ -1,6 +1,6 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
-import { cloneObject, without } from "@esri/hub-common";
+import { cloneObject, without, getProp } from "@esri/hub-common";
 import { IInitiativeModel, IInitiativeItem } from "@esri/hub-common";
 
 import { CURRENT_SCHEMA_VERSION } from "./migrator";
@@ -83,6 +83,10 @@ export function createInitiativeModelFromTemplate(
       bannerImage: cloneObject(template.data.values.bannerImage)
     }
   };
+  // if recommended exists, copy it over
+  if (getProp(template, "data.recommendedTemplates")) {
+    model.data.recommendedTemplates = template.data.recommendedTemplates;
+  }
   Object.assign(model.data.values, options.groupIds); // add the groupIds, TODO stop storing groupIds in data.values
   // just in case the template does not have a banner image defined...
   if (!model.data.values.bannerImage) {

--- a/packages/initiatives/test/templates.test.ts
+++ b/packages/initiatives/test/templates.test.ts
@@ -23,6 +23,7 @@ const defaultTemplate = {
   data: {
     assets: ["things", "that should be cloned forward"],
     steps: ["steps", "should be cloned"],
+    recommendedTemplates: ["bc3", "cc4"],
     values: {
       bannerImage: { should: "also be cloned" }
     }
@@ -64,7 +65,7 @@ describe("Initiative Templates ::", () => {
       ); // TODO remove
       expect(chk.data.values.contentGroupId).toBe(opts.groupIds.contentGroupId); // TODO remove
       expect(chk.item.properties.initialParent).toBe(defaultTemplate.item.id);
-
+      expect(chk.data.recommendedTemplates.length).toEqual(2);
       expect(chk.item.tags).toContain("Hub Initiative");
       expect(chk.item.typeKeywords).toContain("hubInitiative");
       expect(chk.item.typeKeywords).not.toContain("hubInitiativeTemplate");


### PR DESCRIPTION
Ensure that `data.recommendedTemplates` will be taken from the template and applied to the resulting model

AFFECTS PACKAGES:
@esri/hub-initiatives