### PR TITLE
fix(hub-search): hub search requests were sending "undefined" authent…

### DIFF
--- a/packages/search/src/content/index.ts
+++ b/packages/search/src/content/index.ts
@@ -333,16 +333,14 @@ function performHubContentSearch(
 
   const hubApiUrl: string = getHubApiUrl(portal);
   const requestParams: ISearchParams = convertToHubParams(request);
+  const headers = authentication &&
+    authentication.serialize && { authentication: authentication.serialize() };
 
   return hubApiRequest("/search", {
     hubApiUrl,
     authentication,
     isPortal: false,
-    headers: {
-      authentication: authentication
-        ? JSON.stringify(authentication)
-        : undefined,
-    },
+    headers,
     httpMethod: "POST",
     params: requestParams,
   }).then((response: any) =>

--- a/packages/search/test/content/index.test.ts
+++ b/packages/search/test/content/index.test.ts
@@ -491,9 +491,7 @@ describe("Content Search Service", () => {
           hubApiUrl: "https://hubqa.arcgis.com",
           authentication: undefined,
           isPortal: false,
-          headers: {
-            authentication: undefined,
-          },
+          headers: undefined,
           httpMethod: "POST",
           params: {
             sort: "name",
@@ -587,9 +585,7 @@ describe("Content Search Service", () => {
           hubApiUrl: "https://hubqa.arcgis.com",
           authentication: undefined,
           isPortal: false,
-          headers: {
-            authentication: undefined,
-          },
+          headers: undefined,
           httpMethod: "POST",
           params: {
             sort: undefined,
@@ -961,9 +957,7 @@ describe("searchContent function", () => {
           hubApiUrl: "https://hub.arcgis.com",
           authentication: undefined,
           isPortal: false,
-          headers: {
-            authentication: undefined,
-          },
+          headers: undefined,
           httpMethod: "POST",
           params: {
             sort: undefined,
@@ -1065,9 +1059,7 @@ describe("searchContent function", () => {
           hubApiUrl: "https://hubqa.arcgis.com",
           authentication: undefined,
           isPortal: false,
-          headers: {
-            authentication: undefined,
-          },
+          headers: undefined,
           httpMethod: "POST",
           params: {
             sort: "name",


### PR DESCRIPTION
…ication header

affects: @esri/hub-search

don't send any headers if the user is not authenticated

ISSUES CLOSED: https://devtopia.esri.com/dc/hub/issues/1946

1. Description:

1. Instructions for testing:

1. Closes Issues: [1946](https://devtopia.esri.com/dc/hub/issues/1946)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
