### PR TITLE
Change cached download search terms for portal

### DIFF
--- a/packages/downloads/src/portal/portal-export-success-handler.ts
+++ b/packages/downloads/src/portal/portal-export-success-handler.ts
@@ -22,10 +22,15 @@ export function exportSuccessHandler(params: any): Promise<any> {
     authentication
   } = params;
 
+  const [itemId, layerId] = datasetId.split("_");
+  const exportKeyword = layerId
+    ? `exportItem:${itemId},exportLayer:${layerId}`
+    : `exportItem:${itemId},exportLayer:null`;
+
   return updateItem({
     item: {
       id: downloadId,
-      typekeywords: `export:${datasetId},modified:${exportCreated},spatialRefId:${spatialRefId}`
+      typekeywords: `${exportKeyword},modified:${exportCreated},spatialRefId:${spatialRefId}`
     },
     authentication
   })

--- a/packages/downloads/src/portal/portal-export-success-handler.ts
+++ b/packages/downloads/src/portal/portal-export-success-handler.ts
@@ -23,8 +23,10 @@ export function exportSuccessHandler(params: any): Promise<any> {
   } = params;
 
   const [itemId, layerId] = datasetId.split("_");
+
+  // Layer Id's need to be padded with 0 so that /search results are predictable. Searches for exportLayer:1 don't work.
   const exportKeyword = layerId
-    ? `exportItem:${itemId},exportLayer:${layerId}`
+    ? `exportItem:${itemId},exportLayer:0${layerId}`
     : `exportItem:${itemId},exportLayer:null`;
 
   return updateItem({

--- a/packages/downloads/src/portal/portal-request-download-metadata.ts
+++ b/packages/downloads/src/portal/portal-request-download-metadata.ts
@@ -48,6 +48,9 @@ export function portalRequestDownloadMetadata(
   const { datasetId, authentication, format, spatialRefId, target } = params;
 
   const [itemId, layerId] = datasetId.split("_");
+  const exportKeyword = layerId
+    ? `exportItem:${itemId},exportLayer:${layerId}`
+    : `exportItem:${itemId},exportLayer:null`;
   let serviceLastEditDate: number | undefined;
   let itemModifiedDate: number;
   let itemType: string;
@@ -70,7 +73,7 @@ export function portalRequestDownloadMetadata(
       const { modified, format: searchFormat } = metadata;
       serviceLastEditDate = modified;
       return searchItems({
-        q: `type:"${searchFormat}" AND typekeywords:"export:${datasetId},spatialRefId:${spatialRefId}"`,
+        q: `type:"${searchFormat}" AND typekeywords:"${exportKeyword},spatialRefId:${spatialRefId}"`,
         num: 1,
         sortField: "modified",
         sortOrder: "DESC",

--- a/packages/downloads/src/portal/portal-request-download-metadata.ts
+++ b/packages/downloads/src/portal/portal-request-download-metadata.ts
@@ -48,8 +48,9 @@ export function portalRequestDownloadMetadata(
   const { datasetId, authentication, format, spatialRefId, target } = params;
 
   const [itemId, layerId] = datasetId.split("_");
+  // Layer Id's need to be padded with 0 so that /search results are predictable. Searches for exportLayer:1 don't work.
   const exportKeyword = layerId
-    ? `exportItem:${itemId},exportLayer:${layerId}`
+    ? `exportItem:${itemId},exportLayer:0${layerId}`
     : `exportItem:${itemId},exportLayer:null`;
   let serviceLastEditDate: number | undefined;
   let itemModifiedDate: number;

--- a/packages/downloads/test/portal/portal-export-success-handler.test.ts
+++ b/packages/downloads/test/portal/portal-export-success-handler.test.ts
@@ -56,7 +56,7 @@ describe("portalPollExportJobStatus", () => {
           {
             item: {
               id: "download-id",
-              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,modified:1000,spatialRefId:undefined`
+              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`
             },
             authentication
           }
@@ -103,7 +103,7 @@ describe("portalPollExportJobStatus", () => {
           {
             item: {
               id: "download-id",
-              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,modified:1000,spatialRefId:undefined`
+              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`
             },
             authentication
           }
@@ -163,7 +163,7 @@ describe("portalPollExportJobStatus", () => {
           {
             item: {
               id: "download-id",
-              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,modified:1000,spatialRefId:undefined`
+              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`
             },
             authentication
           }
@@ -231,7 +231,7 @@ describe("portalPollExportJobStatus", () => {
           {
             item: {
               id: "download-id",
-              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,modified:1000,spatialRefId:undefined`
+              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`
             },
             authentication
           }
@@ -308,7 +308,7 @@ describe("portalPollExportJobStatus", () => {
           {
             item: {
               id: "download-id",
-              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,modified:1000,spatialRefId:undefined`
+              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`
             },
             authentication
           }
@@ -412,7 +412,7 @@ describe("portalPollExportJobStatus", () => {
           {
             item: {
               id: "download-id",
-              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,modified:1000,spatialRefId:3857`
+              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:3857`
             },
             authentication
           }

--- a/packages/downloads/test/portal/portal-request-download-metadata.test.ts
+++ b/packages/downloads/test/portal/portal-request-download-metadata.test.ts
@@ -355,7 +355,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -443,7 +443,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -531,7 +531,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -620,7 +620,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -709,7 +709,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -971,7 +971,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1578,7 +1578,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1683,7 +1683,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1789,7 +1789,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1895,7 +1895,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1999,7 +1999,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -2103,7 +2103,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -2208,7 +2208,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -2313,7 +2313,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }

--- a/packages/downloads/test/portal/portal-request-download-metadata.test.ts
+++ b/packages/downloads/test/portal/portal-request-download-metadata.test.ts
@@ -271,7 +271,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:null,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -355,7 +355,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -443,7 +443,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -531,7 +531,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -620,7 +620,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -709,7 +709,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -785,7 +785,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:null,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -878,7 +878,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV Collection" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined"',
+              'type:"CSV Collection" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:null,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -971,7 +971,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1073,7 +1073,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV Collection" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined"',
+              'type:"CSV Collection" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:null,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1175,7 +1175,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV Collection" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined"',
+              'type:"CSV Collection" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:null,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1278,7 +1278,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV Collection" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined"',
+              'type:"CSV Collection" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:null,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1381,7 +1381,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV Collection" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined"',
+              'type:"CSV Collection" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:null,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1475,7 +1475,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:null,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1578,7 +1578,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1683,7 +1683,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1789,7 +1789,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1895,7 +1895,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -1999,7 +1999,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -2103,7 +2103,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -2208,7 +2208,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -2313,7 +2313,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789_0,spatialRefId:undefined"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:0,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -2412,7 +2412,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"KML Collection" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined"',
+              'type:"KML Collection" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:null,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -2511,7 +2511,7 @@ describe("portalRequestDownloadMetadata", () => {
             authentication,
             num: 1,
             q:
-              'type:"Shapefile" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:undefined"',
+              'type:"Shapefile" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:null,spatialRefId:undefined"',
             sortField: "modified",
             sortOrder: "DESC"
           }
@@ -2578,7 +2578,7 @@ describe("portalRequestDownloadMetadata", () => {
         expect((portal.searchItems as any).calls.first().args).toEqual([
           {
             q:
-              'type:"CSV" AND typekeywords:"export:abcdef0123456789abcdef0123456789,spatialRefId:4326"',
+              'type:"CSV" AND typekeywords:"exportItem:abcdef0123456789abcdef0123456789,exportLayer:null,spatialRefId:4326"',
             num: 1,
             sortField: "modified",
             sortOrder: "DESC",

--- a/packages/downloads/test/request-download-metadata.test.ts
+++ b/packages/downloads/test/request-download-metadata.test.ts
@@ -102,7 +102,7 @@ describe("requestDownloadMetadata", () => {
       });
 
       fetchMock.mock(
-        "http://portal.com/sharing/rest/search?f=json&q=type%3A%22Shapefile%22%20AND%20typekeywords%3A%22export%3Aabcdef0123456789abcdef0123456789%2CspatialRefId%3A2227%22&num=1&sortField=modified&sortOrder=DESC&token=123",
+        "http://portal.com/sharing/rest/search?f=json&q=type%3A%22Shapefile%22%20AND%20typekeywords%3A%22exportItem%3Aabcdef0123456789abcdef0123456789%2CexportLayer%3Anull%2CspatialRefId%3A2227%22&num=1&sortField=modified&sortOrder=DESC&token=123",
         {
           status: 200,
           body: {
@@ -112,7 +112,7 @@ describe("requestDownloadMetadata", () => {
       );
 
       fetchMock.mock(
-        "http://portal.com/sharing/rest/search?f=json&q=type%3A%22CSV%20Collection%22%20AND%20typekeywords%3A%22export%3Aabcdef0123456789abcdef0123456789%2CspatialRefId%3A2227%22&num=1&sortField=modified&sortOrder=DESC&token=123",
+        "http://portal.com/sharing/rest/search?f=json&q=type%3A%22CSV%20Collection%22%20AND%20typekeywords%3A%22exportItem%3Aabcdef0123456789abcdef0123456789%2CexportLayer%3Anull%2CspatialRefId%3A2227%22&num=1&sortField=modified&sortOrder=DESC&token=123",
         {
           status: 200,
           body: {
@@ -173,7 +173,7 @@ describe("requestDownloadMetadata", () => {
       });
 
       fetchMock.mock(
-        "http://portal.com/sharing/rest/search?f=json&q=type%3A%22Shapefile%22%20AND%20typekeywords%3A%22export%3Aabcdef0123456789abcdef0123456789%2CspatialRefId%3A2227%22&num=1&sortField=modified&sortOrder=DESC&token=123",
+        "http://portal.com/sharing/rest/search?f=json&q=type%3A%22Shapefile%22%20AND%20typekeywords%3A%22exportItem%3Aabcdef0123456789abcdef0123456789%2CexportLayer%3Anull%2CspatialRefId%3A2227%22&num=1&sortField=modified&sortOrder=DESC&token=123",
         {
           status: 200,
           body: {

--- a/packages/downloads/test/request-download-metadata.test.ts
+++ b/packages/downloads/test/request-download-metadata.test.ts
@@ -183,7 +183,7 @@ describe("requestDownloadMetadata", () => {
       );
 
       fetchMock.mock(
-        "http://portal.com/sharing/rest/search?f=json&q=type%3A%22CSV%20Collection%22%20AND%20typekeywords%3A%22export%3Aabcdef0123456789abcdef0123456789%2CspatialRefId%3A2227%22&num=1&sortField=modified&sortOrder=DESC&token=123",
+        "http://portal.com/sharing/rest/search?f=json&q=type%3A%22CSV%20Collection%22%20AND%20typekeywords%3A%22exportItem%3Aabcdef0123456789abcdef0123456789%2CspatialRefId%3A2227%22&num=1&sortField=modified&sortOrder=DESC&token=123",
         {
           status: 200,
           body: {


### PR DESCRIPTION
Portal searches using `typekeywords` appear to have issues with occurrences of `1`. For example, a search for keyword `export:abcdef0123456789abcdef0123456789_1` fails to narrow results properly and returns multiple items with keywords `export:abcdef0123456789abcdef0123456789_0`, `export:abcdef0123456789abcdef0123456789_1`, `export:abcdef0123456789abcdef0123456789_2`.  Changing the item/layer delimiter from `_` to `-` or `~` has no effect. Splitting the item id and layer id into separate terms (exportItem:abcdef0123456789abcdef0123456789, exportLayer:1`) also has no effect.  Attaching a string prefix to the layer index (exportItem:abcdef0123456789abcdef0123456789, exportLayer:layer1`) similarly has no effect.

I've reached out to the search team and the response is to use `filter` instead of `q` if we want non-fuzzy results. But since `filter` is not yet on enterprise we cannot leverage this query parameter.

What finally did end up working was left-padding the layer index with a `0`, e.g.:
`exportItem:abcdef0123456789abcdef0123456789, exportLayer:01`. 
This PR contains that fix.