### PR TITLE
fix(hub-search): searchContent() should return results as IHubContent[]

### DIFF
--- a/packages/search/src/content/helpers/convert-hub-response.ts
+++ b/packages/search/src/content/helpers/convert-hub-response.ts
@@ -1,5 +1,5 @@
 import { UserSession } from "@esri/arcgis-rest-auth";
-import { getProp } from "@esri/hub-common";
+import { datasetToContent, getProp } from "@esri/hub-common";
 import { ISearchParams } from "../../ago/params";
 import {
   IContentAggregations,
@@ -25,9 +25,7 @@ export function convertHubResponse(
   response: any = { data: [], meta: {} },
   defaultAuthentication?: UserSession
 ): IContentSearchResponse {
-  const results: any[] = response.data.map((d: Record<string, any>) =>
-    getAttributes(d)
-  );
+  const results = response.data.map(datasetToContent);
   const { count, total, hasNext, query, aggregations } =
     getResponseMetadata(response);
   const next: (
@@ -132,18 +130,4 @@ function getResponseMetadata(response: any): {
     query,
     aggregations,
   };
-}
-
-function getAttributes(data: Record<string, any>) {
-  const attributes = getProp(data, "attributes");
-  /* istanbul ignore else */
-  if (attributes) {
-    Object.keys(PROP_MAP).map((key: string) => {
-      /* istanbul ignore else */
-      if (PROP_MAP[key]) {
-        attributes[key] = attributes[PROP_MAP[key]];
-      }
-    });
-  }
-  return attributes;
 }

--- a/packages/search/src/content/helpers/convert-portal-response.ts
+++ b/packages/search/src/content/helpers/convert-portal-response.ts
@@ -2,18 +2,18 @@ import {
   IItem,
   ISearchOptions,
   ISearchResult,
-  searchItems
+  searchItems,
 } from "@esri/arcgis-rest-portal";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import {
   IContentSearchResponse,
-  IContentAggregations
+  IContentAggregations,
 } from "../../types/content";
 import {
   IAggregation,
-  IAggregationResult
+  IAggregationResult,
 } from "../../util/aggregations/merge-aggregations";
-import { cloneObject } from "@esri/hub-common";
+import { cloneObject, itemToContent } from "@esri/hub-common";
 
 /**
  * Converts the response format returned by the Portal API to a common format
@@ -24,7 +24,7 @@ export function convertPortalResponse(
   request: ISearchOptions,
   response: ISearchResult<IItem>
 ): IContentSearchResponse {
-  const results: IItem[] = response.results;
+  const results = response.results.map(itemToContent);
   const count: number = response.num;
   const total: number = response.total;
   const hasNext: boolean = response.nextStart > -1;
@@ -47,7 +47,7 @@ export function convertPortalResponse(
     hasNext,
     query,
     aggregations,
-    next
+    next,
   };
 }
 
@@ -74,13 +74,13 @@ function mapCountAggregations(
     const mappedAggs: IAggregation[] = agg.fieldValues.map(
       (aggValue: Record<string, any>) => ({
         label: aggValue.value,
-        value: aggValue.count
+        value: aggValue.count,
       })
     );
 
     return {
       fieldName: agg.fieldName,
-      aggregations: mappedAggs
+      aggregations: mappedAggs,
     };
   });
 }

--- a/packages/search/src/types/content.ts
+++ b/packages/search/src/types/content.ts
@@ -1,4 +1,5 @@
 import { UserSession } from "@esri/arcgis-rest-auth";
+import { IHubContent } from "@esri/hub-common";
 import { IAggregationResult } from "../util/aggregations/merge-aggregations";
 import {
   IDateRange,
@@ -93,7 +94,7 @@ export interface IContentAggregations {
  * a parameterized results list type of any. Includes query, paginated result count,
  * and aggregations
  */
-export interface IContentSearchResponse extends ISearchResponse<any> {
+export interface IContentSearchResponse extends ISearchResponse<IHubContent> {
   query: string;
   count: number;
   aggregations?: IContentAggregations;

--- a/packages/search/test/content/helpers/convert-hub-response.test.ts
+++ b/packages/search/test/content/helpers/convert-hub-response.test.ts
@@ -1,5 +1,6 @@
 import * as fetchMock from "fetch-mock";
 import { UserSession } from "@esri/arcgis-rest-auth";
+import { DatasetResource, datasetToContent } from "@esri/hub-common";
 import { IContentSearchResponse } from "../../../src/types/content";
 import { convertHubResponse } from "../../../src/content/helpers/convert-hub-response";
 import { ISearchResponse } from "../../../src/types/common";
@@ -8,17 +9,17 @@ import { ISearchParams } from "../../../src/ago/params";
 afterEach(fetchMock.restore);
 
 describe("Convert Hub Response function", () => {
-  it("can properly format a response from the Hub API", done => {
+  it("can properly format a response from the Hub API", (done) => {
     // Setup
     const request: ISearchParams = {
       q: "12345",
       sort: "-modified",
       catalog: {
-        groupIds: "any(12345,23456,34567)"
+        groupIds: "any(12345,23456,34567)",
       },
       filter: {
-        type: "any(Feature Layer,Table)"
-      }
+        type: "any(Feature Layer,Table)",
+      },
     };
 
     const documentOne: Record<string, any> = {
@@ -32,8 +33,8 @@ describe("Convert Hub Response function", () => {
         created: 1000,
         modified: 2000,
         numViews: 1,
-        size: 5
-      }
+        size: 5,
+      },
     };
 
     const documentTwo: Record<string, any> = {
@@ -47,8 +48,8 @@ describe("Convert Hub Response function", () => {
         created: 2000,
         modified: 3000,
         numViews: 2,
-        size: 6
-      }
+        size: 6,
+      },
     };
 
     const resultOne: Record<string, any> = {
@@ -59,9 +60,9 @@ describe("Convert Hub Response function", () => {
         stats: {
           count: 1,
           totalCount: 2,
-          aggs: {}
-        }
-      }
+          aggs: {},
+        },
+      },
     };
 
     const resultTwo: Record<string, any> = {
@@ -71,9 +72,9 @@ describe("Convert Hub Response function", () => {
         stats: {
           count: 1,
           totalCount: 2,
-          aggs: {}
-        }
-      }
+          aggs: {},
+        },
+      },
     };
 
     const sessionOne = new UserSession({ portal: "dummy-portal-url-one" });
@@ -91,7 +92,9 @@ describe("Convert Hub Response function", () => {
 
     // Assert
     expect(convertedResponse).toBeDefined();
-    expect(convertedResponse.results).toEqual([documentOne.attributes]);
+    expect(convertedResponse.results).toEqual([
+      datasetToContent(documentOne as any),
+    ]);
     expect(convertedResponse.query).toEqual(
       JSON.stringify(resultOne.meta.queryParameters)
     );
@@ -111,9 +114,11 @@ describe("Convert Hub Response function", () => {
         expect(fetchMock.calls()[0][1]).toEqual({
           method: "GET",
           mode: "cors",
-          headers: new Headers({ authentication: JSON.stringify(sessionTwo) })
+          headers: new Headers({ authentication: JSON.stringify(sessionTwo) }),
         });
-        expect(contentResponse.results).toEqual([documentTwo.attributes]);
+        expect(contentResponse.results).toEqual([
+          datasetToContent(documentTwo as any),
+        ]);
         expect(contentResponse.query).toEqual(
           JSON.stringify(resultTwo.meta.queryParameters)
         );
@@ -126,17 +131,17 @@ describe("Convert Hub Response function", () => {
       });
   });
 
-  it("can properly default to the service session if a user session not provided for next function", done => {
+  it("can properly default to the service session if a user session not provided for next function", (done) => {
     // Setup
     const request: ISearchParams = {
       q: "12345",
       sort: "-modified",
       catalog: {
-        groupIds: "any(12345,23456,34567)"
+        groupIds: "any(12345,23456,34567)",
       },
       filter: {
-        type: "any(Feature Layer,Table)"
-      }
+        type: "any(Feature Layer,Table)",
+      },
     };
 
     const documentOne: Record<string, any> = {
@@ -150,8 +155,8 @@ describe("Convert Hub Response function", () => {
         created: 1000,
         modified: 2000,
         numViews: 1,
-        size: 5
-      }
+        size: 5,
+      },
     };
 
     const documentTwo: Record<string, any> = {
@@ -165,8 +170,8 @@ describe("Convert Hub Response function", () => {
         created: 2000,
         modified: 3000,
         numViews: 2,
-        size: 6
-      }
+        size: 6,
+      },
     };
 
     const resultOne: Record<string, any> = {
@@ -177,9 +182,9 @@ describe("Convert Hub Response function", () => {
         stats: {
           count: 1,
           totalCount: 2,
-          aggs: {}
-        }
-      }
+          aggs: {},
+        },
+      },
     };
 
     const resultTwo: Record<string, any> = {
@@ -189,9 +194,9 @@ describe("Convert Hub Response function", () => {
         stats: {
           count: 1,
           totalCount: 2,
-          aggs: {}
-        }
-      }
+          aggs: {},
+        },
+      },
     };
 
     const sessionOne = new UserSession({ portal: "dummy-portal-url-one" });
@@ -208,7 +213,9 @@ describe("Convert Hub Response function", () => {
 
     // Assert
     expect(convertedResponse).toBeDefined();
-    expect(convertedResponse.results).toEqual([documentOne.attributes]);
+    expect(convertedResponse.results).toEqual([
+      datasetToContent(documentOne as any),
+    ]);
     expect(convertedResponse.query).toEqual(
       JSON.stringify(resultOne.meta.queryParameters)
     );
@@ -226,9 +233,11 @@ describe("Convert Hub Response function", () => {
       expect(fetchMock.calls()[0][1]).toEqual({
         method: "GET",
         mode: "cors",
-        headers: new Headers({ authentication: JSON.stringify(sessionOne) })
+        headers: new Headers({ authentication: JSON.stringify(sessionOne) }),
       });
-      expect(contentResponse.results).toEqual([documentTwo.attributes]);
+      expect(contentResponse.results).toEqual([
+        datasetToContent(documentTwo as any),
+      ]);
       expect(contentResponse.query).toEqual(
         JSON.stringify(resultTwo.meta.queryParameters)
       );
@@ -241,17 +250,17 @@ describe("Convert Hub Response function", () => {
     });
   });
 
-  it("can handle no authentication being provided", done => {
+  it("can handle no authentication being provided", (done) => {
     // Setup
     const request: ISearchParams = {
       q: "12345",
       sort: "-modified",
       catalog: {
-        groupIds: "any(12345,23456,34567)"
+        groupIds: "any(12345,23456,34567)",
       },
       filter: {
-        type: "any(Feature Layer,Table)"
-      }
+        type: "any(Feature Layer,Table)",
+      },
     };
 
     const documentOne: Record<string, any> = {
@@ -265,8 +274,8 @@ describe("Convert Hub Response function", () => {
         created: 1000,
         modified: 2000,
         numViews: 1,
-        size: 5
-      }
+        size: 5,
+      },
     };
 
     const documentTwo: Record<string, any> = {
@@ -280,8 +289,8 @@ describe("Convert Hub Response function", () => {
         created: 2000,
         modified: 3000,
         numViews: 2,
-        size: 6
-      }
+        size: 6,
+      },
     };
 
     const resultOne: Record<string, any> = {
@@ -292,9 +301,9 @@ describe("Convert Hub Response function", () => {
         stats: {
           count: 1,
           totalCount: 2,
-          aggs: {}
-        }
-      }
+          aggs: {},
+        },
+      },
     };
 
     const resultTwo: Record<string, any> = {
@@ -304,9 +313,9 @@ describe("Convert Hub Response function", () => {
         stats: {
           count: 1,
           totalCount: 2,
-          aggs: {}
-        }
-      }
+          aggs: {},
+        },
+      },
     };
 
     // Mock
@@ -320,7 +329,9 @@ describe("Convert Hub Response function", () => {
 
     // Assert
     expect(convertedResponse).toBeDefined();
-    expect(convertedResponse.results).toEqual([documentOne.attributes]);
+    expect(convertedResponse.results).toEqual([
+      datasetToContent(documentOne as any),
+    ]);
     expect(convertedResponse.query).toEqual(
       JSON.stringify(resultOne.meta.queryParameters)
     );
@@ -338,9 +349,11 @@ describe("Convert Hub Response function", () => {
       expect(fetchMock.calls()[0][1]).toEqual({
         method: "GET",
         mode: "cors",
-        headers: undefined
+        headers: undefined,
       });
-      expect(contentResponse.results).toEqual([documentTwo.attributes]);
+      expect(contentResponse.results).toEqual([
+        datasetToContent(documentTwo as any),
+      ]);
       expect(contentResponse.query).toEqual(
         JSON.stringify(resultTwo.meta.queryParameters)
       );
@@ -353,22 +366,22 @@ describe("Convert Hub Response function", () => {
     });
   });
 
-  it("can properly use default metadata if not provided by Hub API", done => {
+  it("can properly use default metadata if not provided by Hub API", (done) => {
     // Setup
     const request: ISearchParams = {
       q: "12345",
       sort: "-modified",
       catalog: {
-        groupIds: "any(12345,23456,34567)"
+        groupIds: "any(12345,23456,34567)",
       },
       filter: {
-        type: "any(Feature Layer,Table)"
-      }
+        type: "any(Feature Layer,Table)",
+      },
     };
 
     const resultOne: Record<string, any> = {
       data: [],
-      meta: {}
+      meta: {},
     };
 
     const sessionOne = new UserSession({ portal: "dummy-portal-url-one" });
@@ -392,17 +405,17 @@ describe("Convert Hub Response function", () => {
     done();
   });
 
-  it("can properly respond to calls to next when there is no more data", done => {
+  it("can properly respond to calls to next when there is no more data", (done) => {
     // Setup
     const request: ISearchParams = {
       q: "12345",
       sort: "-modified",
       catalog: {
-        groupIds: "any(12345,23456,34567)"
+        groupIds: "any(12345,23456,34567)",
       },
       filter: {
-        type: "any(Feature Layer,Table)"
-      }
+        type: "any(Feature Layer,Table)",
+      },
     };
 
     const documentOne: Record<string, any> = {
@@ -415,8 +428,8 @@ describe("Convert Hub Response function", () => {
         created: 1000,
         modified: 2000,
         numViews: 1,
-        size: 5
-      }
+        size: 5,
+      },
     };
 
     const resultOne: Record<string, any> = {
@@ -426,9 +439,9 @@ describe("Convert Hub Response function", () => {
         stats: {
           count: 1,
           totalCount: 2,
-          aggs: {}
-        }
-      }
+          aggs: {},
+        },
+      },
     };
 
     const sessionOne = new UserSession({ portal: "dummy-portal-url-one" });
@@ -442,7 +455,9 @@ describe("Convert Hub Response function", () => {
 
     // Assert
     expect(convertedResponse).toBeDefined();
-    expect(convertedResponse.results).toEqual([documentOne.attributes]);
+    expect(convertedResponse.results).toEqual([
+      datasetToContent(documentOne as any),
+    ]);
     expect(convertedResponse.query).toEqual(
       JSON.stringify(resultOne.meta.queryParameters)
     );
@@ -469,23 +484,25 @@ describe("Convert Hub Response function", () => {
     });
   });
 
-  it("can properly map aggregations", done => {
+  it("can properly map aggregations", (done) => {
     // Setup
     const request: ISearchParams = {
       q: "12345",
       sort: "-modified",
       catalog: {
-        groupIds: "any(12345,23456,34567)"
+        groupIds: "any(12345,23456,34567)",
       },
       filter: {
-        type: "any(Feature Layer,Table)"
+        type: "any(Feature Layer,Table)",
       },
       agg: {
-        fields: "type,access"
-      }
+        fields: "type,access",
+      },
     };
 
-    const documentOne: Record<string, any> = {
+    const documentOne: DatasetResource = {
+      id: "12345",
+      type: "dataset",
       attributes: {
         id: "12345",
         title: "TITLE ONE",
@@ -495,8 +512,8 @@ describe("Convert Hub Response function", () => {
         created: 1000,
         modified: 2000,
         numViews: 1,
-        size: 5
-      }
+        size: 5,
+      },
     };
 
     const resultOne: Record<string, any> = {
@@ -510,30 +527,30 @@ describe("Convert Hub Response function", () => {
             type: [
               {
                 key: "Feature Layer",
-                docCount: 1
+                docCount: 1,
               },
               {
                 key: "Table",
-                docCount: 1
-              }
+                docCount: 1,
+              },
             ],
             access: [
               {
                 key: "private",
-                docCount: 1
+                docCount: 1,
               },
               {
                 key: "public",
-                docCount: 1
+                docCount: 1,
               },
               {
                 key: "org",
-                docCount: 0
-              }
-            ]
-          }
-        }
-      }
+                docCount: 0,
+              },
+            ],
+          },
+        },
+      },
     };
 
     const sessionOne = new UserSession({ portal: "dummy-portal-url-one" });
@@ -547,7 +564,7 @@ describe("Convert Hub Response function", () => {
 
     // Assert
     expect(convertedResponse).toBeDefined();
-    expect(convertedResponse.results).toEqual([documentOne.attributes]);
+    expect(convertedResponse.results).toEqual([datasetToContent(documentOne)]);
     expect(convertedResponse.query).toEqual(
       JSON.stringify(resultOne.meta.queryParameters)
     );
@@ -562,32 +579,32 @@ describe("Convert Hub Response function", () => {
           aggregations: [
             {
               label: "feature layer",
-              value: 1
+              value: 1,
             },
             {
               label: "table",
-              value: 1
-            }
-          ]
+              value: 1,
+            },
+          ],
         },
         {
           fieldName: "access",
           aggregations: [
             {
               label: "private",
-              value: 1
+              value: 1,
             },
             {
               label: "public",
-              value: 1
+              value: 1,
             },
             {
               label: "org",
-              value: 0
-            }
-          ]
-        }
-      ]
+              value: 0,
+            },
+          ],
+        },
+      ],
     });
     expect(convertedResponse.next).toBeDefined();
 
@@ -610,55 +627,57 @@ describe("Convert Hub Response function", () => {
             aggregations: [
               {
                 label: "feature layer",
-                value: 1
+                value: 1,
               },
               {
                 label: "table",
-                value: 1
-              }
-            ]
+                value: 1,
+              },
+            ],
           },
           {
             fieldName: "access",
             aggregations: [
               {
                 label: "private",
-                value: 1
+                value: 1,
               },
               {
                 label: "public",
-                value: 1
+                value: 1,
               },
               {
                 label: "org",
-                value: 0
-              }
-            ]
-          }
-        ]
+                value: 0,
+              },
+            ],
+          },
+        ],
       });
       expect(contentResponse.next).toBeDefined();
       done();
     });
   });
 
-  it("can properly handle undefined aggregations", done => {
+  it("can properly handle undefined aggregations", (done) => {
     // Setup
     const request: ISearchParams = {
       q: "12345",
       sort: "-modified",
       catalog: {
-        groupIds: "any(12345,23456,34567)"
+        groupIds: "any(12345,23456,34567)",
       },
       filter: {
-        type: "any(Feature Layer,Table)"
+        type: "any(Feature Layer,Table)",
       },
       agg: {
-        fields: "type,access"
-      }
+        fields: "type,access",
+      },
     };
 
-    const documentOne: Record<string, any> = {
+    const documentOne: DatasetResource = {
+      id: "12345",
+      type: "dataset",
       attributes: {
         id: "12345",
         title: "TITLE ONE",
@@ -668,8 +687,8 @@ describe("Convert Hub Response function", () => {
         created: 1000,
         modified: 2000,
         numViews: 1,
-        size: 5
-      }
+        size: 5,
+      },
     };
 
     const resultOne: Record<string, any> = {
@@ -684,20 +703,20 @@ describe("Convert Hub Response function", () => {
             access: [
               {
                 key: "private",
-                docCount: 1
+                docCount: 1,
               },
               {
                 key: "public",
-                docCount: 1
+                docCount: 1,
               },
               {
                 key: "org",
-                docCount: 0
-              }
-            ]
-          }
-        }
-      }
+                docCount: 0,
+              },
+            ],
+          },
+        },
+      },
     };
 
     const sessionOne = new UserSession({ portal: "dummy-portal-url-one" });
@@ -711,7 +730,7 @@ describe("Convert Hub Response function", () => {
 
     // Assert
     expect(convertedResponse).toBeDefined();
-    expect(convertedResponse.results).toEqual([documentOne.attributes]);
+    expect(convertedResponse.results).toEqual([datasetToContent(documentOne)]);
     expect(convertedResponse.query).toEqual(
       JSON.stringify(resultOne.meta.queryParameters)
     );
@@ -723,26 +742,26 @@ describe("Convert Hub Response function", () => {
       counts: [
         {
           fieldName: "type",
-          aggregations: []
+          aggregations: [],
         },
         {
           fieldName: "access",
           aggregations: [
             {
               label: "private",
-              value: 1
+              value: 1,
             },
             {
               label: "public",
-              value: 1
+              value: 1,
             },
             {
               label: "org",
-              value: 0
-            }
-          ]
-        }
-      ]
+              value: 0,
+            },
+          ],
+        },
+      ],
     });
     expect(convertedResponse.next).toBeDefined();
 
@@ -762,49 +781,48 @@ describe("Convert Hub Response function", () => {
         counts: [
           {
             fieldName: "type",
-            aggregations: []
+            aggregations: [],
           },
           {
             fieldName: "access",
             aggregations: [
               {
                 label: "private",
-                value: 1
+                value: 1,
               },
               {
                 label: "public",
-                value: 1
+                value: 1,
               },
               {
                 label: "org",
-                value: 0
-              }
-            ]
-          }
-        ]
+                value: 0,
+              },
+            ],
+          },
+        ],
       });
       expect(contentResponse.next).toBeDefined();
       done();
     });
   });
 
-  it("can handle an undefined response", done => {
+  it("can handle an undefined response", (done) => {
     // Setup
     const request: ISearchParams = {
       q: "12345",
       sort: "-modified",
       catalog: {
-        groupIds: "any(12345,23456,34567)"
+        groupIds: "any(12345,23456,34567)",
       },
       filter: {
-        type: "any(Feature Layer,Table)"
-      }
+        type: "any(Feature Layer,Table)",
+      },
     };
 
     // Test
-    const convertedResponse: IContentSearchResponse = convertHubResponse(
-      request
-    );
+    const convertedResponse: IContentSearchResponse =
+      convertHubResponse(request);
 
     // Assert
     expect(convertedResponse).toBeDefined();

--- a/packages/search/test/content/helpers/convert-portal-response.test.ts
+++ b/packages/search/test/content/helpers/convert-portal-response.test.ts
@@ -5,9 +5,10 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 import { IContentSearchResponse } from "../../../src/types/content";
 import { convertPortalResponse } from "../../../src/content/helpers/convert-portal-response";
 import { ISearchResponse } from "../../../src/types/common";
+import { itemToContent } from "@esri/hub-common";
 
 describe("Convert Portal Response function", () => {
-  it("can properly format a response from Portal API", done => {
+  it("can properly format a response from Portal API", (done) => {
     // Setup
     const itemOne: IItem = {
       id: "12345",
@@ -18,7 +19,7 @@ describe("Convert Portal Response function", () => {
       created: 1000,
       modified: 2000,
       numViews: 1,
-      size: 5
+      size: 5,
     };
 
     const itemTwo: IItem = {
@@ -30,7 +31,7 @@ describe("Convert Portal Response function", () => {
       created: 2000,
       modified: 3000,
       numViews: 2,
-      size: 6
+      size: 6,
     };
 
     const request: ISearchOptions = {
@@ -38,7 +39,7 @@ describe("Convert Portal Response function", () => {
       sortOrder: "asc",
       sortField: "title",
       start: 1,
-      num: 1
+      num: 1,
     };
 
     const portalApiResultsOne: ISearchResult<IItem> = {
@@ -47,7 +48,7 @@ describe("Convert Portal Response function", () => {
       start: 1,
       num: 1,
       nextStart: 2,
-      results: [itemOne]
+      results: [itemOne],
     };
 
     const portalApiResultsTwo: ISearchResult<IItem> = {
@@ -56,7 +57,7 @@ describe("Convert Portal Response function", () => {
       start: 2,
       num: 1,
       nextStart: -1,
-      results: [itemTwo]
+      results: [itemTwo],
     };
 
     // Mock
@@ -72,7 +73,9 @@ describe("Convert Portal Response function", () => {
 
     // Assert
     expect(convertedResponse).toBeDefined();
-    expect(convertedResponse.results).toEqual(portalApiResultsOne.results);
+    expect(convertedResponse.results).toEqual(
+      portalApiResultsOne.results.map(itemToContent)
+    );
     expect(convertedResponse.query).toEqual(portalApiResultsOne.query);
     expect(convertedResponse.total).toEqual(portalApiResultsOne.total);
     expect(convertedResponse.count).toEqual(portalApiResultsOne.num);
@@ -92,10 +95,12 @@ describe("Convert Portal Response function", () => {
           start: 2,
           sortField: "title",
           sortOrder: "asc",
-          authentication: undefined
-        }
+          authentication: undefined,
+        },
       ]);
-      expect(contentResponse.results).toEqual(portalApiResultsTwo.results);
+      expect(contentResponse.results).toEqual(
+        portalApiResultsTwo.results.map(itemToContent)
+      );
       expect(contentResponse.query).toEqual(portalApiResultsTwo.query);
       expect(contentResponse.total).toEqual(portalApiResultsTwo.total);
       expect(contentResponse.count).toEqual(portalApiResultsTwo.num);
@@ -106,7 +111,7 @@ describe("Convert Portal Response function", () => {
     });
   });
 
-  it("can properly format a response from Portal API with aggregations", done => {
+  it("can properly format a response from Portal API with aggregations", (done) => {
     // Setup
     const itemOne: IItem = {
       id: "12345",
@@ -117,7 +122,7 @@ describe("Convert Portal Response function", () => {
       created: 1000,
       modified: 2000,
       numViews: 1,
-      size: 5
+      size: 5,
     };
 
     const itemTwo: IItem = {
@@ -129,7 +134,7 @@ describe("Convert Portal Response function", () => {
       created: 2000,
       modified: 3000,
       numViews: 2,
-      size: 6
+      size: 6,
     };
 
     const request: ISearchOptions = {
@@ -138,7 +143,7 @@ describe("Convert Portal Response function", () => {
       sortField: "title",
       start: 1,
       num: 1,
-      aggregations: "type,access"
+      aggregations: "type,access",
     };
 
     const portalApiResultsOne: ISearchResult<IItem> = {
@@ -155,33 +160,33 @@ describe("Convert Portal Response function", () => {
             fieldValues: [
               {
                 value: "Feature Layer",
-                count: 4
+                count: 4,
               },
               {
                 value: "Table",
-                count: 1
-              }
-            ]
+                count: 1,
+              },
+            ],
           },
           {
             fieldName: "access",
             fieldValues: [
               {
                 value: "public",
-                count: 3
+                count: 3,
               },
               {
                 value: "private",
-                count: 1
+                count: 1,
               },
               {
                 value: "org",
-                count: 1
-              }
-            ]
-          }
-        ]
-      }
+                count: 1,
+              },
+            ],
+          },
+        ],
+      },
     };
 
     const portalApiResultsTwo: ISearchResult<IItem> = {
@@ -198,33 +203,33 @@ describe("Convert Portal Response function", () => {
             fieldValues: [
               {
                 value: "Feature Layer",
-                count: 4
+                count: 4,
               },
               {
                 value: "Table",
-                count: 1
-              }
-            ]
+                count: 1,
+              },
+            ],
           },
           {
             fieldName: "access",
             fieldValues: [
               {
                 value: "public",
-                count: 3
+                count: 3,
               },
               {
                 value: "private",
-                count: 1
+                count: 1,
               },
               {
                 value: "org",
-                count: 1
-              }
-            ]
-          }
-        ]
-      }
+                count: 1,
+              },
+            ],
+          },
+        ],
+      },
     };
 
     // Mock
@@ -240,7 +245,9 @@ describe("Convert Portal Response function", () => {
 
     // Assert
     expect(convertedResponse).toBeDefined();
-    expect(convertedResponse.results).toEqual(portalApiResultsOne.results);
+    expect(convertedResponse.results).toEqual(
+      portalApiResultsOne.results.map(itemToContent)
+    );
     expect(convertedResponse.query).toEqual(portalApiResultsOne.query);
     expect(convertedResponse.total).toEqual(portalApiResultsOne.total);
     expect(convertedResponse.count).toEqual(portalApiResultsOne.num);
@@ -252,31 +259,31 @@ describe("Convert Portal Response function", () => {
         aggregations: [
           {
             label: "Feature Layer",
-            value: 4
+            value: 4,
           },
           {
             label: "Table",
-            value: 1
-          }
-        ]
+            value: 1,
+          },
+        ],
       },
       {
         fieldName: "access",
         aggregations: [
           {
             label: "public",
-            value: 3
+            value: 3,
           },
           {
             label: "private",
-            value: 1
+            value: 1,
           },
           {
             label: "org",
-            value: 1
-          }
-        ]
-      }
+            value: 1,
+          },
+        ],
+      },
     ]);
     expect(convertedResponse.next).toBeDefined();
 
@@ -293,10 +300,12 @@ describe("Convert Portal Response function", () => {
           sortField: "title",
           sortOrder: "asc",
           aggregations: "type,access",
-          authentication: undefined
-        }
+          authentication: undefined,
+        },
       ]);
-      expect(contentResponse.results).toEqual(portalApiResultsTwo.results);
+      expect(contentResponse.results).toEqual(
+        portalApiResultsTwo.results.map(itemToContent)
+      );
       expect(contentResponse.query).toEqual(portalApiResultsTwo.query);
       expect(contentResponse.total).toEqual(portalApiResultsTwo.total);
       expect(contentResponse.count).toEqual(portalApiResultsTwo.num);
@@ -308,38 +317,38 @@ describe("Convert Portal Response function", () => {
           aggregations: [
             {
               label: "Feature Layer",
-              value: 4
+              value: 4,
             },
             {
               label: "Table",
-              value: 1
-            }
-          ]
+              value: 1,
+            },
+          ],
         },
         {
           fieldName: "access",
           aggregations: [
             {
               label: "public",
-              value: 3
+              value: 3,
             },
             {
               label: "private",
-              value: 1
+              value: 1,
             },
             {
               label: "org",
-              value: 1
-            }
-          ]
-        }
+              value: 1,
+            },
+          ],
+        },
       ]);
       expect(contentResponse.next).toBeDefined();
       done();
     });
   });
 
-  it("can use different UserSession objects for subsequent requests", done => {
+  it("can use different UserSession objects for subsequent requests", (done) => {
     // Setup
     const itemOne: IItem = {
       id: "12345",
@@ -350,7 +359,7 @@ describe("Convert Portal Response function", () => {
       created: 1000,
       modified: 2000,
       numViews: 1,
-      size: 5
+      size: 5,
     };
 
     const itemTwo: IItem = {
@@ -362,7 +371,7 @@ describe("Convert Portal Response function", () => {
       created: 2000,
       modified: 3000,
       numViews: 2,
-      size: 6
+      size: 6,
     };
 
     const userSessionOne = new UserSession({ portal: "dummy-portal-one" });
@@ -374,7 +383,7 @@ describe("Convert Portal Response function", () => {
       sortField: "title",
       start: 1,
       num: 1,
-      authentication: userSessionOne
+      authentication: userSessionOne,
     };
 
     const portalApiResultsOne: ISearchResult<IItem> = {
@@ -383,7 +392,7 @@ describe("Convert Portal Response function", () => {
       start: 1,
       num: 1,
       nextStart: 2,
-      results: [itemOne]
+      results: [itemOne],
     };
 
     const portalApiResultsTwo: ISearchResult<IItem> = {
@@ -392,7 +401,7 @@ describe("Convert Portal Response function", () => {
       start: 2,
       num: 1,
       nextStart: -1,
-      results: [itemTwo]
+      results: [itemTwo],
     };
 
     // Mock
@@ -408,7 +417,9 @@ describe("Convert Portal Response function", () => {
 
     // Assert
     expect(convertedResponse).toBeDefined();
-    expect(convertedResponse.results).toEqual(portalApiResultsOne.results);
+    expect(convertedResponse.results).toEqual(
+      portalApiResultsOne.results.map(itemToContent)
+    );
     expect(convertedResponse.query).toEqual(portalApiResultsOne.query);
     expect(convertedResponse.total).toEqual(portalApiResultsOne.total);
     expect(convertedResponse.count).toEqual(portalApiResultsOne.num);
@@ -430,10 +441,12 @@ describe("Convert Portal Response function", () => {
             start: 2,
             sortField: "title",
             sortOrder: "asc",
-            authentication: userSessionTwo
-          }
+            authentication: userSessionTwo,
+          },
         ]);
-        expect(contentResponse.results).toEqual(portalApiResultsTwo.results);
+        expect(contentResponse.results).toEqual(
+          portalApiResultsTwo.results.map(itemToContent)
+        );
         expect(contentResponse.query).toEqual(portalApiResultsTwo.query);
         expect(contentResponse.total).toEqual(portalApiResultsTwo.total);
         expect(contentResponse.count).toEqual(portalApiResultsTwo.num);

--- a/packages/search/test/content/index.test.ts
+++ b/packages/search/test/content/index.test.ts
@@ -2,7 +2,11 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 import * as portal from "@esri/arcgis-rest-portal";
 import { IItem, ISearchResult } from "@esri/arcgis-rest-portal";
 import * as common from "@esri/hub-common";
-import { IHubRequestOptions } from "@esri/hub-common";
+import {
+  datasetToContent,
+  IHubRequestOptions,
+  itemToContent,
+} from "@esri/hub-common";
 import { ContentSearchService, searchContent } from "../../src/content/index";
 import {
   IContentSearchFilter,
@@ -57,6 +61,8 @@ describe("Content Search Service", () => {
       results: [itemOne, itemTwo],
     };
 
+    const results = mockedResponse.results.map(itemToContent);
+
     const authentication: UserSession = new UserSession({
       portal: "portal-sharing-url",
     });
@@ -92,7 +98,7 @@ describe("Content Search Service", () => {
           bbox: undefined,
         },
       ]);
-      expect(response.results).toEqual(mockedResponse.results);
+      expect(response.results).toEqual(results);
       expect(response.query).toEqual(mockedResponse.query);
       expect(response.total).toEqual(mockedResponse.total);
       expect(response.count).toEqual(mockedResponse.num);
@@ -138,6 +144,8 @@ describe("Content Search Service", () => {
       results: [itemOne, itemTwo],
     };
 
+    const expectedResults = mockedResponse.results.map(itemToContent);
+
     const authentication: UserSession = new UserSession({
       portal: "portal-sharing-url",
     });
@@ -173,7 +181,7 @@ describe("Content Search Service", () => {
           bbox: undefined,
         },
       ]);
-      expect(response.results).toEqual(mockedResponse.results);
+      expect(response.results).toEqual(expectedResults);
       expect(response.query).toEqual(mockedResponse.query);
       expect(response.total).toEqual(mockedResponse.total);
       expect(response.count).toEqual(mockedResponse.num);
@@ -241,6 +249,8 @@ describe("Content Search Service", () => {
       },
     };
 
+    const results = mockedResponse.data.map(datasetToContent);
+
     const authentication: UserSession = new UserSession({
       portal: "portal-sharing-url",
     });
@@ -282,9 +292,7 @@ describe("Content Search Service", () => {
           },
         },
       ]);
-      const mappedAttributes: Array<Record<string, any>> =
-        mockedResponse.data.map((d: Record<string, any>) => d.attributes);
-      expect(response.results).toEqual(mappedAttributes);
+      expect(response.results).toEqual(results);
       expect(response.query).toEqual(
         JSON.stringify(mockedResponse.meta.queryParameters)
       );
@@ -359,6 +367,8 @@ describe("Content Search Service", () => {
       },
     };
 
+    const expectedResults = mockedResponse.data.map(datasetToContent);
+
     const sessionTwo: UserSession = new UserSession({
       portal: "a-different-Portal",
     });
@@ -400,9 +410,7 @@ describe("Content Search Service", () => {
           },
         },
       ]);
-      const mappedAttributes: Array<Record<string, any>> =
-        mockedResponse.data.map((d: Record<string, any>) => d.attributes);
-      expect(response.results).toEqual(mappedAttributes);
+      expect(response.results).toEqual(expectedResults);
       expect(response.query).toEqual(
         JSON.stringify(mockedResponse.meta.queryParameters)
       );
@@ -473,6 +481,7 @@ describe("Content Search Service", () => {
         },
       },
     };
+    const expectedResults = mockedResponse.data.map(datasetToContent);
 
     const service: ContentSearchService = new ContentSearchService({
       portal: "https://qaext.arcgis.com/sharing/rest",
@@ -508,9 +517,7 @@ describe("Content Search Service", () => {
           },
         },
       ]);
-      const mappedAttributes: Array<Record<string, any>> =
-        mockedResponse.data.map((d: Record<string, any>) => d.attributes);
-      expect(response.results).toEqual(mappedAttributes);
+      expect(response.results).toEqual(expectedResults);
       expect(response.query).toEqual(
         JSON.stringify(mockedResponse.meta.queryParameters)
       );
@@ -568,6 +575,7 @@ describe("Content Search Service", () => {
         },
       },
     };
+    const expectedResults = mockedResponse.data.map(datasetToContent);
 
     const service: ContentSearchService = new ContentSearchService({
       portal: "https://qaext.arcgis.com/sharing/rest",
@@ -601,9 +609,7 @@ describe("Content Search Service", () => {
           },
         },
       ]);
-      const mappedAttributes: Array<Record<string, any>> =
-        mockedResponse.data.map((d: Record<string, any>) => d.attributes);
-      expect(response.results).toEqual(mappedAttributes);
+      expect(response.results).toEqual(expectedResults);
       expect(response.query).toEqual(
         JSON.stringify(mockedResponse.meta.queryParameters)
       );
@@ -753,6 +759,8 @@ describe("searchContent function", () => {
       results: [itemOne, itemTwo],
     };
 
+    const expectedResults = mockedResponse.results.map(itemToContent);
+
     // Mock
     const searchItemsMock = spyOn(portal, "searchItems").and.returnValue(
       Promise.resolve(mockedResponse)
@@ -778,7 +786,7 @@ describe("searchContent function", () => {
           bbox: undefined,
         },
       ]);
-      expect(response.results).toEqual(mockedResponse.results);
+      expect(response.results).toEqual(expectedResults);
       expect(response.query).toEqual(mockedResponse.query);
       expect(response.total).toEqual(mockedResponse.total);
       expect(response.count).toEqual(mockedResponse.num);
@@ -855,6 +863,8 @@ describe("searchContent function", () => {
       },
     };
 
+    const expectedResults = mockedResponse.data.map(datasetToContent);
+
     // Mock
     const hubRequestMock = spyOn(common, "hubApiRequest").and.returnValue(
       Promise.resolve(mockedResponse)
@@ -886,9 +896,7 @@ describe("searchContent function", () => {
           },
         },
       ]);
-      const mappedAttributes: Array<Record<string, any>> =
-        mockedResponse.data.map((d: Record<string, any>) => d.attributes);
-      expect(response.results).toEqual(mappedAttributes);
+      expect(response.results).toEqual(expectedResults);
       expect(response.query).toEqual(
         JSON.stringify(mockedResponse.meta.queryParameters)
       );
@@ -948,6 +956,8 @@ describe("searchContent function", () => {
       },
     };
 
+    const expectedResults = mockedResponse.data.map(datasetToContent);
+
     // Mock
     const hubRequestMock = spyOn(common, "hubApiRequest").and.returnValue(
       Promise.resolve(mockedResponse)
@@ -975,9 +985,7 @@ describe("searchContent function", () => {
           },
         },
       ]);
-      const mappedAttributes: Array<Record<string, any>> =
-        mockedResponse.data.map((d: Record<string, any>) => d.attributes);
-      expect(response.results).toEqual(mappedAttributes);
+      expect(response.results).toEqual(expectedResults);
       expect(response.query).toEqual(
         JSON.stringify(mockedResponse.meta.queryParameters)
       );
@@ -1051,6 +1059,8 @@ describe("searchContent function", () => {
       },
     };
 
+    const expectedResults = mockedResponse.data.map(datasetToContent);
+
     // Mock
     const hubRequestMock = spyOn(common, "hubApiRequest").and.returnValue(
       Promise.resolve(mockedResponse)
@@ -1080,9 +1090,7 @@ describe("searchContent function", () => {
           },
         },
       ]);
-      const mappedAttributes: Array<Record<string, any>> =
-        mockedResponse.data.map((d: Record<string, any>) => d.attributes);
-      expect(response.results).toEqual(mappedAttributes);
+      expect(response.results).toEqual(expectedResults);
       expect(response.query).toEqual(
         JSON.stringify(mockedResponse.meta.queryParameters)
       );


### PR DESCRIPTION
affects: @esri/hub-search

1. Description:

1. Instructions for testing:

1. Resolves #606

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
