### PR TITLE
fix(hub-common): export group utils

### DIFF
--- a/packages/common/src/search/index.ts
+++ b/packages/common/src/search/index.ts
@@ -1,5 +1,6 @@
 export * from "./hub-api-search";
 export * from "./content-utils";
+export * from "./group-utils";
 export * from "./utils";
 export * from "./types";
 export * from "./_searchContent";


### PR DESCRIPTION
1. Description:
As it says - export all fns from `group-utils` in hub-common/search

1. Instructions for testing:

Consume in another app... 

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
