### PR TITLE
Update site category

### DIFF
--- a/packages/common/src/categories.ts
+++ b/packages/common/src/categories.ts
@@ -114,7 +114,10 @@ const other: string[] = [
   "Workflow Manager Package"
 ];
 
-const site: string[] = ["Hub Site Application"];
+const site: string[] = [
+  "Hub Site Application",
+  "Site Application"
+];
 
 // eligible types are listed here: http://doc.arcgis.com/en/arcgis-online/reference/supported-items.htm
 const downloadableTypes: string[] = [


### PR DESCRIPTION
Add the `Site Application` type to the `Site` category. This type is for sites created by ArcGIS Enterprise.