### PR TITLE
WIP: update getContentMetadata to dynamically import fast-xml-parser

### DIFF
--- a/packages/content/src/content.ts
+++ b/packages/content/src/content.ts
@@ -6,7 +6,6 @@ import {
   getUser,
   IGetUserOptions
 } from "@esri/arcgis-rest-portal";
-import { request } from "@esri/arcgis-rest-request";
 import {
   HubType,
   IHubContent,
@@ -14,8 +13,7 @@ import {
   IModel,
   includes,
   cloneObject,
-  getProp,
-  stringToBlob
+  getProp
 } from "@esri/hub-common";
 import { IGetContentOptions, getContentFromHub } from "./hub";
 import {

--- a/packages/content/src/metadata.ts
+++ b/packages/content/src/metadata.ts
@@ -1,16 +1,12 @@
 import { getItemMetadata } from "@esri/arcgis-rest-portal";
 import { IHubRequestOptions } from "@esri/hub-common";
-import { parse } from "fast-xml-parser";
 
-function parseMetadataXml(metadataXml: string): any {
-  const opts = {
-    // options for fastXmlParser to read tag attrs
-    ignoreAttributes: false,
-    attributeNamePrefix: "@_", // attr name will be a new field in the resulting json with this prefix
-    textNodeName: "#value" // the resulting json will have field called #value pointing to the actual tag value,
-  };
-  return parse(metadataXml, opts);
-}
+// options for fastXmlParser to read tag attrs
+const parseOptions = {
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_", // attr name will be a new field in the resulting json with this prefix
+  textNodeName: "#value" // the resulting json will have field called #value pointing to the actual tag value,
+};
 
 /**
  * Fetch an [item's metadata](https://doc.arcgis.com/en/arcgis-online/manage-data/metadata.htm) from a portal
@@ -22,7 +18,9 @@ export function getContentMetadata(
   id: string,
   requestOptions?: IHubRequestOptions
 ): Promise<any> {
-  return getItemMetadata(id, requestOptions).then(metadataXml =>
-    parseMetadataXml(metadataXml)
-  );
+  return import("fast-xml-parser").then(parser => {
+    return getItemMetadata(id, requestOptions).then(metadataXml => {
+      return parser.parse(metadataXml, parseOptions);
+    });
+  });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "es2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
-    "module": "es2015",                     /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "module": "es2020",                     /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": [
       "dom",
       "es2015"


### PR DESCRIPTION
This causes the fast-xml-parser library to be lazy loaded.

Tests pass for me locally and I verified that the ES2017 build works in the webpack and demo builds and that the CJS build works in the node demo. In a production build of the Ember demo this results in lazy loading a ~28kB chunk.

![image](https://user-images.githubusercontent.com/662944/115630252-8d1b7080-a2b8-11eb-9339-5a26c9968597.png)

This breaks in CI b/c it tries to run the ESM ES5 and UMD builds, and I haven't gotten those working yet. I'm wondering how much to invest in that (i.e. how long do we need to support IE and non-ESM loaders (i.e. AMD?).

TODO:
- get ESM ES5 and UMD builds working
