### PR TITLE
fix(hub-common): hupApiUrl, isPortal, and authentication options shou…

### DIFF
--- a/packages/common/src/api.ts
+++ b/packages/common/src/api.ts
@@ -17,5 +17,11 @@ import { _getHubUrlFromPortalHostname } from "./urls/_get-hub-url-from-portal-ho
 export function getHubApiUrl(
   urlOrObject: IPortal | IHubRequestOptions | IRequestOptions | string
 ): string {
+  const hubApiUrl =
+    urlOrObject && (urlOrObject as IHubRequestOptions).hubApiUrl;
+  if (hubApiUrl) {
+    // this is request options w/ hubApiUrl already defined
+    return hubApiUrl;
+  }
   return _getHubUrlFromPortalHostname(getPortalApiUrl(urlOrObject));
 }

--- a/packages/common/src/request.ts
+++ b/packages/common/src/request.ts
@@ -1,3 +1,4 @@
+import { getHubApiUrl } from ".";
 import { IHubRequestOptions } from "./types";
 import { buildUrl } from "./urls/build-url";
 
@@ -35,16 +36,16 @@ export function hubApiRequest(
 ) {
   // merge in default request options
   const options: IHubRequestOptions = {
-    hubApiUrl: "https://opendata.arcgis.com/api/v3/",
+    // why do we default to GET w/ our API?
     httpMethod: "GET",
-    ...requestOptions
+    ...requestOptions,
   };
   // use fetch override if any
   const _fetch = options.fetch || fetch;
   // merge in default headers
   const headers = {
     "Content-Type": "application/json",
-    ...options.headers
+    ...options.headers,
   };
   // build query params/body based on requestOptions.params
   let query;
@@ -58,15 +59,15 @@ export function hubApiRequest(
   }
   // build Hub API URL
   const url = buildUrl({
-    host: options.hubApiUrl,
+    host: getHubApiUrl(options),
     path: `/api/v3/${route}`.replace(/\/\//g, "/"),
-    query
+    query,
   });
   return _fetch(url, {
     method: options.httpMethod,
     headers,
-    body
-  }).then(resp => {
+    body,
+  }).then((resp) => {
     if (resp.ok) {
       return resp.json();
     } else {

--- a/packages/common/src/sites/domains/_get-domain-service-url.ts
+++ b/packages/common/src/sites/domains/_get-domain-service-url.ts
@@ -3,7 +3,7 @@
  * @param {string} hubApiUrl
  * @private
  */
-export function _getDomainServiceUrl(hubApiUrl: string) {
+export function _getDomainServiceUrl(hubApiUrl?: string) {
   const base = hubApiUrl || "https://hub.arcgis.com";
   return `${base}/api/v3/domains`;
 }

--- a/packages/common/src/sites/domains/ensure-unique-domain-name.ts
+++ b/packages/common/src/sites/domains/ensure-unique-domain-name.ts
@@ -3,6 +3,7 @@ import { getUniqueDomainName } from "./get-unique-domain-name";
 import { _ensureSafeDomainLength } from "./_ensure-safe-domain-length";
 import { IHubRequestOptions } from "../../types";
 import { stripProtocol } from "../../urls";
+import { getHubApiUrl } from "../..";
 
 /**
  * Given a subdomain, ensure that we have a unique hostname
@@ -19,7 +20,7 @@ export function ensureUniqueDomainName(
     prms = getUniqueDomainNamePortal(subdomain, hubRequestOptions);
   } else {
     const baseDomain = `${hubRequestOptions.portalSelf.urlKey}.${stripProtocol(
-      hubRequestOptions.hubApiUrl
+      getHubApiUrl(hubRequestOptions)
     )}`;
     prms = getUniqueDomainName(subdomain, baseDomain, hubRequestOptions);
   }

--- a/packages/common/src/sites/domains/is-valid-domain.ts
+++ b/packages/common/src/sites/domains/is-valid-domain.ts
@@ -1,5 +1,6 @@
 import { _getAuthHeader } from "./_get-auth-header";
 import { IHubRequestOptions } from "../../types";
+import { _getDomainServiceUrl } from ".";
 
 /**
  * Validate a custom domain
@@ -13,7 +14,9 @@ export function isValidDomain(
   if (hubRequestOptions.isPortal) {
     throw new Error(`isValidDomain is not available in ArcGIS Enterprise.`);
   }
-  const url = `${hubRequestOptions.hubApiUrl}/api/v3/domains/validate?hostname=${hostname}`;
+  const url = `${_getDomainServiceUrl(
+    hubRequestOptions.hubApiUrl
+  )}/validate?hostname=${hostname}`;
   const headers = _getAuthHeader(hubRequestOptions);
 
   return fetch(url, { method: "GET", headers, mode: "cors" })

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -10,8 +10,9 @@ import {
   ILayerDefinition,
 } from "@esri/arcgis-rest-types";
 import { IPortal, ISearchResult } from "@esri/arcgis-rest-portal";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import { UserSession } from "@esri/arcgis-rest-auth";
 import { IStructuredLicense } from "./items/get-structured-license";
+import { IRequestOptions } from "@esri/arcgis-rest-request";
 
 /**
  * Generic Model, used with all items that have a json
@@ -102,10 +103,18 @@ interface IHubRequestOptionsPortalSelf extends IPortal {
   user?: IUser;
 }
 
-export interface IHubRequestOptions extends IUserRequestOptions {
-  isPortal: boolean;
-  hubApiUrl: string;
+export interface IHubRequestOptions extends IRequestOptions {
+  authentication?: UserSession;
+  isPortal?: boolean;
+  hubApiUrl?: string;
   portalSelf?: IHubRequestOptionsPortalSelf;
+}
+
+/**
+ * Options for requests that require an authenticated user.
+ */
+export interface IHubUserRequestOptions extends IHubRequestOptions {
+  authentication: UserSession;
 }
 
 export interface IItemResource {
@@ -430,9 +439,8 @@ export interface ISerializedOperationStack {
  * @export
  * @interface UpdateSiteOptions
  */
-export interface IUpdateSiteOptions extends IHubRequestOptions {
+export interface IUpdateSiteOptions extends IUpdatePageOptions {
   updateVersions?: boolean;
-  allowList?: string[];
 }
 
 /**
@@ -443,7 +451,7 @@ export interface IUpdateSiteOptions extends IHubRequestOptions {
  * @export
  * @interface UpdatePageOptions
  */
-export interface IUpdatePageOptions extends IHubRequestOptions {
+export interface IUpdatePageOptions extends IHubUserRequestOptions {
   allowList?: string[];
 }
 

--- a/packages/common/src/urls/get-hub-api-url-from-portal.ts
+++ b/packages/common/src/urls/get-hub-api-url-from-portal.ts
@@ -6,5 +6,5 @@ import { getHubUrlFromPortal } from "./get-hub-url-from-portal";
  * @param {Object} portal Portal Self
  */
 export function getHubApiUrlFromPortal(portal: IPortal): string {
-  return `${getHubUrlFromPortal(portal)}/api/v3`;
+  return `${getHubUrlFromPortal(portal)}`;
 }

--- a/packages/common/src/urls/get-hub-api-url-from-portal.ts
+++ b/packages/common/src/urls/get-hub-api-url-from-portal.ts
@@ -6,5 +6,5 @@ import { getHubUrlFromPortal } from "./get-hub-url-from-portal";
  * @param {Object} portal Portal Self
  */
 export function getHubApiUrlFromPortal(portal: IPortal): string {
-  return `${getHubUrlFromPortal(portal)}`;
+  return `${getHubUrlFromPortal(portal)}/api/v3`;
 }

--- a/packages/common/test/api.test.ts
+++ b/packages/common/test/api.test.ts
@@ -1,5 +1,6 @@
 import { getHubApiUrl } from "../src/api";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { IHubRequestOptions } from "../src/types";
 
 describe("getHubApiUrl", () => {
   let ro: IRequestOptions;
@@ -9,8 +10,8 @@ describe("getHubApiUrl", () => {
         portal: null,
         getToken() {
           return Promise.resolve("FAKE-TOKEN");
-        }
-      }
+        },
+      },
     };
   });
 
@@ -49,5 +50,13 @@ describe("getHubApiUrl", () => {
   it("can retrieve dev base url 2", () => {
     ro.authentication.portal = "https://devext.arcgis.com/sharing/rest";
     expect(getHubApiUrl(ro)).toBe("https://hubdev.arcgis.com");
+  });
+
+  it("returns existing hubApiUrl on IHubRequestOptions", () => {
+    const hubApiUrl = "fake.url.com";
+    const hro: IHubRequestOptions = {
+      hubApiUrl,
+    };
+    expect(getHubApiUrl(hro)).toBe(hubApiUrl);
   });
 });

--- a/packages/common/test/request.test.ts
+++ b/packages/common/test/request.test.ts
@@ -2,20 +2,20 @@ import * as fetchMock from "fetch-mock";
 import { hubApiRequest } from "../src/request";
 
 describe("hubApiRequest", () => {
-  it("handles a server error", done => {
+  it("handles a server error", (done) => {
     const status = 403;
     const route = "badurl";
     fetchMock.once("*", {
-      status
+      status,
     });
-    hubApiRequest(route).catch(e => {
+    hubApiRequest(route).catch((e) => {
       expect(e.message).toBe("Forbidden");
       expect(e.status).toBe(status);
-      expect(e.url).toBe(`https://opendata.arcgis.com/api/v3/${route}`);
+      expect(e.url).toBe(`https://hub.arcgis.com/api/v3/${route}`);
       done();
     });
   });
-  it("stringfies params in the body of POST", done => {
+  it("stringfies params in the body of POST", (done) => {
     fetchMock.once("*", { the: "goods" });
     hubApiRequest("datasets", {
       isPortal: false,
@@ -23,9 +23,9 @@ describe("hubApiRequest", () => {
       httpMethod: "POST",
       authentication: null,
       params: {
-        foo: "bar"
-      }
-    }).then(response => {
+        foo: "bar",
+      },
+    }).then((response) => {
       const [url, options] = fetchMock.calls()[0];
       expect(url).toEqual("https://some.url.com/api/v3/datasets");
       expect(options.body).toBe('{"foo":"bar"}');

--- a/packages/sites/src/_remove-site-from-index.ts
+++ b/packages/sites/src/_remove-site-from-index.ts
@@ -1,4 +1,4 @@
-import { IModel, IHubRequestOptions } from "@esri/hub-common";
+import { IModel, IHubRequestOptions, getHubApiUrl } from "@esri/hub-common";
 
 /**
  * Remove a Site from the Hub Index system
@@ -13,21 +13,21 @@ export function _removeSiteFromIndex(
   if (hubRequestOptions.isPortal) {
     return Promise.resolve();
   } else {
-    const url = `${hubRequestOptions.hubApiUrl}/v2/${siteModel.item.id}`;
+    const url = `${getHubApiUrl(hubRequestOptions)}/v2/${siteModel.item.id}`;
     const opts = {
       method: "DELETE",
       mode: "cors",
       headers: {
-        Authorization: hubRequestOptions.authentication.token
-      }
+        Authorization: hubRequestOptions.authentication.token,
+      },
     } as RequestInit;
     return fetch(url, opts)
-      .then(raw => raw.json())
-      .then(_ => {
+      .then((raw) => raw.json())
+      .then((_) => {
         // TODO: Should we do anything here?
         return { success: true };
       })
-      .catch(err => {
+      .catch((err) => {
         throw Error(
           `_removeSiteFromIndex: Error removing site from index: ${err}`
         );

--- a/packages/sites/src/_remove-site-from-index.ts
+++ b/packages/sites/src/_remove-site-from-index.ts
@@ -13,7 +13,9 @@ export function _removeSiteFromIndex(
   if (hubRequestOptions.isPortal) {
     return Promise.resolve();
   } else {
-    const url = `${getHubApiUrl(hubRequestOptions)}/v2/${siteModel.item.id}`;
+    const url = `${getHubApiUrl(hubRequestOptions)}/api/v3/${
+      siteModel.item.id
+    }`;
     const opts = {
       method: "DELETE",
       mode: "cors",

--- a/packages/sites/src/create-site-model-from-template.ts
+++ b/packages/sites/src/create-site-model-from-template.ts
@@ -9,6 +9,7 @@ import {
   stripProtocol,
   interpolate,
   addSolutionResourceUrlToAssets,
+  getHubApiUrl,
 } from "@esri/hub-common";
 import { createHubTeams } from "@esri/hub-teams";
 import { HubTeamType } from "@esri/hub-teams";
@@ -114,12 +115,9 @@ export function createSiteModelFromTemplate(
         );
         settings.solution.url = getPortalSiteUrl(uniqueSubdomain, portal);
       } else {
-        settings.solution.defaultHostname = `${uniqueSubdomain}-${
-          portal.urlKey
-        }.${stripProtocol(hubRequestOptions.hubApiUrl)}`;
-        settings.solution.url = `https://${uniqueSubdomain}-${
-          portal.urlKey
-        }.${stripProtocol(hubRequestOptions.hubApiUrl)}`;
+        const base = stripProtocol(getHubApiUrl(hubRequestOptions));
+        settings.solution.defaultHostname = `${uniqueSubdomain}-${portal.urlKey}.${base}`;
+        settings.solution.url = `https://${uniqueSubdomain}-${portal.urlKey}.${base}`;
       }
 
       // create the initiative

--- a/packages/sites/src/drafts/save-published-status.ts
+++ b/packages/sites/src/drafts/save-published-status.ts
@@ -1,4 +1,4 @@
-import { IModel, IHubRequestOptions } from "@esri/hub-common";
+import { IHubUserRequestOptions, IModel } from "@esri/hub-common";
 import { updateSite } from "../update-site";
 import { updatePage, isPage } from "../pages";
 import { isSite } from "../is-site";
@@ -10,11 +10,11 @@ import { hasUnpublishedChanges } from "./has-unpublished-changes";
  * leaving everything else on the model alone.
  *
  * @param siteOrPageModel
- * @param hubRequestOptions
+ * @param requestOptions
  */
 export function savePublishedStatus(
   siteOrPageModel: IModel,
-  hubRequestOptions: IHubRequestOptions
+  requestOptions: IHubUserRequestOptions
 ): Promise<IUpdateItemResponse> {
   const allowList = ["item.typeKeywords"]; // only want to save typeKeywords
   const { item } = siteOrPageModel;
@@ -28,14 +28,14 @@ export function savePublishedStatus(
     // changes
     const isUnpublished = hasUnpublishedChanges(siteOrPageModel);
     prms = updateSite(siteOrPageModel, {
-      ...hubRequestOptions,
+      ...requestOptions,
       allowList,
-      updateVersions: !isUnpublished
+      updateVersions: !isUnpublished,
     });
   } else if (isPage(item)) {
     prms = updatePage(siteOrPageModel, {
-      ...hubRequestOptions,
-      allowList
+      ...requestOptions,
+      allowList,
     });
   } else {
     throw TypeError(

--- a/packages/sites/src/pages/remove-page.ts
+++ b/packages/sites/src/pages/remove-page.ts
@@ -1,14 +1,14 @@
 import {
   IModel,
-  IHubRequestOptions,
   getModel,
   mapBy,
   getWithDefault,
   failSafe,
-  unprotectModel
+  unprotectModel,
 } from "@esri/hub-common";
 import { unlinkSiteAndPage } from "../unlink-site-and-page";
-import { removeItem } from "@esri/arcgis-rest-portal";
+import { IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 /**
  * Remove a Page Item. This deletes the item.
@@ -17,7 +17,7 @@ import { removeItem } from "@esri/arcgis-rest-portal";
  */
 export function removePage(
   idOrModel: string | IModel,
-  requestOptions: IHubRequestOptions
+  requestOptions: IUserRequestOptions
 ) {
   let modelPromise = Promise.resolve(idOrModel);
   if (typeof idOrModel === "string") {
@@ -26,7 +26,7 @@ export function removePage(
   let pageModel: IModel;
   // fire it to get the model...
   return modelPromise
-    .then(model => {
+    .then((model) => {
       pageModel = model as IModel;
       // get the id's of the sites this page is linked to...
       const linkedSites = mapBy(
@@ -42,7 +42,7 @@ export function removePage(
           const opts = Object.assign(
             {
               pageModel,
-              siteId
+              siteId,
             },
             requestOptions
           );

--- a/packages/sites/src/remove-site.ts
+++ b/packages/sites/src/remove-site.ts
@@ -1,9 +1,9 @@
 import {
   IModel,
-  IHubRequestOptions,
+  IHubUserRequestOptions,
   getModel,
   _unprotectAndRemoveItem,
-  failSafe
+  failSafe,
 } from "@esri/hub-common";
 import { unlinkPagesFromSite } from "./unlink-pages-from-site";
 import { _removeSiteGroups } from "./_remove-site-groups";
@@ -21,11 +21,11 @@ import { _removeSiteFromIndex } from "./_remove-site-from-index";
  * * removes the site item
  *
  * @param {string || Object} idOrModel Id of the site or a site model
- * @param {IHubRequestOptions} hubRequestOptions
+ * @param {IHubUserRequestOptions} hubRequestOptions
  */
 export function removeSite(
   idOrModel: string | IModel,
-  hubRequestOptions: IHubRequestOptions
+  hubRequestOptions: IHubUserRequestOptions
 ) {
   let modelPromise: Promise<IModel>;
   if (typeof idOrModel === "string") {
@@ -35,7 +35,7 @@ export function removeSite(
   }
   let siteModel: IModel;
   return modelPromise
-    .then(model => {
+    .then((model) => {
       siteModel = model;
       return unlinkPagesFromSite(siteModel, hubRequestOptions);
     })
@@ -66,7 +66,7 @@ export function removeSite(
         hubRequestOptions
       );
     })
-    .catch(err => {
+    .catch((err) => {
       throw Error(`removeSite: Error removing site: ${err}`);
     });
 }

--- a/packages/sites/test/_remove-site-from-index.test.ts
+++ b/packages/sites/test/_remove-site-from-index.test.ts
@@ -7,17 +7,17 @@ describe("_removeSiteFromIndex", () => {
     const ro = {
       hubApiUrl: "foobar",
       authentication: {
-        token: "token"
-      }
+        token: "token",
+      },
     } as IHubRequestOptions;
 
     const siteModel = {
       item: {
-        id: "baz"
-      }
+        id: "baz",
+      },
     } as IModel;
 
-    fetchMock.delete(`${ro.hubApiUrl}/v2/${siteModel.item.id}`, {});
+    fetchMock.delete(`${ro.hubApiUrl}/api/v3/${siteModel.item.id}`, {});
 
     await _removeSiteFromIndex(siteModel, ro);
 
@@ -32,17 +32,17 @@ describe("_removeSiteFromIndex", () => {
     const ro = {
       hubApiUrl: "foobar",
       authentication: {
-        token: "token"
-      }
+        token: "token",
+      },
     } as IHubRequestOptions;
 
     const siteModel = {
       item: {
-        id: "baz"
-      }
+        id: "baz",
+      },
     } as IModel;
 
-    fetchMock.delete(`${ro.hubApiUrl}/v2/${siteModel.item.id}`, 400);
+    fetchMock.delete(`${ro.hubApiUrl}/api/v3/${siteModel.item.id}`, 400);
 
     try {
       await _removeSiteFromIndex(siteModel, ro);
@@ -59,17 +59,17 @@ describe("_removeSiteFromIndex", () => {
       isPortal: true,
       hubApiUrl: "foobar",
       authentication: {
-        token: "token"
-      }
+        token: "token",
+      },
     } as IHubRequestOptions;
 
     const siteModel = {
       item: {
-        id: "baz"
-      }
+        id: "baz",
+      },
     } as IModel;
 
-    fetchMock.delete(`${ro.hubApiUrl}/v2/${siteModel.item.id}`, {});
+    fetchMock.delete(`${ro.hubApiUrl}/api/v3/${siteModel.item.id}`, {});
 
     await _removeSiteFromIndex(siteModel, ro);
 

--- a/packages/sites/test/drafts/save-published-status.test.ts
+++ b/packages/sites/test/drafts/save-published-status.test.ts
@@ -2,32 +2,32 @@ import { savePublishedStatus, UNPUBLISHED_CHANGES_KW } from "../../src/drafts";
 import * as pagesModule from "../../src/pages";
 import * as updateSiteModule from "../../src/update-site";
 import { getSiteItemType, getPageItemType } from "../../src";
-import { IHubRequestOptions, IModel, cloneObject } from "@esri/hub-common";
+import { IHubUserRequestOptions, IModel, cloneObject } from "@esri/hub-common";
 
 describe("savePublishedStatus", () => {
   const ro = {
-    isPortal: false
-  } as IHubRequestOptions;
+    isPortal: false,
+  } as IHubUserRequestOptions;
 
   const siteModel = {
     item: {
       type: getSiteItemType(ro.isPortal),
-      typeKeywords: [UNPUBLISHED_CHANGES_KW]
+      typeKeywords: [UNPUBLISHED_CHANGES_KW],
     },
-    data: {}
+    data: {},
   } as IModel;
 
   const pageModel = {
     item: {
       type: getPageItemType(ro.isPortal),
-      typeKeywords: [UNPUBLISHED_CHANGES_KW]
+      typeKeywords: [UNPUBLISHED_CHANGES_KW],
     },
-    data: {}
+    data: {},
   } as IModel;
 
   let updatePageSpy: jasmine.Spy;
   let updateSiteSpy: jasmine.Spy;
-  beforeEach(function() {
+  beforeEach(function () {
     updatePageSpy = spyOn(pagesModule, "updatePage").and.returnValue(
       Promise.resolve()
     );
@@ -41,7 +41,7 @@ describe("savePublishedStatus", () => {
     expect(updateSiteSpy).toHaveBeenCalledWith(siteModel, {
       ...ro,
       allowList: ["item.typeKeywords"],
-      updateVersions: false
+      updateVersions: false,
     });
     expect(updatePageSpy).not.toHaveBeenCalled();
   });
@@ -54,7 +54,7 @@ describe("savePublishedStatus", () => {
     expect(updateSiteSpy).toHaveBeenCalledWith(cloned, {
       ...ro,
       allowList: ["item.typeKeywords"],
-      updateVersions: true
+      updateVersions: true,
     });
     expect(updatePageSpy).not.toHaveBeenCalled();
   });
@@ -64,7 +64,7 @@ describe("savePublishedStatus", () => {
 
     expect(updatePageSpy).toHaveBeenCalledWith(pageModel, {
       ...ro,
-      allowList: ["item.typeKeywords"]
+      allowList: ["item.typeKeywords"],
     });
     expect(updateSiteSpy).not.toHaveBeenCalled();
   });

--- a/packages/sites/test/pages/remove-page.test.ts
+++ b/packages/sites/test/pages/remove-page.test.ts
@@ -3,18 +3,18 @@ import * as commonModule from "@esri/hub-common";
 import * as portalModule from "@esri/arcgis-rest-portal";
 import * as unlinkSiteAndPageModule from "../../src/unlink-site-and-page";
 
-import { IModel, IHubRequestOptions } from "@esri/hub-common";
+import { IModel, IHubUserRequestOptions } from "@esri/hub-common";
 
 function expectAllCalled(spys: jasmine.Spy[], expect: any) {
-  spys.forEach(spy => expect(spy).toHaveBeenCalled());
+  spys.forEach((spy) => expect(spy).toHaveBeenCalled());
 }
 
 describe("removeSite", () => {
   const pageModelFromApi = {
     item: {
       id: "id-from-api",
-      owner: "owner-from-api"
-    }
+      owner: "owner-from-api",
+    },
   } as IModel;
 
   let getModelSpy: jasmine.Spy;
@@ -39,21 +39,21 @@ describe("removeSite", () => {
   });
 
   it("removes a site when given a model", async () => {
-    const model = ({
+    const model = {
       item: {
         id: "some-id",
-        owner: "some-owner"
+        owner: "some-owner",
       },
       data: {
         values: {
-          sites: [{ id: "foo-site" }, { id: "bar-site" }, { id: "baz-site" }]
-        }
-      }
-    } as unknown) as IModel;
+          sites: [{ id: "foo-site" }, { id: "bar-site" }, { id: "baz-site" }],
+        },
+      },
+    } as unknown as IModel;
 
-    await removePage(model, ({
-      propFromRO: "foo"
-    } as unknown) as IHubRequestOptions);
+    await removePage(model, {
+      propFromRO: "foo",
+    } as unknown as IHubUserRequestOptions);
 
     expectAllCalled([unlinkSpy, unprotectSpy, removeSpy], expect);
 
@@ -62,17 +62,17 @@ describe("removeSite", () => {
     expect(unlinkSpy).toHaveBeenCalledWith({
       siteId: "foo-site",
       propFromRO: "foo",
-      pageModel: model
+      pageModel: model,
     });
     expect(unlinkSpy).toHaveBeenCalledWith({
       siteId: "baz-site",
       propFromRO: "foo",
-      pageModel: model
+      pageModel: model,
     });
     expect(unlinkSpy).toHaveBeenCalledWith({
       siteId: "bar-site",
       propFromRO: "foo",
-      pageModel: model
+      pageModel: model,
     });
 
     expect(removeSpy.calls.argsFor(0)[0].id).toBe("some-id");
@@ -81,9 +81,9 @@ describe("removeSite", () => {
   it("removes a site when given an id", async () => {
     const id = "some-id";
 
-    await removePage(id, ({
-      propFromRO: "foo"
-    } as unknown) as IHubRequestOptions);
+    await removePage(id, {
+      propFromRO: "foo",
+    } as unknown as IHubUserRequestOptions);
 
     expect(getModelSpy).toHaveBeenCalled();
 
@@ -94,22 +94,22 @@ describe("removeSite", () => {
   });
 
   it("succeeds even if unlinking fails", async () => {
-    const model = ({
+    const model = {
       item: {
         id: "some-id",
-        owner: "some-owner"
+        owner: "some-owner",
       },
       data: {
         values: {
-          sites: [{ id: "foo-site" }, { id: "bar-site" }, { id: "baz-site" }]
-        }
-      }
-    } as unknown) as IModel;
+          sites: [{ id: "foo-site" }, { id: "bar-site" }, { id: "baz-site" }],
+        },
+      },
+    } as unknown as IModel;
 
     unlinkSpy.and.returnValue(Promise.reject());
 
     try {
-      await removePage(model, {} as IHubRequestOptions);
+      await removePage(model, {} as IHubUserRequestOptions);
     } catch (err) {
       fail("shouldnt reject!");
     }
@@ -121,7 +121,7 @@ describe("removeSite", () => {
     unprotectSpy.and.returnValue(Promise.reject(Error("rejected!")));
 
     try {
-      await removePage(id, {} as IHubRequestOptions);
+      await removePage(id, {} as IHubUserRequestOptions);
       fail("should reject");
     } catch (err) {
       expect(err).toBeDefined();

--- a/packages/sites/test/pages/update-page.test.ts
+++ b/packages/sites/test/pages/update-page.test.ts
@@ -1,30 +1,30 @@
 import { updatePage } from "../../src";
 import * as portalModule from "@esri/arcgis-rest-portal";
 import * as commonModule from "@esri/hub-common";
-import { IModel, IHubRequestOptions, cloneObject } from "@esri/hub-common";
+import { IModel, IHubUserRequestOptions, cloneObject } from "@esri/hub-common";
 
 describe("updatePage", () => {
-  const model = ({
+  const model = {
     item: {
       id: "page-id",
       url: "to-be-deleted",
       someOtherProp: "new version",
-      title: "new title"
+      title: "new title",
     },
     data: {
       values: {
         layout: "new-layout",
         updatedAt: "some-past-ISO",
-        updatedBy: "chewie"
-      }
-    }
-  } as unknown) as IModel;
+        updatedBy: "chewie",
+      },
+    },
+  } as unknown as IModel;
 
   const ro = {
     authentication: {
-      username: "tate"
-    }
-  } as IHubRequestOptions;
+      username: "tate",
+    },
+  } as IHubUserRequestOptions;
 
   let updateSpy: jasmine.Spy;
   beforeEach(() => {
@@ -38,7 +38,7 @@ describe("updatePage", () => {
 
     const updateSiteOptions = {
       ...ro,
-      allowList: [] as string[]
+      allowList: [] as string[],
     };
 
     await updatePage(cloneObject(model), updateSiteOptions);
@@ -67,15 +67,15 @@ describe("updatePage", () => {
         url: "old url",
         title: "old title",
         someOtherProp: "old version",
-        id: "page-id"
+        id: "page-id",
       },
       data: {
         values: {
           layout: "old-layout",
           updatedAt: "some-past-ISO",
-          updatedBy: "chewie"
-        }
-      }
+          updatedBy: "chewie",
+        },
+      },
     };
 
     const getModelSpy = spyOn(commonModule, "getModel").and.returnValue(
@@ -84,7 +84,7 @@ describe("updatePage", () => {
 
     const updateSiteOptions = {
       ...ro,
-      allowList: ["item.title"]
+      allowList: ["item.title"],
     };
 
     await updatePage(cloneObject(model), updateSiteOptions);

--- a/packages/sites/test/remove-site.test.ts
+++ b/packages/sites/test/remove-site.test.ts
@@ -5,18 +5,18 @@ import * as removeGroupsModule from "../src/_remove-site-groups";
 import * as removeInitModule from "../src/_remove-parent-initiative";
 import * as removeDomainsModule from "../src/_remove-site-domains";
 import * as removeIndexModule from "../src/_remove-site-from-index";
-import { IModel, IHubRequestOptions } from "@esri/hub-common";
+import { IModel, IHubUserRequestOptions } from "@esri/hub-common";
 
 function expectAllCalled(spys: jasmine.Spy[], expect: any) {
-  spys.forEach(spy => expect(spy).toHaveBeenCalled());
+  spys.forEach((spy) => expect(spy).toHaveBeenCalled());
 }
 
 describe("removeSite", () => {
   const siteModelFromApi = {
     item: {
       id: "id-from-api",
-      owner: "owner-from-api"
-    }
+      owner: "owner-from-api",
+    },
   } as IModel;
 
   let getModelSpy: jasmine.Spy;
@@ -60,11 +60,11 @@ describe("removeSite", () => {
     const model = {
       item: {
         id: "some-id",
-        owner: "some-owner"
-      }
+        owner: "some-owner",
+      },
     } as IModel;
 
-    await removeSite(model, {} as IHubRequestOptions);
+    await removeSite(model, {} as IHubUserRequestOptions);
 
     expectAllCalled(
       [
@@ -73,7 +73,7 @@ describe("removeSite", () => {
         removeSiteSpy,
         removeInitSpy,
         removeDomainsSpy,
-        removeIndexSpy
+        removeIndexSpy,
       ],
       expect
     );
@@ -86,7 +86,7 @@ describe("removeSite", () => {
   it("removes a site when given an id", async () => {
     const id = "some-id";
 
-    await removeSite(id, {} as IHubRequestOptions);
+    await removeSite(id, {} as IHubUserRequestOptions);
 
     expect(getModelSpy).toHaveBeenCalled();
 
@@ -97,7 +97,7 @@ describe("removeSite", () => {
         removeSiteSpy,
         removeInitSpy,
         removeDomainsSpy,
-        removeIndexSpy
+        removeIndexSpy,
       ],
       expect
     );
@@ -111,7 +111,7 @@ describe("removeSite", () => {
     unlinkSpy.and.returnValue(Promise.reject());
 
     try {
-      await removeSite(id, {} as IHubRequestOptions);
+      await removeSite(id, {} as IHubUserRequestOptions);
       fail("should reject");
     } catch (err) {
       expect(err).toBeDefined();

--- a/packages/sites/test/update-site.test.ts
+++ b/packages/sites/test/update-site.test.ts
@@ -116,7 +116,7 @@ describe("update site", function () {
 
     const ro = {
       authentication: {},
-    } as commonModule.IHubRequestOptions;
+    } as commonModule.IHubUserRequestOptions;
 
     const result = await updateSite(localSite, {
       ...ro,
@@ -153,7 +153,7 @@ describe("update site", function () {
     const ro = {
       isPortal: true,
       authentication: {},
-    } as commonModule.IHubRequestOptions;
+    } as commonModule.IHubUserRequestOptions;
 
     // WITH ALLOW LIST
     const result = await updateSite(localSite, {
@@ -187,7 +187,7 @@ describe("update site", function () {
     // create a siteModel from the fixtures
     const ro = {
       authentication: {},
-    } as commonModule.IHubRequestOptions;
+    } as commonModule.IHubUserRequestOptions;
 
     updateSpy.and.returnValue(Promise.reject());
 


### PR DESCRIPTION
…ld be optional

`authentication` is only required to be a `UserSession` for certain requests, so those use a new `IHubUserRequestOptions` - analogous to `IUserRequestOptions` instead of having `IHubRequestOptions` extend the latter.

`isPortal` is not needed by any fns that request directly to the API, and since it is a `boolean` no changes were needed to support making it optional.

In addition to making `hubApiUrl` optional, this PR ensures that any place `hubApiUrl` was referenced that we supplied a default.

This puts in place some things that will make it easier to do #606 

affects: @esri/hub-common, @esri/hub-discussions, @esri/hub-sites

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
