### PR TITLE
chore(hub-search): added export to searchDatasets function

### DIFF
--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -1,13 +1,17 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 /* istanbul ignore file */
-export { ContentSearchService, searchContent } from "./content/index";
+export {
+  ContentSearchService,
+  searchContent,
+  searchDatasets,
+} from "./content/index";
 
 export {
   agoSearch,
   agoFormatItemCollection,
   serialize,
-  computeItemsFacets
+  computeItemsFacets,
 } from "./ago";
 
 export * from "./util";


### PR DESCRIPTION
affects: @esri/hub-search

1. Description: Quick chore to add searchDatasets to exports

2. Instructions for testing: When linking or pulling release in, ensure searchDatasets can be exported.

3. Closes Issues: #<number> (if appropriate)

4. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
