### PR TITLE
feat(hub-sites): bump site uiVersion to 2.4

### DIFF
--- a/packages/sites/src/site-ui-version.ts
+++ b/packages/sites/src/site-ui-version.ts
@@ -1,1 +1,1 @@
-export const SITE_UI_VERSION = "2.3";
+export const SITE_UI_VERSION = "2.4";


### PR DESCRIPTION
affects: @esri/hub-sites

1. Description:
This is so we can check that version to know whether to apply a base font size css compatibility patch.

https://devtopia.esri.com/dc/hub/issues/2285

1. [X] ran commit script (`npm run c`)