### PR TITLE
feat(hub-common): add mergeGroupFilters

### DIFF
--- a/packages/common/test/search/content-utils.test.ts
+++ b/packages/common/test/search/content-utils.test.ts
@@ -365,6 +365,21 @@ describe("Content:", () => {
       expect(chk.owner).toEqual({ any: ["dave"] });
     });
 
+    it("merges terms", () => {
+      const f1: Filter<"content"> = {
+        filterType: "content",
+        term: "water",
+      };
+      const f2: Filter<"content"> = {
+        filterType: "content",
+        term: "beer",
+      };
+      const chk = mergeContentFilter([f1, f2]);
+
+      expect(chk.filterType).toBe("content");
+      expect(chk.term).toEqual("water beer");
+    });
+
     it("overlapping props", () => {
       const f1: Filter<"content"> = {
         filterType: "content",


### PR DESCRIPTION

1. Description:

- add `mergeGroupFilters(filters: Array<Filter<"group">>): Filter<"group">`
- fix issue in `mergeContentFilters` so multiple `term` entries are appended

1. Instructions for testing:

run tests


1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
