### PR TITLE
fix(Fixes current initiative schema to be 2.2 so that the 2.2 migration runs)

### DIFF
--- a/packages/initiatives/src/migrator.ts
+++ b/packages/initiatives/src/migrator.ts
@@ -12,7 +12,7 @@ import { upgradeToTwoDotTwo } from "./migrations/upgrade-two-dot-two";
  * Current Schema Version
  * @protected
  */
-export const CURRENT_SCHEMA_VERSION = 2.1;
+export const CURRENT_SCHEMA_VERSION = 2.2;
 
 /**
  * Handle Initiative Schema Migrations.


### PR DESCRIPTION
This PR fixes the CURRENT_SCHEMA_VERSION to be 2.2 so that the 2.2 migration runs.

AFFECTS PACKAGES:
@esri/hub-initiatives