### PR TITLE
fix(sites): fix logic for site url on portal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -554,6 +554,71 @@
 				}
 			}
 		},
+		"@esri/arcgis-rest-auth": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.25.0.tgz",
+			"integrity": "sha512-fJHbusenCtna0vZUcqX2L0a3KAKOrXIQJE++qRFK8IaVfIjx2KWgkOfgiAgW4kUkRsF1lq15pXEXVRo5LyD43Q==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.25.0",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/arcgis-rest-feature-layer": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.25.0.tgz",
+			"integrity": "sha512-gg1QoJEIGyRt298N5/9VJ4HKnCWC5SYKw+0Vg77VpotkMcpObw3kAEpKyCc+9FVs4HrF+z6/NWsd84loU6hnOA==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.25.0",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/arcgis-rest-portal": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.25.0.tgz",
+			"integrity": "sha512-OL2b59UhUtSfmJad6EwsOfUZRN031bgLfnznOrONRaB12U4iah+vjsCjkj1+l3sj8O6YlJpedLyP08Ci3IPY+g==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.25.0",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/arcgis-rest-request": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.25.0.tgz",
+			"integrity": "sha512-4KYl+Ene7kwZg/M2ABneZizcWVoQkxDvyB9f6zrcKQ2uYjCj1kEl2OTBFmDhT7HFtBm/8cdLi79p/3kDGtSsqQ==",
+			"requires": {
+				"tslib": "^1.10.0"
+			}
+		},
+		"@esri/arcgis-rest-service-admin": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-2.25.0.tgz",
+			"integrity": "sha512-bxqVhrv7M/CnF0v1Itg/EKQjlFuARUd3I/jPmwmC4tRPGzsck3GMXEmOMzAqIb/uxoUWorRTXTjan+Iw+stOxw==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.25.0",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/arcgis-rest-types": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.25.0.tgz",
+			"integrity": "sha512-2iMwX8tUVTImpoyKjNVsigc0JCUM8hTlyIu/hF2NnehyetvsefSut8njMObwHy872zfBzZ+kOMyulGGzdHvLxg=="
+		},
+		"@esri/hub-auth": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@esri/hub-auth/-/hub-auth-6.10.0.tgz",
+			"integrity": "sha512-7D2J8lL8ZyYVOhZyFZ91hxiGV1y3as0O6Mlm/PZBffHhkMWbJC/nQoNnNoHG1/QfSUjskr+v3IE9+ZKJVk00gw==",
+			"requires": {
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/hub-types": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@esri/hub-types/-/hub-types-6.10.0.tgz",
+			"integrity": "sha512-fv16PUCaLVZY/rRAIg6HV6LxQLxheutaVovcOS3zmyqAgkeNI7keJblz50RrABSmfP7g+N2/XJRTHntze6ZrVA==",
+			"requires": {
+				"tslib": "^1.13.0"
+			}
+		},
 		"@evocateur/libnpmaccess": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz",
@@ -4145,6 +4210,16 @@
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true
 		},
+		"@types/adlib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
+			"integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
+		},
+		"@types/base-64": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-0.1.3.tgz",
+			"integrity": "sha512-DJpw7RKNMXygZ0j2xe6ROBqiJUy7JWEItkzOPBzrT35HUWS7VLYyW9XJX8yCCvE2xg8QD7wesvVyXFg8AVHTMA=="
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -4168,6 +4243,11 @@
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
 			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
 			"dev": true
+		},
+		"@types/faker": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.1.5.tgz",
+			"integrity": "sha512-2uEQFb7bsx68rqD4F8q95wZq6LTLOyexjv6BnvJogCO4jStkyc6IDEkODPQcWfovI6g6M3uPQ2/uD/oedJKkNw=="
 		},
 		"@types/fetch-mock": {
 			"version": "7.3.2",
@@ -4388,6 +4468,14 @@
 			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
 			"dev": true
 		},
+		"adlib": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+			"integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+			"requires": {
+				"esm": "^3.2.25"
+			}
+		},
 		"after": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
@@ -4533,14 +4621,12 @@
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-			"dev": true
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 		},
 		"ansi-wrap": {
 			"version": "0.1.0",
@@ -5471,7 +5557,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
@@ -5602,6 +5687,11 @@
 					}
 				}
 			}
+		},
+		"base-64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+			"integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
 		},
 		"base64-arraybuffer": {
 			"version": "0.1.5",
@@ -5755,6 +5845,11 @@
 					"dev": true
 				}
 			}
+		},
+		"blob": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+			"integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
 		},
 		"block-stream": {
 			"version": "0.0.9",
@@ -6519,7 +6614,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^2.2.1",
 				"escape-string-regexp": "^1.0.2",
@@ -6652,7 +6746,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
@@ -6691,8 +6784,7 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-			"dev": true
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"cliui": {
 			"version": "3.2.0",
@@ -6811,8 +6903,7 @@
 		"colors": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-			"dev": true
+			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
 		},
 		"columnify": {
 			"version": "1.5.4",
@@ -8121,14 +8212,18 @@
 		"core-js": {
 			"version": "2.6.5",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-			"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
-			"dev": true
+			"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
+		},
+		"corser": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+			"integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c="
 		},
 		"cosmiconfig": {
 			"version": "1.1.0",
@@ -9033,6 +9128,24 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
+		"ecstatic": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+			"integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
+			"requires": {
+				"he": "^1.1.1",
+				"mime": "^1.6.0",
+				"minimist": "^1.1.0",
+				"url-join": "^2.0.5"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+				}
+			}
+		},
 		"editions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/editions/-/editions-2.3.0.tgz",
@@ -9305,8 +9418,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
 			"version": "1.8.1",
@@ -9349,6 +9461,11 @@
 				"jest-docblock": "^21.0.0"
 			}
 		},
+		"esm": {
+			"version": "3.2.25",
+			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+		},
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -9378,6 +9495,11 @@
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
 			"dev": true
+		},
+		"eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
 		},
 		"events": {
 			"version": "3.0.0",
@@ -9673,6 +9795,11 @@
 			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
 			"dev": true
 		},
+		"faker": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/faker/-/faker-5.1.0.tgz",
+			"integrity": "sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw=="
+		},
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -9710,6 +9837,16 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
+		},
+		"fast-xml-parser": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.2.4.tgz",
+			"integrity": "sha512-19R4aaHzqsTe7gyL3wthWiyYyNFqVK1tzO6BMEAQEKRu4R3ptkl4FyuEtUMOPKdYsO6k6C/Ym3YJ6eCL49OdSw==",
+			"requires": {
+				"he": "~1.1.1",
+				"nimnjs": "^1.1.0",
+				"opencollective": "^1.0.3"
+			}
 		},
 		"fd-slicer": {
 			"version": "1.0.1",
@@ -9752,7 +9889,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -11722,7 +11858,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -11827,6 +11962,11 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+		},
 		"highlight.js": {
 			"version": "9.15.6",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
@@ -11927,7 +12067,6 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
 			"integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
-			"dev": true,
 			"requires": {
 				"eventemitter3": "1.x.x",
 				"requires-port": "1.x.x"
@@ -11936,8 +12075,7 @@
 				"eventemitter3": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-					"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
-					"dev": true
+					"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
 				}
 			}
 		},
@@ -11976,6 +12114,21 @@
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
+			}
+		},
+		"http-server": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/http-server/-/http-server-0.11.1.tgz",
+			"integrity": "sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w==",
+			"requires": {
+				"colors": "1.0.3",
+				"corser": "~2.0.0",
+				"ecstatic": "^3.0.0",
+				"http-proxy": "^1.8.1",
+				"opener": "~1.4.0",
+				"optimist": "0.6.x",
+				"portfinder": "^1.0.13",
+				"union": "~0.4.3"
 			}
 		},
 		"http-signature": {
@@ -13285,8 +13438,7 @@
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
 		"is-redirect": {
 			"version": "1.0.0",
@@ -13764,11 +13916,24 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
+		"json-typescript": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/json-typescript/-/json-typescript-1.1.2.tgz",
+			"integrity": "sha512-Np07MUsYMKbB0nNlw/MMIRjUK7ehO48LA4FsrzrhCfTUxMKbvOBAo0sc0b4nQ80ge9d32sModCunCgoyUojgUA=="
+		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
 			"dev": true
+		},
+		"jsonapi-typescript": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/jsonapi-typescript/-/jsonapi-typescript-0.1.3.tgz",
+			"integrity": "sha512-uPcPS01GeM+4HIyn18s7l1yD2S3uLZy2TX1UkQffCM0bLb3TMwudXUyVXPHTMZ4vdZT8MqKqN2vjB5PogTAdFQ==",
+			"requires": {
+				"json-typescript": "^1.0.0"
+			}
 		},
 		"jsonfile": {
 			"version": "3.0.1",
@@ -15139,8 +15304,7 @@
 		"mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"dev": true
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 		},
 		"mime-db": {
 			"version": "1.40.0",
@@ -15158,8 +15322,7 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-			"dev": true
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"mimic-response": {
 			"version": "1.0.1",
@@ -15197,8 +15360,7 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"minimist-options": {
 			"version": "4.1.0",
@@ -15388,7 +15550,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -15431,8 +15592,7 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"multimatch": {
 			"version": "4.0.0",
@@ -15464,8 +15624,7 @@
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-			"dev": true
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"mz": {
 			"version": "2.7.0",
@@ -15520,6 +15679,25 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
+		},
+		"nimn-date-parser": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/nimn-date-parser/-/nimn-date-parser-1.0.0.tgz",
+			"integrity": "sha512-1Nf+x3EeMvHUiHsVuEhiZnwA8RMeOBVTQWfB1S2n9+i6PYCofHd2HRMD+WOHIHYshy4T4Gk8wQoCol7Hq3av8Q=="
+		},
+		"nimn_schema_builder": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/nimn_schema_builder/-/nimn_schema_builder-1.1.0.tgz",
+			"integrity": "sha512-DK5/B8CM4qwzG2URy130avcwPev4uO0ev836FbQyKo1ms6I9z/i6EJyiZ+d9xtgloxUri0W+5gfR8YbPq7SheA=="
+		},
+		"nimnjs": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/nimnjs/-/nimnjs-1.3.2.tgz",
+			"integrity": "sha512-TIOtI4iqkQrUM1tiM76AtTQem0c7e56SkDZ7sj1d1MfUsqRcq2ZWQvej/O+HBTZV7u/VKnwlKTDugK/75IRPPw==",
+			"requires": {
+				"nimn-date-parser": "^1.0.0",
+				"nimn_schema_builder": "^1.0.0"
+			}
 		},
 		"node-fetch": {
 			"version": "2.6.0",
@@ -16144,8 +16322,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-component": {
 			"version": "0.0.3",
@@ -16457,7 +16634,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -16471,11 +16647,138 @@
 				"is-wsl": "^1.1.0"
 			}
 		},
+		"opencollective": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
+			"integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
+			"requires": {
+				"babel-polyfill": "6.23.0",
+				"chalk": "1.1.3",
+				"inquirer": "3.0.6",
+				"minimist": "1.2.0",
+				"node-fetch": "1.6.3",
+				"opn": "4.0.2"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"babel-polyfill": {
+					"version": "6.23.0",
+					"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+					"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+					"requires": {
+						"babel-runtime": "^6.22.0",
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.10.0"
+					}
+				},
+				"chardet": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+					"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+				},
+				"external-editor": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+					"requires": {
+						"chardet": "^0.4.0",
+						"iconv-lite": "^0.4.17",
+						"tmp": "^0.0.33"
+					}
+				},
+				"inquirer": {
+					"version": "3.0.6",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
+					"integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
+					"requires": {
+						"ansi-escapes": "^1.1.0",
+						"chalk": "^1.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^2.0.1",
+						"figures": "^2.0.0",
+						"lodash": "^4.3.0",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rx": "^4.1.0",
+						"string-width": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"through": "^2.3.6"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"node-fetch": {
+					"version": "1.6.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+					"integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
+					"requires": {
+						"encoding": "^0.1.11",
+						"is-stream": "^1.0.1"
+					}
+				},
+				"opn": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+					"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+					"requires": {
+						"object-assign": "^4.0.1",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.10.5",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				}
+			}
+		},
 		"opencollective-postinstall": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
 			"integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
 			"dev": true
+		},
+		"opener": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+			"integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
 		},
 		"openurl": {
 			"version": "1.1.1",
@@ -16496,7 +16799,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"dev": true,
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
@@ -16603,8 +16905,7 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"osenv": {
 			"version": "0.1.5",
@@ -17212,14 +17513,12 @@
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-			"dev": true
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"dev": true,
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
@@ -17335,7 +17634,6 @@
 			"version": "1.0.20",
 			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
 			"integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
-			"dev": true,
 			"requires": {
 				"async": "^1.5.2",
 				"debug": "^2.2.0",
@@ -17345,14 +17643,12 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -17904,8 +18200,7 @@
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-			"dev": true
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
@@ -18134,8 +18429,7 @@
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-			"dev": true
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resolve": {
 			"version": "1.10.1",
@@ -18219,7 +18513,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-			"dev": true,
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
@@ -18617,7 +18910,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
@@ -18634,8 +18926,7 @@
 		"rx": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-			"dev": true
+			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
 		},
 		"rxjs": {
 			"version": "5.5.12",
@@ -19071,8 +19362,7 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"slash": {
 			"version": "1.0.0",
@@ -19788,7 +20078,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -19904,8 +20193,7 @@
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-			"dev": true
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 		},
 		"symbol-observable": {
 			"version": "1.0.1",
@@ -20310,8 +20598,7 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "2.0.5",
@@ -20348,7 +20635,6 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
@@ -20862,6 +21148,21 @@
 			"integrity": "sha512-+cHtykLb+eF1yrSLWTwcYBrqJkTfX7Quoyg7Juhe6uylF43ZbMdxMuSHNYlnyLT8T7POAvavgBthzUF9AIaQvQ==",
 			"dev": true
 		},
+		"union": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
+			"integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
+			"requires": {
+				"qs": "~2.3.3"
+			},
+			"dependencies": {
+				"qs": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+					"integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
+				}
+			}
+		},
 		"union-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -21090,6 +21391,11 @@
 					"dev": true
 				}
 			}
+		},
+		"url-join": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+			"integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg="
 		},
 		"url-parse-lax": {
 			"version": "1.0.0",
@@ -21479,8 +21785,7 @@
 		"wordwrap": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-			"dev": true
+			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",

--- a/packages/sites/src/create-site-model-from-template.ts
+++ b/packages/sites/src/create-site-model-from-template.ts
@@ -61,7 +61,12 @@ export function createSiteModelFromTemplate(
 
   const product = getHubProduct(hubRequestOptions.portalSelf);
 
-  const title = getProp(settings, "solution.title") || "New Site";
+  let title = getProp(settings, "solution.title") || "New Site";
+  // handle issue with titles that are just numbers
+  if (typeof title === "number") {
+    title = title.toString();
+    deepSet(settings, "solution.title", title);
+  }
 
   // We need to carry some state through the promise chains
   // so we initialize an object outside the chain
@@ -154,6 +159,11 @@ export function createSiteModelFromTemplate(
       const dcatConfig = cloneObject(template.data.values.dcatConfig);
       delete template.data.values.dcatConfig;
       const siteModel = interpolate(template, settings, transforms);
+      // Special logic for the site title
+      // if the title is a string, containing only numbers, then the interpolation will set it as
+      // a number, which causes some problems. So we stamp in the string value in few places it matters
+      siteModel.item.title = getProp(settings, "solution.title");
+      siteModel.data.values.title = getProp(settings, "solution.title");
       // re-attach dcat...
       if (dcatConfig) {
         siteModel.data.values.dcatConfig = dcatConfig;

--- a/packages/sites/src/get-portal-site-hostname.ts
+++ b/packages/sites/src/get-portal-site-hostname.ts
@@ -1,5 +1,4 @@
 import { IPortal } from "@esri/arcgis-rest-portal";
-import { _getLocation } from "@esri/hub-common";
 
 /**
  * Return the correct route for the portal hosted site
@@ -13,9 +12,14 @@ export function getPortalSiteHostname(subdomain: string, portal: IPortal) {
   } else {
     port = portal.httpPort !== 80 ? `:${portal.httpPort}` : "";
   }
-  const curLocation = _getLocation();
-  const host = curLocation.hostname;
-  const basePath = curLocation.pathname.replace(/\/admin\//, "/");
+  // portalHostname will include the /<instance>
+  // i.e. `dev0016196.esri.com/portal`, but since we may need to
+  const host = portal.portalHostname.split("/")[0];
+  // wrangle the instance using customBaseUrl
+  let instance = "/";
+  if (portal.customBaseUrl) {
+    instance = `/${portal.customBaseUrl}/`;
+  }
 
-  return `${host}${port}${basePath}#/${subdomain}`;
+  return `${host}${port}${instance}apps/sites/#/${subdomain}`;
 }

--- a/packages/sites/test/create-site-model-from-template.test.ts
+++ b/packages/sites/test/create-site-model-from-template.test.ts
@@ -418,6 +418,8 @@ describe("createSiteModelFromTemplate", () => {
     expect(createdSite.item.title).toBe(
       String(numericTitleSettings.solution.title)
     );
+    // ensure the deepSet does not bork things up
+    expect(numericTitleSettings.solution.snippet).toBe("site-snippet");
     expect(createdSite.data.values.title).toBe(
       String(numericTitleSettings.solution.title)
     );

--- a/packages/sites/test/create-site-model-from-template.test.ts
+++ b/packages/sites/test/create-site-model-from-template.test.ts
@@ -177,7 +177,7 @@ describe("createSiteModelFromTemplate", () => {
     expect(createdSite.item.extent).toEqual(
       settings.organization.defaultExtentBBox
     );
-    expect(createdSite.data.values.title).toBe(settings.solution.name);
+    expect(createdSite.data.values.title).toBe(settings.solution.title);
 
     expect(createdSite.item.url).toBe(
       "https://unique-domain-org.hubqa.arcgis.com"
@@ -222,7 +222,7 @@ describe("createSiteModelFromTemplate", () => {
     expect(createdSite.item.extent).toEqual(
       settings.organization.defaultExtentBBox
     );
-    expect(createdSite.data.values.title).toBe(settings.solution.name);
+    expect(createdSite.data.values.title).toBe(settings.solution.title);
 
     expect(createdSite.item.url).toBe(
       "https://unique-domain-org.hubqa.arcgis.com"
@@ -272,7 +272,7 @@ describe("createSiteModelFromTemplate", () => {
     expect(createdSite.item.extent).toEqual(
       settings.organization.defaultExtentBBox
     );
-    expect(createdSite.data.values.title).toBe(settings.solution.name);
+    expect(createdSite.data.values.title).toBe(settings.solution.title);
 
     expect(createdSite.item.url).toBe("http://foobar-portal-baz.com");
     expect(createdSite.data.values.defaultHostname).toBe(portalSiteHostname);
@@ -383,20 +383,46 @@ describe("createSiteModelFromTemplate", () => {
 
     // Verify interpolation
     expect(createdSite.item.title).toBe(unicodeSettings.solution.title);
-    expect(createdSite.data.values.title).toBe(unicodeSettings.solution.name);
-
-    expect(createdSite.item.url).toBe(
-      "https://unique-domain-org.hubqa.arcgis.com"
-    );
-    expect(createdSite.data.values.defaultHostname).toBe(
-      "unique-domain-org.hubqa.arcgis.com"
-    );
-    expect(createdSite.data.values.subdomain).toBe(`unique-domain`);
+    expect(createdSite.data.values.title).toBe(unicodeSettings.solution.title);
 
     const passedDomain = ensureDomainSpy.calls.argsFor(0)[0];
     expect(passedDomain).toBe(
       "site",
       "when unicode chars present, pass site as domain name"
     );
+  });
+  it("handles numeric site title", async () => {
+    getProductSpy.and.returnValue("basic");
+    const numericTitleSettings = {
+      solution: {
+        title: 8888, // <-
+        snippet: "site-snippet",
+        name: "solution-name"
+      },
+      organization: {
+        defaultExtentBBox: [[67, 32], [1, 2]]
+      },
+      user: {
+        username: "tate",
+        culture: "no"
+      }
+    };
+    const createdSite = await createSiteModelFromTemplate(
+      commonModule.cloneObject(siteTemplate),
+      numericTitleSettings,
+      {},
+      MOCK_HUB_REQOPTS
+    );
+
+    // Verify interpolation
+    expect(createdSite.item.title).toBe(
+      String(numericTitleSettings.solution.title)
+    );
+    expect(createdSite.data.values.title).toBe(
+      String(numericTitleSettings.solution.title)
+    );
+
+    const passedDomain = ensureDomainSpy.calls.argsFor(0)[0];
+    expect(passedDomain).toBe("8888", "domain should be string using title");
   });
 });

--- a/packages/sites/test/get-portal-site-hostname.test.ts
+++ b/packages/sites/test/get-portal-site-hostname.test.ts
@@ -3,52 +3,63 @@ import * as commonModule from "@esri/hub-common";
 import { IPortal } from "@esri/arcgis-rest-portal";
 
 describe("getPortalSiteHostname", () => {
-  it("gets the ", async () => {
-    const currentLoc = {
-      hostname: "foobar.com",
-      pathname: "/admin/boop/"
-    };
-
-    spyOn(commonModule, "_getLocation").and.returnValue(currentLoc);
-
+  it("gets the site hostname + fragment", async () => {
     const subDomain = "sub-domain";
 
     let portal = ({
       allSSL: false,
-      httpPort: 80 // random, not 80
+      httpPort: 80,
+      customBaseUrl: "instance",
+      portalHostname: "foobar.com/instance"
     } as unknown) as IPortal;
 
     expect(getPortalSiteHostname(subDomain, portal)).toBe(
-      "foobar.com/boop/#/sub-domain"
+      "foobar.com/instance/apps/sites/#/sub-domain"
     );
 
     portal = ({
       allSSL: false,
-      httpPort: 23 // random, not 80
+      httpPort: 80,
+      portalHostname: "foobar.com/instance"
     } as unknown) as IPortal;
 
     expect(getPortalSiteHostname(subDomain, portal)).toBe(
-      "foobar.com:23/boop/#/sub-domain",
+      "foobar.com/apps/sites/#/sub-domain"
+    );
+
+    portal = ({
+      allSSL: false,
+      httpPort: 23, // random, not 80
+      customBaseUrl: "instance",
+      portalHostname: "foobar.com/instance"
+    } as unknown) as IPortal;
+
+    expect(getPortalSiteHostname(subDomain, portal)).toBe(
+      "foobar.com:23/instance/apps/sites/#/sub-domain",
       "attaches custom http port"
     );
 
     portal = ({
       allSSL: true,
-      httpsPort: 443 // random, not 80
+      httpsPort: 443, // random, not 80
+      customBaseUrl: "instance",
+      portalHostname: "foobar.com/instance"
     } as unknown) as IPortal;
 
     expect(getPortalSiteHostname(subDomain, portal)).toBe(
-      "foobar.com/boop/#/sub-domain",
+      "foobar.com/instance/apps/sites/#/sub-domain",
       "ssl default port"
     );
 
     portal = ({
       allSSL: true,
-      httpsPort: 234 // random, not 80
+      httpsPort: 234, // random, not 80
+      customBaseUrl: "instance",
+      portalHostname: "foobar.com/instance"
     } as unknown) as IPortal;
 
     expect(getPortalSiteHostname(subDomain, portal)).toBe(
-      "foobar.com:234/boop/#/sub-domain",
+      "foobar.com:234/instance/apps/sites/#/sub-domain",
       "attaches ssl custom port"
     );
   });


### PR DESCRIPTION
affects: @esri/hub-sites

Use portalSelf to derive site url for portal

We had some logic that used `window.location` via `_getLocation()` to derive the url of the resulting site. This logic worked when hub.js was running in the context of the Hub application (/apps/sites) but did not work when running in the context of the Solutions app.

This PR changes the logic to use the the `IPortal` passed into `getPortalSiteHostname` to derive the host + instance, and then construct the site url

Also handles the case when the title of a site is a number. This can happen because downstream apps using Hub.js may not be using typescript.