### PR TITLE
C/update default discussions api url

### DIFF
--- a/packages/discussions/src/utils/request.ts
+++ b/packages/discussions/src/utils/request.ts
@@ -62,7 +62,7 @@ export function apiRequest<T>(
     method: options.httpMethod || "GET",
     mode: options.mode,
     cache: options.cache,
-    credentials: options.credentials,
+    credentials: options.credentials
   };
 
   // NOTE: this should default to the prod url once deployed and microservice root URLs
@@ -80,12 +80,12 @@ export function apiRequest<T>(
   }
 
   const url = [apiBase.replace(/\/$/, ""), route.replace(/^\//, "")].join("/");
-  return fetch(url, opts).then((res) => {
+  return fetch(url, opts).then(res => {
     if (res.ok) {
       return res.json();
     } else {
       const { statusText, status } = res;
-      return res.json().then((err) => {
+      return res.json().then(err => {
         throw new RemoteServerError(
           statusText,
           url,

--- a/packages/discussions/src/utils/request.ts
+++ b/packages/discussions/src/utils/request.ts
@@ -62,13 +62,13 @@ export function apiRequest<T>(
     method: options.httpMethod || "GET",
     mode: options.mode,
     cache: options.cache,
-    credentials: options.credentials
+    credentials: options.credentials,
   };
 
   // NOTE: this should default to the prod url once deployed and microservice root URLs
   // are normalized: https://github.com/Esri/hub.js/pull/479#discussion_r607866561
   const apiBase =
-    options.hubApiUrl || "https://hubqa.arcgis.com/api/discussions/v1";
+    options.hubApiUrl || "https://hub.arcgis.com/api/discussions/v1";
 
   if (options.params) {
     if (options.httpMethod === "GET") {
@@ -80,12 +80,12 @@ export function apiRequest<T>(
   }
 
   const url = [apiBase.replace(/\/$/, ""), route.replace(/^\//, "")].join("/");
-  return fetch(url, opts).then(res => {
+  return fetch(url, opts).then((res) => {
     if (res.ok) {
       return res.json();
     } else {
       const { statusText, status } = res;
-      return res.json().then(err => {
+      return res.json().then((err) => {
         throw new RemoteServerError(
           statusText,
           url,

--- a/packages/discussions/test/request.test.ts
+++ b/packages/discussions/test/request.test.ts
@@ -7,7 +7,7 @@ import { IHubRequestOptions } from "../src/types";
 describe("request", () => {
   const url = "foo";
   const options = { params: { foo: "bar" } };
-  it("resolves token before making api request", (done) => {
+  it("resolves token before making api request", done => {
     const token = "thisisatoken";
     const authenticateRequestSpy = spyOn(
       utils,
@@ -15,7 +15,7 @@ describe("request", () => {
     ).and.callFake(async () => token);
     const apiRequestSpy = spyOn(utils, "apiRequest");
 
-    request(url, options as unknown as IHubRequestOptions)
+    request(url, (options as unknown) as IHubRequestOptions)
       .then(() => {
         expect(authenticateRequestSpy).toHaveBeenCalledWith(options);
         expect(apiRequestSpy).toHaveBeenCalledWith(url, options, token);
@@ -32,7 +32,7 @@ describe("authenticateRequest", () => {
     portal,
     getToken() {
       return Promise.resolve(token);
-    },
+    }
   };
 
   let getTokenSpy: any;
@@ -40,7 +40,7 @@ describe("authenticateRequest", () => {
     getTokenSpy = spyOn(authentication, "getToken").and.callThrough();
   });
 
-  it("returns promise resolving token if token provided in request options", (done) => {
+  it("returns promise resolving token if token provided in request options", done => {
     const options = { token };
     utils
       .authenticateRequest(options as IHubRequestOptions)
@@ -51,7 +51,7 @@ describe("authenticateRequest", () => {
       .catch(() => fail());
   });
 
-  it("resolves token from authentication", (done) => {
+  it("resolves token from authentication", done => {
     const options = { authentication };
     utils
       .authenticateRequest(options as IHubRequestOptions)
@@ -82,7 +82,7 @@ describe("apiRequest", () => {
       method: "GET",
       mode: undefined,
       cache: undefined,
-      credentials: undefined,
+      credentials: undefined
     } as RequestInit;
 
     opts = { hubApiUrl } as IHubRequestOptions;
@@ -90,13 +90,13 @@ describe("apiRequest", () => {
 
   afterEach(fetchMock.restore);
 
-  it("handles failed requests", (done) => {
+  it("handles failed requests", done => {
     const status = 400;
     const message = ["go do this", "go do that"];
     fetchMock.reset();
     fetchMock.mock("*", { status, body: { message } });
 
-    utils.apiRequest(url, opts).catch((e) => {
+    utils.apiRequest(url, opts).catch(e => {
       expect(e.message).toBe("Bad Request");
       expect(e.status).toBe(status);
       expect(e.url).toBe(`${hubApiUrl}/${url}`);
@@ -134,7 +134,7 @@ describe("apiRequest", () => {
 
   it(`appends query params to url if GET`, async () => {
     const query = {
-      bar: "baz",
+      bar: "baz"
     };
     const options = { ...opts, params: query, httpMethod: "GET" };
 
@@ -151,7 +151,7 @@ describe("apiRequest", () => {
 
   it(`stringifies and appends body to request options !GET`, async () => {
     const body = {
-      bar: "baz",
+      bar: "baz"
     };
     const options = { ...opts, params: body, httpMethod: "POST" };
 

--- a/packages/discussions/test/request.test.ts
+++ b/packages/discussions/test/request.test.ts
@@ -7,7 +7,7 @@ import { IHubRequestOptions } from "../src/types";
 describe("request", () => {
   const url = "foo";
   const options = { params: { foo: "bar" } };
-  it("resolves token before making api request", done => {
+  it("resolves token before making api request", (done) => {
     const token = "thisisatoken";
     const authenticateRequestSpy = spyOn(
       utils,
@@ -15,7 +15,7 @@ describe("request", () => {
     ).and.callFake(async () => token);
     const apiRequestSpy = spyOn(utils, "apiRequest");
 
-    request(url, (options as unknown) as IHubRequestOptions)
+    request(url, options as unknown as IHubRequestOptions)
       .then(() => {
         expect(authenticateRequestSpy).toHaveBeenCalledWith(options);
         expect(apiRequestSpy).toHaveBeenCalledWith(url, options, token);
@@ -32,7 +32,7 @@ describe("authenticateRequest", () => {
     portal,
     getToken() {
       return Promise.resolve(token);
-    }
+    },
   };
 
   let getTokenSpy: any;
@@ -40,7 +40,7 @@ describe("authenticateRequest", () => {
     getTokenSpy = spyOn(authentication, "getToken").and.callThrough();
   });
 
-  it("returns promise resolving token if token provided in request options", done => {
+  it("returns promise resolving token if token provided in request options", (done) => {
     const options = { token };
     utils
       .authenticateRequest(options as IHubRequestOptions)
@@ -51,7 +51,7 @@ describe("authenticateRequest", () => {
       .catch(() => fail());
   });
 
-  it("resolves token from authentication", done => {
+  it("resolves token from authentication", (done) => {
     const options = { authentication };
     utils
       .authenticateRequest(options as IHubRequestOptions)
@@ -66,7 +66,7 @@ describe("authenticateRequest", () => {
 describe("apiRequest", () => {
   const response = { ok: true };
 
-  const hubApiUrl = "https://hubqa.arcgis.com/api/discussions/v1";
+  const hubApiUrl = "https://hub.arcgis.com/api/discussions/v1";
   const url = "foo";
 
   let expectedOpts: RequestInit;
@@ -82,7 +82,7 @@ describe("apiRequest", () => {
       method: "GET",
       mode: undefined,
       cache: undefined,
-      credentials: undefined
+      credentials: undefined,
     } as RequestInit;
 
     opts = { hubApiUrl } as IHubRequestOptions;
@@ -90,13 +90,13 @@ describe("apiRequest", () => {
 
   afterEach(fetchMock.restore);
 
-  it("handles failed requests", done => {
+  it("handles failed requests", (done) => {
     const status = 400;
     const message = ["go do this", "go do that"];
     fetchMock.reset();
     fetchMock.mock("*", { status, body: { message } });
 
-    utils.apiRequest(url, opts).catch(e => {
+    utils.apiRequest(url, opts).catch((e) => {
       expect(e.message).toBe("Bad Request");
       expect(e.status).toBe(status);
       expect(e.url).toBe(`${hubApiUrl}/${url}`);
@@ -134,7 +134,7 @@ describe("apiRequest", () => {
 
   it(`appends query params to url if GET`, async () => {
     const query = {
-      bar: "baz"
+      bar: "baz",
     };
     const options = { ...opts, params: query, httpMethod: "GET" };
 
@@ -151,7 +151,7 @@ describe("apiRequest", () => {
 
   it(`stringifies and appends body to request options !GET`, async () => {
     const body = {
-      bar: "baz"
+      bar: "baz",
     };
     const options = { ...opts, params: body, httpMethod: "POST" };
 


### PR DESCRIPTION
1. Description: points hub-discussions package at production API instead of QA by default

2. Instructions for testing:

3) Screenshot/GIF:

4) Closes Issues: #<number> (if appropriate)

5) [ ] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
