### PR TITLE
feat(hub-search): expose searchDatasets() to search the Hub API and r…

### DIFF
--- a/packages/common/src/search/hub-api-search.ts
+++ b/packages/common/src/search/hub-api-search.ts
@@ -5,7 +5,7 @@ import { DatasetResource, IHubRequestOptions, hubApiRequest } from "..";
  * @param requestOptions
  * @returns JSONAPI response
  */
-export function searchHub(
+export function hubApiSearch(
   requestOptions: IHubRequestOptions
 ): Promise<{ data: DatasetResource[] }> {
   // derive default headers if authentication

--- a/packages/common/src/search/index.ts
+++ b/packages/common/src/search/index.ts
@@ -1,1 +1,1 @@
-export * from "./search-hub";
+export * from "./hub-api-search";

--- a/packages/common/test/search/search-hub.ts
+++ b/packages/common/test/search/search-hub.ts
@@ -1,8 +1,8 @@
 import { UserSession } from "@esri/arcgis-rest-auth";
 import * as fetchMock from "fetch-mock";
-import { DatasetResource, searchHub } from "../../src";
+import { DatasetResource, hubApiSearch } from "../../src";
 
-describe("searchHub", function () {
+describe("hubApiSearch", function () {
   const response = {
     data: [] as DatasetResource[],
   };
@@ -14,7 +14,7 @@ describe("searchHub", function () {
       password: "notreal",
     });
     fetchMock.once("*", response);
-    await searchHub({
+    await hubApiSearch({
       authentication,
     });
     const [url, options] = fetchMock.lastCall();

--- a/packages/search/src/content/index.ts
+++ b/packages/search/src/content/index.ts
@@ -2,7 +2,7 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 import {
   getHubApiUrl,
   getProp,
-  searchHub,
+  hubApiSearch,
   IHubRequestOptions,
   fetchSite,
   ISiteCatalog,
@@ -327,7 +327,7 @@ function performEnterpriseContentSearch(
 }
 
 /**
- * Internal function to search the Hub API (v3)
+ * Function to search the Hub API (v3)
  * using the same arguments as searchContent()
  *
  * NOTE: this returns the Hub API's raw JSONAPI response
@@ -335,15 +335,13 @@ function performEnterpriseContentSearch(
  *
  * @param request - see searchContent()
  * @returns Hub API's JSONAPI response
- *
- * @private
  */
-export function _searchHubByContentSearchRequest(
+export function searchDatasets(
   request: IContentSearchRequest
 ): Promise<{ data: DatasetResource[] }> {
   const params: ISearchParams = convertToHubParams(request);
   const requestOptions = { ...getHubRequestOptions(request.options), params };
-  return searchHub(requestOptions);
+  return hubApiSearch(requestOptions);
 }
 
 function performHubContentSearch(
@@ -353,7 +351,7 @@ function performHubContentSearch(
     request,
     "options.authentication"
   );
-  return _searchHubByContentSearchRequest(request).then((response) => {
+  return searchDatasets(request).then((response) => {
     const requestParams: ISearchParams = convertToHubParams(request);
     return convertHubResponse(requestParams, response, authentication);
   });


### PR DESCRIPTION
…eturn datasets

affects: @esri/hub-common, @esri/hub-search

1. Description:
Naming things is hard.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
