### PR TITLE
Add _searchGroups function

### DIFF
--- a/packages/common/e2e/search-groups.e2e.ts
+++ b/packages/common/e2e/search-groups.e2e.ts
@@ -37,13 +37,47 @@ fdescribe("SearchGroups:", () => {
       const opts: IHubSearchOptions = {
         apis: ["arcgisQA"],
         authentication: adminSession,
-        aggregations: ["tags", "access"],
         sortField: "created",
         sortOrder: "desc",
       };
       const results = await _searchGroups(f, opts);
       expect(results.groups.length).toBe(10);
-      expect(results.facets?.length).toBe(2);
+    });
+    it("typeKeyword", async () => {
+      const orgName = "hubBasic";
+      let adminSession: UserSession;
+      adminSession = factory.getSession(orgName, "admin");
+      const f: Filter<"group"> = {
+        filterType: "group",
+        tags: {
+          all: ["Hub Content Group", "Hub Initiative Group"],
+        },
+      };
+      const opts: IHubSearchOptions = {
+        apis: ["arcgisQA"],
+        authentication: adminSession,
+        sortField: "created",
+        sortOrder: "desc",
+      };
+      const results = await _searchGroups(f, opts);
+      expect(results.groups.length).toBe(10);
+    });
+    it("searchUserAccess", async () => {
+      const orgName = "hubBasic";
+      let adminSession: UserSession;
+      adminSession = factory.getSession(orgName, "admin");
+      const f: Filter<"group"> = {
+        filterType: "group",
+        searchUserAccess: "groupMember",
+      };
+      const opts: IHubSearchOptions = {
+        apis: ["arcgisQA"],
+        authentication: adminSession,
+        sortField: "created",
+        sortOrder: "desc",
+      };
+      const results = await _searchGroups(f, opts);
+      expect(results.groups.length).toBe(10);
     });
   });
 });

--- a/packages/common/e2e/search-groups.e2e.ts
+++ b/packages/common/e2e/search-groups.e2e.ts
@@ -21,8 +21,8 @@ fdescribe("SearchGroups:", () => {
       const opts: IHubSearchOptions = {
         apis: ["arcgisQA"],
       };
-      const results = await _searchGroups(f, opts);
-      expect(results.groups.length).toBeGreaterThan(1);
+      const response = await _searchGroups(f, opts);
+      expect(response.results.length).toBeGreaterThan(1);
     });
     it("authd", async () => {
       const orgName = "hubBasic";
@@ -40,8 +40,8 @@ fdescribe("SearchGroups:", () => {
         sortField: "created",
         sortOrder: "desc",
       };
-      const results = await _searchGroups(f, opts);
-      expect(results.groups.length).toBe(10);
+      const response = await _searchGroups(f, opts);
+      expect(response.results.length).toBe(10);
     });
     it("typeKeyword", async () => {
       const orgName = "hubBasic";
@@ -59,8 +59,8 @@ fdescribe("SearchGroups:", () => {
         sortField: "created",
         sortOrder: "desc",
       };
-      const results = await _searchGroups(f, opts);
-      expect(results.groups.length).toBe(10);
+      const response = await _searchGroups(f, opts);
+      expect(response.results.length).toBe(10);
     });
     it("searchUserAccess", async () => {
       const orgName = "hubBasic";
@@ -76,8 +76,9 @@ fdescribe("SearchGroups:", () => {
         sortField: "created",
         sortOrder: "desc",
       };
-      const results = await _searchGroups(f, opts);
-      expect(results.groups.length).toBe(10);
+      const response = await _searchGroups(f, opts);
+      expect(response.results.length).toBe(10);
+      // response.results.map((g) => console.log(g.thumbnailUrl));
     });
   });
 });

--- a/packages/common/e2e/search-groups.e2e.ts
+++ b/packages/common/e2e/search-groups.e2e.ts
@@ -1,0 +1,49 @@
+/* Copyright (c) 2018-2020 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import Artifactory from "./helpers/Artifactory";
+import config from "./helpers/config";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { Filter, IHubSearchOptions, _searchGroups } from "../src/search";
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+
+fdescribe("SearchGroups:", () => {
+  let factory: Artifactory;
+  beforeAll(() => {
+    factory = new Artifactory(config);
+  });
+  describe("simple filter", () => {
+    it("unauthd", async () => {
+      const f: Filter<"group"> = {
+        filterType: "group",
+        owner: "dbouwman_dc",
+      };
+      const opts: IHubSearchOptions = {
+        apis: ["arcgisQA"],
+      };
+      const results = await _searchGroups(f, opts);
+      expect(results.groups.length).toBeGreaterThan(1);
+    });
+    it("authd", async () => {
+      const orgName = "hubBasic";
+      let adminSession: UserSession;
+      adminSession = factory.getSession(orgName, "admin");
+      const f: Filter<"group"> = {
+        filterType: "group",
+        owner: {
+          exact: ["qa_bas_sol_admin"],
+        },
+      };
+      const opts: IHubSearchOptions = {
+        apis: ["arcgisQA"],
+        authentication: adminSession,
+        aggregations: ["tags", "access"],
+        sortField: "created",
+        sortOrder: "desc",
+      };
+      const results = await _searchGroups(f, opts);
+      expect(results.groups.length).toBe(10);
+      expect(results.facets?.length).toBe(2);
+    });
+  });
+});

--- a/packages/common/src/search/_searchGroups.ts
+++ b/packages/common/src/search/_searchGroups.ts
@@ -1,6 +1,7 @@
 import { IGroup } from "@esri/arcgis-rest-portal";
 import { Filter, IFacet, IHubSearchOptions } from "./types";
-import { searchGroups } from "@esri/arcgis-rest-portal";
+import { searchGroups as portalGroupSearch } from "@esri/arcgis-rest-portal";
+import { expandApis } from ".";
 export interface IGroupSearchResult {
   groups: IGroup[];
   facets: IFacet[];
@@ -10,5 +11,15 @@ export async function _searchGroups(
   filter: Filter<"group">,
   options: IHubSearchOptions
 ): Promise<IGroupSearchResult> {
-  throw new Error("not implemented");
+  // expand filter so we can serialize to either api
+  const expanded = expandGroupFilter(filter);
+
+  // APIs
+  if (!options.apis) {
+    // default to AGO PROD
+    options.apis = ["arcgis"];
+  }
+  const apis = expandApis(options.apis);
+
+  return portalGroupSearch().then((response) => {});
 }

--- a/packages/common/src/search/_searchGroups.ts
+++ b/packages/common/src/search/_searchGroups.ts
@@ -1,20 +1,33 @@
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup, ISearchResult } from "@esri/arcgis-rest-portal";
 import { Filter, IFacet, IHubSearchOptions } from "./types";
 import { searchGroups as portalGroupSearch } from "@esri/arcgis-rest-portal";
-import { convertPortalResponseToFacets, expandApis } from ".";
+import {
+  convertPortalResponseToFacets,
+  expandApis,
+  mergeSearchResults,
+} from ".";
 import {
   expandGroupFilter,
   serializeGroupFilterForPortal,
 } from "./group-utils";
+import { UserSession } from "@esri/arcgis-rest-auth";
 export interface IGroupSearchResult {
   groups: IGroup[];
   facets: IFacet[];
 }
 
+/**
+ * Search Groups using Filter<"group">
+ *
+ * Currently just returns ISearchResult<IGroup>
+ * @param filter
+ * @param options
+ * @returns
+ */
 export async function _searchGroups(
   filter: Filter<"group">,
   options: IHubSearchOptions
-): Promise<IGroupSearchResult> {
+): Promise<ISearchResult<IGroup>> {
   // expand filter so we can serialize to either api
   const expanded = expandGroupFilter(filter);
 
@@ -25,23 +38,48 @@ export async function _searchGroups(
   }
   const apis = expandApis(options.apis);
   const so = serializeGroupFilterForPortal(expanded);
-  // pass auth forward
+  let token = "";
+  // if we have auth, pass it forward
+  // otherwise set the portal property
   if (options.authentication) {
     so.authentication = options.authentication;
+    const us: UserSession = options.authentication as UserSession;
+    token = us.token;
+  } else {
+    so.portal = `${apis[0].url}/sharing/rest`;
   }
-  // Aggregations
-  if (options.aggregations?.length) {
-    so.countFields = options.aggregations.join(",");
-    so.countSize = 200;
-  }
+
   if (options.num) {
     so.num = options.num;
   }
+
+  let portalUrl = "https://www.arcgis.com/sharing/rest";
+  if (so.authentication?.portal) {
+    portalUrl = so.authentication.portal;
+  }
+
+  const thumbnailify = (group: IGroup) => {
+    return addThumbnailUrl(portalUrl, group, token);
+  };
+
   return portalGroupSearch(so).then((response) => {
-    // TODO: upgrade thumbnail url
-    const groups = response.results;
-    // Group Search does not support any aggregations
-    const facets = [] as IFacet[];
-    return { groups, facets };
+    // upgrade thumbnail url
+    response.results = response.results.map(thumbnailify);
+    return response;
   });
+}
+
+// Need to decide how to handle adding the token is group is not public
+function addThumbnailUrl(
+  portalUrl: string,
+  group: IGroup,
+  token?: string
+): IGroup {
+  if (group.thumbnail) {
+    group.thumnailUrl = `${portalUrl}/community/groups/${group.id}/info/${group.thumbnail}`;
+    if (token) {
+      group.thumbnailUrl = `${group.thumbnailUrl}?token=${token}`;
+    }
+  }
+  return group;
 }

--- a/packages/common/src/search/_searchGroups.ts
+++ b/packages/common/src/search/_searchGroups.ts
@@ -1,0 +1,14 @@
+import { IGroup } from "@esri/arcgis-rest-portal";
+import { Filter, IFacet, IHubSearchOptions } from "./types";
+import { searchGroups } from "@esri/arcgis-rest-portal";
+export interface IGroupSearchResult {
+  groups: IGroup[];
+  facets: IFacet[];
+}
+
+export async function _searchGroups(
+  filter: Filter<"group">,
+  options: IHubSearchOptions
+): Promise<IGroupSearchResult> {
+  throw new Error("not implemented");
+}

--- a/packages/common/src/search/content-utils.ts
+++ b/packages/common/src/search/content-utils.ts
@@ -1,4 +1,9 @@
-import { IItem, ISearchOptions, ISearchResult } from "@esri/arcgis-rest-portal";
+import {
+  IGroup,
+  IItem,
+  ISearchOptions,
+  ISearchResult,
+} from "@esri/arcgis-rest-portal";
 import { cloneObject } from "..";
 
 import {
@@ -156,7 +161,7 @@ const ContentFilterExpansions: IWellKnownContentFilters = {
  * @returns
  */
 export function convertPortalResponseToFacets(
-  response: ISearchResult<IItem>
+  response: ISearchResult<IItem> | ISearchResult<IGroup>
 ): IFacet[] {
   const result: IFacet[] = [];
   if (response.aggregations?.counts) {

--- a/packages/common/src/search/group-utils.ts
+++ b/packages/common/src/search/group-utils.ts
@@ -1,0 +1,54 @@
+import {
+  Filter,
+  IGroupFilterDefinition,
+  IMatchOptions,
+  relativeDateToDateRange,
+  valueToMatchOptions,
+} from ".";
+import { cloneObject } from "..";
+
+export function expandGroupFilter(
+  filter: IGroupFilterDefinition
+): IGroupFilterDefinition {
+  const result = {} as IGroupFilterDefinition;
+  const dateProps = ["created", "modified"];
+  // Some properties should not get converted to MatchOptions
+  const specialProps = ["searchUserAccess", ...dateProps];
+  // Do the conversion
+  Object.entries(filter).forEach(([k, value]) => {
+    const key = k as keyof IGroupFilterDefinition;
+    if (!specialProps.includes(key)) {
+      result[key] = valueToMatchOptions(value) as IMatchOptions;
+    }
+    if (dateProps.includes(key)) {
+      if (typeof filter[key] === "object") {
+        if (filter[key].type === "relative-date") {
+        }
+      }
+    }
+  });
+  // not DRY, but typescript-- when working with things like this
+  if (filter.created) {
+    if (filter.created.type === "relative-date") {
+      result.created = relativeDateToDateRange(filter.created);
+    } else {
+      result.created = cloneObject(filter.created);
+    }
+  }
+
+  if (filter.modified) {
+    if (filter.modified.type === "relative-date") {
+      result.modified = relativeDateToDateRange(filter.modified);
+    } else {
+      result.modified = cloneObject(filter.modified);
+    }
+  }
+
+  // searchUserAccess is boolean, so we check if the prop exists
+  // vs checking if the value is truthy
+  if (filter.hasOwnProperty("searchUserAccess")) {
+    result.searchUserAccess = filter.searchUserAccess;
+  }
+
+  return result;
+}

--- a/packages/common/src/search/group-utils.ts
+++ b/packages/common/src/search/group-utils.ts
@@ -17,14 +17,14 @@ export function expandGroupFilter(
   const result = {} as IGroupFilterDefinition;
   const dateProps = ["created", "modified"];
   // Some properties should not get converted to MatchOptions
-  const specialProps = ["searchUserAccess", ...dateProps];
+  const specialProps = ["term", "searchUserAccess", ...dateProps];
   // Do the conversion
 
   Object.entries(filter).forEach(([key, value]) => {
     // handle Matchish fields
     if (!specialProps.includes(key)) {
       // setProp side-steps typescript complaining
-      setProp(key, valueToMatchOptions(value) as IMatchOptions, result);
+      setProp(key, valueToMatchOptions(value), result);
     }
     // Handle date fields
     if (dateProps.includes(key)) {
@@ -43,6 +43,10 @@ export function expandGroupFilter(
     result.searchUserAccess = filter.searchUserAccess;
   }
 
+  if (filter.term) {
+    result.term = filter.term;
+  }
+
   return result;
 }
 
@@ -55,15 +59,9 @@ export function serializeGroupFilterForPortal(
   } as ISearchOptions;
 
   const dateProps = ["created", "modified"];
-  const specialProps = [
-    "searchUserAccess",
-    "filterType",
-    "subFilters",
-    "term",
-    ...dateProps,
-  ];
+  const specialProps = ["term", "searchUserAccess", "filterType", ...dateProps];
   Object.entries(filter).forEach(([key, value]) => {
-    // MatchOptions may go into either q or filter
+    // MatchOptions fields
     if (!specialProps.includes(key)) {
       result = mergeSearchOptions(
         result,
@@ -83,6 +81,10 @@ export function serializeGroupFilterForPortal(
   // searchUserAccess is also a top-level property
   if (filter.hasOwnProperty("searchUserAccess")) {
     result.searchUserAccess = filter.searchUserAccess;
+  }
+  // add the term
+  if (filter.term) {
+    result.q = `${filter.term} ${result.q}`.trim();
   }
   return result;
 }

--- a/packages/common/src/search/group-utils.ts
+++ b/packages/common/src/search/group-utils.ts
@@ -1,11 +1,15 @@
+import { ISearchOptions } from "@esri/arcgis-rest-portal";
 import {
   Filter,
   IGroupFilterDefinition,
   IMatchOptions,
+  mergeSearchOptions,
   relativeDateToDateRange,
+  serializeDateRange,
+  serializeMatchOptions,
   valueToMatchOptions,
 } from ".";
-import { cloneObject } from "..";
+import { cloneObject, getProp, setProp } from "..";
 
 export function expandGroupFilter(
   filter: IGroupFilterDefinition
@@ -15,34 +19,23 @@ export function expandGroupFilter(
   // Some properties should not get converted to MatchOptions
   const specialProps = ["searchUserAccess", ...dateProps];
   // Do the conversion
-  Object.entries(filter).forEach(([k, value]) => {
-    const key = k as keyof IGroupFilterDefinition;
+
+  Object.entries(filter).forEach(([key, value]) => {
+    // handle Matchish fields
     if (!specialProps.includes(key)) {
-      result[key] = valueToMatchOptions(value) as IMatchOptions;
+      // setProp side-steps typescript complaining
+      setProp(key, valueToMatchOptions(value) as IMatchOptions, result);
     }
+    // Handle date fields
     if (dateProps.includes(key)) {
-      if (typeof filter[key] === "object") {
-        if (filter[key].type === "relative-date") {
-        }
+      const dateFieldValue = cloneObject(getProp(filter, key));
+      if (getProp(filter, `${key}.type`) === "relative-date") {
+        setProp(key, relativeDateToDateRange(dateFieldValue), result);
+      } else {
+        setProp(key, dateFieldValue, result);
       }
     }
   });
-  // not DRY, but typescript-- when working with things like this
-  if (filter.created) {
-    if (filter.created.type === "relative-date") {
-      result.created = relativeDateToDateRange(filter.created);
-    } else {
-      result.created = cloneObject(filter.created);
-    }
-  }
-
-  if (filter.modified) {
-    if (filter.modified.type === "relative-date") {
-      result.modified = relativeDateToDateRange(filter.modified);
-    } else {
-      result.modified = cloneObject(filter.modified);
-    }
-  }
 
   // searchUserAccess is boolean, so we check if the prop exists
   // vs checking if the value is truthy
@@ -50,5 +43,46 @@ export function expandGroupFilter(
     result.searchUserAccess = filter.searchUserAccess;
   }
 
+  return result;
+}
+
+export function serializeGroupFilterForPortal(
+  filter: IGroupFilterDefinition
+): ISearchOptions {
+  let result = {
+    q: "",
+    filter: "",
+  } as ISearchOptions;
+
+  const dateProps = ["created", "modified"];
+  const specialProps = [
+    "searchUserAccess",
+    "filterType",
+    "subFilters",
+    "term",
+    ...dateProps,
+  ];
+  Object.entries(filter).forEach(([key, value]) => {
+    // MatchOptions may go into either q or filter
+    if (!specialProps.includes(key)) {
+      result = mergeSearchOptions(
+        result,
+        serializeMatchOptions(key, value),
+        "AND"
+      );
+    }
+    // Dates only go into q
+    if (dateProps.includes(key)) {
+      result = mergeSearchOptions(
+        result,
+        serializeDateRange(key, value),
+        "AND"
+      );
+    }
+  });
+  // searchUserAccess is also a top-level property
+  if (filter.hasOwnProperty("searchUserAccess")) {
+    result.searchUserAccess = filter.searchUserAccess;
+  }
   return result;
 }

--- a/packages/common/src/search/index.ts
+++ b/packages/common/src/search/index.ts
@@ -3,3 +3,4 @@ export * from "./content-utils";
 export * from "./utils";
 export * from "./types";
 export * from "./_searchContent";
+export * from "./_searchGroups";

--- a/packages/common/src/search/types.ts
+++ b/packages/common/src/search/types.ts
@@ -146,7 +146,7 @@ export interface IGroupFilterDefinition {
   modified?: IDateRange<number> | IRelativeDate;
   orgid?: string | string[] | IMatchOptions;
   owner?: string | string[] | IMatchOptions;
-  searchUserAccess?: "groupMember" | "admin";
+  searchUserAccess?: "groupMember";
   tags?: string | string[] | IMatchOptions;
   title?: string | string[] | IMatchOptions;
   typekeywords?: string | string[] | IMatchOptions;

--- a/packages/common/src/search/types.ts
+++ b/packages/common/src/search/types.ts
@@ -1,4 +1,5 @@
 import { UserSession } from "@esri/arcgis-rest-auth";
+import { IGroup } from "@esri/arcgis-rest-types";
 import { IHubContent, IModel } from "..";
 
 /**
@@ -139,6 +140,7 @@ export interface IUserFilterDefinition {
 }
 
 export interface IGroupFilterDefinition {
+  term?: string;
   access?: string | string[] | IMatchOptions;
   created?: IDateRange<number> | IRelativeDate;
   id?: string | string[] | IMatchOptions;

--- a/packages/common/src/search/types.ts
+++ b/packages/common/src/search/types.ts
@@ -142,9 +142,10 @@ export interface IGroupFilterDefinition {
   access?: string | string[] | IMatchOptions;
   created?: IDateRange<number> | IRelativeDate;
   id?: string | string[] | IMatchOptions;
-  isInvitationOnly: boolean;
+  isInvitationOnly?: boolean;
   modified?: IDateRange<number> | IRelativeDate;
   orgid?: string | string[] | IMatchOptions;
+  owner?: string | string[] | IMatchOptions;
   searchUserAccess?: "groupMember" | "admin";
   tags?: string | string[] | IMatchOptions;
   title?: string | string[] | IMatchOptions;

--- a/packages/common/test/mocks/mock-auth.ts
+++ b/packages/common/test/mocks/mock-auth.ts
@@ -1,0 +1,20 @@
+import { UserSession } from "@esri/arcgis-rest-auth";
+
+const TOMORROW = (function () {
+  const now = new Date();
+  now.setDate(now.getDate() + 1);
+  return now;
+})();
+
+export const MOCK_AUTH = new UserSession({
+  clientId: "clientId",
+  redirectUri: "https://example-app.com/redirect-uri",
+  token: "fake-token",
+  tokenExpires: TOMORROW,
+  refreshToken: "refreshToken",
+  refreshTokenExpires: TOMORROW,
+  refreshTokenTTL: 1440,
+  username: "casey",
+  password: "123456",
+  portal: "https://myorg.maps.arcgis.com/sharing/rest",
+});

--- a/packages/common/test/mocks/portal-groups-search/simple-response.json
+++ b/packages/common/test/mocks/portal-groups-search/simple-response.json
@@ -1,0 +1,85 @@
+{
+    "query": "(Open) ",
+    "total": 2,
+    "start": 1,
+    "num": 20,
+    "nextStart": -1,
+    "results": [
+        {
+            "id": "7d9cc5e39a8f4c0aa29e04a473bf4703",
+            "title": "00 Demo OD Initiative Open Data Group",
+            "isInvitationOnly": false,
+            "owner": "dbouwman",
+            "description": "00 Demo OD Initiative Open Data Group",
+            "snippet": null,
+            "tags": [
+                "Hub Initiative Group",
+                "Open Data"
+            ],
+            "typeKeywords": [],
+            "phone": null,
+            "sortField": "title",
+            "sortOrder": "asc",
+            "isViewOnly": false,
+            "isOpenData": true,
+            "featuredItemsId": null,
+            "thumbnail": "happy-gilmore.png",
+            "created": 1551991859000,
+            "modified": 1551991860000,
+            "access": "public",
+            "capabilities": [],
+            "isFav": false,
+            "isReadOnly": false,
+            "protected": true,
+            "autoJoin": false,
+            "notificationsEnabled": false,
+            "provider": null,
+            "providerGroupName": null,
+            "leavingDisallowed": false,
+            "hiddenMembers": false,
+            "displaySettings": {
+                "itemTypes": ""
+            },
+            "properties": null
+        },
+        {
+            "id": "8564992879dc48ed82780637f99074bf",
+            "title": "Alexandria Open Data Demo Content",
+            "isInvitationOnly": false,
+            "owner": "phammons_dcdev",
+            "description": "Use this group to organize the items that you want to share as part of your initiative. Shared items become available in your initiative's search results and only people who have access to these items will be able to find them. Members of the core team get access to shared items and can update them at any time. Certain cards, like the Gallery card, will automatically populate with shared items so that you don't have to search for them when choosing what you want to display on your site.<br /><br />Contact support with any questions related to this group or content management for your site.<br /><br /><strong>DO NOT DELETE THIS GROUP.</strong>",
+            "snippet": "Applications, maps, data, etc. shared with this group generates the Alexandria Open Data Demo content catalog.",
+            "tags": [
+                "Hub Group",
+                "Hub Content Group",
+                "Hub Site Group",
+                "Hub Initiative Group"
+            ],
+            "typeKeywords": [],
+            "phone": null,
+            "sortField": "modified",
+            "sortOrder": "desc",
+            "isViewOnly": false,
+            "featuredItemsId": null,
+            "thumbnail": null,
+            "created": 1586893843000,
+            "modified": 1586893844000,
+            "access": "public",
+            "capabilities": [],
+            "isFav": false,
+            "isReadOnly": false,
+            "protected": true,
+            "autoJoin": false,
+            "notificationsEnabled": false,
+            "provider": null,
+            "providerGroupName": null,
+            "leavingDisallowed": false,
+            "hiddenMembers": false,
+            "displaySettings": {
+                "itemTypes": ""
+            },
+            "properties": null
+        }
+        
+    ]
+}

--- a/packages/common/test/search/_searchGroups.test.ts
+++ b/packages/common/test/search/_searchGroups.test.ts
@@ -1,0 +1,67 @@
+import {
+  cloneObject,
+  Filter,
+  IHubSearchOptions,
+  _searchGroups,
+} from "../../src";
+import * as Portal from "@esri/arcgis-rest-portal";
+import * as SimpleResponse from "../mocks/portal-groups-search/simple-response.json";
+import { MOCK_AUTH } from "../mocks/mock-auth";
+
+describe("_searchGroups:", () => {
+  it("defaults to ago prod", async () => {
+    const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {
+      return Promise.resolve(cloneObject(SimpleResponse));
+    });
+    const f: Filter<"group"> = {
+      filterType: "group",
+      term: "water",
+    };
+    const o: IHubSearchOptions = {};
+    await _searchGroups(f, o);
+    expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
+    const [expectedParams] = searchGroupsSpy.calls.argsFor(0);
+    expect(expectedParams.q).toEqual("water");
+    expect(expectedParams.portal).toBe("https://www.arcgis.com/sharing/rest");
+  });
+
+  it("uses specified apis, passes num", async () => {
+    const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {
+      return Promise.resolve(cloneObject(SimpleResponse));
+    });
+    const f: Filter<"group"> = {
+      filterType: "group",
+      term: "water",
+    };
+    const o: IHubSearchOptions = {
+      apis: ["arcgisQA"],
+      num: 6,
+    };
+    await _searchGroups(f, o);
+    expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
+    const [expectedParams] = searchGroupsSpy.calls.argsFor(0);
+
+    expect(expectedParams.q).toEqual("water");
+    expect(expectedParams.num).toEqual(6);
+    expect(expectedParams.portal).toBe("https://qaext.arcgis.com/sharing/rest");
+  });
+  it("passes auth", async () => {
+    const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {
+      return Promise.resolve(cloneObject(SimpleResponse));
+    });
+    const f: Filter<"group"> = {
+      filterType: "group",
+      term: "water",
+    };
+    const o: IHubSearchOptions = {
+      authentication: MOCK_AUTH,
+    };
+    const chk = await _searchGroups(f, o);
+    expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
+    const [expectedParams] = searchGroupsSpy.calls.argsFor(0);
+    expect(expectedParams.authentication).toBe(MOCK_AUTH);
+    const g1 = chk.results[0];
+    expect(g1.id).toBe("7d9cc5e39a8f4c0aa29e04a473bf4703");
+    expect(g1.thumbnailUrl).toBeDefined();
+  });
+});

--- a/packages/common/test/search/group-utils.test.ts
+++ b/packages/common/test/search/group-utils.test.ts
@@ -1,0 +1,95 @@
+import { Filter, IDateRange, IGroupFilterDefinition } from "../../src";
+import {
+  expandGroupFilter,
+  serializeGroupFilterForPortal,
+} from "../../src/search/group-utils";
+
+describe("group-utils:", () => {
+  describe("expandGroupFilter:", () => {
+    it("basic props", () => {
+      const f: Filter<"group"> = {
+        filterType: "group",
+        owner: "dbouwman_dc",
+        typekeywords: ["one", "two"],
+        searchUserAccess: "groupMember",
+      };
+      const chk = expandGroupFilter(f);
+      expect(chk.owner).toEqual({ any: ["dbouwman_dc"] });
+      expect(chk.typekeywords).toEqual({ any: ["one", "two"] });
+      expect(chk.searchUserAccess).toBeDefined();
+    });
+    it("match props", () => {
+      const f: Filter<"group"> = {
+        filterType: "group",
+        typekeywords: {
+          all: ["one", "two"],
+          any: ["red"],
+        },
+      };
+      const chk = expandGroupFilter(f);
+      expect(chk.typekeywords).toEqual({ all: ["one", "two"], any: ["red"] });
+    });
+    it("expand dates", () => {
+      const f: Filter<"group"> = {
+        filterType: "group",
+        created: {
+          type: "relative-date",
+          unit: "days",
+          num: 5,
+        },
+        modified: {
+          type: "date-range",
+          from: 10,
+          to: 100,
+        },
+      };
+      const chk = expandGroupFilter(f);
+      expect(chk.modified).toEqual({
+        type: "date-range",
+        from: 10,
+        to: 100,
+      });
+      const c = chk.created as IDateRange<number>;
+      expect(c.from).toBeLessThan(c.to);
+    });
+  });
+  describe("serializers:", () => {
+    describe("serializeGroupFilterForPortal:", () => {
+      it("creates q", () => {
+        const f: Filter<"group"> = {
+          filterType: "group",
+          owner: { all: ["dbouwman_dc"] },
+          typekeywords: {
+            any: ["one", "two"],
+          },
+          created: {
+            type: "date-range",
+            from: 10,
+            to: 100,
+          },
+          modified: {
+            type: "date-range",
+            from: 2,
+            to: 8,
+          },
+        };
+        const chk = serializeGroupFilterForPortal(f);
+        expect(chk.q).toBe(
+          `((((owner:"dbouwman_dc") AND (typekeywords:"one" OR typekeywords:"two")) AND created:[10 TO 100]) AND modified:[2 TO 8])`
+        );
+      });
+      it("creates q", () => {
+        const f: Filter<"group"> = {
+          filterType: "group",
+          typekeywords: {
+            any: ["Hub Content Group"],
+          },
+          searchUserAccess: "groupMember",
+        };
+        const chk = serializeGroupFilterForPortal(f);
+        expect(chk.q).toBe(`(typekeywords:"Hub Content Group")`);
+        expect(chk.searchUserAccess).toBe("groupMember");
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Description:
Add `_searchGroups` to hub-common, using `Filter<"group">`


1. Instructions for testing:
- run tests

1. [x] ran commit script (`npm run c`)


For more information see the README
