### PR TITLE
fix(hub-sites): ensure that we respect interpolation of site title

### DIFF
--- a/packages/sites/src/create-site-model-from-template.ts
+++ b/packages/sites/src/create-site-model-from-template.ts
@@ -161,9 +161,12 @@ export function createSiteModelFromTemplate(
       const siteModel = interpolate(template, settings, transforms);
       // Special logic for the site title
       // if the title is a string, containing only numbers, then the interpolation will set it as
-      // a number, which causes some problems. So we stamp in the string value in few places it matters
-      siteModel.item.title = getProp(settings, "solution.title");
-      siteModel.data.values.title = getProp(settings, "solution.title");
+      // a number, which causes some problems... in that case, we stomp it in as a string...
+      if (typeof siteModel.item.title === "number") {
+        siteModel.item.title = getProp(settings, "solution.title");
+        siteModel.data.values.title = getProp(settings, "solution.title");
+      }
+
       // re-attach dcat...
       if (dcatConfig) {
         siteModel.data.values.dcatConfig = dcatConfig;

--- a/packages/sites/test/create-site-model-from-template.test.ts
+++ b/packages/sites/test/create-site-model-from-template.test.ts
@@ -177,7 +177,7 @@ describe("createSiteModelFromTemplate", () => {
     expect(createdSite.item.extent).toEqual(
       settings.organization.defaultExtentBBox
     );
-    expect(createdSite.data.values.title).toBe(settings.solution.title);
+    expect(createdSite.data.values.title).toBe(settings.solution.name);
 
     expect(createdSite.item.url).toBe(
       "https://unique-domain-org.hubqa.arcgis.com"
@@ -222,7 +222,7 @@ describe("createSiteModelFromTemplate", () => {
     expect(createdSite.item.extent).toEqual(
       settings.organization.defaultExtentBBox
     );
-    expect(createdSite.data.values.title).toBe(settings.solution.title);
+    expect(createdSite.data.values.title).toBe(settings.solution.name);
 
     expect(createdSite.item.url).toBe(
       "https://unique-domain-org.hubqa.arcgis.com"
@@ -272,7 +272,7 @@ describe("createSiteModelFromTemplate", () => {
     expect(createdSite.item.extent).toEqual(
       settings.organization.defaultExtentBBox
     );
-    expect(createdSite.data.values.title).toBe(settings.solution.title);
+    expect(createdSite.data.values.title).toBe(settings.solution.name);
 
     expect(createdSite.item.url).toBe("http://foobar-portal-baz.com");
     expect(createdSite.data.values.defaultHostname).toBe(portalSiteHostname);
@@ -383,7 +383,7 @@ describe("createSiteModelFromTemplate", () => {
 
     // Verify interpolation
     expect(createdSite.item.title).toBe(unicodeSettings.solution.title);
-    expect(createdSite.data.values.title).toBe(unicodeSettings.solution.title);
+    expect(createdSite.data.values.title).toBe(unicodeSettings.solution.name);
 
     const passedDomain = ensureDomainSpy.calls.argsFor(0)[0];
     expect(passedDomain).toBe(


### PR DESCRIPTION
affects: @esri/hub-sites

For complex reasons we were forcing the site title to be the solution title. We needed to dial back
that logic so static site names can be used.

This addresses a bug for the Solutions team needed for their 10.9 certification.