### PR TITLE
Content family and org

### DIFF
--- a/packages/common/src/collections.ts
+++ b/packages/common/src/collections.ts
@@ -50,7 +50,7 @@ const document: string[] = [
 
 const event: string[] = ["Hub Event"];
 
-const feedback: string[] = ["Form"];
+const feedback: string[] = ["Form", "Quick Capture Project"];
 
 const initiative: string[] = ["Hub Initiative"];
 
@@ -64,13 +64,15 @@ const map: string[] = [
   "Map Service Layer",
   "Map Service",
   "Scene Service",
+  "Scene Layer",
   "Vector Tile Service",
   "Web Map Service",
   "Web Map Tile Service",
   "Web Map",
   "Web Scene",
   "WFS",
-  "WMS"
+  "WMS",
+  "WMTS"
 ];
 
 const other: string[] = [

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -270,8 +270,12 @@ export interface IEnrichmentErrorInfo {
 export interface IHubContent extends IHubResource, IItem {
   /**
    * The content's ID for use with the Hub API
+   * For most content this will be the item's id
+   * For layers this will be `<itemId>_<layerId>`
+   * This will be undefined for private items and in enterprise
+   * because only public online items are included in the Hub API
    */
-  hubId: string;
+  hubId?: string;
   // NOTE: we may want to elevate this to IHubResource if it's needed for other subtypes
   /**
    * Content visibility and access control, including groups

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -141,6 +141,7 @@ export type IRevertableTaskResult =
 
 /**
  * Types of Hub resources
+ * DEPRECATED: Use HubFamily instead
  */
 export type HubType =
   | "member"
@@ -154,6 +155,20 @@ export type HubType =
   | "initiative"
   | "template"
   | "organization";
+
+export type HubFamily =
+  | "people"
+  | "team"
+  | "event"
+  | "dataset"
+  | "document"
+  | "feedback"
+  | "map"
+  | "app"
+  | "site"
+  | "initiative"
+  | "template"
+  | "content";
 
 /**
  * Visibility levels of a Hub resource
@@ -269,6 +284,9 @@ export interface IHubContent extends IHubResource, IItem {
     /** The groups that have access to the item (as far as you know) */
     groups?: IGroup[]; // TODO: item.sharing.groups via content/users/:username/items/:id
   };
+
+  // TODO: make this required at next breaking release
+  family?: HubFamily;
 
   // TODO: license: IHubLicense // [Future] item.licenseInfo
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,7 +1,14 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IItem, IUser, IGroup, IGeometry } from "@esri/arcgis-rest-types";
+import {
+  IItem,
+  IUser,
+  IGroup,
+  IGeometry,
+  IFeatureServiceDefinition,
+  ILayerDefinition
+} from "@esri/arcgis-rest-types";
 import { IPortal, ISearchResult } from "@esri/arcgis-rest-portal";
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
@@ -341,11 +348,25 @@ export interface IHubContent extends IHubResource, IItem {
   data?: {
     [propName: string]: any;
   };
+  // service types: Feature Service, Map Service
+  /** service information (currentVersion, capabilities, maxRecordCount etc) */
+  server?: Partial<IFeatureServiceDefinition>;
+  /** layer information (geometryType, fields, etc) for related layers in the service */
+  layers?: Array<Partial<ILayerDefinition>>;
+  // layer types: Feature Layers, Raster Layers
+  /** layer information (geometryType, fields, etc) */
+  layer?: Partial<ILayerDefinition>;
+  recordCount?: number;
+  // TODO: statistics?: ???
   // NOTE: this is usually(? always?) returned by the item endpoint
   // but it's not on IItem, possibly b/c it's not listed here:
   // https://developers.arcgis.com/rest/users-groups-and-items/item.htm
   /** The owner's organization id */
   orgId?: string;
+  /**
+   * The owner's organization (portal) details (id, name, extent, etc)
+   */
+  org?: Partial<IPortal>;
   /** Whether the content is downloadable in the Hub app */
   isDownloadable: boolean;
 }

--- a/packages/content/src/content.ts
+++ b/packages/content/src/content.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IHubContent, IModel } from "@esri/hub-common";
+import { getItemHubId, IHubContent, IModel } from "@esri/hub-common";
 import { IGetContentOptions, getContentFromHub } from "./hub";
 import { getContentFromPortal, itemToContent } from "./portal";
 import { enrichContent } from "./enrichments";
@@ -50,9 +50,15 @@ export function getContent(
   if (typeof idOrModel === "string") {
     getContentPromise = getContentById(idOrModel, options);
   } else {
-    // no need to fetch item and maybe not data
+    // no need to fetch item
     const { item, data } = idOrModel;
     const content = itemToContent(item);
+    if (!options.isPortal) {
+      // try to get the id to use w/ the Hub API
+      // NOTE: this is only set if the item is public
+      content.hubId = getItemHubId(item);
+    }
+    // no need to fetch data if it was passed in
     content.data = data;
     // just fetch and add any missing or desired enrichments
     getContentPromise = enrichContent(content, options);

--- a/packages/content/src/enrichments.ts
+++ b/packages/content/src/enrichments.ts
@@ -428,13 +428,14 @@ export const enrichContent = (
   // fetch any missing or requested enrichments
   return fetchEnrichments(content, requestOptions).then(
     (enrichments: Partial<IHubContent>) => {
+      const serverErrors = content.errors || [];
       // merge derived portal URLs & fetched enrichments into content
       const merged = {
         ...content,
         ...portalUrls,
         ...enrichments,
         // include any previous errors (if any)
-        errors: [...content.errors, ...enrichments.errors]
+        errors: [...serverErrors, ...enrichments.errors]
       };
       // return the content with enriched dates
       return _enrichDates(merged);

--- a/packages/content/src/hub.ts
+++ b/packages/content/src/hub.ts
@@ -138,30 +138,38 @@ export function datasetToContent(dataset: DatasetResource): IHubContent {
     structuredLicense,
     // map and feature server enrichments
     server,
-    // TODO: layers, etc
+    layers,
+    // NOTE: the Hub API also returns the following server properties
+    // but we should be able to get them from the above server object
+    // currentVersion, capabilities, tileInfo, serviceSpatialReference
+    // maxRecordCount, supportedQueryFormats, etc
     // feature and raster layer enrichments
-    layer
-    // TODO: recordCount, fields, geometryType, etc
+    layer,
+    recordCount,
+    statistics,
+    // NOTE: the Hub API also returns the following layer properties
+    // but we should be able to get them from the above layer object
+    // supportedQueryFormats, supportsAdvancedQueries, advancedQueryCapabilities, useStandardizedQueries
+    // geometryType, objectIdField, displayField, fields,
+    // org properties?
+    orgId,
+    orgName,
+    organization,
+    orgExtent
   } = attributes;
+  // NOTE: we could throw or return if there are errors
+  // to prevent type errors trying to read properties below
   content.errors = errors;
+  // common enrichments
   content.boundary = boundary;
-  // setting this to null signals to enrichMetadata to skip this
-  content.metadata = metadata || null;
-  content.slug = slug;
-  content.groupIds = groupIds;
-  content.structuredLicense = structuredLicense;
-  content.layer = layer;
-  content.server = server;
   if (!item.extent.length && extent && extent.coordinates) {
     // we fall back to the extent derived by the API
     // which prefers layer or service extents and ultimately
     // falls back to the org's extent
     content.extent = extent.coordinates;
   }
-  if (searchDescription) {
-    // overwrite default summary (from snippet) w/ search description
-    content.summary = searchDescription;
-  }
+  // setting this to null signals to enrichMetadata to skip this
+  content.metadata = metadata || null;
   if (content.modified !== modified) {
     // capture the enriched modified date
     // NOTE: the item modified date is still available on content.item.modified
@@ -169,7 +177,28 @@ export function datasetToContent(dataset: DatasetResource): IHubContent {
     content.updatedDate = new Date(modified);
     content.updatedDateSource = modifiedProvenance;
   }
-  // TODO: any remaining enrichments?
+  content.slug = slug;
+  if (searchDescription) {
+    // overwrite default summary (from snippet) w/ search description
+    content.summary = searchDescription;
+  }
+  content.groupIds = groupIds;
+  content.structuredLicense = structuredLicense;
+  // server enrichments
+  content.server = server;
+  content.layers = layers;
+  // layer enrichments
+  content.layer = layer;
+  content.recordCount = recordCount;
+  content.statistics = statistics;
+  // org enrichments
+  if (orgId) {
+    content.org = {
+      id: orgId,
+      name: orgName || organization,
+      extent: orgExtent
+    };
+  }
   return content;
 }
 

--- a/packages/content/src/hub.ts
+++ b/packages/content/src/hub.ts
@@ -135,12 +135,12 @@ export function datasetToContent(dataset: DatasetResource): IHubContent {
     searchDescription,
     groupIds,
     structuredLicense,
-    layer,
+    // map and feature server enrichments
     server,
-    // dataset enrichments
-    isProxied
-    // recordCount
-    // TODO: fields, geometryType, layer?, server?, as needed
+    // TODO: layers, etc
+    // feature and raster layer enrichments
+    layer
+    // TODO: recordCount, fields, geometryType, etc
   } = attributes;
   content.errors = errors;
   content.boundary = boundary;
@@ -151,7 +151,6 @@ export function datasetToContent(dataset: DatasetResource): IHubContent {
   content.structuredLicense = structuredLicense;
   content.layer = layer;
   content.server = server;
-  content.isProxied = isProxied;
   if (!item.extent.length && extent && extent.coordinates) {
     // we fall back to the extent derived by the API
     // which prefers layer or service extents and ultimately
@@ -166,14 +165,7 @@ export function datasetToContent(dataset: DatasetResource): IHubContent {
     // overwrite default updated source
     content.updatedDateSource = modifiedProvenance;
   }
-  // type-specific enrichments
-  // TODO: should this be based on existence of attributes instead of hubType?
-  // TODO: if the latter, should we return a different subtype of IHubContent for this?
-  // if (content.hubType === "dataset") {
-  //   content.recordCount = recordCount;
-  //   // TODO: fields, geometryType, etc
-  // }
-  // TODO: any remaining enrichments
+  // TODO: any remaining enrichments?
   return content;
 }
 

--- a/packages/content/src/hub.ts
+++ b/packages/content/src/hub.ts
@@ -301,9 +301,7 @@ export function datasetToItem(dataset: DatasetResource): IItem {
     // for feature layers, modified will usually come from the layer so
     // we prefer itemModified, but fall back to modified if it came from the item
     modified: (itemModified ||
-      (modifiedProvenance === "item.modified"
-        ? modified
-        : undefined)) as number,
+      (modifiedProvenance === "item.modified" && modified)) as number,
     title: (title || name) as string,
     type,
     typeKeywords,

--- a/packages/content/src/portal.ts
+++ b/packages/content/src/portal.ts
@@ -81,9 +81,6 @@ export function itemToContent(item: IItem): IHubContent {
     // we don't store item.name in the Hub API and we use name for title
     name: item.title,
     family: getFamily(normalizedType),
-    // TODO: should we alway be setting hubId here
-    // or only when we know the item exists in the index
-    hubId: item.id,
     hubType: getItemHubType(item),
     normalizedType,
     categories: parseItemCategories(item.categories),

--- a/packages/content/src/portal.ts
+++ b/packages/content/src/portal.ts
@@ -4,6 +4,7 @@
 import { IItem, getItem } from "@esri/arcgis-rest-portal";
 import {
   HubType,
+  HubFamily,
   IHubContent,
   IHubGeography,
   IHubRequestOptions,
@@ -68,6 +69,7 @@ export function itemToContent(item: IItem): IHubContent {
   const createdDate = new Date(item.created);
   const createdDateSource = "item.created";
   const properties = item.properties;
+  const normalizedType = normalizeItemType(item);
   const content = Object.assign({}, item, {
     // no server errors when fetching the item directly
     errors: [],
@@ -78,11 +80,12 @@ export function itemToContent(item: IItem): IHubContent {
     // presumably there to use as the default file name when downloading
     // we don't store item.name in the Hub API and we use name for title
     name: item.title,
+    family: getFamily(normalizedType),
     // TODO: should we alway be setting hubId here
     // or only when we know the item exists in the index
     hubId: item.id,
     hubType: getItemHubType(item),
-    normalizedType: normalizeItemType(item),
+    normalizedType,
     categories: parseItemCategories(item.categories),
     itemCategories: item.categories,
     // can we strip HTML from description, and do we need to trim it to a X chars?
@@ -126,6 +129,47 @@ export function getItemHubType(itemOrType: IItem | string): HubType {
   const itemType = normalizeItemType(itemOrType);
   // TODO: not all categories are Hub types, may need to validate
   return getCollection(itemType) as HubType;
+}
+
+function collectionToFamily(collection: string): string {
+  const overrides: any = {
+    other: "content",
+    solution: "template"
+  };
+  return overrides[collection] || collection;
+}
+
+/**
+ * return the Hub family given an item's type
+ * @param type item type
+ * @returns Hub family
+ */
+export function getFamily(type: string) {
+  let family;
+  // override default behavior for the rows that are highlighted in yellow here:
+  // https://esriis.sharepoint.com/:x:/r/sites/ArcGISHub/_layouts/15/Doc.aspx?sourcedoc=%7BADA1C9DC-4F6C-4DE4-92C6-693EF9571CFA%7D&file=Hub%20Routes.xlsx&nav=MTBfe0VENEREQzI4LUZFMDctNEI0Ri04NjcyLThCQUE2MTA0MEZGRn1fezIwMTIwMEJFLTA4MEQtNEExRC05QzA4LTE5MTAzOUQwMEE1RH0&action=default&mobileredirect=true&cid=df1c874b-c367-4cea-bc13-7bebfad3f2ac
+  switch ((type || "").toLowerCase()) {
+    case "image service":
+      family = "dataset";
+      break;
+    case "feature service":
+    case "raster layer":
+      // TODO: check if feature service has > 1 layer first?
+      family = "map";
+      break;
+    case "microsoft excel":
+      family = "document";
+      break;
+    case "cad drawing":
+    case "feature collection template":
+    case "report template":
+      family = "content";
+      break;
+    default:
+      // by default derive from collection
+      family = collectionToFamily(getCollection(type));
+  }
+  return family as HubFamily;
 }
 
 /**

--- a/packages/content/test/content.test.ts
+++ b/packages/content/test/content.test.ts
@@ -44,13 +44,17 @@ describe("get content", () => {
         }
       } as IModel;
 
-      const ro = {} as IHubRequestOptions;
+      // setting isPortal here for hubId check below
+      const ro = { isPortal: true } as IHubRequestOptions;
 
       const content = await getContent(modelWithItem, ro);
 
       // should not try to fetch content from hub or portal
       expect(getContentFromHubSpy).not.toHaveBeenCalled();
       expect(getContentFromPortalSpy).not.toHaveBeenCalled();
+
+      // should not have set the hubId
+      expect(content.hubId).toBeFalsy("don't set hubId in portal");
 
       // should still load data
       expect(getDataSpy).toHaveBeenCalledWith(modelWithItem.item.id, ro);

--- a/packages/content/test/enrichments.test.ts
+++ b/packages/content/test/enrichments.test.ts
@@ -38,7 +38,6 @@ describe("enrichContent", () => {
     const getItemGroupsSpy = spyOn(arcgisRestPortal, "getItemGroups");
     const getContentMetadataSpy = spyOn(metadataModule, "getContentMetadata");
     const content = {
-      errors: [],
       id: "3ae",
       // signature for a Hub created web map would trigger getUser
       type: "Web Map",

--- a/packages/content/test/hub.test.ts
+++ b/packages/content/test/hub.test.ts
@@ -133,7 +133,7 @@ describe("hub", () => {
       );
       attributes.modifiedProvenance = "layer.editingInfo.lastEditDate";
       item = datasetToItem(dataset);
-      expect(item.modified).toBeUndefined(
+      expect(item.modified).toBeFalsy(
         "is undefined when provenance is layer.editingInfo"
       );
     });

--- a/packages/content/test/hub.test.ts
+++ b/packages/content/test/hub.test.ts
@@ -157,12 +157,34 @@ describe("hub", () => {
       expect(content.updatedDate).toEqual(new Date(attributes.modified));
       expect(content.updatedDateSource).toBe(attributes.modifiedProvenance);
     });
+    it("has org", () => {
+      const dataset = cloneObject(featureLayerJson.data) as DatasetResource;
+      const {
+        orgId: id,
+        orgExtent: extent,
+        orgName: name,
+        organization
+      } = dataset.attributes;
+      let content = datasetToContent(dataset);
+      expect(content.org).toEqual({ id, extent, name });
+      delete dataset.attributes.orgName;
+      content = datasetToContent(dataset);
+      expect(content.org).toEqual(
+        { id, extent, name: organization },
+        "name falls back to organization"
+      );
+    });
     it("only uses enrichment attributes when they exist", () => {
       const dataset = cloneObject(documentsJson.data) as DatasetResource;
+      // NOTE: I don't necessarily expect the API to return w/o these
+      // but our code depends on them, this test is mostly here for coverage
       delete dataset.attributes.searchDescription;
+      delete dataset.attributes.errors;
       const content = datasetToContent(dataset);
       expect(content.summary).toBe(dataset.attributes.snippet);
       expect(content.extent).toEqual([]);
+      // NOTE: the document JSON does not have org attributes
+      expect(content.org).toBeUndefined();
     });
     // NOTE: other use cases are covered by getContent() tests
   });

--- a/packages/content/test/hub.test.ts
+++ b/packages/content/test/hub.test.ts
@@ -137,12 +137,10 @@ describe("hub", () => {
       const dataset = cloneObject(documentsJson.data) as DatasetResource;
       delete dataset.attributes.searchDescription;
       delete dataset.attributes.modifiedProvenance;
-      dataset.attributes.isProxied = false;
       const content = datasetToContent(dataset);
       expect(content.summary).toBe(dataset.attributes.snippet);
       expect(content.updatedDateSource).toBe("item.modified");
       expect(content.extent).toEqual([]);
-      expect(content.isProxied).toBe(false);
     });
     it("has a reference to the item", () => {
       const dataset = cloneObject(documentsJson.data) as DatasetResource;

--- a/packages/content/test/hub.test.ts
+++ b/packages/content/test/hub.test.ts
@@ -119,33 +119,50 @@ describe("hub", () => {
       const item = datasetToItem(dataset);
       expect(item.snippet).toBe(dataset.attributes.snippet);
     });
-    it("falls back to createdAt/updatedAt when no created/modified", () => {
-      const dataset = cloneObject(documentsJson.data) as DatasetResource;
+    it("handles when no itemModified", () => {
+      // NOTE: I expect that the API always returns itemModified
+      // so I don't know if this ever happens
+      const dataset = cloneObject(featureLayerJson.data) as DatasetResource;
       const attributes = dataset.attributes;
-      attributes.createdAt = attributes.created;
-      attributes.updatedAt = attributes.modified;
-      delete attributes.created;
-      delete attributes.modified;
-      const item = datasetToItem(dataset);
-      expect(item.created).toBe(attributes.createdAt);
-      expect(item.modified).toBe(attributes.updatedAt);
+      attributes.modified = 1623232000295;
+      delete attributes.itemModified;
+      let item = datasetToItem(dataset);
+      expect(item.modified).toBe(
+        attributes.modified,
+        "returns modified when provenance is item"
+      );
+      attributes.modifiedProvenance = "layer.editingInfo.lastEditDate";
+      item = datasetToItem(dataset);
+      expect(item.modified).toBeUndefined(
+        "is undefined when provenance is layer.editingInfo"
+      );
     });
     // NOTE: other use cases are covered by getContent() tests
   });
   describe("dataset to content", () => {
-    it("only uses enrichment attributes when they exist", () => {
-      const dataset = cloneObject(documentsJson.data) as DatasetResource;
-      delete dataset.attributes.searchDescription;
-      delete dataset.attributes.modifiedProvenance;
-      const content = datasetToContent(dataset);
-      expect(content.summary).toBe(dataset.attributes.snippet);
-      expect(content.updatedDateSource).toBe("item.modified");
-      expect(content.extent).toEqual([]);
-    });
     it("has a reference to the item", () => {
       const dataset = cloneObject(documentsJson.data) as DatasetResource;
       const content = datasetToContent(dataset);
       expect(content.item).toEqual(datasetToItem(dataset));
+    });
+    it("has enriched updatedDate", () => {
+      const dataset = cloneObject(featureLayerJson.data) as DatasetResource;
+      const attributes = dataset.attributes;
+      // simulate API returning date the layer was last modified
+      // instead of the date the item was last modified
+      attributes.modified = 1623232000295;
+      attributes.modifiedProvenance = "layer.editingInfo.lastEditDate";
+      const content = datasetToContent(dataset);
+      expect(content.modified).toBe(attributes.modified);
+      expect(content.updatedDate).toEqual(new Date(attributes.modified));
+      expect(content.updatedDateSource).toBe(attributes.modifiedProvenance);
+    });
+    it("only uses enrichment attributes when they exist", () => {
+      const dataset = cloneObject(documentsJson.data) as DatasetResource;
+      delete dataset.attributes.searchDescription;
+      const content = datasetToContent(dataset);
+      expect(content.summary).toBe(dataset.attributes.snippet);
+      expect(content.extent).toEqual([]);
     });
     // NOTE: other use cases are covered by getContent() tests
   });

--- a/packages/content/test/portal.test.ts
+++ b/packages/content/test/portal.test.ts
@@ -26,8 +26,9 @@ function validateContentFromPortal(content: IHubContent, item: IItem) {
   });
   // name should be title
   expect(content.name).toBe(item.title);
+  // should not set hubId when in portal
+  expect(content.hubId).toBeUndefined();
   // should include derived properties
-  expect(content.hubId).toBe(item.id);
   expect(content.family).toBe("map");
   // DEPRECATED: remove hubType check
   expect(content.hubType).toBe("map");

--- a/packages/content/test/portal.test.ts
+++ b/packages/content/test/portal.test.ts
@@ -8,8 +8,9 @@ import {
   getContentFromPortal,
   itemToContent,
   parseItemCategories,
-  getItemHubType
-} from "../src/index";
+  getItemHubType,
+  getFamily
+} from "../src/portal";
 import * as metadataModule from "../src/metadata";
 import * as itemJson from "./mocks/items/map-service.json";
 import { mockUserSession } from "./test-helpers/fake-user-session";
@@ -27,6 +28,8 @@ function validateContentFromPortal(content: IHubContent, item: IItem) {
   expect(content.name).toBe(item.title);
   // should include derived properties
   expect(content.hubId).toBe(item.id);
+  expect(content.family).toBe("map");
+  // DEPRECATED: remove hubType check
   expect(content.hubType).toBe("map");
   expect(content.summary).toBe(item.snippet);
   expect(content.publisher).toEqual({
@@ -103,6 +106,29 @@ describe("item to content", () => {
   });
   // NOTE: other use cases (including when a portal is passed)
   // are covered by getContentFromPortal() tests
+});
+describe("get item family", () => {
+  it("returns dataset for image service", () => {
+    expect(getFamily("Image Service")).toBe("dataset");
+  });
+  it("returns map for feature service and raster layer", () => {
+    expect(getFamily("Feature Service")).toBe("map");
+    expect(getFamily("Raster Layer")).toBe("map");
+  });
+  it("returns document for excel", () => {
+    expect(getFamily("Microsoft Excel")).toBe("document");
+  });
+  it("returns template for solution", () => {
+    expect(getFamily("Solution")).toBe("template");
+  });
+  it("returns content for other specific types", () => {
+    expect(getFamily("CAD Drawing")).toBe("content");
+    expect(getFamily("Feature Collection Template")).toBe("content");
+    expect(getFamily("Report Template")).toBe("content");
+  });
+  it("returns content for collection other", () => {
+    expect(getFamily("360 VR Experience")).toBe("content");
+  });
 });
 describe("get item hub type", () => {
   it("normalizes item", () => {

--- a/packages/search/test/ago/encode-ago-query.test.ts
+++ b/packages/search/test/ago/encode-ago-query.test.ts
@@ -46,7 +46,7 @@ describe("encodeAgoQuery test", () => {
     const actual = encodeAgoQuery(params);
     const expected = {
       q:
-        '-type:"code attachment" AND crime AND ((group:"1ef")) AND (type:"Image Collection" OR type:"Image Service" OR type:"Map Service Layer" OR type:"Map Service" OR type:"Scene Service" OR type:"Vector Tile Service" OR type:"Web Map Service" OR type:"Web Map Tile Service" OR type:"Web Map" OR type:"Web Scene" OR type:"WFS" OR type:"WMS") AND (tags:"test")',
+        '-type:"code attachment" AND crime AND ((group:"1ef")) AND (type:"Image Collection" OR type:"Image Service" OR type:"Map Service Layer" OR type:"Map Service" OR type:"Scene Service" OR type:"Scene Layer" OR type:"Vector Tile Service" OR type:"Web Map Service" OR type:"Web Map Tile Service" OR type:"Web Map" OR type:"Web Scene" OR type:"WFS" OR type:"WMS" OR type:"WMTS") AND (tags:"test")',
       start: 1,
       num: 10,
       sortField: "title",


### PR DESCRIPTION
This PR gets closer to resolving #322. In essence, everything we need should be there _if_ the content was fetched from the Hub API. If the content is coming from portal, we still have to add logic to `enrichContent()` to fetch additional enrichments such as `server`, `layers`, `recordCount`, etc.

This PR also makes a few fixes to the way `itemToContent` and `datasetToContent` were handling `hubId` and `isPortal`. TLDR: we should only set `hubId` if we are fairy confident that it is in the index. Also, `isPortal` is not returned by the API, we'll need to set it (and the proxied `url`) in `enrichContent()` before calling `fetchEnrichments()`.

In service of those, the PR also moves several low level utils from the Hub app to Hub.js (getFamily, getItemHubId, etc), and it also re-orders how properties are set in `datasetToConent()` to logically group them (common, server, layer). So it may seem like a lot of 🧀 was moved.