### PR TITLE
feat(hub-common): add createOperationPipeline function

### DIFF
--- a/docs/src/guides/composing-workflows.md
+++ b/docs/src/guides/composing-workflows.md
@@ -1,0 +1,364 @@
+---
+title: Composing Workflows
+navTitle: Composing Workflows
+description: Constructing Pipelines with createOperationPipeline.
+order: 80
+group: 2-concepts
+---
+
+# Composing Workflows
+
+When building complex features using the ArcGIS platform, many times you will need to orchestrate complex workflows.
+
+For example - converting a Site into a Template for use in [Templates.js](https://github.com/Esri/templates-js) involves the following (abbreviated) steps:
+
+- fetch the Site item
+- fetch the Site item's /data
+- walk the layout, and determine what other items the Site depends upon
+- check other parts of the Site configuration for dependencies on Page items
+- verify that all those dependency items exist by fetching them
+- get a list of all the site item's resources
+
+While we can write and test a single function that has a single promise chain that executes all the steps...
+
+```js
+// Pseudo code - this the actual site template process is much more complex
+export function convertToTemplate(id) {
+  const tmpl = {};
+  // get the item
+  return getItem(id)
+    .then((item) => {
+      tmpl.item = item;
+      // get the data
+      return getItemData(id);
+    })
+    .then((itemData) => {
+      tmpl.data = itemData;
+      // extract dependencies from layout cards
+      tmpl.dependencies = itemData.layout.sections.reduce((deps, section) => {
+        return deps.concat(
+          section.rows.reduce((rowDeps, row) => {
+            return rowDeps.concat(
+              row.cards.reduce((cardDeps, card) => {
+                const cardDeps = getCardDependencies(card);
+                if (cardDeps.length) {
+                  deps = deps.concat(cardDeps);
+                }
+                return deps;
+              }, [])
+            );
+          }, [])
+        );
+      }, []);
+      // verify dependendencies exist
+      tmpl.dependencies = tmpl.dependencies.concat(itemData.layout.pages);
+      const q = `id: ${tmpl.dependencies.join(" OR id:")}`;
+      return searchItems(q);
+    })
+    .then((searchResponse) => {
+      const existingIds = searchResponse.results.map((itm) => itm.id);
+      // filter out items which no longer exist, or which the current user can't access
+      tmpl.dependencies = tmpl.dependencies.reduce((acc, entry) => {
+        if (existingIds.includes(entry)) {
+          acc.push(entry);
+        }
+        return acc;
+      });
+      // get the resources
+      return getResources(id);
+    })
+    .then((resources) => {
+      tmpl.resources = resources;
+      return tmpl;
+    });
+}
+```
+
+However that type of solution is very complex to write, difficult to understand, and - since all the logic is inside a single promise chain - we have no means to re-use any of those steps (i.e. Page items also need to walk a layout and determine dependencies).
+
+A better pattern is to break up the steps into focused functions, and then compose those functions into a workflow.
+
+```js
+export function convertToTemplate(id) {
+  const tmpl = {};
+  // we've moved a lot of the work out of this promise chain
+  // but we're still managing the composition of the template
+  return getItem(id)
+    .then((item) => {
+      tmpl.item = item;
+      return getItemData(id);
+    })
+    .then((itemData) => {
+      tmpl.data = itemData;
+      tmpl.dependencies = getLayoutDependencies(tmpl.data.layout);
+      tmpl.dependencies = tmpl.data.pages.concat(tmpl.dependencies);
+      return verifyDependencies(tmpl.dependencies);
+    })
+    .then((verifiedDeps) => {
+      tmpl.dependencies = verifiedDeps;
+      return getResources(id);
+    })
+    .then((resources) => {
+      tmpl.resources = resources;
+      return tmpl;
+    });
+}
+
+// now this can be used for pages or sites
+export function getLayoutDependencies(layout) {
+  return layout.sections.reduce((deps, section) => {
+    return deps.concat(
+      section.rows.reduce((rowDeps, row) => {
+        return rowDeps.concat(
+          row.cards.reduce((cardDeps, card) => {
+            const cardDeps = getCardDependencies(card);
+            if (cardDeps.length) {
+              deps = deps.concat(cardDeps);
+            }
+            return deps;
+          }, [])
+        );
+      }, [])
+    );
+  }, []);
+}
+
+export function verifyDependencies(ids) {
+  const q = `id: ${ids.join(" OR id:")}`;
+  return searchItems(q).then((searchResponse) => {
+    const existingIds = searchResponse.results.map((itm) => itm.id);
+    return ids.reduce((acc, entry) => {
+      if (existingIds.includes(entry)) {
+        acc.push(entry);
+      }
+      return acc;
+    });
+  });
+}
+```
+
+Having separate functions allows us to work with smaller units of code, thus making things easier to understand, and maintain, as well as opens opportunities for re-use in different scenarios. However, we still have significant logic in the main promise chain, and each function has a different signature which adds complexity, and we have no good means to understand the system state when a failure does occur. So let's address those issues next
+
+## Functional Composition
+
+In the last refactor, we still have some logic within the main promise chain. To make this even cleaner, we can design the functions to take and return the same structure. This allows us to chain the functions, effectively executing them in series, with no "connective logic" - aka a "pipeline". This is exactly what `createOperationPipeline` does for us.
+
+### Consistent Arguments and Return Values
+
+To leverage an operation pipeline, we need to ensure that all the functions that will be composed take the same argument and return the same value. In order to make this flexible, we use a "Container Type" `IPipeable<Type>`
+
+```js
+export interface IPipeable<Type> {
+  data: Type;
+  stack: OperationStack;
+  requestOptions?: IHubRequestOptions | IRequestOptions;
+}
+```
+
+What's important is that the `IPipeable<Type>` has a `data` property that can be of whatever type your pipeline is using. If we are "building up" an object we can also leverage the `Partial<Type>` type.
+
+`IPipeable` also includes an `OperationStack` which allows each function in the pipeline to add information about what it is doing internally, effectively providing state information in the event of an exception. This greatly simplifies debugging when things to wrong. Read more in the [OperationStack Guide](../operation-stack)
+
+Since many of the operations we do will be asynchronous, all the functions should return a Promise, even if they do not have to make any async calls. From a typing perspectives, the functions adhere to the `PipelineFn<Type>` signature:
+
+```js
+export type PipelineFn<T> = (value: IPipeable<T>) => Promise<IPipeable<T>>;
+```
+
+Working from the previous example, we could define an `ITemplate` as
+
+```js
+// Note: This is also simpified to demonstrate the concept
+export interface ITemplate {
+  id: string;
+  item: IItem;
+  data: Record<string, unknown>;
+  dependencies: string[];
+  resources: IResource[];
+}
+```
+
+And have functions like
+
+```js
+export function getItemAndData(
+  input: IPipable<Partial<ITemplate>>
+): Promise<IPipable<Partial<ITemplate>>> {
+  // Add wrapper operation to the stack.
+  let opId = input.stack.startOperation("getItemAndData");
+  // add a more detailed operation specific to the xhr getting the site item
+  // this includes more details on the request, and when we finish it we can
+  // provide additional information that may be useful in debugging
+  input.stack.start({
+    id: `getItem - ${input.data.id}`,
+    type: "getItem",
+    inputs: {
+      id: input.data.id,
+    },
+  });
+  return getItem(input.data.id, input.requestOptions)
+    .then((item) => {
+      // finish the getItem operation...
+      input.stack.finish(`getItem - ${input.data.id}`, { success: true });
+      // start one for getItemData
+      input.stack.start({
+        id: `getItemData - ${input.data.id}`,
+        type: "getItemData",
+        inputs: {
+          id: input.data.id,
+        },
+      });
+      input.data.item = item;
+      return getItemData(input.data.id, input.requestOptions);
+    })
+    .then((itemData) => {
+      input.stack.finish(`getItemData - ${input.data.id}`, { success: true });
+      input.stack.finish(opId);
+      input.data.data = itemData;
+      return input;
+    })
+    .catch((err) => {
+      // construct an OperationError so the stack is serialized and returned
+      // If somethign failed
+      const msg = `getSite Error \n Operation Stack: \n ${input.stack.toString()}`;
+      const opErr = new OperationError("pipeline execution error", msg);
+      opErr.operationStack = input.stack.serialize();
+      return Promise.reject(opErr);
+    });
+}
+
+export function getLayoutDependencies(
+  input: IPipable<Partial<ITemplate>>
+): Promise<IPipable<Partial<ITemplate>>> {
+  const opId = input.stack.startOperation("getLayoutDependencies");
+  input.data.dependencies = input.data.data.layout.sections.reduce(
+    (deps, section) => {
+      return deps.concat(
+        section.rows.reduce((rowDeps, row) => {
+          return rowDeps.concat(
+            row.cards.reduce((cardDeps, card) => {
+              const cardDeps = getCardDependencies(card);
+              if (cardDeps.length) {
+                deps = deps.concat(cardDeps);
+              }
+              return deps;
+            }, [])
+          );
+        }, [])
+      );
+    },
+    []
+  );
+  input.stack.finish(opId);
+  // although this is all sycn operations, we still resolve a promise
+  return Promise.resolve(input);
+}
+
+export function verifyDependencies(
+  input: IPipable<Partial<ITemplate>>
+): Promise<IPipable<Partial<ITemplate>>> {
+  const ids = input.data.dependencies || [];
+  const q = `id: ${ids.join(" OR id:")}`;
+  // create the wrapper operation for this function
+  const opId = input.stack.startOperation("verifyDependencies");
+  // start a second operation for the search
+  input.stack.start({
+    id: `dependenciesSearch`,
+    type: "dependency search request",
+    inputs: {
+      q: q,
+    },
+  });
+  return searchItems(q)
+    .then((searchResponse) => {
+      input.stack.finish("dependenciesSearch", {
+        count: searchResponse.results.length,
+      });
+      const existingIds = searchResponse.results.map((itm) => itm.id);
+      input.data.dependencies = ids.reduce((acc, entry) => {
+        if (existingIds.includes(entry)) {
+          acc.push(entry);
+        }
+        return acc;
+      });
+      // finish the wrapper operation
+      input.stack.finish(opId);
+      return input;
+    })
+    .catch((err) => {
+      // construct OperationError and reject with that
+    });
+}
+
+export function getResources(
+  input: IPipable<Partial<ITemplate>>
+): Promise<IPipable<Partial<ITemplate>>> {
+  let opId = input.stack.startOperation("getResources");
+  return getItemResources(input.data.id)
+    .then((resources) => {
+      input.stack.finish(opId);
+      input.data.resources = resources;
+      return input;
+    })
+    .catch((err) => {
+      // construct OperationError and reject with that
+    });
+}
+```
+
+With these functions setup we can then compose them using `createOperationPipeline`
+
+```js
+export function createSiteTemplate(
+  id: string,
+  requestOptions: IHubRequestOptions
+) {
+  // create the pipeline function...
+  const pipeline = createOperationPipeline([
+    getItemAndData,
+    getLayoutDependencies,
+    verifyDependencies,
+    getResources,
+  ]);
+  // create the initial input
+  const input = {
+    data: {},
+    stack: new OperationStack(),
+    requestOptions,
+  };
+  // execute the pipeline
+  return pipeline(input);
+}
+```
+
+What's more, we can make these pipelines configurable... so let's abstract this further...
+
+```js
+export function createTemplate(id: string, type: string, requestOptions: IRequestOptions) {
+  const pipeline = createOperationPipeline(getPipelineFnsByType(type));
+  // create the initial input
+  const input = {
+    data: {},
+    stack: new OperationStack(),
+    requestOptions
+  };
+  // execute the pipeline
+  return pipeline(input);
+}
+
+function getPipelineFnsByType(type: string): PipelineFn<T>[] {
+  const fns = [getItemAndData];
+  // implement whatever sort of logic
+  if type === "Hub Site Application" {
+    fns.push(getLayoutDependencies, verifyDependencies, getResources);
+  }
+  if type === "Web Map" {
+    fns.push(getLayerDependencies);
+  }
+  return fns;
+}
+```
+
+### Summary
+
+Creating pipeline functions via `createOperationPipeline` allows us to compose complex workflows, dyanmically, from a set of focused functions that all share a consistent API.

--- a/docs/src/guides/operation-pipe.md
+++ b/docs/src/guides/operation-pipe.md
@@ -1,0 +1,3 @@
+# Composing Workflows
+
+TODO: Add details and example using `operationPipe`

--- a/docs/src/guides/operation-pipe.md
+++ b/docs/src/guides/operation-pipe.md
@@ -1,3 +1,0 @@
-# Composing Workflows
-
-TODO: Add details and example using `operationPipe`

--- a/packages/common/src/utils/create-operation-pipeline.ts
+++ b/packages/common/src/utils/create-operation-pipeline.ts
@@ -17,9 +17,8 @@ export interface IPipeable<Type> {
 export type PipelineFn<T> = (value: IPipeable<T>) => Promise<IPipeable<T>>;
 
 /**
- * createOperationPipeline
- *
  * Returns a function that orchestrates a pipeline of smaller functions.
+ * See [Composing Workflows](../../../guides/composing-workflows) for more information.
  *
  * All the functions must adhere to the `PipelineFn<T>` signature:
  *
@@ -28,9 +27,9 @@ export type PipelineFn<T> = (value: IPipeable<T>) => Promise<IPipeable<T>>;
  * Given an array of OperationPipeFns, run them in sequence and return the resultant promise
  *
  * i.e. `createOperationPipeline([fn1, fn2, f3])` will return in a function that chains
- * the functions like this: `fn1(input).then(fn2).then(fn3)).then(result)`
+ * the functions like this: `fn1(input).then(fn2).then(fn3).then(result)`
  *
- * @param fns functions to be run in sequence. Nested arrays are run in parallel
+ * @param fns functions to be run in sequence
  * @returns Promise<Pipable<T>>
  */
 export const createOperationPipeline =

--- a/packages/common/src/utils/create-operation-pipeline.ts
+++ b/packages/common/src/utils/create-operation-pipeline.ts
@@ -1,0 +1,54 @@
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import OperationError from "../OperationError";
+import OperationStack from "../OperationStack";
+import { IHubRequestOptions } from "../types";
+
+/**
+ * Container type for Piping in Hub
+ */
+export interface IPipeable<Type> {
+  data: Type;
+  stack: OperationStack;
+  requestOptions?: IHubRequestOptions | IRequestOptions;
+}
+/**
+ * Signature of a function that can be used with createOperationPipeline
+ */
+export type PipelineFn<T> = (value: IPipeable<T>) => Promise<IPipeable<T>>;
+
+/**
+ * createOperationPipeline
+ *
+ * Returns a function that orchestrates a pipeline of smaller functions.
+ *
+ * All the functions must adhere to the `PipelineFn<T>` signature:
+ *
+ * `(value: IPipeable<T>) => Promise<IPipeable<T>>`
+ *
+ * Given an array of OperationPipeFns, run them in sequence and return the resultant promise
+ *
+ * i.e. `createOperationPipeline([fn1, fn2, f3])` will return in a function that chains
+ * the functions like this: `fn1(input).then(fn2).then(fn3)).then(result)`
+ *
+ * @param fns functions to be run in sequence. Nested arrays are run in parallel
+ * @returns Promise<Pipable<T>>
+ */
+export const createOperationPipeline =
+  <T>(fns: Array<PipelineFn<T>>) =>
+  (input: IPipeable<T>): Promise<IPipeable<T>> => {
+    const stack = input.stack;
+    return fns.reduce((chain, func) => {
+      return chain.then(func).catch((err) => {
+        // if it's an OperationError we can just reject with it...
+        if (err.name === "OperationError") {
+          return Promise.reject(err);
+        } else {
+          // otherwise, create an OperationError and reject with that
+          const msg = `IPipeableFn did not reject with an OperationError \n Operation Stack: \n ${input.stack.toString()}`;
+          const opErr = new OperationError("pipeline execution error", msg);
+          opErr.operationStack = input.stack.serialize();
+          return Promise.reject(opErr);
+        }
+      });
+    }, Promise.resolve(input));
+  };

--- a/packages/common/src/utils/create-operation-pipeline.ts
+++ b/packages/common/src/utils/create-operation-pipeline.ts
@@ -36,7 +36,6 @@ export type PipelineFn<T> = (value: IPipeable<T>) => Promise<IPipeable<T>>;
 export const createOperationPipeline =
   <T>(fns: Array<PipelineFn<T>>) =>
   (input: IPipeable<T>): Promise<IPipeable<T>> => {
-    const stack = input.stack;
     return fns.reduce((chain, func) => {
       return chain.then(func).catch((err) => {
         // if it's an OperationError we can just reject with it...

--- a/packages/common/test/utils/create-operation-pipeline.test.ts
+++ b/packages/common/test/utils/create-operation-pipeline.test.ts
@@ -151,6 +151,10 @@ describe("createOperationPipeline:: ", () => {
       fetchOwner,
     ]);
     return pipeline(input).catch((err) => {
+      expect(err.name).toBe(
+        "OperationError",
+        "Should reject with an OperationError"
+      );
       expect(err.operationStack.operations.length).toBe(3);
       expect(err.message).toContain("Operation timeStampName");
       expect(err.message).toContain("Operation addCreatedAt");
@@ -174,6 +178,10 @@ describe("createOperationPipeline:: ", () => {
       fetchOwner,
     ]);
     return pipeline(input).catch((err) => {
+      expect(err.name).toBe(
+        "OperationError",
+        "Should reject with an OperationError"
+      );
       expect(err.operationStack.operations.length).toBe(3);
       expect(err.message).toContain("Operation timeStampName");
       expect(err.message).toContain("Operation addCreatedAt");

--- a/packages/common/test/utils/create-operation-pipeline.test.ts
+++ b/packages/common/test/utils/create-operation-pipeline.test.ts
@@ -1,0 +1,183 @@
+import {
+  createOperationPipeline,
+  IPipeable,
+} from "../../src/utils/create-operation-pipeline";
+import OperationStack from "../../src/OperationStack";
+import { IHubRequestOptions } from "../../src/types";
+import OperationError from "../../src/OperationError";
+// Test Fakes
+interface IFakeItem {
+  id: string;
+  name: string;
+  owner: string;
+  created: number;
+  createdAt: Date;
+  properties: Record<string, unknown>;
+}
+
+const delay = <T>(data: T, delayMs: number): Promise<T> =>
+  new Promise((resolve) =>
+    setTimeout(() => {
+      return resolve(data);
+    }, delayMs)
+  );
+
+const timeStampName = (
+  input: IPipeable<Partial<IFakeItem>>
+): Promise<IPipeable<Partial<IFakeItem>>> => {
+  input.data.name = `${input.data.name}:${new Date().getTime()}`;
+  const opId = input.stack.start("timeStampName");
+  input.stack.finish(opId);
+  return Promise.resolve(input);
+};
+const addCreatedAt = (
+  input: IPipeable<Partial<IFakeItem>>
+): Promise<IPipeable<Partial<IFakeItem>>> => {
+  input.data.createdAt = new Date(input.data.created);
+  const opId = input.stack.start("addCreatedAt");
+  input.stack.finish(opId);
+  return Promise.resolve(input);
+};
+
+const addProperties = (
+  input: IPipeable<Partial<IFakeItem>>
+): Promise<IPipeable<Partial<IFakeItem>>> => {
+  input.data.properties = {
+    foo: "bar",
+    baz: {
+      deep: "nesting",
+    },
+  };
+  // each fn should create a new operation stack
+  const s = new OperationStack();
+  // add operations to it...
+  const opId = s.start("addProperties");
+  s.finish(opId);
+  // then merge into the input stack at the end
+  input.stack.merge(s.serialize());
+
+  return Promise.resolve(input);
+};
+
+const addOwnerThrowsOpError = (
+  input: IPipeable<Partial<IFakeItem>>
+): Promise<IPipeable<Partial<IFakeItem>>> => {
+  input.data.owner = "steve";
+  const opId = input.stack.start("addOwnerThrowsOpError");
+
+  const msg = `Some upstream error \n Operation Stack: \n ${input.stack.toString()}`;
+  const err = new OperationError("addOwnerThrowsOpError", msg);
+  err.operationStack = input.stack.serialize();
+
+  return Promise.reject(err);
+};
+
+const addOwnerThrows = (
+  input: IPipeable<Partial<IFakeItem>>
+): Promise<IPipeable<Partial<IFakeItem>>> => {
+  input.data.owner = "steve";
+  const opId = input.stack.start("addOwnerThrows");
+  return Promise.reject("Some random error");
+};
+
+const fetchOwner = (
+  input: IPipeable<Partial<IFakeItem>>
+): Promise<IPipeable<Partial<IFakeItem>>> => {
+  input.data.owner = "steve";
+  const opId = input.stack.start("fetchOwner");
+  input.stack.finish(opId);
+  return delay(input, 200);
+};
+
+// Fake request options
+const ro = {} as unknown as IHubRequestOptions;
+
+describe("createOperationPipeline:: ", () => {
+  it("runs a single function", () => {
+    const m = {
+      name: "Foo",
+      created: new Date().getTime() - 20000,
+    } as Partial<IFakeItem>;
+    const input = {
+      data: m,
+      stack: new OperationStack(),
+    } as IPipeable<Partial<IFakeItem>>;
+    const pipeline = createOperationPipeline([timeStampName]);
+    return pipeline(input).then((result) => {
+      expect(result.data.name.split(":")[1]).toBeGreaterThan(0);
+    });
+  });
+
+  it("runs multiple functions", () => {
+    const m = {
+      name: "Foo",
+      created: new Date().getTime() - 20000,
+    } as Partial<IFakeItem>;
+    const input = {
+      data: m,
+      stack: new OperationStack(),
+      requestOptions: ro,
+    } as IPipeable<Partial<IFakeItem>>;
+    const pipeline = createOperationPipeline([
+      timeStampName,
+      addCreatedAt,
+      addProperties,
+      fetchOwner,
+    ]);
+    return pipeline(input).then((result) => {
+      expect(result.data.name.split(":")[1]).toBeGreaterThan(0);
+      expect(result.data.createdAt).not.toBeUndefined();
+      expect(result.data.owner).not.toBeUndefined();
+      expect(result.stack.getOperations().length).toBe(
+        4,
+        "should have 4 operations"
+      );
+    });
+  });
+  it("handles subfunction rejecting with OperationError", () => {
+    const m = {
+      name: "Foo",
+      created: new Date().getTime() - 20000,
+    } as Partial<IFakeItem>;
+    const input = {
+      data: m,
+      stack: new OperationStack(),
+      requestOptions: ro,
+    } as IPipeable<Partial<IFakeItem>>;
+    const pipeline = createOperationPipeline([
+      timeStampName,
+      addCreatedAt,
+      addOwnerThrowsOpError,
+      fetchOwner,
+    ]);
+    return pipeline(input).catch((err) => {
+      expect(err.operationStack.operations.length).toBe(3);
+      expect(err.message).toContain("Operation timeStampName");
+      expect(err.message).toContain("Operation addCreatedAt");
+      expect(err.message).toContain("Operation addOwnerThrowsOpError");
+    });
+  });
+  it("handles subfunction rejecting without OperationError", () => {
+    const m = {
+      name: "Foo",
+      created: new Date().getTime() - 20000,
+    } as Partial<IFakeItem>;
+    const input = {
+      data: m,
+      stack: new OperationStack(),
+      requestOptions: ro,
+    } as IPipeable<Partial<IFakeItem>>;
+    const pipeline = createOperationPipeline([
+      timeStampName,
+      addCreatedAt,
+      addOwnerThrows,
+      fetchOwner,
+    ]);
+    return pipeline(input).catch((err) => {
+      expect(err.operationStack.operations.length).toBe(3);
+      expect(err.message).toContain("Operation timeStampName");
+      expect(err.message).toContain("Operation addCreatedAt");
+      expect(err.message).toContain("Operation addOwnerThrows");
+    });
+  });
+});

--- a/packages/common/test/utils/create-operation-pipeline.test.ts
+++ b/packages/common/test/utils/create-operation-pipeline.test.ts
@@ -48,12 +48,15 @@ const addProperties = (
       deep: "nesting",
     },
   };
-  // each fn should create a new operation stack
+  // functions can crate a new operation stack
   const s = new OperationStack();
   // add operations to it...
   const opId = s.start("addProperties");
   s.finish(opId);
   // then merge into the input stack at the end
+  // a similar approach can be used if the function
+  // calls other functions, which themselves
+  // return operation stacks
   input.stack.merge(s.serialize());
 
   return Promise.resolve(input);


### PR DESCRIPTION
1. Description:

Add the `createOperationPipeline` function, for use streamlining the Content Enrichments, and other chain type scenarios

TODO:
- [x] add better jsdoc and verify it's solid
- [x] add guide w/ examples

2. Instructions for testing:

run tests

3) Screenshot/GIF: n/a

4) Closes Issues: #<number> (if appropriate)

5) [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
