### PR TITLE
fix(hub-teams): respect org-level public sharing flag

### DIFF
--- a/packages/teams/src/utils/_create-team-group.ts
+++ b/packages/teams/src/utils/_create-team-group.ts
@@ -18,7 +18,11 @@ export function _createTeamGroup(
   group: IGroupTemplate,
   hubRequestOptions: IHubRequestOptions
 ) {
-  group.access = getAllowedGroupAccess(group.access, user);
+  group.access = getAllowedGroupAccess(
+    group.access,
+    user,
+    hubRequestOptions.portalSelf
+  );
   return getUniqueGroupTitle(group.title, hubRequestOptions)
     .then(uniqueTitle => {
       group.title = uniqueTitle;

--- a/packages/teams/src/utils/get-allowed-group-access.ts
+++ b/packages/teams/src/utils/get-allowed-group-access.ts
@@ -3,19 +3,22 @@ import { hasAllPrivileges } from "./has-all-privileges";
 import { GROUP_ACCESS_PRIVS } from "./group-access-privs";
 import { AGOAccess } from "../types";
 import { IPortal } from "@esri/arcgis-rest-portal";
+import { getProp } from "@esri/hub-common";
 
 /**
  * Returns the allowed group access based on a user's privileges
- * @param {String} requestedAccess public || org || private
- * @param {Object} user User object w/ privileges array
+ * and org level settings
+ * @param requestedAccess public || org || private
+ * @param user User object w/ privileges array
+ * @param portal optional
  */
 export function getAllowedGroupAccess(
   requestedAccess: AGOAccess,
   user: IUser,
-  portal: IPortal
+  portal?: IPortal
 ): AGOAccess {
   // portal-wide flag takes presidence, and is not sync'd with privs
-  const portalWideCanSharePublic = portal.canSharePublic;
+  const portalWideCanSharePublic = getProp(portal, "canSharePublic") || false;
   // compute what access level the current user can create the group with
   const canCreatePublic =
     portalWideCanSharePublic &&

--- a/packages/teams/src/utils/get-allowed-group-access.ts
+++ b/packages/teams/src/utils/get-allowed-group-access.ts
@@ -2,6 +2,7 @@ import { IUser } from "@esri/arcgis-rest-auth";
 import { hasAllPrivileges } from "./has-all-privileges";
 import { GROUP_ACCESS_PRIVS } from "./group-access-privs";
 import { AGOAccess } from "../types";
+import { IPortal } from "@esri/arcgis-rest-portal";
 
 /**
  * Returns the allowed group access based on a user's privileges
@@ -10,10 +11,15 @@ import { AGOAccess } from "../types";
  */
 export function getAllowedGroupAccess(
   requestedAccess: AGOAccess,
-  user: IUser
+  user: IUser,
+  portal: IPortal
 ): AGOAccess {
-  // figure out what they can create...
-  const canCreatePublic = hasAllPrivileges(user, GROUP_ACCESS_PRIVS.public);
+  // portal-wide flag takes presidence, and is not sync'd with privs
+  const portalWideCanSharePublic = portal.canSharePublic;
+  // compute what access level the current user can create the group with
+  const canCreatePublic =
+    portalWideCanSharePublic &&
+    hasAllPrivileges(user, GROUP_ACCESS_PRIVS.public);
   const canCreateOrg = hasAllPrivileges(user, GROUP_ACCESS_PRIVS.org);
   // default to the requested access...
   let result = requestedAccess;

--- a/packages/teams/test/utils/_create-team-group.test.ts
+++ b/packages/teams/test/utils/_create-team-group.test.ts
@@ -4,6 +4,7 @@ import { IHubRequestOptions, cloneObject } from "@esri/hub-common";
 import { IGroupTemplate } from "../../src/types";
 import { _createTeamGroup } from "../../src/utils/_create-team-group";
 import { IUser } from "@esri/arcgis-rest-auth";
+import { IPortal } from "@esri/arcgis-rest-portal";
 
 describe("_createTeamGroup", () => {
   const user = {
@@ -11,7 +12,10 @@ describe("_createTeamGroup", () => {
     privileges: ["portal:user:createGroup"]
   } as IUser;
   const ro = {
-    authentication: { token: "foobar" }
+    authentication: { token: "foobar" },
+    portalSelf: ({
+      canSharePublic: true
+    } as unknown) as IPortal
   } as IHubRequestOptions;
 
   it("should create team group correctly", async () => {

--- a/packages/teams/test/utils/get-allowed-group-access.test.ts
+++ b/packages/teams/test/utils/get-allowed-group-access.test.ts
@@ -1,3 +1,4 @@
+import { IPortal } from "@esri/arcgis-rest-portal";
 import { getAllowedGroupAccess } from "../../src/utils/get-allowed-group-access";
 
 describe("getAllowedGroupAccess", () => {
@@ -5,7 +6,10 @@ describe("getAllowedGroupAccess", () => {
     const user = {
       privileges: ["portal:user:createGroup", "portal:user:shareGroupToPublic"]
     };
-    expect(getAllowedGroupAccess("public", user)).toBe(
+    const portal = ({
+      canSharePublic: true
+    } as unknown) as IPortal;
+    expect(getAllowedGroupAccess("public", user, portal)).toBe(
       "public",
       "should return public if all privs present"
     );
@@ -15,9 +19,29 @@ describe("getAllowedGroupAccess", () => {
     const user = {
       privileges: ["portal:user:createGroup", "portal:user:shareGroupToOrg"]
     };
-    expect(getAllowedGroupAccess("public", user)).toBe(
+    const portal = ({
+      canSharePublic: true
+    } as unknown) as IPortal;
+    expect(getAllowedGroupAccess("public", user, portal)).toBe(
       "org",
       "should downgrade to org if missing priv"
+    );
+  });
+
+  it("retuns org if org level public sharing is disabled", () => {
+    const user = {
+      privileges: [
+        "portal:user:createGroup",
+        "portal:user:shareGroupToPublic",
+        "portal:user:shareGroupToOrg"
+      ]
+    };
+    const portal = ({
+      canSharePublic: false
+    } as unknown) as IPortal;
+    expect(getAllowedGroupAccess("public", user, portal)).toBe(
+      "org",
+      "should downgrade to org if portal public sharing disabled"
     );
   });
 
@@ -25,7 +49,10 @@ describe("getAllowedGroupAccess", () => {
     const user = {
       privileges: ["portal:user:createGroup"]
     };
-    expect(getAllowedGroupAccess("public", user)).toBe(
+    const portal = ({
+      canSharePublic: true
+    } as unknown) as IPortal;
+    expect(getAllowedGroupAccess("public", user, portal)).toBe(
       "private",
       "should downgrade to private if missing priv"
     );
@@ -35,7 +62,10 @@ describe("getAllowedGroupAccess", () => {
     const user = {
       privileges: ["portal:user:createGroup"]
     };
-    expect(getAllowedGroupAccess("org", user)).toBe(
+    const portal = ({
+      canSharePublic: true
+    } as unknown) as IPortal;
+    expect(getAllowedGroupAccess("org", user, portal)).toBe(
       "private",
       "should downgrade to private if missing priv"
     );

--- a/packages/teams/test/utils/get-allowed-group-access.test.ts
+++ b/packages/teams/test/utils/get-allowed-group-access.test.ts
@@ -28,7 +28,7 @@ describe("getAllowedGroupAccess", () => {
     );
   });
 
-  it("retuns org if org level public sharing is disabled", () => {
+  it("retruns org if org level public sharing is disabled", () => {
     const user = {
       privileges: [
         "portal:user:createGroup",
@@ -40,6 +40,19 @@ describe("getAllowedGroupAccess", () => {
       canSharePublic: false
     } as unknown) as IPortal;
     expect(getAllowedGroupAccess("public", user, portal)).toBe(
+      "org",
+      "should downgrade to org if portal public sharing disabled"
+    );
+  });
+  it("retruns org if org level is portal not passed", () => {
+    const user = {
+      privileges: [
+        "portal:user:createGroup",
+        "portal:user:shareGroupToPublic",
+        "portal:user:shareGroupToOrg"
+      ]
+    };
+    expect(getAllowedGroupAccess("public", user)).toBe(
       "org",
       "should downgrade to org if portal public sharing disabled"
     );


### PR DESCRIPTION
affects: @esri/hub-teams

When determining what access level to set for a Team, respect the org level public sharing flag
canSharePublic