### PR TITLE
feat(content): getContent now fetches the item from the AGO API 

### DIFF
--- a/packages/content/src/hub.ts
+++ b/packages/content/src/hub.ts
@@ -27,6 +27,30 @@ export type DatasetResource = ResourceObject<
   }
 >;
 
+// properties to overwrite on the hub api response with the value from the ago api response
+const itemOverrides = [
+  "contentStatus",
+  "spatialReference",
+  "accessInformation",
+  "proxyFilter",
+  "appCategories",
+  "industries",
+  "languages",
+  "largeThumbnail",
+  "banner",
+  "screenshots",
+  "listed",
+  "ownerFolder",
+  "protected",
+  "commentsEnabled",
+  "numComments",
+  "numRatings",
+  "avgRating",
+  "numViews",
+  "itemControl",
+  "scoreCompleteness"
+];
+
 /**
  * Fetch a dataset resource with the given ID from the Hub API
  *
@@ -59,15 +83,16 @@ export function getContentFromHub(
         // we fetch the item - this is because if an item is contentStatus: org_authoritative
         // we do not get that info unless we are authed in the org
         // see https://devtopia.esri.com/dc/hub/issues/53#issuecomment-2769965
-        return getItem(dataset.id, options).then(item => {
-          const itemOverrides = ["contentStatus"];
-          dataset.attributes = mergeObjects(
-            item,
-            dataset.attributes,
-            itemOverrides
-          );
-          return dataset;
-        });
+        return getItem(parseDatasetId(dataset.id).itemId, options).then(
+          item => {
+            dataset.attributes = mergeObjects(
+              item,
+              dataset.attributes,
+              itemOverrides
+            );
+            return dataset;
+          }
+        );
       } else {
         return dataset;
       }

--- a/packages/content/test/mocks/items/map-service.json
+++ b/packages/content/test/mocks/items/map-service.json
@@ -30,7 +30,16 @@
   "snippet": "Percentage claimants of out of work benefit",
   "thumbnail": "thumbnail/census.JPG",
   "documentation": null,
-  "extent": [[-2.732, 53.4452], [-2.4139, 53.6093]],
+  "extent": [
+    [
+      -2.732,
+      53.4452
+    ],
+    [
+      -2.4139,
+      53.6093
+    ]
+  ],
   "categories": [],
   "spatialReference": "27700",
   "accessInformation": null,
@@ -54,5 +63,6 @@
   "avgRating": 0,
   "numViews": 165,
   "scoreCompleteness": 91,
-  "groupDesignations": null
+  "groupDesignations": null,
+  "contentStatus": "org_authoritative"
 }


### PR DESCRIPTION
We now fetch the item from the AGO API even in cases where we were able to fetch it from the Hub API.

https://devtopia.esri.com/dc/hub/issues/53

affects: @esri/hub-content