### PR TITLE
fix: teams get functions needed to pass hubRo to rest-js fns

### DIFF
--- a/packages/teams/src/utils/get-team-by-id.ts
+++ b/packages/teams/src/utils/get-team-by-id.ts
@@ -11,5 +11,5 @@ export function getTeamById(
   id: string,
   hubRequestOptions: IHubRequestOptions
 ): Promise<IGroup> {
-  return getGroup(id, { authentication: hubRequestOptions.authentication });
+  return getGroup(id, hubRequestOptions);
 }

--- a/packages/teams/src/utils/get-team-members.ts
+++ b/packages/teams/src/utils/get-team-members.ts
@@ -11,7 +11,5 @@ export function getTeamMembers(
   id: string,
   hubRequestOptions: IHubRequestOptions
 ): Promise<IGroupUsersResult> {
-  return getGroupUsers(id, {
-    authentication: hubRequestOptions.authentication
-  });
+  return getGroupUsers(id, hubRequestOptions);
 }

--- a/packages/teams/test/utils/get-team-by-id.test.ts
+++ b/packages/teams/test/utils/get-team-by-id.test.ts
@@ -32,4 +32,25 @@ describe("getTeamById", () => {
       "get team spy called with correct group id"
     );
   });
+  it("should pass whole hubRequestOptions forward", async () => {
+    const groupId = "foobarbaz";
+    const getGroupSpy = spyOn(portalModule, "getGroup").and.returnValue(
+      Promise.resolve({})
+    );
+    const unAuthRo = {
+      portal: "https://foo.com"
+    } as IHubRequestOptions;
+    const res = await getTeamById(groupId, unAuthRo);
+
+    expect(res).toBeTruthy();
+
+    expect(getGroupSpy.calls.argsFor(0)[0]).toEqual(
+      groupId,
+      "get team spy called with correct group id"
+    );
+    expect(getGroupSpy.calls.argsFor(0)[1]).toEqual(
+      unAuthRo,
+      "passes through the RO even if not authd"
+    );
+  });
 });

--- a/packages/teams/test/utils/get-team-members.test.ts
+++ b/packages/teams/test/utils/get-team-members.test.ts
@@ -32,5 +32,9 @@ describe("getTeamMembers", () => {
       groupId,
       "get group users spy called with correct group id"
     );
+    expect(getGroupUsersSpy.calls.argsFor(0)[1]).toEqual(
+      ro,
+      "passes whole hubRo forward"
+    );
   });
 });


### PR DESCRIPTION
`getTeamById` and `getTeamMembers` were not passing the `IHubRequestOptions` forward, and instead creating a new object using just the auth... i.e. `{authentication: hubRo.authentication}` and that works for auth'd users. 

But for users who are not auth'd, not passing the whole `IHubRequestOptions` means that the `.portal` property is not available, and thus the urls constructed point to www.arcgis.com vs qaext.

