### PR TITLE
fix(hub-content): introduces empty array to handle servers without layers mistakenly typed as feature

### DIFF
--- a/packages/content/src/enrichments.ts
+++ b/packages/content/src/enrichments.ts
@@ -36,7 +36,7 @@ const getLayer = (content: IHubContent, layerId?: number) => {
       isFeatureService(content.type) && getOnlyQueryLayer(layers);
 };
 
-const getOnlyQueryLayer = (layers: ILayerDefinition[]) => {
+const getOnlyQueryLayer = (layers: ILayerDefinition[] = []) => {
   const layer = layers.length === 1 && layers[0];
   return layer && layer.capabilities.includes("Query") && layer;
 };

--- a/packages/content/src/enrichments.ts
+++ b/packages/content/src/enrichments.ts
@@ -37,7 +37,7 @@ const getLayer = (content: IHubContent, layerId?: number) => {
 };
 
 const getOnlyQueryLayer = (layers: ILayerDefinition[] = []) => {
-  const layer = layers.length === 1 && layers[0];
+  const layer = Array.isArray(layers) && layers.length === 1 && layers[0];
   return layer && layer.capabilities.includes("Query") && layer;
 };
 

--- a/packages/content/test/enrichments.test.ts
+++ b/packages/content/test/enrichments.test.ts
@@ -246,6 +246,86 @@ describe("getLayerContent", () => {
     );
     expect(layerContent.url).toEqual(content.url, "should not set url");
   });
+  it("zero-layered image service w/o layerId", () => {
+    const content = {
+      id: "3ae",
+      type: "Image Service",
+      title: "Item Title",
+      description: "Item description",
+      summary: "Item snippet",
+      layers: undefined,
+      url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+    } as IHubContent;
+    const layerContent = getLayerContent(content);
+    expect(layerContent).toBeFalsy();
+  });
+  it("zero-layered feature service w/o layerId", () => {
+    const content = {
+      id: "3ae",
+      type: "Feature Service",
+      title: "Item Title",
+      description: "Item description",
+      summary: "Item snippet",
+      layers: null,
+      url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+    } as IHubContent;
+    const layerContent = getLayerContent(content);
+    expect(layerContent).toBeFalsy();
+  });
+  it("zero-layered image service w/ layerId", () => {
+    const content = {
+      id: "3ae",
+      type: "Image Service",
+      title: "Item Title",
+      description: "Item description",
+      summary: "Item snippet",
+      layers: null,
+      url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+    } as IHubContent;
+    const layerId = 0;
+    const layerContent = getLayerContent(content, layerId);
+    expect(layerContent).toBeFalsy();
+  });
+  it("zero-layered feature service w/ layerId", () => {
+    const content = {
+      id: "3ae",
+      type: "Feature Service",
+      title: "Item Title",
+      description: "Item description",
+      summary: "Item snippet",
+      layers: null,
+      url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+    } as IHubContent;
+    const layerId = 0;
+    const layerContent = getLayerContent(content, layerId);
+    expect(layerContent).toBeFalsy();
+  });
+  it("image service w/ layerId and undefined layers", () => {
+    const content = {
+      id: "3ae",
+      type: "Image Service",
+      title: "Item Title",
+      description: "Item description",
+      summary: "Item snippet",
+      url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+    } as IHubContent;
+    const layerId = 0;
+    const layerContent = getLayerContent(content, layerId);
+    expect(layerContent).toBeFalsy();
+  });
+  it("feature service w/ layerId and undefined layers", () => {
+    const content = {
+      id: "3ae",
+      type: "Feature Service",
+      title: "Item Title",
+      description: "Item description",
+      summary: "Item snippet",
+      url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+    } as IHubContent;
+    const layerId = 0;
+    const layerContent = getLayerContent(content, layerId);
+    expect(layerContent).toBeFalsy();
+  });
 });
 
 describe("enrichDates", () => {

--- a/packages/content/test/enrichments.test.ts
+++ b/packages/content/test/enrichments.test.ts
@@ -246,6 +246,11 @@ describe("getLayerContent", () => {
     );
     expect(layerContent.url).toEqual(content.url, "should not set url");
   });
+  /**
+   * The following series of tests is to account for occurrences of items that have been uploaded as a
+   * type Feature Service, but are actually other types of services that may not have layers. This is a bug.
+   * See the PR for link to bug description: https://github.com/Esri/hub.js/pull/633
+   */
   it("zero-layered image service w/o layerId", () => {
     const content = {
       id: "3ae",


### PR DESCRIPTION
affects: @esri/hub-content

1. Description:
A bug in the content-upload component of opendata-ui mistakenly characterizes non-feature services as Feature Services, which has downstream effects. In this case, it breaks an assumption that anything characterized as a Feature Service will automatically have layers as part of assembling enrichments. Because these items are now in the open, this change adds a defense mechanism to [prevent 404's from the search page](https://devtopia.esri.com/dc/hub/issues/1908) when clicking on such an item

2. Instructions for testing:
See [issue](https://devtopia.esri.com/dc/hub/issues/1908) for detailed repro. This also happens for **private** ArcGIS Online items. Once released an in UI, 404's should stop happening. **Note that this PR does not address underlying issue in the content upload component**.

3. Closes Issues: #<number> (if appropriate)

4. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
