### PR TITLE
Feat/update well known teams for membership access

### DIFF
--- a/packages/teams/src/create-hub-team.ts
+++ b/packages/teams/src/create-hub-team.ts
@@ -38,7 +38,8 @@ export function createHubTeam(opts: {
   const product = getHubProduct(hubRequestOptions.portalSelf);
   const groupsToCreate = getUserCreatableTeams(
     hubRequestOptions.portalSelf.user,
-    product
+    product,
+    hubRequestOptions.portalSelf.currentVersion
   )
     .filter(g => {
       return g.config.type === type;

--- a/packages/teams/src/create-hub-teams.ts
+++ b/packages/teams/src/create-hub-teams.ts
@@ -29,7 +29,8 @@ export function createHubTeams(opts: {
   // and filter just the team types requested
   const teamsToCreate = getUserCreatableTeams(
     hubRequestOptions.portalSelf.user,
-    product
+    product,
+    hubRequestOptions.portalSelf.currentVersion
   ).filter(g => {
     return types.indexOf(g.config.type) > -1;
   });

--- a/packages/teams/src/older-well-known-teams.ts
+++ b/packages/teams/src/older-well-known-teams.ts
@@ -9,17 +9,14 @@ import { IGroupTemplate } from "./types";
  * This allows us to add/remove/edit groups by simply modifying this hash
  * instead of spreading complex construction logic all over the application
  */
-export const WELLKNOWNTEAMS: IGroupTemplate[] = [
+export const OLDERWELLKNOWNTEAMS: IGroupTemplate[] = [
   {
     config: {
       groupType: "Hub Collaboration Group",
       type: "core",
       availableIn: ["premium"],
       propertyName: "collaborationGroupId",
-      requiredPrivs: [
-        "portal:admin:createUpdateCapableGroup",
-        "portal:user:addExternalMembersToGroup"
-      ],
+      requiredPrivs: ["portal:admin:createUpdateCapableGroup"],
       titleI18n: "collaborationTitle",
       descriptionI18n: "collaborationDesc",
       snippetI18n: "collaborationSnippet"
@@ -31,7 +28,6 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
     sortField: "modified",
     sortOrder: "desc",
     capabilities: "updateitemcontrol",
-    membershipAccess: "collaboration",
     _edit_privacy: "on",
     _edit_contributors: "on",
     tags: [
@@ -100,10 +96,7 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
       type: "content",
       availableIn: ["premium"],
       propertyName: "contentGroupId",
-      requiredPrivs: [
-        "portal:user:createGroup",
-        "portal:user:addExternalMembersToGroup"
-      ],
+      requiredPrivs: ["portal:user:createGroup"],
       titleI18n: "contentTitle",
       descriptionI18n: "contentDesc",
       snippetI18n: "contentSnippet"
@@ -114,7 +107,6 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
     isViewOnly: false,
     sortField: "modified",
     sortOrder: "desc",
-    membershipAccess: "collaboration",
     tags: [
       "Hub Group",
       "Hub Content Group",
@@ -167,10 +159,7 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
       type: "followers",
       availableIn: ["premium"],
       propertyName: "followersGroupId",
-      requiredPrivs: [
-        "portal:user:createGroup",
-        "portal:user:addExternalMembersToGroup"
-      ],
+      requiredPrivs: ["portal:user:createGroup"],
       titleI18n: "followersTitle",
       descriptionI18n: "followersDesc",
       snippetI18n: "followersSnippet"
@@ -182,7 +171,6 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
     notificationsEnabled: true,
     sortField: "title",
     sortOrder: "asc",
-    membershipAccess: "",
     tags: [
       "Hub Group",
       "Hub Initiative Followers Group",
@@ -212,10 +200,7 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
       groupType: "Generic AGO Initiative Team",
       type: "team",
       availableIn: ["premium"],
-      requiredPrivs: [
-        "portal:user:createGroup",
-        "portal:user:addExternalMembersToGroup"
-      ],
+      requiredPrivs: ["portal:user:createGroup"],
       titleI18n: "teamTitle",
       descriptionI18n: "teamDesc",
       snippetI18n: "teamSnippet"
@@ -226,7 +211,6 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
     isViewOnly: false,
     sortField: "modified",
     sortOrder: "desc",
-    membershipAccess: "",
     tags: ["Hub Team Group"]
   },
   {
@@ -252,10 +236,7 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
       groupType: "Generic Event Team",
       type: "event",
       availableIn: ["premium"],
-      requiredPrivs: [
-        "portal:user:createGroup",
-        "portal:user:addExternalMembersToGroup"
-      ],
+      requiredPrivs: ["portal:user:createGroup"],
       titleI18n: "eventTeamTitle",
       descriptionI18n: "eventTeamDesc",
       snippetI18n: "eventTeamSnippet"
@@ -266,7 +247,6 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
     isViewOnly: false,
     sortField: "title",
     sortOrder: "asc",
-    membershipAccess: "",
     tags: ["Hub Group", "Hub Event Group", "Hub Initiative Group"]
   }
 ];

--- a/packages/teams/src/pre-9-1-well-known-teams.ts
+++ b/packages/teams/src/pre-9-1-well-known-teams.ts
@@ -9,6 +9,7 @@ import { IGroupTemplate } from "./types";
  * This allows us to add/remove/edit groups by simply modifying this hash
  * instead of spreading complex construction logic all over the application
  */
+// TODO: remove after May 1st, 2021 as unneeded
 export const PRE_9_1_WELLKNOWNTEAMS: IGroupTemplate[] = [
   {
     config: {

--- a/packages/teams/src/pre-9-1-well-known-teams.ts
+++ b/packages/teams/src/pre-9-1-well-known-teams.ts
@@ -9,7 +9,7 @@ import { IGroupTemplate } from "./types";
  * This allows us to add/remove/edit groups by simply modifying this hash
  * instead of spreading complex construction logic all over the application
  */
-export const OLDERWELLKNOWNTEAMS: IGroupTemplate[] = [
+export const PRE_9_1_WELLKNOWNTEAMS: IGroupTemplate[] = [
   {
     config: {
       groupType: "Hub Collaboration Group",

--- a/packages/teams/src/utils/can-user-create-team.ts
+++ b/packages/teams/src/utils/can-user-create-team.ts
@@ -20,8 +20,10 @@ export function canUserCreateTeam(
   } else {
     const product = getHubProduct(hubRequestOptions.portalSelf);
     // get all the groups the user can create in this product...
-    return getUserCreatableTeams(user, product).some(
-      t => t.config.type === hubTeamType
-    );
+    return getUserCreatableTeams(
+      user,
+      product,
+      hubRequestOptions.portalSelf.currentVersion
+    ).some(t => t.config.type === hubTeamType);
   }
 }

--- a/packages/teams/src/utils/get-team-template.ts
+++ b/packages/teams/src/utils/get-team-template.ts
@@ -7,13 +7,14 @@ import { getTeamsAvailableInProduct } from "./get-teams-available-in-product";
  * group, but in a context outside of the normal team-service functions.
  * @param {string} team core \ content | followers | team
  * @param {string} product basic | premium | portal
+ * @param {string} portalApiVersion portal version
  */
 export function getTeamTemplate(
   type: HubTeamType,
   product: HubProduct,
-  currentVersion: string
+  portalApiVersion: string
 ) {
-  return getTeamsAvailableInProduct(product, currentVersion).find(t => {
+  return getTeamsAvailableInProduct(product, portalApiVersion).find(t => {
     return t.config.type === type;
   });
 }

--- a/packages/teams/src/utils/get-team-template.ts
+++ b/packages/teams/src/utils/get-team-template.ts
@@ -8,8 +8,12 @@ import { getTeamsAvailableInProduct } from "./get-teams-available-in-product";
  * @param {string} team core \ content | followers | team
  * @param {string} product basic | premium | portal
  */
-export function getTeamTemplate(type: HubTeamType, product: HubProduct) {
-  return getTeamsAvailableInProduct(product).find(t => {
+export function getTeamTemplate(
+  type: HubTeamType,
+  product: HubProduct,
+  currentVersion: string
+) {
+  return getTeamsAvailableInProduct(product, currentVersion).find(t => {
     return t.config.type === type;
   });
 }

--- a/packages/teams/src/utils/get-team-types-available-in-product.ts
+++ b/packages/teams/src/utils/get-team-types-available-in-product.ts
@@ -5,8 +5,11 @@ import { getTeamsAvailableInProduct } from "./get-teams-available-in-product";
  * Get the types of teams that can be created given the product
  * @param {string} product Product name portal | basic | premium
  */
-export function getTeamTypesAvailableInProduct(product: HubProduct) {
-  return getTeamsAvailableInProduct(product).map(team => {
+export function getTeamTypesAvailableInProduct(
+  product: HubProduct,
+  currentVersion: string
+) {
+  return getTeamsAvailableInProduct(product, currentVersion).map(team => {
     return team.config.type;
   });
 }

--- a/packages/teams/src/utils/get-team-types-available-in-product.ts
+++ b/packages/teams/src/utils/get-team-types-available-in-product.ts
@@ -7,9 +7,9 @@ import { getTeamsAvailableInProduct } from "./get-teams-available-in-product";
  */
 export function getTeamTypesAvailableInProduct(
   product: HubProduct,
-  currentVersion: string
+  portalApiVersion: string
 ) {
-  return getTeamsAvailableInProduct(product, currentVersion).map(team => {
+  return getTeamsAvailableInProduct(product, portalApiVersion).map(team => {
     return team.config.type;
   });
 }

--- a/packages/teams/src/utils/get-teams-available-in-product.ts
+++ b/packages/teams/src/utils/get-teams-available-in-product.ts
@@ -1,14 +1,22 @@
 import { HubProduct, IGroupTemplate } from "../types";
 import { cloneObject } from "@esri/hub-common";
 import { WELLKNOWNTEAMS } from "../well-known-teams";
+import { OLDERWELLKNOWNTEAMS } from "../older-well-known-teams";
 
 /**
  * Given a product, return the groups templates that are available
  * @param {string} product Product name portal | basic | premium
  */
-export function getTeamsAvailableInProduct(product: HubProduct) {
+export function getTeamsAvailableInProduct(
+  product: HubProduct,
+  currentVersion: string
+) {
+  // TODO: remove this when needed
+  // choosing the type of well known team based on the current portal version
+  const teams =
+    parseFloat(currentVersion) < 9.1 ? OLDERWELLKNOWNTEAMS : WELLKNOWNTEAMS;
   const filterFn = (tmpl: IGroupTemplate) => {
     return tmpl.config.availableIn.indexOf(product) > -1;
   };
-  return cloneObject(WELLKNOWNTEAMS).filter(filterFn);
+  return cloneObject(teams).filter(filterFn);
 }

--- a/packages/teams/src/utils/get-teams-available-in-product.ts
+++ b/packages/teams/src/utils/get-teams-available-in-product.ts
@@ -11,7 +11,7 @@ export function getTeamsAvailableInProduct(
   product: HubProduct,
   portalApiVersion: string
 ) {
-  // TODO: remove this when needed
+  // TODO: remove this when needed (after may 1st 2021)
   // choosing the type of well known team based on the current portal version
   const teams =
     parseFloat(portalApiVersion) < 9.1

--- a/packages/teams/src/utils/get-teams-available-in-product.ts
+++ b/packages/teams/src/utils/get-teams-available-in-product.ts
@@ -1,7 +1,7 @@
 import { HubProduct, IGroupTemplate } from "../types";
 import { cloneObject } from "@esri/hub-common";
 import { WELLKNOWNTEAMS } from "../well-known-teams";
-import { OLDERWELLKNOWNTEAMS } from "../older-well-known-teams";
+import { PRE_9_1_WELLKNOWNTEAMS } from "../pre-9-1-well-known-teams";
 
 /**
  * Given a product, return the groups templates that are available
@@ -9,12 +9,14 @@ import { OLDERWELLKNOWNTEAMS } from "../older-well-known-teams";
  */
 export function getTeamsAvailableInProduct(
   product: HubProduct,
-  currentVersion: string
+  portalApiVersion: string
 ) {
   // TODO: remove this when needed
   // choosing the type of well known team based on the current portal version
   const teams =
-    parseFloat(currentVersion) < 9.1 ? OLDERWELLKNOWNTEAMS : WELLKNOWNTEAMS;
+    parseFloat(portalApiVersion) < 9.1
+      ? PRE_9_1_WELLKNOWNTEAMS
+      : WELLKNOWNTEAMS;
   const filterFn = (tmpl: IGroupTemplate) => {
     return tmpl.config.availableIn.indexOf(product) > -1;
   };

--- a/packages/teams/src/utils/get-user-creatable-teams.ts
+++ b/packages/teams/src/utils/get-user-creatable-teams.ts
@@ -16,7 +16,7 @@ export function getUserCreatableTeams(
   environment: HubProduct,
   portalApiVersion: string
 ): IGroupTemplate[] {
-  // TODO: remove this when needed
+  // TODO: remove this when needed (after may 1st 2021)
   // choosing the type of well known team based on the current portal version
   const teams =
     parseFloat(portalApiVersion) < 9.1

--- a/packages/teams/src/utils/get-user-creatable-teams.ts
+++ b/packages/teams/src/utils/get-user-creatable-teams.ts
@@ -1,7 +1,7 @@
 import { IUser } from "@esri/arcgis-rest-auth";
 import { cloneObject, HubProduct } from "@esri/hub-common";
 import { WELLKNOWNTEAMS } from "../well-known-teams";
-import { OLDERWELLKNOWNTEAMS } from "../older-well-known-teams";
+import { PRE_9_1_WELLKNOWNTEAMS } from "../pre-9-1-well-known-teams";
 import { canUserCreateTeamInProduct } from "./can-user-create-team-in-product";
 import { IGroupTemplate } from "../types";
 
@@ -14,12 +14,14 @@ import { IGroupTemplate } from "../types";
 export function getUserCreatableTeams(
   user: IUser,
   environment: HubProduct,
-  currentVersion: string
+  portalApiVersion: string
 ): IGroupTemplate[] {
   // TODO: remove this when needed
   // choosing the type of well known team based on the current portal version
   const teams =
-    parseFloat(currentVersion) < 9.1 ? OLDERWELLKNOWNTEAMS : WELLKNOWNTEAMS;
+    parseFloat(portalApiVersion) < 9.1
+      ? PRE_9_1_WELLKNOWNTEAMS
+      : WELLKNOWNTEAMS;
   // create partially applied filter fn...
   const filterFn = (tmpl: IGroupTemplate) => {
     return canUserCreateTeamInProduct(user, environment, tmpl);

--- a/packages/teams/src/utils/get-user-creatable-teams.ts
+++ b/packages/teams/src/utils/get-user-creatable-teams.ts
@@ -1,6 +1,7 @@
 import { IUser } from "@esri/arcgis-rest-auth";
 import { cloneObject, HubProduct } from "@esri/hub-common";
 import { WELLKNOWNTEAMS } from "../well-known-teams";
+import { OLDERWELLKNOWNTEAMS } from "../older-well-known-teams";
 import { canUserCreateTeamInProduct } from "./can-user-create-team-in-product";
 import { IGroupTemplate } from "../types";
 
@@ -12,12 +13,17 @@ import { IGroupTemplate } from "../types";
  */
 export function getUserCreatableTeams(
   user: IUser,
-  environment: HubProduct
+  environment: HubProduct,
+  currentVersion: string
 ): IGroupTemplate[] {
+  // TODO: remove this when needed
+  // choosing the type of well known team based on the current portal version
+  const teams =
+    parseFloat(currentVersion) < 9.1 ? OLDERWELLKNOWNTEAMS : WELLKNOWNTEAMS;
   // create partially applied filter fn...
   const filterFn = (tmpl: IGroupTemplate) => {
     return canUserCreateTeamInProduct(user, environment, tmpl);
   };
   // get the templates current user can create in this environment...
-  return cloneObject(WELLKNOWNTEAMS).filter(filterFn);
+  return cloneObject(teams).filter(filterFn);
 }

--- a/packages/teams/test/create-hub-team.test.ts
+++ b/packages/teams/test/create-hub-team.test.ts
@@ -15,6 +15,7 @@ describe("createHubTeam", () => {
       isPortal: false,
       id: "",
       name: "",
+      currentVersion: "8.4",
       portalProperties: {
         hub: {
           enabled: true

--- a/packages/teams/test/create-hub-teams.test.ts
+++ b/packages/teams/test/create-hub-teams.test.ts
@@ -13,6 +13,7 @@ describe("createHubTeams", () => {
       isPortal: false,
       id: "",
       name: "",
+      currentVersion: "8.4",
       portalProperties: {
         hub: {
           enabled: true

--- a/packages/teams/test/utils/get-team-template.test.ts
+++ b/packages/teams/test/utils/get-team-template.test.ts
@@ -3,16 +3,16 @@ import { HubProduct, HubTeamType } from "../../src/types";
 
 describe("getTeamTemplate", () => {
   it("it returns nothing for invalid product or team", function() {
-    expect(getTeamTemplate("fake" as HubTeamType, "basic")).toBeUndefined(
-      "should return undefined if invalid team"
-    );
-    expect(getTeamTemplate("core", "foo" as HubProduct)).toBeUndefined(
+    expect(
+      getTeamTemplate("fake" as HubTeamType, "basic", "8.4")
+    ).toBeUndefined("should return undefined if invalid team");
+    expect(getTeamTemplate("core", "foo" as HubProduct, "8.4")).toBeUndefined(
       "should return undefined if invalid product"
     );
   });
 
   it("it returns the correct template", function() {
-    const chk = getTeamTemplate("content", "portal");
+    const chk = getTeamTemplate("content", "portal", "8.4");
     expect(chk.config.groupType).toBe(
       "Portal Content Group",
       "should return the correct group"

--- a/packages/teams/test/utils/get-team-types-available-in-product.test.ts
+++ b/packages/teams/test/utils/get-team-types-available-in-product.test.ts
@@ -15,6 +15,6 @@ describe("getTeamTypesAvailableInProduct", () => {
       })
     );
 
-    expect(getTeamTypesAvailableInProduct("premium")).toEqual(teamTypes);
+    expect(getTeamTypesAvailableInProduct("premium", "8.4")).toEqual(teamTypes);
   });
 });

--- a/packages/teams/test/utils/get-team-types-available-in-product.test.ts
+++ b/packages/teams/test/utils/get-team-types-available-in-product.test.ts
@@ -16,5 +16,6 @@ describe("getTeamTypesAvailableInProduct", () => {
     );
 
     expect(getTeamTypesAvailableInProduct("premium", "8.4")).toEqual(teamTypes);
+    expect(getTeamTypesAvailableInProduct("premium", "9.1")).toEqual(teamTypes);
   });
 });

--- a/packages/teams/test/utils/get-teams-available-in-product.test.ts
+++ b/packages/teams/test/utils/get-teams-available-in-product.test.ts
@@ -8,4 +8,11 @@ describe("getTeamsAvailableInProduct", () => {
     );
     expect(chk.length).toBe(3, "should return 3 of team templates for basic");
   });
+  it("return teams for a specific product in 9.1", () => {
+    const chk = getTeamsAvailableInProduct("basic", "9.1");
+    expect(Array.isArray(chk)).toBeTruthy(
+      "should return array of team templates"
+    );
+    expect(chk.length).toBe(3, "should return 3 of team templates for basic");
+  });
 });

--- a/packages/teams/test/utils/get-teams-available-in-product.test.ts
+++ b/packages/teams/test/utils/get-teams-available-in-product.test.ts
@@ -9,10 +9,18 @@ describe("getTeamsAvailableInProduct", () => {
     expect(chk.length).toBe(3, "should return 3 of team templates for basic");
   });
   it("return teams for a specific product in 9.1", () => {
-    const chk = getTeamsAvailableInProduct("basic", "9.1");
+    const chk = getTeamsAvailableInProduct("premium", "9.1");
     expect(Array.isArray(chk)).toBeTruthy(
       "should return array of team templates"
     );
-    expect(chk.length).toBe(3, "should return 3 of team templates for basic");
+    expect(chk.length).toBe(5, "should return 5 of team templates for basic");
+    expect(chk[0].membershipAccess).toBe(
+      "collaboration",
+      "core team should be set to collaboration"
+    );
+    expect(chk[4].membershipAccess).toBe(
+      "",
+      "event team should be an empty string membershipAccess"
+    );
   });
 });

--- a/packages/teams/test/utils/get-teams-available-in-product.test.ts
+++ b/packages/teams/test/utils/get-teams-available-in-product.test.ts
@@ -2,7 +2,7 @@ import { getTeamsAvailableInProduct } from "../../src/utils/get-teams-available-
 
 describe("getTeamsAvailableInProduct", () => {
   it("return teams for a specific product", () => {
-    const chk = getTeamsAvailableInProduct("basic");
+    const chk = getTeamsAvailableInProduct("basic", "8.4");
     expect(Array.isArray(chk)).toBeTruthy(
       "should return array of team templates"
     );

--- a/packages/teams/test/utils/get-user-creatable-teams.test.ts
+++ b/packages/teams/test/utils/get-user-creatable-teams.test.ts
@@ -56,4 +56,61 @@ describe("getUserCreatableTeams", () => {
       "no groups should be created if user lacks all privs"
     );
   });
+  it("respects product and privs for 9.1", () => {
+    const user = {
+      privileges: [
+        "portal:user:createGroup",
+        "portal:admin:updateGroups",
+        "portal:admin:createUpdateCapableGroup",
+        "portal:admin:",
+        "portal:user:addExternalMembersToGroup"
+      ]
+    };
+    expect(getUserCreatableTeams(user, "premium", "9.1").length).toBe(
+      5,
+      "Premium, all privs, should be 5 creatable team types"
+    );
+    expect(getUserCreatableTeams(user, "basic", "9.1").length).toBe(
+      3,
+      "Basic, all privs, should be 3 creatable team types"
+    );
+    expect(getUserCreatableTeams(user, "portal", "9.1").length).toBe(
+      3,
+      "Portal, all privs, should be 3 creatable team types"
+    );
+
+    // remove updateGroups...
+    user.privileges = [
+      "portal:user:createGroup",
+      "opendata:user:designateGroup",
+      "portal:user:addExternalMembersToGroup"
+    ];
+    expect(getUserCreatableTeams(user, "premium", "9.1").length).toBe(
+      4,
+      "Premium, all privs, should be 5 creatable team types"
+    );
+    expect(getUserCreatableTeams(user, "basic", "9.1").length).toBe(
+      2,
+      "Basic, all privs, should be 3 creatable team types"
+    );
+    expect(getUserCreatableTeams(user, "portal", "9.1").length).toBe(
+      2,
+      "Portal, all privs, should be 3 creatable team types"
+    );
+
+    // clear all privs and we should not get any groups back...
+    user.privileges = [];
+    expect(getUserCreatableTeams(user, "premium", "9.1").length).toBe(
+      0,
+      "no groups should be created if user lacks all privs"
+    );
+    expect(getUserCreatableTeams(user, "basic", "9.1").length).toBe(
+      0,
+      "no groups should be created if user lacks all privs"
+    );
+    expect(getUserCreatableTeams(user, "portal", "9.1").length).toBe(
+      0,
+      "no groups should be created if user lacks all privs"
+    );
+  });
 });

--- a/packages/teams/test/utils/get-user-creatable-teams.test.ts
+++ b/packages/teams/test/utils/get-user-creatable-teams.test.ts
@@ -10,15 +10,15 @@ describe("getUserCreatableTeams", () => {
         "opendata:user:designateGroup"
       ]
     };
-    expect(getUserCreatableTeams(user, "premium").length).toBe(
+    expect(getUserCreatableTeams(user, "premium", "8.4").length).toBe(
       5,
       "Premium, all privs, should be 5 creatable team types"
     );
-    expect(getUserCreatableTeams(user, "basic").length).toBe(
+    expect(getUserCreatableTeams(user, "basic", "8.4").length).toBe(
       3,
       "Basic, all privs, should be 3 creatable team types"
     );
-    expect(getUserCreatableTeams(user, "portal").length).toBe(
+    expect(getUserCreatableTeams(user, "portal", "8.4").length).toBe(
       3,
       "Portal, all privs, should be 3 creatable team types"
     );
@@ -28,30 +28,30 @@ describe("getUserCreatableTeams", () => {
       "portal:user:createGroup",
       "opendata:user:designateGroup"
     ];
-    expect(getUserCreatableTeams(user, "premium").length).toBe(
+    expect(getUserCreatableTeams(user, "premium", "8.4").length).toBe(
       4,
       "Premium, all privs, should be 5 creatable team types"
     );
-    expect(getUserCreatableTeams(user, "basic").length).toBe(
+    expect(getUserCreatableTeams(user, "basic", "8.4").length).toBe(
       2,
       "Basic, all privs, should be 3 creatable team types"
     );
-    expect(getUserCreatableTeams(user, "portal").length).toBe(
+    expect(getUserCreatableTeams(user, "portal", "8.4").length).toBe(
       2,
       "Portal, all privs, should be 3 creatable team types"
     );
 
     // clear all privs and we should not get any groups back...
     user.privileges = [];
-    expect(getUserCreatableTeams(user, "premium").length).toBe(
+    expect(getUserCreatableTeams(user, "premium", "8.4").length).toBe(
       0,
       "no groups should be created if user lacks all privs"
     );
-    expect(getUserCreatableTeams(user, "basic").length).toBe(
+    expect(getUserCreatableTeams(user, "basic", "8.4").length).toBe(
       0,
       "no groups should be created if user lacks all privs"
     );
-    expect(getUserCreatableTeams(user, "portal").length).toBe(
+    expect(getUserCreatableTeams(user, "portal", "8.4").length).toBe(
       0,
       "no groups should be created if user lacks all privs"
     );


### PR DESCRIPTION
We are updating well known teams to account for 9.1 group changes (WRT permissions / who can be added). This PR makes these changes, and also conditionally loads old/new well known team types based on the current portal version.