### PR TITLE
fix(hub-teams): add groupId to each groups add members response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37843,9 +37843,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "16.4.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.0.tgz",
-					"integrity": "sha512-HrJuE7Mlqcjj+00JqMWpZ3tY8w7EUd+S0U3L1+PQSWiXZbOgyQDvi+ogoUxaHApPJq5diKxYBQwA3iIlNcPqOg=="
+					"version": "16.4.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.1.tgz",
+					"integrity": "sha512-UW7cbLqf/Wu5XH2RKKY1cHwUNLicIDRLMraYKz+HHAerJ0ZffUEk+fMnd8qU2JaS6cAy0r8tsaf7yqHASf/Y0Q=="
 				},
 				"component-emitter": {
 					"version": "1.3.0",

--- a/packages/teams/src/add-or-invite-users-to-team.ts
+++ b/packages/teams/src/add-or-invite-users-to-team.ts
@@ -58,6 +58,7 @@ export async function addOrInviteUsersToTeam(
     notInvited: [],
     notEmailed: [],
     errors: [],
+    groupId,
   };
   // Bring not added / invited / emailed / errors up to the top level
   result.notAdded = [

--- a/packages/teams/src/types.ts
+++ b/packages/teams/src/types.ts
@@ -135,6 +135,7 @@ export interface IAddOrInviteToTeamResult {
   community: IAddOrInviteResponse;
   org: IAddOrInviteResponse;
   world: IAddOrInviteResponse;
+  groupId: string;
 }
 
 /**

--- a/packages/teams/test/add-or-invite-users-to-team.test.ts
+++ b/packages/teams/test/add-or-invite-users-to-team.test.ts
@@ -79,5 +79,6 @@ describe("addOrInviteUsersToTeam: ", () => {
     expect(response.notInvited.length).toEqual(2);
     expect(response.notEmailed.length).toEqual(1);
     expect(response.errors.length).toEqual(4);
+    expect(response.groupId).toEqual("abc123");
   });
 });

--- a/packages/teams/test/add-or-invite-users-to-teams.test.ts
+++ b/packages/teams/test/add-or-invite-users-to-teams.test.ts
@@ -20,6 +20,7 @@ describe("addOrInviteUsersToTeams: ", () => {
       "addOrInviteUsersToTeam"
     ).and.callFake(() => {
       const response: IAddOrInviteToTeamResult = {
+        groupId: "abc123",
         notAdded: ["dobby", "frank"],
         notInvited: ["bob", "bobb"],
         notEmailed: ["dobby"],


### PR DESCRIPTION
1. Description: I neglected to add the groupId onto each groups response object thereby making it rather hard to locate. This is now corrected.

2. Instructions for testing:

3) Screenshot/GIF:

4) Closes Issues: #<number> (if appropriate)

5) [ ] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
