### PR TITLE
feat(everything): distribute es2017 build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,7 +32,7 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-          
       - run: npm install         
-      - run: npm run bootstrap
+      - run: npm run build
       - run: npm run test:ci
         env:
           MOZ_HEADLESS: 1

--- a/package.json
+++ b/package.json
@@ -83,7 +83,9 @@
     ]
   },
   "scripts": {
-    "build": "lerna run build",
+    "build": "npm run bootstrap && npm run build:umd && npm run build:es2017",
+    "build:es2017": "lerna run build:es2017",
+    "build:umd": "lerna run build:umd",
     "clean": "npm run clean:dist & npm run clean:deps",
     "clean:dist": "rm -rf packages/*/dist/",
     "clean:deps": "rm -rf node_modules && rm -rf packages/*/node_modules/",
@@ -123,7 +125,7 @@
     "gen-util": "yo ./scaffolder/index.js",
     "precommit": "node exit-if-no-staged.js && lint-staged",
     "bootstrap": "lerna bootstrap --hoist",
-    "prerelease:prepare": "git fetch --all && npm run clean:dist && npm run bootstrap && lerna run build:umd && npm test",
+    "prerelease:prepare": "git fetch --all && npm run clean:dist && npm run build && npm test",
     "release:prepare": "lerna publish --skip-git --skip-npm --yes && node ./support/changelog.js",
     "release:review": "git --no-pager diff --word-diff",
     "release:publish": "./support/publish.sh",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -5,9 +5,9 @@
   "main": "dist/node/index.js",
   "unpkg": "dist/umd/annotations.umd.js",
   "module": "dist/esm/index.js",
-  "js:next": "dist/esm/index.js",
+  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
-  "types": "dist/esm/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
     "tslib": "^1.13.0"
@@ -41,7 +41,8 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration",
+    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:es2017": "tsc --outDir ./dist/es2017",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --target es5 --outDir ./dist/esm --declaration",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -5,9 +5,9 @@
   "main": "dist/node/index.js",
   "unpkg": "dist/umd/common.umd.js",
   "module": "dist/esm/index.js",
-  "js:next": "dist/esm/index.js",
+  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
-  "types": "dist/esm/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "author": "",
   "license": "Apache-2.0",
   "files": [
@@ -40,7 +40,8 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration",
+    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:es2017": "tsc --outDir ./dist/es2017",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --target es5 --outDir ./dist/esm --declaration",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -5,9 +5,9 @@
   "main": "dist/node/index.js",
   "unpkg": "dist/umd/content.umd.js",
   "module": "dist/esm/index.js",
-  "js:next": "dist/esm/index.js",
+  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
-  "types": "dist/esm/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
     "fast-xml-parser": "~3.2.4",
@@ -39,7 +39,8 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration",
+    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:es2017": "tsc --outDir ./dist/es2017",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --target es5 --outDir ./dist/esm --declaration",

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -5,9 +5,9 @@
   "main": "dist/node/index.js",
   "unpkg": "dist/umd/downloads.umd.js",
   "module": "dist/esm/index.js",
-  "js:next": "dist/esm/index.js",
+  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
-  "types": "dist/esm/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
     "@esri/arcgis-rest-feature-layer": "^2.21.0",
@@ -37,7 +37,8 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration",
+    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:es2017": "tsc --outDir ./dist/es2017",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --target es5 --outDir ./dist/esm --declaration",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -5,9 +5,9 @@
   "main": "dist/node/index.js",
   "unpkg": "dist/umd/events.umd.js",
   "module": "dist/esm/index.js",
-  "js:next": "dist/esm/index.js",
+  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
-  "types": "dist/esm/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
     "tslib": "^1.13.0"
@@ -41,7 +41,8 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration",
+    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:es2017": "tsc --outDir ./dist/es2017",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --target es5 --outDir ./dist/esm --declaration",

--- a/packages/initiatives/package.json
+++ b/packages/initiatives/package.json
@@ -5,9 +5,9 @@
   "main": "dist/node/index.js",
   "unpkg": "dist/umd/initiatives.umd.js",
   "module": "dist/esm/index.js",
-  "js:next": "dist/esm/index.js",
+  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
-  "types": "dist/esm/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
     "tslib": "^1.13.0"
@@ -38,7 +38,8 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration",
+    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:es2017": "tsc --outDir ./dist/es2017",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --target es5 --outDir ./dist/esm --declaration",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -5,9 +5,9 @@
   "main": "dist/node/index.js",
   "unpkg": "dist/umd/search.umd.js",
   "module": "dist/esm/index.js",
-  "js:next": "dist/esm/index.js",
+  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
-  "types": "dist/esm/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
     "base-64": "^1.0.0",
@@ -45,7 +45,8 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration",
+    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:es2017": "tsc --outDir ./dist/es2017",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --target es5 --outDir ./dist/esm --declaration",

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -5,9 +5,9 @@
   "main": "dist/node/index.js",
   "unpkg": "dist/umd/sites.umd.js",
   "module": "dist/esm/index.js",
-  "js:next": "dist/esm/index.js",
+  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
-  "types": "dist/esm/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
     "tslib": "^1.13.0"
@@ -42,7 +42,8 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration",
+    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:es2017": "tsc --outDir ./dist/es2017",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --target es5 --outDir ./dist/esm --declaration",

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -5,9 +5,9 @@
   "main": "dist/node/index.js",
   "unpkg": "dist/umd/surveys.umd.js",
   "module": "dist/esm/index.js",
-  "js:next": "dist/esm/index.js",
+  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
-  "types": "dist/esm/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
     "tslib": "^1.13.0"
@@ -41,7 +41,8 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration",
+    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:es2017": "tsc --outDir ./dist/es2017",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --target es5 --outDir ./dist/esm --declaration",

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -5,9 +5,9 @@
   "main": "dist/node/index.js",
   "unpkg": "dist/umd/teams.umd.js",
   "module": "dist/esm/index.js",
-  "js:next": "dist/esm/index.js",
+  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
-  "types": "dist/esm/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
     "tslib": "^1.13.0"
@@ -39,7 +39,8 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration",
+    "build:esm": "tsc --module es2015 --target es5 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:es2017": "tsc --outDir ./dist/es2017",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "tsc -w --module es2015 --target es5 --outDir ./dist/esm --declaration",


### PR DESCRIPTION
affects: @esri/hub-annotations, @esri/hub-common, @esri/hub-content, @esri/hub-downloads,
@esri/hub-events, @esri/hub-initiatives, @esri/hub-search, @esri/hub-sites, @esri/hub-surveys,
@esri/hub-teams

implements first phase of #488