### PR TITLE
getContent() handles slugs

### DIFF
--- a/packages/common/src/request.ts
+++ b/packages/common/src/request.ts
@@ -50,16 +50,26 @@ export function hubApiRequest(
     ...{ "Content-Type": "application/json" },
     ...options.headers
   };
-  // TODO: build query params/body based on requestOptions.params?
+  // build query params/body based on requestOptions.params
+  let query;
+  let body;
+  if (options.httpMethod === "GET") {
+    // pass params in query string
+    query = options.params;
+  } else {
+    // pass params in request body
+    body = JSON.stringify(options.params);
+  }
   // build Hub API URL
   const url = buildUrl({
     host: options.hubApiUrl,
-    path: `/api/v3/${route}`.replace(/\/\//g, "/")
+    path: `/api/v3/${route}`.replace(/\/\//g, "/"),
+    query
   });
   return _fetch(url, {
     method: options.httpMethod,
-    headers
-    // body: JSON.stringify(body)
+    headers,
+    body
   }).then(resp => {
     if (resp.ok) {
       return resp.json();

--- a/packages/common/src/request.ts
+++ b/packages/common/src/request.ts
@@ -37,17 +37,15 @@ export function hubApiRequest(
 ) {
   // merge in default request options
   const options: IHubRequestOptions = {
-    ...{
-      hubApiUrl: "https://opendata.arcgis.com/api/v3/",
-      httpMethod: "GET"
-    },
+    hubApiUrl: "https://opendata.arcgis.com/api/v3/",
+    httpMethod: "GET",
     ...requestOptions
   };
   // use fetch override if any
   const _fetch = options.fetch || fetch;
   // merge in default headers
   const headers = {
-    ...{ "Content-Type": "application/json" },
+    "Content-Type": "application/json",
     ...options.headers
   };
   // build query params/body based on requestOptions.params

--- a/packages/common/test/request.test.ts
+++ b/packages/common/test/request.test.ts
@@ -15,6 +15,24 @@ describe("hubApiRequest", () => {
       done();
     });
   });
-  // NOTE: successful request cases are covered by tests
+  it("stringfies params in the body of POST", done => {
+    fetchMock.once("*", { the: "goods" });
+    hubApiRequest("datasets", {
+      isPortal: false,
+      hubApiUrl: "https://some.url.com/",
+      httpMethod: "POST",
+      authentication: null,
+      params: {
+        foo: "bar"
+      }
+    }).then(response => {
+      const [url, options] = fetchMock.calls()[0];
+      expect(url).toEqual("https://some.url.com/api/v3/datasets");
+      expect(options.body).toBe('{"foo":"bar"}');
+      expect(response.the).toEqual("goods");
+      done();
+    });
+  });
+  // NOTE: additional request cases are covered by tests
   // of functions in other packages that use hubRequest
 });

--- a/packages/content/src/content.ts
+++ b/packages/content/src/content.ts
@@ -2,7 +2,7 @@
  * Apache-2.0 */
 
 import { request } from "@esri/arcgis-rest-request";
-import { IHubContent, IHubRequestOptions } from "@esri/hub-common";
+import { IHubContent } from "@esri/hub-common";
 import { IGetContentOptions, getContentFromHub } from "./hub";
 import { getContentFromPortal } from "./portal";
 import { isSlug } from "./slugs";

--- a/packages/content/src/content.ts
+++ b/packages/content/src/content.ts
@@ -5,25 +5,28 @@ import { request } from "@esri/arcgis-rest-request";
 import { IHubContent, IHubRequestOptions } from "@esri/hub-common";
 import { getContentFromHub } from "./hub";
 import { getContentFromPortal } from "./portal";
+import { isSlug } from "./slugs";
 
 /**
  * Fetch content using either the Hub API or the ArcGIS REST API
- * @param id - content (item) id
+ * @param identifier Hub API slug ({orgKey}::{title-as-slug} or {title-as-slug})
+ * or record id ((itemId}_{layerId} or {itemId})
  * @param requestOptions - request options that may include authentication
  */
 export function getContent(
-  // TODO: this should take a slug as well
-  id: string,
+  identifier: string,
   requestOptions?: IHubRequestOptions
 ): Promise<IHubContent> {
   if (requestOptions && requestOptions.isPortal) {
-    return getContentFromPortal(id, requestOptions);
+    return getContentFromPortal(identifier, requestOptions);
   } else {
-    return getContentFromHub(id, requestOptions).catch(() => {
-      // TODO: inspect error?
+    return getContentFromHub(identifier, requestOptions).catch(e => {
       // dataset is not in index (i.e. might be a private item)
-      // try fetching from portal instead
-      return getContentFromPortal(id, requestOptions);
+      if (!isSlug(identifier)) {
+        // try fetching from portal instead
+        return getContentFromPortal(identifier, requestOptions);
+      }
+      return Promise.reject(e);
     });
   }
 }

--- a/packages/content/src/content.ts
+++ b/packages/content/src/content.ts
@@ -3,7 +3,7 @@
 
 import { request } from "@esri/arcgis-rest-request";
 import { IHubContent, IHubRequestOptions } from "@esri/hub-common";
-import { getContentFromHub } from "./hub";
+import { IGetContentOptions, getContentFromHub } from "./hub";
 import { getContentFromPortal } from "./portal";
 import { isSlug } from "./slugs";
 
@@ -11,20 +11,20 @@ import { isSlug } from "./slugs";
  * Fetch content using either the Hub API or the ArcGIS REST API
  * @param identifier Hub API slug ({orgKey}::{title-as-slug} or {title-as-slug})
  * or record id ((itemId}_{layerId} or {itemId})
- * @param requestOptions - request options that may include authentication
+ * @param options - request options that may include authentication
  */
 export function getContent(
   identifier: string,
-  requestOptions?: IHubRequestOptions
+  options?: IGetContentOptions
 ): Promise<IHubContent> {
-  if (requestOptions && requestOptions.isPortal) {
-    return getContentFromPortal(identifier, requestOptions);
+  if (options && options.isPortal) {
+    return getContentFromPortal(identifier, options);
   } else {
-    return getContentFromHub(identifier, requestOptions).catch(e => {
+    return getContentFromHub(identifier, options).catch(e => {
       // dataset is not in index (i.e. might be a private item)
       if (!isSlug(identifier)) {
         // try fetching from portal instead
-        return getContentFromPortal(identifier, requestOptions);
+        return getContentFromPortal(identifier, options);
       }
       return Promise.reject(e);
     });

--- a/packages/content/src/slugs.ts
+++ b/packages/content/src/slugs.ts
@@ -34,3 +34,18 @@ export function addContextToSlug(slug: string, context: string): string {
     return `${context}::${slug}`;
   }
 }
+
+/**
+ * Remove context (prefix) from a slug
+ *
+ * @param slug Hub API slug with context
+ * @param context usually a portal's orgKey
+ * @returns slug without context
+ */
+export function removeContextFromSlug(slug: string, context: string): string {
+  if (context && slug.match(`${context}::`)) {
+    return slug.split(`${context}::`)[1];
+  } else {
+    return slug;
+  }
+}

--- a/packages/content/src/slugs.ts
+++ b/packages/content/src/slugs.ts
@@ -1,0 +1,19 @@
+import { isGuid } from "@esri/hub-common";
+import { parseDatasetId } from "./hub";
+
+/**
+ * Determine if an identifier is a Hub API slug
+ *
+ * @param identifier Hub API slug ({orgKey}::{title-as-slug} or {title-as-slug})
+ * or record id ((itemId}_{layerId} or {itemId})
+ * @returns true if the identifier is valid _and_ is **not** a record id
+ */
+export function isSlug(identifier: string): boolean {
+  const { itemId } = parseDatasetId(identifier);
+  if (!itemId || isGuid(itemId)) {
+    // it's either invalid, or an item id, or a dataset id
+    return false;
+  }
+  // otherwise assume it's a slug
+  return true;
+}

--- a/packages/content/src/slugs.ts
+++ b/packages/content/src/slugs.ts
@@ -17,3 +17,20 @@ export function isSlug(identifier: string): boolean {
   // otherwise assume it's a slug
   return true;
 }
+
+/**
+ * Add a context (prefix) to slug if it doesn't already have one
+ *
+ * @param slug Hub API slug (with or without context)
+ * @param context usually a portal's orgKey
+ * @returns slug with context ({context}::{slug})
+ */
+export function addContextToSlug(slug: string, context: string): string {
+  // the slug has an org key already e.g. dc::crime-incidents
+  if (/.+::.+/.test(slug)) {
+    return slug;
+    // the slug belongs to the org that owns the site e.g. crime-incidents
+  } else {
+    return `${context}::${slug}`;
+  }
+}

--- a/packages/content/test/content.test.ts
+++ b/packages/content/test/content.test.ts
@@ -22,47 +22,67 @@ describe("get content", () => {
   });
   afterEach(fetchMock.restore);
   describe("from hub", () => {
-    it("should call getContentFromHub", done => {
+    beforeEach(() => {
       requestOpts.isPortal = false;
       requestOpts.portalSelf.isPortal = false;
-      const id = "foo";
-      const getContentFromHubSpy = spyOn(
-        hubModule,
-        "getContentFromHub"
-      ).and.returnValue(Promise.resolve({}));
-      getContent(id, requestOpts).then(() => {
-        expect(getContentFromHubSpy.calls.count()).toBe(1);
-        expect(getContentFromHubSpy.calls.argsFor(0)).toEqual([
-          id,
-          requestOpts
-        ]);
-        done();
+    });
+    describe("with an id", () => {
+      const id = "7a153563b0c74f7eb2b3eae8a66f2fbb";
+      it("should call getContentFromHub", done => {
+        const getContentFromHubSpy = spyOn(
+          hubModule,
+          "getContentFromHub"
+        ).and.returnValue(Promise.resolve({}));
+        getContent(id, requestOpts).then(() => {
+          expect(getContentFromHubSpy.calls.count()).toBe(1);
+          expect(getContentFromHubSpy.calls.argsFor(0)).toEqual([
+            id,
+            requestOpts
+          ]);
+          done();
+        });
+      });
+      it("handles private items", done => {
+        const getContentFromHubSpy = spyOn(
+          hubModule,
+          "getContentFromHub"
+        ).and.returnValue(Promise.reject({}));
+        const getContentFromPortalSpy = spyOn(
+          portalModule,
+          "getContentFromPortal"
+        ).and.returnValue(Promise.resolve({}));
+        getContent(id, requestOpts).then(() => {
+          expect(getContentFromHubSpy.calls.count()).toBe(1);
+          expect(getContentFromHubSpy.calls.argsFor(0)).toEqual([
+            id,
+            requestOpts
+          ]);
+          expect(getContentFromPortalSpy.calls.count()).toBe(1);
+          expect(getContentFromPortalSpy.calls.argsFor(0)).toEqual([
+            id,
+            requestOpts
+          ]);
+          done();
+        });
       });
     });
-    it("handles private items", done => {
-      requestOpts.isPortal = false;
-      requestOpts.portalSelf.isPortal = false;
-      const id = "foo";
-      const getContentFromHubSpy = spyOn(
-        hubModule,
-        "getContentFromHub"
-      ).and.returnValue(Promise.reject({}));
-      const getContentFromPortalSpy = spyOn(
-        portalModule,
-        "getContentFromPortal"
-      ).and.returnValue(Promise.resolve({}));
-      getContent(id, requestOpts).then(() => {
-        expect(getContentFromHubSpy.calls.count()).toBe(1);
-        expect(getContentFromHubSpy.calls.argsFor(0)).toEqual([
-          id,
-          requestOpts
-        ]);
-        expect(getContentFromPortalSpy.calls.count()).toBe(1);
-        expect(getContentFromPortalSpy.calls.argsFor(0)).toEqual([
-          "foo",
-          requestOpts
-        ]);
-        done();
+    describe("with a slug", () => {
+      const slug = "foo";
+      it("rejects when not in the index", done => {
+        const err = new Error("test");
+        const getContentFromHubSpy = spyOn(
+          hubModule,
+          "getContentFromHub"
+        ).and.returnValue(Promise.reject(err));
+        getContent(slug, requestOpts).catch(e => {
+          expect(getContentFromHubSpy.calls.count()).toBe(1);
+          expect(getContentFromHubSpy.calls.argsFor(0)).toEqual([
+            slug,
+            requestOpts
+          ]);
+          expect(e).toEqual(err);
+          done();
+        });
       });
     });
   });

--- a/packages/content/test/hub.test.ts
+++ b/packages/content/test/hub.test.ts
@@ -158,7 +158,7 @@ describe("hub", () => {
       };
     });
     afterEach(fetchMock.restore);
-    it("should fetch a dataset record and return content", done => {
+    it("should fetch a dataset record by id and return content", done => {
       fetchMock.once("*", featureLayerJson);
       const dataset = featureLayerJson.data as DatasetResource;
       const id = dataset.id;
@@ -166,6 +166,25 @@ describe("hub", () => {
         // verify that we attempted to fetch from the portal API
         const [url, opts] = fetchMock.calls()[0];
         expect(url).toBe(`https://some.url.com/api/v3/datasets/${id}`);
+        expect(opts.method).toBe("GET");
+        validateContentFromDataset(content, dataset, "dataset");
+        // TODO: content type specific properties
+        // expect(content.recordCount).toBe(attributes.recordCount);
+        done();
+      });
+    });
+    it("should fetch a dataset record by slug and return content", done => {
+      fetchMock.once("*", featureLayerJson);
+      const dataset = featureLayerJson.data as DatasetResource;
+      const slug = "Wigan::out-of-work-benefit-claims";
+      getContentFromHub(slug, requestOpts).then(content => {
+        // verify that we attempted to fetch from the portal API
+        const [url, opts] = fetchMock.calls()[0];
+        expect(url).toBe(
+          `https://some.url.com/api/v3/datasets?${encodeURIComponent(
+            "filter[slug]"
+          )}=${encodeURIComponent(slug)}`
+        );
         expect(opts.method).toBe("GET");
         validateContentFromDataset(content, dataset, "dataset");
         // TODO: content type specific properties

--- a/packages/content/test/slugs.test.ts
+++ b/packages/content/test/slugs.test.ts
@@ -1,0 +1,22 @@
+import { isSlug } from "../src/slugs";
+
+describe("slugs", () => {
+  describe("isSlug", function() {
+    it("returns false when identifier is undefined", () => {
+      const result = isSlug(undefined);
+      expect(result).toBe(false);
+    });
+    it("returns false when identifier is an item id", () => {
+      const result = isSlug("7a153563b0c74f7eb2b3eae8a66f2fbb");
+      expect(result).toBe(false);
+    });
+    it("returns true when identifier is a slug w/o orgKey", () => {
+      const result = isSlug("foo-bar");
+      expect(result).toBe(true);
+    });
+    it("returns true when identifier is a slug w/ orgKey", () => {
+      const result = isSlug("org-key::foo-bar");
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/packages/content/test/slugs.test.ts
+++ b/packages/content/test/slugs.test.ts
@@ -1,4 +1,4 @@
-import { isSlug } from "../src/slugs";
+import { isSlug, addContextToSlug } from "../src/slugs";
 
 describe("slugs", () => {
   describe("isSlug", function() {
@@ -17,6 +17,23 @@ describe("slugs", () => {
     it("returns true when identifier is a slug w/ orgKey", () => {
       const result = isSlug("org-key::foo-bar");
       expect(result).toBe(true);
+    });
+  });
+  describe("addContextToSlug", () => {
+    const title = "foo-bar";
+    const orgKey = "org-key";
+    const slugWithContext = `${orgKey}::${title}`;
+    it("appends the context to slug without context", () => {
+      const slug = addContextToSlug(title, orgKey);
+      expect(slug).toBe(slugWithContext);
+    });
+    it("returns the slug as is when it already has context", () => {
+      const slug = addContextToSlug(slugWithContext, orgKey);
+      expect(slug).toBe(slugWithContext);
+    });
+    it("returns the slug as is when it has a different context", () => {
+      const slug = addContextToSlug(slugWithContext, "another-org");
+      expect(slug).toBe(slugWithContext);
     });
   });
 });

--- a/packages/content/test/slugs.test.ts
+++ b/packages/content/test/slugs.test.ts
@@ -1,6 +1,9 @@
-import { isSlug, addContextToSlug } from "../src/slugs";
+import { isSlug, addContextToSlug, removeContextFromSlug } from "../src/slugs";
 
 describe("slugs", () => {
+  const title = "foo-bar";
+  const orgKey = "org-key";
+  const slugWithContext = `${orgKey}::${title}`;
   describe("isSlug", function() {
     it("returns false when identifier is undefined", () => {
       const result = isSlug(undefined);
@@ -20,9 +23,6 @@ describe("slugs", () => {
     });
   });
   describe("addContextToSlug", () => {
-    const title = "foo-bar";
-    const orgKey = "org-key";
-    const slugWithContext = `${orgKey}::${title}`;
     it("appends the context to slug without context", () => {
       const slug = addContextToSlug(title, orgKey);
       expect(slug).toBe(slugWithContext);
@@ -32,7 +32,17 @@ describe("slugs", () => {
       expect(slug).toBe(slugWithContext);
     });
     it("returns the slug as is when it has a different context", () => {
-      const slug = addContextToSlug(slugWithContext, "another-org");
+      const slug = addContextToSlug(slugWithContext, "other-org");
+      expect(slug).toBe(slugWithContext);
+    });
+  });
+  describe("removeContextFromSlug", () => {
+    it("removes context when present", () => {
+      const slug = removeContextFromSlug(slugWithContext, orgKey);
+      expect(slug).toBe(title);
+    });
+    it("doesn't remove context when not present", () => {
+      const slug = removeContextFromSlug(slugWithContext, "other-org");
       expect(slug).toBe(slugWithContext);
     });
   });

--- a/packages/content/test/slugs.test.ts
+++ b/packages/content/test/slugs.test.ts
@@ -31,6 +31,10 @@ describe("slugs", () => {
       const slug = addContextToSlug(slugWithContext, orgKey);
       expect(slug).toBe(slugWithContext);
     });
+    it("returns the slug as is when no context is passed", () => {
+      const slug = addContextToSlug(slugWithContext, undefined);
+      expect(slug).toBe(slugWithContext);
+    });
     it("returns the slug as is when it has a different context", () => {
       const slug = addContextToSlug(slugWithContext, "other-org");
       expect(slug).toBe(slugWithContext);


### PR DESCRIPTION
The slug handling logic is copied (roughly) from the composer service in the Hub app.

I also had to add the ability for `hubRequest()` to pass params, either in the query string or body of the request, and I'd like @rgwozdz to review that b/c we'll eventually want to have all the download code start using that fn.
