### PR TITLE
fix(content): return content.item &  handle when itemExtent is []

### DIFF
--- a/packages/content/src/portal.ts
+++ b/packages/content/src/portal.ts
@@ -141,6 +141,8 @@ export function itemToContent(item: IItem): IHubContent {
   const createdDateSource = "item.created";
   const properties = item.properties;
   const content = Object.assign({}, item, {
+    // store a reference to the item
+    item,
     // NOTE: this will overwrite any existing item.name, which is
     // The file name of the item for file types. Read-only.
     // presumably there to use as the default file name when downloading

--- a/packages/content/test/hub.test.ts
+++ b/packages/content/test/hub.test.ts
@@ -138,8 +138,13 @@ describe("hub", () => {
       const content = datasetToContent(dataset);
       expect(content.summary).toBe(dataset.attributes.snippet);
       expect(content.updatedDateSource).toBe("item.modified");
-      expect(content.extent).toBeUndefined();
+      expect(content.extent).toEqual([]);
       expect(content.isProxied).toBe(false);
+    });
+    it("has a reference to the item", () => {
+      const dataset = cloneObject(documentsJson.data) as DatasetResource;
+      const content = datasetToContent(dataset);
+      expect(content.item).toEqual(datasetToItem(dataset));
     });
     // NOTE: other use cases are covered by getContent() tests
   });

--- a/packages/content/test/mocks/datasets/document.json
+++ b/packages/content/test/mocks/datasets/document.json
@@ -31,6 +31,7 @@
       "hasApi": false,
       "hubType": "PDF",
       "id": "afcf88c4fb244973a59defde7f6d8dfb",
+      "itemExtent": [],
       "itemModified": 1571933048000,
       "layer": null,
       "layers": null,

--- a/packages/content/test/mocks/datasets/feature-layer-with-metadata.json
+++ b/packages/content/test/mocks/datasets/feature-layer-with-metadata.json
@@ -286,6 +286,7 @@
       "hasApi": true,
       "hubType": "Feature Layer",
       "id": "1ce4060e854747038b153c5c8f8c894d_0",
+      "itemExtent": [[55.00687876313506,24.749573764658628],[56.38435669830817,25.911597786107645]],
       "itemModified": 1587021241000,
       "layer": {
         "extent": {

--- a/packages/content/test/mocks/datasets/feature-layer.json
+++ b/packages/content/test/mocks/datasets/feature-layer.json
@@ -137,6 +137,7 @@
       "hasApi": true,
       "hubType": "Feature Layer",
       "id": "7a153563b0c74f7eb2b3eae8a66f2fbb_0",
+      "itemExtent": [],
       "itemModified": 1479739491000,
       "layer": {
         "extent": {

--- a/packages/content/test/portal.test.ts
+++ b/packages/content/test/portal.test.ts
@@ -97,6 +97,10 @@ describe("item to content", () => {
       expect(content.actionLinks).toEqual(item.properties.links);
     });
   });
+  it("has a reference to the item", () => {
+    const content = itemToContent(item);
+    expect(content.item).toBe(item);
+  });
   // NOTE: other use cases (including when a portal is passed)
   // are covered by getContentFromPortal() tests
 });


### PR DESCRIPTION
affects: @esri/hub-content

looks like the API defaults to [] for itemExtent. previously I assumed it was falsey.
also, always return content.item, including the actual item extent for comparison