### PR TITLE
fix(sites): Handle unicode chars in Site title

### DIFF
--- a/packages/sites/src/create-site-model-from-template.ts
+++ b/packages/sites/src/create-site-model-from-template.ts
@@ -80,8 +80,15 @@ export function createSiteModelFromTemplate(
       if (getProp(teams, "props.contentGroupId")) {
         deepSet(template, "data.catalog.groups", [teams.props.contentGroupId]);
       }
-      // sites need unique names...
-      return ensureUniqueDomainName(slugify(title), hubRequestOptions);
+      // sites need unique domains names
+      // We derive this from the title, unless the title has unicode chars
+      // in which case we use `site`, and the `ensureUniqueDomainName` function
+      // will increment that as needed - i.e. `site-23`
+      let domainTitle = title;
+      if (hasUnicodeChars(domainTitle)) {
+        domainTitle = "site";
+      }
+      return ensureUniqueDomainName(slugify(domainTitle), hubRequestOptions);
     })
     .then(uniqueSubdomain => {
       const portal = hubRequestOptions.portalSelf;
@@ -151,4 +158,15 @@ export function createSiteModelFromTemplate(
     .catch(ex => {
       throw Error(`site-utils::createSiteModelFromTemplate Error ${ex}`);
     });
+}
+
+/**
+ * From Stackoverflow
+ * https://stackoverflow.com/questions/147824/how-to-find-whether-a-particular-string-has-unicode-characters-esp-double-byte
+ * This is the highest performance solution, combining three approaches
+ */
+const unicodeCharRegex = /[^\u0000-\u00ff]/;
+function hasUnicodeChars(value: string): boolean {
+  if (value.charCodeAt(0) > 255) return true;
+  return unicodeCharRegex.test(value);
 }

--- a/packages/sites/src/create-site-model-from-template.ts
+++ b/packages/sites/src/create-site-model-from-template.ts
@@ -23,6 +23,11 @@ import { ensureUniqueDomainName } from "./domains";
  * Convert a Site Template into a Site Model
  * This will create Hub Teams and an Initiative, depending on licensing
  * and privs.
+ *
+ * The subdomain for the site will be constructed from the `settings.solution.title`
+ * unless that contains unicode chars. In that case the initial subdomain will be `site`
+ * and `ensureUniqueDomainName` will increment it as necessary (i.e. site-1, site-2 etc)
+ *
  * This returns the Model that still needs to be saved!
  * @param {object} template Site Template
  * @param {object} settings Adlib interpolation hash


### PR DESCRIPTION
Typically we derive the site subdomain based on the site title. But if the title contains unicode chars, we can't use it, so instead we start from "site" and `ensureUniqueDomain` will increment that depending on existing sites until we get something like `site-21-<orgkey>.hub.arcgis.com`

Needed to address an issue in Hub re: cloning sites w/ Japanese titles, but will be an issue for any scenario where the title has unicode chars