### PR TITLE
fix(downloads): portalRequestDownloadMetadata() function did not recongize layer id

### DIFF
--- a/packages/downloads/src/portal/portal-request-download-metadata.ts
+++ b/packages/downloads/src/portal/portal-request-download-metadata.ts
@@ -42,7 +42,7 @@ export function portalRequestDownloadMetadata(
 ): Promise<any> {
   const { datasetId, authentication, format, spatialRefId } = params;
 
-  const [itemId] = datasetId.split("_");
+  const [itemId, layerId] = datasetId.split("_");
   let serviceLastEditDate: number | undefined;
   let itemModifiedDate: number;
   let itemType: string;
@@ -57,7 +57,8 @@ export function portalRequestDownloadMetadata(
         authentication,
         type,
         modified,
-        format
+        format,
+        layerId
       });
     })
     .then((metadata: ICacheSearchMetadata) => {

--- a/packages/downloads/test/portal/portal-request-download-metadata.test.ts
+++ b/packages/downloads/test/portal/portal-request-download-metadata.test.ts
@@ -554,7 +554,7 @@ describe("portalRequestDownloadMetadata", () => {
       }
     });
 
-    it("layer id, multi-layer, no cachehd", async done => {
+    it("layer id, multi-layer, no cached", async done => {
       try {
         const getItemSpy = spyOn(portal, "getItem").and.returnValue(
           new Promise(resolve => {


### PR DESCRIPTION
affects: @esri/hub-downloads

The `fetchCacheSearchMetadata()` in the `downloads` package was not passing the layer id to its internal util function `fetchCacheSearchMetadata`. As a result, it created incorrect item types to query cache for sublayers of a feature service item. For example, it should be `CSV`, not `CSV Collection` for an individual sublayer.