### PR TITLE
138621 - Don't share survey feature service from setAccess method

### DIFF
--- a/packages/surveys/src/sharing/set-access.ts
+++ b/packages/surveys/src/sharing/set-access.ts
@@ -20,8 +20,8 @@ export const setAccess = (
   requestOptions: IRequestOptions
 ): Promise<any[]> => {
   return getSurveyModels(formId, requestOptions)
-    .then(({ form, featureService, fieldworker }) => {
-      const modelsToChangeAccess = [form, featureService];
+    .then(({ form, fieldworker }) => {
+      const modelsToChangeAccess = [form];
       if (isPublished(form.item)) {
         modelsToChangeAccess.push(fieldworker);
       }

--- a/packages/surveys/test/sharing/set-access.test.ts
+++ b/packages/surveys/test/sharing/set-access.test.ts
@@ -44,11 +44,6 @@ describe("setAccess", function () {
       },
       {
         status: "fullfilled",
-        revert: () => Promise.resolve("featureService"),
-        results: { notSharedWith: [], itemId: featureServiceModel.item.id }
-      },
-      {
-        status: "fullfilled",
         revert: () => Promise.resolve("fieldworker"),
         results: { notSharedWith: [], itemId: fieldworkerModel.item.id }
       }
@@ -75,10 +70,9 @@ describe("setAccess", function () {
     expect(getSurveyModelsSpy.calls.argsFor(0)).toEqual([FormItemPublished.id, requestOptions]);
     expect(isPublishedSpy.calls.count()).toBe(1);
     expect(isPublishedSpy.calls.argsFor(0)).toEqual([formModel.item]);
-    expect(setAccessRevertableSpy.calls.count()).toBe(3);
+    expect(setAccessRevertableSpy.calls.count()).toBe(2);
     expect(setAccessRevertableSpy.calls.argsFor(0)).toEqual([formModel, "public", requestOptions]);
-    expect(setAccessRevertableSpy.calls.argsFor(1)).toEqual([featureServiceModel, "public", requestOptions]);
-    expect(setAccessRevertableSpy.calls.argsFor(2)).toEqual([fieldworkerModel, "public", requestOptions]);
+    expect(setAccessRevertableSpy.calls.argsFor(1)).toEqual([fieldworkerModel, "public", requestOptions]);
     expect(processRevertableTasksSpy.calls.count()).toBe(1);
     expect(processRevertableTasksSpy.calls.argsFor(0)).toEqual([setAccessRevertablePromiseResults]);
     expect(results).toEqual(processRevertableTasksResults);
@@ -101,9 +95,8 @@ describe("setAccess", function () {
     expect(getSurveyModelsSpy.calls.argsFor(0)).toEqual([FormItemPublished.id, requestOptions]);
     expect(isPublishedSpy.calls.count()).toBe(1);
     expect(isPublishedSpy.calls.argsFor(0)).toEqual([formModel.item]);
-    expect(setAccessRevertableSpy.calls.count()).toBe(2);
+    expect(setAccessRevertableSpy.calls.count()).toBe(1);
     expect(setAccessRevertableSpy.calls.argsFor(0)).toEqual([formModel, "public", requestOptions]);
-    expect(setAccessRevertableSpy.calls.argsFor(1)).toEqual([featureServiceModel, "public", requestOptions]);
     expect(processRevertableTasksSpy.calls.count()).toBe(1);
     expect(processRevertableTasksSpy.calls.argsFor(0)).toEqual([setAccessRevertablePromiseResults]);
     expect(results).toEqual(processRevertableTasksResults);
@@ -131,9 +124,8 @@ describe("setAccess", function () {
     expect(getSurveyModelsSpy.calls.argsFor(0)).toEqual([FormItemPublished.id, requestOptions]);
     expect(isPublishedSpy.calls.count()).toBe(1);
     expect(isPublishedSpy.calls.argsFor(0)).toEqual([formModel.item]);
-    expect(setAccessRevertableSpy.calls.count()).toBe(2);
+    expect(setAccessRevertableSpy.calls.count()).toBe(1);
     expect(setAccessRevertableSpy.calls.argsFor(0)).toEqual([formModel, "public", requestOptions]);
-    expect(setAccessRevertableSpy.calls.argsFor(1)).toEqual([featureServiceModel, "public", requestOptions]);
     expect(processRevertableTasksSpy.calls.count()).toBe(1);
     expect(processRevertableTasksSpy.calls.argsFor(0)).toEqual([setAccessRevertablePromiseResults]);
     expect(results).toEqual(processRevertableTasksResults);
@@ -156,10 +148,9 @@ describe("setAccess", function () {
       expect(getSurveyModelsSpy.calls.argsFor(0)).toEqual([FormItemPublished.id, requestOptions]);
       expect(isPublishedSpy.calls.count()).toBe(1);
       expect(isPublishedSpy.calls.argsFor(0)).toEqual([formModel.item]);
-      expect(setAccessRevertableSpy.calls.count()).toBe(3);
+      expect(setAccessRevertableSpy.calls.count()).toBe(2);
       expect(setAccessRevertableSpy.calls.argsFor(0)).toEqual([formModel, "public", requestOptions]);
-      expect(setAccessRevertableSpy.calls.argsFor(1)).toEqual([featureServiceModel, "public", requestOptions]);
-      expect(setAccessRevertableSpy.calls.argsFor(2)).toEqual([fieldworkerModel, "public", requestOptions]);
+      expect(setAccessRevertableSpy.calls.argsFor(1)).toEqual([fieldworkerModel, "public", requestOptions]);
       expect(processRevertableTasksSpy.calls.count()).toBe(1);
       expect(processRevertableTasksSpy.calls.argsFor(0)).toEqual([setAccessRevertablePromiseResults]);
       expect(e).toEqual(new Error(`Failed to set survey ${formModel.item.id} items access to public`));


### PR DESCRIPTION
[138621](https://esriarlington.tpondemand.com/entity/138621-owneradmin-can-set-sharing-level-for)

The `setAccess` method should only update access for the `Form` and `Fieldworker`, if it exists.