### PR TITLE
Downloads package.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,15 @@
       ]
     },
     {
+      "type": "node", 
+      "request": "launch", 
+      "name": "Debug Node Tests, Current File", 
+      "program": "${workspaceRoot}/node_modules/.bin/jasmine",
+      "args": ["--config=jasmine.json", "${file}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "Debug Changelog Script",

--- a/packages/auth/package-lock.json
+++ b/packages/auth/package-lock.json
@@ -3,26 +3,26 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
-			"version": "2.13.2",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.13.2.tgz",
-			"integrity": "sha512-NrNMnqJQphUljXUSZbdzz94kd90UaU3tRoe3Ez6T3RURzqKvKCXZ3VDhrKS41+Bgrmwow+RwJGgjJ6nxooHmUQ==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.14.0.tgz",
+			"integrity": "sha512-qsLip4vFi4PgWTiSiDsO415aOcjdjfni4ZZBTyacfyzEdJhQuoIzUS9JSSMWW+/D4wkudZzwdI7hZGwhfHeNRA==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.13.2",
+				"@esri/arcgis-rest-types": "^2.14.0",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "2.13.2",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.13.2.tgz",
-			"integrity": "sha512-h0RUQRx8dFLrMv6qCyWubyYIcacrdzilgaOIQRc2HInuSyjmSrp1kHDS1IAQ8fnkHvYriUsRIlFOyduB4BkJaA==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.14.0.tgz",
+			"integrity": "sha512-RxF957PHzcI3JVd6y0NOvJtEgRxphyTa7Gajjcu0gEuniJzdsAIy9lywIZ8NPj6KqK5GTTxgFlWPs9p1A1xERA==",
 			"requires": {
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-types": {
-			"version": "2.13.2",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.13.2.tgz",
-			"integrity": "sha512-FLFU4709JFVofMPdxvUwVkXU8KM8wOY84B9kKHeTm5vRvIJ1g7t6BvGzQoCMJsaVZcyt9xvGAI+BCuBC5+ogbA=="
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.14.0.tgz",
+			"integrity": "sha512-ZivBW3vPT8pi+pg9PstvvlDuM02i5unOHOjhsJoWDGX+TzDB709HGucXY4ul3YB5O2xF2ryjGjbhkGkseMs1dQ=="
 		},
 		"tslib": {
 			"version": "1.11.1",

--- a/packages/auth/package-lock.json
+++ b/packages/auth/package-lock.json
@@ -3,26 +3,26 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.14.0.tgz",
-			"integrity": "sha512-qsLip4vFi4PgWTiSiDsO415aOcjdjfni4ZZBTyacfyzEdJhQuoIzUS9JSSMWW+/D4wkudZzwdI7hZGwhfHeNRA==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.14.1.tgz",
+			"integrity": "sha512-v81kaGhTYDTXgICImfOvhGGvPIiH2iYswcwq6VaTEtT3JAJg+eUMlyLYJLAJKiYcvG9h+wOQxKm5OIg4wgcs0Q==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.14.0",
+				"@esri/arcgis-rest-types": "^2.14.1",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.14.0.tgz",
-			"integrity": "sha512-RxF957PHzcI3JVd6y0NOvJtEgRxphyTa7Gajjcu0gEuniJzdsAIy9lywIZ8NPj6KqK5GTTxgFlWPs9p1A1xERA==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.14.1.tgz",
+			"integrity": "sha512-adTq5yGbzGGWA0+Oq6eEu+sJAK0CLyeM4Peh8q9jS7Kpj7YhBnzaP/Z2hnLAE/fu9ZG8xZTUiAqojGGBvd7LkQ==",
 			"requires": {
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-types": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.14.0.tgz",
-			"integrity": "sha512-ZivBW3vPT8pi+pg9PstvvlDuM02i5unOHOjhsJoWDGX+TzDB709HGucXY4ul3YB5O2xF2ryjGjbhkGkseMs1dQ=="
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.14.1.tgz",
+			"integrity": "sha512-hlmu7qGKteuF5NiVDX/oWuT6zJnq+P0ns6BkKM/s94MApZlS1FCFxAQS3wl/1MiUPtQykApE4prcyjlknuWglQ=="
 		},
 		"tslib": {
 			"version": "1.11.1",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -13,12 +13,12 @@
     "tslib": "^1.11.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.0",
-    "@esri/arcgis-rest-request": "^2.14.0"
+    "@esri/arcgis-rest-auth": "^2.14.1",
+    "@esri/arcgis-rest-request": "^2.14.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.0",
-    "@esri/arcgis-rest-request": "^2.14.0"
+    "@esri/arcgis-rest-auth": "^2.14.1",
+    "@esri/arcgis-rest-request": "^2.14.1"
   },
   "files": [
     "dist/**"

--- a/packages/downloads/package-lock.json
+++ b/packages/downloads/package-lock.json
@@ -3,58 +3,44 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.14.0.tgz",
-			"integrity": "sha512-qsLip4vFi4PgWTiSiDsO415aOcjdjfni4ZZBTyacfyzEdJhQuoIzUS9JSSMWW+/D4wkudZzwdI7hZGwhfHeNRA==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.14.1.tgz",
+			"integrity": "sha512-v81kaGhTYDTXgICImfOvhGGvPIiH2iYswcwq6VaTEtT3JAJg+eUMlyLYJLAJKiYcvG9h+wOQxKm5OIg4wgcs0Q==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.14.0",
+				"@esri/arcgis-rest-types": "^2.14.1",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-feature-layer": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.14.0.tgz",
-			"integrity": "sha512-KATRimT9lV7bo0yHHsaj5NGPqBV7ai34k98yPXxhZnSzBRMtZrDRfQq5k4/RDOUkaUfA2iKHWQgXy1Gw6gr0rQ==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.14.1.tgz",
+			"integrity": "sha512-6tR6IKQpM2UJkUYmOB4ZcpgCfJfqy/UGXL8p/tbDTHcri7sKQpJgnQL9Y6Zuo73Cxm581HyCVhHdXZYKgpZ/xQ==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.14.0",
+				"@esri/arcgis-rest-types": "^2.14.1",
 				"tslib": "^1.9.3"
-			},
-			"dependencies": {
-				"@esri/arcgis-rest-types": {
-					"version": "2.14.0",
-					"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.14.0.tgz",
-					"integrity": "sha512-ZivBW3vPT8pi+pg9PstvvlDuM02i5unOHOjhsJoWDGX+TzDB709HGucXY4ul3YB5O2xF2ryjGjbhkGkseMs1dQ=="
-				}
 			}
 		},
 		"@esri/arcgis-rest-portal": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.14.0.tgz",
-			"integrity": "sha512-Sh5kTO0eivgSZ/5xJ+dRARYKshL2AfpLnMnVEV9tRQLKNqUJ5XsjReEoN+3a4yj12WDFcztTqHuqwZ7HPaNZMA==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.14.1.tgz",
+			"integrity": "sha512-xuUUrnHaIXzCe2DqzfbIwC41dzQ0e2/ywZrpoasxQSHSjIHUzKmNrV0kp+kTAnnCF6wGJdWRI1Ffkr32OLqarA==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.14.0",
+				"@esri/arcgis-rest-types": "^2.14.1",
 				"tslib": "^1.9.3"
-			},
-			"dependencies": {
-				"@esri/arcgis-rest-types": {
-					"version": "2.14.0",
-					"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.14.0.tgz",
-					"integrity": "sha512-ZivBW3vPT8pi+pg9PstvvlDuM02i5unOHOjhsJoWDGX+TzDB709HGucXY4ul3YB5O2xF2ryjGjbhkGkseMs1dQ=="
-				}
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.14.0.tgz",
-			"integrity": "sha512-RxF957PHzcI3JVd6y0NOvJtEgRxphyTa7Gajjcu0gEuniJzdsAIy9lywIZ8NPj6KqK5GTTxgFlWPs9p1A1xERA==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.14.1.tgz",
+			"integrity": "sha512-adTq5yGbzGGWA0+Oq6eEu+sJAK0CLyeM4Peh8q9jS7Kpj7YhBnzaP/Z2hnLAE/fu9ZG8xZTUiAqojGGBvd7LkQ==",
 			"requires": {
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-types": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.14.0.tgz",
-			"integrity": "sha512-ZivBW3vPT8pi+pg9PstvvlDuM02i5unOHOjhsJoWDGX+TzDB709HGucXY4ul3YB5O2xF2ryjGjbhkGkseMs1dQ=="
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.14.1.tgz",
+			"integrity": "sha512-hlmu7qGKteuF5NiVDX/oWuT6zJnq+P0ns6BkKM/s94MApZlS1FCFxAQS3wl/1MiUPtQykApE4prcyjlknuWglQ=="
 		},
 		"eventemitter3": {
 			"version": "4.0.4",

--- a/packages/downloads/package-lock.json
+++ b/packages/downloads/package-lock.json
@@ -1,0 +1,70 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@esri/arcgis-rest-auth": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.14.0.tgz",
+			"integrity": "sha512-qsLip4vFi4PgWTiSiDsO415aOcjdjfni4ZZBTyacfyzEdJhQuoIzUS9JSSMWW+/D4wkudZzwdI7hZGwhfHeNRA==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.14.0",
+				"tslib": "^1.9.3"
+			}
+		},
+		"@esri/arcgis-rest-feature-layer": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.14.0.tgz",
+			"integrity": "sha512-KATRimT9lV7bo0yHHsaj5NGPqBV7ai34k98yPXxhZnSzBRMtZrDRfQq5k4/RDOUkaUfA2iKHWQgXy1Gw6gr0rQ==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.14.0",
+				"tslib": "^1.9.3"
+			},
+			"dependencies": {
+				"@esri/arcgis-rest-types": {
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.14.0.tgz",
+					"integrity": "sha512-ZivBW3vPT8pi+pg9PstvvlDuM02i5unOHOjhsJoWDGX+TzDB709HGucXY4ul3YB5O2xF2ryjGjbhkGkseMs1dQ=="
+				}
+			}
+		},
+		"@esri/arcgis-rest-portal": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.14.0.tgz",
+			"integrity": "sha512-Sh5kTO0eivgSZ/5xJ+dRARYKshL2AfpLnMnVEV9tRQLKNqUJ5XsjReEoN+3a4yj12WDFcztTqHuqwZ7HPaNZMA==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.14.0",
+				"tslib": "^1.9.3"
+			},
+			"dependencies": {
+				"@esri/arcgis-rest-types": {
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.14.0.tgz",
+					"integrity": "sha512-ZivBW3vPT8pi+pg9PstvvlDuM02i5unOHOjhsJoWDGX+TzDB709HGucXY4ul3YB5O2xF2ryjGjbhkGkseMs1dQ=="
+				}
+			}
+		},
+		"@esri/arcgis-rest-request": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.14.0.tgz",
+			"integrity": "sha512-RxF957PHzcI3JVd6y0NOvJtEgRxphyTa7Gajjcu0gEuniJzdsAIy9lywIZ8NPj6KqK5GTTxgFlWPs9p1A1xERA==",
+			"requires": {
+				"tslib": "^1.9.3"
+			}
+		},
+		"@esri/arcgis-rest-types": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.14.0.tgz",
+			"integrity": "sha512-ZivBW3vPT8pi+pg9PstvvlDuM02i5unOHOjhsJoWDGX+TzDB709HGucXY4ul3YB5O2xF2ryjGjbhkGkseMs1dQ=="
+		},
+		"eventemitter3": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+			"integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+		},
+		"tslib": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+		}
+	}
+}

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "@esri/hub-auth",
-  "version": "6.0.1",
-  "description": "Module to help the community authenticate and interact with ArcGIS Hub.",
+  "name": "@esri/hub-downloads",
+  "version": "4.2.2",
+  "description": "Service for Hub downloads",
   "main": "dist/node/index.js",
-  "unpkg": "dist/umd/auth.umd.js",
+  "unpkg": "dist/umd/downloads.umd.js",
   "module": "dist/esm/index.js",
   "js:next": "dist/esm/index.js",
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
+    "@esri/arcgis-rest-feature-layer": "^2.14.0",
+    "@esri/arcgis-rest-portal": "^2.14.0",
+    "@esri/arcgis-rest-request": "^2.14.0",
+    "eventemitter3": "^4.0.4",
     "tslib": "^1.11.1"
   },
-  "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.0",
-    "@esri/arcgis-rest-request": "^2.14.0"
-  },
+  "peerDependencies": {},
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.0",
-    "@esri/arcgis-rest-request": "^2.14.0"
+    "@esri/arcgis-rest-auth": "^2.14.0"
   },
   "files": [
     "dist/**"
@@ -42,12 +42,8 @@
   },
   "contributors": [
     {
-      "name": "John Gravois",
-      "email": "john@esri.com"
-    },
-    {
-      "name": "Tom Wayson",
-      "email": "twayson@esri.com"
+      "name": "Rich Gwozdz",
+      "email": "rgwozdz@esri.com"
     }
   ],
   "bugs": {

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -10,15 +10,15 @@
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-feature-layer": "^2.14.0",
-    "@esri/arcgis-rest-portal": "^2.14.0",
-    "@esri/arcgis-rest-request": "^2.14.0",
+    "@esri/arcgis-rest-feature-layer": "^2.14.1",
+    "@esri/arcgis-rest-portal": "^2.14.1",
+    "@esri/arcgis-rest-request": "^2.14.1",
     "eventemitter3": "^4.0.4",
     "tslib": "^1.11.1"
   },
   "peerDependencies": {},
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.0"
+    "@esri/arcgis-rest-auth": "^2.14.1"
   },
   "files": [
     "dist/**"

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/hub-downloads",
-  "version": "4.2.2",
+  "version": "6.0.1",
   "description": "Service for Hub downloads",
   "main": "dist/node/index.js",
   "unpkg": "dist/umd/downloads.umd.js",

--- a/packages/downloads/src/download-format.ts
+++ b/packages/downloads/src/download-format.ts
@@ -1,0 +1,8 @@
+export type DownloadFormat = 'Shapefile' |
+'CSV' |
+'File Geodatabase' |
+'Feature Collection' |
+'GeoJson' |
+'Scene Package' |
+'KML' |
+'Excel';

--- a/packages/downloads/src/hub/format-converter.ts
+++ b/packages/downloads/src/hub/format-converter.ts
@@ -8,6 +8,9 @@ const HUB_FORMAT_LOOKUP: any = {
   'KML': 'kml'
 }
 
+/**
+ * @private
+ */
 export function convertToHubFormat(format: DownloadFormat ): string {
   if (!HUB_FORMAT_LOOKUP[format]) {
     throw new Error (`Unsupported Hub download format: ${format}`)

--- a/packages/downloads/src/hub/format-converter.ts
+++ b/packages/downloads/src/hub/format-converter.ts
@@ -1,0 +1,10 @@
+import { DownloadFormat } from "../download-format"
+
+export function convertToHubFormat(format: DownloadFormat ) {
+  if (format === 'Shapefile') return 'shp';
+  if (format === 'CSV') return 'csv';
+  if (format === 'File Geodatabase') return 'fgdb';
+  if (format === 'GeoJson') return 'geojson';
+  if (format === 'KML') return 'kml';
+  throw new Error (`Unsupported Hub download format: ${format}`)
+}

--- a/packages/downloads/src/hub/format-converter.ts
+++ b/packages/downloads/src/hub/format-converter.ts
@@ -1,10 +1,16 @@
 import { DownloadFormat } from "../download-format"
 
-export function convertToHubFormat(format: DownloadFormat ) {
-  if (format === 'Shapefile') return 'shp';
-  if (format === 'CSV') return 'csv';
-  if (format === 'File Geodatabase') return 'fgdb';
-  if (format === 'GeoJson') return 'geojson';
-  if (format === 'KML') return 'kml';
-  throw new Error (`Unsupported Hub download format: ${format}`)
+const HUB_FORMAT_LOOKUP: any = {
+  'Shapefile': 'shp',
+  'CSV': 'csv',
+  'File Geodatabase': 'fgdb',
+  'GeoJson': 'geojson',
+  'KML': 'kml'
+}
+
+export function convertToHubFormat(format: DownloadFormat ): string {
+  if (!HUB_FORMAT_LOOKUP[format]) {
+    throw new Error (`Unsupported Hub download format: ${format}`)
+  }
+  return HUB_FORMAT_LOOKUP[format];
 }

--- a/packages/downloads/src/hub/hub-poll-download-metadata.ts
+++ b/packages/downloads/src/hub/hub-poll-download-metadata.ts
@@ -32,7 +32,6 @@ export function hubPollDownloadMetadata (params:IHubDownloadMetadataPollParamete
         hubPollDownloadMetadata(params);
       }, pollingInterval);
     }).catch(error => {
-      console.log(error.message)
       return eventEmitter.emit(`${downloadId}PollingError`, { detail: { error } });
     });
 }

--- a/packages/downloads/src/hub/hub-poll-download-metadata.ts
+++ b/packages/downloads/src/hub/hub-poll-download-metadata.ts
@@ -1,0 +1,56 @@
+import { hubRequestDownloadMetadata, IHubDownloadMetadataRequestParams } from "./hub-request-download-metadata";
+import * as EventEmitter from 'eventemitter3';
+
+export interface IHubDownloadMetadataPollParameters extends IHubDownloadMetadataRequestParams {
+  downloadId: string;
+  eventEmitter: EventEmitter;
+  pollingInterval: number;
+}
+
+/**
+ * ```js
+ * import { hubPollDownloadMetadata } from "@esri/hub-downloads";
+ * const params = {
+ *   downloadId: 'abcdef0123456789abcdef0123456789_0::csv'
+ *   host: 'https://hub.arcgis.com,
+ *   datasetId: 'abcdef0123456789abcdef0123456789_0',
+ *   format: 'CSV'
+ * };
+ * hubPollDownloadMetadata(params);
+ * ```
+ * 
+ * Poll the Hub API for status of a dataset export until the download is ready or export/polling fails. Emits `<downloadId>ExportComplete` event when polling loop receives completion status. Emits `<downloadId>ExportError` event when the export fails. Emits `<downloadId>PollingError` event when polling fails.
+ * @param params - parameters that define the download
+ * @param eventEmitter an Event Emitter
+ * @param pollingInterval number of milliseconds for the polling interval
+ */
+export function hubPollDownloadMetadata (params:IHubDownloadMetadataPollParameters): void {
+  const {
+    downloadId,
+    eventEmitter,
+    pollingInterval
+  } = params;
+
+  hubRequestDownloadMetadata(params)
+    .then(metadata => {
+      if (isUpToDate(metadata)) {
+        return eventEmitter.emit(`${downloadId}ExportComplete`, { detail: { metadata } });
+      }
+      if (exportDatasetFailed(metadata)) {
+        return eventEmitter.emit(`${downloadId}ExportError`, { detail: { metadata } });
+      }
+      return setTimeout(() => {
+        hubPollDownloadMetadata(params);
+      }, pollingInterval);
+    }).catch(error => {
+      return eventEmitter.emit(`${downloadId}PollingError`, { detail: { error } });
+    });
+}
+
+function isUpToDate (metadata: any) {
+  return metadata && (metadata.status === 'ready');
+}
+
+function exportDatasetFailed (metadata: any) {
+  return metadata && (metadata.status === 'error_updating' || metadata.status === 'error_creating');
+}

--- a/packages/downloads/src/hub/hub-poll-download-metadata.ts
+++ b/packages/downloads/src/hub/hub-poll-download-metadata.ts
@@ -1,6 +1,9 @@
 import { hubRequestDownloadMetadata, IHubDownloadMetadataRequestParams } from "./hub-request-download-metadata";
 import * as EventEmitter from 'eventemitter3';
 
+/**
+ * @private
+ */
 export interface IHubDownloadMetadataPollParameters extends IHubDownloadMetadataRequestParams {
   downloadId: string;
   eventEmitter: EventEmitter;
@@ -8,21 +11,7 @@ export interface IHubDownloadMetadataPollParameters extends IHubDownloadMetadata
 }
 
 /**
- * ```js
- * import { hubPollDownloadMetadata } from "@esri/hub-downloads";
- * const params = {
- *   downloadId: 'abcdef0123456789abcdef0123456789_0::csv'
- *   host: 'https://hub.arcgis.com,
- *   datasetId: 'abcdef0123456789abcdef0123456789_0',
- *   format: 'CSV'
- * };
- * hubPollDownloadMetadata(params);
- * ```
- * 
- * Poll the Hub API for status of a dataset export until the download is ready or export/polling fails. Emits `<downloadId>ExportComplete` event when polling loop receives completion status. Emits `<downloadId>ExportError` event when the export fails. Emits `<downloadId>PollingError` event when polling fails.
- * @param params - parameters that define the download
- * @param eventEmitter an Event Emitter
- * @param pollingInterval number of milliseconds for the polling interval
+ * @private
  */
 export function hubPollDownloadMetadata (params:IHubDownloadMetadataPollParameters): void {
   const {
@@ -43,6 +32,7 @@ export function hubPollDownloadMetadata (params:IHubDownloadMetadataPollParamete
         hubPollDownloadMetadata(params);
       }, pollingInterval);
     }).catch(error => {
+      console.log(error.message)
       return eventEmitter.emit(`${downloadId}PollingError`, { detail: { error } });
     });
 }

--- a/packages/downloads/src/hub/hub-request-dataset-export.ts
+++ b/packages/downloads/src/hub/hub-request-dataset-export.ts
@@ -3,34 +3,20 @@ import { composeDownloadId } from '../utils';
 import { DownloadFormat } from "../download-format";
 import { convertToHubFormat } from "./format-converter";
 
+/**
+ * @private
+ */
 export interface IHubDatasetExportRequestParams {
   host: string;
   datasetId: string;
   format: DownloadFormat;
-  spatialRefId?: string;
-  spatialRefWkt?: string;
+  spatialRefId: string;
   geometry?: string;
   where?: string;
 }
 
 /**
- * ```js
- * import { hubRequestDatasetExport } from "@esri/hub-downloads";
- * 
- * const params = {
- *   host: 'https://hub.arcgis.com,
- *   datasetId: 'abcdef0123456789abcdef0123456789_0',
- *   format: 'CSV'
- * };
- * hubRequestDatasetExport(params)
- *   .then(response => {
- *     // {
- *     //   downloadId: 'abcdef0123456789abcdef0123456789_0::csv',
- *     // }
- *   });
- * ```
- * Request an export of a dataset to a particular file format.
- * @param params - parameters defining a dataset export job
+ * @private
  */
 export function hubRequestDatasetExport (params: IHubDatasetExportRequestParams) {
   const {

--- a/packages/downloads/src/hub/hub-request-dataset-export.ts
+++ b/packages/downloads/src/hub/hub-request-dataset-export.ts
@@ -1,0 +1,74 @@
+import { RemoteServerError } from '../remote-server-error';
+import { composeDownloadId } from '../utils';
+import { DownloadFormat } from "../download-format";
+import { convertToHubFormat } from "./format-converter";
+
+export interface IHubDatasetExportRequestParams {
+  host: string;
+  datasetId: string;
+  format: DownloadFormat;
+  spatialRefId?: string;
+  spatialRefWkt?: string;
+  geometry?: string;
+  where?: string;
+}
+
+/**
+ * ```js
+ * import { hubRequestDatasetExport } from "@esri/hub-downloads";
+ * 
+ * const params = {
+ *   host: 'https://hub.arcgis.com,
+ *   datasetId: 'abcdef0123456789abcdef0123456789_0',
+ *   format: 'CSV'
+ * };
+ * hubRequestDatasetExport(params)
+ *   .then(response => {
+ *     // {
+ *     //   downloadId: 'abcdef0123456789abcdef0123456789_0::csv',
+ *     // }
+ *   });
+ * ```
+ * Request an export of a dataset to a particular file format.
+ * @param params - parameters defining a dataset export job
+ */
+export function hubRequestDatasetExport (params: IHubDatasetExportRequestParams) {
+  const {
+    host,
+    datasetId,
+    spatialRefId,
+    geometry,
+    where
+  } = params;
+
+  const body = {
+    spatialRefId,
+    format: convertToHubFormat(params.format),
+    geometry,
+    where
+  };
+
+  const url = requestBuilder(host, `/api/v3/datasets/${datasetId}/downloads`)
+
+  return fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  }).then(resp => {
+    const { ok, status, statusText } = resp;
+    if (!ok) {
+      throw new RemoteServerError(statusText, url, status);
+    }
+    return
+  }).then(() => {
+    return { downloadId: composeDownloadId(params) };
+  });
+}
+
+function requestBuilder (host: string, route: string): string {
+  const baseUrl = host.endsWith('/') ? host : `${host}/`
+  const url = new URL(route, baseUrl)
+  return url.toString()
+}

--- a/packages/downloads/src/hub/hub-request-download-metadata.ts
+++ b/packages/downloads/src/hub/hub-request-download-metadata.ts
@@ -1,0 +1,123 @@
+import { RemoteServerError } from "../remote-server-error";
+import { urlBuilder, composeDownloadId } from "../utils";
+import { DownloadFormat } from "../download-format"
+import { convertToHubFormat } from "./format-converter";
+
+export interface IHubDownloadMetadataRequestParams {
+  host: string;
+  datasetId: string;
+  format: DownloadFormat;
+  spatialRefId?: string;
+  geometry?: string;
+  where?: string;
+}
+
+/**
+ * ```js
+ * import { hubRequestDownloadMetadata } from "@esri/hub-downloads";
+ * const params = {
+ *   host: 'https://hub.arcgis.com,
+ *   datasetId: 'abcdef0123456789abcdef0123456789_0',
+ *   format: 'CSV'
+ * };
+ * hubRequestDownloadMetadata(params)
+ *   .then(response => {
+ *     // {
+ *     //   downloadId: 'abcdef0123456789abcdef0123456789_0::csv',
+ *     //   contentLastModified: '2020-06-17T01:16:01.933Z',
+ *     //   lastEditDate: '2020-06-18T01:17:31.492Z',
+ *     //   lastModified: '2020-06-17T13:04:28.000Z',
+ *     //   status: 'stale',
+ *     //   downloadUrl: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv',
+ *     //   contentLength: 1391454,
+ *     //   cacheTime: 13121
+ *     // }
+ *   });
+ * ```
+ * Fetch metadata for a Hub download.
+ * @param params - parameters that define the download
+ * @returns A Promise that will resolve with download metadata.
+ */
+export function hubRequestDownloadMetadata(
+  params: IHubDownloadMetadataRequestParams
+): Promise<any> {
+  const {
+    host,
+    datasetId,
+    spatialRefId,
+    geometry,
+    where
+  } = params;
+
+  const queryParams = {
+    spatialRefId,
+    formats: convertToHubFormat(params.format),
+    geometry: geometry ? JSON.stringify(geometry) : undefined,
+    where
+  };
+  const url = urlBuilder({ host, route: `/api/v3/datasets/${datasetId}/downloads`, query: queryParams });
+
+  return fetch(url).then(resp => {
+    const { ok, status, statusText } = resp;
+    if (!ok) {
+      throw new RemoteServerError(statusText, url, status);
+    }
+    return resp.json();
+    })
+    .then(json => {
+      validateApiResponse(json);
+      return formatApiResponse(json, composeDownloadId(params));
+    });
+}
+
+function validateApiResponse ({ data }: any): void {
+  if (!data) {
+    throw new Error('Unexpected API response; no "data" property.');
+  }
+
+  if (!Array.isArray(data)) {
+    throw new Error('Unexpected API response; "data" is not an array.');
+  }
+
+  if (data.length > 1) {
+    throw new Error('Unexpected API response; "data" contains more than one download.')
+  }
+}
+
+function formatApiResponse(json: any, downloadId: string) {
+  const { data: [ metadata ] } = json;
+
+  if (!metadata) {
+    return {
+      downloadId,
+      status: 'not_ready'
+    };
+  }
+
+  const {
+      attributes: {
+        contentLastModified,
+        lastModified,
+        status,
+        contentLength,
+        cacheTime,
+        source: {
+          lastEditDate,
+        }
+      },
+      links: {
+        content: downloadUrl
+      }
+    } = metadata;
+
+  return {
+    downloadId,
+    contentLastModified,
+    lastEditDate,
+    lastModified,
+    status,
+    downloadUrl,
+    contentLength,
+    cacheTime
+   };
+};

--- a/packages/downloads/src/hub/hub-request-download-metadata.ts
+++ b/packages/downloads/src/hub/hub-request-download-metadata.ts
@@ -3,6 +3,9 @@ import { urlBuilder, composeDownloadId } from "../utils";
 import { DownloadFormat } from "../download-format"
 import { convertToHubFormat } from "./format-converter";
 
+/**
+ * @private
+ */
 export interface IHubDownloadMetadataRequestParams {
   host: string;
   datasetId: string;
@@ -13,30 +16,7 @@ export interface IHubDownloadMetadataRequestParams {
 }
 
 /**
- * ```js
- * import { hubRequestDownloadMetadata } from "@esri/hub-downloads";
- * const params = {
- *   host: 'https://hub.arcgis.com,
- *   datasetId: 'abcdef0123456789abcdef0123456789_0',
- *   format: 'CSV'
- * };
- * hubRequestDownloadMetadata(params)
- *   .then(response => {
- *     // {
- *     //   downloadId: 'abcdef0123456789abcdef0123456789_0::csv',
- *     //   contentLastModified: '2020-06-17T01:16:01.933Z',
- *     //   lastEditDate: '2020-06-18T01:17:31.492Z',
- *     //   lastModified: '2020-06-17T13:04:28.000Z',
- *     //   status: 'stale',
- *     //   downloadUrl: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv',
- *     //   contentLength: 1391454,
- *     //   cacheTime: 13121
- *     // }
- *   });
- * ```
- * Fetch metadata for a Hub download.
- * @param params - parameters that define the download
- * @returns A Promise that will resolve with download metadata.
+ * @private
  */
 export function hubRequestDownloadMetadata(
   params: IHubDownloadMetadataRequestParams

--- a/packages/downloads/src/index.ts
+++ b/packages/downloads/src/index.ts
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+export * from "./poll-download-metadata"
+export * from "./request-dataset-export";
+export * from "./request-download-metadata";
+export * from "./download-format";

--- a/packages/downloads/src/poll-download-metadata.ts
+++ b/packages/downloads/src/poll-download-metadata.ts
@@ -62,6 +62,7 @@ export function pollDownloadMetadata (params: IPollDownloadMetadataRequestParams
       authentication,
       exportCreated,
       format,
+      spatialRefId,
       eventEmitter,
       pollingInterval,
       geometry,

--- a/packages/downloads/src/poll-download-metadata.ts
+++ b/packages/downloads/src/poll-download-metadata.ts
@@ -1,0 +1,84 @@
+import * as EventEmitter from 'eventemitter3';
+import { UserSession } from '@esri/arcgis-rest-auth';
+import { hubPollDownloadMetadata } from './hub/hub-poll-download-metadata';
+import { portalPollExportJobStatus } from './portal/portal-poll-export-job-status';
+import { DownloadFormat } from "./download-format";
+
+export interface IPollDownloadMetadataParams {
+  /* Identifier for the download.  Used to emit events for success or failure */
+  downloadId: string,
+  eventEmitter: EventEmitter;
+  pollingInterval: number;
+  /* API target for downloads: 'hub' (default) or 'portal' */
+  target?: string;
+  /* Hub API host name. Not required for Portal API downloads (stored in the authentication object) */
+  host?: string;
+  /* ID for the downloads source dataset; e.g. "abcdef0123456789abcdef0123456789_0" */
+  datasetId: string;
+  /* Download format/file-type. */
+  format: DownloadFormat;
+  /* Spatial reference well-known ID (WKID) for the download data.  Must be "4326" (WGS) or the WKID for the spatial reference of the service */
+  spatialRefId?: string;
+  /* A geometry envelope for filtering the data */
+  geometry?: string;
+  /* A SQL-style WHERE filter for attribute values */
+  where?: string;
+  /* Portal downloads only. */
+  authentication?: UserSession;
+  /* Identifier for the export job. Portal downloads only. */
+  jobId?: string;
+  /* Time-stamp for export start. Portal downloads only. */
+  exportCreated?: number;
+}
+
+/**
+ *
+ * Poll the status of a download job / portal export. Emit event when completed
+ * (with download link) or failed (with error)
+ * @param params - parameters defining a dataset export job
+ */
+export function pollDownloadMetadata (params: IPollDownloadMetadataParams): void {
+  const {
+    target,
+    downloadId,
+    datasetId,
+    jobId,
+    format,
+    authentication,
+    exportCreated,
+    eventEmitter,
+    pollingInterval,
+    spatialRefId,
+    geometry,
+    where,
+    host
+  } = params;
+
+  if (target === 'portal') {
+    return portalPollExportJobStatus({
+      downloadId,
+      datasetId,
+      jobId,
+      authentication,
+      exportCreated,
+      format,
+      eventEmitter,
+      pollingInterval,
+      spatialRefId,
+      geometry,
+      where
+    });
+  }
+
+  return hubPollDownloadMetadata({
+    host,
+    downloadId,
+    datasetId,
+    format,
+    eventEmitter,
+    pollingInterval,
+    spatialRefId,
+    geometry,
+    where
+  })
+}

--- a/packages/downloads/src/poll-download-metadata.ts
+++ b/packages/downloads/src/poll-download-metadata.ts
@@ -4,7 +4,7 @@ import { hubPollDownloadMetadata } from './hub/hub-poll-download-metadata';
 import { portalPollExportJobStatus } from './portal/portal-poll-export-job-status';
 import { DownloadFormat } from "./download-format";
 
-export interface IPollDownloadMetadataParams {
+export interface IPollDownloadMetadataRequestParams {
   /* Identifier for the download.  Used to emit events for success or failure */
   downloadId: string,
   eventEmitter: EventEmitter;
@@ -17,17 +17,17 @@ export interface IPollDownloadMetadataParams {
   datasetId: string;
   /* Download format/file-type. */
   format: DownloadFormat;
-  /* Spatial reference well-known ID (WKID) for the download data.  Must be "4326" (WGS) or the WKID for the spatial reference of the service */
+  /* Spatial reference well-known ID (WKID) for the download data. Applicable to Hub API downloads only. Must be "4326" (WGS) or the WKID for the spatial reference of the service */
   spatialRefId?: string;
-  /* A geometry envelope for filtering the data */
+  /* A geometry envelope for filtering the data. Applicable to Hub API downloads only. */
   geometry?: string;
-  /* A SQL-style WHERE filter for attribute values */
+  /* A SQL-style WHERE filter for attribute values.  Applicable to Hub API downloads only. */
   where?: string;
-  /* Portal downloads only. */
+  /* Required for Portal downloads only. */
   authentication?: UserSession;
-  /* Identifier for the export job. Portal downloads only. */
+  /* Identifier for the export job. Required for Portal downloads only. */
   jobId?: string;
-  /* Time-stamp for export start. Portal downloads only. */
+  /* Time-stamp for export start. Required for Portal downloads only. */
   exportCreated?: number;
 }
 
@@ -37,7 +37,7 @@ export interface IPollDownloadMetadataParams {
  * (with download link) or failed (with error)
  * @param params - parameters defining a dataset export job
  */
-export function pollDownloadMetadata (params: IPollDownloadMetadataParams): void {
+export function pollDownloadMetadata (params: IPollDownloadMetadataRequestParams): void {
   const {
     target,
     downloadId,
@@ -64,7 +64,6 @@ export function pollDownloadMetadata (params: IPollDownloadMetadataParams): void
       format,
       eventEmitter,
       pollingInterval,
-      spatialRefId,
       geometry,
       where
     });

--- a/packages/downloads/src/portal/portal-poll-export-job-status.ts
+++ b/packages/downloads/src/portal/portal-poll-export-job-status.ts
@@ -24,16 +24,8 @@ class ExportCompletionError extends Error {
 }
 
 /**
- * Poll Portal API for status of a dataset export until the download is ready
- * or export/polling fails. Emits `<downloadId>ExportComplete` event with 
- * download link when polling loop receives completion status. Emits 
- * `<downloadId>ExportError` event with error when the export fails. 
- * Emits `<downloadId>PollingError` event when polling fails.
- * @param params - parameters that define the download
- * @param eventEmitter an Event Emitter
- * @param pollingInterval number of milliseconds for the polling interval
+ * @private
  */
-
 export interface IPortalPollExportJobStatusParams {
   downloadId: string,
   datasetId: string;
@@ -43,11 +35,13 @@ export interface IPortalPollExportJobStatusParams {
   exportCreated: number;
   eventEmitter: EventEmitter;
   pollingInterval: number;
-  spatialRefId?: string;
   geometry?: string;
   where?: string;
 }
 
+/**
+ * @private
+ */
 export function portalPollExportJobStatus (params:IPortalPollExportJobStatusParams): void {
   const {
     downloadId,
@@ -56,7 +50,6 @@ export function portalPollExportJobStatus (params:IPortalPollExportJobStatusPara
     jobId,
     authentication,
     exportCreated,
-    spatialRefId,
     eventEmitter,
     pollingInterval
   } = params;
@@ -70,7 +63,6 @@ export function portalPollExportJobStatus (params:IPortalPollExportJobStatusPara
           authentication,
           downloadId,
           exportCreated,
-          spatialRefId,
           eventEmitter
         })
       }
@@ -113,7 +105,7 @@ function completedHandler (params: any): Promise<any> {
   return updateItem({
     item: {
       id: downloadId,
-      typeKeywords: `export:${datasetId},modified:${exportCreated},exportFormat:${format},spatialRefId:${spatialRefId}`
+      typeKeywords: `export:${datasetId},modified:${exportCreated},exportFormat:${format}`
     },
     authentication
   }).then(() => {

--- a/packages/downloads/src/portal/portal-poll-export-job-status.ts
+++ b/packages/downloads/src/portal/portal-poll-export-job-status.ts
@@ -1,0 +1,178 @@
+import {
+  getItemStatus,
+  IGetItemStatusResponse,
+  updateItem,
+  removeItem,
+  moveItem,
+  createFolder,
+  IAddFolderResponse,
+  IFolder,
+  setItemAccess,
+  getUserContent
+} from "@esri/arcgis-rest-portal";
+import { DownloadFormat } from "../download-format";
+import * as EventEmitter from 'eventemitter3';
+import { urlBuilder } from '../utils';
+import { UserSession } from '@esri/arcgis-rest-auth';
+
+class ExportCompletionError extends Error {
+  constructor(message: string) {
+    /* istanbul ignore next */
+    super(message);
+    Object.setPrototypeOf(this, ExportCompletionError.prototype);
+  }
+}
+
+/**
+ * Poll Portal API for status of a dataset export until the download is ready
+ * or export/polling fails. Emits `<downloadId>ExportComplete` event with 
+ * download link when polling loop receives completion status. Emits 
+ * `<downloadId>ExportError` event with error when the export fails. 
+ * Emits `<downloadId>PollingError` event when polling fails.
+ * @param params - parameters that define the download
+ * @param eventEmitter an Event Emitter
+ * @param pollingInterval number of milliseconds for the polling interval
+ */
+
+export interface IPortalPollExportJobStatusParams {
+  downloadId: string,
+  datasetId: string;
+  format: DownloadFormat;
+  authentication: UserSession;
+  jobId: string;
+  exportCreated: number;
+  eventEmitter: EventEmitter;
+  pollingInterval: number;
+  spatialRefId?: string;
+  geometry?: string;
+  where?: string;
+}
+
+export function portalPollExportJobStatus (params:IPortalPollExportJobStatusParams): void {
+  const {
+    downloadId,
+    datasetId,
+    format,
+    jobId,
+    authentication,
+    exportCreated,
+    spatialRefId,
+    eventEmitter,
+    pollingInterval
+  } = params;
+
+  getItemStatus({ id: downloadId, jobId, jobType: 'export', authentication })
+    .then((metadata:IGetItemStatusResponse) => {
+      if (metadata.status === 'completed') {
+        return completedHandler({
+          datasetId,
+          format,
+          authentication,
+          downloadId,
+          exportCreated,
+          spatialRefId,
+          eventEmitter
+        })
+      }
+
+      if (metadata.status === 'failed') {
+        return eventEmitter.emit(`${downloadId}ExportError`, {
+          detail: {
+            metadata: {
+              errors: [new Error(metadata.statusMessage)]
+            }
+          }
+        });
+      }
+
+      return setTimeout(() => {
+        portalPollExportJobStatus(params);
+      }, pollingInterval);
+    }).catch((error:any) => {
+      if (error instanceof ExportCompletionError) {
+        return eventEmitter.emit(`${downloadId}ExportError`, {
+          detail: { metadata: { errors: [error] } }
+        });
+      }
+
+      return eventEmitter.emit(`${downloadId}PollingError`, { detail: { error } });
+    });
+}
+
+function completedHandler (params: any): Promise<any> {
+  const {
+    downloadId,
+    datasetId,
+    exportCreated,
+    format,
+    spatialRefId,
+    eventEmitter,
+    authentication
+  } = params;
+
+  return updateItem({
+    item: {
+      id: downloadId,
+      typeKeywords: `export:${datasetId},modified:${exportCreated},exportFormat:${format},spatialRefId:${spatialRefId}`
+    },
+    authentication
+  }).then(() => {
+    return setItemAccess({
+      id: downloadId,
+      authentication,
+      access: 'private'
+    })
+  }).then(() => {
+    return getExportsFolderId(authentication)
+  }).then(exportFolderId => {
+    return moveItem({
+      itemId: downloadId,
+      folderId: exportFolderId,
+      authentication
+    })
+  }).catch(err => {
+    if (err && err.code === 'CONT_0011') {
+      // Skipping file move, already exists in target folder
+      return;
+    }
+
+    removeItem({
+      id: downloadId,
+      authentication
+    })
+    throw new ExportCompletionError(err.message);
+
+  }).then(() => {
+    return eventEmitter.emit(`${downloadId}ExportComplete`, {
+      detail: {
+        metadata: {
+          downloadId,
+          status: 'ready',
+          lastModified: (new Date()).toISOString(),
+          downloadUrl: urlBuilder({
+            host: authentication.portal,
+            route: `content/items/${downloadId}/data`,
+            query: { token: authentication.token }
+          })
+        }
+      }
+    });
+  })
+}
+
+function getExportsFolderId(authentication: UserSession): Promise<string> {
+  return getUserContent({ authentication })
+    .then((userContent: any) => {
+      const exportFolder = userContent.folders.find((folder: any) => {
+        return folder.title === 'item-exports'
+      });
+      if (exportFolder) {
+        return { folder: exportFolder };
+      }
+      return createFolder({ authentication, title: 'item-exports' });
+    }).then((response: unknown) => {
+      const { folder } = response as IAddFolderResponse;
+      return folder.id;
+    })
+}
+

--- a/packages/downloads/src/portal/portal-poll-export-job-status.ts
+++ b/packages/downloads/src/portal/portal-poll-export-job-status.ts
@@ -35,6 +35,7 @@ export interface IPortalPollExportJobStatusParams {
   exportCreated: number;
   eventEmitter: EventEmitter;
   pollingInterval: number;
+  spatialRefId?: string;
   geometry?: string;
   where?: string;
 }
@@ -47,6 +48,7 @@ export function portalPollExportJobStatus (params:IPortalPollExportJobStatusPara
     downloadId,
     datasetId,
     format,
+    spatialRefId,
     jobId,
     authentication,
     exportCreated,
@@ -62,6 +64,7 @@ export function portalPollExportJobStatus (params:IPortalPollExportJobStatusPara
           format,
           authentication,
           downloadId,
+          spatialRefId,
           exportCreated,
           eventEmitter
         })
@@ -105,7 +108,7 @@ function completedHandler (params: any): Promise<any> {
   return updateItem({
     item: {
       id: downloadId,
-      typeKeywords: `export:${datasetId},modified:${exportCreated},exportFormat:${format}`
+      typeKeywords: `export:${datasetId},modified:${exportCreated},exportFormat:${format},spatialRefId:${spatialRefId}`
     },
     authentication
   }).then(() => {

--- a/packages/downloads/src/portal/portal-request-dataset-export.ts
+++ b/packages/downloads/src/portal/portal-request-dataset-export.ts
@@ -1,0 +1,43 @@
+import { exportItem } from "@esri/arcgis-rest-portal";
+import { DownloadFormat } from "../download-format";
+
+export interface IPortalDatasetExportRequestParams {
+  datasetId: string;
+  format: DownloadFormat;
+  authentication: any;
+  title?: string;
+}
+
+/**
+ * Request a portal export of a dataset to a particular file format.
+ * @param params - parameters defining a dataset export job
+ */
+export function portalRequestDatasetExport (params: IPortalDatasetExportRequestParams): Promise<any> {
+  const {
+    datasetId,
+    title,
+    format,
+    authentication
+  } = params;
+  const [itemId, layerId = 0] = datasetId.split('_');
+  return exportItem({
+    id: itemId,
+    exportFormat: format,
+    exportParameters: { layers: [{ id: Number(layerId) }]},
+    title,
+    authentication
+  }).then((resp: any) => {
+    const {
+      size,
+      jobId,
+      exportItemId,
+    } = resp;
+
+    return {
+      downloadId: exportItemId,
+      jobId,
+      size,
+      exportCreated: Date.now()
+    };
+  })
+}

--- a/packages/downloads/src/portal/portal-request-dataset-export.ts
+++ b/packages/downloads/src/portal/portal-request-dataset-export.ts
@@ -9,6 +9,7 @@ export interface IPortalDatasetExportRequestParams {
   format: DownloadFormat;
   authentication: any;
   title?: string;
+  spatialRefId?: string;
 }
 
 /**
@@ -19,13 +20,14 @@ export function portalRequestDatasetExport (params: IPortalDatasetExportRequestP
     datasetId,
     title,
     format,
-    authentication
+    authentication,
+    spatialRefId
   } = params;
-  const [itemId, layerId = 0] = datasetId.split('_');
+  const [itemId] = datasetId.split('_');
   return exportItem({
     id: itemId,
     exportFormat: format,
-    exportParameters: { layers: [{ id: Number(layerId) }]},
+    exportParameters: composeExportParameters(params),
     title,
     authentication
   }).then((resp: any) => {
@@ -42,4 +44,19 @@ export function portalRequestDatasetExport (params: IPortalDatasetExportRequestP
       exportCreated: Date.now()
     };
   })
+}
+
+function composeExportParameters (params: any) {
+  const {
+    datasetId,
+    spatialRefId
+  } = params;
+  const layerId = datasetId.split('_')[1] || 0;
+  const layers = [{ id: Number(layerId) }];
+  return spatialRefId ? {
+    layers,
+    targetSR: {
+      wkid: Number(spatialRefId)
+    }
+  } : { layers };
 }

--- a/packages/downloads/src/portal/portal-request-dataset-export.ts
+++ b/packages/downloads/src/portal/portal-request-dataset-export.ts
@@ -1,6 +1,9 @@
 import { exportItem } from "@esri/arcgis-rest-portal";
 import { DownloadFormat } from "../download-format";
 
+/**
+ * @private
+ */
 export interface IPortalDatasetExportRequestParams {
   datasetId: string;
   format: DownloadFormat;
@@ -9,8 +12,7 @@ export interface IPortalDatasetExportRequestParams {
 }
 
 /**
- * Request a portal export of a dataset to a particular file format.
- * @param params - parameters defining a dataset export job
+ * @private
  */
 export function portalRequestDatasetExport (params: IPortalDatasetExportRequestParams): Promise<any> {
   const {

--- a/packages/downloads/src/portal/portal-request-download-metadata.ts
+++ b/packages/downloads/src/portal/portal-request-download-metadata.ts
@@ -11,6 +11,7 @@ export interface IPortalDownloadMetadataRequestParams {
   datasetId: string;
   format: DownloadFormat;
   authentication: UserSession;
+  spatialRefId?: string;
 }
 
 /**
@@ -22,7 +23,8 @@ export function portalRequestDownloadMetadata(
   const {
     datasetId,
     authentication,
-    format
+    format,
+    spatialRefId
   } = params;
 
   const [itemId] = datasetId.split('_');
@@ -38,7 +40,7 @@ export function portalRequestDownloadMetadata(
   }).then((result: number) => {
     serviceLastEditDate = result;
     return searchItems({
-      q: `type:"${format}" AND typekeywords:"export:${datasetId},exportFormat:${format}"`,
+      q: `type:"${format}" AND typekeywords:"export:${datasetId},exportFormat:${format},spatialRefId:${spatialRefId}"`,
       num: 1,
       sortField: 'modified',
       sortOrder: 'DESC',
@@ -49,6 +51,7 @@ export function portalRequestDownloadMetadata(
       cachedDownload: searchResponse.results[0],
       datasetId,
       format,
+      spatialRefId,
       serviceLastEditDate,
       itemModifiedDate,
       itemType,

--- a/packages/downloads/src/portal/portal-request-download-metadata.ts
+++ b/packages/downloads/src/portal/portal-request-download-metadata.ts
@@ -4,24 +4,23 @@ import { getLayer } from "@esri/arcgis-rest-feature-layer";
 import { DownloadFormat } from "../download-format";
 import { urlBuilder, composeDownloadId } from "../utils"
 
+/**
+ * @private
+ */
 export interface IPortalDownloadMetadataRequestParams {
   datasetId: string;
   format: DownloadFormat;
   authentication: UserSession;
-  spatialRefId?: string; 
 }
 
 /**
- * Fetch metadata for an Enterprise download.
- * @param params - parameters that define the download
- * @returns A Promise that will resolve with download metadata.
+ * @private
  */
 export function portalRequestDownloadMetadata(
   params: IPortalDownloadMetadataRequestParams
 ): Promise<any> {
   const {
     datasetId,
-    spatialRefId,
     authentication,
     format
   } = params;
@@ -39,7 +38,7 @@ export function portalRequestDownloadMetadata(
   }).then((result: number) => {
     serviceLastEditDate = result;
     return searchItems({
-      q: `type:"${format}" AND typekeywords:"export:${datasetId},spatialRefId:${spatialRefId},exportFormat:${format}"`,
+      q: `type:"${format}" AND typekeywords:"export:${datasetId},exportFormat:${format}"`,
       num: 1,
       sortField: 'modified',
       sortOrder: 'DESC',

--- a/packages/downloads/src/portal/portal-request-download-metadata.ts
+++ b/packages/downloads/src/portal/portal-request-download-metadata.ts
@@ -1,0 +1,116 @@
+import { getItem, IItem, searchItems } from "@esri/arcgis-rest-portal";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { getLayer } from "@esri/arcgis-rest-feature-layer";
+import { DownloadFormat } from "../download-format";
+import { urlBuilder, composeDownloadId } from "../utils"
+
+export interface IPortalDownloadMetadataRequestParams {
+  datasetId: string;
+  format: DownloadFormat;
+  authentication: UserSession;
+  spatialRefId?: string; 
+}
+
+/**
+ * Fetch metadata for an Enterprise download.
+ * @param params - parameters that define the download
+ * @returns A Promise that will resolve with download metadata.
+ */
+export function portalRequestDownloadMetadata(
+  params: IPortalDownloadMetadataRequestParams
+): Promise<any> {
+  const {
+    datasetId,
+    spatialRefId,
+    authentication,
+    format
+  } = params;
+
+  const [itemId] = datasetId.split('_');
+  let serviceLastEditDate: number | undefined;
+  let itemModifiedDate: number;
+  let itemType: string;
+
+  return getItem(itemId, { authentication }).then((item: IItem) => {
+    const { type, modified, url } = item
+    itemModifiedDate = modified;
+    itemType = type;
+    return fetchLastEditDate({ datasetId, url, authentication, type, modified });
+  }).then((result: number) => {
+    serviceLastEditDate = result;
+    return searchItems({
+      q: `type:"${format}" AND typekeywords:"export:${datasetId},spatialRefId:${spatialRefId},exportFormat:${format}"`,
+      num: 1,
+      sortField: 'modified',
+      sortOrder: 'DESC',
+      authentication,
+    })
+  }).then((searchResponse: any) => {
+    return formatDownloadMetadata({
+      cachedDownload: searchResponse.results[0],
+      datasetId,
+      format,
+      serviceLastEditDate,
+      itemModifiedDate,
+      itemType,
+      authentication
+    });
+  }).catch((err: any) => {
+    throw err;
+  });
+}
+
+function fetchLastEditDate(
+  params: any
+): Promise<number | undefined> {
+  const {
+    datasetId,
+    url,
+    type,
+    modified,
+    authentication
+  } = params;
+
+  const layerId = datasetId.split('_')[1] || 0;
+
+  if (type !== "Feature Service" && type !== 'Map Service') {
+    return Promise.resolve(modified);
+  }
+
+  return getLayer({
+    url: `${url}/${layerId}`,
+    authentication,
+  })
+  .then((layer: any) => {
+    const editingInfo: any | null = layer.editingInfo;
+    return editingInfo ? editingInfo.lastEditDate : undefined
+  });
+}
+
+function formatDownloadMetadata (params: any) {
+  const {
+    cachedDownload,
+    serviceLastEditDate,
+    authentication
+  } = params;
+
+  const lastEditDate = serviceLastEditDate ? (new Date(serviceLastEditDate)).toISOString() : undefined
+  
+  if (!cachedDownload) {
+    return {
+      downloadId: composeDownloadId(params),
+      status: 'not_ready',
+      lastEditDate
+    };
+  }
+
+  const { created, id } = cachedDownload; 
+  return {
+    downloadId: id,
+    status: serviceLastEditDate && serviceLastEditDate > created ? 'stale' : 'ready',
+    lastEditDate,
+    contentLastModified: (new Date(created)).toISOString(),
+    lastModified: (new Date(created)).toISOString(),
+    downloadUrl: urlBuilder({ host: authentication.portal, route: `content/items/${id}/data`, query: { token: authentication.token } }),
+  };
+}

--- a/packages/downloads/src/remote-server-error.ts
+++ b/packages/downloads/src/remote-server-error.ts
@@ -1,0 +1,15 @@
+/**
+ * @ignore
+ */
+export class RemoteServerError extends Error {
+  status: number;
+  url: string;
+  
+  // Istanbul erroneously treats extended class constructors as an uncovered branch: https://github.com/gotwarlost/istanbul/issues/690
+  /* istanbul ignore next */
+  constructor (message: string, url: string, status: number) {
+    super(message);
+    this.status = status;
+    this.url = url;
+  }
+}

--- a/packages/downloads/src/request-dataset-export.ts
+++ b/packages/downloads/src/request-dataset-export.ts
@@ -6,21 +6,21 @@ import { DownloadFormat } from "./download-format";
 export interface IDatasetExportRequestParams {
   /* API target for downloads: 'hub' (default) or 'portal' */
   target?: string;
-  /* Hub API host name. Not required for Portal API downloads (stored in the authentication object) */
+  /* Hub API host name. Required for Hub API exports (stored in the authentication object) */
   host?: string;
   /* ID for the downloads source dataset; e.g. "abcdef0123456789abcdef0123456789_0" */
   datasetId: string;
   /* Download format/file-type. */
   format: DownloadFormat;
-  /* Spatial reference well-known ID (WKID) for the download data.  Must be "4326" (WGS) or the WKID for the spatial reference of the service */
+  /* Spatial reference well-known ID (WKID) for the download data. Required for Hub API exports only. Must be "4326" (WGS) or the WKID for the spatial reference of the service */
   spatialRefId?: string;
-  /* A geometry envelope for filtering the data */
+  /* A geometry envelope for filtering the data. Applicable to Hub API exports only. */
   geometry?: string;
-  /* A SQL-style WHERE filter for attribute values */
+  /* A SQL-style WHERE filter for attribute values.  Applicable to Hub API exports only. */
   where?: string;
-  /* Portal downloads only. */
+  /* Required Portal downloads only. */
   authentication?: UserSession;
-  /* A title/filename for the download. Portal downloads only. */
+  /* A title/filename for the download. Applicable to Portal API exports only. */
   title?: string;
 }
 

--- a/packages/downloads/src/request-dataset-export.ts
+++ b/packages/downloads/src/request-dataset-export.ts
@@ -1,0 +1,69 @@
+import { UserSession } from '@esri/arcgis-rest-auth';
+import { hubRequestDatasetExport } from './hub/hub-request-dataset-export';
+import { portalRequestDatasetExport } from './portal/portal-request-dataset-export';
+import { DownloadFormat } from "./download-format";
+
+export interface IDatasetExportRequestParams {
+  /* API target for downloads: 'hub' (default) or 'portal' */
+  target?: string;
+  /* Hub API host name. Not required for Portal API downloads (stored in the authentication object) */
+  host?: string;
+  /* ID for the downloads source dataset; e.g. "abcdef0123456789abcdef0123456789_0" */
+  datasetId: string;
+  /* Download format/file-type. */
+  format: DownloadFormat;
+  /* Spatial reference well-known ID (WKID) for the download data.  Must be "4326" (WGS) or the WKID for the spatial reference of the service */
+  spatialRefId?: string;
+  /* A geometry envelope for filtering the data */
+  geometry?: string;
+  /* A SQL-style WHERE filter for attribute values */
+  where?: string;
+  /* Portal downloads only. */
+  authentication?: UserSession;
+  /* A title/filename for the download. Portal downloads only. */
+  title?: string;
+}
+
+export interface IDatasetExportResult {
+  /* Identifier for the download */
+  downloadId: string;
+  /* Identifier for the export job. Portal downloads only. */
+  jobId?: string;
+  /* Time-stamp for export start. Portal downloads only. */
+  exportCreated?: number;
+
+  size?: number;
+}
+/**
+ * ```js
+ * import { requestDatasetExport } from "@esri/hub-downloads";
+ *
+ * Request an export of a dataset to a particular file format.
+ * @param params - parameters defining a dataset export job
+ */
+export function requestDatasetExport (params: IDatasetExportRequestParams): Promise<IDatasetExportResult> {
+  const {
+    host,
+    datasetId,
+    format,
+    spatialRefId,
+    geometry,
+    where,
+    title,
+    target,
+    authentication
+  } = params;
+
+  if (target === 'portal') {
+      return portalRequestDatasetExport({ datasetId, format, title, authentication });
+  }
+
+  return hubRequestDatasetExport({
+    host,
+    datasetId,
+    format,
+    spatialRefId,
+    geometry,
+    where
+  });
+}

--- a/packages/downloads/src/request-dataset-export.ts
+++ b/packages/downloads/src/request-dataset-export.ts
@@ -55,7 +55,7 @@ export function requestDatasetExport (params: IDatasetExportRequestParams): Prom
   } = params;
 
   if (target === 'portal') {
-      return portalRequestDatasetExport({ datasetId, format, title, authentication });
+      return portalRequestDatasetExport({ datasetId, format, title, authentication, spatialRefId });
   }
 
   return hubRequestDatasetExport({

--- a/packages/downloads/src/request-download-metadata.ts
+++ b/packages/downloads/src/request-download-metadata.ts
@@ -93,7 +93,8 @@ export function requestDownloadMetadata(
     return portalRequestDownloadMetadata({
       datasetId,
       format,
-      authentication
+      authentication,
+      spatialRefId
     });
   }
 

--- a/packages/downloads/src/request-download-metadata.ts
+++ b/packages/downloads/src/request-download-metadata.ts
@@ -1,0 +1,109 @@
+import { portalRequestDownloadMetadata } from "./portal/portal-request-download-metadata";
+import { hubRequestDownloadMetadata } from "./hub/hub-request-download-metadata"
+import { DownloadFormat } from "./download-format";
+import { UserSession } from '@esri/arcgis-rest-auth';
+
+export interface IDownloadMetadataRequestParams {
+  /* API target for downloads: 'hub' (default) or 'portal' */
+  target?: string;
+  /* Hub API host name. Not required for Portal API downloads (stored in the authentication object) */
+  host?: string;
+  /* ID for the downloads source dataset; e.g. "abcdef0123456789abcdef0123456789_0" */
+  datasetId: string;
+  /* Download format/file-type. */
+  format: DownloadFormat;
+  /* Spatial reference well-known ID (WKID) for the download data.  Must be "4326" (WGS) or the WKID for the spatial reference of the service */
+  spatialRefId?: string;
+  /* A geometry envelope for filtering the data */
+  geometry?: string;
+  /* A SQL-style WHERE filter for attribute values */
+  where?: string;
+  /* Portal downloads only. */
+  authentication?: UserSession;
+}
+
+export interface IDownloadMetadataResults {
+  /* Identifier for the download */
+  downloadId: string,
+
+  /* ready, not_ready, creating, updating, failed*/
+  status: string,
+
+  /* ISO date of the service's last edit date */
+  lastEditDate?:string,
+
+  /* ISO date of the download file's data - the last edit date of the service when the download export started */
+  contentLastModified?: string,
+
+  /* File timestamp */
+  lastModified?: string,
+
+  /* URL for downloading the file */
+  downloadUrl?: string,
+
+  /* File size */
+  contentLength?: number,
+
+  /* Time (milliseconds) it took to export and cache the download file */
+  cacheTime?: number
+}
+
+/**
+ * ```js
+ * import { requestDownloadMetadata } from "@esri/hub-downloads";
+ * const params = {
+ *   host: 'https://opendata.arcgis.com,
+ *   datasetId: 'abcdef0123456789abcdef0123456789_0',
+ *   format: 'CSV',
+ *   target: 'hub'
+ * };
+ * requestDownloadMetadata(params)
+ *   .then(response => {
+ *     // {
+ *     //   downloadId: 'abcdef0123456789abcdef0123456789_0::csv',
+ *     //   contentLastModified: '2020-06-17T01:16:01.933Z',
+ *     //   lastEditDate: '2020-06-18T01:17:31.492Z',
+ *     //   lastModified: '2020-06-17T13:04:28.000Z',
+ *     //   status: 'stale',
+ *     //   downloadUrl: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv',
+ *     //   contentLength: 1391454,
+ *     //   cacheTime: 13121
+ *     // }
+ *   });
+ * ```
+ * Fetch metadata for a Hub download.
+ * @param {IDownloadMetadataRequestParams} params
+ * @returns {Promise<ISearchResult>}
+ */
+export function requestDownloadMetadata(
+  params: IDownloadMetadataRequestParams
+): Promise<IDownloadMetadataResults> {
+  const {
+    host,
+    datasetId,
+    spatialRefId,
+    format,
+    geometry,
+    where,
+    target,
+    authentication
+  } = params;
+
+  if (target === 'portal') {
+    return portalRequestDownloadMetadata({
+      datasetId,
+      format,
+      authentication,
+      spatialRefId
+    });
+  }
+
+  return hubRequestDownloadMetadata({
+    host,
+    datasetId,
+    format,
+    spatialRefId,
+    geometry,
+    where
+  });
+}

--- a/packages/downloads/src/request-download-metadata.ts
+++ b/packages/downloads/src/request-download-metadata.ts
@@ -12,13 +12,13 @@ export interface IDownloadMetadataRequestParams {
   datasetId: string;
   /* Download format/file-type. */
   format: DownloadFormat;
-  /* Spatial reference well-known ID (WKID) for the download data.  Must be "4326" (WGS) or the WKID for the spatial reference of the service */
+  /* Spatial reference well-known ID (WKID) for the download data. Applicable to Hub API exports only. Must be "4326" (WGS) or the WKID for the spatial reference of the service */
   spatialRefId?: string;
-  /* A geometry envelope for filtering the data */
+  /* A geometry envelope for filtering the data. Applicable to Hub API exports only. */
   geometry?: string;
-  /* A SQL-style WHERE filter for attribute values */
+  /* A SQL-style WHERE filter for attribute values.  Applicable to Hub API exports only. */
   where?: string;
-  /* Portal downloads only. */
+  /* Required for Portal downloads only. */
   authentication?: UserSession;
 }
 
@@ -93,8 +93,7 @@ export function requestDownloadMetadata(
     return portalRequestDownloadMetadata({
       datasetId,
       format,
-      authentication,
-      spatialRefId
+      authentication
     });
   }
 

--- a/packages/downloads/src/utils.ts
+++ b/packages/downloads/src/utils.ts
@@ -2,6 +2,9 @@ interface IQueryParams {
   [key: string]: string;
 }
 
+/**
+ * @private
+ */
 export function urlBuilder (params: { host: string, route: string, query?: IQueryParams }): string {
   const { host, route, query } = params;
   const baseUrl = host.endsWith('/') ? host : `${host}/`
@@ -20,6 +23,9 @@ function buildQueryString (params: IQueryParams = {}): string {
   return (new URLSearchParams(queryParams)).toString()
 }
 
+/**
+ * @private
+ */
 export interface IDownloadIdParams {
   datasetId: string;
   format: string;
@@ -28,6 +34,9 @@ export interface IDownloadIdParams {
   where?: string;
 }
 
+/**
+ * @private
+ */
 export function composeDownloadId (params: IDownloadIdParams): string {
   const {
     datasetId,

--- a/packages/downloads/src/utils.ts
+++ b/packages/downloads/src/utils.ts
@@ -1,0 +1,40 @@
+interface IQueryParams {
+  [key: string]: string;
+}
+
+export function urlBuilder (params: { host: string, route: string, query?: IQueryParams }): string {
+  const { host, route, query } = params;
+  const baseUrl = host.endsWith('/') ? host : `${host}/`
+  const url = new URL(route, baseUrl)
+  url.search = buildQueryString(query)
+  return url.toString()
+}
+
+function buildQueryString (params: IQueryParams = {}): string {
+  const queryParams = Object.keys(params).filter(key => {
+    return params[key] !== undefined;
+  }).reduce((acc:any, key:string) => {
+    acc[key] = params[key];
+    return acc;
+  }, {})
+  return (new URLSearchParams(queryParams)).toString()
+}
+
+export interface IDownloadIdParams {
+  datasetId: string;
+  format: string;
+  spatialRefId?: string;
+  geometry?: string;
+  where?: string;
+}
+
+export function composeDownloadId (params: IDownloadIdParams): string {
+  const {
+    datasetId,
+    format,
+    spatialRefId,
+    geometry,
+    where,
+  } = params;
+  return `${datasetId}:${format}:${spatialRefId}:${geometry}:${where}`
+}

--- a/packages/downloads/test/hub/format-converter.test.ts
+++ b/packages/downloads/test/hub/format-converter.test.ts
@@ -1,0 +1,31 @@
+import { convertToHubFormat } from "../../src/hub/format-converter"
+describe('hub-format-converter', () => {
+  it('converts CSV to csv', () => {
+    const result = convertToHubFormat('CSV')
+    expect(result).toEqual('csv');
+  })
+  it('converts KML to kml', () => {
+    const result = convertToHubFormat('KML')
+    expect(result).toEqual('kml');
+  })
+  it('converts Shapefile to shp', () => {
+    const result = convertToHubFormat('Shapefile')
+    expect(result).toEqual('shp');
+  })
+  it('converts File Geodatabase to fgdb', () => {
+    const result = convertToHubFormat('File Geodatabase')
+    expect(result).toEqual('fgdb');
+  })
+  it('converts GeoJson to geojson', () => {
+    const result = convertToHubFormat('GeoJson')
+    expect(result).toEqual('geojson');
+  })
+  it('should throw error on unsupported type', () => {
+    try {
+      convertToHubFormat('Excel')
+    } catch (error) {
+      expect(error).toEqual(new Error('Unsupported Hub download format: Excel'));
+    }
+    
+  })
+})

--- a/packages/downloads/test/hub/hub-poll-download-metadata.test.ts
+++ b/packages/downloads/test/hub/hub-poll-download-metadata.test.ts
@@ -1,0 +1,219 @@
+import * as fetchMock from 'fetch-mock';
+import { hubPollDownloadMetadata } from "../../src/hub/hub-poll-download-metadata";
+import * as EventEmitter from 'eventemitter3';
+
+function delay (milliseconds: number) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+describe("hubPollDownloadMetadata", () => {
+
+  afterEach(() => fetchMock.restore());
+
+  it('handle remote server 502 error', async done => {
+    try {
+      fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
+        status: 502,
+      });
+      const mockEventEmitter = new EventEmitter();
+      spyOn(mockEventEmitter, 'emit');
+      hubPollDownloadMetadata({
+        host: 'http://hub.com',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        downloadId: 'test-id',
+        spatialRefId: '4326',
+        format: 'CSV',
+        eventEmitter: mockEventEmitter,
+        pollingInterval: 10
+      });
+      await delay(0);
+      expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+      expect((mockEventEmitter.emit as any).calls.first().args).toEqual([
+        'test-idPollingError', { detail: { error: new Error('Bad Gateway') } }
+      ])
+    } catch (err) {
+      expect(err).toEqual(undefined);
+    } finally {
+      done();
+    }
+  });
+
+  it('handle failed export', async done => {
+    try {
+      fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
+        status: 200,
+        body: {
+          data: [
+            {
+              id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
+              type: 'downloads',
+              attributes: {
+                spatialRefId: '4326',
+                format: 'CSV',
+                status: 'error_creating',
+                featureSet: 'full',
+                source: {
+                  type: 'Feature Service',
+                  url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
+                  supportsExtract: true,
+                  lastEditDate: '2020-06-18T01:17:31.492Z',
+                  spatialRefId: '4326'
+                }
+              },
+              links: {
+                content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
+              }
+            }
+          ]
+        }
+      });
+      const mockEventEmitter = new EventEmitter();
+      spyOn(mockEventEmitter, 'emit');
+      hubPollDownloadMetadata({
+        host: 'http://hub.com',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        downloadId: 'test-id',
+        spatialRefId: '4326',
+        format: 'CSV',
+        eventEmitter: mockEventEmitter,
+        pollingInterval: 10
+      });
+      await delay(50);
+      expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+      const [topic, customEvent] = (mockEventEmitter.emit as any).calls.first().args;
+      expect(topic).toEqual('test-idExportError');
+      expect(customEvent.detail.metadata).toEqual({
+        downloadId: 'abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined',
+        contentLastModified: undefined,
+        lastEditDate: '2020-06-18T01:17:31.492Z',
+        lastModified: undefined,
+        status: 'error_creating',
+        downloadUrl: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv',
+        contentLength: undefined,
+        cacheTime: undefined
+      });
+    } catch (err) {
+      expect(err).toEqual(undefined);
+    } finally {
+      done();
+    }
+  });
+
+  it('handle successful export', async done => {
+    try {
+      fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
+        status: 200,
+        body: {
+          data: [
+            {
+              id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
+              type: 'downloads',
+              attributes: {
+                spatialRefId: '4326',
+                format: 'CSV',
+                contentLength: 1391454,
+                lastModified: '2020-06-17T13:04:28.000Z',
+                contentLastModified: '2020-06-17T01:16:01.933Z',
+                cacheTime: 13121,
+                status: 'ready',
+                featureSet: 'full',
+                source: {
+                  type: 'Feature Service',
+                  url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
+                  supportsExtract: true,
+                  lastEditDate: '2020-06-18T01:15:31.492Z',
+                  spatialRefId: '4326'
+                }
+              },
+              links: {
+                content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
+              }
+            }
+          ]
+        }
+      });
+      const mockEventEmitter = new EventEmitter();
+      spyOn(mockEventEmitter, 'emit');
+      hubPollDownloadMetadata({
+        host: 'http://hub.com',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        downloadId: 'test-id',
+        spatialRefId: '4326',
+        format: 'CSV',
+        eventEmitter: mockEventEmitter,
+        pollingInterval: 10
+      });
+      await delay(50);
+      expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+      const [topic, customEvent] = (mockEventEmitter.emit as any).calls.first().args;
+      expect(topic).toEqual('test-idExportComplete');
+      expect(customEvent.detail.metadata).toEqual({
+        downloadId: 'abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined',
+        contentLastModified: '2020-06-17T01:16:01.933Z',
+        lastEditDate: '2020-06-18T01:15:31.492Z',
+        lastModified: '2020-06-17T13:04:28.000Z',
+        status: 'ready',
+        downloadUrl: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv',
+        contentLength: 1391454,
+        cacheTime: 13121
+      });
+    } catch (err) {
+      expect(err).toEqual(undefined);
+    } finally {
+      done();
+    }
+  });
+
+  it('handle multiple polls', async done => {
+    try {
+      fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
+        status: 200,
+        body: {
+          data: [
+            {
+              id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
+              type: 'downloads',
+              attributes: {
+                spatialRefId: '4326',
+                format: 'CSV',
+                contentLength: 1391454,
+                lastModified: '2020-06-17T13:04:28.000Z',
+                contentLastModified: '2020-06-17T01:16:01.933Z',
+                cacheTime: 13121,
+                status: 'updating',
+                featureSet: 'full',
+                source: {
+                  type: 'Feature Service',
+                  url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
+                  supportsExtract: true,
+                  lastEditDate: '2020-06-18T01:19:31.492Z',
+                  spatialRefId: '4326'
+                }
+              },
+              links: {
+                content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
+              }
+            }
+          ]
+        }
+      });
+      const mockEventEmitter = new EventEmitter();
+      spyOn(mockEventEmitter, 'emit');
+      hubPollDownloadMetadata({
+        host: 'http://hub.com',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        downloadId: 'test-id',
+        spatialRefId: '4326',
+        format: 'CSV',
+        eventEmitter: mockEventEmitter,
+        pollingInterval: 10
+      });
+      await delay(50);
+      expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(0);
+    } catch (err) {
+      expect(err).toEqual(undefined);
+    } finally {
+      done();
+    }
+  }, 16000);
+});

--- a/packages/downloads/test/hub/hub-poll-download-metadata.test.ts
+++ b/packages/downloads/test/hub/hub-poll-download-metadata.test.ts
@@ -6,6 +6,61 @@ function delay (milliseconds: number) {
   return new Promise(resolve => setTimeout(resolve, milliseconds));
 }
 
+const fixtures = {
+  exportFailed: {
+    data: [
+      {
+        id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
+        type: 'downloads',
+        attributes: {
+          spatialRefId: '4326',
+          format: 'CSV',
+          status: 'error_creating',
+          featureSet: 'full',
+          source: {
+            type: 'Feature Service',
+            url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
+            supportsExtract: true,
+            lastEditDate: '2020-06-18T01:17:31.492Z',
+            spatialRefId: '4326'
+          }
+        },
+        links: {
+          content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
+        }
+      }
+    ]
+  },
+  exportSucceeded: {
+    data: [
+      {
+        id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
+        type: 'downloads',
+        attributes: {
+          spatialRefId: '4326',
+          format: 'CSV',
+          contentLength: 1391454,
+          lastModified: '2020-06-17T13:04:28.000Z',
+          contentLastModified: '2020-06-17T01:16:01.933Z',
+          cacheTime: 13121,
+          status: 'ready',
+          featureSet: 'full',
+          source: {
+            type: 'Feature Service',
+            url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
+            supportsExtract: true,
+            lastEditDate: '2020-06-18T01:15:31.492Z',
+            spatialRefId: '4326'
+          }
+        },
+        links: {
+          content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
+        }
+      }
+    ]
+  }
+};
+
 describe("hubPollDownloadMetadata", () => {
 
   afterEach(() => fetchMock.restore());
@@ -42,30 +97,7 @@ describe("hubPollDownloadMetadata", () => {
     try {
       fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
         status: 200,
-        body: {
-          data: [
-            {
-              id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
-              type: 'downloads',
-              attributes: {
-                spatialRefId: '4326',
-                format: 'CSV',
-                status: 'error_creating',
-                featureSet: 'full',
-                source: {
-                  type: 'Feature Service',
-                  url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
-                  supportsExtract: true,
-                  lastEditDate: '2020-06-18T01:17:31.492Z',
-                  spatialRefId: '4326'
-                }
-              },
-              links: {
-                content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
-              }
-            }
-          ]
-        }
+        body: fixtures.exportFailed
       });
       const mockEventEmitter = new EventEmitter();
       spyOn(mockEventEmitter, 'emit');
@@ -103,34 +135,7 @@ describe("hubPollDownloadMetadata", () => {
     try {
       fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
         status: 200,
-        body: {
-          data: [
-            {
-              id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
-              type: 'downloads',
-              attributes: {
-                spatialRefId: '4326',
-                format: 'CSV',
-                contentLength: 1391454,
-                lastModified: '2020-06-17T13:04:28.000Z',
-                contentLastModified: '2020-06-17T01:16:01.933Z',
-                cacheTime: 13121,
-                status: 'ready',
-                featureSet: 'full',
-                source: {
-                  type: 'Feature Service',
-                  url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
-                  supportsExtract: true,
-                  lastEditDate: '2020-06-18T01:15:31.492Z',
-                  spatialRefId: '4326'
-                }
-              },
-              links: {
-                content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
-              }
-            }
-          ]
-        }
+        body: fixtures.exportSucceeded
       });
       const mockEventEmitter = new EventEmitter();
       spyOn(mockEventEmitter, 'emit');

--- a/packages/downloads/test/hub/hub-request-dataset-export.test.ts
+++ b/packages/downloads/test/hub/hub-request-dataset-export.test.ts
@@ -1,0 +1,87 @@
+import * as fetchMock from 'fetch-mock';
+import { hubRequestDatasetExport } from "../../src/hub/hub-request-dataset-export";
+
+describe("hubRequestDatasetExport", () => {
+
+  afterEach(() => fetchMock.restore());
+
+  it('handle remote server 502 error', async done => {
+    try {
+      fetchMock.post('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads', {
+        status: 502
+      }, {
+        body: {
+          spatialRefId: '4326',
+          format: 'csv'
+        }
+      });
+
+      await hubRequestDatasetExport({
+        host: 'http://hub.com',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV'
+      })
+    
+    } catch (err) {
+      const { message, status, url } = err;
+      expect(message).toEqual('Bad Gateway');
+      expect(status).toEqual(502);
+      expect(url).toEqual('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads');
+    } finally {
+      done();
+    }
+  });
+
+  it('success', async done => {
+    try {
+      fetchMock.post('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads', {
+        status: 200,
+        body: {}
+      }, {
+        body: {
+          spatialRefId: '4326',
+          format: 'csv'
+        }
+      });
+
+      const json:any = await hubRequestDatasetExport({
+        host: 'http://hub.com',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV'
+      });
+      expect(json.downloadId).toEqual('abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined')
+    } catch (err) {
+      expect(err).toBeUndefined()
+    } finally {
+      done();
+    }
+  });
+
+  it('success with a host that has trailing slash', async done => {
+    try {
+      fetchMock.post('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads', {
+        status: 200,
+        body: {}
+      }, {
+        body: {
+          spatialRefId: '4326',
+          format: 'csv'
+        }
+      });
+
+      const json:any = await hubRequestDatasetExport({
+        host: 'http://hub.com/',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV'
+      });
+      expect(json.downloadId).toEqual('abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined')
+    } catch (err) {
+      expect(err).toBeUndefined()
+    } finally {
+      done();
+    }
+  });
+});

--- a/packages/downloads/test/hub/hub-request-download-metadata.test.ts
+++ b/packages/downloads/test/hub/hub-request-download-metadata.test.ts
@@ -2,6 +2,35 @@
 import * as fetchMock from 'fetch-mock';
 import { hubRequestDownloadMetadata } from "../../src/hub/hub-request-download-metadata";
 
+const apiResponsefixture = {
+  data: [
+    {
+      id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
+      type: 'downloads',
+      attributes: {
+        spatialRefId: '4326',
+        format: 'CSV',
+        contentLength: 1391454,
+        lastModified: '2020-06-17T13:04:28.000Z',
+        contentLastModified: '2020-06-17T01:16:01.933Z',
+        cacheTime: 13121,
+        status: 'stale',
+        featureSet: 'full',
+        source: {
+          type: 'Feature Service',
+          url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
+          supportsExtract: true,
+          lastEditDate: '2020-06-18T01:17:31.492Z',
+          spatialRefId: '4326'
+        }
+      },
+      links: {
+        content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
+      }
+    }
+  ]
+};
+
 describe("hubRequestDownloadMetadata", () => {
 
   afterEach(() => fetchMock.restore());
@@ -122,34 +151,7 @@ describe("hubRequestDownloadMetadata", () => {
     try {
       fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
         status: 200,
-        body: {
-          data: [
-            {
-              id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
-              type: 'downloads',
-              attributes: {
-                spatialRefId: '4326',
-                format: 'CSV',
-                contentLength: 1391454,
-                lastModified: '2020-06-17T13:04:28.000Z',
-                contentLastModified: '2020-06-17T01:16:01.933Z',
-                cacheTime: 13121,
-                status: 'stale',
-                featureSet: 'full',
-                source: {
-                  type: 'Feature Service',
-                  url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
-                  supportsExtract: true,
-                  lastEditDate: '2020-06-18T01:17:31.492Z',
-                  spatialRefId: '4326'
-                }
-              },
-              links: {
-                content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
-              }
-            }
-          ]
-        }
+        body: apiResponsefixture
       });
 
       const result = await hubRequestDownloadMetadata({
@@ -180,34 +182,7 @@ describe("hubRequestDownloadMetadata", () => {
     try {
       fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
         status: 200,
-        body: {
-          data: [
-            {
-              id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
-              type: 'downloads',
-              attributes: {
-                spatialRefId: '4326',
-                format: 'CSV',
-                contentLength: 1391454,
-                lastModified: '2020-06-17T13:04:28.000Z',
-                contentLastModified: '2020-06-17T01:16:01.933Z',
-                cacheTime: 13121,
-                status: 'stale',
-                featureSet: 'full',
-                source: {
-                  type: 'Feature Service',
-                  url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
-                  supportsExtract: true,
-                  lastEditDate: '2020-06-18T01:17:31.492Z',
-                  spatialRefId: '4326'
-                }
-              },
-              links: {
-                content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
-              }
-            }
-          ]
-        }
+        body: apiResponsefixture
       });
 
       const result = await hubRequestDownloadMetadata({
@@ -238,34 +213,7 @@ describe("hubRequestDownloadMetadata", () => {
     try {
       fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv&geometry=%22%7B%5C%22xmin%5C%22%3A0%2C%5C%22xmax%5C%22%3A10%2C%5C%22ymin%5C%22%3A0%2C%5C%22ymax%5C%22%3A10%2C%5C%22spatialReference%5C%22%3A%7B%5C%22wkid%5C%22%3A4326%7D%7D%22', {
         status: 200,
-        body: {
-          data: [
-            {
-              id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
-              type: 'downloads',
-              attributes: {
-                spatialRefId: '4326',
-                format: 'CSV',
-                contentLength: 1391454,
-                lastModified: '2020-06-17T13:04:28.000Z',
-                contentLastModified: '2020-06-17T01:16:01.933Z',
-                cacheTime: 13121,
-                status: 'stale',
-                featureSet: 'full',
-                source: {
-                  type: 'Feature Service',
-                  url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
-                  supportsExtract: true,
-                  lastEditDate: '2020-06-18T01:17:31.492Z',
-                  spatialRefId: '4326'
-                }
-              },
-              links: {
-                content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
-              }
-            }
-          ]
-        }
+        body: apiResponsefixture
       });
 
       const result = await hubRequestDownloadMetadata({

--- a/packages/downloads/test/hub/hub-request-download-metadata.test.ts
+++ b/packages/downloads/test/hub/hub-request-download-metadata.test.ts
@@ -1,0 +1,303 @@
+
+import * as fetchMock from 'fetch-mock';
+import { hubRequestDownloadMetadata } from "../../src/hub/hub-request-download-metadata";
+
+describe("hubRequestDownloadMetadata", () => {
+
+  afterEach(() => fetchMock.restore());
+
+  it('handle remote server 502 error', async done => {
+    try {
+      fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
+        status: 502
+      });
+
+      await hubRequestDownloadMetadata({
+        host: 'http://hub.com',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV'
+      });
+    } catch (err) {
+      const { message, status, url } = err;
+      expect(message).toEqual('Bad Gateway');
+      expect(status).toEqual(502);
+      expect(url).toEqual('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv');
+    } finally {
+      done();
+    }
+  });
+
+  it('handle missing data property', async done => {
+    try {
+      fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
+        status: 200,
+        body: {}
+      });
+
+      const result = await hubRequestDownloadMetadata({
+        host: 'http://hub.com',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV'
+      });
+
+      expect(result).toEqual(undefined);
+    } catch (err) {
+      expect(err.message).toEqual('Unexpected API response; no "data" property.');
+    } finally {
+      done();
+    }
+  });
+
+  it('handle data is not array', async done => {
+    try {
+      fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
+        status: 200,
+        body: { data: {} }
+      });
+
+      const result = await hubRequestDownloadMetadata({
+        host: 'http://hub.com',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV'
+      });
+
+      expect(result).toEqual(undefined);
+    } catch (err) {
+      expect(err.message).toEqual('Unexpected API response; "data" is not an array.');
+    } finally {
+      done();
+    }
+  });
+
+  it('handle data array with more than one element', async done => {
+    try {
+      fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?formats=csv', {
+        status: 200,
+        body: { data: [{}, {}] }
+      });
+
+      await hubRequestDownloadMetadata({
+        host: 'http://hub.com',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        format: 'CSV'
+      });
+    } catch (err) {
+      expect(err.message).toEqual('Unexpected API response; "data" contains more than one download.');
+    } finally {
+      done();
+    }
+  });
+
+  it('handle zero download results', async done => {
+    try {
+      fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
+        status: 200,
+        body: {
+          data: []
+        }
+      });
+
+      const result = await hubRequestDownloadMetadata({
+        host: 'http://hub.com',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV'
+      });
+
+      expect(result).toEqual({
+        downloadId: 'abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined',
+        status: 'not_ready'
+      });
+    } catch (err) {
+      expect(err).toEqual(undefined);
+    } finally {
+      done();
+    }
+  });
+
+  it('handle downloaded result', async done => {
+    try {
+      fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
+        status: 200,
+        body: {
+          data: [
+            {
+              id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
+              type: 'downloads',
+              attributes: {
+                spatialRefId: '4326',
+                format: 'CSV',
+                contentLength: 1391454,
+                lastModified: '2020-06-17T13:04:28.000Z',
+                contentLastModified: '2020-06-17T01:16:01.933Z',
+                cacheTime: 13121,
+                status: 'stale',
+                featureSet: 'full',
+                source: {
+                  type: 'Feature Service',
+                  url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
+                  supportsExtract: true,
+                  lastEditDate: '2020-06-18T01:17:31.492Z',
+                  spatialRefId: '4326'
+                }
+              },
+              links: {
+                content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
+              }
+            }
+          ]
+        }
+      });
+
+      const result = await hubRequestDownloadMetadata({
+        host: 'http://hub.com',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV'
+      });
+
+      expect(result).toEqual({
+        downloadId: 'abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined',
+        contentLastModified: '2020-06-17T01:16:01.933Z',
+        lastEditDate: '2020-06-18T01:17:31.492Z',
+        lastModified: '2020-06-17T13:04:28.000Z',
+        status: 'stale',
+        downloadUrl: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv',
+        contentLength: 1391454,
+        cacheTime: 13121
+      });
+    } catch (err) {
+      expect(err).toEqual(undefined);
+    } finally {
+      done();
+    }
+  });
+
+  it('handle downloaded result with host including trailing slash', async done => {
+    try {
+      fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
+        status: 200,
+        body: {
+          data: [
+            {
+              id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
+              type: 'downloads',
+              attributes: {
+                spatialRefId: '4326',
+                format: 'CSV',
+                contentLength: 1391454,
+                lastModified: '2020-06-17T13:04:28.000Z',
+                contentLastModified: '2020-06-17T01:16:01.933Z',
+                cacheTime: 13121,
+                status: 'stale',
+                featureSet: 'full',
+                source: {
+                  type: 'Feature Service',
+                  url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
+                  supportsExtract: true,
+                  lastEditDate: '2020-06-18T01:17:31.492Z',
+                  spatialRefId: '4326'
+                }
+              },
+              links: {
+                content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
+              }
+            }
+          ]
+        }
+      });
+
+      const result = await hubRequestDownloadMetadata({
+        host: 'http://hub.com/',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV'
+      });
+
+      expect(result).toEqual({
+        downloadId: 'abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined',
+        contentLastModified: '2020-06-17T01:16:01.933Z',
+        lastEditDate: '2020-06-18T01:17:31.492Z',
+        lastModified: '2020-06-17T13:04:28.000Z',
+        status: 'stale',
+        downloadUrl: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv',
+        contentLength: 1391454,
+        cacheTime: 13121
+      });
+    } catch (err) {
+      expect(err).toEqual(undefined);
+    } finally {
+      done();
+    }
+  });
+
+ it('handle downloaded result with geometry filter', async done => {
+    try {
+      fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv&geometry=%22%7B%5C%22xmin%5C%22%3A0%2C%5C%22xmax%5C%22%3A10%2C%5C%22ymin%5C%22%3A0%2C%5C%22ymax%5C%22%3A10%2C%5C%22spatialReference%5C%22%3A%7B%5C%22wkid%5C%22%3A4326%7D%7D%22', {
+        status: 200,
+        body: {
+          data: [
+            {
+              id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
+              type: 'downloads',
+              attributes: {
+                spatialRefId: '4326',
+                format: 'CSV',
+                contentLength: 1391454,
+                lastModified: '2020-06-17T13:04:28.000Z',
+                contentLastModified: '2020-06-17T01:16:01.933Z',
+                cacheTime: 13121,
+                status: 'stale',
+                featureSet: 'full',
+                source: {
+                  type: 'Feature Service',
+                  url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
+                  supportsExtract: true,
+                  lastEditDate: '2020-06-18T01:17:31.492Z',
+                  spatialRefId: '4326'
+                }
+              },
+              links: {
+                content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
+              }
+            }
+          ]
+        }
+      });
+
+      const result = await hubRequestDownloadMetadata({
+        host: 'http://hub.com/',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV',
+        geometry: JSON.stringify({
+          xmin: 0,
+          xmax: 10,
+          ymin: 0,
+          ymax: 10,
+          spatialReference: {
+            wkid: 4326
+          }
+        })
+      });
+
+      expect(result).toEqual({
+        downloadId: 'abcdef0123456789abcdef0123456789_0:CSV:4326:{"xmin":0,"xmax":10,"ymin":0,"ymax":10,"spatialReference":{"wkid":4326}}:undefined',
+        contentLastModified: '2020-06-17T01:16:01.933Z',
+        lastEditDate: '2020-06-18T01:17:31.492Z',
+        lastModified: '2020-06-17T13:04:28.000Z',
+        status: 'stale',
+        downloadUrl: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv',
+        contentLength: 1391454,
+        cacheTime: 13121
+      });
+    } catch (err) {
+      expect(err).toEqual(undefined);
+    } finally {
+      done();
+    }
+  });
+});

--- a/packages/downloads/test/poll-download-metadata.test.ts
+++ b/packages/downloads/test/poll-download-metadata.test.ts
@@ -1,0 +1,100 @@
+
+import { UserSession } from '@esri/arcgis-rest-auth';
+import { pollDownloadMetadata } from "../src/poll-download-metadata";
+import * as hubPoller from '../src/hub/hub-poll-download-metadata';
+import * as portalPoller from '../src/portal/portal-poll-export-job-status'
+import * as EventEmitter from 'eventemitter3';
+
+describe("pollDownloadMetadata", () => {
+  it('handle hub polling', async done => {
+    try {
+      const mockEventEmitter = new EventEmitter();
+      spyOn(mockEventEmitter, 'emit');
+
+      spyOn(hubPoller, 'hubPollDownloadMetadata').and.returnValue(
+        new Promise((resolve, reject) => {
+        resolve();
+      }))
+
+      pollDownloadMetadata({
+        host: 'http://hub.com/',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV',
+        downloadId: 'download-id',
+        eventEmitter: mockEventEmitter,
+        pollingInterval: 10
+      });
+
+      expect(hubPoller.hubPollDownloadMetadata as any).toHaveBeenCalledTimes(1)
+      expect((hubPoller.hubPollDownloadMetadata as any).calls.first().args).toEqual([{
+        host: 'http://hub.com/',
+        downloadId: 'download-id',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        format: 'CSV',
+        eventEmitter: mockEventEmitter,
+        pollingInterval: 10,
+        spatialRefId: '4326',
+        geometry: undefined,
+        where: undefined
+      }])
+    } catch (err) {
+      expect(err).toBeUndefined();
+    } finally {
+      done();
+    }
+  });
+
+  it('handle portal download', async done => {
+    const authentication = new UserSession({
+      username: 'portal-user',
+      portal: 'http://portal.com/sharing/rest',
+      token: '123',
+    });
+    authentication.getToken = () => new Promise((resolve) => {
+      resolve('123')
+    });
+
+    try {
+      const mockEventEmitter = new EventEmitter();
+      spyOn(mockEventEmitter, 'emit');
+
+      spyOn(portalPoller, 'portalPollExportJobStatus').and.returnValue(
+        new Promise((resolve, reject) => {
+        resolve();
+      }))
+
+      pollDownloadMetadata({
+        target: 'portal',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV',
+        downloadId: 'download-id',
+        jobId: 'job-id',
+        exportCreated: 1000,
+        eventEmitter: mockEventEmitter,
+        pollingInterval: 10,
+        authentication
+      });
+
+      expect(portalPoller.portalPollExportJobStatus as any).toHaveBeenCalledTimes(1)
+      expect((portalPoller.portalPollExportJobStatus as any).calls.first().args).toEqual([{
+        downloadId: 'download-id',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        jobId: 'job-id',
+        format: 'CSV',
+        eventEmitter: mockEventEmitter,
+        pollingInterval: 10,
+        spatialRefId: '4326',
+        authentication,
+        exportCreated: 1000,
+        geometry: undefined,
+        where: undefined
+      }])
+    } catch (err) {
+      expect(err).toBeUndefined();
+    } finally {
+      done();
+    }
+  });
+});

--- a/packages/downloads/test/poll-download-metadata.test.ts
+++ b/packages/downloads/test/poll-download-metadata.test.ts
@@ -85,7 +85,6 @@ describe("pollDownloadMetadata", () => {
         format: 'CSV',
         eventEmitter: mockEventEmitter,
         pollingInterval: 10,
-        spatialRefId: '4326',
         authentication,
         exportCreated: 1000,
         geometry: undefined,

--- a/packages/downloads/test/poll-download-metadata.test.ts
+++ b/packages/downloads/test/poll-download-metadata.test.ts
@@ -83,6 +83,7 @@ describe("pollDownloadMetadata", () => {
         datasetId: 'abcdef0123456789abcdef0123456789_0',
         jobId: 'job-id',
         format: 'CSV',
+        spatialRefId: '4326',
         eventEmitter: mockEventEmitter,
         pollingInterval: 10,
         authentication,

--- a/packages/downloads/test/portal/portal-poll-export-job-status.test.ts
+++ b/packages/downloads/test/portal/portal-poll-export-job-status.test.ts
@@ -1,0 +1,966 @@
+
+import * as portal from "@esri/arcgis-rest-portal";
+import { UserSession } from '@esri/arcgis-rest-auth';
+import { portalPollExportJobStatus } from "../../src/portal/portal-poll-export-job-status";
+import * as EventEmitter from 'eventemitter3';
+
+function delay (milliseconds: number) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+class RestJsError extends Error {
+  code: string;
+  constructor(message: string, code: string) {
+      super(message);
+      Object.setPrototypeOf(this, RestJsError.prototype);
+      this.code = code;
+  }
+}
+
+describe('portalPollExportJobStatus', () => {
+  const authentication = new UserSession({
+    username: 'portal-user',
+    portal: 'http://portal.com/sharing/rest',
+    token: '123',
+  })
+  authentication.getToken = () => new Promise((resolve) => {
+    resolve('123')
+  })
+
+  it('handle export failure', async (done) => {
+    try {
+      spyOn(portal, 'getItemStatus').and.returnValue(
+        new Promise((resolve, reject) => {
+          resolve({
+            status: 'failed',
+            statusMessage: 'Export failed'
+          });
+        })
+      );
+
+      const mockEventEmitter = new EventEmitter();
+      spyOn(mockEventEmitter, 'emit');
+      portalPollExportJobStatus({
+        downloadId: 'download-id',
+        jobId: 'test-id',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        format: 'CSV',
+        authentication,
+        exportCreated: 1000,
+        pollingInterval: 10,
+        eventEmitter: mockEventEmitter
+      });
+
+      await delay(0);
+      expect(portal.getItemStatus).toHaveBeenCalledTimes(1);
+      expect((portal.getItemStatus as any).calls.first().args).toEqual([
+        { id: 'download-id', jobId: 'test-id', jobType: 'export', authentication }
+      ]);
+      expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+      expect((mockEventEmitter.emit as any).calls.first().args).toEqual([
+        'download-idExportError', {
+          detail: {
+            metadata: {
+              errors: [ new Error('Export failed')]
+            }
+          }
+        }
+      ])
+    } catch (err) {
+      expect(err).toEqual(undefined);
+    } finally {
+      done();
+    }
+  });
+
+  it('handle polling error', async (done) => {
+    try {
+      spyOn(portal, 'getItemStatus').and.returnValue(
+        new Promise((resolve, reject) => {
+          reject(new Error('Not Found'));
+        })
+      );
+
+      const mockEventEmitter = new EventEmitter();
+      spyOn(mockEventEmitter, 'emit');
+      portalPollExportJobStatus({
+        downloadId: 'download-id',
+        jobId: 'test-id',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        format: 'CSV',
+        authentication,
+        exportCreated: 1000,
+        pollingInterval: 10,
+        eventEmitter: mockEventEmitter
+      });
+
+      await delay(0);
+      expect(portal.getItemStatus).toHaveBeenCalledTimes(1);
+      expect((portal.getItemStatus as any).calls.first().args).toEqual([
+        { id: 'download-id', jobId: 'test-id', jobType: 'export', authentication }
+      ]);
+      expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+      expect((mockEventEmitter.emit as any).calls.first().args).toEqual([
+        'download-idPollingError', {
+          detail: {
+            error: new Error('Not Found')
+          }
+        }
+      ])
+    } catch (err) {
+      expect(err).toEqual(undefined);
+    } finally {
+      done();
+    }
+  });
+
+  describe('export-completed handling errors', () => {
+    it('updateItem failure', async (done) => {
+      try {
+        spyOn(portal, 'getItemStatus').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({
+              status: 'completed'
+            });
+          })
+        );
+  
+        spyOn(portal, 'updateItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            reject(new Error('5xx'));
+          })
+        );
+
+        spyOn(portal, 'removeItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+        const mockEventEmitter = new EventEmitter();
+        spyOn(mockEventEmitter, 'emit');
+        portalPollExportJobStatus({
+          downloadId: 'download-id',
+          jobId: 'test-id',
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication,
+          exportCreated: 1000,
+          pollingInterval: 10,
+          eventEmitter: mockEventEmitter
+        });
+  
+        await delay(0);
+        expect(portal.getItemStatus).toHaveBeenCalledTimes(1);
+        expect((portal.getItemStatus as any).calls.first().args).toEqual([
+          { id: 'download-id', jobId: 'test-id', jobType: 'export', authentication }
+        ]);
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: 'download-id',
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(1);
+        expect((portal.removeItem as any).calls.first().args).toEqual([
+          {
+            id: 'download-id',
+            authentication
+          }
+        ]);
+        expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+        expect((mockEventEmitter.emit as any).calls.first().args).toEqual([
+          'download-idExportError', {
+            detail: {
+              metadata: { errors: [new Error('5xx')] }
+            }
+          }
+        ])
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+
+    it('setItemAccess failure', async (done) => {
+      try {
+        spyOn(portal, 'getItemStatus').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({
+              status: 'completed'
+            });
+          })
+        );
+  
+        spyOn(portal, 'updateItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+  
+        spyOn(portal, 'setItemAccess').and.returnValue(
+          new Promise((resolve, reject) => {
+            reject(new Error('5xx'));
+          })
+        );
+  
+        spyOn(portal, 'removeItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+        const mockEventEmitter = new EventEmitter();
+        spyOn(mockEventEmitter, 'emit');
+        portalPollExportJobStatus({
+          downloadId: 'download-id',
+          jobId: 'test-id',
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication,
+          exportCreated: 1000,
+          pollingInterval: 10,
+          eventEmitter: mockEventEmitter
+        });
+  
+        await delay(0);
+        expect(portal.getItemStatus).toHaveBeenCalledTimes(1);
+        expect((portal.getItemStatus as any).calls.first().args).toEqual([
+          { id: 'download-id', jobId: 'test-id', jobType: 'export', authentication }
+        ]);
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: 'download-id',
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
+        expect((portal.setItemAccess as any).calls.first().args).toEqual([
+          {
+            id: 'download-id',
+            authentication,
+            access: 'private'
+          }
+        ]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(1);
+        expect((portal.removeItem as any).calls.first().args).toEqual([
+          {
+            id: 'download-id',
+            authentication
+          }
+        ]);
+        expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+        expect((mockEventEmitter.emit as any).calls.first().args).toEqual([
+          'download-idExportError', {
+            detail: {
+              metadata: { errors: [new Error('5xx')] }
+            }
+          }
+        ])
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+
+    it('userContent failure', async (done) => {
+      try {
+        spyOn(portal, 'getItemStatus').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({
+              status: 'completed'
+            });
+          })
+        );
+  
+        spyOn(portal, 'updateItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+  
+        spyOn(portal, 'setItemAccess').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+  
+        spyOn(portal, 'getUserContent').and.returnValue(
+          new Promise((resolve, reject) => {
+            reject(new Error('5xx'));
+          })
+        );
+
+        spyOn(portal, 'removeItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+        const mockEventEmitter = new EventEmitter();
+        spyOn(mockEventEmitter, 'emit');
+        portalPollExportJobStatus({
+          downloadId: 'download-id',
+          jobId: 'test-id',
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication,
+          exportCreated: 1000,
+          pollingInterval: 10,
+          eventEmitter: mockEventEmitter
+        });
+  
+        await delay(0);
+        expect(portal.getItemStatus).toHaveBeenCalledTimes(1);
+        expect((portal.getItemStatus as any).calls.first().args).toEqual([
+          { id: 'download-id', jobId: 'test-id', jobType: 'export', authentication }
+        ]);
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: 'download-id',
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
+        expect((portal.setItemAccess as any).calls.first().args).toEqual([
+          {
+            id: 'download-id',
+            authentication,
+            access: 'private'
+          }
+        ]);
+        expect(portal.getUserContent).toHaveBeenCalledTimes(1);
+        expect((portal.getUserContent as any).calls.first().args).toEqual([{ authentication }]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(1);
+        expect((portal.removeItem as any).calls.first().args).toEqual([
+          {
+            id: 'download-id',
+            authentication
+          }
+        ]);
+        expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+        expect((mockEventEmitter.emit as any).calls.first().args).toEqual([
+          'download-idExportError', {
+            detail: {
+              metadata: { errors: [new Error('5xx')] }
+            }
+          }
+        ])
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+
+    it('createFolder failure', async (done) => {
+      try {
+        spyOn(portal, 'getItemStatus').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({
+              status: 'completed'
+            });
+          })
+        );
+  
+        spyOn(portal, 'updateItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+  
+        spyOn(portal, 'setItemAccess').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+  
+        spyOn(portal, 'getUserContent').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({ folders: [] });
+          })
+        );
+
+        spyOn(portal, 'createFolder').and.returnValue(
+          new Promise((resolve, reject) => {
+            reject(new Error('5xx'));
+          })
+        );
+
+        spyOn(portal, 'removeItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+        const mockEventEmitter = new EventEmitter();
+        spyOn(mockEventEmitter, 'emit');
+        portalPollExportJobStatus({
+          downloadId: 'download-id',
+          jobId: 'test-id',
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication,
+          exportCreated: 1000,
+          pollingInterval: 10,
+          eventEmitter: mockEventEmitter
+        });
+  
+        await delay(0);
+        expect(portal.getItemStatus).toHaveBeenCalledTimes(1);
+        expect((portal.getItemStatus as any).calls.first().args).toEqual([
+          { id: 'download-id', jobId: 'test-id', jobType: 'export', authentication }
+        ]);
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: 'download-id',
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
+        expect((portal.setItemAccess as any).calls.first().args).toEqual([
+          {
+            id: 'download-id',
+            authentication,
+            access: 'private'
+          }
+        ]);
+        expect(portal.getUserContent).toHaveBeenCalledTimes(1);
+        expect((portal.getUserContent as any).calls.first().args).toEqual([{ authentication }]);
+        expect(portal.createFolder).toHaveBeenCalledTimes(1);
+        expect((portal.createFolder as any).calls.first().args).toEqual([
+          {
+            title: 'item-exports',
+            authentication
+          }
+        ]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(1);
+        expect((portal.removeItem as any).calls.first().args).toEqual([
+          {
+            id: 'download-id',
+            authentication
+          }
+        ]);
+        expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+        expect((mockEventEmitter.emit as any).calls.first().args).toEqual([
+          'download-idExportError', {
+            detail: {
+              metadata: { errors: [new Error('5xx')] }
+            }
+          }
+        ])
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+
+    it('moveItem failure', async (done) => {
+      try {
+        spyOn(portal, 'getItemStatus').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({
+              status: 'completed'
+            });
+          })
+        );
+  
+        spyOn(portal, 'updateItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+  
+        spyOn(portal, 'setItemAccess').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+
+        spyOn(portal, 'getUserContent').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({ folders: [] });
+          })
+        );
+
+        spyOn(portal, 'createFolder').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({ folder: { id: 'export-folder-id' } });
+          })
+        );
+
+        spyOn(portal, 'moveItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            reject(new Error('5xx'));
+          })
+        );
+
+        spyOn(portal, 'removeItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+        const mockEventEmitter = new EventEmitter();
+        spyOn(mockEventEmitter, 'emit');
+        portalPollExportJobStatus({
+          downloadId: 'download-id',
+          jobId: 'test-id',
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication,
+          exportCreated: 1000,
+          pollingInterval: 10,
+          eventEmitter: mockEventEmitter
+        });
+  
+        await delay(0);
+        expect(portal.getItemStatus).toHaveBeenCalledTimes(1);
+        expect((portal.getItemStatus as any).calls.first().args).toEqual([
+          { id: 'download-id', jobId: 'test-id', jobType: 'export', authentication }
+        ]);
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: 'download-id',
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
+        expect((portal.setItemAccess as any).calls.first().args).toEqual([
+          {
+            id: 'download-id',
+            authentication,
+            access: 'private'
+          }
+        ]);
+        expect(portal.getUserContent).toHaveBeenCalledTimes(1);
+        expect((portal.getUserContent as any).calls.first().args).toEqual([{ authentication }]);
+        expect(portal.createFolder).toHaveBeenCalledTimes(1);
+        expect((portal.createFolder as any).calls.first().args).toEqual([
+          {
+            title: 'item-exports',
+            authentication
+          }
+        ]);
+        expect(portal.moveItem).toHaveBeenCalledTimes(1);
+        expect((portal.moveItem as any).calls.first().args).toEqual([
+          {
+            itemId: 'download-id',
+            folderId: 'export-folder-id',
+            authentication
+          }
+        ]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(1);
+        expect((portal.removeItem as any).calls.first().args).toEqual([
+          {
+            id: 'download-id',
+            authentication
+          }
+        ]);
+        expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+        expect((mockEventEmitter.emit as any).calls.first().args).toEqual([
+          'download-idExportError', {
+            detail: {
+              metadata: { errors: [new Error('5xx')] }
+            }
+          }
+        ])
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+  });
+
+  describe('exported-completed, successful handling', () => {
+    it('succeeds without existing exports folder', async (done) => {
+      try {
+        spyOn(portal, 'getItemStatus').and.returnValues(
+          new Promise((resolve, reject) => {
+            resolve({
+              status: 'progress'
+            });
+          }),
+          new Promise((resolve, reject) => {
+            resolve({
+              status: 'completed'
+            });
+          }),
+        );
+  
+        spyOn(portal, 'updateItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+  
+        spyOn(portal, 'setItemAccess').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+
+        spyOn(portal, 'getUserContent').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({ folders: [] });
+          })
+        );
+
+        spyOn(portal, 'createFolder').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({ folder: { id: 'export-folder-id' } });
+          })
+        );
+
+        spyOn(portal, 'moveItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+
+        spyOn(portal, 'removeItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+        const mockEventEmitter = new EventEmitter();
+        spyOn(mockEventEmitter, 'emit');
+        portalPollExportJobStatus({
+          downloadId: 'download-id',
+          jobId: 'test-id',
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication,
+          exportCreated: 1000,
+          pollingInterval: 10,
+          eventEmitter: mockEventEmitter
+        });
+  
+        await delay(100);
+        expect(portal.getItemStatus).toHaveBeenCalledTimes(2);
+        expect((portal.getItemStatus as any).calls.first().args).toEqual([
+          { id: 'download-id', jobId: 'test-id', jobType: 'export', authentication }
+        ]);
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: 'download-id',
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
+        expect((portal.setItemAccess as any).calls.first().args).toEqual([
+          {
+            id: 'download-id',
+            authentication,
+            access: 'private'
+          }
+        ]);
+        expect(portal.getUserContent).toHaveBeenCalledTimes(1);
+        expect((portal.getUserContent as any).calls.first().args).toEqual([{ authentication }]);
+        expect(portal.createFolder).toHaveBeenCalledTimes(1);
+        expect((portal.createFolder as any).calls.first().args).toEqual([
+          {
+            title: 'item-exports',
+            authentication
+          }
+        ]);
+        expect(portal.moveItem).toHaveBeenCalledTimes(1);
+        expect((portal.moveItem as any).calls.first().args).toEqual([
+          {
+            itemId: 'download-id',
+            folderId: 'export-folder-id',
+            authentication
+          }
+        ]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(0)
+
+        expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+        expect((mockEventEmitter.emit as any).calls.first().args[0]).toEqual('download-idExportComplete');
+        const {
+          detail: {
+            metadata: {
+              downloadId,
+              status,
+              downloadUrl,
+              lastModified
+            }
+          }
+        } = (mockEventEmitter.emit as any).calls.first().args[1]
+        expect(downloadId).toEqual('download-id');
+        expect(status).toEqual('ready');
+        expect(downloadUrl).toEqual('http://portal.com/sharing/rest/content/items/download-id/data?token=123');
+        expect(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/.test(lastModified)).toEqual(true);
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+
+    it('succeeds without exist exports folder', async (done) => {
+      try {
+        spyOn(portal, 'getItemStatus').and.returnValues(
+          new Promise((resolve, reject) => {
+            resolve({
+              status: 'progress'
+            });
+          }),
+          new Promise((resolve, reject) => {
+            resolve({
+              status: 'completed'
+            });
+          }),
+        );
+  
+        spyOn(portal, 'updateItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+  
+        spyOn(portal, 'setItemAccess').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+
+        spyOn(portal, 'getUserContent').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({ folders: [ {
+              id: 'export-folder-id',
+              title: 'item-exports'
+            }] });
+          })
+        );
+
+        spyOn(portal, 'createFolder');
+
+        spyOn(portal, 'moveItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+
+        spyOn(portal, 'removeItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+        const mockEventEmitter = new EventEmitter();
+        spyOn(mockEventEmitter, 'emit');
+        portalPollExportJobStatus({
+          downloadId: 'download-id',
+          jobId: 'test-id',
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication,
+          exportCreated: 1000,
+          pollingInterval: 10,
+          eventEmitter: mockEventEmitter
+        });
+  
+        await delay(100);
+        expect(portal.getItemStatus).toHaveBeenCalledTimes(2);
+        expect((portal.getItemStatus as any).calls.first().args).toEqual([
+          { id: 'download-id', jobId: 'test-id', jobType: 'export', authentication }
+        ]);
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: 'download-id',
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
+        expect((portal.setItemAccess as any).calls.first().args).toEqual([
+          {
+            id: 'download-id',
+            authentication,
+            access: 'private'
+          }
+        ]);
+        expect(portal.getUserContent).toHaveBeenCalledTimes(1);
+        expect((portal.getUserContent as any).calls.first().args).toEqual([{ authentication }]);
+        expect(portal.createFolder).toHaveBeenCalledTimes(0);
+        expect(portal.moveItem).toHaveBeenCalledTimes(1);
+        expect((portal.moveItem as any).calls.first().args).toEqual([
+          {
+            itemId: 'download-id',
+            folderId: 'export-folder-id',
+            authentication
+          }
+        ]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(0)
+
+        expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+        expect((mockEventEmitter.emit as any).calls.first().args[0]).toEqual('download-idExportComplete');
+        const {
+          detail: {
+            metadata: {
+              downloadId,
+              status,
+              downloadUrl,
+              lastModified
+            }
+          }
+        } = (mockEventEmitter.emit as any).calls.first().args[1]
+        expect(downloadId).toEqual('download-id');
+        expect(status).toEqual('ready');
+        expect(downloadUrl).toEqual('http://portal.com/sharing/rest/content/items/download-id/data?token=123');
+        expect(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/.test(lastModified)).toEqual(true);
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+
+    it('succeeds without moving download', async (done) => {
+      try {
+        spyOn(portal, 'getItemStatus').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({
+              status: 'completed'
+            });
+          })
+        );
+  
+        spyOn(portal, 'updateItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+  
+        spyOn(portal, 'setItemAccess').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+
+        spyOn(portal, 'getUserContent').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({ folders: [] });
+          })
+        );
+
+        spyOn(portal, 'createFolder').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve({ folder: { id: 'export-folder-id' } });
+          })
+        );
+
+        spyOn(portal, 'moveItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            reject(new RestJsError('Already moved', 'CONT_0011'));
+          })
+        );
+
+        spyOn(portal, 'removeItem').and.returnValue(
+          new Promise((resolve, reject) => {
+            resolve();
+          })
+        );
+        const mockEventEmitter = new EventEmitter();
+        spyOn(mockEventEmitter, 'emit');
+        portalPollExportJobStatus({
+          downloadId: 'download-id',
+          jobId: 'test-id',
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication,
+          exportCreated: 1000,
+          pollingInterval: 10,
+          eventEmitter: mockEventEmitter
+        });
+  
+        await delay(0);
+        expect(portal.getItemStatus).toHaveBeenCalledTimes(1);
+        expect((portal.getItemStatus as any).calls.first().args).toEqual([
+          { id: 'download-id', jobId: 'test-id', jobType: 'export', authentication }
+        ]);
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: 'download-id',
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
+        expect((portal.setItemAccess as any).calls.first().args).toEqual([
+          {
+            id: 'download-id',
+            authentication,
+            access: 'private'
+          }
+        ]);
+        expect(portal.getUserContent).toHaveBeenCalledTimes(1);
+        expect((portal.getUserContent as any).calls.first().args).toEqual([{ authentication }]);
+        expect(portal.createFolder).toHaveBeenCalledTimes(1);
+        expect((portal.createFolder as any).calls.first().args).toEqual([
+          {
+            title: 'item-exports',
+            authentication
+          }
+        ]);
+        expect(portal.moveItem).toHaveBeenCalledTimes(1);
+        expect((portal.moveItem as any).calls.first().args).toEqual([
+          {
+            itemId: 'download-id',
+            folderId: 'export-folder-id',
+            authentication
+          }
+        ]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(0)
+        expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+        expect((mockEventEmitter.emit as any).calls.first().args[0]).toEqual('download-idExportComplete');
+        const {
+          detail: {
+            metadata: {
+              downloadId,
+              status,
+              downloadUrl,
+              lastModified
+            }
+          }
+        } = (mockEventEmitter.emit as any).calls.first().args[1]
+        expect(downloadId).toEqual('download-id');
+        expect(status).toEqual('ready');
+        expect(downloadUrl).toEqual('http://portal.com/sharing/rest/content/items/download-id/data?token=123');
+        expect(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/.test(lastModified)).toEqual(true);
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+  })
+});

--- a/packages/downloads/test/portal/portal-poll-export-job-status.test.ts
+++ b/packages/downloads/test/portal/portal-poll-export-job-status.test.ts
@@ -159,7 +159,7 @@ describe('portalPollExportJobStatus', () => {
           {
             item: {
               id: 'download-id',
-              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV`
             },
             authentication
           }
@@ -236,7 +236,7 @@ describe('portalPollExportJobStatus', () => {
           {
             item: {
               id: 'download-id',
-              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV`
             },
             authentication
           }
@@ -327,7 +327,7 @@ describe('portalPollExportJobStatus', () => {
           {
             item: {
               id: 'download-id',
-              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV`
             },
             authentication
           }
@@ -426,7 +426,7 @@ describe('portalPollExportJobStatus', () => {
           {
             item: {
               id: 'download-id',
-              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV`
             },
             authentication
           }
@@ -538,7 +538,7 @@ describe('portalPollExportJobStatus', () => {
           {
             item: {
               id: 'download-id',
-              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV`
             },
             authentication
           }
@@ -665,7 +665,7 @@ describe('portalPollExportJobStatus', () => {
           {
             item: {
               id: 'download-id',
-              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV`
             },
             authentication
           }
@@ -792,7 +792,7 @@ describe('portalPollExportJobStatus', () => {
           {
             item: {
               id: 'download-id',
-              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV`
             },
             authentication
           }
@@ -909,7 +909,7 @@ describe('portalPollExportJobStatus', () => {
           {
             item: {
               id: 'download-id',
-              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV,spatialRefId:undefined`
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,exportFormat:CSV`
             },
             authentication
           }

--- a/packages/downloads/test/portal/portal-request-dataset-export.test.ts
+++ b/packages/downloads/test/portal/portal-request-dataset-export.test.ts
@@ -1,0 +1,121 @@
+import * as portal from "@esri/arcgis-rest-portal";
+import { UserSession } from '@esri/arcgis-rest-auth';
+import { portalRequestDatasetExport } from "../../src/portal/portal-request-dataset-export";
+
+const authentication = new UserSession({
+  username: 'portal-user',
+  portal: 'http://portal.com/sharing/rest',
+  token: '123',
+})
+authentication.getToken = () => new Promise((resolve) => {
+  resolve('123')
+})
+
+describe("portalRequestDatasetExport", () => {
+  
+  it('exportItem fails', async done => {
+    try {
+      spyOn(portal, 'exportItem').and.returnValue(
+        new Promise((resolve, reject) => {
+          reject(new Error('5xx'));
+        })
+      );
+
+      const result = await portalRequestDatasetExport({
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        format: 'CSV',
+        authentication,
+        title: 'test-export'
+      });
+      expect(result).toBeUndefined();
+    } catch (err) {
+      expect(err.message).toEqual('5xx');
+      expect(portal.exportItem).toHaveBeenCalledTimes(1);
+      expect((portal.exportItem as any).calls.first().args).toEqual([{
+        id: 'abcdef0123456789abcdef0123456789',
+        exportFormat: 'CSV',
+        exportParameters: { layers: [ Object({ id: 0 }) ] },
+        title: 'test-export',
+        authentication
+      }]);
+    } finally {
+      done();
+    }
+  })
+
+  it('succeeds', async done => {
+    try {
+      spyOn(portal, 'exportItem').and.returnValue(
+        new Promise((resolve, reject) => {
+          resolve({
+            size: 1000,
+            jobId: 'job-id',
+            exportItemId: 'abcdef'
+          });
+        })
+      );
+
+      const result = await portalRequestDatasetExport({
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        format: 'CSV',
+        authentication,
+        title: 'test-export'
+      });
+      expect(portal.exportItem).toHaveBeenCalledTimes(1);
+      expect((portal.exportItem as any).calls.first().args).toEqual([{
+        id: 'abcdef0123456789abcdef0123456789',
+        exportFormat: 'CSV',
+        exportParameters: { layers: [ Object({ id: 0 }) ] },
+        title: 'test-export',
+        authentication
+      }]);
+      expect(result).toBeDefined();
+      expect(result.downloadId).toEqual('abcdef');
+      expect(result.jobId).toEqual('job-id');
+      expect(result.size).toEqual(1000);
+      expect(typeof result.exportCreated === 'number').toEqual(true)
+    } catch (err) {
+      expect(err).toBeUndefined();
+    } finally {
+      done();
+    }
+  })
+
+  it('succeeds, dataset has no layer id', async done => {
+    try {
+      spyOn(portal, 'exportItem').and.returnValue(
+        new Promise((resolve, reject) => {
+          resolve({
+            size: 1000,
+            jobId: 'job-id',
+            exportItemId: 'abcdef'
+          });
+        })
+      );
+
+      const result = await portalRequestDatasetExport({
+        datasetId: 'abcdef0123456789abcdef0123456789',
+        format: 'CSV',
+        authentication,
+        title: 'test-export'
+      });
+      expect(portal.exportItem).toHaveBeenCalledTimes(1);
+      expect((portal.exportItem as any).calls.first().args).toEqual([{
+        id: 'abcdef0123456789abcdef0123456789',
+        exportFormat: 'CSV',
+        exportParameters: { layers: [ Object({ id: 0 }) ] },
+        title: 'test-export',
+        authentication
+      }]);
+      expect(result).toBeDefined();
+      expect(result.downloadId).toEqual('abcdef');
+      expect(result.jobId).toEqual('job-id');
+      expect(result.size).toEqual(1000);
+      expect(typeof result.exportCreated === 'number').toEqual(true)
+    } catch (err) {
+      expect(err).toBeUndefined();
+    } finally {
+      done();
+    }
+  })
+});

--- a/packages/downloads/test/portal/portal-request-dataset-export.test.ts
+++ b/packages/downloads/test/portal/portal-request-dataset-export.test.ts
@@ -117,5 +117,44 @@ describe("portalRequestDatasetExport", () => {
     } finally {
       done();
     }
+  });
+
+  it('succeeds, uses spatialRefId', async done => {
+    try {
+      spyOn(portal, 'exportItem').and.returnValue(
+        new Promise((resolve, reject) => {
+          resolve({
+            size: 1000,
+            jobId: 'job-id',
+            exportItemId: 'abcdef'
+          });
+        })
+      );
+
+      const result = await portalRequestDatasetExport({
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        format: 'CSV',
+        authentication,
+        spatialRefId: '4326',
+        title: 'test-export'
+      });
+      expect(portal.exportItem).toHaveBeenCalledTimes(1);
+      expect((portal.exportItem as any).calls.first().args).toEqual([{
+        id: 'abcdef0123456789abcdef0123456789',
+        exportFormat: 'CSV',
+        exportParameters: { layers: [ Object({ id: 0 }) ], targetSR: { wkid: 4326 } },
+        title: 'test-export',
+        authentication
+      }]);
+      expect(result).toBeDefined();
+      expect(result.downloadId).toEqual('abcdef');
+      expect(result.jobId).toEqual('job-id');
+      expect(result.size).toEqual(1000);
+      expect(typeof result.exportCreated === 'number').toEqual(true)
+    } catch (err) {
+      expect(err).toBeUndefined();
+    } finally {
+      done();
+    }
   })
 });

--- a/packages/downloads/test/portal/portal-request-download-metadata.test.ts
+++ b/packages/downloads/test/portal/portal-request-download-metadata.test.ts
@@ -238,7 +238,7 @@ describe("portalRequestDownloadMetadata", () => {
           {
             authentication,
             num: 1,
-            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined,exportFormat:CSV"',
+            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789,exportFormat:CSV"',
             sortField: 'modified',
             sortOrder: 'DESC'
           }
@@ -305,7 +305,7 @@ describe("portalRequestDownloadMetadata", () => {
           {
             authentication,
             num: 1,
-            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined,exportFormat:CSV"',
+            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,exportFormat:CSV"',
             sortField: 'modified',
             sortOrder: 'DESC'
           }
@@ -378,7 +378,7 @@ describe("portalRequestDownloadMetadata", () => {
           {
             authentication,
             num: 1,
-            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined,exportFormat:CSV"',
+            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789,exportFormat:CSV"',
             sortField: 'modified',
             sortOrder: 'DESC'
           }
@@ -455,7 +455,7 @@ describe("portalRequestDownloadMetadata", () => {
           {
             authentication,
             num: 1,
-            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined,exportFormat:CSV"',
+            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,exportFormat:CSV"',
             sortField: 'modified',
             sortOrder: 'DESC'
           }
@@ -532,7 +532,7 @@ describe("portalRequestDownloadMetadata", () => {
           {
             authentication,
             num: 1,
-            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined,exportFormat:CSV"',
+            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,exportFormat:CSV"',
             sortField: 'modified',
             sortOrder: 'DESC'
           }

--- a/packages/downloads/test/portal/portal-request-download-metadata.test.ts
+++ b/packages/downloads/test/portal/portal-request-download-metadata.test.ts
@@ -1,0 +1,547 @@
+
+import * as fetchMock from 'fetch-mock';
+import * as portal from "@esri/arcgis-rest-portal";
+import * as featureLayer from "@esri/arcgis-rest-feature-layer";
+import { UserSession } from '@esri/arcgis-rest-auth';
+import { portalRequestDownloadMetadata } from "../../src/portal/portal-request-download-metadata";
+
+describe("portalRequestDownloadMetadata", () => {
+
+  const authentication = new UserSession({
+    username: 'portal-user',
+    portal: `http://portal.com/sharing/rest`,
+    token: '123',
+  })
+  authentication.getToken = () => new Promise((resolve) => {
+    resolve('123')
+  })
+  afterEach(() => fetchMock.restore());
+
+  describe("portal errors", () => {
+    it('handle remote server 502 error', async done => {
+      try {
+        fetchMock.mock('http://portal.com/sharing/rest/content/items/abcdef0123456789abcdef0123456789?f=json&token=123', {
+          status: 502
+        });
+  
+        await portalRequestDownloadMetadata({
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication
+        });
+      } catch (err) {
+        expect(err.code).toEqual('HTTP 502');
+      } finally {
+        done();
+      }
+    });
+  
+    it('handle missing invalid token', async done => {
+      try {
+        fetchMock.mock('http://portal.com/sharing/rest/content/items/abcdef0123456789abcdef0123456789?f=json&token=123', {
+          status: 200,
+          body: {
+            "error": {
+                "code": 498,
+                "message": "Invalid token.",
+                "details": []
+            }
+          }
+        });
+  
+        const result = await portalRequestDownloadMetadata({
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication
+        });
+  
+        expect(result).toEqual(undefined);
+      } catch (err) {
+        expect(err.message).toEqual('498: Invalid token.');
+      } finally {
+        done();
+      }
+    });
+  })
+
+  describe("non-service item", () => {
+    it('not cached', async done => {
+      try {
+        spyOn(portal, 'getItem').and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              type: 'CSV',
+              modified: (new Date(1593450876000)).getTime()
+            });
+          })
+        );
+  
+        spyOn(portal, 'searchItems').and.returnValue(
+          new Promise(resolve => {
+            resolve({ results: [] });
+          })
+        );
+  
+        const result = await portalRequestDownloadMetadata({
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication
+        });
+  
+        expect(result).toEqual({
+          downloadId: 'abcdef0123456789abcdef0123456789_0:CSV:undefined:undefined:undefined',
+          lastEditDate: '2020-06-29T17:14:36.000Z',
+          status: 'not_ready'
+        });
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+  
+    it('cached, stale', async done => {
+      try {
+        spyOn(portal, 'getItem').and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              type: 'CSV',
+              modified: (new Date(1593450876000)).getTime()
+            });
+          })
+        );
+  
+        spyOn(portal, 'searchItems').and.returnValue(
+          new Promise(resolve => {
+            resolve({ results: [{
+              id: 'abcdef',
+              created: (new Date(1583450876000)).getTime()
+            }] });
+          })
+        );
+  
+        const result = await portalRequestDownloadMetadata({
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication
+        });
+  
+        expect(result).toEqual({
+          downloadId: 'abcdef',
+          lastEditDate: '2020-06-29T17:14:36.000Z',
+          status: 'stale',
+          contentLastModified: '2020-03-05T23:27:56.000Z',
+          lastModified: '2020-03-05T23:27:56.000Z',
+          downloadUrl: 'http://portal.com/sharing/rest/content/items/abcdef/data?token=123'
+        });
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+  
+    it('cached, ready', async done => {
+      try {
+        spyOn(portal, 'getItem').and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              type: 'CSV',
+              modified: (new Date(1593450876000)).getTime()
+            });
+          })
+        );
+  
+        spyOn(portal, 'searchItems').and.returnValue(
+          new Promise(resolve => {
+            resolve({ results: [{
+              id: 'abcdef',
+              created: (new Date(1594450876000)).getTime()
+            }] });
+          })
+        );
+  
+        const result = await portalRequestDownloadMetadata({
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication
+        });
+  
+        expect(result).toEqual({
+          downloadId: 'abcdef',
+          lastEditDate: '2020-06-29T17:14:36.000Z',
+          status: 'ready',
+          contentLastModified: '2020-07-11T07:01:16.000Z',
+          lastModified: '2020-07-11T07:01:16.000Z',
+          downloadUrl: 'http://portal.com/sharing/rest/content/items/abcdef/data?token=123'
+        });
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+  });
+
+  describe("feature-service items", () => {
+    it('no layer id, no lastEditDate, not cached', async done => {
+      try {
+        const getItemSpy = spyOn(portal, 'getItem').and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              type: 'Feature Service',
+              modified: (new Date(1593450876)).getTime(),
+              url: 'http://feature-service.com/FeatureServer'
+            });
+          })
+        );
+  
+        const getLayerSpy = spyOn(featureLayer, 'getLayer').and.returnValue(
+          new Promise(resolve => {
+            resolve({});
+          })
+        );
+
+        const searchItemsSpy = spyOn(portal, 'searchItems').and.returnValue(
+          new Promise(resolve => {
+            resolve({ results: [] });
+          })
+        );
+  
+        const result = await portalRequestDownloadMetadata({
+          datasetId: 'abcdef0123456789abcdef0123456789',
+          format: 'CSV',
+          authentication
+        });
+  
+        expect(result).toEqual({
+          downloadId: 'abcdef0123456789abcdef0123456789:CSV:undefined:undefined:undefined',
+          lastEditDate: undefined,
+          status: 'not_ready'
+        });
+        expect(getItemSpy.calls.count()).toEqual(1);
+        expect(getItemSpy.calls.argsFor(0)).toEqual([
+          'abcdef0123456789abcdef0123456789',
+          {
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(1);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: 'http://feature-service.com/FeatureServer/0',
+            authentication
+          }
+        ]);
+        expect(searchItemsSpy.calls.count()).toEqual(1);
+        expect(searchItemsSpy.calls.argsFor(0)).toEqual([
+          {
+            authentication,
+            num: 1,
+            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined,exportFormat:CSV"',
+            sortField: 'modified',
+            sortOrder: 'DESC'
+          }
+        ]);
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+
+    it('no lastEditDate, not cached', async done => {
+      try {
+        const getItemSpy = spyOn(portal, 'getItem').and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              type: 'Feature Service',
+              modified: (new Date(1593450876)).getTime(),
+              url: 'http://feature-service.com/FeatureServer'
+            });
+          })
+        );
+  
+        const getLayerSpy = spyOn(featureLayer, 'getLayer').and.returnValue(
+          new Promise(resolve => {
+            resolve({});
+          })
+        );
+
+        const searchItemsSpy = spyOn(portal, 'searchItems').and.returnValue(
+          new Promise(resolve => {
+            resolve({ results: [] });
+          })
+        );
+  
+        const result = await portalRequestDownloadMetadata({
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication
+        });
+  
+        expect(result).toEqual({
+          downloadId: 'abcdef0123456789abcdef0123456789_0:CSV:undefined:undefined:undefined',
+          lastEditDate: undefined,
+          status: 'not_ready'
+        });
+
+        expect(getItemSpy.calls.count()).toEqual(1);
+        expect(getItemSpy.calls.argsFor(0)).toEqual([
+          'abcdef0123456789abcdef0123456789',
+          {
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(1);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: 'http://feature-service.com/FeatureServer/0',
+            authentication
+          }
+        ]);
+        expect(searchItemsSpy.calls.count()).toEqual(1);
+        expect(searchItemsSpy.calls.argsFor(0)).toEqual([
+          {
+            authentication,
+            num: 1,
+            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined,exportFormat:CSV"',
+            sortField: 'modified',
+            sortOrder: 'DESC'
+          }
+        ]);
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+
+    it('no lastEditDate, cached, ready (unknown)', async done => {
+      try {
+        const getItemSpy = spyOn(portal, 'getItem').and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              type: 'Feature Service',
+              modified: (new Date(1593450876)).getTime(),
+              url: 'http://feature-service.com/FeatureServer'
+            });
+          })
+        );
+  
+        const getLayerSpy = spyOn(featureLayer, 'getLayer').and.returnValue(
+          new Promise(resolve => {
+            resolve({});
+          })
+        );
+
+        const searchItemsSpy = spyOn(portal, 'searchItems').and.returnValue(
+          new Promise(resolve => {
+            resolve({ results: [{
+              id: 'abcdef',
+              created: (new Date(1594450876000)).getTime()
+            }] });
+          })
+        );
+  
+        const result = await portalRequestDownloadMetadata({
+          datasetId: 'abcdef0123456789abcdef0123456789',
+          format: 'CSV',
+          authentication
+        });
+  
+        expect(result).toEqual({
+          downloadId: 'abcdef',
+          lastEditDate: undefined,
+          status: 'ready',
+          contentLastModified: '2020-07-11T07:01:16.000Z',
+          lastModified: '2020-07-11T07:01:16.000Z',
+          downloadUrl: 'http://portal.com/sharing/rest/content/items/abcdef/data?token=123'
+        });
+
+        expect(getItemSpy.calls.count()).toEqual(1);
+        expect(getItemSpy.calls.argsFor(0)).toEqual([
+          'abcdef0123456789abcdef0123456789',
+          {
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(1);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: 'http://feature-service.com/FeatureServer/0',
+            authentication
+          }
+        ]);
+        expect(searchItemsSpy.calls.count()).toEqual(1);
+        expect(searchItemsSpy.calls.argsFor(0)).toEqual([
+          {
+            authentication,
+            num: 1,
+            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined,exportFormat:CSV"',
+            sortField: 'modified',
+            sortOrder: 'DESC'
+          }
+        ]);
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+
+    it('has lastEditDate, cached, ready', async done => {
+      try {
+        const getItemSpy = spyOn(portal, 'getItem').and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              type: 'Feature Service',
+              modified: (new Date(1593450876)).getTime(),
+              url: 'http://feature-service.com/FeatureServer'
+            });
+          })
+        );
+  
+        const getLayerSpy = spyOn(featureLayer, 'getLayer').and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              editingInfo: {
+                lastEditDate: (new Date(1584450876000)).getTime()
+              }
+            });
+          })
+        );
+
+        const searchItemsSpy = spyOn(portal, 'searchItems').and.returnValue(
+          new Promise(resolve => {
+            resolve({ results: [{
+              id: 'abcdef',
+              created: (new Date(1594450876000)).getTime()
+            }] });
+          })
+        );
+  
+        const result = await portalRequestDownloadMetadata({
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication
+        });
+  
+        expect(result).toEqual({
+          downloadId: 'abcdef',
+          lastEditDate: '2020-03-17T13:14:36.000Z',
+          status: 'ready',
+          contentLastModified: '2020-07-11T07:01:16.000Z',
+          lastModified: '2020-07-11T07:01:16.000Z',
+          downloadUrl: 'http://portal.com/sharing/rest/content/items/abcdef/data?token=123'
+        });
+
+        expect(getItemSpy.calls.count()).toEqual(1);
+        expect(getItemSpy.calls.argsFor(0)).toEqual([
+          'abcdef0123456789abcdef0123456789',
+          {
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(1);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: 'http://feature-service.com/FeatureServer/0',
+            authentication
+          }
+        ]);
+        expect(searchItemsSpy.calls.count()).toEqual(1);
+        expect(searchItemsSpy.calls.argsFor(0)).toEqual([
+          {
+            authentication,
+            num: 1,
+            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined,exportFormat:CSV"',
+            sortField: 'modified',
+            sortOrder: 'DESC'
+          }
+        ]);
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+
+    it('has lastEditDate, cached, stale', async done => {
+      try {
+        const getItemSpy = spyOn(portal, 'getItem').and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              type: 'Feature Service',
+              modified: (new Date(1573450876)).getTime(),
+              url: 'http://feature-service.com/FeatureServer'
+            });
+          })
+        );
+  
+        const getLayerSpy = spyOn(featureLayer, 'getLayer').and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              editingInfo: {
+                lastEditDate: (new Date(1584450876000)).getTime()
+              }
+            });
+          })
+        );
+
+        const searchItemsSpy = spyOn(portal, 'searchItems').and.returnValue(
+          new Promise(resolve => {
+            resolve({ results: [{
+              id: 'abcdef',
+              created: (new Date(1574450876000)).getTime()
+            }] });
+          })
+        );
+  
+        const result = await portalRequestDownloadMetadata({
+          datasetId: 'abcdef0123456789abcdef0123456789_0',
+          format: 'CSV',
+          authentication
+        });
+  
+        expect(result).toEqual({
+          downloadId: 'abcdef',
+          lastEditDate: '2020-03-17T13:14:36.000Z',
+          status: 'stale',
+          contentLastModified: '2019-11-22T19:27:56.000Z',
+          lastModified: '2019-11-22T19:27:56.000Z',
+          downloadUrl: 'http://portal.com/sharing/rest/content/items/abcdef/data?token=123'
+        });
+
+        expect(getItemSpy.calls.count()).toEqual(1);
+        expect(getItemSpy.calls.argsFor(0)).toEqual([
+          'abcdef0123456789abcdef0123456789',
+          {
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(1);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: 'http://feature-service.com/FeatureServer/0',
+            authentication
+          }
+        ]);
+        expect(searchItemsSpy.calls.count()).toEqual(1);
+        expect(searchItemsSpy.calls.argsFor(0)).toEqual([
+          {
+            authentication,
+            num: 1,
+            q: 'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined,exportFormat:CSV"',
+            sortField: 'modified',
+            sortOrder: 'DESC'
+          }
+        ]);
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+  })
+});

--- a/packages/downloads/test/request-dataset-export.test.ts
+++ b/packages/downloads/test/request-dataset-export.test.ts
@@ -67,7 +67,8 @@ describe("requestDownloadMetadata", () => {
         format: 'CSV',
         authentication,
         title: 'test-export',
-        target: 'portal'
+        target: 'portal',
+        spatialRefId: '2227'
       });
 
       expect(portalExport.portalRequestDatasetExport).toHaveBeenCalledTimes(1)
@@ -75,7 +76,8 @@ describe("requestDownloadMetadata", () => {
         datasetId: 'abcdef0123456789abcdef0123456789_0',
         format: 'CSV',
         title: 'test-export',
-        authentication
+        authentication,
+        spatialRefId: '2227'
       }])
       expect(result).toBeDefined();
       expect(result.downloadId).toEqual('abcdef');

--- a/packages/downloads/test/request-dataset-export.test.ts
+++ b/packages/downloads/test/request-dataset-export.test.ts
@@ -1,0 +1,91 @@
+
+import { UserSession } from '@esri/arcgis-rest-auth';
+import { requestDatasetExport } from "../src/request-dataset-export";
+import * as hubExport from '../src/hub/hub-request-dataset-export';
+import * as portalExport from '../src/portal/portal-request-dataset-export'
+
+describe("requestDownloadMetadata", () => {
+  it('handle hub export', async done => {
+    try {
+      spyOn(hubExport, 'hubRequestDatasetExport').and.returnValue(
+        new Promise((resolve, reject) => {
+        resolve({
+          downloadId: 'abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined'
+        });
+      }))
+
+      const result = await requestDatasetExport({
+        host: 'http://hub.com/',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV'
+      });
+
+      expect(hubExport.hubRequestDatasetExport).toHaveBeenCalledTimes(1)
+      expect((hubExport.hubRequestDatasetExport as any).calls.first().args).toEqual([{
+        host: 'http://hub.com/',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        format: 'CSV',
+        spatialRefId: '4326',
+        geometry: undefined,
+        where: undefined
+      }])
+
+      expect(result).toEqual({
+        downloadId: 'abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined'
+      })
+    } catch (err) {
+      expect(err).toBeUndefined();
+    } finally {
+      done();
+    }
+  });
+
+  it('handle portal export', async done => {
+    try {
+      spyOn(portalExport, 'portalRequestDatasetExport').and.returnValue(
+        new Promise((resolve, reject) => {
+        resolve({
+          size: 1000,
+          jobId: 'job-id',
+          downloadId: 'abcdef',
+          exportCreated: Date.now()
+        });
+      }))
+
+      const authentication = new UserSession({
+        username: 'portal-user',
+        portal: 'http://portal.com/sharing/rest',
+        token: '123',
+      })
+      authentication.getToken = () => new Promise((resolve) => {
+        resolve('123')
+      })
+      
+      const result = await requestDatasetExport({
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        format: 'CSV',
+        authentication,
+        title: 'test-export',
+        target: 'portal'
+      });
+
+      expect(portalExport.portalRequestDatasetExport).toHaveBeenCalledTimes(1)
+      expect((portalExport.portalRequestDatasetExport as any).calls.first().args).toEqual([{
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        format: 'CSV',
+        title: 'test-export',
+        authentication
+      }])
+      expect(result).toBeDefined();
+      expect(result.downloadId).toEqual('abcdef');
+      expect(result.jobId).toEqual('job-id');
+      expect(result.size).toEqual(1000);
+      expect(typeof result.exportCreated === 'number').toEqual(true)
+    } catch (err) {
+      expect(err).toBeUndefined();
+    } finally {
+      done();
+    }
+  });
+});

--- a/packages/downloads/test/request-download-metadata.test.ts
+++ b/packages/downloads/test/request-download-metadata.test.ts
@@ -1,0 +1,119 @@
+
+import * as fetchMock from 'fetch-mock';
+import { UserSession } from '@esri/arcgis-rest-auth';
+import { requestDownloadMetadata } from "../src/request-download-metadata";
+
+describe("requestDownloadMetadata", () => {
+
+  afterEach(() => fetchMock.restore());
+
+  it('handle hub download', async done => {
+    try {
+      fetchMock.mock('http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv', {
+        status: 200,
+        body: {
+          data: [
+            {
+              id: 'dd4580c810204019a7b8eb3e0b329dd6_0',
+              type: 'downloads',
+              attributes: {
+                spatialRefId: '4326',
+                format: 'CSV',
+                contentLength: 1391454,
+                lastModified: '2020-06-17T13:04:28.000Z',
+                contentLastModified: '2020-06-17T01:16:01.933Z',
+                cacheTime: 13121,
+                status: 'stale',
+                featureSet: 'full',
+                source: {
+                  type: 'Feature Service',
+                  url: 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json',
+                  supportsExtract: true,
+                  lastEditDate: '2020-06-18T01:17:31.492Z',
+                  spatialRefId: '4326'
+                }
+              },
+              links: {
+                content: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv'
+              }
+            }
+          ]
+        }
+      });
+
+      const result = await requestDownloadMetadata({
+        host: 'http://hub.com/',
+        datasetId: 'abcdef0123456789abcdef0123456789_0',
+        spatialRefId: '4326',
+        format: 'CSV'
+      });
+
+      expect(result).toEqual({
+        downloadId: 'abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined',
+        contentLastModified: '2020-06-17T01:16:01.933Z',
+        lastEditDate: '2020-06-18T01:17:31.492Z',
+        lastModified: '2020-06-17T13:04:28.000Z',
+        status: 'stale',
+        downloadUrl: 'https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv',
+        contentLength: 1391454,
+        cacheTime: 13121
+      });
+    } catch (err) {
+      expect(err).toBeUndefined();
+    } finally {
+      done();
+    }
+  });
+
+  it('handle portal download', async done => {
+    const authentication = new UserSession({
+      username: 'portal-user',
+      portal: `http://portal.com/sharing/rest`,
+      token: '123',
+    })
+    authentication.getToken = () => new Promise((resolve) => {
+      resolve('123')
+    })
+    
+    try {
+      fetchMock.mock('http://portal.com/sharing/rest/content/items/abcdef0123456789abcdef0123456789?f=json&token=123', {
+        status: 200,
+        body: {
+          type: 'Feature Service',
+          created: 1592360698651,
+          modified: 1592360698651,
+          url:'https://feature-service.com/FeatureServer'
+        }
+      });
+
+      fetchMock.post('https://feature-service.com/FeatureServer/0', {
+        status: 200,
+        body: {}
+      });
+
+      fetchMock.mock('http://portal.com/sharing/rest/search?f=json&q=type%3A%22Shapefile%22%20AND%20typekeywords%3A%22export%3Aabcdef0123456789abcdef0123456789%2CspatialRefId%3Aundefined%2CexportFormat%3AShapefile%22&num=1&sortField=modified&sortOrder=DESC&token=123', {
+        status: 200,
+        body: {
+          results: []
+        }
+      });
+
+      const result = await requestDownloadMetadata({
+        datasetId: 'abcdef0123456789abcdef0123456789',
+        format: 'Shapefile',
+        authentication,
+        target: 'portal'
+      });
+
+      expect(result).toEqual({
+        downloadId: 'abcdef0123456789abcdef0123456789:Shapefile:undefined:undefined:undefined',
+        lastEditDate: undefined,
+        status: 'not_ready',
+      });
+    } catch (err) {
+      expect(err).toEqual(undefined);
+    } finally {
+      done();
+    }
+  });
+});

--- a/packages/downloads/test/request-download-metadata.test.ts
+++ b/packages/downloads/test/request-download-metadata.test.ts
@@ -91,7 +91,7 @@ describe("requestDownloadMetadata", () => {
         body: {}
       });
 
-      fetchMock.mock('http://portal.com/sharing/rest/search?f=json&q=type%3A%22Shapefile%22%20AND%20typekeywords%3A%22export%3Aabcdef0123456789abcdef0123456789%2CspatialRefId%3Aundefined%2CexportFormat%3AShapefile%22&num=1&sortField=modified&sortOrder=DESC&token=123', {
+      fetchMock.mock('http://portal.com/sharing/rest/search?f=json&q=type%3A%22Shapefile%22%20AND%20typekeywords%3A%22export%3Aabcdef0123456789abcdef0123456789%2CexportFormat%3AShapefile%22&num=1&sortField=modified&sortOrder=DESC&token=123', {
         status: 200,
         body: {
           results: []

--- a/packages/downloads/test/request-download-metadata.test.ts
+++ b/packages/downloads/test/request-download-metadata.test.ts
@@ -91,7 +91,7 @@ describe("requestDownloadMetadata", () => {
         body: {}
       });
 
-      fetchMock.mock('http://portal.com/sharing/rest/search?f=json&q=type%3A%22Shapefile%22%20AND%20typekeywords%3A%22export%3Aabcdef0123456789abcdef0123456789%2CexportFormat%3AShapefile%22&num=1&sortField=modified&sortOrder=DESC&token=123', {
+      fetchMock.mock('http://portal.com/sharing/rest/search?f=json&q=type%3A%22Shapefile%22%20AND%20typekeywords%3A%22export%3Aabcdef0123456789abcdef0123456789%2CexportFormat%3AShapefile%2CspatialRefId%3A2227%22&num=1&sortField=modified&sortOrder=DESC&token=123', {
         status: 200,
         body: {
           results: []
@@ -102,11 +102,12 @@ describe("requestDownloadMetadata", () => {
         datasetId: 'abcdef0123456789abcdef0123456789',
         format: 'Shapefile',
         authentication,
-        target: 'portal'
+        target: 'portal',
+        spatialRefId: '2227'
       });
 
       expect(result).toEqual({
-        downloadId: 'abcdef0123456789abcdef0123456789:Shapefile:undefined:undefined:undefined',
+        downloadId: 'abcdef0123456789abcdef0123456789:Shapefile:2227:undefined:undefined',
         lastEditDate: undefined,
         status: 'not_ready',
       });

--- a/packages/downloads/test/utils.test.ts
+++ b/packages/downloads/test/utils.test.ts
@@ -1,0 +1,23 @@
+import { urlBuilder } from "../src/utils";
+
+describe("utils", () => {
+  describe("urlBuilder", () => {
+    it('should build url without query params', done => {
+      const result = urlBuilder({ host: 'https://test.com', route: '/foo/bar' });
+      expect(result).toEqual('https://test.com/foo/bar');
+      done();
+    });
+
+    it('should build url with query params', done => {
+      const result = urlBuilder({ host: 'https://test.com', route: '/foo/bar', query: { hello: 'world' } });
+      expect(result).toEqual('https://test.com/foo/bar?hello=world');
+      done();
+    });
+
+    it('should build url when host', done => {
+      const result = urlBuilder({ host: 'https://test.com/', route: '/foo/bar'});
+      expect(result).toEqual('https://test.com/foo/bar');
+      done();
+    });
+  });
+})

--- a/packages/downloads/test/utils.test.ts
+++ b/packages/downloads/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { urlBuilder } from "../src/utils";
+import { urlBuilder, composeDownloadId } from "../src/utils";
 
 describe("utils", () => {
   describe("urlBuilder", () => {
@@ -20,4 +20,27 @@ describe("utils", () => {
       done();
     });
   });
+
+  describe("composeDownloadId", () => {
+    it('should compose download ID with all parameters defined', done => {
+      const result = composeDownloadId({
+        datasetId: 'abc',
+        format: 'efg',
+        spatialRefId: '1234',
+        geometry: 'geom-envelope',
+        where: '1=1'
+      });
+      expect(result).toEqual('abc:efg:1234:geom-envelope:1=1');
+      done();
+    })
+
+    it('should compose download ID with optional parameters undefined', done => {
+      const result = composeDownloadId({
+        datasetId: 'abc',
+        format: 'efg',
+      });
+      expect(result).toEqual('abc:efg:undefined:undefined:undefined');
+      done();
+    })
+  })
 })

--- a/packages/downloads/tsconfig.json
+++ b/packages/downloads/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": [
+        "src/**/*.ts"
+    ]
+}


### PR DESCRIPTION
Adds downloads package with methods for:
* getting metadata for a particular dataset download file from Hub API or Portal API (private/enterprise datasets)
* requesting the export of a dataset to a particular download file format from Hub API or Portal API (private/enterprise datasets)
* polling the status of download export from Hub API or Portal API (private/enterprise datasets)