### PR TITLE
fix(hub-teams): export canEditTeam

### DIFF
--- a/packages/teams/src/utils/index.ts
+++ b/packages/teams/src/utils/index.ts
@@ -19,3 +19,4 @@ export * from "./get-team-by-id";
 export * from "./get-team-members";
 export * from "./search-team-members";
 export * from "./search-team-content";
+export * from "./can-edit-team";


### PR DESCRIPTION
Signed-off-by: Vivian Zhang <vzhang@esri.com>

1. Description:
export `canEditTeam` fn that was added in https://github.com/Esri/hub.js/pull/558
2. Instructions for testing:

3) Screenshot/GIF:

4) Closes Issues: #<number> (if appropriate)

5) [ ] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
