### PR TITLE
fix(getContentFromHub): return first record when filtering by slug

### DIFF
--- a/packages/content/src/hub.ts
+++ b/packages/content/src/hub.ts
@@ -56,12 +56,15 @@ export function getContentFromHub(
     const slug = addContextToSlug(identifier, options && options.siteOrgKey);
     const opts = cloneObject(options);
     opts.params = { ...opts.params, "filter[slug]": slug };
-    request = hubApiRequest(`/datasets`, opts);
+    request = hubApiRequest(`/datasets`, opts).then(
+      resp => resp && resp.data[0]
+    );
   } else {
-    request = hubApiRequest(`/datasets/${identifier}`, options);
+    request = hubApiRequest(`/datasets/${identifier}`, options).then(
+      resp => resp && resp.data
+    );
   }
-  return request.then((resp: any) => {
-    const dataset = resp && resp.data;
+  return request.then((dataset: any) => {
     return dataset && withPortalUrls(datasetToContent(dataset), options);
   });
 }

--- a/packages/content/test/hub.test.ts
+++ b/packages/content/test/hub.test.ts
@@ -174,8 +174,13 @@ describe("hub", () => {
       });
     });
     it("should fetch a dataset record by slug and return content", done => {
-      fetchMock.once("*", featureLayerJson);
-      const dataset = featureLayerJson.data as DatasetResource;
+      const featureLayersJson = {
+        // slug requests to datasets w/ filter which returns an array
+        data: [featureLayerJson.data],
+        meta: featureLayerJson.meta
+      };
+      fetchMock.once("*", featureLayersJson);
+      const dataset = featureLayersJson.data[0] as DatasetResource;
       const slug = "Wigan::out-of-work-benefit-claims";
       getContentFromHub(slug, requestOpts).then(content => {
         // verify that we attempted to fetch from the portal API


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/hub-content

ISSUES CLOSED: #372