### PR TITLE
F/169 add telemetry and consent notice config

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -372,3 +372,16 @@ export interface IOperation {
 export interface ISerializedOperationStack {
   operations: IOperation[];
 }
+
+/**
+ * IUpdateSiteOptions
+ *
+ * Options for site updates
+ *
+ * @export
+ * @interface UpdateSiteOptions
+ */
+export interface IUpdateSiteOptions extends IHubRequestOptions {
+  updateVersions?: boolean;
+  allowList: string[];
+}

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -383,5 +383,5 @@ export interface ISerializedOperationStack {
  */
 export interface IUpdateSiteOptions extends IHubRequestOptions {
   updateVersions?: boolean;
-  allowList: string[];
+  allowList?: string[];
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -385,3 +385,15 @@ export interface IUpdateSiteOptions extends IHubRequestOptions {
   updateVersions?: boolean;
   allowList?: string[];
 }
+
+/**
+ * IUpdatePageOptions
+ *
+ * Options for page updates
+ *
+ * @export
+ * @interface UpdatePageOptions
+ */
+export interface IUpdatePageOptions extends IHubRequestOptions {
+  allowList?: string[];
+}

--- a/packages/sites/src/_ensure-telemetry.ts
+++ b/packages/sites/src/_ensure-telemetry.ts
@@ -1,0 +1,32 @@
+import { IModel, getProp, deleteProp, cloneObject } from "@esri/hub-common";
+
+/**
+ * Add telemetry config object
+ * @private
+ * @param {object} model Site Model
+ * @returns {object}
+ */
+export function _ensureTelemetry(model: IModel) {
+  if (getProp(model, "item.properties.schemaVersion") >= 1.4) return model;
+  const clone = cloneObject(model);
+  const gacode = getProp(clone, "data.values.gacode");
+  clone.data.values.telemetry = {
+    consentNotice: {
+      isTheme: true,
+      consentText: "",
+      policyURL: ""
+    },
+    customAnalytics: {
+      ga: [
+        {
+          enabled: Boolean(gacode),
+          id: gacode,
+          name: "customerTracker"
+        }
+      ]
+    }
+  };
+  deleteProp(clone, "data.values.gacode");
+  clone.item.properties.schemaVersion = 1.4;
+  return clone;
+}

--- a/packages/sites/src/_ensure-telemetry.ts
+++ b/packages/sites/src/_ensure-telemetry.ts
@@ -17,13 +17,12 @@ export function _ensureTelemetry(model: IModel) {
       policyURL: ""
     },
     customAnalytics: {
-      ga: [
-        {
+      ga: {
+        customerTracker: {
           enabled: Boolean(gacode),
-          id: gacode,
-          name: "customerTracker"
+          id: gacode
         }
-      ]
+      }
     }
   };
   deleteProp(clone, "data.values.gacode");

--- a/packages/sites/src/drafts/save-published-status.ts
+++ b/packages/sites/src/drafts/save-published-status.ts
@@ -26,12 +26,11 @@ export function savePublishedStatus(
     // browser after saving the draft without first publishing,
     // migration changes can be lost
     const isUnpublished = hasUnpublishedChanges(siteOrPageModel);
-    prms = updateSite(
-      siteOrPageModel,
+    prms = updateSite(siteOrPageModel, {
+      ...hubRequestOptions,
       allowList,
-      hubRequestOptions,
-      !isUnpublished
-    );
+      updateVersions: !isUnpublished
+    });
   } else if (isPage(item)) {
     prms = updatePage(siteOrPageModel, allowList, hubRequestOptions);
   } else {

--- a/packages/sites/src/drafts/save-published-status.ts
+++ b/packages/sites/src/drafts/save-published-status.ts
@@ -22,9 +22,10 @@ export function savePublishedStatus(
 
   if (isSite(item)) {
     // when saving a draft site, we need to prevent the schemaVersion
-    // from being updated. if not, and the user refreshes the
-    // browser after saving the draft without first publishing,
-    // migration changes can be lost
+    // from being updated. otherwise, if the user does not publish the draft,
+    // functionality potentially will be broken for all users because the item
+    // reflects the most recent schemaVersion without any of the actual schema
+    // changes
     const isUnpublished = hasUnpublishedChanges(siteOrPageModel);
     prms = updateSite(siteOrPageModel, {
       ...hubRequestOptions,

--- a/packages/sites/src/drafts/save-published-status.ts
+++ b/packages/sites/src/drafts/save-published-status.ts
@@ -33,7 +33,10 @@ export function savePublishedStatus(
       updateVersions: !isUnpublished
     });
   } else if (isPage(item)) {
-    prms = updatePage(siteOrPageModel, allowList, hubRequestOptions);
+    prms = updatePage(siteOrPageModel, {
+      ...hubRequestOptions,
+      allowList
+    });
   } else {
     throw TypeError(
       "@esri/hub-sites: only page or site models have a published state"

--- a/packages/sites/src/drafts/save-published-status.ts
+++ b/packages/sites/src/drafts/save-published-status.ts
@@ -3,6 +3,7 @@ import { updateSite } from "../update-site";
 import { updatePage, isPage } from "../pages";
 import { isSite } from "../is-site";
 import { IUpdateItemResponse } from "@esri/arcgis-rest-portal";
+import { hasUnpublishedChanges } from "./has-unpublished-changes";
 
 /**
  * Saves the published status of a site or page model
@@ -20,7 +21,17 @@ export function savePublishedStatus(
   let prms;
 
   if (isSite(item)) {
-    prms = updateSite(siteOrPageModel, allowList, hubRequestOptions);
+    // when saving a draft site, we need to prevent the schemaVersion
+    // from being updated. if not, and the user refreshes the
+    // browser after saving the draft without first publishing,
+    // migration changes can be lost
+    const isUnpublished = hasUnpublishedChanges(siteOrPageModel);
+    prms = updateSite(
+      siteOrPageModel,
+      allowList,
+      hubRequestOptions,
+      !isUnpublished
+    );
   } else if (isPage(item)) {
     prms = updatePage(siteOrPageModel, allowList, hubRequestOptions);
   } else {

--- a/packages/sites/src/drafts/site-draft-include-list.ts
+++ b/packages/sites/src/drafts/site-draft-include-list.ts
@@ -12,7 +12,7 @@ export const SITE_DRAFT_INCLUDE_LIST = [
   "data.values.footerSass",
   "data.values.footerCss",
   "data.values.faviconUrl",
-  "data.values.gacode",
+  "data.values.telemetry",
   "data.values.map",
   "data.values.capabilities"
 ];

--- a/packages/sites/src/index.ts
+++ b/packages/sites/src/index.ts
@@ -58,3 +58,4 @@ export * from "./get-data-for-site-item";
 export * from "./get-site-by-id";
 export * from "./is-site";
 export * from "./get-members";
+export * from "./_ensure-telemetry";

--- a/packages/sites/src/site-schema-version.ts
+++ b/packages/sites/src/site-schema-version.ts
@@ -1,1 +1,1 @@
-export const SITE_SCHEMA_VERSION = 1.3;
+export const SITE_SCHEMA_VERSION = 1.4;

--- a/packages/sites/src/update-site.ts
+++ b/packages/sites/src/update-site.ts
@@ -1,6 +1,5 @@
 import {
   IModel,
-  IHubRequestOptions,
   IUpdateSiteOptions,
   deepSet,
   getProp,

--- a/packages/sites/src/update-site.ts
+++ b/packages/sites/src/update-site.ts
@@ -1,6 +1,7 @@
 import {
   IModel,
   IHubRequestOptions,
+  IUpdateSiteOptions,
   deepSet,
   getProp,
   getModel,
@@ -15,77 +16,73 @@ import { updateItem, IUpdateItemResponse } from "@esri/arcgis-rest-portal";
  * Update an existing site item
  * This function supports the equivalent of a PATCH REST operation
  * It will fetch the current item from ago, and then apply
- * a subset of property changes to the model if a patchList is included.
- * The patchList can include any property paths on the item.
+ * a subset of property changes to the model if a allowList is included.
+ * The allowList can include any property paths on the item.
  * If the list is empty, then the entire site model is overwritten.
  * @param {Object} model Site Model to update
- * @param {Array} patchList Array of property paths to update
- * @param {IHubRequestOptions} hubRequestOptions
- * @param {boolean} [updateVersions=true] Optionally update the versions, defaults to true
+ * @param {IUpdateSiteOptions} updateSiteOptions
  */
 export function updateSite(
   model: IModel,
-  patchList: string[],
-  hubRequestOptions: IHubRequestOptions,
-  updateVersions: boolean = true
+  updateSiteOptions: IUpdateSiteOptions
 ): Promise<IUpdateItemResponse> {
-  patchList = patchList || [];
-
+  const allowList = updateSiteOptions.allowList || [];
+  const { updateVersions = true } = updateSiteOptions;
   // apply any on-save site upgrades here...
   deepSet(model, "data.values.uiVersion", SITE_UI_VERSION);
   deepSet(model, "data.values.updatedAt", new Date().toISOString());
   deepSet(
     model,
     "data.values.updatedBy",
-    hubRequestOptions.authentication.username
+    updateSiteOptions.authentication.username
   );
 
-  // we only add these in if an patchList was passed in
-  if (patchList.length) {
-    patchList.push("data.values.updatedAt");
-    patchList.push("data.values.updatedBy");
+  // we only add these in if an allowList was passed in
+  if (allowList.length) {
+    allowList.push("data.values.updatedAt");
+    allowList.push("data.values.updatedBy");
     if (updateVersions) {
-      patchList.push("data.values.uiVersion");
+      allowList.push("data.values.uiVersion");
       // any save needs to be able to update the schema version
       // which will have been bumped if a schema migration
       // occured during the load cycle
-      patchList.push("item.properties.schemaVersion");
+      allowList.push("item.properties.schemaVersion");
     }
   }
 
   // PORTAL-ENV: no domain service so we encode the subdomain in a typeKeyword
-  if (hubRequestOptions.isPortal) {
+  if (updateSiteOptions.isPortal) {
     model.item.typeKeywords = _ensurePortalDomainKeyword(
       getProp(model, "data.values.subdomain"),
       model.item.typeKeywords
     );
     // see above comment why ths is gated...
-    if (patchList.length) {
-      patchList.push("item.typeKeywords");
+    if (allowList.length) {
+      allowList.push("item.typeKeywords");
     }
   }
   // Actually start the update process...
 
   let agoModelPromise;
-  // if we have a patchList, refetch the site to check for changes...
-  if (patchList.length) {
-    agoModelPromise = getModel(model.item.id, hubRequestOptions);
+  // if we have a allowList, refetch the site to check for changes...
+  if (allowList.length) {
+    agoModelPromise = getModel(model.item.id, updateSiteOptions);
   } else {
-    // if we dont have a patchList, just resolve with the model we have
+    // if we dont have a allowList, just resolve with the model we have
     agoModelPromise = Promise.resolve(model);
   }
 
   // Kick things off...
   return agoModelPromise
     .then(agoModel => {
-      if (patchList.length) {
+      if (allowList.length) {
         // merge the props in the allow list into the model from AGO
-        model = mergeObjects(model, agoModel, patchList);
+        model = mergeObjects(model, agoModel, allowList);
       }
       // send the update to ago
       return updateItem({
         item: serializeModel(model),
-        authentication: hubRequestOptions.authentication,
+        authentication: updateSiteOptions.authentication,
         params: { clearEmptyFields: true }
       });
     })

--- a/packages/sites/src/update-site.ts
+++ b/packages/sites/src/update-site.ts
@@ -21,11 +21,13 @@ import { updateItem, IUpdateItemResponse } from "@esri/arcgis-rest-portal";
  * @param {Object} model Site Model to update
  * @param {Array} patchList Array of property paths to update
  * @param {IHubRequestOptions} hubRequestOptions
+ * @param {boolean} [updateVersions=true] Optionally update the versions, defaults to true
  */
 export function updateSite(
   model: IModel,
   patchList: string[],
-  hubRequestOptions: IHubRequestOptions
+  hubRequestOptions: IHubRequestOptions,
+  updateVersions: boolean = true
 ): Promise<IUpdateItemResponse> {
   patchList = patchList || [];
 
@@ -42,11 +44,13 @@ export function updateSite(
   if (patchList.length) {
     patchList.push("data.values.updatedAt");
     patchList.push("data.values.updatedBy");
-    patchList.push("data.values.uiVersion");
-    // any save needs to be able to update the schema version
-    // which will have been bumped if a schema migration
-    // occured during the load cycle
-    patchList.push("item.properties.schemaVersion");
+    if (updateVersions) {
+      patchList.push("data.values.uiVersion");
+      // any save needs to be able to update the schema version
+      // which will have been bumped if a schema migration
+      // occured during the load cycle
+      patchList.push("item.properties.schemaVersion");
+    }
   }
 
   // PORTAL-ENV: no domain service so we encode the subdomain in a typeKeyword

--- a/packages/sites/src/upgrade-site-schema.ts
+++ b/packages/sites/src/upgrade-site-schema.ts
@@ -4,6 +4,7 @@ import { _applySiteSchema } from "./_apply-site-schema";
 import { _enforceLowercaseDomains } from "./_enforce-lowercase-domains";
 import { _ensureCatalog } from "./_ensure-catalog";
 import { _purgeNonGuidsFromCatalog } from "./_purge-non-guids-from-catalog";
+import { _ensureTelemetry } from "./_ensure-telemetry";
 
 /**
  * Upgrades the schema upgrades
@@ -18,6 +19,7 @@ export function upgradeSiteSchema(model: IModel) {
     model = _enforceLowercaseDomains(model);
     model = _ensureCatalog(model);
     model = _purgeNonGuidsFromCatalog(model);
+    model = _ensureTelemetry(model);
     return model;
   }
 }

--- a/packages/sites/test/_ensure-telemetry.test.ts
+++ b/packages/sites/test/_ensure-telemetry.test.ts
@@ -30,13 +30,12 @@ describe("_ensure-telemetry", () => {
         policyURL: ""
       },
       customAnalytics: {
-        ga: [
-          {
+        ga: {
+          customerTracker: {
             enabled: true,
-            id: "UA-123456-0",
-            name: "customerTracker"
+            id: "UA-123456-0"
           }
-        ]
+        }
       }
     };
     expected.item.properties.schemaVersion = 1.4;
@@ -55,13 +54,12 @@ describe("_ensure-telemetry", () => {
         policyURL: ""
       },
       customAnalytics: {
-        ga: [
-          {
+        ga: {
+          customerTracker: {
             enabled: false,
-            id: "",
-            name: "customerTracker"
+            id: ""
           }
-        ]
+        }
       }
     };
     expected.item.properties.schemaVersion = 1.4;

--- a/packages/sites/test/_ensure-telemetry.test.ts
+++ b/packages/sites/test/_ensure-telemetry.test.ts
@@ -1,0 +1,77 @@
+import { _ensureTelemetry } from "../src";
+import { IModel, cloneObject } from "@esri/hub-common";
+
+describe("_ensure-telemetry", () => {
+  let model: IModel;
+
+  beforeEach(function() {
+    model = ({
+      item: {
+        id: "3ef",
+        properties: {
+          schemaVersion: 1.3
+        }
+      },
+      data: {
+        values: {
+          gacode: "UA-123456-0"
+        }
+      }
+    } as unknown) as IModel;
+  });
+
+  it("deletes gacode and adds telemetry with ga enabled", function() {
+    const expected: IModel = cloneObject(model);
+    delete expected.data.values.gacode;
+    expected.data.values.telemetry = {
+      consentNotice: {
+        isTheme: true,
+        consentText: "",
+        policyURL: ""
+      },
+      customAnalytics: {
+        ga: [
+          {
+            enabled: true,
+            id: "UA-123456-0",
+            name: "customerTracker"
+          }
+        ]
+      }
+    };
+    expected.item.properties.schemaVersion = 1.4;
+    const results = _ensureTelemetry(model);
+    expect(results).toEqual(expected);
+  });
+
+  it("deletes gacode and adds telemetry with ga disabled", function() {
+    model.data.values.gacode = "";
+    const expected: IModel = cloneObject(model);
+    delete expected.data.values.gacode;
+    expected.data.values.telemetry = {
+      consentNotice: {
+        isTheme: true,
+        consentText: "",
+        policyURL: ""
+      },
+      customAnalytics: {
+        ga: [
+          {
+            enabled: false,
+            id: "",
+            name: "customerTracker"
+          }
+        ]
+      }
+    };
+    expected.item.properties.schemaVersion = 1.4;
+    const results = _ensureTelemetry(model);
+    expect(results).toEqual(expected);
+  });
+
+  it("does nothing if schema >= 1.4", function() {
+    model.item.properties.schemaVersion = 1.4;
+    const results = _ensureTelemetry(model);
+    expect(results).toEqual(model);
+  });
+});

--- a/packages/sites/test/drafts/save-published-status.test.ts
+++ b/packages/sites/test/drafts/save-published-status.test.ts
@@ -62,11 +62,10 @@ describe("savePublishedStatus", () => {
   it("saves the published status of a page", async () => {
     await savePublishedStatus(pageModel, ro);
 
-    expect(updatePageSpy).toHaveBeenCalledWith(
-      pageModel,
-      ["item.typeKeywords"],
-      ro
-    );
+    expect(updatePageSpy).toHaveBeenCalledWith(pageModel, {
+      ...ro,
+      allowList: ["item.typeKeywords"]
+    });
     expect(updateSiteSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/sites/test/drafts/save-published-status.test.ts
+++ b/packages/sites/test/drafts/save-published-status.test.ts
@@ -38,12 +38,11 @@ describe("savePublishedStatus", () => {
 
   it("saves the draft status of a site", async () => {
     await savePublishedStatus(siteModel, ro);
-    expect(updateSiteSpy).toHaveBeenCalledWith(
-      siteModel,
-      ["item.typeKeywords"],
-      ro,
-      false
-    );
+    expect(updateSiteSpy).toHaveBeenCalledWith(siteModel, {
+      ...ro,
+      allowList: ["item.typeKeywords"],
+      updateVersions: false
+    });
     expect(updatePageSpy).not.toHaveBeenCalled();
   });
 
@@ -52,12 +51,11 @@ describe("savePublishedStatus", () => {
     cloned.item.typeKeywords = [];
     await savePublishedStatus(cloned, ro);
 
-    expect(updateSiteSpy).toHaveBeenCalledWith(
-      cloned,
-      ["item.typeKeywords"],
-      ro,
-      true
-    );
+    expect(updateSiteSpy).toHaveBeenCalledWith(cloned, {
+      ...ro,
+      allowList: ["item.typeKeywords"],
+      updateVersions: true
+    });
     expect(updatePageSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/sites/test/drafts/save-published-status.test.ts
+++ b/packages/sites/test/drafts/save-published-status.test.ts
@@ -2,7 +2,7 @@ import { savePublishedStatus, UNPUBLISHED_CHANGES_KW } from "../../src/drafts";
 import * as pagesModule from "../../src/pages";
 import * as updateSiteModule from "../../src/update-site";
 import { getSiteItemType, getPageItemType } from "../../src";
-import { IHubRequestOptions, IModel } from "@esri/hub-common";
+import { IHubRequestOptions, IModel, cloneObject } from "@esri/hub-common";
 
 describe("savePublishedStatus", () => {
   const ro = {
@@ -36,13 +36,27 @@ describe("savePublishedStatus", () => {
     );
   });
 
-  it("saves the published status of a site", async () => {
+  it("saves the draft status of a site", async () => {
     await savePublishedStatus(siteModel, ro);
-
     expect(updateSiteSpy).toHaveBeenCalledWith(
       siteModel,
       ["item.typeKeywords"],
-      ro
+      ro,
+      false
+    );
+    expect(updatePageSpy).not.toHaveBeenCalled();
+  });
+
+  it("saves the published status of a site", async () => {
+    const cloned = cloneObject(siteModel);
+    cloned.item.typeKeywords = [];
+    await savePublishedStatus(cloned, ro);
+
+    expect(updateSiteSpy).toHaveBeenCalledWith(
+      cloned,
+      ["item.typeKeywords"],
+      ro,
+      true
     );
     expect(updatePageSpy).not.toHaveBeenCalled();
   });

--- a/packages/sites/test/pages/update-page.test.ts
+++ b/packages/sites/test/pages/update-page.test.ts
@@ -36,7 +36,12 @@ describe("updatePage", () => {
   it("updates the page", async () => {
     const getModelSpy = spyOn(commonModule, "getModel");
 
-    await updatePage(cloneObject(model), [], ro);
+    const updateSiteOptions = {
+      ...ro,
+      allowList: [] as string[]
+    };
+
+    await updatePage(cloneObject(model), updateSiteOptions);
 
     // model not fetched from ago when patchList empty
     expect(getModelSpy).not.toHaveBeenCalled();
@@ -77,10 +82,15 @@ describe("updatePage", () => {
       Promise.resolve(modelInAGO)
     );
 
-    await updatePage(cloneObject(model), ["item.title"], ro);
+    const updateSiteOptions = {
+      ...ro,
+      allowList: ["item.title"]
+    };
+
+    await updatePage(cloneObject(model), updateSiteOptions);
 
     // model fetched from ago when patchList not empty
-    expect(getModelSpy).toHaveBeenCalledWith("page-id", ro);
+    expect(getModelSpy).toHaveBeenCalledWith("page-id", updateSiteOptions);
     expect(updateSpy).toHaveBeenCalled();
 
     const savedItem = updateSpy.calls.argsFor(0)[0].item;
@@ -92,22 +102,10 @@ describe("updatePage", () => {
     );
   });
 
-  it("handles old call signature", async () => {
-    const getModelSpy = spyOn(commonModule, "getModel").and.returnValue(
-      Promise.resolve({})
-    );
-
-    await updatePage(cloneObject(model), ro);
-
-    // model not fetched from ago when patchList empty
-    expect(getModelSpy).not.toHaveBeenCalled();
-    expect(updateSpy).toHaveBeenCalled();
-  });
-
   it("doesnt remove unused resources if update failed", async () => {
     updateSpy.and.returnValue(Promise.resolve({ success: false }));
 
-    await updatePage(cloneObject(model), [], ro);
+    await updatePage(cloneObject(model), ro);
 
     expect(updateSpy).toHaveBeenCalled();
   });

--- a/packages/sites/test/update-site.test.ts
+++ b/packages/sites/test/update-site.test.ts
@@ -39,18 +39,18 @@ describe("update site", function() {
     delete localSite.data.values.layout.sections[0].style.background.fileSrc;
     delete localSite.data.values.layout.sections[0].style.background.cropSrc;
 
-    const ro = {
-      authentication: {}
-    } as commonModule.IHubRequestOptions;
+    const updateSiteOptions = {
+      authentication: {},
+      allowList: ["item.properties", "data.layout"]
+    } as commonModule.IUpdateSiteOptions;
 
-    const result = await updateSite(
-      localSite,
-      ["item.properties", "data.layout"],
-      ro
-    );
+    const result = await updateSite(localSite, updateSiteOptions);
 
     // Model should be fetched when allow-list is passed in
-    expect(getModelSpy).toHaveBeenCalledWith(localSite.item.id, ro);
+    expect(getModelSpy).toHaveBeenCalledWith(
+      localSite.item.id,
+      updateSiteOptions
+    );
     expect(result.success).toBeTruthy("should return sucess");
     expect(updateSpy).toHaveBeenCalled();
 
@@ -76,19 +76,19 @@ describe("update site", function() {
     delete localSite.data.values.layout.sections[0].style.background.fileSrc;
     delete localSite.data.values.layout.sections[0].style.background.cropSrc;
 
-    const ro = {
-      authentication: {}
-    } as commonModule.IHubRequestOptions;
+    const updateSiteOptions = {
+      authentication: {},
+      allowList: ["item.properties", "data.layout"],
+      updateVersions: false
+    } as commonModule.IUpdateSiteOptions;
 
-    const result = await updateSite(
-      localSite,
-      ["item.properties", "data.layout"],
-      ro,
-      false
-    );
+    const result = await updateSite(localSite, updateSiteOptions);
 
     // Model should be fetched when allow-list is passed in
-    expect(getModelSpy).toHaveBeenCalledWith(localSite.item.id, ro);
+    expect(getModelSpy).toHaveBeenCalledWith(
+      localSite.item.id,
+      updateSiteOptions
+    );
     expect(result.success).toBeTruthy("should return sucess");
     expect(updateSpy).toHaveBeenCalled();
 
@@ -118,7 +118,10 @@ describe("update site", function() {
       authentication: {}
     } as commonModule.IHubRequestOptions;
 
-    const result = await updateSite(localSite, null, ro);
+    const result = await updateSite(localSite, {
+      ...ro,
+      allowList: null
+    });
 
     expect(result.success).toBeTruthy("should return sucess");
 
@@ -153,7 +156,10 @@ describe("update site", function() {
     } as commonModule.IHubRequestOptions;
 
     // WITH ALLOW LIST
-    const result = await updateSite(localSite, ["item.properties"], ro);
+    const result = await updateSite(localSite, {
+      ...ro,
+      allowList: ["item.properties"]
+    });
 
     expect(result.success).toBeTruthy("should return success");
     // Model should NOT be fetched when allow-list is NOT passed in
@@ -164,7 +170,10 @@ describe("update site", function() {
 
     // WITH ALLOW LIST
     updateSpy.calls.reset();
-    const result2 = await updateSite(localSite, null, ro);
+    const result2 = await updateSite(localSite, {
+      ...ro,
+      allowList: null
+    });
 
     expect(result2.success).toBeTruthy("should return success");
     // Model should NOT be fetched when allow-list is NOT passed in
@@ -184,7 +193,10 @@ describe("update site", function() {
 
     // WITH ALLOW LIST
     try {
-      await updateSite(localSite, ["item.properties"], ro);
+      await updateSite(localSite, {
+        ...ro,
+        allowList: ["item.properties"]
+      });
       fail("should reject");
     } catch (err) {
       expect(err).toBeDefined();

--- a/packages/sites/test/upgrade-site-schema.test.ts
+++ b/packages/sites/test/upgrade-site-schema.test.ts
@@ -3,6 +3,7 @@ import * as _applySiteSchemaModule from "../src/_apply-site-schema";
 import * as _enforceLowercaseDomainsModule from "../src/_enforce-lowercase-domains";
 import * as _ensureCatalogModule from "../src/_ensure-catalog";
 import * as _purgeNonGuidsFromCatalogModule from "../src/_purge-non-guids-from-catalog";
+import * as _ensureTelemetryModule from "../src/_ensure-telemetry";
 import { IModel } from "@esri/hub-common";
 import { SITE_SCHEMA_VERSION } from "../src/site-schema-version";
 import { expectAllCalled, expectAll } from "./test-helpers.test";
@@ -12,6 +13,7 @@ describe("upgradeSiteSchema", () => {
   let enforceLowercaseSpy: jasmine.Spy;
   let ensureCatalogSpy: jasmine.Spy;
   let purgeNonGuidsSpy: jasmine.Spy;
+  let ensureTelemetrySpy: jasmine.Spy;
   beforeEach(() => {
     applySpy = spyOn(_applySiteSchemaModule, "_applySiteSchema").and.callFake(
       (model: IModel) => model
@@ -28,6 +30,10 @@ describe("upgradeSiteSchema", () => {
       _purgeNonGuidsFromCatalogModule,
       "_purgeNonGuidsFromCatalog"
     ).and.callFake((model: IModel) => model);
+    ensureTelemetrySpy = spyOn(
+      _ensureTelemetryModule,
+      "_ensureTelemetry"
+    ).and.callFake((model: IModel) => model);
   });
 
   it("runs schema upgrades", async () => {
@@ -42,7 +48,13 @@ describe("upgradeSiteSchema", () => {
     upgradeSiteSchema(model);
 
     expectAllCalled(
-      [applySpy, enforceLowercaseSpy, ensureCatalogSpy, purgeNonGuidsSpy],
+      [
+        applySpy,
+        enforceLowercaseSpy,
+        ensureCatalogSpy,
+        purgeNonGuidsSpy,
+        ensureTelemetrySpy
+      ],
       expect
     );
   });


### PR DESCRIPTION
…new site.data.values.telemetry object. Additionally, prevent the schemaVersion from being incremented when only updating published status when saving a draft.

[169](https://devtopia.esri.com/dc/hub/issues/169)

1) Adds new `site.data.values.telemetry` config object
2) Move existing `gacode` under `site.data.values.telemetry.customAnalytics.ga`
3) Fixes bug where saving a site draft can cause loss of migration changes