### PR TITLE
[DNM] Initial prototype of Hub content methods

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -46,15 +46,6 @@
 			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
 			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
 		},
-		"fetch-blob": {
-			"version": "github:node-fetch/fetch-blob#4a46def45247e7e1fac18b9e399e0969b2c4a962",
-			"from": "github:node-fetch/fetch-blob#master"
-		},
-		"node-fetch": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-		},
 		"tslib": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",

--- a/packages/common/src/api.ts
+++ b/packages/common/src/api.ts
@@ -1,6 +1,8 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { getPortalUrl } from "@esri/arcgis-rest-portal";
 import { _getHubUrlFromPortalHostname } from './urls/_get-hub-url-from-portal-hostname';
+import { IHubRequestOptions } from "./types";
+
 /**
  * ```js
  * import { getHubApiUrl() } from "@esri/hub-common";
@@ -17,4 +19,29 @@ export function getHubApiUrl(requestOptions: IRequestOptions): string {
   
 }
 
+export function getFromHubAPI(id:string, hubRequestOptions?: IHubRequestOptions): Promise<any> {
+  let hubUrl = "https://hub.arcgis.com/api";
+  let headers:any = {};
 
+  if (hubRequestOptions !== undefined) {
+    hubUrl = hubRequestOptions.hubApiUrl;
+    headers['Authorization'] =  hubRequestOptions.authentication.token;
+  }
+  
+  const url = `${hubUrl}/v3/datasets/${id}`;
+  const opts = {
+    method: "GET",
+    mode: "cors",
+    headers
+  } as RequestInit;
+  return fetch(url, opts)
+    .then(raw => raw.json())
+    .then(contentData => {
+      return contentData;
+    })
+    .catch(err => {
+      throw Error(
+        `getFromHubAPI: Error requesting from Hub API: ${err}`
+      );
+    }); 
+}

--- a/packages/common/src/api.ts
+++ b/packages/common/src/api.ts
@@ -34,8 +34,16 @@ export function getFromHubAPI(id:string, hubRequestOptions?: IHubRequestOptions)
     mode: "cors",
     headers
   } as RequestInit;
+
+  // TODO: handle Hub missing content by ID
   return fetch(url, opts)
-    .then(raw => raw.json())
+    .then(response => {
+      if (!response.ok) {
+        // TODO: handle passing up enumerated Hub API error codes
+        throw Error(response);
+      }
+      return response.json()
+    )
     .then(contentData => {
       return contentData;
     })

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -1,0 +1,148 @@
+# @esri/hub-content
+
+> Manage Hub content [`@esri/hub.js`](https://github.com/Esri/hub.js).
+
+### Example
+
+```bash
+npm install @esri/hub-content
+```
+
+```js
+import { getContent  } from '@esri/hub-content';
+
+// pass in a site id
+getContent("abc123")
+    .then(
+        contentModel => {
+            contentModel.title; // access content information
+        }
+    );
+```
+
+## Design
+
+Hub Content is the generic term for Hub-related items and integrated metadata. Content types include datasets, maps, documents, apps, surveys, as well as events, sites, pages, and initiatives. Content provides a common metadata model and interface for creating, viewing, and managing content - as well as content-specific attributes and associations such as map basemap, app datasets, site pages, and initiative site. 
+
+Content have common metadata, associated content or resources (e.g. owner member), and actions (update, delete). Content metadata is composed of the Portal Item + Data with content- or org-specific enrichments. For example, a Map content item has 
+- _literal metadata_ like `title`
+- _inferred metadata_ such as `coverage` (global, regional, local) derived from the geographic extent, 
+- _linked metadata_ `license` created through `licenseInfo`
+- _associated resources_ such as datasets via `operationalLayers` or `owner` (`as IHubMember`) via the `item.owner`
+
+### Methods
+
+- `getContent(id, associatedOptions, hubRequestOptions)`
+- `createContent(id, attributes, hubRequestOptions)`
+- `updateContent(id, attributes, hubRequestOptions)`
+- `deleteContent(id, hubRequestOptions)`
+
+`associatedOptions` is proposed to support external references that may require additional XHR to fetch. Similar to JSON-API or GraphQL. 
+For example `associatedOptions: { itemInfo: true, itemData: true, connectedContent: 5 }`
+
+- Question: should download formats + links be optional associations or require XHR via the download components?
+
+### Metadata
+
+Based on the [Hub Content UI Inventory](https://app.lucidchart.com/invitations/accept/dab82a25-2ed9-4f63-8075-3db8873087e3)
+
+Attemping a simple _Hungarian Notation_ for attributes suffix: `*Date`, `*Id`, `*Number`. Plural (e.g. `tags`) is an array.
+
+```ts
+export interface IContentModel extends IModel {
+    id: string; 
+    type: 'document' | 'dataset' | 'map' | 'app' | 'site' | 'initiative' | 'event' | 'template' ;
+    owner: IHubMember;
+    
+    access: {
+        visibility: 'private' | 'org' | 'public';
+        permission?: 'view' | 'edit' | 'admin'; // based on User requesting the info
+        updateGroups?: Array<IGroup>;
+        viewGroups?: Array<IGroup>;
+    };
+
+    metrics?: {
+        visibility: 'private' | 'org' | 'updateGroups' | 'public'  ; // TODO: should we share with specific groups?
+        viewNumber?: number; // available depending on visibility; 
+    };
+
+    // Common metadata
+    title: string;
+    summary: string;
+    description: string;
+    license: IHubLicense; // title, description, and optional link to license item with more info
+    source: IHubOrg | IHubTeam | IHubMember; // each of these has common metadata like `title`, `thumbnail` , and `link`
+    createdDate: Date; 
+    publishedDate: Date;
+    updatedDate: Date;
+    geography: IHubGeography; // {title, coverage (global|regional|local), extent (WSEN), geometry, source}
+    categories?: Array<string>;
+    tags: Array<string>;
+    language: string; // written locale e.g. en, es, cn
+    contentUrl: string; // Link the the raw content
+    thumbnailUrl: string; // Full URL
+    status?: string; // e.g. [in-development, maintained, archived, unreviewed, prototype]
+
+    // Unique or additional formal metadata that will be displayed in sidebar
+    metadata?: {
+        // Additional custom/formal metadata elements
+    };
+
+    // Content specific attributes such as 
+    attributes?: {
+        // Dataset, e.g.
+        fields?: [{name:string, type:string, statistics:Array<any>}];
+        recordNumber?: number;
+        // Map, e.g.
+        layers?: [];
+        basemap?: string;
+        // Document
+        format?: 'link' | 'PDF' | 'MS Word' | 'MS Excel' | 'Text';
+        // Initiative
+        stage?: string;
+        followersNumber?: number;
+        coreTeamId?: string; 
+        contentTeamId?: string;
+        supportingTeamsNumber?: number;
+        // Event
+        sponsors?: Array<any>;
+        attendeesNumber?: number;
+        limitNumber?: number;
+        startDate?: Date;
+        endDate?: Date;
+        videoUrl?: string;
+    };
+
+    // Depending on the association requests, e.g.
+    associations?: {
+        relatedContent?: Array<IContentModel>;  // Automatically determined through similar metadata, usages
+        connectedContent?: Array<IContentModel>; // Explicit through usage, e.g. a dataset is connected to the Maps that use it.
+    }
+
+    // Optional configured app links that replace "Create StoryMap" with links to specific apps/sites
+    // 'home' is special as the landing page for the item instead of /content/:id/about or ../explore
+    links?: {
+        home: string;
+    };
+
+    // [Future] View configuration options such as cartography, charts, table, etc.
+    contentDisplay?: 'thumbnail' | 'map'; 
+    // [Future] Optional configured home at `/content/:id` such as a Page or App 
+    home?: {
+        type: IContentType;
+        contentId?: string; // if type is a Hub content type
+        contentUrl?: string; // if type is an external link that will be iframed?
+    }
+
+    // Legacy / optional Portal items. TODO: Should these be in `associations`
+    item?: IItem; // Portal Item
+    data?: { // Portal item.data
+        [propName: string]: any;
+    };
+}
+
+```
+
+### Raw Info
+
+Content also include the original portal info via `content.item` and `content.data` for backwards compatibility and staging of new content model attributes.

--- a/packages/content/package-lock.json
+++ b/packages/content/package-lock.json
@@ -1,0 +1,33 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@esri/arcgis-rest-portal": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.13.1.tgz",
+			"integrity": "sha512-6DNJ1ko3FBKDQh/+ekh+x9UB5tP6a9SzJLVzO0f0YFvOH2uRLa2yfs37fcsZWKlZ6pJvl93zduZcqeZREngn7A==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.13.1",
+				"tslib": "^1.9.3"
+			}
+		},
+		"@esri/arcgis-rest-request": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.13.1.tgz",
+			"integrity": "sha512-6VYfUgzgLEQ2rXFf2i2UdF4VPYbc6lNOWIaNzym6FYqnFDXZGD2bx5ZsFOga9KxXh44vNgFpFRHc0MqTsgYh+g==",
+			"requires": {
+				"tslib": "^1.9.3"
+			}
+		},
+		"@esri/arcgis-rest-types": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.13.1.tgz",
+			"integrity": "sha512-XF8V6GE6WtN1/LRQSZk6EygbSACHsDBJrxIiZDQiqjqD1k/xf6X8dbvXO6aFUFTAUFzFHOOtw8lleeVAXsSv9w=="
+		},
+		"tslib": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+		}
+	}
+}

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@esri/hub-content",
+  "version": "1.0.0",
+  "description": "Module to interact with ArcGIS Hub Content items.",
+  "main": "dist/node/index.js",
+  "unpkg": "dist/umd/content.umd.js",
+  "module": "dist/esm/index.js",
+  "js:next": "dist/esm/index.js",
+  "sideEffects": false,
+  "types": "dist/esm/index.d.ts",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "tslib": "^1.11.1"
+  },
+  "peerDependencies": {
+    "@esri/arcgis-rest-portal": "^2.0.0",
+    "@esri/arcgis-rest-request": "^2.0.0",
+    "@esri/hub-common": "^4.0.0"
+  },
+  "devDependencies": {
+    "@esri/arcgis-rest-portal": "^2.0.0",
+    "@esri/arcgis-rest-request": "^2.0.0",
+    "@esri/hub-common": "^4.2.0"
+  },
+  "files": [
+    "dist/**"
+  ],
+  "scripts": {
+    "prepare": "npm run build",
+    "build": "npm run build:node && npm run build:umd && npm run build:esm",
+    "build:esm": "tsc --module es2015 --outDir ./dist/esm --declaration",
+    "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
+    "build:node": "tsc --module commonjs --outDir ./dist/node",
+    "dev:esm": "tsc -w --module es2015 --outDir ./dist/esm --declaration",
+    "dev:umd": "rollup -w -c ../../umd-base-profile.js",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": "github:Esri/hub.js",
+  "contributors": [
+    {
+      "name": "Andrew Turner",
+      "email": "aturner@esri.com",
+      "url": "http://dc.esri.com/"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/Esri/hub.js/issues"
+  },
+  "homepage": "https://github.com/Esri/hub.js#readme"
+}

--- a/packages/content/src/create.ts
+++ b/packages/content/src/create.ts
@@ -1,0 +1,81 @@
+import { IContentModel } from "./index";
+import { IHubRequestOptions } from "@esri/hub-common";
+import { createItem, IItem } from "@esri/arcgis-rest-portal";
+
+/**
+ * ```js
+ * createContent(content)
+ *  .then(result => {
+ *    // handle result including new item id
+ *  })
+ * ```
+ * Create the content in Portal and also ping Hub API to update index.
+ *
+ *
+ * @param content - Content Model
+ * @param requestOptions - Tequest options that may have authentication manager
+ * @returns A Promise that will resolve with the entire Content object including the new ID 
+ * @export
+ */
+export function createContent(
+  content: IContentModel,
+  hubRequestOptions?: IHubRequestOptions
+): Promise<any> {
+
+  if(hubRequestOptions.isPortal) {
+    return _createContentInPortal(content, hubRequestOptions);
+  } else {
+    return _createContentInHub(content, hubRequestOptions);
+  }
+}
+
+/**
+ * Create the content in Portal
+ *
+ * @param content - Content Model
+ * @param requestOptions - Request options that may have authentication manager
+ * @returns A Promise that will resolve with the entire Content object including the new ID 
+ * @export
+ */
+async function _createContentInPortal(
+  content: IContentModel,
+  hubRequestOptions?: IHubRequestOptions
+): Promise<IContentModel> {
+
+  // TODO: make this functional
+  let item = _convertContentToItem(content);
+  const createResponse = await createItem({
+    item: item,
+  });
+  // hold onto the Id so we can return a complete model
+  content.id = createResponse.id;
+  content.item.id = createResponse.id;
+  return new Promise((resolve) => resolve(content));
+}
+function _convertContentToItem(content: IContentModel):IItem {
+  // TODO Convert Content to Item using mdJSON translations
+  let item:IItem; 
+  return item;
+}
+
+/**
+ * Create the content in Hub + Portal
+ *
+ * @param content - Content Model
+ * @param requestOptions - Request options that may have authentication manager
+ * @returns A Promise that will resolve with the entire Content object including the new ID 
+ * @export
+ */
+async function _createContentInHub(
+  content: IContentModel,
+  hubRequestOptions?: IHubRequestOptions
+): Promise<any> {
+
+  // First we create the item in Portal, then also add to the Hub API index
+  // in the future the Hub API can use Hub.js to do the Portal proxy
+  const updatedContent = await _createContentInPortal(content);
+  // Add API and methods to directly update Hub
+  // hubModule.createContent(updatedContent);
+  return new Promise((resolve) => resolve(content));
+  
+}

--- a/packages/content/src/delete.ts
+++ b/packages/content/src/delete.ts
@@ -1,0 +1,24 @@
+import { IContentModel } from "./index";
+import { IHubRequestOptions } from "@esri/hub-common";
+
+/**
+ * Delete the content in Portal and also ping Hub API to remove from index.
+ *
+ * @param content - Content ID
+ * @param requestOptions - Request options that may have authentication manager
+ * @returns A Promise that will resolve with the entire Content object 
+ * @export
+ */
+export function deleteContent(
+  id: string,
+  hubRequestOptions?: IHubRequestOptions
+): Promise<any> {
+
+  // TODO Implement methods
+  if(hubRequestOptions.isPortal) {
+    return _deleteContentFromPortal(content, hubRequestOptions);
+  } else {
+    // will remove from Portal and if successful remove from Hub index
+    return _deleteContentFromHub(content, hubRequestOptions);
+  }
+}

--- a/packages/content/src/get.ts
+++ b/packages/content/src/get.ts
@@ -113,7 +113,15 @@ export function _getContentFromHub(
   hubRequestOptions?: IHubRequestOptions
 ): Promise<any> {
 
-  return getFromHubAPI(id, hubRequestOptions);
+  return getFromHubAPI(id, hubRequestOptions).then((hubResponse: any) => {
+    return new Promise((resolve) => {resolve(hubResponse)})
+  }).catch(err =>  {
+    // TODO: better enumeration / encapsultion of Hub API error handling
+    if(err.status == 403) {
+      // Hub API failed or item not found. Try Portal b/c not-public or not-yet-indexed
+      return _getContentFromPortal(id, hubRequestOptions);
+    }
+  })
 }
 
 /**

--- a/packages/content/src/get.ts
+++ b/packages/content/src/get.ts
@@ -1,0 +1,156 @@
+/* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { IHubRequestOptions, getModel, getFromHubAPI } from "@esri/hub-common";
+// TODO: why won't this import from hub-common?
+// import { getFromHubAPI } from "../../common/src/api";
+
+import { IModel } from "@esri/hub-common";
+import { getCategory } from "@esri/hub-common";
+import { IContentModel } from "./index";
+
+/**
+ * ```js
+ * getContent('3ef...')
+ *  .then(contentModel => {
+ *    // work with the model
+ *  })
+ * ```
+ * Get the content by unique ID. 
+ * This method works to call either the Portal (AGO) API or Hub API
+ * and return a common data model.
+ *
+ *
+ * @param id - Content Id
+ * @param requestOptions - Tequest options that may have authentication manager
+ * @returns A Promise that will resolve with the Content metadata
+ * @export
+ */
+export function getContent(
+  id: string,
+  hubRequestOptions?: IHubRequestOptions
+): Promise<any> {
+
+  if(hubRequestOptions.isPortal) {
+    return _getContentFromPortal(id, hubRequestOptions);
+  } else {
+    return _getContentFromHub(id, hubRequestOptions);
+  }
+}
+
+/**
+ * ```js
+ * _getContentFromPortal('3ef...')
+ *  .then(contentModel => {
+ *    // work with the model
+ *  })
+ * ```
+ * Get the content data from Portal or Online 
+ *
+ *
+ * @param {String} id Content Id
+ * @param {IHubRequestOptions} hubRequestOptions Request options that may have authentication manager
+ * @returns A Promise that will resolve with the item and data
+ * @export
+ */
+export function _getContentFromPortal(
+  id: string,
+  hubRequestOptions?: IHubRequestOptions
+): Promise<any> {
+
+  return getModel(id, hubRequestOptions).then((item:IModel) => {
+    return new Promise(resolve => {
+      const content = _convertItemToContent(item);
+      resolve(content);
+    })
+  });
+}
+
+/**
+ * Convert a Portal Item to a Hub Content 
+ * TODO: Change to use mdJSON translation for configurable metadata
+ *
+ *
+ * @param {IModel} item Portal Item
+ * @returns {IContentModel} Hub content object
+ * @export
+ */
+export function _convertItemToContent(
+  item: IModel
+): IContentModel {
+  let content:IContentModel = {
+    id: item.item.id,
+    type: getCategory(item.item.type),
+    title: item.item.title,
+    summary: item.item.snippet,
+    description: item.item.description,
+    owner: { username: item.item.owner },
+
+    item: item.item, // Kept for temporary backwards compatibility, but redundant
+    data: item.data
+  };
+
+  return content;
+}
+
+/**
+ * ```js
+ * _getContentFromHub('3ef...')
+ *  .then(contentModel => {
+ *    // work with the model
+ *  })
+ * ```
+ * Get the content data from the Hub API
+ *
+ *
+ * @param {String} id Content Id
+ * @param {IHubRequestOptions} hubRequestOptions Request options that may have authentication manager
+ * @returns A Promise that will resolve with the item and data
+ * @export
+ */
+export function _getContentFromHub(
+  id: string,
+  hubRequestOptions?: IHubRequestOptions
+): Promise<any> {
+
+  return getFromHubAPI(id, hubRequestOptions);
+}
+
+/**
+ * Convert a Hub v3 Dataset to Hub Content 
+ * TODO: Change to use mdJSON translation for configurable metadata
+ *
+ *
+ * @param {IModel} item Hub Item
+ * @returns {IContentModel} Hub content object
+ * @export
+ */
+export function _convertv3ToContent(
+  hubmodel: any
+): IContentModel {
+  let content:IContentModel = {
+    id: hubmodel.id,
+    type: hubmodel.type,
+    title: hubmodel.attributes.name,
+    summary: "Missing from Hub API v3",
+    description: hubmodel.attributes.description,
+    owner: { username: hubmodel.attributes.owner },
+
+    // TODO: Temp backwards compatibility
+    item: {
+      id: hubmodel.id,
+      title: hubmodel.attributes.name,
+      snippet: "Missing from Hub API v3",
+      owner: hubmodel.attributes.owner,
+      description: hubmodel.attributes.description,
+      tags: hubmodel.attributes.tags,
+      created: hubmodel.attributes.created,
+      numViews: 0,
+      modified: hubmodel.attributes.modified,
+      size: hubmodel.attributes.size,
+      type: hubmodel.attributes.type
+    }
+  };
+
+  return content;
+}

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -1,0 +1,27 @@
+/* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { IModel } from "@esri/hub-common";
+
+/**
+ * Content Model
+ * Temporary here to make discussion easier
+ * See README.md for outline of full content model
+ *
+ * @export
+ * @interface IContentModel
+ * @extends {IModel}
+ */
+export interface IContentModel extends IModel {
+  id: string; 
+  type: string; // Content type [dataset, map, document, app]
+  owner: { username: string };
+  title: string;
+  summary: string;
+  description: string;
+
+  metadata?: any;
+}
+
+
+export * from "./get";

--- a/packages/content/src/update.ts
+++ b/packages/content/src/update.ts
@@ -1,0 +1,24 @@
+import { IContentModel } from "./index";
+import { IHubRequestOptions } from "@esri/hub-common";
+
+/**
+ * Update the content in Portal and also ping Hub API to update index.
+ *
+ * @param content - Content Model
+ * @param requestOptions - Request options that may have authentication manager
+ * @returns A Promise that will resolve with the entire Content object 
+ * @export
+ */
+export function updateContent(
+  content: IContentModel,
+  hubRequestOptions?: IHubRequestOptions
+): Promise<any> {
+
+  // TODO Implement methods
+  if(hubRequestOptions.isPortal) {
+    return _updateContentInPortal(content, hubRequestOptions);
+  } else {
+    // will update in Portal and if successful update in Hub index    
+    return _updateContentInHub(content, hubRequestOptions);
+  }
+}

--- a/packages/content/test/_get-content.test.ts
+++ b/packages/content/test/_get-content.test.ts
@@ -1,0 +1,29 @@
+import { getContent } from "../src";
+import * as portalModule from "@esri/arcgis-rest-portal";
+import * as hubModule from "@esri/hub-common";
+
+describe("getContent", () => {
+  it("get content data from portal", async () => {
+    spyOn(hubModule, "getModel").and.returnValue(
+      Promise.resolve({
+        description: "Content from Portal"
+      })
+    );
+
+    const content = await getContent("some-id", {isPortal: true} as hubModule.IHubRequestOptions);
+
+    expect(content.description).toBe("Content from Portal");
+  });
+
+  it("get content data from Hub", async () => {
+    spyOn(hubModule, "getFromHubAPI").and.returnValue(
+      Promise.resolve({
+        description: "Content from Hub"
+      })
+    );
+
+    const content = await getContent("some-id", {isPortal: false} as hubModule.IHubRequestOptions);
+
+    expect(content.description).toBe("Content from Hub");
+  });
+});

--- a/packages/content/tsconfig.json
+++ b/packages/content/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+      "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
This is a suggested package for managing "Hub Content". Content are a composition of Portal Items plus additional metadata, relationships, and capabilities (e.g. downloads). 

The `hub-content` package provides standard _CRUD_ operations using a proposed `Hub Content Model` that has common elements for all content types and specific `attributes` per unique content type (e.g. Event times, dataset fields, etc.) 

The primary purpose of this package is to provide a simple, consistent, and extensible interface to Hub content to improve the developer experience for Hub sub-systems (UI, API, widgets, etc) and possibly performance by dynamic loading Hub packages as necessary - and not up-front in the client UI.

The CRUD methods are also a facade for the dual Hub API and Portal API. All content information is durably stored in Portal, but when there is a Hub API (online, public items). Then the content is also added directly to that index. While Hub does create an index through backend notifications and harvesting, there can be significant delay or multiple edits that may result in out-of-date information being available in Hub index. So when using the Hub UI and Hub.js this information can be more consistent. 

Content that is not yet in the Hub API (non-public, or created outside of Hub) then Hub API calls fall-back to direct Portal calls. 

## Content-specific metadata and methods

While this prototype provides a single common interface to all Content types - there may be significant additional methods for specific content types that suggests new packages. For example, `hub-datasets` may be useful for download, field operations, analyses, etc. These content-type packages would use `hub-content` for the information interface and then add specifics methods or metadata modifications.

## Other Hub.js packages

This prototype focused on Hub content. However, we should also prototype a complete Hub API wrapper for `hub-search` to call the Hub and Portal Search API, content downloads, as well as interfaces for `hub-users`, `hub-teams`, etc. 