### PR TITLE
Downloads: if item is a portal item and it is multilayer, export all layers

### DIFF
--- a/demos/oauth2-browser/package.json
+++ b/demos/oauth2-browser/package.json
@@ -6,8 +6,8 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-auth": "^1.16.0",
-    "@esri/arcgis-rest-request": "^1.16.0",
+    "@esri/arcgis-rest-auth": "^2.21.0",
+    "@esri/arcgis-rest-request": "^2.21.0",
     "@esri/hub-auth": "^6.10.0"
   },
   "devDependencies": {

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -21,10 +21,10 @@
     "@esri/arcgis-rest-types": "^2.13.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.1",
-    "@esri/arcgis-rest-feature-layer": "^2.14.1",
-    "@esri/arcgis-rest-portal": "^2.18.0",
-    "@esri/arcgis-rest-request": "^2.14.1",
+    "@esri/arcgis-rest-auth": "^2.21.0",
+    "@esri/arcgis-rest-feature-layer": "^2.21.0",
+    "@esri/arcgis-rest-portal": "^2.21.0",
+    "@esri/arcgis-rest-request": "^2.21.0",
     "@esri/arcgis-rest-service-admin": "^2.14.1",
     "@esri/arcgis-rest-types": "^2.15.0",
     "@rollup/plugin-commonjs": "^15.0.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,9 +24,9 @@
     "@esri/arcgis-rest-types": "^2.15.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.1",
-    "@esri/arcgis-rest-portal": "^2.18.0",
-    "@esri/arcgis-rest-request": "^2.14.1",
+    "@esri/arcgis-rest-auth": "^2.21.0",
+    "@esri/arcgis-rest-portal": "^2.21.0",
+    "@esri/arcgis-rest-request": "^2.21.0",
     "@esri/arcgis-rest-types": "^2.15.0",
     "@rollup/plugin-commonjs": "^15.0.0",
     "@rollup/plugin-json": "^4.1.0",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -20,9 +20,9 @@
     "@esri/hub-common": "^6.15.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.1",
-    "@esri/arcgis-rest-portal": "^2.18.0",
-    "@esri/arcgis-rest-request": "^2.14.1",
+    "@esri/arcgis-rest-auth": "^2.21.0",
+    "@esri/arcgis-rest-portal": "^2.21.0",
+    "@esri/arcgis-rest-request": "^2.21.0",
     "@esri/hub-common": "^6.18.0",
     "@rollup/plugin-commonjs": "^15.0.0",
     "@rollup/plugin-json": "^4.1.0",

--- a/packages/downloads/package-lock.json
+++ b/packages/downloads/package-lock.json
@@ -4,24 +4,29 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@esri/arcgis-rest-portal": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.14.1.tgz",
-			"integrity": "sha512-xuUUrnHaIXzCe2DqzfbIwC41dzQ0e2/ywZrpoasxQSHSjIHUzKmNrV0kp+kTAnnCF6wGJdWRI1Ffkr32OLqarA==",
+		"@esri/arcgis-rest-auth": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.21.0.tgz",
+			"integrity": "sha512-9g+qDOno+wL5oXoEbkTpm9mvsVzSDOE3KP/FE/h9hQBcHtIKM7kjFNwxucYibQ5yF3O6CUxYa1Jns3baCuUAWA==",
+			"dev": true,
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.14.1",
-				"tslib": "^1.9.3"
+				"@esri/arcgis-rest-types": "^2.21.0",
+				"tslib": "^1.13.0"
+			},
+			"dependencies": {
+				"@esri/arcgis-rest-types": {
+					"version": "2.21.0",
+					"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.21.0.tgz",
+					"integrity": "sha512-Yo7r66W1e4qwfR62qklOORNqJv87uoZrHZnuw5ffTJ1eb0Hefa7k/xtCAClVocFZis3fbz51/TwyugxvFwriHw==",
+					"dev": true
+				}
 			}
-		},
-		"@esri/arcgis-rest-types": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.14.1.tgz",
-			"integrity": "sha512-hlmu7qGKteuF5NiVDX/oWuT6zJnq+P0ns6BkKM/s94MApZlS1FCFxAQS3wl/1MiUPtQykApE4prcyjlknuWglQ=="
 		},
 		"tslib": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+			"dev": true
 		}
 	}
 }

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -10,14 +10,14 @@
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-feature-layer": "^2.14.1",
-    "@esri/arcgis-rest-portal": "^2.14.1",
-    "@esri/arcgis-rest-request": "^2.14.1",
+    "@esri/arcgis-rest-feature-layer": "^2.21.0",
+    "@esri/arcgis-rest-portal": "^2.21.0",
+    "@esri/arcgis-rest-request": "^2.21.0",
     "eventemitter3": "^4.0.4",
     "tslib": "^1.13.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.1",
+    "@esri/arcgis-rest-auth": "^2.21.0",
     "@rollup/plugin-commonjs": "^15.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/downloads/src/portal/portal-request-dataset-export.ts
+++ b/packages/downloads/src/portal/portal-request-dataset-export.ts
@@ -42,7 +42,12 @@ export function portalRequestDatasetExport(
 
 function composeExportParameters(params: any) {
   const { datasetId, spatialRefId, where } = params;
-  const layerId = datasetId.split("_")[1] || 0;
+  const layerId = datasetId.split("_")[1];
+
+  if (!layerId) {
+    return spatialRefId ? { targetSR: { wkid: Number(spatialRefId) } } : {};
+  }
+
   const layers = [{ id: Number(layerId), where }];
   return spatialRefId
     ? {

--- a/packages/downloads/src/portal/portal-request-dataset-export.ts
+++ b/packages/downloads/src/portal/portal-request-dataset-export.ts
@@ -42,6 +42,8 @@ export function portalRequestDatasetExport(
 
 function composeExportParameters(params: any) {
   const { datasetId, spatialRefId, where } = params;
+
+  // TODO: move parseDatasetId() to hub-common and use that here
   const layerId = datasetId.split("_")[1];
 
   if (!layerId) {

--- a/packages/downloads/test/portal/portal-request-dataset-export.test.ts
+++ b/packages/downloads/test/portal/portal-request-dataset-export.test.ts
@@ -108,7 +108,7 @@ describe("portalRequestDatasetExport", () => {
         {
           id: "abcdef0123456789abcdef0123456789",
           exportFormat: "CSV",
-          exportParameters: { layers: [Object({ id: 0, where: undefined })] },
+          exportParameters: {},
           title: "test-export",
           authentication
         }
@@ -125,7 +125,7 @@ describe("portalRequestDatasetExport", () => {
     }
   });
 
-  it("succeeds, uses spatialRefId", async done => {
+  it("succeeds, uses single layer and spatialRefId", async done => {
     try {
       spyOn(portal, "exportItem").and.returnValue(
         new Promise((resolve, reject) => {
@@ -151,6 +151,49 @@ describe("portalRequestDatasetExport", () => {
           exportFormat: "CSV",
           exportParameters: {
             layers: [Object({ id: 0, where: undefined })],
+            targetSR: { wkid: 4326 }
+          },
+          title: "test-export",
+          authentication
+        }
+      ]);
+      expect(result).toBeDefined();
+      expect(result.downloadId).toEqual("abcdef");
+      expect(result.jobId).toEqual("job-id");
+      expect(result.size).toEqual(1000);
+      expect(typeof result.exportCreated === "number").toEqual(true);
+    } catch (err) {
+      expect(err).toBeUndefined();
+    } finally {
+      done();
+    }
+  });
+
+  it("succeeds, uses no layers and spatialRefId", async done => {
+    try {
+      spyOn(portal, "exportItem").and.returnValue(
+        new Promise((resolve, reject) => {
+          resolve({
+            size: 1000,
+            jobId: "job-id",
+            exportItemId: "abcdef"
+          });
+        })
+      );
+
+      const result = await portalRequestDatasetExport({
+        datasetId: "abcdef0123456789abcdef0123456789",
+        format: "CSV",
+        authentication,
+        spatialRefId: "4326",
+        title: "test-export"
+      });
+      expect(portal.exportItem).toHaveBeenCalledTimes(1);
+      expect((portal.exportItem as any).calls.first().args).toEqual([
+        {
+          id: "abcdef0123456789abcdef0123456789",
+          exportFormat: "CSV",
+          exportParameters: {
             targetSR: { wkid: 4326 }
           },
           title: "test-export",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -21,10 +21,10 @@
     "@esri/hub-common": "4.x || 5.x || 6.x"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.1",
-    "@esri/arcgis-rest-feature-layer": "^2.14.1",
-    "@esri/arcgis-rest-portal": "^2.18.0",
-    "@esri/arcgis-rest-request": "^2.14.1",
+    "@esri/arcgis-rest-auth": "^2.21.0",
+    "@esri/arcgis-rest-feature-layer": "^2.21.0",
+    "@esri/arcgis-rest-portal": "^2.21.0",
+    "@esri/arcgis-rest-request": "^2.21.0",
     "@esri/arcgis-rest-types": "^2.15.0",
     "@esri/hub-common": "^6.18.0",
     "@rollup/plugin-commonjs": "^15.0.0",

--- a/packages/initiatives/package.json
+++ b/packages/initiatives/package.json
@@ -19,9 +19,9 @@
     "@esri/hub-common": "^6.4.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.1",
-    "@esri/arcgis-rest-portal": "^2.18.0",
-    "@esri/arcgis-rest-request": "^2.14.1",
+    "@esri/arcgis-rest-request": "^2.21.0",
+    "@esri/arcgis-rest-portal": "^2.21.0",
+    "@esri/arcgis-rest-auth": "^2.21.0",
     "@esri/hub-common": "^6.18.0",
     "@rollup/plugin-commonjs": "^15.0.0",
     "@rollup/plugin-json": "^4.1.0",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -21,10 +21,10 @@
     "@esri/hub-common": "4.x || 5.x || 6.x"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.1",
-    "@esri/arcgis-rest-feature-layer": "^2.14.1",
-    "@esri/arcgis-rest-portal": "^2.18.0",
-    "@esri/arcgis-rest-request": "^2.14.1",
+    "@esri/arcgis-rest-auth": "^2.21.0",
+    "@esri/arcgis-rest-feature-layer": "^2.21.0",
+    "@esri/arcgis-rest-portal": "^2.21.0",
+    "@esri/arcgis-rest-request": "^2.21.0",
     "@esri/arcgis-rest-types": "^2.15.0",
     "@esri/hub-common": "^6.18.0",
     "@rollup/plugin-commonjs": "^15.0.0",

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -21,9 +21,9 @@
     "@esri/hub-teams": "^6.11.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.1",
-    "@esri/arcgis-rest-portal": "^2.19.0",
-    "@esri/arcgis-rest-request": "^2.14.1",
+    "@esri/arcgis-rest-auth": "^2.21.0",
+    "@esri/arcgis-rest-portal": "^2.21.0",
+    "@esri/arcgis-rest-request": "^2.21.0",
     "@esri/hub-common": "^6.18.0",
     "@esri/hub-initiatives": "^6.18.0",
     "@esri/hub-teams": "^6.18.0",

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -21,10 +21,10 @@
     "@esri/hub-common": "4.x || 5.x || 6.x"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.1",
-    "@esri/arcgis-rest-feature-layer": "^2.14.1",
-    "@esri/arcgis-rest-portal": "^2.18.0",
-    "@esri/arcgis-rest-request": "^2.14.1",
+    "@esri/arcgis-rest-auth": "^2.21.0",
+    "@esri/arcgis-rest-feature-layer": "^2.21.0",
+    "@esri/arcgis-rest-portal": "^2.21.0",
+    "@esri/arcgis-rest-request": "^2.21.0",
     "@esri/arcgis-rest-types": "^2.15.0",
     "@esri/hub-common": "^6.18.0",
     "@rollup/plugin-commonjs": "^15.0.0",

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -20,9 +20,9 @@
     "@esri/hub-common": "4.x || 5.x || 6.x"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^2.14.1",
-    "@esri/arcgis-rest-portal": "^2.18.0",
-    "@esri/arcgis-rest-request": "^2.14.1",
+    "@esri/arcgis-rest-auth": "^2.21.0",
+    "@esri/arcgis-rest-portal": "^2.21.0",
+    "@esri/arcgis-rest-request": "^2.21.0",
     "@esri/arcgis-rest-types": "^2.15.0",
     "@esri/hub-common": "^6.18.0",
     "@rollup/plugin-commonjs": "^15.0.0",


### PR DESCRIPTION
Download export requests for multilayer, portal items should export ALL layers.  This PR ensures that occurs by remove the "layers" property from the `exportItem` call.