### PR TITLE
feat(sites): preserve a created initiative's id

### DIFF
--- a/packages/sites/src/create-site-model-from-template.ts
+++ b/packages/sites/src/create-site-model-from-template.ts
@@ -5,6 +5,7 @@ import {
   getProp,
   cloneObject,
   deepSet,
+  setProp,
   slugify,
   stripProtocol,
   interpolate,
@@ -159,6 +160,11 @@ export function createSiteModelFromTemplate(
       const dcatConfig = cloneObject(template.data.values.dcatConfig);
       delete template.data.values.dcatConfig;
       const siteModel = interpolate(template, settings, transforms);
+      setProp(
+        "properties.initiativeTemplate.item.id",
+        getProp(settings, "initiative.item.id"),
+        siteModel
+      ); // preserve the created initiative's id
       // Special logic for the site title
       // if the title is a string, containing only numbers, then the interpolation will set it as
       // a number, which causes some problems... in that case, we stomp it in as a string...


### PR DESCRIPTION
affects: @esri/hub-sites

By adding the id of a created initiative to its record within a hub site, it is easier to trace from the site to the initiative during cleanup