### PR TITLE
fix(hub-teams): content teams membershipAccess set to everyone

### DIFF
--- a/packages/teams/src/well-known-teams.ts
+++ b/packages/teams/src/well-known-teams.ts
@@ -118,7 +118,7 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
     isViewOnly: false,
     sortField: "modified",
     sortOrder: "desc",
-    membershipAccess: "collaboration",
+    membershipAccess: "",
     tags: [
       "Hub Group",
       "Hub Content Group",
@@ -132,7 +132,10 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
       type: "content",
       availableIn: ["basic"],
       propertyName: "contentGroupId",
-      requiredPrivs: ["portal:user:createGroup"],
+      requiredPrivs: [
+        "portal:user:createGroup",
+        "portal:user:addExternalMembersToGroup"
+      ],
       titleI18n: "contentTitleBasic",
       descriptionI18n: "contentDescBasic",
       snippetI18n: "contentSnippetBasic"
@@ -143,6 +146,7 @@ export const WELLKNOWNTEAMS: IGroupTemplate[] = [
     isViewOnly: false,
     sortField: "modified",
     sortOrder: "desc",
+    membershipAccess: "",
     tags: ["Hub Group", "Hub Content Group", "Hub Site Group"]
   },
   {


### PR DESCRIPTION
affects: @esri/hub-teams

Content teams, in well known teams, membershipAccess set to everyone.

