### PR TITLE
Add new canEditTeam fn in teams package util

### DIFF
--- a/packages/teams/src/utils/can-edit-team.ts
+++ b/packages/teams/src/utils/can-edit-team.ts
@@ -7,13 +7,10 @@ import { IGroup, IUser } from "@esri/arcgis-rest-types";
  * @returns {boolean}
  */
 export function canEditTeam(group: IGroup, user: IUser): boolean {
-  let result = false;
-  if (user) {
-    const memberType = group.userMembership.memberType;
-    const userName = group.userMembership.username;
-    result =
-      userName === user.username &&
-      (memberType === "owner" || memberType === "admin");
-  }
-  return result;
+  const memberType = group.userMembership.memberType;
+  const userName = group.userMembership.username;
+  return (
+    userName === user.username &&
+    (memberType === "owner" || memberType === "admin")
+  );
 }

--- a/packages/teams/src/utils/can-edit-team.ts
+++ b/packages/teams/src/utils/can-edit-team.ts
@@ -7,9 +7,13 @@ import { IGroup, IUser } from "@esri/arcgis-rest-types";
  * @returns {boolean}
  */
 export function canEditTeam(group: IGroup, user: IUser): boolean {
-  const memberType = group.userMembership.memberType;
-  return (
-    group.userMembership.username === user.username &&
-    (memberType === "owner" || memberType === "admin")
-  );
+  let canEdit = false;
+  if (user) {
+    const memberType = group.userMembership.memberType;
+    const userName = group.userMembership.username;
+    canEdit =
+      userName === user.username &&
+      (memberType === "owner" || memberType === "admin");
+  }
+  return canEdit;
 }

--- a/packages/teams/src/utils/can-edit-team.ts
+++ b/packages/teams/src/utils/can-edit-team.ts
@@ -7,13 +7,13 @@ import { IGroup, IUser } from "@esri/arcgis-rest-types";
  * @returns {boolean}
  */
 export function canEditTeam(group: IGroup, user: IUser): boolean {
-  let canEdit = false;
+  let result = false;
   if (user) {
     const memberType = group.userMembership.memberType;
     const userName = group.userMembership.username;
-    canEdit =
+    result =
       userName === user.username &&
       (memberType === "owner" || memberType === "admin");
   }
-  return canEdit;
+  return result;
 }

--- a/packages/teams/src/utils/can-edit-team.ts
+++ b/packages/teams/src/utils/can-edit-team.ts
@@ -1,0 +1,12 @@
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
+
+/**
+ * Checks if user has access to edit a team in Hub
+ * @param {IGroup} group
+ * @param {IUser} user
+ * @returns {boolean}
+ */
+export function canEditTeam(group: IGroup, user: IUser): boolean {
+  const memberType = group.userMembership.memberType;
+  return memberType === "owner" || memberType === "admin";
+}

--- a/packages/teams/src/utils/can-edit-team.ts
+++ b/packages/teams/src/utils/can-edit-team.ts
@@ -1,7 +1,7 @@
 import { IGroup, IUser } from "@esri/arcgis-rest-types";
 
 /**
- * Checks if user has access to edit a team in Hub
+ * Checks if user has access to edit a team
  * @param {IGroup} group
  * @param {IUser} user
  * @returns {boolean}

--- a/packages/teams/src/utils/can-edit-team.ts
+++ b/packages/teams/src/utils/can-edit-team.ts
@@ -8,5 +8,8 @@ import { IGroup, IUser } from "@esri/arcgis-rest-types";
  */
 export function canEditTeam(group: IGroup, user: IUser): boolean {
   const memberType = group.userMembership.memberType;
-  return memberType === "owner" || memberType === "admin";
+  return (
+    group.userMembership.username === user.username &&
+    (memberType === "owner" || memberType === "admin")
+  );
 }

--- a/packages/teams/src/utils/can-edit-team.ts
+++ b/packages/teams/src/utils/can-edit-team.ts
@@ -7,8 +7,8 @@ import { IGroup, IUser } from "@esri/arcgis-rest-types";
  * @returns {boolean}
  */
 export function canEditTeam(group: IGroup, user: IUser): boolean {
-  const memberType = group.userMembership.memberType;
-  const userName = group.userMembership.username;
+  const memberType = group.userMembership?.memberType;
+  const userName = group.userMembership?.username;
   return (
     userName === user.username &&
     (memberType === "owner" || memberType === "admin")

--- a/packages/teams/test/utils/can-edit-team.test.ts
+++ b/packages/teams/test/utils/can-edit-team.test.ts
@@ -1,0 +1,67 @@
+import { canEditTeam } from "../../src/utils/can-edit-team";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
+
+describe("canEditTeam", function () {
+  const getUser = (props: any = {}) => props as IUser;
+  const getGroup = (props: any) => props as IGroup;
+
+  it("returns true if user is an admin or owner of the team", function () {
+    const groupId = "foo";
+    let group = getGroup({
+      id: groupId,
+      userMembership: {
+        memberType: "owner",
+        username: "scooby-doo",
+      },
+    });
+    const user = getUser({
+      groups: [group],
+      username: "scooby-doo",
+    });
+    let result = canEditTeam(group, user);
+    expect(result).toBe(true);
+    group = getGroup({
+      id: groupId,
+      userMembership: {
+        memberType: "admin",
+        username: "scooby-doo",
+      },
+    });
+    result = canEditTeam(group, user);
+    expect(result).toBe(true);
+  });
+
+  it("returns false if user is a member of the team", function () {
+    const groupId = "foo";
+    const group = getGroup({
+      id: groupId,
+      userMembership: {
+        memberType: "member",
+        username: "scooby-doo",
+      },
+    });
+    const user = getUser({
+      groups: [group],
+      username: "scooby-doo",
+    });
+    const result = canEditTeam(group, user);
+    expect(result).toBe(false);
+  });
+
+  it("returns false if the user does not belong to the team", function () {
+    const groupId = "foo";
+    const group = getGroup({
+      id: groupId,
+      userMembership: {
+        memberType: "admin",
+        username: "scooby-doo",
+      },
+    });
+    const user = getUser({
+      groups: [group],
+      username: "bing-bong",
+    });
+    const result = canEditTeam(group, user);
+    expect(result).toBe(false);
+  });
+});

--- a/packages/teams/test/utils/can-edit-team.test.ts
+++ b/packages/teams/test/utils/can-edit-team.test.ts
@@ -2,65 +2,74 @@ import { canEditTeam } from "../../src/utils/can-edit-team";
 import { IGroup, IUser } from "@esri/arcgis-rest-types";
 
 describe("canEditTeam", function () {
-  const getUser = (props: any = {}) => props as IUser;
-  const getGroup = (props: any) => props as IGroup;
-
   it("returns true if user is an admin or owner of the team", function () {
     const groupId = "foo";
-    let group = getGroup({
+    let group = {
       id: groupId,
       userMembership: {
         memberType: "owner",
         username: "scooby-doo",
       },
-    });
-    const user = getUser({
+    } as IGroup;
+
+    const user = {
       groups: [group],
       username: "scooby-doo",
-    });
+    } as IUser;
     let result = canEditTeam(group, user);
     expect(result).toBe(true);
-    group = getGroup({
+    group = {
       id: groupId,
       userMembership: {
         memberType: "admin",
         username: "scooby-doo",
       },
-    });
+    } as IGroup;
     result = canEditTeam(group, user);
     expect(result).toBe(true);
   });
 
   it("returns false if user is a member of the team", function () {
     const groupId = "foo";
-    const group = getGroup({
+    const group = {
       id: groupId,
       userMembership: {
         memberType: "member",
         username: "scooby-doo",
       },
-    });
-    const user = getUser({
+    } as IGroup;
+    const user = {
       groups: [group],
       username: "scooby-doo",
-    });
+    } as IUser;
     const result = canEditTeam(group, user);
     expect(result).toBe(false);
   });
 
-  it("returns false if user does not belong to the team", function () {
-    const groupId = "foo";
-    const group = getGroup({
-      id: groupId,
+  it("handles case where Group was not fetched in context of the user", function () {
+    const group = {
+      id: "00c",
       userMembership: {
         memberType: "admin",
         username: "scooby-doo",
       },
-    });
-    const user = getUser({
+    } as IGroup;
+    const user = {
       groups: [group],
       username: "bing-bong",
-    });
+    } as IUser;
+    const result = canEditTeam(group, user);
+    expect(result).toBe(false);
+  });
+
+  it("handles group w/o userMembership", () => {
+    const group = {
+      id: "00c",
+    } as IGroup;
+    const user = {
+      groups: [group],
+      username: "bing-bong",
+    } as IUser;
     const result = canEditTeam(group, user);
     expect(result).toBe(false);
   });

--- a/packages/teams/test/utils/can-edit-team.test.ts
+++ b/packages/teams/test/utils/can-edit-team.test.ts
@@ -48,7 +48,7 @@ describe("canEditTeam", function () {
     expect(result).toBe(false);
   });
 
-  it("returns false if the user does not belong to the team", function () {
+  it("returns false if user does not belong to the team", function () {
     const groupId = "foo";
     const group = getGroup({
       id: groupId,

--- a/packages/teams/test/utils/can-edit-team.test.ts
+++ b/packages/teams/test/utils/can-edit-team.test.ts
@@ -64,18 +64,4 @@ describe("canEditTeam", function () {
     const result = canEditTeam(group, user);
     expect(result).toBe(false);
   });
-
-  it("returns false if user is not auth'd", function () {
-    const groupId = "foo";
-    const group = getGroup({
-      id: groupId,
-      userMembership: {
-        memberType: "admin",
-        username: "scooby-doo",
-      },
-    });
-    const user = getUser({});
-    const result = canEditTeam(group, user);
-    expect(result).toBe(false);
-  });
 });

--- a/packages/teams/test/utils/can-edit-team.test.ts
+++ b/packages/teams/test/utils/can-edit-team.test.ts
@@ -64,4 +64,18 @@ describe("canEditTeam", function () {
     const result = canEditTeam(group, user);
     expect(result).toBe(false);
   });
+
+  it("returns false if user is not auth'd", function () {
+    const groupId = "foo";
+    const group = getGroup({
+      id: groupId,
+      userMembership: {
+        memberType: "admin",
+        username: "scooby-doo",
+      },
+    });
+    const user = getUser({});
+    const result = canEditTeam(group, user);
+    expect(result).toBe(false);
+  });
 });


### PR DESCRIPTION
1. Description:
Add a new `canEditTeam` fn in teams package util to check whether a user has access to edit a team
2. Instructions for testing:

3) Screenshot/GIF:

4) Closes Issues: #<number> (if appropriate)

5) [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
