### PR TITLE
feat(sites): enable the new download sidebar capability by default

### DIFF
--- a/packages/sites/src/ensure-required-site-properties.ts
+++ b/packages/sites/src/ensure-required-site-properties.ts
@@ -65,7 +65,8 @@ export function ensureRequiredSiteProperties(
     "document_iframes",
     "items_view",
     "app_page",
-    "globalNav"
+    "globalNav",
+    "downloadSidebar"
   ];
   if (!isPortal) {
     caps.push("socialSharing");


### PR DESCRIPTION
affects: @esri/hub-sites

enable the `downloadSidebar` capability by default for new sites