### PR TITLE
Add Site ID to Initiative if it was created with the Site

### DIFF
--- a/packages/initiatives/src/activate.ts
+++ b/packages/initiatives/src/activate.ts
@@ -27,6 +27,7 @@ import { getProp } from "@esri/hub-common";
  * @param {any} groupIds hash of group props and ids
  * @param {IRequestOptions} requestOptions
  * @returns {Promise<IInitiativeModel>}
+ * @private
  */
 export function activateInitiative(
   template: string | any,

--- a/packages/initiatives/src/index.ts
+++ b/packages/initiatives/src/index.ts
@@ -19,3 +19,4 @@ export { geometryService };
 export * from "./_fetch-and-convert-initiative-to-template";
 export * from "./get-default-initiative-template";
 export * from "./get-initiative-template";
+export * from "./update-initiative-site-id";

--- a/packages/initiatives/src/update-initiative-site-id.ts
+++ b/packages/initiatives/src/update-initiative-site-id.ts
@@ -1,0 +1,62 @@
+/* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import { IItem } from "@esri/arcgis-rest-portal";
+import { IModel, IHubRequestOptions, getProp, isGuid } from "@esri/hub-common";
+import { updateItem, getItem } from "@esri/arcgis-rest-portal";
+
+/**
+ * Update the Site associated with an Initiative by setting the
+ * `item.properties.siteId` to a new value
+ *
+ * Used during createSite(...) and any time we need to
+ * connect a different Site to an Initiative
+ *
+ * @param initiativeItemId string | IItem | IModel
+ * @param siteId string
+ * @param hubRequestOptions IHubRequestOptions
+ */
+export function updateInitiativeSiteId(
+  maybeModel: string | IItem | IModel,
+  siteId: string,
+  hubRequestOptions: IHubRequestOptions
+): Promise<any> {
+  // assume it's an IItem
+  let itemPromise = Promise.resolve(maybeModel);
+
+  // if we got a string, treat it as an id
+  if (typeof maybeModel === "string") {
+    if (!isGuid(maybeModel)) {
+      return Promise.reject(
+        new Error(
+          "updateInitiativeSiteId was passed a string that is not a GUID."
+        )
+      );
+    } else {
+      itemPromise = getItem(maybeModel, {
+        authentication: hubRequestOptions.authentication
+      });
+    }
+  } else {
+    // if it's an IModel it will have `.item.id` defined
+    if (getProp(maybeModel as IModel, "item.id")) {
+      const m = maybeModel as IModel;
+      itemPromise = Promise.resolve(m.item);
+    }
+  }
+
+  // kick off the promise that will return an IItem
+  return itemPromise.then((item: any) => {
+    // oddly, IItem does not have .properties even as an optional O_o
+    // regardless, ensure .properties exists
+    if (!item.properties) {
+      item.properties = {};
+    }
+    // set the siteId
+    item.properties.siteId = siteId;
+    // and... update the item
+    return updateItem({
+      item,
+      authentication: hubRequestOptions.authentication
+    });
+  });
+}

--- a/packages/initiatives/test/mocks/fake-session.ts
+++ b/packages/initiatives/test/mocks/fake-session.ts
@@ -2,6 +2,7 @@
  * Apache-2.0 */
 
 import { UserSession } from "@esri/arcgis-rest-auth";
+import { IHubRequestOptions } from "@esri/hub-common";
 // Fake Session for use in tests...
 
 export const TOMORROW = (function() {
@@ -20,3 +21,14 @@ export const MOCK_USER_SESSION = new UserSession({
 export const MOCK_REQUEST_OPTIONS = {
   authentication: MOCK_USER_SESSION
 };
+
+export const MOCK_HUB_REQOPTS = ({
+  authentication: MOCK_USER_SESSION,
+  portalSelf: {
+    id: "orgIdFromPortalSelf",
+    name: "my spiffy org",
+    urlKey: "org"
+  },
+  isPortal: false,
+  hubApiUrl: "https://hubqa.arcgis.com"
+} as unknown) as IHubRequestOptions;

--- a/packages/initiatives/test/update-initiative-site-id.test.ts
+++ b/packages/initiatives/test/update-initiative-site-id.test.ts
@@ -3,7 +3,7 @@
 
 import { updateInitiativeSiteId } from "../src/update-initiative-site-id";
 import { MOCK_HUB_REQOPTS } from "./mocks/fake-session";
-import * as fetchMock from "../../../docs/node_modules/fetch-mock";
+import * as fetchMock from "fetch-mock";
 import { IItem } from "@esri/arcgis-rest-portal";
 import { IModel } from "@esri/hub-common";
 const apiBaseUrl = "https://www.arcgis.com/sharing/rest";

--- a/packages/initiatives/test/update-initiative-site-id.test.ts
+++ b/packages/initiatives/test/update-initiative-site-id.test.ts
@@ -1,0 +1,176 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { updateInitiativeSiteId } from "../src/update-initiative-site-id";
+import { MOCK_HUB_REQOPTS } from "./mocks/fake-session";
+import * as fetchMock from "../../../docs/node_modules/fetch-mock";
+import { IItem } from "@esri/arcgis-rest-portal";
+import { IModel } from "@esri/hub-common";
+const apiBaseUrl = "https://www.arcgis.com/sharing/rest";
+const itemBaseUrl = `${apiBaseUrl}/content/items`;
+const userItemBaseUrl = `${apiBaseUrl}/content/users`;
+
+function bodyToJson(body: string): any {
+  return body.split("&").reduce((acc: any, entry: string) => {
+    const [key, val] = entry.split("=");
+    if (key && val) {
+      if (!acc.hasOwnProperty(key)) {
+        acc[key] = decodeURIComponent(val);
+      }
+    }
+    return acc;
+  }, {});
+}
+
+describe("update-initiative-site-id ::", () => {
+  afterEach(fetchMock.restore);
+  describe("accepts a string ::", () => {
+    it("should throw if string is not a guid", done => {
+      return updateInitiativeSiteId("bargle", "3ef", MOCK_HUB_REQOPTS).catch(
+        ex => {
+          expect(ex.message).toBe(
+            "updateInitiativeSiteId was passed a string that is not a GUID.",
+            "should throw when non-guid passed"
+          );
+          done();
+        }
+      );
+    });
+    it("should fetch the item and update it", () => {
+      const m = {
+        item: {
+          id: "c90c8745f1854420b1c23e407941fd45",
+          title: "Fake initiative 1",
+          type: "Hub Initiative"
+        },
+        data: {
+          source: "bc3",
+          values: {}
+        }
+      };
+
+      fetchMock
+        .once(
+          `${itemBaseUrl}/c90c8745f1854420b1c23e407941fd45?f=json&token=fake-token`,
+          m.item
+        )
+        .post(
+          `${userItemBaseUrl}/vader/items/c90c8745f1854420b1c23e407941fd45/update`,
+          { success: true, itemId: "c90c8745f1854420b1c23e407941fd45" }
+        );
+
+      return updateInitiativeSiteId(
+        "c90c8745f1854420b1c23e407941fd45",
+        "3ef",
+        MOCK_HUB_REQOPTS
+      ).then(result => {
+        expect(result.success).toBeTruthy(
+          "should return the update xhr result"
+        );
+        expect(fetchMock.done()).toBeTruthy();
+        const getCall = fetchMock.lastCall(
+          `${itemBaseUrl}/c90c8745f1854420b1c23e407941fd45?f=json&token=fake-token`
+        );
+        const getUrl = getCall[0];
+        expect(getUrl).toContain("f=json");
+        expect(getUrl).toContain("items/c90c8745f1854420b1c23e407941fd45");
+
+        const updateCall = fetchMock.lastCall(
+          `${userItemBaseUrl}/vader/items/c90c8745f1854420b1c23e407941fd45/update`
+        );
+        const updateOptions = updateCall[1];
+        expect(updateOptions.method).toBe("POST");
+        expect(updateOptions.body).toContain("f=json");
+        expect(updateOptions.body).toContain("token=fake-token");
+        const bodyJson = bodyToJson(updateOptions.body as string);
+
+        if (bodyJson.properties) {
+          const props = JSON.parse(bodyJson.properties);
+          expect(props.siteId).toBe("3ef", "properties.siteId should be set");
+        }
+      });
+    });
+  });
+
+  describe("accepts a IItem ::", () => {
+    it("should just update the item", () => {
+      const i = {
+        id: "c90c8745f1854420b1c23e407941fd45",
+        title: "Fake initiative 1",
+        type: "Hub Initiative",
+        properties: {
+          otherProp: "present"
+        }
+      } as IItem;
+      fetchMock.post(
+        `${userItemBaseUrl}/vader/items/c90c8745f1854420b1c23e407941fd45/update`,
+        { success: true, itemId: "c90c8745f1854420b1c23e407941fd45" }
+      );
+
+      return updateInitiativeSiteId(i, "3ef", MOCK_HUB_REQOPTS).then(result => {
+        expect(result.success).toBeTruthy(
+          "should return the update xhr result"
+        );
+        expect(fetchMock.done()).toBeTruthy();
+
+        const updateCall = fetchMock.lastCall(
+          `${userItemBaseUrl}/vader/items/c90c8745f1854420b1c23e407941fd45/update`
+        );
+        const updateOptions = updateCall[1];
+        expect(updateOptions.method).toBe("POST");
+        expect(updateOptions.body).toContain("f=json");
+        expect(updateOptions.body).toContain("token=fake-token");
+        const bodyJson = bodyToJson(updateOptions.body as string);
+        if (bodyJson.properties) {
+          const props = JSON.parse(bodyJson.properties);
+          expect(props.siteId).toBe("3ef", "properties.siteId should be set");
+          expect(props.otherProp).toBe(
+            "present",
+            "existing properties should be kept"
+          );
+        }
+      });
+    });
+  });
+
+  describe("accepts a IModel ::", () => {
+    it("should extract the item and update it", () => {
+      const m = {
+        item: {
+          id: "c90c8745f1854420b1c23e407941fd45",
+          title: "Fake initiative 1",
+          type: "Hub Initiative"
+        } as IItem,
+        data: {
+          source: "bc3",
+          values: {}
+        }
+      } as IModel;
+
+      fetchMock.post(
+        `${userItemBaseUrl}/vader/items/c90c8745f1854420b1c23e407941fd45/update`,
+        { success: true, itemId: "c90c8745f1854420b1c23e407941fd45" }
+      );
+
+      return updateInitiativeSiteId(m, "3ef", MOCK_HUB_REQOPTS).then(result => {
+        expect(result.success).toBeTruthy(
+          "should return the update xhr result"
+        );
+        expect(fetchMock.done()).toBeTruthy();
+
+        const updateCall = fetchMock.lastCall(
+          `${userItemBaseUrl}/vader/items/c90c8745f1854420b1c23e407941fd45/update`
+        );
+        const updateOptions = updateCall[1];
+        expect(updateOptions.method).toBe("POST");
+        expect(updateOptions.body).toContain("f=json");
+        expect(updateOptions.body).toContain("token=fake-token");
+        const bodyJson = bodyToJson(updateOptions.body as string);
+        if (bodyJson.properties) {
+          const props = JSON.parse(bodyJson.properties);
+          expect(props.siteId).toBe("3ef", "properties.siteId should be set");
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
Convoluted, but basically when we create a site, if the user has Hub Premium licensing, we also create an Initiative item. But we create that _before_ we create the site item... so we can't interpolate the siteId into the Initiative.

This adds a step to the createSite fn to lookup the initiative and add the siteId to it.

That step is backed by a function that we will use in opendata-ui to "heal" initiatives that do not have a siteId in them