### PR TITLE
B/layer datasets have wrong item type

### DIFF
--- a/packages/common/src/urls/index.ts
+++ b/packages/common/src/urls/index.ts
@@ -1,3 +1,4 @@
+import { capitalize } from "../util";
 export * from "./build-url";
 export * from "./get-hub-locale-asset-url";
 export * from "./get-portal-api-url";
@@ -12,6 +13,25 @@ export * from "./get-item-home-url";
 export * from "./get-item-api-url";
 export * from "./get-item-data-url";
 
+const MAP_OR_FEATURE_SERVER_URL_REGEX = /\/(map|feature)server/i;
+
+/**
+ *
+ * @param url
+ * @returns true if the url is of a map or feature service
+ */
 export const isMapOrFeatureServerUrl = (url: string) => {
-  return /\/(map|feature)server/i.test(url);
+  return MAP_OR_FEATURE_SERVER_URL_REGEX.test(url);
+};
+
+/**
+ * parses map or feature service type from URL
+ * @param url map or feature service URL
+ * @returns item type, either "Map Service" or "Feature Service"
+ * or undefined for other types of URLs
+ */
+export const getServiceTypeFromUrl = (url: string) => {
+  const match = url.match(MAP_OR_FEATURE_SERVER_URL_REGEX);
+  const mapOrFeature = match && match[1];
+  return mapOrFeature && `${capitalize(mapOrFeature)} Service`;
 };

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -395,3 +395,15 @@ export function chunkArray(arr: any[], size: number) {
  * @returns
  */
 export const isNil = (value: unknown) => value == null;
+
+/**
+ * Upper case first letter (only) of a string
+ * @param word
+ * @returns Word
+ */
+export const capitalize = (word: string) => {
+  // upper case first letter and return as element in array for backwards compatibility
+  const chars = Array.from(word);
+  chars[0] = chars[0].toUpperCase();
+  return chars.join("");
+};

--- a/packages/content/src/portal.ts
+++ b/packages/content/src/portal.ts
@@ -82,6 +82,7 @@ export function itemToContent(item: IItem): IHubContent {
     // we don't store item.name in the Hub API and we use name for title
     name: item.title,
     family: getFamily(normalizedType),
+    // TODO: hubType is no longer used, remove it at next breaking change
     hubType: getItemHubType(item),
     normalizedType,
     categories: parseItemCategories(item.categories),
@@ -117,11 +118,16 @@ export function itemToContent(item: IItem): IHubContent {
 }
 
 /**
+ * DEPRECATED: Use getFamily() instead.
+ *
  * get the HubType for a given item or item type
  *
  * @param itemOrType an item or item.type
  */
 export function getItemHubType(itemOrType: IItem | string): HubType {
+  console.warn(
+    "DEPRECATED: Use getFamily() instead. getItemHubType() will be removed at v9.0.0"
+  );
   if (typeof itemOrType === "string") {
     itemOrType = { type: itemOrType } as IItem;
   }

--- a/packages/content/test/hub.test.ts
+++ b/packages/content/test/hub.test.ts
@@ -4,7 +4,7 @@ import {
   parseDatasetId,
   datasetToItem,
   getContentFromHub,
-  datasetToContent
+  datasetToContent,
 } from "../src/index";
 import { IHubRequestOptions, cloneObject, IHubContent } from "@esri/hub-common";
 import * as documentsJson from "./mocks/datasets/document.json";
@@ -15,7 +15,7 @@ import { mockUserSession } from "./test-helpers/fake-user-session";
 function validateContentFromDataset(
   content: IHubContent,
   dataset: DatasetResource,
-  expectedHubType: string
+  expectedFamily: string
 ) {
   const { id, attributes } = dataset;
   // should have copied these attributes directly
@@ -37,11 +37,11 @@ function validateContentFromDataset(
     "url",
     "access",
     "size",
-    "commentsEnabled"
+    "commentsEnabled",
     // TODO: what about the others that will be undefined?
   ];
   // should have set item properties
-  itemProperties.forEach(key => {
+  itemProperties.forEach((key) => {
     expect(content[key]).toEqual(attributes[key]);
   });
   // we use attributes.name for both name and title
@@ -51,13 +51,13 @@ function validateContentFromDataset(
   expect(content.hubId).toBe(id);
   const extent = attributes.extent;
   expect(content.extent).toEqual(extent && extent.coordinates);
-  expect(content.hubType).toBe(expectedHubType);
+  expect(content.family).toBe(expectedFamily);
   expect(content.summary).toBe(
     attributes.searchDescription || attributes.snippet
   );
   expect(content.publisher).toEqual({
     name: attributes.owner,
-    username: attributes.owner
+    username: attributes.owner,
   });
   expect(content.permissions.visibility).toBe(attributes.access);
   // no itemControl returned w/ this item, expect default
@@ -86,7 +86,7 @@ function validateContentFromDataset(
 }
 
 describe("hub", () => {
-  describe("parseDatasetId", function() {
+  describe("parseDatasetId", function () {
     it("returns undefined", () => {
       const result = parseDatasetId(undefined);
       expect(result).toEqual({ itemId: undefined, layerId: undefined });
@@ -95,14 +95,14 @@ describe("hub", () => {
       const result = parseDatasetId("7a153563b0c74f7eb2b3eae8a66f2fbb");
       expect(result).toEqual({
         itemId: "7a153563b0c74f7eb2b3eae8a66f2fbb",
-        layerId: undefined
+        layerId: undefined,
       });
     });
     it("parse item id and layer id", () => {
       const result = parseDatasetId("7a153563b0c74f7eb2b3eae8a66f2fbb_0");
       expect(result).toEqual({
         itemId: "7a153563b0c74f7eb2b3eae8a66f2fbb",
-        layerId: "0"
+        layerId: "0",
       });
     });
   });
@@ -163,7 +163,7 @@ describe("hub", () => {
         orgId: id,
         orgExtent: extent,
         orgName: name,
-        organization
+        organization,
       } = dataset.attributes;
       let content = datasetToContent(dataset);
       expect(content.org).toEqual({ id, extent, name });
@@ -196,15 +196,15 @@ describe("hub", () => {
           user: {},
           id: "123",
           isPortal: false,
-          name: "some-portal"
+          name: "some-portal",
         },
         isPortal: false,
         hubApiUrl: "https://some.url.com/",
-        authentication: mockUserSession
+        authentication: mockUserSession,
       };
     });
     afterEach(fetchMock.restore);
-    it("should fetch a dataset record by id and return content", done => {
+    it("should fetch a dataset record by id and return content", (done) => {
       fetchMock.once(
         "https://some.url.com/api/v3/datasets/7a153563b0c74f7eb2b3eae8a66f2fbb_0",
         featureLayerJson
@@ -216,7 +216,7 @@ describe("hub", () => {
       const dataset = featureLayerJson.data as DatasetResource;
       const datasetId = dataset.id;
       const itemId = parseDatasetId(datasetId).itemId;
-      getContentFromHub(datasetId, requestOpts).then(content => {
+      getContentFromHub(datasetId, requestOpts).then((content) => {
         // verify that we attempted to fetch from the portal API
         let [url, opts] = fetchMock.calls()[0];
         expect(url).toBe(`https://some.url.com/api/v3/datasets/${datasetId}`);
@@ -242,7 +242,7 @@ describe("hub", () => {
         done();
       });
     });
-    it("should fetch a dataset record by id when unauthenticated and return content", done => {
+    it("should fetch a dataset record by id when unauthenticated and return content", (done) => {
       fetchMock.once(
         "https://some.url.com/api/v3/datasets/7a153563b0c74f7eb2b3eae8a66f2fbb_0",
         featureLayerJson
@@ -250,7 +250,7 @@ describe("hub", () => {
       const dataset = featureLayerJson.data as DatasetResource;
       const id = dataset.id;
       delete requestOpts.authentication;
-      getContentFromHub(id, requestOpts).then(content => {
+      getContentFromHub(id, requestOpts).then((content) => {
         // verify that we attempted to fetch from the portal API
         const [url, opts] = fetchMock.calls()[0];
         expect(url).toBe(`https://some.url.com/api/v3/datasets/${id}`);
@@ -272,11 +272,11 @@ describe("hub", () => {
         done();
       });
     });
-    it("should fetch a dataset record by slug and return content", done => {
+    it("should fetch a dataset record by slug and return content", (done) => {
       const featureLayersJson = {
         // slug requests to datasets w/ filter which returns an array
         data: [featureLayerJson.data],
-        meta: featureLayerJson.meta
+        meta: featureLayerJson.meta,
       };
       fetchMock.once(
         "https://some.url.com/api/v3/datasets?filter%5Bslug%5D=Wigan%3A%3Aout-of-work-benefit-claims",
@@ -289,7 +289,7 @@ describe("hub", () => {
       const dataset = featureLayersJson.data[0] as DatasetResource;
       const ItemId = parseDatasetId(dataset.id).itemId;
       const slug = "Wigan::out-of-work-benefit-claims";
-      getContentFromHub(slug, requestOpts).then(content => {
+      getContentFromHub(slug, requestOpts).then((content) => {
         // verify that we attempted to fetch from the portal API
         let [url, opts] = fetchMock.calls()[0];
         expect(url).toBe(


### PR DESCRIPTION
1. Description: add `getServiceTypeFromUrl()` to derive the item type based on URL b/c the `type` returned from the Hub API will be the layer's type for feature layers, tables, and raster layers. Fix `content.item.type` so that it has the correct type in these cases.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
