### PR TITLE
feat(hub-common): add searchHub() to exectue searches against the Hub…

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -12,6 +12,7 @@ export * from "./groups";
 export * from "./items";
 export * from "./objects";
 export * from "./resources";
+export * from "./search";
 export * from "./sites";
 export * from "./types";
 export * from "./urls";

--- a/packages/common/src/search/index.ts
+++ b/packages/common/src/search/index.ts
@@ -1,0 +1,1 @@
+export * from "./search-hub";

--- a/packages/common/src/search/search-hub.ts
+++ b/packages/common/src/search/search-hub.ts
@@ -1,0 +1,23 @@
+import { DatasetResource, IHubRequestOptions, hubApiRequest } from "..";
+/**
+ * Search the Hub API
+ *
+ * @param requestOptions
+ * @returns JSONAPI response
+ */
+export function searchHub(
+  requestOptions: IHubRequestOptions
+): Promise<{ data: DatasetResource[] }> {
+  // derive default headers if authentication
+  const authentication = requestOptions.authentication;
+  const headers = authentication &&
+    authentication.serialize && { authentication: authentication.serialize() };
+  const defaults: IHubRequestOptions = {
+    headers,
+    httpMethod: "POST",
+  };
+  return hubApiRequest("/search", {
+    ...defaults,
+    ...requestOptions,
+  });
+}

--- a/packages/common/test/search/search-hub.ts
+++ b/packages/common/test/search/search-hub.ts
@@ -1,0 +1,26 @@
+import { UserSession } from "@esri/arcgis-rest-auth";
+import * as fetchMock from "fetch-mock";
+import { DatasetResource, searchHub } from "../../src";
+
+describe("searchHub", function () {
+  const response = {
+    data: [] as DatasetResource[],
+  };
+  // TODO: is this needed?
+  afterEach(fetchMock.restore);
+  it("POSTs to the correct URL and serializes authentication", async function () {
+    const authentication = new UserSession({
+      username: "tom",
+      password: "notreal",
+    });
+    fetchMock.once("*", response);
+    await searchHub({
+      authentication,
+    });
+    const [url, options] = fetchMock.lastCall();
+    expect(url).toBe("https://hub.arcgis.com/api/v3/search");
+    // ts will throw errors if you try to access headers w/o casting to any
+    const headers = options.headers as any;
+    expect(headers.authentication).toBe(authentication.serialize());
+  });
+});

--- a/packages/search/src/content/index.ts
+++ b/packages/search/src/content/index.ts
@@ -2,11 +2,12 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 import {
   getHubApiUrl,
   getProp,
-  hubApiRequest,
+  searchHub,
   IHubRequestOptions,
   fetchSite,
   ISiteCatalog,
   getPortalApiUrl,
+  DatasetResource,
 } from "@esri/hub-common";
 import { IItem, ISearchOptions, ISearchResult } from "@esri/arcgis-rest-portal";
 import { searchItems } from "@esri/arcgis-rest-portal";
@@ -81,7 +82,10 @@ export class ContentSearchService
   private onlineSearch(
     request: IContentSearchRequest = { filter: {}, options: {} }
   ): Promise<IContentSearchResponse> {
-    return performHubContentSearch(request, this.portal, this.authentication);
+    // merge instance's portal and authentication into options
+    const { portal, authentication } = this;
+    const options = { portal, authentication, ...request.options };
+    return performHubContentSearch({ ...request, options });
   }
 }
 
@@ -322,30 +326,37 @@ function performEnterpriseContentSearch(
   );
 }
 
+/**
+ * Internal function to search the Hub API (v3)
+ * using the same arguments as searchContent()
+ *
+ * NOTE: this returns the Hub API's raw JSONAPI response
+ * and invalid parameters like isPortal will be ignored
+ *
+ * @param request - see searchContent()
+ * @returns Hub API's JSONAPI response
+ *
+ * @private
+ */
+export function _searchHubByContentSearchRequest(
+  request: IContentSearchRequest
+): Promise<{ data: DatasetResource[] }> {
+  const params: ISearchParams = convertToHubParams(request);
+  const requestOptions = { ...getHubRequestOptions(request.options), params };
+  return searchHub(requestOptions);
+}
+
 function performHubContentSearch(
-  request: IContentSearchRequest,
-  defaultPortal?: string,
-  defaultAuthentication?: UserSession
+  request: IContentSearchRequest
 ): Promise<IContentSearchResponse> {
-  const portal: string = getProp(request, "options.portal") || defaultPortal;
-  const authentication: UserSession =
-    getProp(request, "options.authentication") || defaultAuthentication;
-
-  const hubApiUrl: string = getHubApiUrl(portal);
-  const requestParams: ISearchParams = convertToHubParams(request);
-  const headers = authentication &&
-    authentication.serialize && { authentication: authentication.serialize() };
-
-  return hubApiRequest("/search", {
-    hubApiUrl,
-    authentication,
-    isPortal: false,
-    headers,
-    httpMethod: "POST",
-    params: requestParams,
-  }).then((response: any) =>
-    convertHubResponse(requestParams, response, authentication)
+  const authentication: UserSession = getProp(
+    request,
+    "options.authentication"
   );
+  return _searchHubByContentSearchRequest(request).then((response) => {
+    const requestParams: ISearchParams = convertToHubParams(request);
+    return convertHubResponse(requestParams, response, authentication);
+  });
 }
 
 function getSiteCatalogFromOptions(

--- a/packages/search/test/content/index.test.ts
+++ b/packages/search/test/content/index.test.ts
@@ -263,8 +263,9 @@ describe("Content Search Service", () => {
         "/search",
         {
           hubApiUrl: "https://hubqa.arcgis.com",
+          portal: "https://qaext.arcgis.com/sharing/rest",
           authentication,
-          isPortal: false,
+          isPortal: undefined,
           headers: {
             authentication: JSON.stringify(authentication),
           },
@@ -380,8 +381,9 @@ describe("Content Search Service", () => {
         "/search",
         {
           hubApiUrl: "https://hubqa.arcgis.com",
+          portal: "https://qaext.arcgis.com/sharing/rest",
           authentication: sessionOne,
-          isPortal: false,
+          isPortal: undefined,
           headers: {
             authentication: JSON.stringify(sessionOne),
           },
@@ -489,8 +491,9 @@ describe("Content Search Service", () => {
         "/search",
         {
           hubApiUrl: "https://hubqa.arcgis.com",
+          portal: "https://qaext.arcgis.com/sharing/rest",
           authentication: undefined,
-          isPortal: false,
+          isPortal: undefined,
           headers: undefined,
           httpMethod: "POST",
           params: {
@@ -583,8 +586,9 @@ describe("Content Search Service", () => {
         "/search",
         {
           hubApiUrl: "https://hubqa.arcgis.com",
+          portal: "https://qaext.arcgis.com/sharing/rest",
           authentication: undefined,
-          isPortal: false,
+          isPortal: undefined,
           headers: undefined,
           httpMethod: "POST",
           params: {
@@ -863,6 +867,7 @@ describe("searchContent function", () => {
         "/search",
         {
           hubApiUrl: "https://hubqa.arcgis.com",
+          portal: "https://qaext.arcgis.com/sharing/rest",
           authentication,
           isPortal: false,
           headers: {
@@ -955,8 +960,9 @@ describe("searchContent function", () => {
         "/search",
         {
           hubApiUrl: "https://hub.arcgis.com",
+          portal: "https://www.arcgis.com/sharing/rest",
           authentication: undefined,
-          isPortal: false,
+          isPortal: undefined,
           headers: undefined,
           httpMethod: "POST",
           params: {
@@ -1057,6 +1063,7 @@ describe("searchContent function", () => {
         "/search",
         {
           hubApiUrl: "https://hubqa.arcgis.com",
+          portal: "https://qaext.arcgis.com/sharing/rest",
           authentication: undefined,
           isPortal: false,
           headers: undefined,


### PR DESCRIPTION
1. Description:

Adds public `searchHub()` fn to call Hub API's `/search` end point.

Updates `searchContent()` to use `searchHub()` internally and to expose a private (undocumented)`_searchHubByContentSearchRequest()` fn that addresses https://github.com/Esri/hub.js/issues/606#issuecomment-912107464

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
