### PR TITLE
c/141567 changed Hub Page and Site Page types to Site types from Document

### DIFF
--- a/packages/common/src/categories.ts
+++ b/packages/common/src/categories.ts
@@ -32,8 +32,6 @@ const dataset: string[] = [
 const document: string[] = [
   "CAD Drawing",
   "Document Link",
-  "Hub Page",
-  "Site Page",
   "Image",
   "iWork Keynote",
   "iWork Numbers",
@@ -114,7 +112,7 @@ const other: string[] = [
   "Workflow Manager Package"
 ];
 
-const site: string[] = ["Hub Site Application", "Site Application"];
+const site: string[] = ["Hub Site Application", "Site Application", "Hub Page", "Site Page"];
 
 // eligible types are listed here: http://doc.arcgis.com/en/arcgis-online/reference/supported-items.htm
 const downloadableTypes: string[] = [

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -26,7 +26,9 @@ describe("getTypes", () => {
   it("can get a list of types for a category", () => {
     expect(getTypes("site")).toEqual([
       "Hub Site Application",
-      "Site Application"
+      "Site Application",
+      "Hub Page", 
+      "Site Page"
     ]);
   });
 });

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -18,7 +18,7 @@
     "@esri/arcgis-rest-portal": "^2.6.1",
     "@esri/arcgis-rest-request": "^2.13.0",
     "@esri/arcgis-rest-types": "^2.13.0",
-    "@esri/hub-common": "^4.0.0"
+    "@esri/hub-common": "^6.0.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^2.13.0",

--- a/packages/search/test/ago/encode-ago-query.test.ts
+++ b/packages/search/test/ago/encode-ago-query.test.ts
@@ -62,7 +62,7 @@ describe("encodeAgoQuery test", () => {
     const params: any = {
       q: "",
       groupIds: "6f063f2d05824bd898ca0d5089d93614",
-      type: "hub page",
+      type: "document link",
       collection: "Document",
       sort: "relevance",
       agg: {
@@ -74,7 +74,7 @@ describe("encodeAgoQuery test", () => {
     const actual = encodeAgoQuery(params);
     const expected = {
       q:
-        '-type:"code attachment" AND ((group:"6f063f2d05824bd898ca0d5089d93614") OR (id:"4dd789d0c75a4ebb8805b1314c1cc974")) AND ((type:"hub page") AND (type:"CAD Drawing" OR type:"Document Link" OR type:"Hub Page" OR type:"Site Page" OR type:"Image" OR type:"iWork Keynote" OR type:"iWork Numbers" OR type:"iWork Pages" OR type:"Microsoft Powerpoint" OR type:"Microsoft Visio" OR type:"Microsoft Word" OR type:"PDF" OR type:"Pro Map" OR type:"Report Template"))',
+        '-type:"code attachment" AND ((group:"6f063f2d05824bd898ca0d5089d93614") OR (id:"4dd789d0c75a4ebb8805b1314c1cc974")) AND ((type:"document link") AND (type:"CAD Drawing" OR type:"Document Link" OR type:"Image" OR type:"iWork Keynote" OR type:"iWork Numbers" OR type:"iWork Pages" OR type:"Microsoft Powerpoint" OR type:"Microsoft Visio" OR type:"Microsoft Word" OR type:"PDF" OR type:"Pro Map" OR type:"Report Template"))',
       start: 1,
       num: 10,
       countFields: "tags,type,access",

--- a/packages/search/test/ago/helpers/filters/collection.test.ts
+++ b/packages/search/test/ago/helpers/filters/collection.test.ts
@@ -9,7 +9,7 @@ describe("collection test", () => {
       }
     };
     const expected =
-      '(type:"CSV Collection" OR type:"CSV" OR type:"Feature Collection Template" OR type:"Feature Collection" OR type:"Feature Layer" OR type:"Feature Service" OR type:"File Geodatabase" OR type:"GeoJSON" OR type:"GeoJson" OR type:"KML Collection" OR type:"KML" OR type:"Microsoft Excel" OR type:"Raster Layer" OR type:"Shapefile" OR type:"Stream Service" OR type:"Table" OR type:"CAD Drawing" OR type:"Document Link" OR type:"Hub Page" OR type:"Site Page" OR type:"Image" OR type:"iWork Keynote" OR type:"iWork Numbers" OR type:"iWork Pages" OR type:"Microsoft Powerpoint" OR type:"Microsoft Visio" OR type:"Microsoft Word" OR type:"PDF" OR type:"Pro Map" OR type:"Report Template")';
+      '(type:"CSV Collection" OR type:"CSV" OR type:"Feature Collection Template" OR type:"Feature Collection" OR type:"Feature Layer" OR type:"Feature Service" OR type:"File Geodatabase" OR type:"GeoJSON" OR type:"GeoJson" OR type:"KML Collection" OR type:"KML" OR type:"Microsoft Excel" OR type:"Raster Layer" OR type:"Shapefile" OR type:"Stream Service" OR type:"Table" OR type:"CAD Drawing" OR type:"Document Link" OR type:"Image" OR type:"iWork Keynote" OR type:"iWork Numbers" OR type:"iWork Pages" OR type:"Microsoft Powerpoint" OR type:"Microsoft Visio" OR type:"Microsoft Word" OR type:"PDF" OR type:"Pro Map" OR type:"Report Template")';
     expect(collectionFilter(queryFilters)).toBe(expected);
   });
 
@@ -27,7 +27,7 @@ describe("collection test", () => {
       }
     };
     const expected =
-      '(type:"CSV Collection" OR type:"CSV" OR type:"Feature Collection Template" OR type:"Feature Collection" OR type:"Feature Layer" OR type:"Feature Service" OR type:"File Geodatabase" OR type:"GeoJSON" OR type:"GeoJson" OR type:"KML Collection" OR type:"KML" OR type:"Microsoft Excel" OR type:"Raster Layer" OR type:"Shapefile" OR type:"Stream Service" OR type:"Table" OR type:"CAD Drawing" OR type:"Document Link" OR type:"Hub Page" OR type:"Site Page" OR type:"Image" OR type:"iWork Keynote" OR type:"iWork Numbers" OR type:"iWork Pages" OR type:"Microsoft Powerpoint" OR type:"Microsoft Visio" OR type:"Microsoft Word" OR type:"PDF" OR type:"Pro Map" OR type:"Report Template")';
+      '(type:"CSV Collection" OR type:"CSV" OR type:"Feature Collection Template" OR type:"Feature Collection" OR type:"Feature Layer" OR type:"Feature Service" OR type:"File Geodatabase" OR type:"GeoJSON" OR type:"GeoJson" OR type:"KML Collection" OR type:"KML" OR type:"Microsoft Excel" OR type:"Raster Layer" OR type:"Shapefile" OR type:"Stream Service" OR type:"Table" OR type:"CAD Drawing" OR type:"Document Link" OR type:"Image" OR type:"iWork Keynote" OR type:"iWork Numbers" OR type:"iWork Pages" OR type:"Microsoft Powerpoint" OR type:"Microsoft Visio" OR type:"Microsoft Word" OR type:"PDF" OR type:"Pro Map" OR type:"Report Template")';
     expect(collectionFilter(queryFilters)).toBe(expected);
   });
 


### PR DESCRIPTION
https://esriarlington.tpondemand.com/entity/141567-chore-move-pages-into-initiatives-collection

Hub Pages currently exist under documents but should exist under the 'sites' collection. This PR contains a change to move these under 'sites'