### PR TITLE
refactor(content): expose getOwnerOrgId method

### DIFF
--- a/packages/content/src/content.ts
+++ b/packages/content/src/content.ts
@@ -46,7 +46,7 @@ function shouldFetchOrgId(content: IHubContent) {
   return !content.orgId && isHubCreatedContent(content);
 }
 
-function getOwnerOrgId(
+export function getOwnerOrgId(
   content: IHubContent,
   requestOptions: IHubRequestOptions
 ): Promise<string> {


### PR DESCRIPTION
affects: @esri/hub-content

ISSUES CLOSED: [1036](https://devtopia.esri.com/dc/hub/issues/1036)