### PR TITLE
fix(hub-sites): correctly generate site url

### DIFF
--- a/packages/sites/src/get-portal-site-hostname.ts
+++ b/packages/sites/src/get-portal-site-hostname.ts
@@ -12,14 +12,19 @@ export function getPortalSiteHostname(subdomain: string, portal: IPortal) {
   } else {
     port = portal.httpPort !== 80 ? `:${portal.httpPort}` : "";
   }
-  // portalHostname will include the /<instance>
-  // i.e. `dev0016196.esri.com/portal`, but since we may need to
-  const host = portal.portalHostname.split("/")[0];
-  // wrangle the instance using customBaseUrl
-  let instance = "/";
-  if (portal.customBaseUrl) {
-    instance = `/${portal.customBaseUrl}/`;
+  // portalHostname will include the /<adaptor>
+  // i.e. `dev0016196.esri.com/portal`, but since we may need to inject a port
+  // we split things apart, and then recombine
+  const parts = portal.portalHostname.split("/");
+  const host = parts[0];
+  let adaptor = "/"; // if there is no /<adaptor> then / should be valid
+  if (parts[1]) {
+    adaptor = `/${parts[1]}/`;
   }
-
-  return `${host}${port}${instance}apps/sites/#/${subdomain}`;
+  // construct the url
+  return `${host}${port}${adaptor}apps/sites/#/${subdomain}`;
+  // Note: in *most* cases the result would be the same as the line below
+  // but there are some scenarios where we need to do the construction
+  // so we can't simply use portalHostname
+  // return `${portal.portalHostname}/apps/sites/#/${subdomain}`
 }

--- a/packages/sites/test/get-portal-site-hostname.test.ts
+++ b/packages/sites/test/get-portal-site-hostname.test.ts
@@ -20,7 +20,8 @@ describe("getPortalSiteHostname", () => {
     portal = ({
       allSSL: false,
       httpPort: 80,
-      portalHostname: "foobar.com/instance"
+      customBaseUrl: "other",
+      portalHostname: "foobar.com"
     } as unknown) as IPortal;
 
     expect(getPortalSiteHostname(subDomain, portal)).toBe(
@@ -29,7 +30,7 @@ describe("getPortalSiteHostname", () => {
 
     portal = ({
       allSSL: false,
-      httpPort: 23, // random, not 80
+      httpPort: 23,
       customBaseUrl: "instance",
       portalHostname: "foobar.com/instance"
     } as unknown) as IPortal;
@@ -41,8 +42,8 @@ describe("getPortalSiteHostname", () => {
 
     portal = ({
       allSSL: true,
-      httpsPort: 443, // random, not 80
-      customBaseUrl: "instance",
+      httpsPort: 443,
+      customBaseUrl: "other",
       portalHostname: "foobar.com/instance"
     } as unknown) as IPortal;
 
@@ -54,7 +55,7 @@ describe("getPortalSiteHostname", () => {
     portal = ({
       allSSL: true,
       httpsPort: 234, // random, not 80
-      customBaseUrl: "instance",
+      customBaseUrl: "other",
       portalHostname: "foobar.com/instance"
     } as unknown) as IPortal;
 


### PR DESCRIPTION
Correctly use portalSelf to compute the url for a newly created site

Resolves #552 

