### PR TITLE
feat(hub-common): add isMapOrFeatureServerUrl

### DIFF
--- a/packages/common/src/urls/index.ts
+++ b/packages/common/src/urls/index.ts
@@ -11,3 +11,7 @@ export * from "./get-hub-url-from-portal";
 export * from "./get-item-home-url";
 export * from "./get-item-api-url";
 export * from "./get-item-data-url";
+
+export const isMapOrFeatureServerUrl = (url: string) => {
+  return /\/(map|feature)server/i.test(url);
+};

--- a/packages/content/src/enrichments.ts
+++ b/packages/content/src/enrichments.ts
@@ -19,6 +19,7 @@ import {
   getLayerIdFromUrl,
   includes,
   isFeatureService,
+  isMapOrFeatureServerUrl,
   isNil,
   OperationStack,
 } from "@esri/hub-common";
@@ -438,10 +439,6 @@ const isHubCreatedContent = (content: IHubContent) => {
 
 const shouldFetchOrgId = (content: IHubContent) => {
   return !content.orgId && isHubCreatedContent(content);
-};
-
-const isMapOrFeatureServerUrl = (url: string) => {
-  return /\/(map|feature)server/i.test(url);
 };
 
 // as this becomes more complicated, we'll probably want to


### PR DESCRIPTION
affects: @esri/hub-common, @esri/hub-content

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
