### PR TITLE
chore(hub-common): allow commits that start w/ 'pr:' to address PR re…

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -25,7 +25,12 @@ const Configuration = {
   /*
    * Functions that return true if commitlint should ignore the given message.
    */
-  ignores: [(commit) => commit === ''],
+  ignores: [
+    // empty commit messages
+    (commit) => commit === '', 
+    // pr feedback
+    (commit) => /^PR:/i.test(commit)
+  ],
   /*
    * Whether commitlint uses the default ignore rules.
    */


### PR DESCRIPTION
…view

1. Description:

allows commit messages to start w `pr: ` to address PR feedback w/o needing to add a commit message that will end up in the CHANGELOG.

Example: https://github.com/Esri/hub.js/commit/9f840a70cb0204e2bcfd45caa49595fd1ae55f30

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
