### PR TITLE
fix(hub-content): getLayerContent should update hubId

### DIFF
--- a/packages/content/src/enrichments.ts
+++ b/packages/content/src/enrichments.ts
@@ -38,8 +38,8 @@ const getLayer = (content: IHubContent, layerId?: number) => {
       isFeatureService(content.type) && getOnlyQueryLayer(layers);
 };
 
-const getOnlyQueryLayer = (layers: ILayerDefinition[] = []) => {
-  const layer = Array.isArray(layers) && layers.length === 1 && layers[0];
+const getOnlyQueryLayer = (layers: ILayerDefinition[]) => {
+  const layer = layers && layers.length === 1 && layers[0];
   return layer && layer.capabilities.includes("Query") && layer;
 };
 
@@ -597,11 +597,17 @@ export const getLayerContent = (
   if (!layer) {
     return;
   }
-  const { type, name, description } = layer;
+  const { item } = content;
+  // get type name and description from layer
+  const { id, type, name, description } = layer;
   // get family and normalized type based on layer type
   const family = getFamily(type);
-  const normalizedType = normalizeItemType({ ...content.item, type });
+  const normalizedType = normalizeItemType({ ...item, type });
   const layerContent = { ...content, layer, type, family, normalizedType };
+  if (item.access === "public") {
+    // we assume this is in the index,
+    layerContent.hubId = `${item.id}_${id}`;
+  }
   if (shouldUseLayerInfo(layerContent)) {
     // NOTE: composer updated dataset name and description
     // but b/c the layer enrichments now happen _after_ datasetToContent()

--- a/packages/content/test/enrichments.test.ts
+++ b/packages/content/test/enrichments.test.ts
@@ -179,20 +179,36 @@ describe("getLayerContent", () => {
       capabilities: "Query",
     },
   ] as Array<Partial<arcgisRestFeatureLayer.ILayerDefinition>>;
-  it("multi-layer feature service w/ layerId", () => {
-    const content = {
+  let item: arcgisRestPortal.IItem;
+  beforeEach(() => {
+    item = {
       id: "3ae",
       type: "Feature Service",
       title: "Item Title",
       description: "Item description",
       summary: "Item snippet",
-      layers,
       url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+      access: "public",
+      owner: "me",
+      tags: ["test"],
+      created: 1526675011000,
+      modified: 1526675614000,
+      numViews: 1,
+      size: null,
+    };
+  });
+  it("non-public, multi-layer feature service w/ layerId", () => {
+    item.access = "private";
+    const content = {
+      ...item,
+      layers,
     } as IHubContent;
+    content.item = item;
     let layerId = 0;
     let layerContent = getLayerContent(content, layerId);
     let layer = layers[0];
     expect(layerContent.layer).toEqual(layer, "should set layer");
+    expect(layerContent.hubId).toBeUndefined("should not set hubId");
     expect(layerContent.type).toBe(layer.type, "should set type");
     expect(layerContent.family).toBe("dataset", "should set family");
     expect(layerContent.title).toEqual(layer.name, "should set title");
@@ -224,19 +240,19 @@ describe("getLayerContent", () => {
       "should set url"
     );
   });
-  it("single-layer feature service w/o layerId", () => {
+  it("public, single-layer feature service w/o layerId", () => {
     const layer = layers[0];
     const content = {
-      id: "3ae",
-      type: "Feature Service",
-      title: "Item Title",
-      description: "Item description",
-      summary: "Item snippet",
+      ...item,
       layers: [layer],
-      url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
     } as IHubContent;
+    content.item = item;
     const layerContent = getLayerContent(content);
     expect(layerContent.layer).toEqual(layer, "should set layer");
+    expect(layerContent.hubId).toBe(
+      `${item.id}_${layer.id}`,
+      "should set hubId"
+    );
     expect(layerContent.type).toBe(layer.type, "should set type");
     expect(layerContent.family).toBe("dataset", "should set family");
     expect(layerContent.title).toEqual(content.title, "should not set title");


### PR DESCRIPTION
affects: @esri/hub-content

1. Description: After pulling #637 into the -ui app, I realized that we also needed to ser `hubId` for public layers, so here we are.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
