### PR TITLE
fix(getItemThumbnailUrl): pass token when calling from withPortalUrls…

### DIFF
--- a/packages/common/src/resources/get-item-thumbnail-url.ts
+++ b/packages/common/src/resources/get-item-thumbnail-url.ts
@@ -6,11 +6,9 @@ import { IItem } from "@esri/arcgis-rest-types";
 import { IPortal } from "@esri/arcgis-rest-portal";
 import { IHubRequestOptions } from "../types";
 import { getItemApiUrl } from "../urls/get-item-api-url";
-import { type } from "os";
 
 export interface IThumbnailOptions {
   token?: string;
-  width?: number;
 }
 
 /**
@@ -30,8 +28,8 @@ export function getItemThumbnailUrl(
     return null;
   }
   // tslint:disable-next-line prefer-const
-  let { token, width } = (optionsOrToken as IThumbnailOptions) || {};
-  // TODO: at the next breaking change drop support for passing token as string
+  let { token } = (optionsOrToken as IThumbnailOptions) || {};
+  // TODO: at the next breaking change drop support for passing options
   if (!token && typeof optionsOrToken === "string") {
     token = optionsOrToken;
   }
@@ -39,9 +37,6 @@ export function getItemThumbnailUrl(
   const [baseUrl, search] = itemApiUrl.split("?");
   const searchParams = new URLSearchParams(search);
   searchParams.delete("f");
-  if (width) {
-    searchParams.append("w", width + "");
-  }
   const newSearch = searchParams.toString();
   const url = `${baseUrl}/info/${item.thumbnail}`;
   return newSearch ? `${url}?${newSearch}` : url;

--- a/packages/common/src/urls/get-item-api-url.ts
+++ b/packages/common/src/urls/get-item-api-url.ts
@@ -20,6 +20,7 @@ export const getItemApiUrl = (
   const { id, access } = item;
   const url = `${getPortalApiUrl(portalUrlOrObject)}/content/items/${id}`;
   const params = new URLSearchParams({ f: "json" });
+  // TODO: derive token from from requestOptions if passed in?
   if (access !== "public" && token) {
     params.append("token", token);
   }

--- a/packages/common/test/resources/get-item-thumbnail-url.test.ts
+++ b/packages/common/test/resources/get-item-thumbnail-url.test.ts
@@ -41,10 +41,7 @@ describe("getItemThumbnailUrl", function() {
 
   it("computes url with options", function() {
     const token = "token";
-    const width = 1200;
-    const url = getItemThumbnailUrl(item, portalApiUrl, { token, width });
-    expect(url).toBe(
-      `${itemApiUrlBase}/info/thumbnail.png?token=${token}&w=1200`
-    );
+    const url = getItemThumbnailUrl(item, portalApiUrl, { token });
+    expect(url).toBe(`${itemApiUrlBase}/info/thumbnail.png?token=${token}`);
   });
 });

--- a/packages/content/src/portal.ts
+++ b/packages/content/src/portal.ts
@@ -122,7 +122,11 @@ export function withPortalUrls(
   // the URL of the item's data API end point
   newContent.portalDataUrl = getItemDataUrl(newContent, requestOptions, token);
   // the full URL of the thumbnail
-  newContent.thumbnailUrl = getItemThumbnailUrl(newContent, requestOptions);
+  newContent.thumbnailUrl = getItemThumbnailUrl(
+    newContent,
+    requestOptions,
+    token
+  );
   return newContent;
 }
 


### PR DESCRIPTION
…(); drop support for options.wi

affects: @esri/hub-common, @esri/hub-content