### PR TITLE
docs(hub-common): add warning message around site schema migrations

### DIFF
--- a/packages/common/src/sites/upgrade-site-schema.ts
+++ b/packages/common/src/sites/upgrade-site-schema.ts
@@ -23,6 +23,9 @@ export function upgradeSiteSchema(model: IModel) {
     model = _purgeNonGuidsFromCatalog(model);
     model = _ensureTelemetry<IModel>(model);
     model = _migrateFeedConfig(model);
+    // WARNING - If you are writing a site schema migration,
+    // you probably need to apply it to site drafts as well!
+    // See https://github.com/Esri/hub.js/issues/498 for more details.
     return model;
   }
 }


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
This PR adds an important warning to anyone adding a site schema migration.

1. Instructions for testing: n/a

1. Closes Issues: none

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
