### PR TITLE
fix(common): fix the missing "Site Application" type for the "site" ategory

### DIFF
--- a/packages/common/src/categories.ts
+++ b/packages/common/src/categories.ts
@@ -114,7 +114,7 @@ const other: string[] = [
   "Workflow Manager Package"
 ];
 
-const site: string[] = ["Hub Site Application"];
+const site: string[] = ["Hub Site Application", "Site Application"];
 
 // eligible types are listed here: http://doc.arcgis.com/en/arcgis-online/reference/supported-items.htm
 const downloadableTypes: string[] = [

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -24,7 +24,10 @@ describe("getTypes", () => {
     expect(getTypes()).toBe(undefined);
   });
   it("can get a list of types for a category", () => {
-    expect(getTypes("site")).toEqual(["Hub Site Application"]);
+    expect(getTypes("site")).toEqual([
+      "Hub Site Application",
+      "Site Application"
+    ]);
   });
 });
 


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/hub-common

The `Site Application` type is for sites created by ArcGIS Enterprise.