### PR TITLE
Revert "feat(sites): enable the new download sidebar capability by default"

### DIFF
--- a/packages/sites/src/ensure-required-site-properties.ts
+++ b/packages/sites/src/ensure-required-site-properties.ts
@@ -65,8 +65,7 @@ export function ensureRequiredSiteProperties(
     "document_iframes",
     "items_view",
     "app_page",
-    "globalNav",
-    "downloadSidebar"
+    "globalNav"
   ];
   if (!isPortal) {
     caps.push("socialSharing");


### PR DESCRIPTION
Reverts Esri/hub.js#460

We need to remove the capability from the default list due to an issue in the new download UI.