### PR TITLE
Remove determineOwner, stop setting Admin Url

### DIFF
--- a/packages/initiatives/src/activate.ts
+++ b/packages/initiatives/src/activate.ts
@@ -2,7 +2,7 @@
  * Apache-2.0 */
 
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IInitiativeModel, camelize } from "@esri/hub-common";
+import { IInitiativeModel, camelize, IModel } from "@esri/hub-common";
 import { getInitiative } from "./get";
 import {
   createInitiativeModelFromTemplate,
@@ -64,7 +64,7 @@ export function activateInitiative(
       // now save it...
       return addInitiative(state.initiativeModel, ro);
     })
-    .then((newModel: IInitiativeModel) => {
+    .then((newModel: IModel) => {
       state.initiativeModel = newModel;
       const assets = getProp(state, "template.assets");
       if (assets) {

--- a/packages/initiatives/src/add.ts
+++ b/packages/initiatives/src/add.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IInitiativeModel } from "@esri/hub-common";
+import { IInitiativeModel, IModel } from "@esri/hub-common";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { saveModel, updateModel } from "./model";
 import { getHubApiUrl } from "@esri/hub-common";
@@ -21,13 +21,9 @@ export const INITIATIVE_TYPE_NAME = "Hub Initiative";
 export function addInitiative(
   model: IInitiativeModel,
   requestOptions: IRequestOptions
-): Promise<IInitiativeModel> {
+): Promise<IModel> {
   // delegate to model to do the save...
-  return saveModel(model, requestOptions).then(newModel => {
-    // ensure ew have a url to the iniative item...
-    newModel.item.url = getInitiativeUrl(newModel.item.id, requestOptions);
-    return updateModel(newModel, requestOptions) as Promise<IInitiativeModel>;
-  });
+  return saveModel(model, requestOptions);
 }
 
 /**

--- a/packages/initiatives/src/add.ts
+++ b/packages/initiatives/src/add.ts
@@ -3,7 +3,7 @@
 
 import { IInitiativeModel, IModel } from "@esri/hub-common";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { saveModel, updateModel } from "./model";
+import { saveModel } from "./model";
 import { getHubApiUrl } from "@esri/hub-common";
 
 export const INITIATIVE_TYPE_NAME = "Hub Initiative";

--- a/packages/initiatives/src/model.ts
+++ b/packages/initiatives/src/model.ts
@@ -8,8 +8,7 @@ import {
   updateItem,
   IUpdateItemOptions,
   ICreateItemOptions,
-  ICreateItemResponse,
-  determineOwner
+  ICreateItemResponse
 } from "@esri/arcgis-rest-portal";
 
 /**
@@ -30,7 +29,6 @@ export function saveModel(
   return createItem(opts as ICreateItemOptions).then(
     (response: ICreateItemResponse) => {
       clone.item.id = response.id;
-      clone.item.owner = determineOwner(requestOptions);
       return clone as IModel;
     }
   );

--- a/packages/initiatives/test/add.test.ts
+++ b/packages/initiatives/test/add.test.ts
@@ -14,7 +14,8 @@ const newInitiative = {
     title: "Fake Initiative",
     owner: "vader",
     type: "Hub Initiative",
-    tags: ["test webmap"]
+    tags: ["test webmap"],
+    url: "https://some-site.com"
   },
   data: {
     some: {
@@ -46,14 +47,14 @@ describe("Add Initiative ::", () => {
           "from-spy",
           "should have the id from the spy result"
         );
-        expect(result.item.url).toContain(`admin/initiatives/from-spy`);
+        expect(result.item.url).toContain(`some-site.com`);
         expect(saveSpy.calls.count()).toEqual(
           1,
           "should make one call to model::saveModel"
         );
         expect(updateSpy.calls.count()).toEqual(
-          1,
-          "should make one call to model::updateModel"
+          0,
+          "should make not call to model::updateModel"
         );
         done();
       })


### PR DESCRIPTION
- remove use of determineOwner internal fn coming from rest-js, 
- stop injecting admin url for new initiatives

AFFECTS PACKAGES:
@esri/hub-initiatives