### PR TITLE
fix(common): refactors hasBasePriv to support falsy users & simplifie…

### DIFF
--- a/packages/common/src/access/can-edit-item.ts
+++ b/packages/common/src/access/can-edit-item.ts
@@ -1,35 +1,13 @@
-import { IItem, IUser, IGroup } from "@esri/arcgis-rest-types";
-import { isUpdateGroup, includes } from "../utils";
-import { getProp } from "../objects";
+import { IItem, IUser } from "@esri/arcgis-rest-types";
 import { hasBasePriv } from "./has-base-priv";
+import { includes } from "../utils";
 
 /**
  * Checks if user has access to edit an item in Hub
- * @param {IItem} item
- * @param {IUser} user
+ * @param {IItem} item The item to be edited
+ * @param {IUser} [user] An optional user
  * @returns {boolean}
  */
-export function canEditItem(item: IItem, user: IUser): boolean {
-  let res = false;
-  const itemControls = ["admin", "update"];
-  const { itemControl, owner, orgId: itemOrgId } = item;
-  const { roleId, role, username, groups: userGroups, orgId: userOrgId } = user;
-  const hasItemControl = includes(itemControls, itemControl);
-  const isOwner = !!owner && owner === username;
-  const isOrgItem = !!itemOrgId && itemOrgId === userOrgId;
-  const isItemOrgAdmin = !!isOrgItem && !roleId && role === "org_admin";
-  const hasPlatformControl = hasItemControl || isOwner || isItemOrgAdmin;
-  const hasPriv = hasBasePriv(user);
-  if (hasPriv && hasPlatformControl) {
-    res = true;
-  } else if (hasPriv) {
-    const itemGroups = [
-      ...(getProp(item, "groupIds") || []),
-      getProp(item, "properties.collaborationGroupId")
-    ];
-    const isGroupEditable = (group: IGroup): boolean =>
-      isUpdateGroup(group) && includes(itemGroups, group.id);
-    res = userGroups.some(isGroupEditable);
-  }
-  return res;
+export function canEditItem(item: IItem, user?: IUser): boolean {
+  return hasBasePriv(user) && includes(["admin", "update"], item.itemControl);
 }

--- a/packages/common/src/access/has-base-priv.ts
+++ b/packages/common/src/access/has-base-priv.ts
@@ -3,10 +3,14 @@ import { includes } from "../utils";
 
 /**
  * Checks for fundamental privilege required by all access checks
- * @param {IUser} user
+ * @param {IUser} [user] An optional user
  * @returns {boolean}
  */
-export function hasBasePriv(user: IUser): boolean {
-  const { privileges = [] } = user;
-  return includes(privileges, "portal:user:createItem");
+export function hasBasePriv(user?: IUser): boolean {
+  let result = false;
+  if (user) {
+    const { privileges = [] } = user;
+    result = includes(privileges, "portal:user:createItem");
+  }
+  return result;
 }

--- a/packages/common/test/access/can-edit-item.test.ts
+++ b/packages/common/test/access/can-edit-item.test.ts
@@ -1,15 +1,15 @@
 import { canEditItem } from "../../src/access/can-edit-item";
-import { IUser, IItem, IGroup } from "@esri/arcgis-rest-types";
+import { IUser, IItem } from "@esri/arcgis-rest-types";
 import * as baseUtils from "../../src/access/has-base-priv";
 
 describe("canEditItem", function() {
-  const getModel = (props: any) => props as IItem;
-  const getUser = (props: any = {}) => props as IUser;
-  const getGroup = (props: any) => props as IGroup;
-
   let hasBasePrivSpy: jasmine.Spy;
+  let user: IUser;
+  let item: IItem;
 
   beforeEach(() => {
+    user = { groups: [] };
+    item = ({ itemControl: "admin" } as unknown) as IItem;
     hasBasePrivSpy = spyOn(baseUtils, "hasBasePriv").and.returnValue(true);
   });
 
@@ -17,60 +17,32 @@ describe("canEditItem", function() {
     hasBasePrivSpy.calls.reset();
   });
 
-  it("returns true if user has priv and itemControl", function() {
-    const model = getModel({ itemControl: "admin" });
-    const user = getUser();
-    const result = canEditItem(model, user);
+  it("returns true if user has priv and itemControl=admin (owner or item org admin)", function() {
+    const result = canEditItem(item, user);
     expect(result).toBe(true);
     expect(hasBasePrivSpy.calls.count()).toBe(1);
     expect(hasBasePrivSpy.calls.argsFor(0)).toEqual([user]);
   });
 
-  it("returns true if user has priv and is owner", function() {
-    const username = "jdoe";
-    const model = getModel({ owner: username });
-    const user = getUser({ username });
-    const result = canEditItem(model, user);
+  it("returns true if user has priv and itemControl=update (edit group member)", function() {
+    item.itemControl = "update";
+    const result = canEditItem(item, user);
     expect(result).toBe(true);
     expect(hasBasePrivSpy.calls.count()).toBe(1);
     expect(hasBasePrivSpy.calls.argsFor(0)).toEqual([user]);
   });
 
-  it("returns true if user has priv and is itemOrgAdmin", function() {
-    const orgId = "foo";
-    const model = getModel({ orgId });
-    const user = getUser({ orgId, role: "org_admin", roleId: null });
-    const result = canEditItem(model, user);
-    expect(result).toBe(true);
+  it("returns false if user has priv and itemControl is neither admin or update", function() {
+    delete item.itemControl;
+    const result = canEditItem(item, user);
+    expect(result).toBe(false);
     expect(hasBasePrivSpy.calls.count()).toBe(1);
     expect(hasBasePrivSpy.calls.argsFor(0)).toEqual([user]);
-  });
-
-  it("returns true if user has priv and belongs to any item update groups", function() {
-    const groupId = "foo";
-    const group = getGroup({
-      id: groupId,
-      capabilities: ["updateitemcontrol"]
-    });
-    const user = getUser({ groups: [group] });
-    let model = getModel({ groupIds: [groupId] });
-    let result = canEditItem(model, user);
-    expect(result).toBe(true);
-    expect(hasBasePrivSpy.calls.count()).toBe(1);
-    expect(hasBasePrivSpy.calls.argsFor(0)).toEqual([user]);
-
-    model = getModel({ properties: { collaborationGroupId: groupId } });
-    result = canEditItem(model, user);
-    expect(result).toBe(true);
-    expect(hasBasePrivSpy.calls.count()).toBe(2);
-    expect(hasBasePrivSpy.calls.argsFor(1)).toEqual([user]);
   });
 
   it("returns false if user lacks basic priv", function() {
     hasBasePrivSpy.and.returnValue(false);
-    const model = getModel({ itemControl: "admin" });
-    const user = getUser();
-    const result = canEditItem(model, user);
+    const result = canEditItem(item, user);
     expect(result).toBe(false);
     expect(hasBasePrivSpy.calls.count()).toBe(1);
     expect(hasBasePrivSpy.calls.argsFor(0)).toEqual([user]);

--- a/packages/common/test/access/has-base-priv.test.ts
+++ b/packages/common/test/access/has-base-priv.test.ts
@@ -13,4 +13,9 @@ describe("hasBasePriv", function() {
     const result = hasBasePriv({} as IUser);
     expect(result).toBe(false);
   });
+
+  it("returns false if user is falsy", function() {
+    const result = hasBasePriv();
+    expect(result).toBe(false);
+  });
 });


### PR DESCRIPTION
[269](https://devtopia.esri.com/dc/hub/issues/269)

1. Refactors `hasBasePriv` to handle `undefined` users vs throwing an error.
2. Simplifies logic in `canEditItem` to leverage `itemControl` property.