### PR TITLE
chore: bump karma-jasmine package to fix deprecation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -761,9 +761,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.16.2",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
-					"integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw=="
+					"version": "7.16.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.3.tgz",
+					"integrity": "sha512-dcNwU1O4sx57ClvLBVFbEgx0UZWfd0JQX5X6fxFRCLHelFBGXFfSz6Y0FAq2PEwUqlqLkdVjVr4VASEOuUnLJw=="
 				},
 				"@babel/template": {
 					"version": "7.16.0",
@@ -776,16 +776,16 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.16.0",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
-					"integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+					"version": "7.16.3",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+					"integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
 					"requires": {
 						"@babel/code-frame": "^7.16.0",
 						"@babel/generator": "^7.16.0",
 						"@babel/helper-function-name": "^7.16.0",
 						"@babel/helper-hoist-variables": "^7.16.0",
 						"@babel/helper-split-export-declaration": "^7.16.0",
-						"@babel/parser": "^7.16.0",
+						"@babel/parser": "^7.16.3",
 						"@babel/types": "^7.16.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0"
@@ -1680,9 +1680,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.16.2",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
-					"integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw=="
+					"version": "7.16.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.3.tgz",
+					"integrity": "sha512-dcNwU1O4sx57ClvLBVFbEgx0UZWfd0JQX5X6fxFRCLHelFBGXFfSz6Y0FAq2PEwUqlqLkdVjVr4VASEOuUnLJw=="
 				},
 				"@babel/template": {
 					"version": "7.16.0",
@@ -1695,16 +1695,16 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.16.0",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
-					"integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+					"version": "7.16.3",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+					"integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
 					"requires": {
 						"@babel/code-frame": "^7.16.0",
 						"@babel/generator": "^7.16.0",
 						"@babel/helper-function-name": "^7.16.0",
 						"@babel/helper-hoist-variables": "^7.16.0",
 						"@babel/helper-split-export-declaration": "^7.16.0",
-						"@babel/parser": "^7.16.0",
+						"@babel/parser": "^7.16.3",
 						"@babel/types": "^7.16.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0"
@@ -7815,71 +7815,6 @@
 						"lru-cache": "^6.0.0"
 					}
 				},
-				"is-binary-path": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg="
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.3",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-							"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-						}
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.3",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-							"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-						}
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
 				"lru-cache": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -7887,36 +7822,6 @@
 					"dev": true,
 					"requires": {
 						"yallist": "^4.0.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.3",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-							"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-						}
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"requires": {
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
-					}
-				},
-				"normalize-path": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"requires": {
-						"remove-trailing-separator": "^1.0.1"
 					}
 				},
 				"npm-package-arg": {
@@ -7942,195 +7847,6 @@
 						"semver": "^7.3.4"
 					}
 				},
-				"readdirp": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"micromatch": "^3.1.10",
-						"readable-stream": "^2.0.2"
-					},
-					"dependencies": {
-						"arr-diff": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-							"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-						},
-						"array-unique": {
-							"version": "0.3.2",
-							"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-							"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-						},
-						"braces": {
-							"version": "2.3.2",
-							"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-							"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-							"requires": {
-								"arr-flatten": "^1.1.0",
-								"array-unique": "^0.3.2",
-								"extend-shallow": "^2.0.1",
-								"fill-range": "^4.0.0",
-								"isobject": "^3.0.1",
-								"repeat-element": "^1.1.2",
-								"snapdragon": "^0.8.1",
-								"snapdragon-node": "^2.0.1",
-								"split-string": "^3.0.2",
-								"to-regex": "^3.0.1"
-							},
-							"dependencies": {
-								"extend-shallow": {
-									"version": "2.0.1",
-									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-									"requires": {
-										"is-extendable": "^0.1.0"
-									}
-								}
-							}
-						},
-						"expand-brackets": {
-							"version": "2.1.4",
-							"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-							"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-							"requires": {
-								"define-property": "^0.2.5",
-								"extend-shallow": "^2.0.1",
-								"posix-character-classes": "^0.1.0",
-								"regex-not": "^1.0.0",
-								"snapdragon": "^0.8.1",
-								"to-regex": "^3.0.1"
-							},
-							"dependencies": {
-								"define-property": {
-									"version": "0.2.5",
-									"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-									"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-									"requires": {
-										"is-descriptor": "^0.1.0"
-									}
-								},
-								"extend-shallow": {
-									"version": "2.0.1",
-									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-									"requires": {
-										"is-extendable": "^0.1.0"
-									}
-								},
-								"is-descriptor": {
-									"version": "0.1.6",
-									"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-									"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-									"requires": {
-										"is-accessor-descriptor": "^0.1.6",
-										"is-data-descriptor": "^0.1.4",
-										"kind-of": "^5.0.0"
-									}
-								},
-								"kind-of": {
-									"version": "5.1.0",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-									"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-								}
-							}
-						},
-						"extglob": {
-							"version": "2.0.4",
-							"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-							"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-							"requires": {
-								"array-unique": "^0.3.2",
-								"define-property": "^1.0.0",
-								"expand-brackets": "^2.1.4",
-								"extend-shallow": "^2.0.1",
-								"fragment-cache": "^0.2.1",
-								"regex-not": "^1.0.0",
-								"snapdragon": "^0.8.1",
-								"to-regex": "^3.0.1"
-							},
-							"dependencies": {
-								"define-property": {
-									"version": "1.0.0",
-									"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-									"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-									"requires": {
-										"is-descriptor": "^1.0.0"
-									}
-								},
-								"extend-shallow": {
-									"version": "2.0.1",
-									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-									"requires": {
-										"is-extendable": "^0.1.0"
-									}
-								}
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"kind-of": {
-							"version": "6.0.3",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-							"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-						},
-						"micromatch": {
-							"version": "3.1.10",
-							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-							"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-							"requires": {
-								"arr-diff": "^4.0.0",
-								"array-unique": "^0.3.2",
-								"braces": "^2.3.1",
-								"define-property": "^2.0.2",
-								"extend-shallow": "^3.0.2",
-								"extglob": "^2.0.4",
-								"fragment-cache": "^0.2.1",
-								"kind-of": "^6.0.2",
-								"nanomatch": "^1.2.9",
-								"object.pick": "^1.3.0",
-								"regex-not": "^1.0.0",
-								"snapdragon": "^0.8.1",
-								"to-regex": "^3.0.2"
-							}
-						}
-					}
-				},
 				"semver": {
 					"version": "7.3.5",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -8138,15 +7854,6 @@
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
 					}
 				},
 				"which": {
@@ -9256,349 +8963,11 @@
 				"yargs": "^6.6.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-					"requires": {
-						"@babel/highlight": "^7.14.5"
-					}
-				},
-				"@babel/compat-data": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.5.tgz",
-					"integrity": "sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w=="
-				},
-				"@babel/core": {
-					"version": "7.14.6",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
-					"integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/generator": "^7.14.5",
-						"@babel/helper-compilation-targets": "^7.14.5",
-						"@babel/helper-module-transforms": "^7.14.5",
-						"@babel/helpers": "^7.14.6",
-						"@babel/parser": "^7.14.6",
-						"@babel/template": "^7.14.5",
-						"@babel/traverse": "^7.14.5",
-						"@babel/types": "^7.14.5",
-						"convert-source-map": "^1.7.0",
-						"debug": "^4.1.0",
-						"gensync": "^1.0.0-beta.2",
-						"json5": "^2.1.2",
-						"semver": "^6.3.0",
-						"source-map": "^0.5.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "4.3.1",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-							"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-							"requires": {
-								"ms": "2.1.2"
-							}
-						},
-						"semver": {
-							"version": "6.3.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-						}
-					}
-				},
-				"@babel/generator": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
-					"integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
-					"requires": {
-						"@babel/types": "^7.14.5",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-compilation-targets": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
-					"integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
-					"requires": {
-						"@babel/compat-data": "^7.14.5",
-						"@babel/helper-validator-option": "^7.14.5",
-						"browserslist": "^4.16.6",
-						"semver": "^6.3.0"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "6.3.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-						}
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.14.5",
-						"@babel/template": "^7.14.5",
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
-					"requires": {
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-hoist-variables": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-					"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
-					"requires": {
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz",
-					"integrity": "sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==",
-					"requires": {
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-module-imports": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-					"integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
-					"requires": {
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-module-transforms": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
-					"integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
-					"requires": {
-						"@babel/helper-module-imports": "^7.14.5",
-						"@babel/helper-replace-supers": "^7.14.5",
-						"@babel/helper-simple-access": "^7.14.5",
-						"@babel/helper-split-export-declaration": "^7.14.5",
-						"@babel/helper-validator-identifier": "^7.14.5",
-						"@babel/template": "^7.14.5",
-						"@babel/traverse": "^7.14.5",
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-optimise-call-expression": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-					"integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-					"requires": {
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-replace-supers": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
-					"integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
-					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.14.5",
-						"@babel/helper-optimise-call-expression": "^7.14.5",
-						"@babel/traverse": "^7.14.5",
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-simple-access": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
-					"integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
-					"requires": {
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
-					"requires": {
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
-				},
-				"@babel/helper-validator-option": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-					"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
-				},
-				"@babel/helpers": {
-					"version": "7.14.6",
-					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
-					"integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
-					"requires": {
-						"@babel/template": "^7.14.5",
-						"@babel/traverse": "^7.14.5",
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
-						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.14.6",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.6.tgz",
-					"integrity": "sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ=="
-				},
-				"@babel/runtime": {
-					"version": "7.14.6",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
-					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg=="
-				},
-				"@babel/template": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/parser": "^7.14.5",
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
-					"integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/generator": "^7.14.5",
-						"@babel/helper-function-name": "^7.14.5",
-						"@babel/helper-hoist-variables": "^7.14.5",
-						"@babel/helper-split-export-declaration": "^7.14.5",
-						"@babel/parser": "^7.14.5",
-						"@babel/types": "^7.14.5",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "4.3.1",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-							"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-							"requires": {
-								"ms": "2.1.2"
-							}
-						}
-					}
-				},
-				"@babel/types": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
 					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
 					"dev": true
-				},
-				"async-disk-cache": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-					"integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-					"requires": {
-						"debug": "^4.1.1",
-						"heimdalljs": "^0.2.3",
-						"istextorbinary": "^2.5.1",
-						"mkdirp": "^0.5.0",
-						"rsvp": "^4.8.5",
-						"username-sync": "^1.0.2"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "4.3.1",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-							"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-							"requires": {
-								"ms": "2.1.2"
-							}
-						}
-					}
-				},
-				"broccoli-persistent-filter": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
-					"integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
-					"requires": {
-						"async-disk-cache": "^2.0.0",
-						"async-promise-queue": "^1.0.3",
-						"broccoli-plugin": "^4.0.3",
-						"fs-tree-diff": "^2.0.0",
-						"hash-for-dep": "^1.5.0",
-						"heimdalljs": "^0.2.1",
-						"heimdalljs-logger": "^0.1.7",
-						"promise-map-series": "^0.2.1",
-						"symlink-or-copy": "^1.0.1"
-					}
-				},
-				"broccoli-plugin": {
-					"version": "4.0.7",
-					"resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-					"integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-					"requires": {
-						"broccoli-node-api": "^1.7.0",
-						"broccoli-output-wrapper": "^3.2.5",
-						"fs-merger": "^3.2.1",
-						"promise-map-series": "^0.3.0",
-						"quick-temp": "^0.1.8",
-						"symlink-or-copy": "^1.3.1"
-					},
-					"dependencies": {
-						"promise-map-series": {
-							"version": "0.3.0",
-							"resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-							"integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA=="
-						}
-					}
-				},
-				"broccoli-source": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-3.0.1.tgz",
-					"integrity": "sha512-ZbGVQjivWi0k220fEeIUioN6Y68xjMy0xiLAc0LdieHI99gw+tafU8w0CggBDYVNsJMKUr006AZaM7gNEwCxEg==",
-					"requires": {
-						"broccoli-node-api": "^1.6.0"
-					}
-				},
-				"browserslist": {
-					"version": "4.16.6",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-					"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
-					"requires": {
-						"caniuse-lite": "^1.0.30001219",
-						"colorette": "^1.2.2",
-						"electron-to-chromium": "^1.3.723",
-						"escalade": "^3.1.1",
-						"node-releases": "^1.1.71"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001237",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz",
-					"integrity": "sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw=="
 				},
 				"chalk": {
 					"version": "1.1.3",
@@ -9621,16 +8990,6 @@
 						}
 					}
 				},
-				"electron-to-chromium": {
-					"version": "1.3.752",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz",
-					"integrity": "sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A=="
-				},
-				"escape-string-regexp": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-				},
 				"eslint-plugin-prettier": {
 					"version": "2.7.0",
 					"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz",
@@ -9641,68 +9000,20 @@
 						"jest-docblock": "^21.0.0"
 					}
 				},
-				"filesize": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/filesize/-/filesize-4.2.1.tgz",
-					"integrity": "sha512-bP82Hi8VRZX/TUBKfE24iiUGsB/sfm2WUrwTQyAzQrhO3V9IhcBBNBXMyzLY5orACxRyYJ3d2HeRVX+eFv4lmA=="
-				},
-				"fs-tree-diff": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-					"integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-					"requires": {
-						"@types/symlink-or-copy": "^1.2.0",
-						"heimdalljs-logger": "^0.1.7",
-						"object-assign": "^4.1.0",
-						"path-posix": "^1.0.0",
-						"symlink-or-copy": "^1.1.8"
-					}
-				},
-				"gensync": {
-					"version": "1.0.0-beta.2",
-					"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-					"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
-				},
-				"handlebars": {
-					"version": "4.7.7",
-					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-					"integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-					"requires": {
-						"minimist": "^1.2.5",
-						"neo-async": "^2.6.0",
-						"source-map": "^0.6.1",
-						"uglify-js": "^3.1.4"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.6.1",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-						}
-					}
-				},
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="
-				},
 				"minimist": {
 					"version": "1.2.5",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.5",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"dev": true,
 					"requires": {
 						"minimist": "^1.2.5"
 					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
 			}
 		},
@@ -10085,7 +9396,8 @@
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+			"dev": true
 		},
 		"array-flatten": {
 			"version": "1.1.1",
@@ -11294,58 +10606,6 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-				},
-				"meow": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-					"requires": {
-						"decamelize": "^1.1.2",
-						"loud-rejection": "^1.0.0",
-						"map-obj": "^1.0.1",
-						"minimist": "^1.1.3",
-						"normalize-package-data": "^2.3.4",
-						"object-assign": "^4.0.1",
-						"read-pkg-up": "^1.0.1",
-						"redent": "^1.0.0",
-						"trim-newlines": "^1.0.0"
-					}
-				},
-				"redent": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"requires": {
-						"indent-string": "^2.1.0",
-						"strip-indent": "^1.0.1"
-					}
-				},
-				"strip-indent": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"requires": {
-						"get-stdin": "^4.0.1"
-					}
-				},
-				"through2": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-					"requires": {
-						"readable-stream": "~2.3.6",
-						"xtend": "~4.0.1"
-					}
-				},
-				"trim-newlines": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
 				}
 			}
 		},
@@ -14936,16 +14196,6 @@
 					"requires": {
 						"is-obj": "^2.0.0"
 					}
-				},
-				"ip-regex": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-					"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				}
 			}
 		},
@@ -16649,6 +15899,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"dev": true,
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
@@ -16886,7 +16137,8 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",
@@ -22478,7 +21730,8 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
 		},
 		"filename-reserved-regex": {
 			"version": "1.0.0",
@@ -22894,6 +22147,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"requires": {
 				"for-in": "^1.0.1"
 			}
@@ -23103,29 +22357,25 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": false,
-					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": false,
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"resolved": false,
-					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.5",
-					"resolved": false,
-					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23135,15 +22385,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": false,
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23153,43 +22401,37 @@
 				},
 				"chownr": {
 					"version": "1.1.1",
-					"resolved": false,
-					"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": false,
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": false,
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": false,
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "4.1.1",
-					"resolved": false,
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23198,29 +22440,25 @@
 				},
 				"deep-extend": {
 					"version": "0.6.0",
-					"resolved": false,
-					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"resolved": false,
-					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
-					"resolved": false,
-					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23229,15 +22467,13 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": false,
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23253,8 +22489,7 @@
 				},
 				"glob": {
 					"version": "7.1.3",
-					"resolved": false,
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23268,15 +22503,13 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": false,
-					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.24",
-					"resolved": false,
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23285,8 +22518,7 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
-					"resolved": false,
-					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23295,8 +22527,7 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": false,
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23306,22 +22537,19 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": false,
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"resolved": false,
-					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23330,15 +22558,13 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": false,
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23347,15 +22573,13 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": false,
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
-					"resolved": false,
-					"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23365,8 +22589,7 @@
 				},
 				"minizlib": {
 					"version": "1.2.1",
-					"resolved": false,
-					"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23375,8 +22598,7 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": false,
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23385,15 +22607,13 @@
 				},
 				"ms": {
 					"version": "2.1.1",
-					"resolved": false,
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.3.0",
-					"resolved": false,
-					"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23404,8 +22624,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": false,
-					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23423,8 +22642,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": false,
-					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23434,15 +22652,13 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.6",
-					"resolved": false,
-					"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.4.1",
-					"resolved": false,
-					"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23452,8 +22668,7 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"resolved": false,
-					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23465,22 +22680,19 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": false,
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": false,
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23489,22 +22701,19 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": false,
-					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23514,22 +22723,19 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.8",
-					"resolved": false,
-					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23541,8 +22747,7 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": false,
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						}
@@ -23550,8 +22755,7 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": false,
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23566,8 +22770,7 @@
 				},
 				"rimraf": {
 					"version": "2.6.3",
-					"resolved": false,
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23576,50 +22779,43 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": false,
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": false,
-					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"resolved": false,
-					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.7.0",
-					"resolved": false,
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": false,
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23630,8 +22826,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": false,
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23640,8 +22835,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": false,
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23650,15 +22844,13 @@
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": false,
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.8",
-					"resolved": false,
-					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23673,15 +22865,13 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.3",
-					"resolved": false,
-					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -23690,15 +22880,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"resolved": false,
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				}
@@ -24682,6 +23870,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"requires": {
 				"glob-parent": "^2.0.0",
 				"is-glob": "^2.0.0"
@@ -24691,6 +23880,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
 					"requires": {
 						"is-glob": "^2.0.0"
 					}
@@ -24698,12 +23888,14 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -25817,6 +25009,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+			"dev": true,
 			"requires": {
 				"repeating": "^2.0.0"
 			}
@@ -26634,7 +25827,8 @@
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
 		},
 		"ip": {
 			"version": "1.1.5",
@@ -26796,12 +25990,14 @@
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"requires": {
 				"is-primitive": "^2.0.0"
 			}
@@ -26986,7 +26182,8 @@
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
 		},
 		"is-promise": {
 			"version": "2.2.2",
@@ -27187,7 +26384,8 @@
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
 		},
 		"is-weakref": {
 			"version": "1.0.1",
@@ -28516,10 +27714,13 @@
 			}
 		},
 		"karma-jasmine": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-1.1.2.tgz",
-			"integrity": "sha1-OU8rJf+0pkS5rabyLUQ+L9CIhsM=",
-			"dev": true
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-2.0.1.tgz",
+			"integrity": "sha512-iuC0hmr9b+SNn1DaUD2QEYtUxkS1J+bSJSn7ejdEexs7P8EYvA1CWkEdrDQ+8jVH3AgWlCNwjYsT1chjcNW9lA==",
+			"dev": true,
+			"requires": {
+				"jasmine-core": "^3.3"
+			}
 		},
 		"karma-jasmine-diff-reporter": {
 			"version": "1.2.1",
@@ -28761,6 +27962,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
@@ -29151,6 +28353,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^2.2.0",
@@ -29163,6 +28366,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -29673,6 +28877,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"dev": true,
 			"requires": {
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.0"
@@ -30370,15 +29575,6 @@
 					"version": "4.12.0",
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
 					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-				},
-				"yargs": {
-					"version": "3.32.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-					"requires": {
-						"decamelize": "^1.1.1",
-						"os-locale": "^1.4.0"
-					}
 				}
 			}
 		},
@@ -31879,11 +31075,6 @@
 					"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
 					"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
 					"dev": true
-				},
-				"normalize-url": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
 				}
 			}
 		},
@@ -32028,6 +31219,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"requires": {
 				"for-own": "^0.1.4",
 				"is-extendable": "^0.1.1"
@@ -32105,11 +31297,6 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
 					"dev": true
-				},
-				"binary-extensions": {
-					"version": "1.13.1",
-					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-					"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
 				},
 				"braces": {
 					"version": "1.8.5",
@@ -32779,6 +31966,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"dev": true,
 			"requires": {
 				"lcid": "^1.0.0"
 			}
@@ -33296,6 +32484,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"requires": {
 				"glob-base": "^0.3.0",
 				"is-dotfile": "^1.0.0",
@@ -33306,12 +32495,14 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -33331,6 +32522,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"dev": true,
 			"requires": {
 				"error-ex": "^1.2.0"
 			}
@@ -33500,11 +32692,6 @@
 					"requires": {
 						"pump": "^3.0.0"
 					}
-				},
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 				}
 			}
 		},
@@ -33573,6 +32760,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"pify": "^2.0.0",
@@ -33621,7 +32809,8 @@
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
@@ -34378,6 +33567,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"dev": true,
 			"requires": {
 				"load-json-file": "^1.0.0",
 				"normalize-package-data": "^2.3.2",
@@ -34388,6 +33578,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"dev": true,
 			"requires": {
 				"find-up": "^1.0.0",
 				"read-pkg": "^1.0.0"
@@ -34397,6 +33588,7 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -34406,6 +33598,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -34557,19 +33750,13 @@
 			"integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
 			"requires": {
 				"@babel/runtime": "^7.8.4"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-					"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
-				}
 			}
 		},
 		"regex-cache": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
 			"requires": {
 				"is-equal-shallow": "^0.1.3"
 			}
@@ -34792,127 +33979,11 @@
 				"resolve-from": "^3.0.0"
 			},
 			"dependencies": {
-				"@nodelib/fs.stat": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
-				},
-				"array-union": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"detect-indent": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-					"integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="
-				},
-				"dir-glob": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-					"requires": {
-						"path-type": "^4.0.0"
-					}
-				},
-				"fast-glob": {
-					"version": "3.2.5",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-					"integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
-					"requires": {
-						"@nodelib/fs.stat": "^2.0.2",
-						"@nodelib/fs.walk": "^1.2.3",
-						"glob-parent": "^5.1.0",
-						"merge2": "^1.3.0",
-						"micromatch": "^4.0.2",
-						"picomatch": "^2.2.1"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"glob-parent": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				},
-				"globby": {
-					"version": "10.0.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
-					"integrity": "sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==",
-					"requires": {
-						"@types/glob": "^7.1.1",
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.0.3",
-						"glob": "^7.1.3",
-						"ignore": "^5.1.1",
-						"merge2": "^1.2.3",
-						"slash": "^3.0.0"
-					}
-				},
-				"ignore": {
-					"version": "5.1.8",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"is-plain-obj": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-				},
-				"micromatch": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.2.3"
-					},
-					"dependencies": {
-						"picomatch": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-							"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
-						}
-					}
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
-				},
 				"resolve-from": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
 					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
 					"dev": true
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 				}
 			}
 		},
@@ -37531,16 +36602,6 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 					"dev": true
-				},
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
 				}
 			}
 		},
@@ -38743,28 +37804,6 @@
 						"color-convert": "^1.9.0"
 					}
 				},
-				"anymatch": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-					"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-					"requires": {
-						"normalize-path": "^3.0.0",
-						"picomatch": "^2.0.4"
-					}
-				},
-				"binary-extensions": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-					"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -38774,20 +37813,6 @@
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
-					}
-				},
-				"chokidar": {
-					"version": "3.5.2",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-					"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-					"requires": {
-						"anymatch": "~3.1.2",
-						"braces": "~3.0.2",
-						"fsevents": "~2.3.2",
-						"glob-parent": "~5.1.2",
-						"is-glob": "~4.0.1",
-						"normalize-path": "~3.0.0",
-						"readdirp": "~3.6.0"
 					}
 				},
 				"color-convert": {
@@ -38804,41 +37829,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"fsevents": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-					"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-					"optional": true
-				},
-				"glob-parent": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"readdirp": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-					"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-					"requires": {
-						"picomatch": "^2.2.1"
-					}
 				},
 				"supports-color": {
 					"version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"karma-env-preprocessor": "^0.1.1",
 		"karma-firefox-launcher": "^1.1.0",
 		"karma-ie-launcher": "^1.0.0",
-		"karma-jasmine": "^1.1.1",
+		"karma-jasmine": "^2.0.1",
 		"karma-jasmine-diff-reporter": "^1.1.1",
 		"karma-safari-launcher": "^1.0.0",
 		"karma-spec-reporter": "^0.0.32",


### PR DESCRIPTION
1. Description:

This warning has been appearing for some time now, but it seems something bumped up versions and now it's actually erroring:

![image](https://user-images.githubusercontent.com/119129/141138116-a49f3360-3bb1-4765-a1c0-e70899dc625b.png)


1. Instructions for testing:

GH Actions should not throw this error


1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
