### PR TITLE
fix(hub-content): normalizedType should be based on content.type, not…

### DIFF
--- a/packages/content/src/hub.ts
+++ b/packages/content/src/hub.ts
@@ -11,6 +11,7 @@ import { getFamily, itemToContent } from "./portal";
 import { isSlug, addContextToSlug, parseDatasetId } from "./slugs";
 import { enrichContent, IEnrichContentOptions } from "./enrichments";
 import { isExtentCoordinateArray } from "@esri/hub-common";
+import { normalizeItemType } from "@esri/hub-common";
 
 export interface IGetContentOptions extends IEnrichContentOptions {
   siteOrgKey?: string;
@@ -165,6 +166,7 @@ export function datasetToContent(dataset: DatasetResource): IHubContent {
 
   // use the type returned by the API (i.e. possibly layer.type)
   content.type = type;
+  content.normalizedType = normalizeItemType({ ...content.item, type });
   content.family = getFamily(type);
 
   // NOTE: we could throw or return if there are errors


### PR DESCRIPTION
… item.type

affects: @esri/hub-content

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
