### PR TITLE
fix(cloneObject): fix cloneObject's handling of Date properties

### DIFF
--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -19,10 +19,15 @@ export function cloneObject<T>(obj: T): T {
     clone = obj.map(cloneObject);
   } else if (typeof obj === "object") {
     for (const i in obj) {
-      if (obj[i] != null && typeof obj[i] === "object") {
-        clone[i] = cloneObject(obj[i]);
-      } else {
-        clone[i] = obj[i];
+      /* istanbul ignore next no need to deal w/ other side of hasOwnProperty() */
+      if (obj.hasOwnProperty(i)) {
+        const value = obj[i];
+        const isDate = value instanceof Date;
+        if (value != null && typeof value === "object" && !isDate) {
+          clone[i] = cloneObject(value);
+        } else {
+          clone[i] = value;
+        }
       }
     }
   } else {

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -22,9 +22,12 @@ export function cloneObject<T>(obj: T): T {
       /* istanbul ignore next no need to deal w/ other side of hasOwnProperty() */
       if (obj.hasOwnProperty(i)) {
         const value = obj[i];
-        const isDate = value instanceof Date;
-        if (value != null && typeof value === "object" && !isDate) {
-          clone[i] = cloneObject(value);
+        if (value != null && typeof value === "object") {
+          if (value instanceof Date) {
+            clone[i] = new Date(value.getTime())
+          } else {
+            clone[i] = cloneObject(value);
+          }
         } else {
           clone[i] = value;
         }

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -21,12 +21,13 @@ describe("util functions", () => {
   it("can clone a shallow object", () => {
     const obj = {
       color: "red",
-      length: 12
+      length: 12,
+      startDate: new Date()
     } as any;
     const c = cloneObject(obj);
     expect(c).not.toBe(obj);
 
-    ["color", "length"].map(prop => {
+    ["color", "length", "startDate"].map(prop => {
       expect(c[prop]).toEqual(obj[prop]);
     });
   });

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -30,6 +30,8 @@ describe("util functions", () => {
     ["color", "length", "startDate"].map(prop => {
       expect(c[prop]).toEqual(obj[prop]);
     });
+    // should have created a new Date object
+    expect(c["startDate"]).not.toBe(obj["startDate"]);
   });
 
   it("can clone a deep object", () => {


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/hub-common

ISSUES CLOSED: #309