### PR TITLE
feat(hub-common): add next() to _searchContent and _searchGroups

### DIFF
--- a/packages/common/e2e/search-content.e2e.ts
+++ b/packages/common/e2e/search-content.e2e.ts
@@ -19,10 +19,23 @@ fdescribe("SearchContent:", () => {
         owner: "dbouwman_dc",
       };
       const opts: IHubSearchOptions = {
-        apis: ["arcgisQA"],
+        api: "arcgisQA",
       };
       const results = await _searchContent(f, opts);
       expect(results.results.length).toBeGreaterThan(1);
+    });
+    it("unauthd next", async () => {
+      const f: Filter<"content"> = {
+        filterType: "content",
+        term: "water",
+      };
+      const opts: IHubSearchOptions = {
+        api: "arcgisQA",
+      };
+      const results = await _searchContent(f, opts);
+      expect(results.results.length).toBeGreaterThan(1);
+      const results2 = await results.next();
+      expect(results2.results.length).toBeGreaterThan(1);
     });
     it("authd", async () => {
       const orgName = "hubBasic";
@@ -35,7 +48,7 @@ fdescribe("SearchContent:", () => {
         },
       };
       const opts: IHubSearchOptions = {
-        apis: ["arcgisQA"],
+        api: "arcgisQA",
         authentication: adminSession,
         aggregations: ["tags", "access"],
         sortField: "created",
@@ -44,6 +57,30 @@ fdescribe("SearchContent:", () => {
       const results = await _searchContent(f, opts);
       expect(results.results.length).toBe(10);
       expect(results.facets?.length).toBe(2);
+      const r2 = await results.next();
+      expect(r2.results.length).toBe(10);
+    });
+    it("authd next", async () => {
+      const orgName = "hubBasic";
+      let adminSession: UserSession;
+      adminSession = factory.getSession(orgName, "admin");
+      const f: Filter<"content"> = {
+        filterType: "content",
+        owner: {
+          exact: ["qa_bas_sol_admin"],
+        },
+      };
+      const opts: IHubSearchOptions = {
+        api: "arcgisQA",
+        authentication: adminSession,
+        aggregations: ["tags", "access"],
+        sortField: "created",
+        sortOrder: "desc",
+      };
+      const results = await _searchContent(f, opts);
+      const results2 = await results.next(adminSession);
+      expect(results2.results.length).toBe(10);
+      expect(results2.facets?.length).toBe(2);
     });
   });
 });

--- a/packages/common/e2e/search-groups.e2e.ts
+++ b/packages/common/e2e/search-groups.e2e.ts
@@ -19,10 +19,23 @@ fdescribe("SearchGroups:", () => {
         owner: "dbouwman_dc",
       };
       const opts: IHubSearchOptions = {
-        apis: ["arcgisQA"],
+        api: "arcgisQA",
       };
       const response = await _searchGroups(f, opts);
       expect(response.results.length).toBeGreaterThan(1);
+    });
+    it("unauthd next", async () => {
+      const f: Filter<"group"> = {
+        filterType: "group",
+        owner: "dbouwman_dc",
+      };
+      const opts: IHubSearchOptions = {
+        api: "arcgisQA",
+      };
+      const response = await _searchGroups(f, opts);
+      expect(response.results.length).toBeGreaterThan(1);
+      const response2 = await response.next();
+      expect(response2.results.length).toBeGreaterThan(1);
     });
     it("authd", async () => {
       const orgName = "hubBasic";
@@ -35,7 +48,7 @@ fdescribe("SearchGroups:", () => {
         },
       };
       const opts: IHubSearchOptions = {
-        apis: ["arcgisQA"],
+        api: "arcgisQA",
         authentication: adminSession,
         sortField: "created",
         sortOrder: "desc",
@@ -54,7 +67,7 @@ fdescribe("SearchGroups:", () => {
         },
       };
       const opts: IHubSearchOptions = {
-        apis: ["arcgisQA"],
+        api: "arcgisQA",
         authentication: adminSession,
         sortField: "created",
         sortOrder: "desc",
@@ -71,7 +84,7 @@ fdescribe("SearchGroups:", () => {
         searchUserAccess: "groupMember",
       };
       const opts: IHubSearchOptions = {
-        apis: ["arcgisQA"],
+        api: "arcgisQA",
         authentication: adminSession,
         sortField: "created",
         sortOrder: "desc",

--- a/packages/common/src/search/_searchContent.ts
+++ b/packages/common/src/search/_searchContent.ts
@@ -31,13 +31,8 @@ export async function _searchContent(
   // expand filter so we can serialize to either api
   const expanded = expandContentFilter(filter);
 
-  // APIs
-  if (!options.api) {
-    // default to AGO PROD
-    options.api = "arcgis";
-  }
-
-  const api = expandApi(options.api);
+  // API
+  const api = expandApi(options.api || "arcgis");
 
   let searchPromise;
   // map over the apis, depending on the type we issue the queries

--- a/packages/common/src/search/_searchContent.ts
+++ b/packages/common/src/search/_searchContent.ts
@@ -49,6 +49,8 @@ export async function _searchContent(
     // pass auth forward
     if (options.authentication) {
       so.authentication = options.authentication;
+    } else {
+      so.portal = `${api.url}/sharing/rest`;
     }
     // Aggregations
     if (options.aggregations?.length) {

--- a/packages/common/src/search/_searchGroups.ts
+++ b/packages/common/src/search/_searchGroups.ts
@@ -1,16 +1,13 @@
-import { IGroup, ISearchResult } from "@esri/arcgis-rest-portal";
+import { IGroup, ISearchOptions } from "@esri/arcgis-rest-portal";
 import { Filter, IFacet, IHubSearchOptions } from "./types";
 import { searchGroups as portalGroupSearch } from "@esri/arcgis-rest-portal";
-import {
-  convertPortalResponseToFacets,
-  expandApis,
-  mergeSearchResults,
-} from ".";
+import { expandApi, getNextFunction } from ".";
 import {
   expandGroupFilter,
   serializeGroupFilterForPortal,
 } from "./group-utils";
 import { UserSession } from "@esri/arcgis-rest-auth";
+import { cloneObject, ISearchResponse } from "..";
 export interface IGroupSearchResult {
   groups: IGroup[];
   facets: IFacet[];
@@ -27,58 +24,103 @@ export interface IGroupSearchResult {
 export async function _searchGroups(
   filter: Filter<"group">,
   options: IHubSearchOptions
-): Promise<ISearchResult<IGroup>> {
+): Promise<ISearchResponse<IGroup>> {
   // expand filter so we can serialize to either api
   const expanded = expandGroupFilter(filter);
 
   // APIs
-  if (!options.apis) {
+  if (!options.api) {
     // default to AGO PROD
-    options.apis = ["arcgis"];
+    options.api = "arcgis";
   }
-  const apis = expandApis(options.apis);
-  const so = serializeGroupFilterForPortal(expanded);
-  let token = "";
-  // if we have auth, pass it forward
-  // otherwise set the portal property
-  if (options.authentication) {
-    so.authentication = options.authentication;
-    const us: UserSession = options.authentication as UserSession;
-    token = us.token;
+  const api = expandApi(options.api);
+  if (api.type === "arcgis") {
+    const so = serializeGroupFilterForPortal(expanded);
+    let token = "";
+    // if we have auth, pass it forward
+    // otherwise set the portal property
+    if (options.authentication) {
+      so.authentication = options.authentication;
+      const us: UserSession = options.authentication as UserSession;
+      token = us.token;
+    } else {
+      so.portal = `${api.url}/sharing/rest`;
+    }
+
+    if (options.num) {
+      so.num = options.num;
+    }
+
+    let portalUrl = "https://www.arcgis.com/sharing/rest";
+    if (so.authentication?.portal) {
+      portalUrl = so.authentication.portal;
+    }
+
+    if (options.site) {
+      so.site = cloneObject(options.site);
+    }
+
+    return searchPortalGroups(so);
   } else {
-    so.portal = `${apis[0].url}/sharing/rest`;
+    throw new Error("_searchGroups is not implemented for non-arcgis apis");
   }
+}
 
-  if (options.num) {
-    so.num = options.num;
+function searchPortalGroups(
+  searchOptions: ISearchOptions
+): Promise<ISearchResponse<IGroup>> {
+  const teamLinkify = (group: IGroup) => {
+    group.siteTeamUrl = `${searchOptions.site.item.url}/teams/${group.id}/about`;
+    return group;
+  };
+
+  const portalUrl =
+    searchOptions.authentication?.portal ||
+    "https://www.arcgis.com/sharing/rest";
+  let token: string;
+  if (searchOptions.authentication) {
+    const us: UserSession = searchOptions.authentication as UserSession;
+    token = us.token;
   }
-
-  let portalUrl = "https://www.arcgis.com/sharing/rest";
-  if (so.authentication?.portal) {
-    portalUrl = so.authentication.portal;
-  }
-
+  // Partially apply url and token to addThumbnailUrl fn
   const thumbnailify = (group: IGroup) => {
     return addThumbnailUrl(portalUrl, group, token);
   };
 
-  const teamLinkify = (group: IGroup) => {
-    group.siteTeamUrl = `${options.site.item.url}/teams/${group.id}/about`;
-    return group;
-  };
+  // execute the search
+  return portalGroupSearch(searchOptions).then((response) => {
+    const hasNext: boolean = response.nextStart > -1;
 
-  return portalGroupSearch(so).then((response) => {
     // upgrade thumbnail url
-    response.results = response.results.map(thumbnailify);
+    let results = response.results.map(thumbnailify);
     // generate the site team url if site url is provided
-    if (options.site?.item?.url) {
-      response.results = response.results.map(teamLinkify);
+    if (searchOptions.site?.item?.url) {
+      results = response.results.map(teamLinkify);
     }
-    return response;
+
+    return {
+      hasNext,
+      total: response.total,
+      results,
+      next: getNextFunction<IGroup>(
+        searchOptions,
+        response.nextStart,
+        response.total,
+        searchPortalGroups
+      ),
+    } as ISearchResponse<IGroup>;
   });
 }
 
-// Need to decide how to handle adding the token is group is not public
+/**
+ * Internal helper that adds  `thumbnailUrl` property to an `IGroup`
+ * if the `.thumbnail` property is defined.
+ * Will add a token if group is not public and a token is passed in
+ * @param portalUrl
+ * @param group
+ * @param token
+ * @returns
+ */
 function addThumbnailUrl(
   portalUrl: string,
   group: IGroup,
@@ -86,7 +128,7 @@ function addThumbnailUrl(
 ): IGroup {
   if (group.thumbnail) {
     group.thumbnailUrl = `${portalUrl}/community/groups/${group.id}/info/${group.thumbnail}`;
-    if (token) {
+    if (token && group.access !== "public") {
       group.thumbnailUrl = `${group.thumbnailUrl}?token=${token}`;
     }
   }

--- a/packages/common/src/search/_searchGroups.ts
+++ b/packages/common/src/search/_searchGroups.ts
@@ -51,7 +51,7 @@ export async function _searchGroups(
       so.num = options.num;
     }
 
-    let portalUrl = "https://www.arcgis.com/sharing/rest";
+    let portalUrl = `${api.url}/sharing/rest`;
     if (so.authentication?.portal) {
       portalUrl = so.authentication.portal;
     }

--- a/packages/common/src/search/_searchGroups.ts
+++ b/packages/common/src/search/_searchGroups.ts
@@ -28,12 +28,9 @@ export async function _searchGroups(
   // expand filter so we can serialize to either api
   const expanded = expandGroupFilter(filter);
 
-  // APIs
-  if (!options.api) {
-    // default to AGO PROD
-    options.api = "arcgis";
-  }
-  const api = expandApi(options.api);
+  // API
+  const api = expandApi(options.api || "arcgis");
+
   if (api.type === "arcgis") {
     const so = serializeGroupFilterForPortal(expanded);
     let token = "";

--- a/packages/common/src/search/types.ts
+++ b/packages/common/src/search/types.ts
@@ -1,5 +1,4 @@
 import { UserSession } from "@esri/arcgis-rest-auth";
-import { IGroup } from "@esri/arcgis-rest-types";
 import { IHubContent, IModel } from "..";
 
 /**
@@ -258,6 +257,9 @@ export interface ICatalog {
   facets?: IFacet[];
 }
 
+/**
+ * Sort Option to be displayed in a UI
+ */
 export interface ISortOption {
   // String to show in the UI. translated.
   label: string;
@@ -273,15 +275,19 @@ export interface ICollection {
   filter: Filter<FilterType>;
   facets?: IFacet[];
 }
-
+/**
+ * Defines a span of time by specifying a `from` and `to` Date
+ * as either a number or a ISO string
+ */
 export interface IDateRange<T> {
   type?: "date-range";
   from: T;
   to: T;
 }
 
-// Relative Date will be convertd to a real date-range
-// at run-time
+/**
+ * Relative Date will be convertd to a `IDateRange` at run-time
+ */
 export interface IRelativeDate {
   type: "relative-date";
   num: number;
@@ -330,7 +336,7 @@ export interface IHubSearchOptions {
   aggregations?: string[];
   bbox?: string;
   fields?: string;
-  apis?: Array<NamedApis | IApiDefinition>;
+  api?: NamedApis | IApiDefinition;
 }
 
 /**
@@ -340,6 +346,8 @@ export interface IContentSearchResult {
   total: number;
   results: IHubContent[];
   facets?: IFacet[];
+  hasNext: boolean;
+  next: (params?: any) => Promise<IContentSearchResult>;
 }
 
 export interface IWellKnownApis {

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -398,8 +398,13 @@ export function getNextFunction<T>(
 ): () => Promise<ISearchResponse<T>> {
   const clonedRequest = cloneObject(request);
 
-  // Can't clone a UserSession
-  clonedRequest.authentication = request.authentication;
+  // clone will not handle authentication so we do it manually
+  if (request.authentication) {
+    clonedRequest.authentication = UserSession.deserialize(
+      (request.authentication as UserSession).serialize()
+    );
+  }
+
   // figure out the start
   clonedRequest.start = nextStart > -1 ? nextStart : total + 1;
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -13,6 +13,7 @@ import { IPortal, ISearchResult } from "@esri/arcgis-rest-portal";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { IStructuredLicense } from "./items/get-structured-license";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { IFacet } from "./search";
 
 /**
  * Generic Model, used with all items that have a json
@@ -491,4 +492,21 @@ export interface IHubTeam extends IGroup {
   properties: {
     [key: string]: any;
   };
+}
+
+/**
+ * Defines a generic search response interface with parameterized result type
+ * for different types of searches
+ *
+ * total - total number of results
+ * results - potentially paginated list of results
+ * hasNext - boolean flag for if there are any more pages ofresults
+ * next - invokable function for obtaining next page of results
+ */
+export interface ISearchResponse<T> {
+  total: number;
+  results: T[];
+  hasNext: boolean;
+  next: (params?: any) => Promise<ISearchResponse<T>>;
+  facets?: IFacet[];
 }

--- a/packages/common/test/mocks/portal-groups-search/simple-response.json
+++ b/packages/common/test/mocks/portal-groups-search/simple-response.json
@@ -79,6 +79,44 @@
                 "itemTypes": ""
             },
             "properties": null
+        },
+        {
+            "id": "a564992879dc48ed82780637f99074bf",
+            "title": "Open Data Demo Content",
+            "isInvitationOnly": false,
+            "owner": "phammons_dcdev",
+            "description": "Use this group to organize the items that you want to share as part of your initiative. Shared items become available in your initiative's search results and only people who have access to these items will be able to find them. Members of the core team get access to shared items and can update them at any time. Certain cards, like the Gallery card, will automatically populate with shared items so that you don't have to search for them when choosing what you want to display on your site.<br /><br />Contact support with any questions related to this group or content management for your site.<br /><br /><strong>DO NOT DELETE THIS GROUP.</strong>",
+            "snippet": "Applications, maps, data, etc. shared with this group generates the Alexandria Open Data Demo content catalog.",
+            "tags": [
+                "Hub Group",
+                "Hub Content Group",
+                "Hub Site Group",
+                "Hub Initiative Group"
+            ],
+            "typeKeywords": [],
+            "phone": null,
+            "sortField": "modified",
+            "sortOrder": "desc",
+            "isViewOnly": false,
+            "featuredItemsId": null,
+            "thumbnail": "happy-cat.png",
+            "created": 1586893843000,
+            "modified": 1586893844000,
+            "access": "private",
+            "capabilities": [],
+            "isFav": false,
+            "isReadOnly": false,
+            "protected": true,
+            "autoJoin": false,
+            "notificationsEnabled": false,
+            "provider": null,
+            "providerGroupName": null,
+            "leavingDisallowed": false,
+            "hiddenMembers": false,
+            "displaySettings": {
+                "itemTypes": ""
+            },
+            "properties": null
         }
         
     ]

--- a/packages/common/test/search/_searchContent.test.ts
+++ b/packages/common/test/search/_searchContent.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../src";
 import * as AggResponse from "../mocks/portal-search/response-with-aggregations.json";
 import * as SimpleResponse from "../mocks/portal-search/simple-response.json";
+import { MOCK_AUTH } from "../mocks/mock-auth";
 
 describe("_searchContent:", () => {
   describe("portal:", () => {
@@ -141,7 +142,7 @@ describe("_searchContent:", () => {
         term: "water",
       };
       const opts: IHubSearchOptions = {
-        authentication: { fake: "auth" } as unknown as UserSession,
+        authentication: MOCK_AUTH,
         num: 22,
       };
 
@@ -165,7 +166,7 @@ describe("_searchContent:", () => {
         term: "water",
       };
       const opts: IHubSearchOptions = {
-        authentication: { fake: "auth" } as unknown as UserSession,
+        authentication: MOCK_AUTH,
       };
 
       const res = await _searchContent(f, opts);

--- a/packages/common/test/search/_searchContent.test.ts
+++ b/packages/common/test/search/_searchContent.test.ts
@@ -30,6 +30,33 @@ describe("_searchContent:", () => {
       // verify countFields
       expect(expectedParams.countFields).not.toBeDefined();
     });
+    it("simple search enterprise", async () => {
+      const searchItemsSpy = spyOn(Portal, "searchItems").and.callFake(() => {
+        return Promise.resolve(cloneObject(SimpleResponse));
+      });
+      const f: Filter<"content"> = {
+        filterType: "content",
+        term: "water",
+      };
+      const opts: IHubSearchOptions = {
+        api: {
+          type: "arcgis",
+          url: "https://my-portal.com/gis",
+        },
+      };
+
+      const res = await _searchContent(f, opts);
+
+      expect(searchItemsSpy.calls.count()).toBe(1, "should call searchItems");
+      const [expectedParams] = searchItemsSpy.calls.argsFor(0);
+      // verify q
+      expect(expectedParams.q).toEqual("water");
+      expect(expectedParams.portal).toEqual(
+        "https://my-portal.com/gis/sharing/rest"
+      );
+      // verify countFields
+      expect(expectedParams.countFields).not.toBeDefined();
+    });
     it("simple search next", async () => {
       const searchItemsSpy = spyOn(Portal, "searchItems").and.callFake(() => {
         return Promise.resolve(cloneObject(SimpleResponse));

--- a/packages/common/test/search/_searchContent.test.ts
+++ b/packages/common/test/search/_searchContent.test.ts
@@ -30,6 +30,23 @@ describe("_searchContent:", () => {
       // verify countFields
       expect(expectedParams.countFields).not.toBeDefined();
     });
+    it("simple search next", async () => {
+      const searchItemsSpy = spyOn(Portal, "searchItems").and.callFake(() => {
+        return Promise.resolve(cloneObject(SimpleResponse));
+      });
+      const f: Filter<"content"> = {
+        filterType: "content",
+        term: "water",
+      };
+      const opts: IHubSearchOptions = {};
+
+      const res = await _searchContent(f, opts);
+      await res.next();
+      expect(searchItemsSpy.calls.count()).toBe(2, "should call searchItems");
+      const [expectedParams] = searchItemsSpy.calls.argsFor(1);
+      // verify q
+      expect(expectedParams.q).toEqual("water");
+    });
     it("search with siteModel", async () => {
       const searchItemsSpy = spyOn(Portal, "searchItems").and.callFake(() => {
         return Promise.resolve(cloneObject(SimpleResponse));
@@ -69,7 +86,7 @@ describe("_searchContent:", () => {
         term: "water",
       };
       const opts: IHubSearchOptions = {
-        apis: ["arcgis"],
+        api: "arcgis",
         aggregations: ["tags", "access"],
         sortField: "title",
         sortOrder: "desc",
@@ -112,6 +129,27 @@ describe("_searchContent:", () => {
       // verify auth
       expect(expectedParams.authentication).toBeDefined();
     });
+    it("next with auth", async () => {
+      const searchItemsSpy = spyOn(Portal, "searchItems").and.callFake(() => {
+        return Promise.resolve(cloneObject(SimpleResponse));
+      });
+      const f: Filter<"content"> = {
+        filterType: "content",
+        term: "water",
+      };
+      const opts: IHubSearchOptions = {
+        authentication: { fake: "auth" } as unknown as UserSession,
+      };
+
+      const res = await _searchContent(f, opts);
+      await res.next(opts.authentication);
+      expect(searchItemsSpy.calls.count()).toBe(2, "should call searchItems");
+      const [expectedParams] = searchItemsSpy.calls.argsFor(1);
+      // verify q
+      expect(expectedParams.q).toEqual("water");
+      // verify auth
+      expect(expectedParams.authentication).toBeDefined();
+    });
   });
 
   describe("hub api: ", () => {
@@ -121,11 +159,27 @@ describe("_searchContent:", () => {
         term: "water",
       };
       const opts: IHubSearchOptions = {
-        apis: ["hubQA"],
+        api: "hubQA",
       };
 
       const res = await _searchContent(f, opts);
 
+      // TODO: Add tests for real implementation
+      expect(res.facets?.length).toEqual(0);
+      expect(res.facets?.length).toEqual(0);
+    });
+    it("next", async () => {
+      const f: Filter<"content"> = {
+        filterType: "content",
+        term: "water",
+      };
+      const opts: IHubSearchOptions = {
+        api: "hubQA",
+      };
+
+      const res = await _searchContent(f, opts);
+      const res2 = await res.next();
+      expect(res2).not.toBeDefined();
       // TODO: Add tests for real implementation
       expect(res.facets?.length).toEqual(0);
       expect(res.facets?.length).toEqual(0);

--- a/packages/common/test/search/_searchGroups.test.ts
+++ b/packages/common/test/search/_searchGroups.test.ts
@@ -10,88 +10,111 @@ import { MOCK_AUTH } from "../mocks/mock-auth";
 import { IModel } from "../../src";
 
 describe("_searchGroups:", () => {
-  it("defaults to ago prod", async () => {
-    const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {
-      return Promise.resolve(cloneObject(SimpleResponse));
+  describe("portal:", () => {
+    it("defaults to ago prod", async () => {
+      const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {
+        return Promise.resolve(cloneObject(SimpleResponse));
+      });
+      const f: Filter<"group"> = {
+        filterType: "group",
+        term: "water",
+      };
+      const o: IHubSearchOptions = {};
+      await _searchGroups(f, o);
+      expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
+      const [expectedParams] = searchGroupsSpy.calls.argsFor(0);
+      expect(expectedParams.q).toEqual("water");
+      expect(expectedParams.portal).toBe("https://www.arcgis.com/sharing/rest");
     });
-    const f: Filter<"group"> = {
-      filterType: "group",
-      term: "water",
-    };
-    const o: IHubSearchOptions = {};
-    await _searchGroups(f, o);
-    expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
-    const [expectedParams] = searchGroupsSpy.calls.argsFor(0);
-    expect(expectedParams.q).toEqual("water");
-    expect(expectedParams.portal).toBe("https://www.arcgis.com/sharing/rest");
+
+    it("uses specified apis, passes num", async () => {
+      const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {
+        return Promise.resolve(cloneObject(SimpleResponse));
+      });
+      const f: Filter<"group"> = {
+        filterType: "group",
+        term: "water",
+      };
+      const o: IHubSearchOptions = {
+        api: "arcgisQA",
+        num: 6,
+      };
+      await _searchGroups(f, o);
+      expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
+      const [expectedParams] = searchGroupsSpy.calls.argsFor(0);
+
+      expect(expectedParams.q).toEqual("water");
+      expect(expectedParams.num).toEqual(6);
+      expect(expectedParams.portal).toBe(
+        "https://qaext.arcgis.com/sharing/rest"
+      );
+    });
+    it("passes auth", async () => {
+      const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {
+        return Promise.resolve(cloneObject(SimpleResponse));
+      });
+      const f: Filter<"group"> = {
+        filterType: "group",
+        term: "water",
+      };
+      const o: IHubSearchOptions = {
+        authentication: MOCK_AUTH,
+        site: {
+          item: {
+            id: "3ef",
+          },
+        } as unknown as IModel,
+      };
+      const chk = await _searchGroups(f, o);
+      expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
+      const [expectedParams] = searchGroupsSpy.calls.argsFor(0);
+      expect(expectedParams.authentication).toBe(MOCK_AUTH);
+      const g1 = chk.results[0];
+      expect(g1.id).toBe("7d9cc5e39a8f4c0aa29e04a473bf4703");
+      expect(g1.siteTeamUrl).not.toBeDefined();
+    });
+    it("adds urls", async () => {
+      const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {
+        return Promise.resolve(cloneObject(SimpleResponse));
+      });
+      const f: Filter<"group"> = {
+        filterType: "group",
+        term: "water",
+      };
+      const o: IHubSearchOptions = {
+        authentication: MOCK_AUTH,
+        site: {
+          item: {
+            url: "https://mysite.com",
+          },
+        } as unknown as IModel,
+      };
+      const chk = await _searchGroups(f, o);
+      const g1 = chk.results[0];
+      expect(g1.id).toBe("7d9cc5e39a8f4c0aa29e04a473bf4703");
+      expect(g1.thumbnailUrl).toBeDefined();
+      expect(g1.siteTeamUrl).toBe(
+        "https://mysite.com/teams/7d9cc5e39a8f4c0aa29e04a473bf4703/about"
+      );
+    });
   });
 
-  it("uses specified apis, passes num", async () => {
-    const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {
-      return Promise.resolve(cloneObject(SimpleResponse));
+  describe("hub api:", () => {
+    it("throws if a non-arcgis api is specified", async () => {
+      const f: Filter<"group"> = {
+        filterType: "group",
+        term: "water",
+      };
+      const o: IHubSearchOptions = {
+        api: "hub",
+      };
+      try {
+        await _searchGroups(f, o);
+      } catch (ex) {
+        expect(ex.message).toBe(
+          "_searchGroups is not implemented for non-arcgis apis"
+        );
+      }
     });
-    const f: Filter<"group"> = {
-      filterType: "group",
-      term: "water",
-    };
-    const o: IHubSearchOptions = {
-      apis: ["arcgisQA"],
-      num: 6,
-    };
-    await _searchGroups(f, o);
-    expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
-    const [expectedParams] = searchGroupsSpy.calls.argsFor(0);
-
-    expect(expectedParams.q).toEqual("water");
-    expect(expectedParams.num).toEqual(6);
-    expect(expectedParams.portal).toBe("https://qaext.arcgis.com/sharing/rest");
-  });
-  it("passes auth", async () => {
-    const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {
-      return Promise.resolve(cloneObject(SimpleResponse));
-    });
-    const f: Filter<"group"> = {
-      filterType: "group",
-      term: "water",
-    };
-    const o: IHubSearchOptions = {
-      authentication: MOCK_AUTH,
-      site: {
-        item: {
-          id: "3ef",
-        },
-      } as unknown as IModel,
-    };
-    const chk = await _searchGroups(f, o);
-    expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
-    const [expectedParams] = searchGroupsSpy.calls.argsFor(0);
-    expect(expectedParams.authentication).toBe(MOCK_AUTH);
-    const g1 = chk.results[0];
-    expect(g1.id).toBe("7d9cc5e39a8f4c0aa29e04a473bf4703");
-    expect(g1.siteTeamUrl).not.toBeDefined();
-  });
-  it("adds urls", async () => {
-    const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {
-      return Promise.resolve(cloneObject(SimpleResponse));
-    });
-    const f: Filter<"group"> = {
-      filterType: "group",
-      term: "water",
-    };
-    const o: IHubSearchOptions = {
-      authentication: MOCK_AUTH,
-      site: {
-        item: {
-          url: "https://mysite.com",
-        },
-      } as unknown as IModel,
-    };
-    const chk = await _searchGroups(f, o);
-    const g1 = chk.results[0];
-    expect(g1.id).toBe("7d9cc5e39a8f4c0aa29e04a473bf4703");
-    expect(g1.thumbnailUrl).toBeDefined();
-    expect(g1.siteTeamUrl).toBe(
-      "https://mysite.com/teams/7d9cc5e39a8f4c0aa29e04a473bf4703/about"
-    );
   });
 });

--- a/packages/common/test/search/_searchGroups.test.ts
+++ b/packages/common/test/search/_searchGroups.test.ts
@@ -26,6 +26,28 @@ describe("_searchGroups:", () => {
       expect(expectedParams.q).toEqual("water");
       expect(expectedParams.portal).toBe("https://www.arcgis.com/sharing/rest");
     });
+    it("search enterprise", async () => {
+      const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {
+        return Promise.resolve(cloneObject(SimpleResponse));
+      });
+      const f: Filter<"group"> = {
+        filterType: "group",
+        term: "water",
+      };
+      const o: IHubSearchOptions = {
+        api: {
+          type: "arcgis",
+          url: "https://my-portal.com/gis",
+        },
+      };
+      await _searchGroups(f, o);
+      expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
+      const [expectedParams] = searchGroupsSpy.calls.argsFor(0);
+      expect(expectedParams.q).toEqual("water");
+      expect(expectedParams.portal).toBe(
+        "https://my-portal.com/gis/sharing/rest"
+      );
+    });
 
     it("uses specified apis, passes num", async () => {
       const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {

--- a/packages/common/test/search/utils.test.ts
+++ b/packages/common/test/search/utils.test.ts
@@ -1,11 +1,4 @@
-import { IHubContent } from "../../src";
-import {
-  IContentSearchResult,
-  IFacet,
-  IMatchOptions,
-  IRelativeDate,
-  mergeSearchResults,
-} from "../../src/search";
+import { IMatchOptions, IRelativeDate } from "../../src/search";
 import {
   expandApis,
   mergeMatchOptions,
@@ -261,40 +254,6 @@ describe("Search Utils:", () => {
       expect(chk.all).toEqual(["cat", "dog", "fish"]);
       expect(chk.not).toEqual(["bmw"]);
       expect(chk.exact).not.toBeDefined();
-    });
-  });
-  describe("mergeSearchResults:", () => {
-    it("merges content and facet arrays", () => {
-      const r0: IContentSearchResult = {
-        total: 10,
-        results: ["a", "b"] as unknown as IHubContent[],
-        facets: ["fa", "fb"] as unknown as IFacet[],
-      };
-      const r1: IContentSearchResult = {
-        total: 5,
-        results: ["d", "e"] as unknown as IHubContent[],
-        facets: ["fd", "fe"] as unknown as IFacet[],
-      };
-      const chk = mergeSearchResults([r0, r1]);
-
-      expect(chk.results.length).toBe(4);
-      expect(chk.total).toBe(15);
-      expect(chk.facets?.length).toBe(4);
-    });
-    it("handles responses with missing props", () => {
-      const r0: IContentSearchResult = {
-        total: 2,
-        results: ["a", "b"] as unknown as IHubContent[],
-      };
-      const r1 = {
-        total: 0,
-        facets: ["fd", "fe"] as unknown as IFacet[],
-      } as unknown as IContentSearchResult;
-
-      const chk = mergeSearchResults([r0, r1]);
-
-      expect(chk.results.length).toBe(2);
-      expect(chk.facets?.length).toBe(2);
     });
   });
 });

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -18,7 +18,7 @@
     "@esri/arcgis-rest-portal": "^2.6.1 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "^8.0.0 || 9"
+    "@esri/hub-common": "^9.7.1"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",

--- a/packages/search/src/types/common.ts
+++ b/packages/search/src/types/common.ts
@@ -1,3 +1,6 @@
+// Re-export so we don't have a breaking change
+export { ISearchResponse } from "@esri/hub-common";
+
 /**
  * Defines a generic date range interface
  */
@@ -24,20 +27,4 @@ export enum SortDirection {
 export interface ISearchRequest<T, U> {
   filter?: T;
   options?: U;
-}
-
-/**
- * Defines a generic search response interface with parameterized result type
- * for different types of searches
- *
- * total - total number of results
- * results - potentially paginated list of results
- * hasNext - boolean flag for if there are any more pages ofresults
- * next - invokable function for obtaining next page of results
- */
-export interface ISearchResponse<T> {
-  total: number;
-  results: T[];
-  hasNext: boolean;
-  next: (params?: any) => Promise<ISearchResponse<T>>;
 }

--- a/packages/search/src/types/common.ts
+++ b/packages/search/src/types/common.ts
@@ -1,4 +1,4 @@
-// Re-export so we don't have a breaking change
+// DEPRECATED: remove this at the next breaking change
 export { ISearchResponse } from "@esri/hub-common";
 
 /**

--- a/packages/search/src/types/content.ts
+++ b/packages/search/src/types/content.ts
@@ -1,12 +1,7 @@
 import { UserSession } from "@esri/arcgis-rest-auth";
-import { IHubContent } from "@esri/hub-common";
+import { ISearchResponse, IHubContent } from "@esri/hub-common";
 import { IAggregationResult } from "../util/aggregations/merge-aggregations";
-import {
-  IDateRange,
-  SortDirection,
-  ISearchRequest,
-  ISearchResponse,
-} from "./common";
+import { IDateRange, SortDirection, ISearchRequest } from "./common";
 
 /**
  * Defines an enum for common booleans used to create a search filter


### PR DESCRIPTION
1. Description:

- adds `hasNext` and `.next()` to the response from `_searchContent` and `_searchGroups`
- changes the return types to `ISearchResponse<IHubContent>` and `ISearchResponse<IGroup>`
- removes multi-api search/merge logic from `_searchContent` as that is not needed and adds a lot of complexity for the `next()` function
- ensures that passing an `IApiDefinition` without auth, directs the search to the specified url (i.e. works with Enterprise)

1. Instructions for testing:
-run tests


1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
