### PR TITLE
fix(hub-sites): fixes return type for _getSharingEligibleModels method

### DIFF
--- a/packages/sites/src/_get-sharing-eligible-models.ts
+++ b/packages/sites/src/_get-sharing-eligible-models.ts
@@ -41,7 +41,7 @@ export function _getSharingEligibleModels(
           ineligibleModels.find(({ item: { id } }) => model.item.id === id)
             ? acc
             : [...acc, model],
-        []
+        [] as IModel[]
       )
   );
 }


### PR DESCRIPTION
affects: @esri/hub-sites

1. Description:
The absence of the below cast caused issues when I pulled the latest tag into Solutions.js. Without this cast, the return type for this method was being inferred as `Promise<any[]>` when it should have been `Promise<IModel[]>` and caused the TS compiler to error.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
