### PR TITLE
fix(everything): adding rest-js 3 to peer dep ranges

### DIFF
--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -13,12 +13,12 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^2.13.0",
-    "@esri/arcgis-rest-feature-layer": "^2.13.0",
-    "@esri/arcgis-rest-portal": "^2.13.0",
-    "@esri/arcgis-rest-request": "^2.13.0",
-    "@esri/arcgis-rest-service-admin": "^2.13.0",
-    "@esri/arcgis-rest-types": "^2.13.0"
+    "@esri/arcgis-rest-auth": "^2.13.0 || 3",
+    "@esri/arcgis-rest-feature-layer": "^2.13.0 || 3",
+    "@esri/arcgis-rest-portal": "^2.13.0 || 3",
+    "@esri/arcgis-rest-request": "^2.13.0 || 3",
+    "@esri/arcgis-rest-service-admin": "^2.13.0 || 3",
+    "@esri/arcgis-rest-types": "^2.13.0 || 3"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^2.21.0",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -14,9 +14,9 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^2.13.0",
-    "@esri/arcgis-rest-portal": "^2.18.0",
-    "@esri/arcgis-rest-request": "^2.13.0",
+    "@esri/arcgis-rest-auth": "^2.13.0 || 3",
+    "@esri/arcgis-rest-portal": "^2.18.0 || 3",
+    "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/hub-common": "^7.0.1"
   },
   "devDependencies": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -13,11 +13,11 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^2.13.0",
-    "@esri/arcgis-rest-feature-layer": "^2.13.0",
-    "@esri/arcgis-rest-portal": "^2.15.0",
-    "@esri/arcgis-rest-request": "^2.13.0",
-    "@esri/arcgis-rest-types": "^2.13.0",
+    "@esri/arcgis-rest-auth": "^2.13.0 || 3",
+    "@esri/arcgis-rest-feature-layer": "^2.13.0 || 3",
+    "@esri/arcgis-rest-portal": "^2.15.0 || 3",
+    "@esri/arcgis-rest-request": "^2.13.0 || 3",
+    "@esri/arcgis-rest-types": "^2.13.0 || 3",
     "@esri/hub-common": "^7.0.1"
   },
   "devDependencies": {

--- a/packages/initiatives/package.json
+++ b/packages/initiatives/package.json
@@ -13,9 +13,9 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^2.13.0",
-    "@esri/arcgis-rest-portal": "^2.13.0",
-    "@esri/arcgis-rest-request": "^2.13.0",
+    "@esri/arcgis-rest-auth": "^2.13.0 || 3",
+    "@esri/arcgis-rest-portal": "^2.13.0 || 3",
+    "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/hub-common": "^7.0.1"
   },
   "devDependencies": {

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -14,11 +14,11 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^2.13.0",
-    "@esri/arcgis-rest-feature-layer": "^2.13.0",
-    "@esri/arcgis-rest-portal": "^2.6.1",
-    "@esri/arcgis-rest-request": "^2.13.0",
-    "@esri/arcgis-rest-types": "^2.13.0",
+    "@esri/arcgis-rest-auth": "^2.13.0 || 3",
+    "@esri/arcgis-rest-feature-layer": "^2.13.0 || 3",
+    "@esri/arcgis-rest-portal": "^2.6.1 || 3",
+    "@esri/arcgis-rest-request": "^2.13.0 || 3",
+    "@esri/arcgis-rest-types": "^2.13.0 || 3",
     "@esri/hub-common": "^7.0.1"
   },
   "devDependencies": {

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -13,9 +13,9 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^2.13.0",
-    "@esri/arcgis-rest-portal": "^2.19.0",
-    "@esri/arcgis-rest-request": "^2.13.0",
+    "@esri/arcgis-rest-auth": "^2.13.0 || 3",
+    "@esri/arcgis-rest-portal": "^2.19.0 || 3",
+    "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/hub-common": "^7.0.1",
     "@esri/hub-initiatives": "^7.0.1",
     "@esri/hub-teams": "^7.0.1"

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -13,11 +13,11 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^2.13.0",
-    "@esri/arcgis-rest-feature-layer": "^2.13.0",
-    "@esri/arcgis-rest-portal": "^2.13.0",
-    "@esri/arcgis-rest-request": "^2.13.0",
-    "@esri/arcgis-rest-types": "^2.13.0",
+    "@esri/arcgis-rest-auth": "^2.13.0 || 3",
+    "@esri/arcgis-rest-feature-layer": "^2.13.0 || 3",
+    "@esri/arcgis-rest-portal": "^2.13.0 || 3",
+    "@esri/arcgis-rest-request": "^2.13.0 || 3",
+    "@esri/arcgis-rest-types": "^2.13.0 || 3",
     "@esri/hub-common": "^7.0.1"
   },
   "devDependencies": {

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -13,10 +13,10 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^2.13.0",
-    "@esri/arcgis-rest-portal": "^2.15.0",
-    "@esri/arcgis-rest-request": "^2.13.0",
-    "@esri/arcgis-rest-types": "^2.13.0",
+    "@esri/arcgis-rest-auth": "^2.13.0 || 3",
+    "@esri/arcgis-rest-portal": "^2.15.0 || 3",
+    "@esri/arcgis-rest-request": "^2.13.0 || 3",
+    "@esri/arcgis-rest-types": "^2.13.0 || 3",
     "@esri/hub-common": "^7.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
affects: @esri/hub-annotations, @esri/hub-content, @esri/hub-events, @esri/hub-initiatives,
@esri/hub-search, @esri/hub-sites, @esri/hub-surveys, @esri/hub-teams

ISSUES CLOSED: #473