### PR TITLE
fix: fix thumbnailUrl typo in _searchGroups

### DIFF
--- a/packages/common/src/search/_searchGroups.ts
+++ b/packages/common/src/search/_searchGroups.ts
@@ -76,7 +76,7 @@ function addThumbnailUrl(
   token?: string
 ): IGroup {
   if (group.thumbnail) {
-    group.thumnailUrl = `${portalUrl}/community/groups/${group.id}/info/${group.thumbnail}`;
+    group.thumbnailUrl = `${portalUrl}/community/groups/${group.id}/info/${group.thumbnail}`;
     if (token) {
       group.thumbnailUrl = `${group.thumbnailUrl}?token=${token}`;
     }


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Fix thumbnailUrl typo in `_searchGroups`
1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
