### PR TITLE
fix(hub-teams): createHubTeams in Enterprise

### DIFF
--- a/packages/teams/src/create-hub-teams.ts
+++ b/packages/teams/src/create-hub-teams.ts
@@ -3,7 +3,9 @@ import {
   getHubProduct,
   getCulture,
   convertToWellKnownLocale,
-  fetchHubTranslation
+  fetchHubTranslation,
+  getWithDefault,
+  getProp,
 } from "@esri/hub-common";
 import { getUserCreatableTeams } from "./utils/get-user-creatable-teams";
 import { _createTeamGroups } from "./utils/_create-team-groups";
@@ -27,12 +29,17 @@ export function createHubTeams(opts: {
   const product = getHubProduct(hubRequestOptions.portalSelf);
   // get all the groups that this user can create in this environment
   // and filter just the team types requested
+  const subscriptionType = getWithDefault(
+    hubRequestOptions.portalSelf,
+    "subscriptionInfo.type",
+    "Enterprise"
+  );
   const teamsToCreate = getUserCreatableTeams(
     hubRequestOptions.portalSelf.user,
     product,
     hubRequestOptions.portalSelf.currentVersion,
-    hubRequestOptions.portalSelf.subscriptionInfo.type
-  ).filter(g => {
+    subscriptionType
+  ).filter((g) => {
     return types.indexOf(g.config.type) > -1;
   });
   // get the culture out of the
@@ -40,7 +47,7 @@ export function createHubTeams(opts: {
   const locale = convertToWellKnownLocale(culture);
   // Fire that off
   return fetchHubTranslation(locale, hubRequestOptions.portalSelf)
-    .then(translations => {
+    .then((translations) => {
       // create the team groups
       return _createTeamGroups(
         title,
@@ -49,7 +56,7 @@ export function createHubTeams(opts: {
         hubRequestOptions
       );
     })
-    .catch(ex => {
+    .catch((ex) => {
       throw Error(`Error in team-utils::createHubTeams ${ex}`);
     });
 }

--- a/packages/teams/src/utils/remove-invalid-privs.ts
+++ b/packages/teams/src/utils/remove-invalid-privs.ts
@@ -10,7 +10,7 @@ const ALLOWED_SUBSCRIPTION_TYPES = [
   "ELA",
   "Education Site License",
   "Education",
-  "HUP Online"
+  "HUP Online",
 ];
 
 /**

--- a/packages/teams/test/create-hub-teams.test.ts
+++ b/packages/teams/test/create-hub-teams.test.ts
@@ -4,6 +4,7 @@ import { IGroup } from "@esri/arcgis-rest-types";
 import * as _createTeamGroupsModule from "../src/utils/_create-team-groups";
 import { createHubTeams } from "../src/create-hub-teams";
 import { HubTeamType } from "../src/types";
+import { cloneObject } from "@esri/hub-common";
 
 describe("createHubTeams", () => {
   const ro = {
@@ -33,6 +34,44 @@ describe("createHubTeams", () => {
   } as commonModule.IHubRequestOptions;
 
   it("creates the correct hub teams", async () => {
+    const translations = {};
+
+    const fetchTranslationSpy = spyOn(
+      commonModule,
+      "fetchHubTranslation"
+    ).and.returnValue(Promise.resolve(translations));
+
+    const createTeamGroupsRes = {
+      props: {},
+      groups: [{ id: "foo" }, { id: "bar" }],
+    } as { props: any; groups: IGroup[] };
+    const createGroupsSpy = spyOn(
+      _createTeamGroupsModule,
+      "_createTeamGroups"
+    ).and.returnValue(Promise.resolve(createTeamGroupsRes));
+
+    const types: HubTeamType[] = ["content", "event"];
+
+    const createTeamsOpts = {
+      title: "foo team",
+      types,
+      hubRequestOptions: ro,
+    };
+
+    const res = await createHubTeams(createTeamsOpts);
+
+    expect(res).toEqual(createTeamGroupsRes);
+    expect(fetchTranslationSpy).toHaveBeenCalled();
+    expect(createGroupsSpy).toHaveBeenCalled();
+    expect(createGroupsSpy.calls.argsFor(0)[1].length).toBe(
+      2,
+      "created two teams"
+    );
+  });
+
+  it("works for enterprise w/o subscriptionType", async () => {
+    const enterpriseRo = cloneObject(ro);
+    delete enterpriseRo.portalSelf.subscriptionInfo;
     const translations = {};
 
     const fetchTranslationSpy = spyOn(

--- a/packages/teams/test/utils/remove-invalid-privs.test.ts
+++ b/packages/teams/test/utils/remove-invalid-privs.test.ts
@@ -11,14 +11,14 @@ describe("removeInvalidPrivs", () => {
       "ELA",
       "Education Site License",
       "Education",
-      "HUP Online"
+      "HUP Online",
     ];
-    subTypes.forEach(type => {
+    subTypes.forEach((type) => {
       const user = {
         privileges: [
           "portal:user:addExternalMembersToGroup",
-          "portal:admin:assignToGroups"
-        ]
+          "portal:admin:assignToGroups",
+        ],
       };
       expect(removeInvalidPrivs(user, type).privileges.length).toBe(
         2,
@@ -27,13 +27,19 @@ describe("removeInvalidPrivs", () => {
     });
   });
   it("Correctly removes priv for non-allowed types", () => {
-    const subTypes = ["Trial", "Personal Use", "Developer", "Evaluation"];
-    subTypes.forEach(type => {
+    const subTypes = [
+      "Trial",
+      "Personal Use",
+      "Developer",
+      "Evaluation",
+      "Enterprise",
+    ];
+    subTypes.forEach((type) => {
       const user = {
         privileges: [
           "portal:user:addExternalMembersToGroup",
-          "portal:admin:assignToGroups"
-        ]
+          "portal:admin:assignToGroups",
+        ],
       };
       expect(removeInvalidPrivs(user, type).privileges.length).toBe(
         1,


### PR DESCRIPTION
affects: @esri/hub-teams

Handle missing subscriptionType prop in Enterprise

1. Description:

In enterprise portalSelf.subscriptionInfo.type is not defined. This will allow that to fail gracefully

2. Instructions for testing:

3) Screenshot/GIF:

4) Closes Issues: #<number> (if appropriate)

5) [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
