### PR TITLE
fix(hub-teams): allow for emails to be sent to only a single group

### DIFF
--- a/packages/teams/src/types.ts
+++ b/packages/teams/src/types.ts
@@ -109,6 +109,7 @@ export interface IAddOrInviteResponse {
 export interface IAddOrInviteEmail {
   message: IEmail;
   auth: IAuthenticationManager;
+  groupId?: string;
 }
 
 /**

--- a/packages/teams/src/utils/handle-no-users.ts
+++ b/packages/teams/src/utils/handle-no-users.ts
@@ -1,4 +1,4 @@
-import { IAddOrInviteResponse } from "../types";
+import { IAddOrInviteContext, IAddOrInviteResponse } from "../types";
 
 /**
  * @private
@@ -10,7 +10,11 @@ import { IAddOrInviteResponse } from "../types";
  * @export
  * @return {IAddOrInviteResponse}
  */
-export function handleNoUsers(): IAddOrInviteResponse {
+export async function handleNoUsers(
+  context?: IAddOrInviteContext,
+  userType?: "world" | "org" | "community",
+  shouldEmail?: boolean
+): Promise<IAddOrInviteResponse> {
   return {
     notAdded: [],
     notEmailed: [],

--- a/packages/teams/test/utils/add-or-invite-community-users.test.ts
+++ b/packages/teams/test/utils/add-or-invite-community-users.test.ts
@@ -50,6 +50,51 @@ describe("addOrInviteCommunityUsers:", () => {
     const actual = await addOrInviteCommunityUsers(context);
     expect(processAutoAddUsersSpy).toHaveBeenCalled();
   });
+  it("Properly autoAdds when an email is supplied for a given groupID", async () => {
+    const context: IAddOrInviteContext = {
+      groupId: "abc123",
+      primaryRO: MOCK_AUTH,
+      allUsers: [{ orgType: "community" }],
+      canAutoAddUser: true,
+      addUserAsGroupAdmin: false,
+      email: { message: {}, auth: MOCK_AUTH, groupId: "abc123" },
+      world: [],
+      org: [],
+      community: [{ orgType: "community" }],
+    };
+    const processAutoAddUsersSpy = spyOn(
+      processAutoAddUsersModule,
+      "processAutoAddUsers"
+    ).and.callFake(() => {
+      Promise.resolve();
+    });
+
+    const actual = await addOrInviteCommunityUsers(context);
+    expect(processAutoAddUsersSpy).toHaveBeenCalled();
+    expect(processAutoAddUsersSpy.calls.count()).toEqual(1);
+  });
+  it("Properly invites when an email is supplied, but groups dont match", async () => {
+    const context: IAddOrInviteContext = {
+      groupId: "abc123",
+      primaryRO: MOCK_AUTH,
+      allUsers: [{ orgType: "community" }],
+      canAutoAddUser: false,
+      addUserAsGroupAdmin: false,
+      email: { message: {}, auth: MOCK_AUTH, groupId: "def456" },
+      world: [],
+      org: [],
+      community: [{ orgType: "community" }],
+    };
+    const processInviteUsersSpy = spyOn(
+      processInviteUsersModule,
+      "processInviteUsers"
+    ).and.callFake(() => {
+      Promise.resolve();
+    });
+
+    const actual = await addOrInviteCommunityUsers(context);
+    expect(processInviteUsersSpy).toHaveBeenCalled();
+  });
   it("Properly autoAdds when canAutoAdd is supplied", async () => {
     const context: IAddOrInviteContext = {
       groupId: "abc123",

--- a/packages/teams/test/utils/handle-no-users.test.ts
+++ b/packages/teams/test/utils/handle-no-users.test.ts
@@ -1,8 +1,8 @@
 import { handleNoUsers } from "../../src/utils/handle-no-users";
 
 describe("handleNoUsers: ", () => {
-  it("returns expected empty addOrInviteReponse object", () => {
-    const result = handleNoUsers();
+  it("returns expected empty addOrInviteReponse object", async () => {
+    const result = await handleNoUsers();
     expect(result.notAdded.length).toBe(0);
     expect(result.notEmailed.length).toBe(0);
     expect(result.notInvited.length).toBe(0);


### PR DESCRIPTION
1. Description: This allows one to limit sending emails to a single group out of n, while users are still added to all groups.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
