### PR TITLE
Fix CDN Guide and Doc Publishing Base Url

### DIFF
--- a/docs/src/guides/from-a-cdn.md
+++ b/docs/src/guides/from-a-cdn.md
@@ -32,17 +32,16 @@ group: 1-get-started
   <!-- require @esri/hub.js libraries from https://unpkg.com too -->
   <script src="{% cdnUrl data.typedoc | findPackage('@esri/hub-common') %}"></script>
   <script src="{% cdnUrl data.typedoc | findPackage('@esri/hub-sites') %}"></script>
-  <script src="{% cdnUrl data.typedoc | findPackage('@esri/hub-initiatives') %}"></script>
+  
 
   <script>
     // all exports are available from an arcgisHub global
-    arcgisHub.searchInitiatives({
-      q: "Share Open Data"
-    })
-      .then(response => {
-        arcgisHub.getInitiative(response.results[0].id).then(response => {
-          console.log(response);
-        });
+    arcgisHub.lookupDomain('coronavirus-resources.esri.com', {isPortal: false})
+    .then(response => {
+      console.log(response);
+      arcgisHub.getSiteById(response.siteId).then(response => {
+        console.log(response);
       });
+    });
   </script>
 </html>

--- a/support/deploy-doc-site.js
+++ b/support/deploy-doc-site.js
@@ -1,7 +1,7 @@
 const ghpages = require("gh-pages");
 
 ghpages.publish(
-  "docs/build",
+  "docs/build/hub.js",
   {
     branch: "gh-pages",
     repo: "https://github.com/Esri/hub.js.git"


### PR DESCRIPTION
Fitlering out the initiatives package from the tsdoc broke the cdn guide page, so I changed the example to use a few functions from the sites package.

I then re-built and deployed the docs, but found that i had to change the ghpages.publish call to publish `docs/build/hub.js` otherwise the gh-pages branch would have `/hub.js` as it's root, changing the doc url to `https://esri.github.io/hub.js/hub.js` instead of just `https://esri.github.io/hub.js/`

This seems baffling as I don't see any other recent changes that would have changed the doc build output location... but reading the `travis.yml` file I *think* CI will be fine as it does not actually use the `deploy-doc-site.sh` script

