### PR TITLE
141783 - Fix JS error that when no feature service resolves in getSur…

### DIFF
--- a/packages/surveys/src/items/get-survey-models.ts
+++ b/packages/surveys/src/items/get-survey-models.ts
@@ -41,7 +41,7 @@ export const getSurveyModels = (
         .then(([featureServiceOrFieldworkerModelResult, stakeholderResult]) => {
           stakeholder = stakeholderResult;
 
-          if (isFieldworkerView(featureServiceOrFieldworkerModelResult.item)) {
+          if (featureServiceOrFieldworkerModelResult && isFieldworkerView(featureServiceOrFieldworkerModelResult.item)) {
             fieldworker = featureServiceOrFieldworkerModelResult;
             // if the primary input is the fieldworker, fetch
             // the source feature service

--- a/packages/surveys/test/items/get-survey-models.test.ts
+++ b/packages/surveys/test/items/get-survey-models.test.ts
@@ -15,7 +15,7 @@ import * as getSourceFeatureServiceModelFromFieldworker from "../../src/items/ge
 import * as getStakeholderModel from "../../src/items/get-stakeholder-model";
 import { IRequestOptions } from "@esri/hub-common/node_modules/@esri/arcgis-rest-request";
 
-describe("getSurveyModels", function () {
+fdescribe("getSurveyModels", function () {
   let formModel: IModel;
   let featureServiceModel: IModel;
   let fieldworkerModel: IModel;
@@ -53,7 +53,7 @@ describe("getSurveyModels", function () {
     expect(results.stakeholder).toEqual(stakeholderModel);
   });
 
-  it("does not attempt to fetch the feature service when a fieldworker is absent", async function () {
+  it("does not attempt to fetch the feature service when the feature service is resolved from getInputFeatureServiceModel", async function () {
     const getItemStub = spyOn(restPortal, "getItem").and.returnValue(Promise.resolve(FormItemPublished));
     const isFieldworkerViewSpy = spyOn(isFieldworkerView, "isFieldworkerView").and.returnValue(false);
     const getInputFeatureServiceModelSpy = spyOn(getInputFeatureServiceModel, "getInputFeatureServiceModel").and.returnValue(Promise.resolve(featureServiceModel));
@@ -71,6 +71,27 @@ describe("getSurveyModels", function () {
     expect(getStakeholderModelSpy.calls.argsFor(0)).toEqual([FormItemPublished.id, requestOptions]);
     expect(results.form).toEqual(formModel);
     expect(results.featureService).toEqual(featureServiceModel);
+    expect(results.fieldworker).toBeUndefined();
+    expect(results.stakeholder).toBeUndefined();
+  });
+
+  it("does not attempt to fetch the feature service when nothing is resolved from getInputFeatureServiceModel", async function () {
+    const getItemStub = spyOn(restPortal, "getItem").and.returnValue(Promise.resolve(FormItemPublished));
+    const isFieldworkerViewSpy = spyOn(isFieldworkerView, "isFieldworkerView").and.returnValue(false);
+    const getInputFeatureServiceModelSpy = spyOn(getInputFeatureServiceModel, "getInputFeatureServiceModel").and.returnValue(Promise.resolve());
+    const getSourceFeatureServiceModelFromFieldworkerSpy = spyOn(getSourceFeatureServiceModelFromFieldworker, "getSourceFeatureServiceModelFromFieldworker");
+    const getStakeholderModelSpy = spyOn(getStakeholderModel, "getStakeholderModel").and.returnValue(Promise.resolve());
+    const results = await getSurveyModels(formModel.item.id, requestOptions);
+    expect(getItemStub.calls.count()).toBe(1);
+    expect(getItemStub.calls.argsFor(0)).toEqual([FormItemPublished.id, requestOptions]);
+    expect(getInputFeatureServiceModelSpy.calls.count()).toBe(1);
+    expect(getInputFeatureServiceModelSpy.calls.argsFor(0)).toEqual([formModel.item.id, requestOptions]);
+    expect(getSourceFeatureServiceModelFromFieldworkerSpy.calls.count()).toBe(0);
+    expect(isFieldworkerViewSpy.calls.count()).toBe(0);
+    expect(getStakeholderModelSpy.calls.count()).toBe(1);
+    expect(getStakeholderModelSpy.calls.argsFor(0)).toEqual([FormItemPublished.id, requestOptions]);
+    expect(results.form).toEqual(formModel);
+    expect(results.featureService).toBeUndefined();
     expect(results.fieldworker).toBeUndefined();
     expect(results.stakeholder).toBeUndefined();
   });

--- a/packages/surveys/test/items/get-survey-models.test.ts
+++ b/packages/surveys/test/items/get-survey-models.test.ts
@@ -15,7 +15,7 @@ import * as getSourceFeatureServiceModelFromFieldworker from "../../src/items/ge
 import * as getStakeholderModel from "../../src/items/get-stakeholder-model";
 import { IRequestOptions } from "@esri/hub-common/node_modules/@esri/arcgis-rest-request";
 
-fdescribe("getSurveyModels", function () {
+describe("getSurveyModels", function () {
   let formModel: IModel;
   let featureServiceModel: IModel;
   let fieldworkerModel: IModel;


### PR DESCRIPTION
…veyModels method

[141783](https://esriarlington.tpondemand.com/entity/141783-collaborators-can-use-sharing-quick-actions)

This prevents an error when only the `Form` item is accessible, e.g. the `Form` is shared _publicly_ while the related `Feature Service`, `Fieldworker`, and `Stakeholder` are shared _privately_. Previously the `getSurveyModels` model _assumed_ it would receive either a `Fieldworker` or `Feature Service`, this PR accounts for the possibility that neither will be accessible.