### PR TITLE
feat(hub-common): add fetchDatasets() function

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -19,6 +19,7 @@ export * from "./util";
 export * from "./utils";
 export * from "./i18n";
 export * from "./request";
+export * from "./search";
 
 import OperationStack from "./OperationStack";
 import OperationError from "./OperationError";

--- a/packages/common/src/search/fetch-datasets.ts
+++ b/packages/common/src/search/fetch-datasets.ts
@@ -1,0 +1,18 @@
+import { DatasetResource, IHubRequestOptions, hubApiRequest } from "..";
+
+export function fetchDatasets(
+  requestOptions: IHubRequestOptions
+): Promise<{ data: DatasetResource[] }> {
+  // derive default headers if authentication
+  const authentication = requestOptions.authentication;
+  const headers = authentication &&
+    authentication.serialize && { authentication: authentication.serialize() };
+  const defaults: IHubRequestOptions = {
+    headers,
+    httpMethod: "POST",
+  };
+  return hubApiRequest("/search", {
+    ...defaults,
+    ...requestOptions,
+  });
+}

--- a/packages/common/src/search/index.ts
+++ b/packages/common/src/search/index.ts
@@ -1,0 +1,1 @@
+export * from "./fetch-datasets";

--- a/packages/common/test/search/fetch-datasets.test.ts
+++ b/packages/common/test/search/fetch-datasets.test.ts
@@ -1,0 +1,26 @@
+import { UserSession } from "@esri/arcgis-rest-auth";
+import * as fetchMock from "fetch-mock";
+import { DatasetResource, fetchDatasets } from "../../src";
+
+describe("fetchDatasets", function () {
+  const response = {
+    data: [] as DatasetResource[],
+  };
+  // TODO: is this needed?
+  afterEach(fetchMock.restore);
+  it("POSTs to the correct URL and serializes authentication", async function () {
+    const authentication = new UserSession({
+      username: "tom",
+      password: "notreal",
+    });
+    fetchMock.once("*", response);
+    await fetchDatasets({
+      authentication,
+    });
+    const [url, options] = fetchMock.lastCall();
+    expect(url).toBe("https://hub.arcgis.com/api/v3/search");
+    // ts will throw errors if you try to access headers w/o casting to any
+    const headers = options.headers as any;
+    expect(headers.authentication).toBe(authentication.serialize());
+  });
+});


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: add fetchDatasets() fn

1. Instructions for testing:

1. another step towards #606 

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
