### PR TITLE
fix(content): update datasetToContent method to add isProxied propert…

### DIFF
--- a/packages/content/src/hub.ts
+++ b/packages/content/src/hub.ts
@@ -131,8 +131,9 @@ export function datasetToContent(dataset: DatasetResource): IHubContent {
     searchDescription,
     groupIds,
     structuredLicense,
-    layer
+    layer,
     // dataset enrichments
+    isProxied
     // recordCount
     // TODO: fields, geometryType, layer?, server?, as needed
   } = attributes;
@@ -142,6 +143,7 @@ export function datasetToContent(dataset: DatasetResource): IHubContent {
   content.groupIds = groupIds;
   content.structuredLicense = structuredLicense;
   content.layer = layer;
+  content.isProxied = isProxied;
   //
   if (searchDescription) {
     // overwrite default summary (from snippet) w/ search description

--- a/packages/content/test/hub.test.ts
+++ b/packages/content/test/hub.test.ts
@@ -134,10 +134,12 @@ describe("hub", () => {
       const dataset = cloneObject(documentsJson.data) as DatasetResource;
       delete dataset.attributes.searchDescription;
       delete dataset.attributes.modifiedProvenance;
+      dataset.attributes.isProxied = false;
       const content = datasetToContent(dataset);
       expect(content.summary).toBe(dataset.attributes.snippet);
       expect(content.updatedDateSource).toBe("item.modified");
       expect(content.extent).toBeUndefined();
+      expect(content.isProxied).toBe(false);
     });
     // NOTE: other use cases are covered by getContent() tests
   });


### PR DESCRIPTION
…y to result

affects: @esri/hub-content

ISSUES CLOSED: https://devtopia.esri.com/dc/hub/issues/71

Adds `isProxied` to the result of `datasetToContent` method so `opendata-ui` can more accurately represent proxied CSVs as `CSV` vs `Table` in type metadata.