### PR TITLE
Bug/fix membership access hub basic core team

### DIFF
--- a/packages/teams/src/well-known-teams.ts
+++ b/packages/teams/src/well-known-teams.ts
@@ -48,7 +48,10 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
       type: "core",
       availableIn: ["basic"],
       propertyName: "collaborationGroupId",
-      requiredPrivs: ["portal:admin:createUpdateCapableGroup"],
+      requiredPrivs: [
+        "portal:admin:createUpdateCapableGroup",
+        "portal:user:addExternalMembersToGroup"
+      ],
       titleI18n: "collaborationTitleBasic",
       descriptionI18n: "collaborationDescBasic",
       snippetI18n: "collaborationSnippetBasic"

--- a/packages/teams/src/well-known-teams.ts
+++ b/packages/teams/src/well-known-teams.ts
@@ -60,7 +60,7 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
     sortField: "modified",
     sortOrder: "desc",
     capabilities: "updateitemcontrol",
-    membershipAccess: "org",
+    membershipAccess: "collaboration",
     _edit_privacy: "on",
     _edit_contributors: "on",
     tags: [

--- a/packages/teams/src/well-known-teams.ts
+++ b/packages/teams/src/well-known-teams.ts
@@ -60,7 +60,7 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
     sortField: "modified",
     sortOrder: "desc",
     capabilities: "updateitemcontrol",
-    membershipAccess: "collaboration",
+    membershipAccess: "collaborations",
     _edit_privacy: "on",
     _edit_contributors: "on",
     tags: [

--- a/packages/teams/src/well-known-teams.ts
+++ b/packages/teams/src/well-known-teams.ts
@@ -60,6 +60,7 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
     sortField: "modified",
     sortOrder: "desc",
     capabilities: "updateitemcontrol",
+    membershipAccess: "org",
     _edit_privacy: "on",
     _edit_contributors: "on",
     tags: [

--- a/packages/teams/src/well-known-teams.ts
+++ b/packages/teams/src/well-known-teams.ts
@@ -60,7 +60,7 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
     sortField: "modified",
     sortOrder: "desc",
     capabilities: "updateitemcontrol",
-    membershipAccess: "collaborations",
+    membershipAccess: "collaboration",
     _edit_privacy: "on",
     _edit_contributors: "on",
     tags: [


### PR DESCRIPTION
https://devtopia.esri.com/dc/hub/issues/474

We were previously erroneously omitting membershipAcess from hub basic core teams in well known teams. This properly adds `membershipAccess: "collaboration"` to hub basic core teams.