### PR TITLE
feat: actually export OperationError and OperationStack

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -17,3 +17,8 @@ export * from "./util";
 export * from "./utils";
 export * from "./i18n";
 export * from "./request";
+
+import OperationStack from "./OperationStack";
+import OperationError from "./OperationError";
+// Re-exports
+export { OperationStack, OperationError };


### PR DESCRIPTION
Although I added `OperationStack` and `OperationError` 3 months back, I did not actually _export_ them. 

Oh the shame.

