### PR TITLE
fix(hub-teams): allow for user to be invited as group admin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -649,11 +649,11 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.14.9",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.9.tgz",
-					"integrity": "sha512-4yoHbhDYzFa0GLfCzLp5GxH7vPPMAHdZjyE7M/OajM9037zhx0rf+iNsJwp4PT0MSFpwjG7BsHEbPkBQpZ6cYA==",
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+					"integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
 					"requires": {
-						"@babel/types": "^7.14.9",
+						"@babel/types": "^7.15.0",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
@@ -667,15 +667,15 @@
 					}
 				},
 				"@babel/helper-create-class-features-plugin": {
-					"version": "7.14.8",
-					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.8.tgz",
-					"integrity": "sha512-bpYvH8zJBWzeqi1o+co8qOrw+EXzQ/0c74gVmY205AWXy9nifHrOg77y+1zwxX5lXE7Icq4sPlSQ4O2kWBrteQ==",
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.0.tgz",
+					"integrity": "sha512-MdmDXgvTIi4heDVX/e9EFfeGpugqm9fobBVg/iioE8kueXrOHdRDe36FAY7SnE9xXLVeYCoJR/gdrBEIHRC83Q==",
 					"requires": {
 						"@babel/helper-annotate-as-pure": "^7.14.5",
 						"@babel/helper-function-name": "^7.14.5",
-						"@babel/helper-member-expression-to-functions": "^7.14.7",
+						"@babel/helper-member-expression-to-functions": "^7.15.0",
 						"@babel/helper-optimise-call-expression": "^7.14.5",
-						"@babel/helper-replace-supers": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.15.0",
 						"@babel/helper-split-export-declaration": "^7.14.5"
 					}
 				},
@@ -706,11 +706,11 @@
 					}
 				},
 				"@babel/helper-member-expression-to-functions": {
-					"version": "7.14.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
-					"integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
+					"integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
 					"requires": {
-						"@babel/types": "^7.14.5"
+						"@babel/types": "^7.15.0"
 					}
 				},
 				"@babel/helper-optimise-call-expression": {
@@ -727,14 +727,14 @@
 					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
-					"integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
+					"integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.14.5",
+						"@babel/helper-member-expression-to-functions": "^7.15.0",
 						"@babel/helper-optimise-call-expression": "^7.14.5",
-						"@babel/traverse": "^7.14.5",
-						"@babel/types": "^7.14.5"
+						"@babel/traverse": "^7.15.0",
+						"@babel/types": "^7.15.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
@@ -761,9 +761,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.14.9",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.9.tgz",
-					"integrity": "sha512-RdUTOseXJ8POjjOeEBEvNMIZU/nm4yu2rufRkcibzkkg7DmQvXU8v3M4Xk9G7uuI86CDGkKcuDWgioqZm+mScQ=="
+					"version": "7.15.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+					"integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA=="
 				},
 				"@babel/template": {
 					"version": "7.14.5",
@@ -776,25 +776,25 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.14.9",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.9.tgz",
-					"integrity": "sha512-bldh6dtB49L8q9bUyB7bC20UKgU+EFDwKJylwl234Kv+ySZeMD31Xeht6URyueQ6LrRRpF2tmkfcZooZR9/e8g==",
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+					"integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
 					"requires": {
 						"@babel/code-frame": "^7.14.5",
-						"@babel/generator": "^7.14.9",
+						"@babel/generator": "^7.15.0",
 						"@babel/helper-function-name": "^7.14.5",
 						"@babel/helper-hoist-variables": "^7.14.5",
 						"@babel/helper-split-export-declaration": "^7.14.5",
-						"@babel/parser": "^7.14.9",
-						"@babel/types": "^7.14.9",
+						"@babel/parser": "^7.15.0",
+						"@babel/types": "^7.15.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0"
 					}
 				},
 				"@babel/types": {
-					"version": "7.14.9",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
-					"integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.14.9",
 						"to-fast-properties": "^2.0.0"
@@ -1369,9 +1369,9 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.14.5.tgz",
-			"integrity": "sha512-fPMBhh1AV8ZyneiCIA+wYYUH1arzlXR1UMcApjvchDhfKxhy2r2lReJv8uHEyihi4IFIGlr1Pdx7S5fkESDQsg==",
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.0.tgz",
+			"integrity": "sha512-sfHYkLGjhzWTq6xsuQ01oEsUYjkHRux9fW1iUA68dC7Qd8BS1Unq4aZ8itmQp95zUzIcyR2EbNMTzAicFj+guw==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.14.5",
 				"@babel/helper-plugin-utils": "^7.14.5",
@@ -1400,9 +1400,9 @@
 					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
 				},
 				"@babel/types": {
-					"version": "7.14.9",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
-					"integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.14.9",
 						"to-fast-properties": "^2.0.0"
@@ -1457,11 +1457,11 @@
 			}
 		},
 		"@babel/plugin-transform-typescript": {
-			"version": "7.14.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.14.6.tgz",
-			"integrity": "sha512-XlTdBq7Awr4FYIzqhmYY80WN0V0azF74DMPyFqVHBvf81ZUgc4X7ZOpx6O8eLDK6iM5cCQzeyJw0ynTaefixRA==",
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.0.tgz",
+			"integrity": "sha512-WIIEazmngMEEHDaPTx0IZY48SaAmjVWe3TRSX7cmJXn0bEv9midFzAjxiruOWYIVf5iQ10vFx7ASDpgEO08L5w==",
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.14.6",
+				"@babel/helper-create-class-features-plugin": "^7.15.0",
 				"@babel/helper-plugin-utils": "^7.14.5",
 				"@babel/plugin-syntax-typescript": "^7.14.5"
 			},
@@ -1475,11 +1475,11 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.14.9",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.9.tgz",
-					"integrity": "sha512-4yoHbhDYzFa0GLfCzLp5GxH7vPPMAHdZjyE7M/OajM9037zhx0rf+iNsJwp4PT0MSFpwjG7BsHEbPkBQpZ6cYA==",
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+					"integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
 					"requires": {
-						"@babel/types": "^7.14.9",
+						"@babel/types": "^7.15.0",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
@@ -1493,15 +1493,15 @@
 					}
 				},
 				"@babel/helper-create-class-features-plugin": {
-					"version": "7.14.8",
-					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.8.tgz",
-					"integrity": "sha512-bpYvH8zJBWzeqi1o+co8qOrw+EXzQ/0c74gVmY205AWXy9nifHrOg77y+1zwxX5lXE7Icq4sPlSQ4O2kWBrteQ==",
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.0.tgz",
+					"integrity": "sha512-MdmDXgvTIi4heDVX/e9EFfeGpugqm9fobBVg/iioE8kueXrOHdRDe36FAY7SnE9xXLVeYCoJR/gdrBEIHRC83Q==",
 					"requires": {
 						"@babel/helper-annotate-as-pure": "^7.14.5",
 						"@babel/helper-function-name": "^7.14.5",
-						"@babel/helper-member-expression-to-functions": "^7.14.7",
+						"@babel/helper-member-expression-to-functions": "^7.15.0",
 						"@babel/helper-optimise-call-expression": "^7.14.5",
-						"@babel/helper-replace-supers": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.15.0",
 						"@babel/helper-split-export-declaration": "^7.14.5"
 					}
 				},
@@ -1532,11 +1532,11 @@
 					}
 				},
 				"@babel/helper-member-expression-to-functions": {
-					"version": "7.14.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
-					"integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
+					"integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
 					"requires": {
-						"@babel/types": "^7.14.5"
+						"@babel/types": "^7.15.0"
 					}
 				},
 				"@babel/helper-optimise-call-expression": {
@@ -1553,14 +1553,14 @@
 					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
-					"integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
+					"integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.14.5",
+						"@babel/helper-member-expression-to-functions": "^7.15.0",
 						"@babel/helper-optimise-call-expression": "^7.14.5",
-						"@babel/traverse": "^7.14.5",
-						"@babel/types": "^7.14.5"
+						"@babel/traverse": "^7.15.0",
+						"@babel/types": "^7.15.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
@@ -1587,9 +1587,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.14.9",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.9.tgz",
-					"integrity": "sha512-RdUTOseXJ8POjjOeEBEvNMIZU/nm4yu2rufRkcibzkkg7DmQvXU8v3M4Xk9G7uuI86CDGkKcuDWgioqZm+mScQ=="
+					"version": "7.15.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+					"integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA=="
 				},
 				"@babel/template": {
 					"version": "7.14.5",
@@ -1602,25 +1602,25 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.14.9",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.9.tgz",
-					"integrity": "sha512-bldh6dtB49L8q9bUyB7bC20UKgU+EFDwKJylwl234Kv+ySZeMD31Xeht6URyueQ6LrRRpF2tmkfcZooZR9/e8g==",
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+					"integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
 					"requires": {
 						"@babel/code-frame": "^7.14.5",
-						"@babel/generator": "^7.14.9",
+						"@babel/generator": "^7.15.0",
 						"@babel/helper-function-name": "^7.14.5",
 						"@babel/helper-hoist-variables": "^7.14.5",
 						"@babel/helper-split-export-declaration": "^7.14.5",
-						"@babel/parser": "^7.14.9",
-						"@babel/types": "^7.14.9",
+						"@babel/parser": "^7.15.0",
+						"@babel/types": "^7.15.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0"
 					}
 				},
 				"@babel/types": {
-					"version": "7.14.9",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
-					"integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.14.9",
 						"to-fast-properties": "^2.0.0"
@@ -2772,9 +2772,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"is-stream": {
 					"version": "2.0.1",
@@ -2967,9 +2967,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"is-stream": {
 					"version": "2.0.1",
@@ -3166,9 +3166,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"is-stream": {
 					"version": "2.0.1",
@@ -3370,9 +3370,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"inflection": {
 					"version": "1.12.0",
@@ -3702,9 +3702,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"has-flag": {
 					"version": "4.0.0",
@@ -3937,9 +3937,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"is-stream": {
 					"version": "2.0.1",
@@ -4140,9 +4140,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"is-stream": {
 					"version": "2.0.1",
@@ -4340,9 +4340,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"heimdalljs": {
 					"version": "0.3.3",
@@ -4613,13 +4613,13 @@
 			}
 		},
 		"@ember/test-helpers": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-2.3.0.tgz",
-			"integrity": "sha512-MwG80aJj5NO19CgHHIQyrSXwzo0Xz0Vfx3MrvbzkqZSYowyazOrve8/UEt00ot6h3JxCVnbvL6rY/+G41pLE3A==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-2.4.0.tgz",
+			"integrity": "sha512-tNYc7rsgr6vWfwSD7dkGZzCovrbdPdPwdqs1Q3m38rCGry00PUNadFGM4LL8T/4YmJMghAri3FpVv685ZPVBUA==",
 			"requires": {
-				"@ember/test-waiters": "^2.4.4",
+				"@ember/test-waiters": "^2.4.5",
 				"broccoli-debug": "^0.6.5",
-				"broccoli-funnel": "^3.0.6",
+				"broccoli-funnel": "^3.0.8",
 				"ember-cli-babel": "^7.26.6",
 				"ember-cli-htmlbars": "^5.7.1",
 				"ember-destroyable-polyfill": "^2.0.3"
@@ -4964,9 +4964,9 @@
 					}
 				},
 				"globals": {
-					"version": "13.10.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-					"integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+					"version": "13.11.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+					"integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
 					"requires": {
 						"type-fest": "^0.20.2"
 					}
@@ -5342,9 +5342,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"is-stream": {
 					"version": "2.0.1",
@@ -8900,9 +8900,9 @@
 			}
 		},
 		"@types/faker": {
-			"version": "5.5.7",
-			"resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.7.tgz",
-			"integrity": "sha512-ejzb61Q5zQTtS0ZIafgQ7ahO5ACzmGhG5PfX2hxWyth3k0/aysb4ZOxKQB8DbzwSPppA5jmFBwqnBxjv5hqI5Q=="
+			"version": "5.5.8",
+			"resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.8.tgz",
+			"integrity": "sha512-bsl0rYsaZVHlZkynL5O04q6YXDmVjcid6MbOHWqvtE2WWs/EKhp0qchDDhVWlWyQXUffX1G83X9LnMxRl8S/Mw=="
 		},
 		"@types/fetch-mock": {
 			"version": "7.3.3",
@@ -9071,9 +9071,9 @@
 			"integrity": "sha512-Lja2xYuuf2B3knEsga8ShbOdsfNOtzT73GyJmZyY7eGl2+ajOqrs8yM5ze0fsSoYwvA6bw7/Qr7OZ7PEEmYwWg=="
 		},
 		"@types/url-parse": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
-			"integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw=="
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.4.tgz",
+			"integrity": "sha512-KtQLad12+4T/NfSxpoDhmr22+fig3T7/08QCgmutYA6QSznSRmEtuL95GrhVV40/0otTEdFc+etRcCTqhh1q5Q=="
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.9.0",
@@ -9246,9 +9246,9 @@
 			}
 		},
 		"@webpack-cli/serve": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.1.tgz",
-			"integrity": "sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw=="
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
+			"integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw=="
 		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
@@ -12356,9 +12356,9 @@
 					},
 					"dependencies": {
 						"graceful-fs": {
-							"version": "4.2.6",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-							"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+							"version": "4.2.8",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+							"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 						}
 					}
 				},
@@ -12735,9 +12735,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"jsonfile": {
 					"version": "4.0.0",
@@ -13120,9 +13120,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"jsonfile": {
 					"version": "4.0.0",
@@ -17311,9 +17311,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-					"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 				}
 			}
 		},
@@ -17463,9 +17463,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.794",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.794.tgz",
-			"integrity": "sha512-lN6h2N16+B64/DDNefd2qvehTJl/LDZ/ORXKL2JHaLGhVxjj7ybuA/oVprKtTNvmOTgzUrpP02HhgoS27E2rGA=="
+			"version": "1.3.806",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
+			"integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA=="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",
@@ -17500,9 +17500,9 @@
 			}
 		},
 		"ember-auto-import": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-1.11.3.tgz",
-			"integrity": "sha512-ekq/XCvsonESobFU30zjZ0I4XMy2E/2ZILCYWuQ1JdhcCSTYhnXDZcqRW8itUG7kbsPqAHT/XZ1LEZYm3seVwQ==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-1.12.0.tgz",
+			"integrity": "sha512-fzMGnyHGfUNFHchpLbJ98Vs/c5H2wZBMR9r/XwW+WOWPisZDGLUPPyhJQsSREPoUQ+o8GvyLaD/rkrKqW8bmgw==",
 			"requires": {
 				"@babel/core": "^7.1.6",
 				"@babel/preset-env": "^7.10.2",
@@ -17968,9 +17968,9 @@
 							}
 						},
 						"graceful-fs": {
-							"version": "4.2.6",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-							"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+							"version": "4.2.8",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+							"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 						},
 						"matcher-collection": {
 							"version": "2.0.1",
@@ -18005,9 +18005,9 @@
 					},
 					"dependencies": {
 						"graceful-fs": {
-							"version": "4.2.6",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-							"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+							"version": "4.2.8",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+							"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 						},
 						"jsonfile": {
 							"version": "6.1.0",
@@ -19067,9 +19067,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"is-stream": {
 					"version": "2.0.1",
@@ -19219,9 +19219,9 @@
 			}
 		},
 		"ember-compatibility-helpers": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.4.tgz",
-			"integrity": "sha512-qjzQVtogyYJrSs6I4DuyCDwDCaj5JWBVNPoZDZBk8pt7caNoN0eBYRYJdin95QKaNMQODxTLPWaI4UUDQ1YWhg==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.5.tgz",
+			"integrity": "sha512-7cddkQQp8Rs2Mqrj0xqZ0uO7eC9tBCKyZNcP2iE1RxQqOGPv8fiPkj1TUeidUB/Qe80lstoVXWMEuqqhW7Yy9A==",
 			"requires": {
 				"babel-plugin-debug-macros": "^0.2.0",
 				"ember-cli-version-checker": "^5.1.1",
@@ -19249,9 +19249,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"jsonfile": {
 					"version": "6.1.0",
@@ -19399,9 +19399,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"is-stream": {
 					"version": "2.0.1",
@@ -19529,11 +19529,11 @@
 			"integrity": "sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw=="
 		},
 		"ember-fetch": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-8.1.0.tgz",
-			"integrity": "sha512-797IPPuXrWGAecsAuCPH6+2pJCcawy7+CiRrtoe1qLhXJ6Ue0Lxu4loXxHHQNCxRvvUvx8tTDuP63sOKfi3xug==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-8.1.1.tgz",
+			"integrity": "sha512-Xi1wNmPtVmfIoFH675AA0ELIdYUcoZ2p+6j9c8eDFjiGJiFesyp01bDtl5ryBI/1VPOByJLsDkT+4C11HixsJw==",
 			"requires": {
-				"abortcontroller-polyfill": "^1.7.1",
+				"abortcontroller-polyfill": "^1.7.3",
 				"broccoli-concat": "^4.2.5",
 				"broccoli-debug": "^0.6.5",
 				"broccoli-merge-trees": "^4.2.0",
@@ -19543,22 +19543,12 @@
 				"calculate-cache-key-for-tree": "^2.0.0",
 				"caniuse-api": "^3.0.0",
 				"ember-cli-babel": "^7.23.1",
-				"ember-cli-typescript": "^3.1.3",
+				"ember-cli-typescript": "^4.1.0",
 				"ember-cli-version-checker": "^5.1.2",
 				"node-fetch": "^2.6.1",
 				"whatwg-fetch": "^3.6.2"
 			},
 			"dependencies": {
-				"@babel/plugin-transform-typescript": {
-					"version": "7.8.7",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz",
-					"integrity": "sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==",
-					"requires": {
-						"@babel/helper-create-class-features-plugin": "^7.8.3",
-						"@babel/helper-plugin-utils": "^7.8.3",
-						"@babel/plugin-syntax-typescript": "^7.8.3"
-					}
-				},
 				"@types/node": {
 					"version": "9.6.61",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.61.tgz",
@@ -19639,116 +19629,6 @@
 						}
 					}
 				},
-				"cross-spawn": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-					"requires": {
-						"path-key": "^3.1.0",
-						"shebang-command": "^2.0.0",
-						"which": "^2.0.1"
-					}
-				},
-				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ember-cli-typescript": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz",
-					"integrity": "sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==",
-					"requires": {
-						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
-						"@babel/plugin-proposal-optional-chaining": "^7.6.0",
-						"@babel/plugin-transform-typescript": "~7.8.0",
-						"ansi-to-html": "^0.6.6",
-						"broccoli-stew": "^3.0.0",
-						"debug": "^4.0.0",
-						"ember-cli-babel-plugin-helpers": "^1.0.0",
-						"execa": "^3.0.0",
-						"fs-extra": "^8.0.0",
-						"resolve": "^1.5.0",
-						"rsvp": "^4.8.1",
-						"semver": "^6.3.0",
-						"stagehand": "^1.0.0",
-						"walk-sync": "^2.0.0"
-					},
-					"dependencies": {
-						"rsvp": {
-							"version": "4.8.5",
-							"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-							"integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
-						},
-						"walk-sync": {
-							"version": "2.2.0",
-							"resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-							"integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-							"requires": {
-								"@types/minimatch": "^3.0.3",
-								"ensure-posix-path": "^1.1.0",
-								"matcher-collection": "^2.0.0",
-								"minimatch": "^3.0.4"
-							}
-						}
-					}
-				},
-				"execa": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-					"integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
-					"requires": {
-						"cross-spawn": "^7.0.0",
-						"get-stream": "^5.0.0",
-						"human-signals": "^1.1.1",
-						"is-stream": "^2.0.0",
-						"merge-stream": "^2.0.0",
-						"npm-run-path": "^4.0.0",
-						"onetime": "^5.1.0",
-						"p-finally": "^2.0.0",
-						"signal-exit": "^3.0.2",
-						"strip-final-newline": "^2.0.0"
-					}
-				},
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"get-stream": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
-				},
-				"is-stream": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-					"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
 				"magic-string": {
 					"version": "0.24.1",
 					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.24.1.tgz",
@@ -19756,51 +19636,6 @@
 					"requires": {
 						"sourcemap-codec": "^1.4.1"
 					}
-				},
-				"matcher-collection": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-					"integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-					"requires": {
-						"@types/minimatch": "^3.0.3",
-						"minimatch": "^3.0.2"
-					}
-				},
-				"mimic-fn": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				},
-				"npm-run-path": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-					"requires": {
-						"path-key": "^3.0.0"
-					}
-				},
-				"onetime": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-					"requires": {
-						"mimic-fn": "^2.1.0"
-					}
-				},
-				"p-finally": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-					"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
-				},
-				"path-key": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
 				},
 				"promise-map-series": {
 					"version": "0.3.0",
@@ -19837,32 +19672,6 @@
 					"version": "3.6.2",
 					"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
 					"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				},
-				"shebang-command": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-					"requires": {
-						"shebang-regex": "^3.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"requires": {
-						"isexe": "^2.0.0"
-					}
 				}
 			}
 		},
@@ -20499,9 +20308,9 @@
 			}
 		},
 		"ember-source": {
-			"version": "3.24.4",
-			"resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.24.4.tgz",
-			"integrity": "sha512-C5sFGxT743n2PCaTnpvy3GWHdPz+/Ve9qjcSdfRjUvFCSYNhsRkxkpXRvXEU8WoUXY35Pm4vV9RsiorX1M+/Tw==",
+			"version": "3.24.5",
+			"resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.24.5.tgz",
+			"integrity": "sha512-j39L7C+q9o9qkwrwNtRN1AVGzE8TlxHm0c6xMzFZFaWMyQt3E7ov72fz3oIn17h8H7zZ1i7dl471Rbqx1GZsLw==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.8.3",
 				"@babel/plugin-transform-block-scoping": "^7.8.3",
@@ -21288,9 +21097,9 @@
 					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
 				},
 				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
 				},
 				"object-inspect": {
 					"version": "1.11.0",
@@ -21493,9 +21302,9 @@
 					}
 				},
 				"globals": {
-					"version": "13.10.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-					"integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+					"version": "13.11.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+					"integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
 					"requires": {
 						"type-fest": "^0.20.2"
 					}
@@ -23089,9 +22898,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"jsonfile": {
 					"version": "4.0.0",
@@ -29720,9 +29529,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-					"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 				}
 			}
 		},
@@ -30937,9 +30746,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-					"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 				}
 			}
 		},
@@ -35309,9 +35118,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+					"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 				},
 				"jsonfile": {
 					"version": "4.0.0",
@@ -35974,9 +35783,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-					"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 				}
 			}
 		},
@@ -37849,9 +37658,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "16.4.10",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
-					"integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ=="
+					"version": "16.6.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
+					"integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw=="
 				},
 				"component-emitter": {
 					"version": "1.3.0",
@@ -39499,14 +39308,14 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.7.2.tgz",
-			"integrity": "sha512-mEoLmnmOIZQNiRl0ebnjzQ74Hk0iKS5SiEEnpq3dRezoyR3yPaeQZCMCe+db4524pj1Pd5ghZXjT41KLzIhSLw==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.8.0.tgz",
+			"integrity": "sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==",
 			"requires": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^1.0.4",
 				"@webpack-cli/info": "^1.3.0",
-				"@webpack-cli/serve": "^1.5.1",
+				"@webpack-cli/serve": "^1.5.2",
 				"colorette": "^1.2.1",
 				"commander": "^7.0.0",
 				"execa": "^5.0.0",

--- a/packages/common/src/groups/add-users-workflow/workflow-sections/invite-users.ts
+++ b/packages/common/src/groups/add-users-workflow/workflow-sections/invite-users.ts
@@ -2,7 +2,7 @@ import { IUser } from "@esri/arcgis-rest-auth";
 import {
   IInviteGroupUsersResult,
   IInviteGroupUsersOptions,
-  inviteGroupUsers
+  inviteGroupUsers,
 } from "@esri/arcgis-rest-portal";
 import { IAuthenticationManager } from "@esri/arcgis-rest-request";
 
@@ -21,16 +21,17 @@ export function inviteUsers(
   id: string,
   users: IUser[],
   authentication: IAuthenticationManager,
-  expiration = 20160 // default to 2 week expiration TODO: is this actually 2 weeks?
+  expiration = 20160, // default to 2 week expiration TODO: is this actually 2 weeks?
+  role: string = "group_member" // default to group member, but allow for team_admin as well
 ): Promise<IInviteGroupUsersResult> {
   let response: Promise<IInviteGroupUsersResult> = Promise.resolve(null);
   if (users.length) {
     const args: IInviteGroupUsersOptions = {
       id,
-      users: users.map(u => u.username),
+      users: users.map((u) => u.username),
       authentication,
-      role: "group_member",
-      expiration
+      role,
+      expiration,
     };
 
     response = inviteGroupUsers(args);

--- a/packages/common/src/groups/add-users-workflow/workflow-sections/invite-users.ts
+++ b/packages/common/src/groups/add-users-workflow/workflow-sections/invite-users.ts
@@ -14,6 +14,7 @@ import { IAuthenticationManager } from "@esri/arcgis-rest-request";
  * @param {object[]} users
  * @param {object} authentication
  * @param {number} expiration How long the invite will be active (in minutes)
+ * @param {string} role What role should they be added as. Defaults to group member
  *
  * @returns {object|null} Result of the transaction (null if no users are passed in)
  */
@@ -22,7 +23,7 @@ export function inviteUsers(
   users: IUser[],
   authentication: IAuthenticationManager,
   expiration = 20160, // default to 2 week expiration TODO: is this actually 2 weeks?
-  role: string = "group_member" // default to group member, but allow for team_admin as well
+  role: "group_member" | "group_admin" = "group_member" // default to group member, but allow for team_admin as well
 ): Promise<IInviteGroupUsersResult> {
   let response: Promise<IInviteGroupUsersResult> = Promise.resolve(null);
   if (users.length) {

--- a/packages/teams/src/utils/process-invite-users.ts
+++ b/packages/teams/src/utils/process-invite-users.ts
@@ -22,6 +22,7 @@ export async function processInviteUsers(
   const users: IUser[] = getProp(context, userType);
   const notInvited: string[] = [];
   let errors: ArcGISRequestError[] = [];
+  const { addUserAsGroupAdmin } = context;
   // iterate through users as we want a distinct invite call per user due to how
   // batch invites will only respond with success: true/false
   // and if there is an error then it gets priority even though successes do still go through
@@ -30,7 +31,9 @@ export async function processInviteUsers(
     const inviteResponse = await inviteUsers(
       getProp(context, "groupId"),
       [user],
-      getProp(context, "primaryRO")
+      getProp(context, "primaryRO"),
+      20160, // timeout
+      addUserAsGroupAdmin ? "group_admin" : "group_member" // if we are in a core team we want to invite them as a group admin, otherwise a group member
     );
     // If it's just a failed invite then
     // add username to notInvited array

--- a/packages/teams/test/utils/process-invite-users.test.ts
+++ b/packages/teams/test/utils/process-invite-users.test.ts
@@ -17,18 +17,64 @@ describe("processInviteUsers: ", () => {
     const context: IAddOrInviteContext = {
       groupId: "abc123",
       primaryRO: MOCK_AUTH,
-      allUsers: [{ orgType: "world", username: "bob" }, { orgType: "world", username: "frank" }, { orgType: "community", username: "bob" }, { orgType: "community", username: "frank" }],
+      allUsers: [
+        { orgType: "world", username: "bob" },
+        { orgType: "world", username: "frank" },
+        { orgType: "community", username: "bob" },
+        { orgType: "community", username: "frank" },
+      ],
       canAutoAddUser: false,
       addUserAsGroupAdmin: false,
       email: undefined,
-      world: [{ orgType: "world", username: "bob" }, { orgType: "world", username: "frank" }],
+      world: [
+        { orgType: "world", username: "bob" },
+        { orgType: "world", username: "frank" },
+      ],
       org: [],
-      community: [{ orgType: "community", username: "bob" }, { orgType: "community", username: "frank" }],
+      community: [
+        { orgType: "community", username: "bob" },
+        { orgType: "community", username: "frank" },
+      ],
     };
     inviteUsersSpy.and.callFake(() => Promise.resolve({ success: true }));
     const result = await processInviteUsers(context, "community");
     expect(inviteUsersSpy).toHaveBeenCalled();
     expect(inviteUsersSpy.calls.count()).toEqual(2);
+    expect(inviteUsersSpy.calls.argsFor(0)[4]).toEqual("group_member");
+    expect(inviteUsersSpy.calls.argsFor(1)[4]).toEqual("group_member");
+    expect(result.users.length).toEqual(2);
+    expect(result.notInvited.length).toEqual(0);
+    expect(result.errors.length).toEqual(0);
+  });
+  it("flows through happy path...when inviting as admin", async () => {
+    const context: IAddOrInviteContext = {
+      groupId: "abc123",
+      primaryRO: MOCK_AUTH,
+      allUsers: [
+        { orgType: "world", username: "bob" },
+        { orgType: "world", username: "frank" },
+        { orgType: "community", username: "bob" },
+        { orgType: "community", username: "frank" },
+      ],
+      canAutoAddUser: false,
+      addUserAsGroupAdmin: true,
+      email: undefined,
+      world: [
+        { orgType: "world", username: "bob" },
+        { orgType: "world", username: "frank" },
+      ],
+      org: [],
+      community: [
+        { orgType: "community", username: "bob" },
+        { orgType: "community", username: "frank" },
+      ],
+    };
+    inviteUsersSpy.and.callFake(() => Promise.resolve({ success: true }));
+    const result = await processInviteUsers(context, "community");
+    expect(inviteUsersSpy).toHaveBeenCalled();
+    expect(inviteUsersSpy.calls.count()).toEqual(2);
+    expect(inviteUsersSpy.calls.argsFor(0)[4]).toEqual("group_admin");
+    expect(inviteUsersSpy.calls.argsFor(1)[4]).toEqual("group_admin");
     expect(result.users.length).toEqual(2);
     expect(result.notInvited.length).toEqual(0);
     expect(result.errors.length).toEqual(0);
@@ -37,13 +83,24 @@ describe("processInviteUsers: ", () => {
     const context: IAddOrInviteContext = {
       groupId: "abc123",
       primaryRO: MOCK_AUTH,
-      allUsers: [{ orgType: "world", username: "bob" }, { orgType: "world", username: "frank" }, { orgType: "community", username: "bob" }, { orgType: "community", username: "frank" }],
+      allUsers: [
+        { orgType: "world", username: "bob" },
+        { orgType: "world", username: "frank" },
+        { orgType: "community", username: "bob" },
+        { orgType: "community", username: "frank" },
+      ],
       canAutoAddUser: false,
       addUserAsGroupAdmin: false,
       email: undefined,
-      world: [{ orgType: "world", username: "bob" }, { orgType: "world", username: "frank" }],
+      world: [
+        { orgType: "world", username: "bob" },
+        { orgType: "world", username: "frank" },
+      ],
       org: [],
-      community: [{ orgType: "community", username: "bob" }, { orgType: "community", username: "frank" }],
+      community: [
+        { orgType: "community", username: "bob" },
+        { orgType: "community", username: "frank" },
+      ],
     };
     inviteUsersSpy.and.callFake(() => Promise.resolve({ success: false }));
     const result = await processInviteUsers(context, "community");
@@ -57,13 +114,24 @@ describe("processInviteUsers: ", () => {
     const context: IAddOrInviteContext = {
       groupId: "abc123",
       primaryRO: MOCK_AUTH,
-      allUsers: [{ orgType: "community", username: "bob" }, { orgType: "community", username: "frank" }, { orgType: "world", username: "bob" }, { orgType: "world", username: "frank" }],
+      allUsers: [
+        { orgType: "community", username: "bob" },
+        { orgType: "community", username: "frank" },
+        { orgType: "world", username: "bob" },
+        { orgType: "world", username: "frank" },
+      ],
       canAutoAddUser: false,
       addUserAsGroupAdmin: false,
       email: undefined,
-      world: [{ orgType: "world", username: "bob" }, { orgType: "world", username: "frank" }],
+      world: [
+        { orgType: "world", username: "bob" },
+        { orgType: "world", username: "frank" },
+      ],
       org: [],
-      community: [{ orgType: "community", username: "bob" }, { orgType: "community", username: "frank" }],
+      community: [
+        { orgType: "community", username: "bob" },
+        { orgType: "community", username: "frank" },
+      ],
     };
     const error = new ArcGISRequestError("Email not sent");
     inviteUsersSpy.and.callFake(() =>


### PR DESCRIPTION
1. Description:
Made a slight oversight in a case where an admin in a core team can only invite users (not auto add them), we still want the person invited to be invited as an admin. This opens that option up.

1. Instructions for testing:

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/1758

1. [ ] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
