### PR TITLE
fix(hub-teams): canCreateTeam fatal error when portalSelf is missing …

### DIFF
--- a/packages/teams/src/utils/can-user-create-team.ts
+++ b/packages/teams/src/utils/can-user-create-team.ts
@@ -18,13 +18,15 @@ export function canUserCreateTeam(
   if (userGroups.length > 510) {
     return false;
   } else {
-    const product = getHubProduct(hubRequestOptions.portalSelf);
+    const portalSelf = hubRequestOptions.portalSelf;
+    const product = getHubProduct(portalSelf);
+    const subscriptionInfo = portalSelf.subscriptionInfo;
     // get all the groups the user can create in this product...
     return getUserCreatableTeams(
       user,
       product,
-      hubRequestOptions.portalSelf.currentVersion,
-      hubRequestOptions.portalSelf.subscriptionInfo.type
-    ).some(t => t.config.type === hubTeamType);
+      portalSelf.currentVersion,
+      subscriptionInfo && subscriptionInfo.type
+    ).some((t) => t.config.type === hubTeamType);
   }
 }


### PR DESCRIPTION
…subscription

affects: @esri/hub-teams

this happens in portal

1. Description:


1. Instructions for testing:

1. Closes Issues: #1564 (https://devtopia.esri.com/dc/hub/issues/1564)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
