### PR TITLE
fix(hub-teams): template was not properly updated based on privPropValue

### DIFF
--- a/packages/teams/src/utils/get-user-creatable-teams.ts
+++ b/packages/teams/src/utils/get-user-creatable-teams.ts
@@ -30,11 +30,16 @@ export function getUserCreatableTeams(
   // Online is not properly respecting addExternalMembersToGroup for
   // certain subscription types known ones so far: Trial, personal use, developer, and evaluation
   const updatedUser = removeInvalidPrivs(user, subscriptionInfoType);
-  // create partially applied filter fn...
-  const filterFn = (tmpl: IGroupTemplate) => {
-    const copyTemplate = applyPrivPropValuesToTemplate(updatedUser, tmpl);
-    return canUserCreateTeamInProduct(updatedUser, environment, copyTemplate);
-  };
-  // get the templates current user can create in this environment...
-  return cloneObject(teams).filter(filterFn);
+
+  // Update templates and remove the ones that aren't applicable.
+  return cloneObject(teams).reduce((acc, teamTmpl) => {
+    // Update template based on privPropValue
+    const copyTemplate = applyPrivPropValuesToTemplate(updatedUser, teamTmpl);
+    // If the user can create the team....
+    if (canUserCreateTeamInProduct(updatedUser, environment, copyTemplate)) {
+      // Add the team to the accumulator
+      acc.push(copyTemplate);
+    }
+    return acc;
+  }, []);
 }

--- a/packages/teams/test/utils/get-user-creatable-teams.test.ts
+++ b/packages/teams/test/utils/get-user-creatable-teams.test.ts
@@ -71,4 +71,20 @@ describe("getUserCreatableTeams", () => {
       getUserCreatableTeams(user, "portal", "9.1", "In House").length
     ).toBe(0, "no groups should be created if user lacks all privs");
   });
+  it("properly updates membershipAccess... when warranted", () => {
+    const user = {
+      privileges: [
+        "portal:user:createGroup",
+        "portal:admin:updateGroups",
+        "portal:admin:createUpdateCapableGroup",
+        "portal:admin:",
+        "portal:user:addExternalMembersToGroup",
+      ],
+    };
+    const teams = getUserCreatableTeams(user, "premium", "9.1", "In House");
+    expect(teams[0].membershipAccess).toBe(
+      "collaboration",
+      "membershipAccess should be updated to collaboration"
+    );
+  });
 });


### PR DESCRIPTION
1. Description:
Previously we were updating the template inside the filter function, which didn't actually update the template that was output from getUserCreatableTeams. Swapped to using a reduce to both update the template and filter it.

2. Instructions for testing:

3) Screenshot/GIF:

4) Closes Issues: #<number> (if appropriate)

5) [ ] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
