### PR TITLE
fix(sites): coerce numeric site title to string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -554,71 +554,6 @@
 				}
 			}
 		},
-		"@esri/arcgis-rest-auth": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.24.0.tgz",
-			"integrity": "sha512-ntq9zI3+RqY7MQwuzpj9mZ9mzx32LnjApUJWGUTUL6nlPEb8JNY6cchZxISt1KNOQ3j/ElE8xaMl8sX+MzM1+w==",
-			"requires": {
-				"@esri/arcgis-rest-types": "^2.24.0",
-				"tslib": "^1.13.0"
-			}
-		},
-		"@esri/arcgis-rest-feature-layer": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.24.0.tgz",
-			"integrity": "sha512-bo1nspr1ZdJPDyVsZhnEuGQ6uz8HCp3BCbGeFok/e33Swoj1gi2553H9F4i2mDwskGH1oYafw2JQEU1j2eBs7Q==",
-			"requires": {
-				"@esri/arcgis-rest-types": "^2.24.0",
-				"tslib": "^1.13.0"
-			}
-		},
-		"@esri/arcgis-rest-portal": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.24.0.tgz",
-			"integrity": "sha512-06y3/FpG3GUCY7RyvvyXa+3/Ss6hRudTRGSzJUjQrjV+r7dkz6wxZplYBOqIW8ZibY3x7pUuvYVQV4hGZFxhPg==",
-			"requires": {
-				"@esri/arcgis-rest-types": "^2.24.0",
-				"tslib": "^1.13.0"
-			}
-		},
-		"@esri/arcgis-rest-request": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.24.0.tgz",
-			"integrity": "sha512-HXEG7z7yuqlP1tvagsuftwhKLtWKZXkkfUbUBFAaYFZSSz50yiKH3rk5ODc/dRCWoHPabUMpQBoGwY88lMANxA==",
-			"requires": {
-				"tslib": "^1.10.0"
-			}
-		},
-		"@esri/arcgis-rest-service-admin": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-2.24.0.tgz",
-			"integrity": "sha512-hVOa56VDBDkKmSRUEEjVugBjPIHN47Zo5LNKDIUwk9wH8hNS36Sdd+NvG6nx304+OFPub4n5SfIqV8D9yqmF6g==",
-			"requires": {
-				"@esri/arcgis-rest-types": "^2.24.0",
-				"tslib": "^1.13.0"
-			}
-		},
-		"@esri/arcgis-rest-types": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.24.0.tgz",
-			"integrity": "sha512-Lfg+1EyQYqcCC8c2hyKHuJLTHdEEOvERC6VZco9h4sLZfDvUv2nwdrs9sxX/1xg0dJl/5ytpXKgFdNv6AXOGnw=="
-		},
-		"@esri/hub-auth": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-auth/-/hub-auth-6.10.0.tgz",
-			"integrity": "sha512-7D2J8lL8ZyYVOhZyFZ91hxiGV1y3as0O6Mlm/PZBffHhkMWbJC/nQoNnNoHG1/QfSUjskr+v3IE9+ZKJVk00gw==",
-			"requires": {
-				"tslib": "^1.13.0"
-			}
-		},
-		"@esri/hub-types": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-types/-/hub-types-6.10.0.tgz",
-			"integrity": "sha512-fv16PUCaLVZY/rRAIg6HV6LxQLxheutaVovcOS3zmyqAgkeNI7keJblz50RrABSmfP7g+N2/XJRTHntze6ZrVA==",
-			"requires": {
-				"tslib": "^1.13.0"
-			}
-		},
 		"@evocateur/libnpmaccess": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz",
@@ -4210,11 +4145,6 @@
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true
 		},
-		"@types/adlib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
-			"integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
-		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -4238,11 +4168,6 @@
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
 			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
 			"dev": true
-		},
-		"@types/faker": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.1.5.tgz",
-			"integrity": "sha512-2uEQFb7bsx68rqD4F8q95wZq6LTLOyexjv6BnvJogCO4jStkyc6IDEkODPQcWfovI6g6M3uPQ2/uD/oedJKkNw=="
 		},
 		"@types/fetch-mock": {
 			"version": "7.3.2",
@@ -4463,14 +4388,6 @@
 			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
 			"dev": true
 		},
-		"adlib": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
-			"integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
-			"requires": {
-				"esm": "^3.2.25"
-			}
-		},
 		"after": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
@@ -4616,12 +4533,14 @@
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"ansi-wrap": {
 			"version": "0.1.0",
@@ -5552,6 +5471,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
@@ -5835,11 +5755,6 @@
 					"dev": true
 				}
 			}
-		},
-		"blob": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-			"integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
 		},
 		"block-stream": {
 			"version": "0.0.9",
@@ -6604,6 +6519,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^2.2.1",
 				"escape-string-regexp": "^1.0.2",
@@ -6736,6 +6652,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
@@ -6774,7 +6691,8 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"cliui": {
 			"version": "3.2.0",
@@ -6893,7 +6811,8 @@
 		"colors": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+			"dev": true
 		},
 		"columnify": {
 			"version": "1.5.4",
@@ -8202,18 +8121,14 @@
 		"core-js": {
 			"version": "2.6.5",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-			"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+			"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
-		},
-		"corser": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
-			"integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c="
 		},
 		"cosmiconfig": {
 			"version": "1.1.0",
@@ -9118,24 +9033,6 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"ecstatic": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
-			"integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
-			"requires": {
-				"he": "^1.1.1",
-				"mime": "^1.6.0",
-				"minimist": "^1.1.0",
-				"url-join": "^2.0.5"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-				}
-			}
-		},
 		"editions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/editions/-/editions-2.3.0.tgz",
@@ -9408,7 +9305,8 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
 			"version": "1.8.1",
@@ -9451,11 +9349,6 @@
 				"jest-docblock": "^21.0.0"
 			}
 		},
-		"esm": {
-			"version": "3.2.25",
-			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
-		},
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -9485,11 +9378,6 @@
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
 			"dev": true
-		},
-		"eventemitter3": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
 		},
 		"events": {
 			"version": "3.0.0",
@@ -9785,11 +9673,6 @@
 			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
 			"dev": true
 		},
-		"faker": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/faker/-/faker-5.1.0.tgz",
-			"integrity": "sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw=="
-		},
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -9827,16 +9710,6 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
-		},
-		"fast-xml-parser": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.2.4.tgz",
-			"integrity": "sha512-19R4aaHzqsTe7gyL3wthWiyYyNFqVK1tzO6BMEAQEKRu4R3ptkl4FyuEtUMOPKdYsO6k6C/Ym3YJ6eCL49OdSw==",
-			"requires": {
-				"he": "~1.1.1",
-				"nimnjs": "^1.1.0",
-				"opencollective": "^1.0.3"
-			}
 		},
 		"fd-slicer": {
 			"version": "1.0.1",
@@ -9879,6 +9752,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -11848,6 +11722,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -11952,11 +11827,6 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
-		"he": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
-		},
 		"highlight.js": {
 			"version": "9.15.6",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
@@ -12057,6 +11927,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
 			"integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
+			"dev": true,
 			"requires": {
 				"eventemitter3": "1.x.x",
 				"requires-port": "1.x.x"
@@ -12065,7 +11936,8 @@
 				"eventemitter3": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-					"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+					"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
+					"dev": true
 				}
 			}
 		},
@@ -12104,21 +11976,6 @@
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
-			}
-		},
-		"http-server": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/http-server/-/http-server-0.11.1.tgz",
-			"integrity": "sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w==",
-			"requires": {
-				"colors": "1.0.3",
-				"corser": "~2.0.0",
-				"ecstatic": "^3.0.0",
-				"http-proxy": "^1.8.1",
-				"opener": "~1.4.0",
-				"optimist": "0.6.x",
-				"portfinder": "^1.0.13",
-				"union": "~0.4.3"
 			}
 		},
 		"http-signature": {
@@ -13428,7 +13285,8 @@
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-redirect": {
 			"version": "1.0.0",
@@ -13906,24 +13764,11 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
-		"json-typescript": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/json-typescript/-/json-typescript-1.1.2.tgz",
-			"integrity": "sha512-Np07MUsYMKbB0nNlw/MMIRjUK7ehO48LA4FsrzrhCfTUxMKbvOBAo0sc0b4nQ80ge9d32sModCunCgoyUojgUA=="
-		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
 			"dev": true
-		},
-		"jsonapi-typescript": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/jsonapi-typescript/-/jsonapi-typescript-0.1.3.tgz",
-			"integrity": "sha512-uPcPS01GeM+4HIyn18s7l1yD2S3uLZy2TX1UkQffCM0bLb3TMwudXUyVXPHTMZ4vdZT8MqKqN2vjB5PogTAdFQ==",
-			"requires": {
-				"json-typescript": "^1.0.0"
-			}
 		},
 		"jsonfile": {
 			"version": "3.0.1",
@@ -15294,7 +15139,8 @@
 		"mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true
 		},
 		"mime-db": {
 			"version": "1.40.0",
@@ -15312,7 +15158,8 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
 		},
 		"mimic-response": {
 			"version": "1.0.1",
@@ -15350,7 +15197,8 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"minimist-options": {
 			"version": "4.1.0",
@@ -15540,6 +15388,7 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -15582,7 +15431,8 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"multimatch": {
 			"version": "4.0.0",
@@ -15614,7 +15464,8 @@
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"mz": {
 			"version": "2.7.0",
@@ -15669,25 +15520,6 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
-		},
-		"nimn-date-parser": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/nimn-date-parser/-/nimn-date-parser-1.0.0.tgz",
-			"integrity": "sha512-1Nf+x3EeMvHUiHsVuEhiZnwA8RMeOBVTQWfB1S2n9+i6PYCofHd2HRMD+WOHIHYshy4T4Gk8wQoCol7Hq3av8Q=="
-		},
-		"nimn_schema_builder": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/nimn_schema_builder/-/nimn_schema_builder-1.1.0.tgz",
-			"integrity": "sha512-DK5/B8CM4qwzG2URy130avcwPev4uO0ev836FbQyKo1ms6I9z/i6EJyiZ+d9xtgloxUri0W+5gfR8YbPq7SheA=="
-		},
-		"nimnjs": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/nimnjs/-/nimnjs-1.3.2.tgz",
-			"integrity": "sha512-TIOtI4iqkQrUM1tiM76AtTQem0c7e56SkDZ7sj1d1MfUsqRcq2ZWQvej/O+HBTZV7u/VKnwlKTDugK/75IRPPw==",
-			"requires": {
-				"nimn-date-parser": "^1.0.0",
-				"nimn_schema_builder": "^1.0.0"
-			}
 		},
 		"node-fetch": {
 			"version": "2.6.0",
@@ -16312,7 +16144,8 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-component": {
 			"version": "0.0.3",
@@ -16624,6 +16457,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -16637,138 +16471,11 @@
 				"is-wsl": "^1.1.0"
 			}
 		},
-		"opencollective": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
-			"integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
-			"requires": {
-				"babel-polyfill": "6.23.0",
-				"chalk": "1.1.3",
-				"inquirer": "3.0.6",
-				"minimist": "1.2.0",
-				"node-fetch": "1.6.3",
-				"opn": "4.0.2"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-				},
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"babel-polyfill": {
-					"version": "6.23.0",
-					"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-					"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-					"requires": {
-						"babel-runtime": "^6.22.0",
-						"core-js": "^2.4.0",
-						"regenerator-runtime": "^0.10.0"
-					}
-				},
-				"chardet": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-					"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
-				},
-				"external-editor": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-					"requires": {
-						"chardet": "^0.4.0",
-						"iconv-lite": "^0.4.17",
-						"tmp": "^0.0.33"
-					}
-				},
-				"inquirer": {
-					"version": "3.0.6",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
-					"integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
-					"requires": {
-						"ansi-escapes": "^1.1.0",
-						"chalk": "^1.0.0",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^2.0.1",
-						"figures": "^2.0.0",
-						"lodash": "^4.3.0",
-						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rx": "^4.1.0",
-						"string-width": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"through": "^2.3.6"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"node-fetch": {
-					"version": "1.6.3",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-					"integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
-					"requires": {
-						"encoding": "^0.1.11",
-						"is-stream": "^1.0.1"
-					}
-				},
-				"opn": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-					"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-					"requires": {
-						"object-assign": "^4.0.1",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.10.5",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					},
-					"dependencies": {
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
-					}
-				}
-			}
-		},
 		"opencollective-postinstall": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
 			"integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
 			"dev": true
-		},
-		"opener": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-			"integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
 		},
 		"openurl": {
 			"version": "1.1.1",
@@ -16789,6 +16496,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
@@ -16895,7 +16603,8 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"osenv": {
 			"version": "0.1.5",
@@ -17503,12 +17212,14 @@
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
@@ -17624,6 +17335,7 @@
 			"version": "1.0.20",
 			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
 			"integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
+			"dev": true,
 			"requires": {
 				"async": "^1.5.2",
 				"debug": "^2.2.0",
@@ -17633,12 +17345,14 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
 				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -18190,7 +17904,8 @@
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
@@ -18419,7 +18134,8 @@
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.10.1",
@@ -18503,6 +18219,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
@@ -18900,6 +18617,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
@@ -18916,7 +18634,8 @@
 		"rx": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+			"dev": true
 		},
 		"rxjs": {
 			"version": "5.5.12",
@@ -19352,7 +19071,8 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
@@ -20068,6 +19788,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -20183,7 +19904,8 @@
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"symbol-observable": {
 			"version": "1.0.1",
@@ -20588,7 +20310,8 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"through2": {
 			"version": "2.0.5",
@@ -20625,6 +20348,7 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
@@ -21138,21 +20862,6 @@
 			"integrity": "sha512-+cHtykLb+eF1yrSLWTwcYBrqJkTfX7Quoyg7Juhe6uylF43ZbMdxMuSHNYlnyLT8T7POAvavgBthzUF9AIaQvQ==",
 			"dev": true
 		},
-		"union": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
-			"integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
-			"requires": {
-				"qs": "~2.3.3"
-			},
-			"dependencies": {
-				"qs": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-					"integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
-				}
-			}
-		},
 		"union-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -21381,11 +21090,6 @@
 					"dev": true
 				}
 			}
-		},
-		"url-join": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
-			"integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg="
 		},
 		"url-parse-lax": {
 			"version": "1.0.0",
@@ -21775,7 +21479,8 @@
 		"wordwrap": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+			"dev": true
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",

--- a/packages/sites/src/domains/add-domain.ts
+++ b/packages/sites/src/domains/add-domain.ts
@@ -21,6 +21,11 @@ export function addDomain(
   const headers = _getAuthHeader(hubRequestOptions);
   headers["Content-Type"] = "application/json";
   const url = `${_getDomainServiceUrl(hubRequestOptions.hubApiUrl)}`;
+  // handle case of siteTitle being numeric
+  const title = domainEntry.siteTitle as unknown;
+  if (typeof title === "number") {
+    domainEntry.siteTitle = title.toString();
+  }
   return fetch(url, {
     method: "POST",
     headers,

--- a/packages/sites/src/domains/update-domain.ts
+++ b/packages/sites/src/domains/update-domain.ts
@@ -23,6 +23,11 @@ export function updateDomain(
   const url = `${_getDomainServiceUrl(hubRequestOptions.hubApiUrl)}/${
     domainEntry.id
   }`;
+  // handle case of siteTitle being numeric
+  const title = domainEntry.siteTitle as unknown;
+  if (typeof title === "number") {
+    domainEntry.siteTitle = title.toString();
+  }
   return fetch(url, {
     method: "PUT",
     headers,

--- a/packages/sites/test/domains/add-domain.test.ts
+++ b/packages/sites/test/domains/add-domain.test.ts
@@ -1,5 +1,5 @@
-import { IHubRequestOptions } from "@esri/hub-common";
-import { addDomain } from "../../src/domains";
+import { IHubRequestOptions, cloneObject, getProp } from "@esri/hub-common";
+import { addDomain, IDomainEntry } from "../../src/domains";
 import * as fetchMock from "fetch-mock";
 import * as _checkStatusAndParseJsonModule from "../../src/domains/_check-status-and-parse-json";
 
@@ -18,7 +18,7 @@ describe("addDomain", function() {
     sslOnly: true
   };
 
-  it("throws error on portal", async function() {
+  it("sends request in AGO", async function() {
     const ro = { isPortal: false } as IHubRequestOptions;
 
     spyOn(
@@ -30,6 +30,40 @@ describe("addDomain", function() {
 
     const res = await addDomain(domainEntry, ro);
     expect(fetchMock.done()).toBeTruthy("fetch should have been called once");
+    expect(res.success).toBeTruthy("json parsed and response returned");
+  });
+
+  it("converts title to string", async function() {
+    const entry = ({
+      clientKey: "hdlf3lCPRguoTFr6",
+      domain: "zebra-dc.hubqa.arcgis.com",
+      hostname: "zebra-dc.hubqa.arcgis.com",
+      id: "146663",
+      orgId: "97KLIFOSt5CxbiRI",
+      orgKey: "dc",
+      orgTitle: "Washington, DC R&D Center (QA)",
+      permanentRedirect: false,
+      siteId: "9697f67b6d6343fa823dcdbe2d172073",
+      siteTitle: 1234,
+      sslOnly: true
+    } as unknown) as IDomainEntry;
+    const ro = { isPortal: false } as IHubRequestOptions;
+
+    spyOn(
+      _checkStatusAndParseJsonModule,
+      "_checkStatusAndParseJson"
+    ).and.returnValue(Promise.resolve({ success: true }));
+
+    fetchMock.post("end:api/v3/domains", {});
+
+    const res = await addDomain(entry, ro);
+    expect(fetchMock.done()).toBeTruthy("fetch should have been called once");
+    const opts = fetchMock.lastOptions("end:api/v3/domains");
+    const body = JSON.parse(opts.body as string);
+    expect(getProp(body, "siteTitle")).toBe(
+      "1234",
+      "should coerce numeric title to a string"
+    );
     expect(res.success).toBeTruthy("json parsed and response returned");
   });
 


### PR DESCRIPTION
affects: @esri/hub-sites

Ensure that domain add/update coerce numeric site title to a string

When consuming hub.js in Ember (non-typescript) numeric site title can be passed into the add/update domain functions. This PR adds checks to coerce numerics to strings on this property.