### PR TITLE
fix: check user groups before confirming they can create a team

### DIFF
--- a/packages/teams/src/utils/can-user-create-team-in-product.ts
+++ b/packages/teams/src/utils/can-user-create-team-in-product.ts
@@ -20,7 +20,7 @@ export function canUserCreateTeamInProduct(
   const userGroups = getProp(user, "groups") || [];
   // can this be created in the current environment?
   if (
-    userGroups.length < 510 &&
+    userGroups.length < 507 &&
     includes(template.config.availableIn, product)
   ) {
     // and user has required privs...

--- a/packages/teams/src/utils/can-user-create-team-in-product.ts
+++ b/packages/teams/src/utils/can-user-create-team-in-product.ts
@@ -1,6 +1,6 @@
 import { IUser } from "@esri/arcgis-rest-auth";
 import { hasAllPrivileges } from "./has-all-privileges";
-import { HubProduct, includes } from "@esri/hub-common";
+import { getProp, HubProduct, includes } from "@esri/hub-common";
 import { IGroupTemplate } from "../types";
 
 /**
@@ -17,8 +17,12 @@ export function canUserCreateTeamInProduct(
   template: IGroupTemplate
 ) {
   let result = false;
+  const userGroups = getProp(user, "groups") || [];
   // can this be created in the current environment?
-  if (includes(template.config.availableIn, product)) {
+  if (
+    userGroups.length < 510 &&
+    includes(template.config.availableIn, product)
+  ) {
     // and user has required privs...
     result = hasAllPrivileges(user, template.config.requiredPrivs);
   }

--- a/packages/teams/test/utils/can-user-create-team-in-product.test.ts
+++ b/packages/teams/test/utils/can-user-create-team-in-product.test.ts
@@ -33,14 +33,14 @@ describe("teams:utils:canUserCreateTeamInProduct:", () => {
     expect(result).toBeFalsy("Team not in product should not be creatable");
   });
 
-  it("returns false if user has 511 groups", () => {
+  it("returns false if user has 507 or more groups", () => {
     const user = {
       privileges: ["baz"],
-      groups: new Array(511)
+      groups: new Array(507)
     };
 
     const result = canUserCreateTeamInProduct(user, "basic", tmpl);
-    expect(result).toBeFalsy("User with > 510 groups can't create team");
+    expect(result).toBeFalsy("User with > 507 groups can't create team");
   });
 
   it("returns true if user has privs and less than 511 groups", () => {

--- a/packages/teams/test/utils/can-user-create-team-in-product.test.ts
+++ b/packages/teams/test/utils/can-user-create-team-in-product.test.ts
@@ -1,0 +1,55 @@
+/* Copyright (c) 2018-2020 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { IGroupTemplate } from "../../src/types";
+import { canUserCreateTeamInProduct } from "../../src/utils/can-user-create-team-in-product";
+
+describe("teams:utils:canUserCreateTeamInProduct:", () => {
+  const tmpl = {
+    config: {
+      requiredPrivs: ["baz"],
+      availableIn: ["basic"]
+    }
+  } as IGroupTemplate;
+
+  it("returns false if user lacks privs", () => {
+    const user = {
+      privileges: ["foo"],
+      groups: [] as any[]
+    };
+
+    const result = canUserCreateTeamInProduct(user, "basic", tmpl);
+    expect(result).toBeFalsy(
+      "User without privs should not be able to create group"
+    );
+  });
+  it("returns false if team not availble in product", () => {
+    const user = {
+      privileges: ["foo"],
+      groups: [] as any[]
+    };
+
+    const result = canUserCreateTeamInProduct(user, "premium", tmpl);
+    expect(result).toBeFalsy("Team not in product should not be creatable");
+  });
+
+  it("returns false if user has 511 groups", () => {
+    const user = {
+      privileges: ["baz"],
+      groups: new Array(511)
+    };
+
+    const result = canUserCreateTeamInProduct(user, "basic", tmpl);
+    expect(result).toBeFalsy("User with > 510 groups can't create team");
+  });
+
+  it("returns true if user has privs and less than 511 groups", () => {
+    const user = {
+      privileges: ["baz"],
+      groups: [] as any[]
+    };
+
+    const result = canUserCreateTeamInProduct(user, "basic", tmpl);
+    expect(result).toBeTruthy("user can creat team if they have privs");
+  });
+});

--- a/packages/teams/test/utils/can-user-create-team-in-product.test.ts
+++ b/packages/teams/test/utils/can-user-create-team-in-product.test.ts
@@ -36,7 +36,7 @@ describe("teams:utils:canUserCreateTeamInProduct:", () => {
   it("returns false if user has 507 or more groups", () => {
     const user = {
       privileges: ["baz"],
-      groups: new Array(507)
+      groups: new Array(508)
     };
 
     const result = canUserCreateTeamInProduct(user, "basic", tmpl);


### PR DESCRIPTION
This ensures that during the site deployment process we check that the user has some group capacity before 