### PR TITLE
fix(@esri/hub-downloads): add support of ready_unknown status for portal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -554,71 +554,6 @@
 				}
 			}
 		},
-		"@esri/arcgis-rest-auth": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.25.0.tgz",
-			"integrity": "sha512-fJHbusenCtna0vZUcqX2L0a3KAKOrXIQJE++qRFK8IaVfIjx2KWgkOfgiAgW4kUkRsF1lq15pXEXVRo5LyD43Q==",
-			"requires": {
-				"@esri/arcgis-rest-types": "^2.25.0",
-				"tslib": "^1.13.0"
-			}
-		},
-		"@esri/arcgis-rest-feature-layer": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.25.0.tgz",
-			"integrity": "sha512-gg1QoJEIGyRt298N5/9VJ4HKnCWC5SYKw+0Vg77VpotkMcpObw3kAEpKyCc+9FVs4HrF+z6/NWsd84loU6hnOA==",
-			"requires": {
-				"@esri/arcgis-rest-types": "^2.25.0",
-				"tslib": "^1.13.0"
-			}
-		},
-		"@esri/arcgis-rest-portal": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.25.0.tgz",
-			"integrity": "sha512-OL2b59UhUtSfmJad6EwsOfUZRN031bgLfnznOrONRaB12U4iah+vjsCjkj1+l3sj8O6YlJpedLyP08Ci3IPY+g==",
-			"requires": {
-				"@esri/arcgis-rest-types": "^2.25.0",
-				"tslib": "^1.13.0"
-			}
-		},
-		"@esri/arcgis-rest-request": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.25.0.tgz",
-			"integrity": "sha512-4KYl+Ene7kwZg/M2ABneZizcWVoQkxDvyB9f6zrcKQ2uYjCj1kEl2OTBFmDhT7HFtBm/8cdLi79p/3kDGtSsqQ==",
-			"requires": {
-				"tslib": "^1.10.0"
-			}
-		},
-		"@esri/arcgis-rest-service-admin": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-2.25.0.tgz",
-			"integrity": "sha512-bxqVhrv7M/CnF0v1Itg/EKQjlFuARUd3I/jPmwmC4tRPGzsck3GMXEmOMzAqIb/uxoUWorRTXTjan+Iw+stOxw==",
-			"requires": {
-				"@esri/arcgis-rest-types": "^2.25.0",
-				"tslib": "^1.13.0"
-			}
-		},
-		"@esri/arcgis-rest-types": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.25.0.tgz",
-			"integrity": "sha512-2iMwX8tUVTImpoyKjNVsigc0JCUM8hTlyIu/hF2NnehyetvsefSut8njMObwHy872zfBzZ+kOMyulGGzdHvLxg=="
-		},
-		"@esri/hub-auth": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-auth/-/hub-auth-6.10.0.tgz",
-			"integrity": "sha512-7D2J8lL8ZyYVOhZyFZ91hxiGV1y3as0O6Mlm/PZBffHhkMWbJC/nQoNnNoHG1/QfSUjskr+v3IE9+ZKJVk00gw==",
-			"requires": {
-				"tslib": "^1.13.0"
-			}
-		},
-		"@esri/hub-types": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-types/-/hub-types-6.10.0.tgz",
-			"integrity": "sha512-fv16PUCaLVZY/rRAIg6HV6LxQLxheutaVovcOS3zmyqAgkeNI7keJblz50RrABSmfP7g+N2/XJRTHntze6ZrVA==",
-			"requires": {
-				"tslib": "^1.13.0"
-			}
-		},
 		"@evocateur/libnpmaccess": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz",
@@ -4210,16 +4145,6 @@
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true
 		},
-		"@types/adlib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
-			"integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
-		},
-		"@types/base-64": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-0.1.3.tgz",
-			"integrity": "sha512-DJpw7RKNMXygZ0j2xe6ROBqiJUy7JWEItkzOPBzrT35HUWS7VLYyW9XJX8yCCvE2xg8QD7wesvVyXFg8AVHTMA=="
-		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -4243,11 +4168,6 @@
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
 			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
 			"dev": true
-		},
-		"@types/faker": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.1.5.tgz",
-			"integrity": "sha512-2uEQFb7bsx68rqD4F8q95wZq6LTLOyexjv6BnvJogCO4jStkyc6IDEkODPQcWfovI6g6M3uPQ2/uD/oedJKkNw=="
 		},
 		"@types/fetch-mock": {
 			"version": "7.3.2",
@@ -4468,14 +4388,6 @@
 			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
 			"dev": true
 		},
-		"adlib": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
-			"integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
-			"requires": {
-				"esm": "^3.2.25"
-			}
-		},
 		"after": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
@@ -4621,12 +4533,14 @@
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"ansi-wrap": {
 			"version": "0.1.0",
@@ -5557,6 +5471,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
@@ -5687,11 +5602,6 @@
 					}
 				}
 			}
-		},
-		"base-64": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-			"integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
 		},
 		"base64-arraybuffer": {
 			"version": "0.1.5",
@@ -5845,11 +5755,6 @@
 					"dev": true
 				}
 			}
-		},
-		"blob": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-			"integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
 		},
 		"block-stream": {
 			"version": "0.0.9",
@@ -6614,6 +6519,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^2.2.1",
 				"escape-string-regexp": "^1.0.2",
@@ -6746,6 +6652,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
@@ -6784,7 +6691,8 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"cliui": {
 			"version": "3.2.0",
@@ -6903,7 +6811,8 @@
 		"colors": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+			"dev": true
 		},
 		"columnify": {
 			"version": "1.5.4",
@@ -8212,18 +8121,14 @@
 		"core-js": {
 			"version": "2.6.5",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-			"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+			"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
-		},
-		"corser": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
-			"integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c="
 		},
 		"cosmiconfig": {
 			"version": "1.1.0",
@@ -9128,24 +9033,6 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"ecstatic": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
-			"integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
-			"requires": {
-				"he": "^1.1.1",
-				"mime": "^1.6.0",
-				"minimist": "^1.1.0",
-				"url-join": "^2.0.5"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-				}
-			}
-		},
 		"editions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/editions/-/editions-2.3.0.tgz",
@@ -9418,7 +9305,8 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
 			"version": "1.8.1",
@@ -9461,11 +9349,6 @@
 				"jest-docblock": "^21.0.0"
 			}
 		},
-		"esm": {
-			"version": "3.2.25",
-			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
-		},
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -9495,11 +9378,6 @@
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
 			"dev": true
-		},
-		"eventemitter3": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
 		},
 		"events": {
 			"version": "3.0.0",
@@ -9795,11 +9673,6 @@
 			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
 			"dev": true
 		},
-		"faker": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/faker/-/faker-5.1.0.tgz",
-			"integrity": "sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw=="
-		},
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -9837,16 +9710,6 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
-		},
-		"fast-xml-parser": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.2.4.tgz",
-			"integrity": "sha512-19R4aaHzqsTe7gyL3wthWiyYyNFqVK1tzO6BMEAQEKRu4R3ptkl4FyuEtUMOPKdYsO6k6C/Ym3YJ6eCL49OdSw==",
-			"requires": {
-				"he": "~1.1.1",
-				"nimnjs": "^1.1.0",
-				"opencollective": "^1.0.3"
-			}
 		},
 		"fd-slicer": {
 			"version": "1.0.1",
@@ -9889,6 +9752,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -11858,6 +11722,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -11962,11 +11827,6 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
-		"he": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
-		},
 		"highlight.js": {
 			"version": "9.15.6",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
@@ -12067,6 +11927,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
 			"integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
+			"dev": true,
 			"requires": {
 				"eventemitter3": "1.x.x",
 				"requires-port": "1.x.x"
@@ -12075,7 +11936,8 @@
 				"eventemitter3": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-					"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+					"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
+					"dev": true
 				}
 			}
 		},
@@ -12114,21 +11976,6 @@
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
-			}
-		},
-		"http-server": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/http-server/-/http-server-0.11.1.tgz",
-			"integrity": "sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w==",
-			"requires": {
-				"colors": "1.0.3",
-				"corser": "~2.0.0",
-				"ecstatic": "^3.0.0",
-				"http-proxy": "^1.8.1",
-				"opener": "~1.4.0",
-				"optimist": "0.6.x",
-				"portfinder": "^1.0.13",
-				"union": "~0.4.3"
 			}
 		},
 		"http-signature": {
@@ -13438,7 +13285,8 @@
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-redirect": {
 			"version": "1.0.0",
@@ -13755,13 +13603,35 @@
 			}
 		},
 		"jasmine": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.4.0.tgz",
-			"integrity": "sha512-sR9b4n+fnBFDEd7VS2el2DeHgKcPiMVn44rtKFumq9q7P/t8WrxsVIZPob4UDdgcDNCwyDqwxCt4k9TDRmjPoQ==",
+			"version": "3.6.4",
+			"resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.6.4.tgz",
+			"integrity": "sha512-hIeOou6y0BgCOKYgXYveQvlY+PTHgDPajFf+vLCYbMTQ+VjAP9+EQv0nuC9+gyCAAWISRFauB1XUb9kFuOKtcQ==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.1.3",
-				"jasmine-core": "~3.4.0"
+				"glob": "^7.1.6",
+				"jasmine-core": "~3.6.0"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"jasmine-core": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.6.0.tgz",
+					"integrity": "sha512-8uQYa7zJN8hq9z+g8z1bqCfdC8eoDAeVnM5sfqs7KHv9/ifoJ500m018fpFc7RDaO6SWCLCXwo/wPSNcdYTgcw==",
+					"dev": true
+				}
 			}
 		},
 		"jasmine-core": {
@@ -13916,24 +13786,11 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
-		"json-typescript": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/json-typescript/-/json-typescript-1.1.2.tgz",
-			"integrity": "sha512-Np07MUsYMKbB0nNlw/MMIRjUK7ehO48LA4FsrzrhCfTUxMKbvOBAo0sc0b4nQ80ge9d32sModCunCgoyUojgUA=="
-		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
 			"dev": true
-		},
-		"jsonapi-typescript": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/jsonapi-typescript/-/jsonapi-typescript-0.1.3.tgz",
-			"integrity": "sha512-uPcPS01GeM+4HIyn18s7l1yD2S3uLZy2TX1UkQffCM0bLb3TMwudXUyVXPHTMZ4vdZT8MqKqN2vjB5PogTAdFQ==",
-			"requires": {
-				"json-typescript": "^1.0.0"
-			}
 		},
 		"jsonfile": {
 			"version": "3.0.1",
@@ -15304,7 +15161,8 @@
 		"mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true
 		},
 		"mime-db": {
 			"version": "1.40.0",
@@ -15322,7 +15180,8 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
 		},
 		"mimic-response": {
 			"version": "1.0.1",
@@ -15360,7 +15219,8 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"minimist-options": {
 			"version": "4.1.0",
@@ -15550,6 +15410,7 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -15592,7 +15453,8 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"multimatch": {
 			"version": "4.0.0",
@@ -15624,7 +15486,8 @@
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"mz": {
 			"version": "2.7.0",
@@ -15679,25 +15542,6 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
-		},
-		"nimn-date-parser": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/nimn-date-parser/-/nimn-date-parser-1.0.0.tgz",
-			"integrity": "sha512-1Nf+x3EeMvHUiHsVuEhiZnwA8RMeOBVTQWfB1S2n9+i6PYCofHd2HRMD+WOHIHYshy4T4Gk8wQoCol7Hq3av8Q=="
-		},
-		"nimn_schema_builder": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/nimn_schema_builder/-/nimn_schema_builder-1.1.0.tgz",
-			"integrity": "sha512-DK5/B8CM4qwzG2URy130avcwPev4uO0ev836FbQyKo1ms6I9z/i6EJyiZ+d9xtgloxUri0W+5gfR8YbPq7SheA=="
-		},
-		"nimnjs": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/nimnjs/-/nimnjs-1.3.2.tgz",
-			"integrity": "sha512-TIOtI4iqkQrUM1tiM76AtTQem0c7e56SkDZ7sj1d1MfUsqRcq2ZWQvej/O+HBTZV7u/VKnwlKTDugK/75IRPPw==",
-			"requires": {
-				"nimn-date-parser": "^1.0.0",
-				"nimn_schema_builder": "^1.0.0"
-			}
 		},
 		"node-fetch": {
 			"version": "2.6.0",
@@ -16322,7 +16166,8 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-component": {
 			"version": "0.0.3",
@@ -16634,6 +16479,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -16647,138 +16493,11 @@
 				"is-wsl": "^1.1.0"
 			}
 		},
-		"opencollective": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
-			"integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
-			"requires": {
-				"babel-polyfill": "6.23.0",
-				"chalk": "1.1.3",
-				"inquirer": "3.0.6",
-				"minimist": "1.2.0",
-				"node-fetch": "1.6.3",
-				"opn": "4.0.2"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-				},
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"babel-polyfill": {
-					"version": "6.23.0",
-					"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-					"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-					"requires": {
-						"babel-runtime": "^6.22.0",
-						"core-js": "^2.4.0",
-						"regenerator-runtime": "^0.10.0"
-					}
-				},
-				"chardet": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-					"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
-				},
-				"external-editor": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-					"requires": {
-						"chardet": "^0.4.0",
-						"iconv-lite": "^0.4.17",
-						"tmp": "^0.0.33"
-					}
-				},
-				"inquirer": {
-					"version": "3.0.6",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
-					"integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
-					"requires": {
-						"ansi-escapes": "^1.1.0",
-						"chalk": "^1.0.0",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^2.0.1",
-						"figures": "^2.0.0",
-						"lodash": "^4.3.0",
-						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rx": "^4.1.0",
-						"string-width": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"through": "^2.3.6"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"node-fetch": {
-					"version": "1.6.3",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-					"integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
-					"requires": {
-						"encoding": "^0.1.11",
-						"is-stream": "^1.0.1"
-					}
-				},
-				"opn": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-					"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-					"requires": {
-						"object-assign": "^4.0.1",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.10.5",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					},
-					"dependencies": {
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
-					}
-				}
-			}
-		},
 		"opencollective-postinstall": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
 			"integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
 			"dev": true
-		},
-		"opener": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-			"integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
 		},
 		"openurl": {
 			"version": "1.1.1",
@@ -16799,6 +16518,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
@@ -16905,7 +16625,8 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"osenv": {
 			"version": "0.1.5",
@@ -17513,12 +17234,14 @@
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
@@ -17634,6 +17357,7 @@
 			"version": "1.0.20",
 			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
 			"integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
+			"dev": true,
 			"requires": {
 				"async": "^1.5.2",
 				"debug": "^2.2.0",
@@ -17643,12 +17367,14 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
 				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -18200,7 +17926,8 @@
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
@@ -18429,7 +18156,8 @@
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.10.1",
@@ -18513,6 +18241,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
@@ -18910,6 +18639,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
@@ -18926,7 +18656,8 @@
 		"rx": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+			"dev": true
 		},
 		"rxjs": {
 			"version": "5.5.12",
@@ -19362,7 +19093,8 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
@@ -20078,6 +19810,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -20193,7 +19926,8 @@
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"symbol-observable": {
 			"version": "1.0.1",
@@ -20598,7 +20332,8 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"through2": {
 			"version": "2.0.5",
@@ -20635,6 +20370,7 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
@@ -21148,21 +20884,6 @@
 			"integrity": "sha512-+cHtykLb+eF1yrSLWTwcYBrqJkTfX7Quoyg7Juhe6uylF43ZbMdxMuSHNYlnyLT8T7POAvavgBthzUF9AIaQvQ==",
 			"dev": true
 		},
-		"union": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
-			"integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
-			"requires": {
-				"qs": "~2.3.3"
-			},
-			"dependencies": {
-				"qs": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-					"integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
-				}
-			}
-		},
 		"union-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -21391,11 +21112,6 @@
 					"dev": true
 				}
 			}
-		},
-		"url-join": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
-			"integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg="
 		},
 		"url-parse-lax": {
 			"version": "1.0.0",
@@ -21785,7 +21501,8 @@
 		"wordwrap": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+			"dev": true
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gh-release": "^3.4.0",
     "husky": "^4.2.5",
     "inspect-process": "^0.5.0",
-    "jasmine": "^3.4.0",
+    "jasmine": "^3.6.4",
     "jasmine-core": "^3.4.0",
     "karma": "^4.0.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/packages/downloads/src/download-status.ts
+++ b/packages/downloads/src/download-status.ts
@@ -1,4 +1,16 @@
-export type DownloadStatus =
+export enum DownloadStatus {
+  READY = "ready",
+  READY_UNKNOWN = "ready_unknown",
+  STALE = "stale",
+  NOT_READY = "not_ready",
+  CREATING = "creating",
+  UPDATING = "updating",
+  ERROR_CREATING = "error_creating",
+  ERROR_UPDATING = "error_updating",
+  ERROR = "error"
+}
+
+export type DownloadStatuses =
   | "ready"
   | "ready_unknown"
   | "stale"

--- a/packages/downloads/src/portal/portal-export-completion-error.ts
+++ b/packages/downloads/src/portal/portal-export-completion-error.ts
@@ -1,0 +1,10 @@
+/**
+ * @private
+ */
+export default class ExportCompletionError extends Error {
+  constructor(message: string) {
+    /* istanbul ignore next */
+    super(message);
+    Object.setPrototypeOf(this, ExportCompletionError.prototype);
+  }
+}

--- a/packages/downloads/src/portal/portal-export-success-handler.ts
+++ b/packages/downloads/src/portal/portal-export-success-handler.ts
@@ -1,0 +1,77 @@
+import {
+  updateItem,
+  removeItem,
+  moveItem,
+  setItemAccess
+} from "@esri/arcgis-rest-portal";
+import { urlBuilder } from "../utils";
+import { getExportsFolderId } from "./portal-get-exports-folder-id";
+import { DownloadStatus } from "../download-status";
+import ExportCompletionError from "./portal-export-completion-error";
+
+/**
+ * @private
+ */
+export function exportSuccessHandler(params: any): Promise<any> {
+  const {
+    downloadId,
+    datasetId,
+    exportCreated,
+    spatialRefId,
+    eventEmitter,
+    authentication
+  } = params;
+
+  return updateItem({
+    item: {
+      id: downloadId,
+      typeKeywords: `export:${datasetId},modified:${exportCreated},spatialRefId:${spatialRefId}`
+    },
+    authentication
+  })
+    .then(() => {
+      return setItemAccess({
+        id: downloadId,
+        authentication,
+        access: "private"
+      });
+    })
+    .then(() => {
+      return getExportsFolderId(authentication);
+    })
+    .then(exportFolderId => {
+      return moveItem({
+        itemId: downloadId,
+        folderId: exportFolderId,
+        authentication
+      });
+    })
+    .catch(err => {
+      if (err && err.code === "CONT_0011") {
+        // Skipping file move, already exists in target folder
+        return;
+      }
+
+      removeItem({
+        id: downloadId,
+        authentication
+      });
+      throw new ExportCompletionError(err.message);
+    })
+    .then(() => {
+      return eventEmitter.emit(`${downloadId}ExportComplete`, {
+        detail: {
+          metadata: {
+            downloadId,
+            status: DownloadStatus.READY,
+            lastModified: new Date().toISOString(),
+            downloadUrl: urlBuilder({
+              host: authentication.portal,
+              route: `content/items/${downloadId}/data`,
+              query: { token: authentication.token }
+            })
+          }
+        }
+      });
+    });
+}

--- a/packages/downloads/src/portal/portal-get-exports-folder-id.ts
+++ b/packages/downloads/src/portal/portal-get-exports-folder-id.ts
@@ -1,0 +1,30 @@
+import {
+  createFolder,
+  IAddFolderResponse,
+  getUserContent
+} from "@esri/arcgis-rest-portal";
+import { UserSession } from "@esri/arcgis-rest-auth";
+
+/**
+ * @private
+ */
+export function getExportsFolderId(
+  authentication: UserSession
+): Promise<string> {
+  return getUserContent({ authentication })
+    .then((userContent: any) => {
+      const exportFolder = userContent.folders.find((folder: any) => {
+        return folder.title === "item-exports";
+      });
+
+      if (exportFolder) {
+        return { folder: exportFolder };
+      }
+
+      return createFolder({ authentication, title: "item-exports" });
+    })
+    .then((response: unknown) => {
+      const { folder } = response as IAddFolderResponse;
+      return folder.id;
+    });
+}

--- a/packages/downloads/src/request-download-metadata.ts
+++ b/packages/downloads/src/request-download-metadata.ts
@@ -1,7 +1,7 @@
 import { portalRequestDownloadMetadata } from "./portal/portal-request-download-metadata";
 import { hubRequestDownloadMetadata } from "./hub/hub-request-download-metadata";
 import { DownloadFormat } from "./download-format";
-import { DownloadStatus } from "./download-status";
+import { DownloadStatuses } from "./download-status";
 import { UserSession } from "@esri/arcgis-rest-auth";
 
 export interface IDownloadMetadataRequestParams {
@@ -28,7 +28,7 @@ export interface IDownloadMetadataResults {
   downloadId: string;
 
   /* ready, not_ready, creating, updating, failed */
-  status: DownloadStatus;
+  status: DownloadStatuses;
 
   /* array of any errors related to exporting*/
   errors?: Error[];

--- a/packages/downloads/test/portal/portal-export-success-handler.test.ts
+++ b/packages/downloads/test/portal/portal-export-success-handler.test.ts
@@ -1,0 +1,466 @@
+import * as portal from "@esri/arcgis-rest-portal";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import * as folderHelper from "../../src/portal/portal-get-exports-folder-id";
+import { exportSuccessHandler } from "../../src/portal/portal-export-success-handler";
+import * as EventEmitter from "eventemitter3";
+
+function delay(milliseconds: number) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+class RestJsError extends Error {
+  code: string;
+  constructor(message: string, code: string) {
+    super(message);
+    Object.setPrototypeOf(this, RestJsError.prototype);
+    this.code = code;
+  }
+}
+
+describe("portalPollExportJobStatus", () => {
+  const authentication = new UserSession({
+    username: "portal-user",
+    portal: "http://portal.com/sharing/rest",
+    token: "123"
+  });
+  authentication.getToken = () =>
+    new Promise(resolve => {
+      resolve("123");
+    });
+
+  describe("export-completed handling errors", () => {
+    it("updateItem failure", async done => {
+      try {
+        spyOn(portal, "updateItem").and.callFake(async () => {
+          return Promise.reject(new Error("5xx"));
+        });
+
+        spyOn(portal, "removeItem").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        const mockEventEmitter = new EventEmitter();
+        await exportSuccessHandler({
+          downloadId: "download-id",
+          datasetId: "abcdef0123456789abcdef0123456789_0",
+          authentication,
+          exportCreated: 1000,
+          eventEmitter: mockEventEmitter
+        });
+        throw new Error("should have errored");
+      } catch (err) {
+        expect(err.message).toBe("5xx");
+      } finally {
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: "download-id",
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(1);
+        expect((portal.removeItem as any).calls.first().args).toEqual([
+          {
+            id: "download-id",
+            authentication
+          }
+        ]);
+        done();
+      }
+    });
+
+    it("setItemAccess failure", async done => {
+      try {
+        spyOn(portal, "updateItem").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        spyOn(portal, "setItemAccess").and.callFake(async () => {
+          return Promise.reject(new Error("5xx"));
+        });
+
+        spyOn(portal, "removeItem").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        const mockEventEmitter = new EventEmitter();
+
+        await exportSuccessHandler({
+          downloadId: "download-id",
+          datasetId: "abcdef0123456789abcdef0123456789_0",
+          authentication,
+          exportCreated: 1000,
+          eventEmitter: mockEventEmitter
+        });
+        throw new Error("should have errored");
+      } catch (err) {
+        expect(err.message).toEqual("5xx");
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: "download-id",
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
+        expect((portal.setItemAccess as any).calls.first().args).toEqual([
+          {
+            id: "download-id",
+            authentication,
+            access: "private"
+          }
+        ]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(1);
+        expect((portal.removeItem as any).calls.first().args).toEqual([
+          {
+            id: "download-id",
+            authentication
+          }
+        ]);
+      } finally {
+        done();
+      }
+    });
+
+    it("getExportsFolderId failure", async done => {
+      try {
+        spyOn(portal, "updateItem").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        spyOn(portal, "setItemAccess").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        spyOn(folderHelper, "getExportsFolderId").and.callFake(async () => {
+          return Promise.reject(new Error("5xx"));
+        });
+
+        spyOn(portal, "removeItem").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        const mockEventEmitter = new EventEmitter();
+
+        await exportSuccessHandler({
+          downloadId: "download-id",
+          datasetId: "abcdef0123456789abcdef0123456789_0",
+          authentication,
+          exportCreated: 1000,
+          eventEmitter: mockEventEmitter
+        });
+        throw new Error("should have errored");
+      } catch (err) {
+        expect(err.message).toEqual("5xx");
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: "download-id",
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
+        expect((portal.setItemAccess as any).calls.first().args).toEqual([
+          {
+            id: "download-id",
+            authentication,
+            access: "private"
+          }
+        ]);
+        expect(folderHelper.getExportsFolderId).toHaveBeenCalledTimes(1);
+        expect(
+          (folderHelper.getExportsFolderId as any).calls.first().args
+        ).toEqual([authentication]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(1);
+        expect((portal.removeItem as any).calls.first().args).toEqual([
+          {
+            id: "download-id",
+            authentication
+          }
+        ]);
+      } finally {
+        done();
+      }
+    });
+
+    it("moveItem failure", async done => {
+      try {
+        spyOn(portal, "updateItem").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        spyOn(portal, "setItemAccess").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        spyOn(folderHelper, "getExportsFolderId").and.callFake(async () => {
+          return Promise.resolve("export-folder-id");
+        });
+
+        spyOn(portal, "moveItem").and.callFake(async () => {
+          return Promise.reject(new Error("5xx"));
+        });
+
+        spyOn(portal, "removeItem").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        const mockEventEmitter = new EventEmitter();
+
+        await exportSuccessHandler({
+          downloadId: "download-id",
+          datasetId: "abcdef0123456789abcdef0123456789_0",
+          authentication,
+          exportCreated: 1000,
+          eventEmitter: mockEventEmitter
+        });
+        throw new Error("should have errored");
+      } catch (err) {
+        expect(err.message).toEqual("5xx");
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: "download-id",
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
+        expect((portal.setItemAccess as any).calls.first().args).toEqual([
+          {
+            id: "download-id",
+            authentication,
+            access: "private"
+          }
+        ]);
+        expect(folderHelper.getExportsFolderId).toHaveBeenCalledTimes(1);
+        expect(
+          (folderHelper.getExportsFolderId as any).calls.first().args
+        ).toEqual([authentication]);
+        expect(portal.moveItem).toHaveBeenCalledTimes(1);
+        expect((portal.moveItem as any).calls.first().args).toEqual([
+          {
+            itemId: "download-id",
+            folderId: "export-folder-id",
+            authentication
+          }
+        ]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(1);
+        expect((portal.removeItem as any).calls.first().args).toEqual([
+          {
+            id: "download-id",
+            authentication
+          }
+        ]);
+      } finally {
+        done();
+      }
+    });
+  });
+
+  describe("exported-completed, successful handling", () => {
+    it("succeeds without moving download", async done => {
+      try {
+        spyOn(portal, "updateItem").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        spyOn(portal, "setItemAccess").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        spyOn(folderHelper, "getExportsFolderId").and.callFake(async () => {
+          return Promise.resolve("export-folder-id");
+        });
+
+        spyOn(portal, "moveItem").and.callFake(async () => {
+          return Promise.reject(new RestJsError("Already moved", "CONT_0011"));
+        });
+
+        spyOn(portal, "removeItem").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        const mockEventEmitter = new EventEmitter();
+        spyOn(mockEventEmitter, "emit");
+        await exportSuccessHandler({
+          downloadId: "download-id",
+          datasetId: "abcdef0123456789abcdef0123456789_0",
+          authentication,
+          exportCreated: 1000,
+          eventEmitter: mockEventEmitter
+        });
+
+        await delay(100);
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: "download-id",
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
+        expect((portal.setItemAccess as any).calls.first().args).toEqual([
+          {
+            id: "download-id",
+            authentication,
+            access: "private"
+          }
+        ]);
+        expect(folderHelper.getExportsFolderId).toHaveBeenCalledTimes(1);
+        expect(
+          (folderHelper.getExportsFolderId as any).calls.first().args
+        ).toEqual([authentication]);
+        expect(portal.moveItem).toHaveBeenCalledTimes(1);
+        expect((portal.moveItem as any).calls.first().args).toEqual([
+          {
+            itemId: "download-id",
+            folderId: "export-folder-id",
+            authentication
+          }
+        ]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(0);
+        expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+        expect((mockEventEmitter.emit as any).calls.first().args[0]).toEqual(
+          "download-idExportComplete"
+        );
+        const {
+          detail: {
+            metadata: { downloadId, status, downloadUrl, lastModified }
+          }
+        } = (mockEventEmitter.emit as any).calls.first().args[1];
+        expect(downloadId).toEqual("download-id");
+        expect(status).toEqual("ready");
+        expect(downloadUrl).toEqual(
+          "http://portal.com/sharing/rest/content/items/download-id/data?token=123"
+        );
+        expect(
+          /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/.test(
+            lastModified
+          )
+        ).toEqual(true);
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+
+    it("succeeds with spatialRefId", async done => {
+      try {
+        spyOn(portal, "getItemStatus").and.returnValues(
+          new Promise((resolve, reject) => {
+            resolve({
+              status: "progress"
+            });
+          }),
+          new Promise((resolve, reject) => {
+            resolve({
+              status: "completed"
+            });
+          })
+        );
+
+        spyOn(portal, "updateItem").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        spyOn(portal, "setItemAccess").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        spyOn(folderHelper, "getExportsFolderId").and.callFake(async () => {
+          return Promise.resolve("export-folder-id");
+        });
+
+        spyOn(portal, "moveItem").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        spyOn(portal, "removeItem").and.callFake(async () => {
+          return Promise.resolve();
+        });
+
+        const mockEventEmitter = new EventEmitter();
+        spyOn(mockEventEmitter, "emit");
+        await exportSuccessHandler({
+          downloadId: "download-id",
+          datasetId: "abcdef0123456789abcdef0123456789_0",
+          authentication,
+          exportCreated: 1000,
+          eventEmitter: mockEventEmitter
+        });
+
+        await delay(100);
+        expect(portal.updateItem).toHaveBeenCalledTimes(1);
+        expect((portal.updateItem as any).calls.first().args).toEqual([
+          {
+            item: {
+              id: "download-id",
+              typeKeywords: `export:abcdef0123456789abcdef0123456789_0,modified:1000,spatialRefId:undefined`
+            },
+            authentication
+          }
+        ]);
+        expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
+        expect((portal.setItemAccess as any).calls.first().args).toEqual([
+          {
+            id: "download-id",
+            authentication,
+            access: "private"
+          }
+        ]);
+        expect(folderHelper.getExportsFolderId).toHaveBeenCalledTimes(1);
+        expect(
+          (folderHelper.getExportsFolderId as any).calls.first().args
+        ).toEqual([authentication]);
+        expect(portal.moveItem).toHaveBeenCalledTimes(1);
+        expect((portal.moveItem as any).calls.first().args).toEqual([
+          {
+            itemId: "download-id",
+            folderId: "export-folder-id",
+            authentication
+          }
+        ]);
+        expect(portal.removeItem).toHaveBeenCalledTimes(0);
+        expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
+        expect((mockEventEmitter.emit as any).calls.first().args[0]).toEqual(
+          "download-idExportComplete"
+        );
+        const {
+          detail: {
+            metadata: { downloadId, status, downloadUrl, lastModified }
+          }
+        } = (mockEventEmitter.emit as any).calls.first().args[1];
+        expect(downloadId).toEqual("download-id");
+        expect(status).toEqual("ready");
+        expect(downloadUrl).toEqual(
+          "http://portal.com/sharing/rest/content/items/download-id/data?token=123"
+        );
+        expect(
+          /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/.test(
+            lastModified
+          )
+        ).toEqual(true);
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+  });
+});

--- a/packages/downloads/test/portal/portal-get-exports-folder-id.test.ts
+++ b/packages/downloads/test/portal/portal-get-exports-folder-id.test.ts
@@ -1,0 +1,130 @@
+import * as portal from "@esri/arcgis-rest-portal";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { getExportsFolderId } from "../../src/portal/portal-get-exports-folder-id";
+
+describe("portalPollExportJobStatus", () => {
+  const authentication = new UserSession({
+    username: "portal-user",
+    portal: "http://portal.com/sharing/rest",
+    token: "123"
+  });
+  authentication.getToken = () =>
+    new Promise(resolve => {
+      resolve("123");
+    });
+
+  it("userContent failure", async done => {
+    try {
+      spyOn(portal, "getUserContent").and.callFake(async () => {
+        return Promise.reject(new Error("5xx"));
+      });
+
+      await getExportsFolderId(authentication);
+      fail();
+    } catch (err) {
+      expect(err.message).toEqual("5xx");
+      expect(portal.getUserContent).toHaveBeenCalledTimes(1);
+      expect((portal.getUserContent as any).calls.first().args).toEqual([
+        { authentication }
+      ]);
+    } finally {
+      done();
+    }
+  });
+
+  it("createFolder failure", async done => {
+    try {
+      spyOn(portal, "getUserContent").and.callFake(async () => {
+        return Promise.resolve({ folders: [] });
+      });
+
+      spyOn(portal, "createFolder").and.callFake(async () => {
+        return Promise.reject(new Error("5xx"));
+      });
+
+      spyOn(portal, "removeItem").and.callFake(async () => {
+        return Promise.resolve();
+      });
+
+      await getExportsFolderId(authentication);
+      fail();
+    } catch (err) {
+      expect(err.message).toEqual("5xx");
+      expect(portal.getUserContent).toHaveBeenCalledTimes(1);
+      expect((portal.getUserContent as any).calls.first().args).toEqual([
+        { authentication }
+      ]);
+      expect(portal.createFolder).toHaveBeenCalledTimes(1);
+      expect((portal.createFolder as any).calls.first().args).toEqual([
+        {
+          title: "item-exports",
+          authentication
+        }
+      ]);
+    } finally {
+      done();
+    }
+  });
+
+  it("succeeds without existing exports folder", async done => {
+    try {
+      spyOn(portal, "getUserContent").and.callFake(async () => {
+        return Promise.resolve({ folders: [] });
+      });
+
+      spyOn(portal, "createFolder").and.callFake(async () => {
+        return Promise.resolve({ folder: { id: "export-folder-id" } });
+      });
+
+      const result = await getExportsFolderId(authentication);
+      expect(result).toBe("export-folder-id");
+      expect(portal.getUserContent).toHaveBeenCalledTimes(1);
+      expect((portal.getUserContent as any).calls.first().args).toEqual([
+        { authentication }
+      ]);
+      expect(portal.createFolder).toHaveBeenCalledTimes(1);
+      expect((portal.createFolder as any).calls.first().args).toEqual([
+        {
+          title: "item-exports",
+          authentication
+        }
+      ]);
+    } catch (err) {
+      expect(err).toEqual(undefined);
+    } finally {
+      done();
+    }
+  });
+
+  it("succeeds with existing exports folder", async done => {
+    try {
+      spyOn(portal, "getUserContent").and.returnValue(
+        new Promise((resolve, reject) => {
+          resolve({
+            folders: [
+              {
+                id: "export-folder-id",
+                title: "item-exports"
+              }
+            ]
+          });
+        })
+      );
+
+      spyOn(portal, "createFolder");
+
+      const result = await getExportsFolderId(authentication);
+      expect(result).toBe("export-folder-id");
+
+      expect(portal.getUserContent).toHaveBeenCalledTimes(1);
+      expect((portal.getUserContent as any).calls.first().args).toEqual([
+        { authentication }
+      ]);
+      expect(portal.createFolder).toHaveBeenCalledTimes(0);
+    } catch (err) {
+      expect(err).toEqual(undefined);
+    } finally {
+      done();
+    }
+  });
+});

--- a/packages/downloads/test/portal/portal-request-download-metadata.test.ts
+++ b/packages/downloads/test/portal/portal-request-download-metadata.test.ts
@@ -220,6 +220,12 @@ describe("portalRequestDownloadMetadata", () => {
           })
         );
 
+        const getLayerSpy = spyOn(featureLayer, "getLayer").and.returnValue(
+          new Promise(resolve => {
+            resolve({ id: 0 });
+          })
+        );
+
         const searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
           new Promise(resolve => {
             resolve({ results: [] });
@@ -249,6 +255,13 @@ describe("portalRequestDownloadMetadata", () => {
         expect(getServiceSpy.calls.argsFor(0)).toEqual([
           {
             url: "http://feature-service.com/FeatureServer",
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(1);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/0",
             authentication
           }
         ]);
@@ -290,6 +303,12 @@ describe("portalRequestDownloadMetadata", () => {
           })
         );
 
+        const getLayerSpy = spyOn(featureLayer, "getLayer").and.returnValue(
+          new Promise(resolve => {
+            resolve({ id: 0 });
+          })
+        );
+
         const searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
           new Promise(resolve => {
             resolve({ results: [] });
@@ -323,6 +342,13 @@ describe("portalRequestDownloadMetadata", () => {
             authentication
           }
         ]);
+        expect(getLayerSpy.calls.count()).toEqual(1);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/0",
+            authentication
+          }
+        ]);
         expect(searchItemsSpy.calls.count()).toEqual(1);
         expect(searchItemsSpy.calls.argsFor(0)).toEqual([
           {
@@ -342,6 +368,7 @@ describe("portalRequestDownloadMetadata", () => {
     });
 
     it("layer id, single-layer, has lastEditDate, not cached", async done => {
+      const elevenMinsAgo = new Date(new Date().getTime() - 11 * 60 * 1000);
       try {
         const getItemSpy = spyOn(portal, "getItem").and.returnValue(
           new Promise(resolve => {
@@ -356,9 +383,16 @@ describe("portalRequestDownloadMetadata", () => {
         const getServiceSpy = spyOn(featureLayer, "getService").and.returnValue(
           new Promise(resolve => {
             resolve({
-              layers: [
-                { id: 0, editingInfo: { lastEditDate: new Date(0).getTime() } }
-              ]
+              layers: [{ id: 0 }]
+            });
+          })
+        );
+
+        const getLayerSpy = spyOn(featureLayer, "getLayer").and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              id: 0,
+              editingInfo: { lastEditDate: elevenMinsAgo.getTime() }
             });
           })
         );
@@ -378,7 +412,7 @@ describe("portalRequestDownloadMetadata", () => {
         expect(result).toEqual({
           downloadId:
             "abcdef0123456789abcdef0123456789_0:CSV:undefined:undefined:undefined",
-          lastEditDate: new Date(0).toISOString(),
+          lastEditDate: elevenMinsAgo.toISOString(),
           status: "not_ready"
         });
 
@@ -393,6 +427,13 @@ describe("portalRequestDownloadMetadata", () => {
         expect(getServiceSpy.calls.argsFor(0)).toEqual([
           {
             url: "http://feature-service.com/FeatureServer",
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(1);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/0",
             authentication
           }
         ]);
@@ -432,6 +473,12 @@ describe("portalRequestDownloadMetadata", () => {
           })
         );
 
+        const getLayerSpy = spyOn(featureLayer, "getLayer").and.returnValue(
+          new Promise(resolve => {
+            resolve({});
+          })
+        );
+
         const searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
           new Promise(resolve => {
             resolve({ results: [] });
@@ -465,6 +512,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication
           }
         ]);
+        expect(getLayerSpy.calls.count()).toEqual(0);
         expect(searchItemsSpy.calls.count()).toEqual(1);
         expect(searchItemsSpy.calls.argsFor(0)).toEqual([
           {
@@ -503,6 +551,15 @@ describe("portalRequestDownloadMetadata", () => {
           })
         );
 
+        const getLayerSpy = spyOn(featureLayer, "getLayer").and.returnValues(
+          new Promise(resolve => {
+            resolve({ id: 0 });
+          }),
+          new Promise(resolve => {
+            resolve({ id: 1 });
+          })
+        );
+
         const searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
           new Promise(resolve => {
             resolve({ results: [] });
@@ -533,6 +590,19 @@ describe("portalRequestDownloadMetadata", () => {
         expect(getServiceSpy.calls.argsFor(0)).toEqual([
           {
             url: "http://feature-service.com/FeatureServer",
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(2);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/0",
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.argsFor(1)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/1",
             authentication
           }
         ]);
@@ -574,6 +644,15 @@ describe("portalRequestDownloadMetadata", () => {
           })
         );
 
+        const getLayer = spyOn(featureLayer, "getLayer").and.returnValues(
+          new Promise(resolve => {
+            resolve({ id: 0 });
+          }),
+          new Promise(resolve => {
+            resolve({ id: 1 });
+          })
+        );
+
         const searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
           new Promise(resolve => {
             resolve({ results: [] });
@@ -607,6 +686,19 @@ describe("portalRequestDownloadMetadata", () => {
             authentication
           }
         ]);
+        expect(getLayer.calls.count()).toEqual(2);
+        expect(getLayer.calls.argsFor(0)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/0",
+            authentication
+          }
+        ]);
+        expect(getLayer.calls.argsFor(1)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/1",
+            authentication
+          }
+        ]);
         expect(searchItemsSpy.calls.count()).toEqual(1);
         expect(searchItemsSpy.calls.argsFor(0)).toEqual([
           {
@@ -626,6 +718,9 @@ describe("portalRequestDownloadMetadata", () => {
     });
 
     it("no layer id, multi-layer, has lastEditDate, not cached", async done => {
+      const twelveMinsAgo = new Date(new Date().getTime() - 12 * 60 * 1000);
+      const elevenMinsAgo = new Date(new Date().getTime() - 11 * 60 * 1000);
+
       try {
         const getItemSpy = spyOn(portal, "getItem").and.returnValue(
           new Promise(resolve => {
@@ -640,13 +735,22 @@ describe("portalRequestDownloadMetadata", () => {
         const getServiceSpy = spyOn(featureLayer, "getService").and.returnValue(
           new Promise(resolve => {
             resolve({
-              layers: [
-                { id: 0, editingInfo: { lastEditDate: new Date(0).getTime() } },
-                {
-                  id: 1,
-                  editingInfo: { lastEditDate: new Date(100000000).getTime() }
-                }
-              ]
+              layers: [{ id: 0 }, { id: 1 }]
+            });
+          })
+        );
+
+        const getLayerSpy = spyOn(featureLayer, "getLayer").and.returnValues(
+          new Promise(resolve => {
+            resolve({
+              id: 0,
+              editingInfo: { lastEditDate: twelveMinsAgo.getTime() }
+            });
+          }),
+          new Promise(resolve => {
+            resolve({
+              id: 1,
+              editingInfo: { lastEditDate: elevenMinsAgo.getTime() }
             });
           })
         );
@@ -666,7 +770,7 @@ describe("portalRequestDownloadMetadata", () => {
         expect(result).toEqual({
           downloadId:
             "abcdef0123456789abcdef0123456789:CSV:undefined:undefined:undefined",
-          lastEditDate: new Date(100000000).toISOString(),
+          lastEditDate: elevenMinsAgo.toISOString(),
           status: "not_ready"
         });
 
@@ -681,6 +785,19 @@ describe("portalRequestDownloadMetadata", () => {
         expect(getServiceSpy.calls.argsFor(0)).toEqual([
           {
             url: "http://feature-service.com/FeatureServer",
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(2);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/0",
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.argsFor(1)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/1",
             authentication
           }
         ]);
@@ -722,6 +839,12 @@ describe("portalRequestDownloadMetadata", () => {
           })
         );
 
+        const getLayerSpy = spyOn(featureLayer, "getLayer").and.returnValue(
+          new Promise(resolve => {
+            resolve({ id: 0 });
+          })
+        );
+
         const searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
           new Promise(resolve => {
             resolve({
@@ -744,7 +867,7 @@ describe("portalRequestDownloadMetadata", () => {
         expect(result).toEqual({
           downloadId: "abcdef",
           lastEditDate: undefined,
-          status: "ready",
+          status: "ready_unknown",
           contentLastModified: "2020-07-11T07:01:16.000Z",
           lastModified: "2020-07-11T07:01:16.000Z",
           downloadUrl:
@@ -762,6 +885,13 @@ describe("portalRequestDownloadMetadata", () => {
         expect(getServiceSpy.calls.argsFor(0)).toEqual([
           {
             url: "http://feature-service.com/FeatureServer",
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(1);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/0",
             authentication
           }
         ]);
@@ -800,12 +930,20 @@ describe("portalRequestDownloadMetadata", () => {
             resolve({
               layers: [
                 {
-                  id: 0,
-                  editingInfo: {
-                    lastEditDate: new Date(1584450876000).getTime()
-                  }
+                  id: 0
                 }
               ]
+            });
+          })
+        );
+
+        const getLayerSpy = spyOn(featureLayer, "getLayer").and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              id: 0,
+              editingInfo: {
+                lastEditDate: new Date(1584450876000).getTime()
+              }
             });
           })
         );
@@ -853,6 +991,118 @@ describe("portalRequestDownloadMetadata", () => {
             authentication
           }
         ]);
+        expect(getLayerSpy.calls.count()).toEqual(1);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/0",
+            authentication
+          }
+        ]);
+        expect(searchItemsSpy.calls.count()).toEqual(1);
+        expect(searchItemsSpy.calls.argsFor(0)).toEqual([
+          {
+            authentication,
+            num: 1,
+            q:
+              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+            sortField: "modified",
+            sortOrder: "DESC"
+          }
+        ]);
+      } catch (err) {
+        expect(err).toEqual(undefined);
+      } finally {
+        done();
+      }
+    });
+
+    it("has lastEditDate within last 10 mins, cached, ready", async done => {
+      const nineMinsAgo = new Date(new Date().getTime() - 9 * 60 * 1000);
+
+      try {
+        const getItemSpy = spyOn(portal, "getItem").and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              type: "Feature Service",
+              modified: nineMinsAgo.getTime(),
+              url: "http://feature-service.com/FeatureServer"
+            });
+          })
+        );
+
+        const getServiceSpy = spyOn(featureLayer, "getService").and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              layers: [
+                {
+                  id: 0
+                }
+              ]
+            });
+          })
+        );
+
+        const getLayerSpy = spyOn(featureLayer, "getLayer").and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              id: 0,
+              editingInfo: {
+                lastEditDate: nineMinsAgo.getTime()
+              }
+            });
+          })
+        );
+
+        const searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              results: [
+                {
+                  id: "abcdef",
+                  created: nineMinsAgo.getTime()
+                }
+              ]
+            });
+          })
+        );
+
+        const result = await portalRequestDownloadMetadata({
+          datasetId: "abcdef0123456789abcdef0123456789_0",
+          format: "CSV",
+          authentication
+        });
+
+        expect(result).toEqual({
+          downloadId: "abcdef",
+          lastEditDate: nineMinsAgo.toISOString(),
+          status: "ready",
+          contentLastModified: nineMinsAgo.toISOString(),
+          lastModified: nineMinsAgo.toISOString(),
+          downloadUrl:
+            "http://portal.com/sharing/rest/content/items/abcdef/data?token=123"
+        });
+
+        expect(getItemSpy.calls.count()).toEqual(1);
+        expect(getItemSpy.calls.argsFor(0)).toEqual([
+          "abcdef0123456789abcdef0123456789",
+          {
+            authentication
+          }
+        ]);
+        expect(getServiceSpy.calls.count()).toEqual(1);
+        expect(getServiceSpy.calls.argsFor(0)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer",
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(1);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/0",
+            authentication
+          }
+        ]);
         expect(searchItemsSpy.calls.count()).toEqual(1);
         expect(searchItemsSpy.calls.argsFor(0)).toEqual([
           {
@@ -872,6 +1122,7 @@ describe("portalRequestDownloadMetadata", () => {
     });
 
     it("has lastEditDate, cached, stale", async done => {
+      const elevenMinsAgo = new Date(new Date().getTime() - 11 * 60 * 1000);
       try {
         const getItemSpy = spyOn(portal, "getItem").and.returnValue(
           new Promise(resolve => {
@@ -888,12 +1139,20 @@ describe("portalRequestDownloadMetadata", () => {
             resolve({
               layers: [
                 {
-                  id: 0,
-                  editingInfo: {
-                    lastEditDate: new Date(1584450876000).getTime()
-                  }
+                  id: 0
                 }
               ]
+            });
+          })
+        );
+
+        const getLayerSpy = spyOn(featureLayer, "getLayer").and.returnValue(
+          new Promise(resolve => {
+            resolve({
+              id: 0,
+              editingInfo: {
+                lastEditDate: elevenMinsAgo.getTime()
+              }
             });
           })
         );
@@ -919,7 +1178,7 @@ describe("portalRequestDownloadMetadata", () => {
 
         expect(result).toEqual({
           downloadId: "abcdef",
-          lastEditDate: "2020-03-17T13:14:36.000Z",
+          lastEditDate: elevenMinsAgo.toISOString(),
           status: "stale",
           contentLastModified: "2019-11-22T19:27:56.000Z",
           lastModified: "2019-11-22T19:27:56.000Z",
@@ -938,6 +1197,13 @@ describe("portalRequestDownloadMetadata", () => {
         expect(getServiceSpy.calls.argsFor(0)).toEqual([
           {
             url: "http://feature-service.com/FeatureServer",
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(1);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/0",
             authentication
           }
         ]);
@@ -981,6 +1247,19 @@ describe("portalRequestDownloadMetadata", () => {
           })
         );
 
+        const getLayerSpy = spyOn(featureLayer, "getLayer").and.returnValues(
+          new Promise(resolve => {
+            resolve({
+              id: 0
+            });
+          }),
+          new Promise(resolve => {
+            resolve({
+              id: 1
+            });
+          })
+        );
+
         const searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
           new Promise(resolve => {
             resolve({ results: [] });
@@ -1011,6 +1290,19 @@ describe("portalRequestDownloadMetadata", () => {
         expect(getServiceSpy.calls.argsFor(0)).toEqual([
           {
             url: "http://feature-service.com/FeatureServer",
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(2);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/0",
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.argsFor(1)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/1",
             authentication
           }
         ]);
@@ -1054,6 +1346,19 @@ describe("portalRequestDownloadMetadata", () => {
           })
         );
 
+        const getLayerSpy = spyOn(featureLayer, "getLayer").and.returnValues(
+          new Promise(resolve => {
+            resolve({
+              id: 0
+            });
+          }),
+          new Promise(resolve => {
+            resolve({
+              id: 1
+            });
+          })
+        );
+
         const searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
           new Promise(resolve => {
             resolve({ results: [] });
@@ -1084,6 +1389,19 @@ describe("portalRequestDownloadMetadata", () => {
         expect(getServiceSpy.calls.argsFor(0)).toEqual([
           {
             url: "http://feature-service.com/FeatureServer",
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.count()).toEqual(2);
+        expect(getLayerSpy.calls.argsFor(0)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/0",
+            authentication
+          }
+        ]);
+        expect(getLayerSpy.calls.argsFor(1)).toEqual([
+          {
+            url: "http://feature-service.com/FeatureServer/1",
             authentication
           }
         ]);


### PR DESCRIPTION
* Adds a `ready_unknown` status for portal downloads
* Puts the portal export-complete handler in its own file
* Puts the function for acquiring exports folder id in its own file.
* Adds tests.