### PR TITLE
B/add sort to _searchGroups

### DIFF
--- a/packages/common/src/search/_searchGroups.ts
+++ b/packages/common/src/search/_searchGroups.ts
@@ -48,6 +48,14 @@ export async function _searchGroups(
       so.num = options.num;
     }
 
+    if (options.sortField) {
+      so.sortField = options.sortField;
+    }
+
+    if (options.sortOrder) {
+      so.sortOrder = options.sortOrder;
+    }
+
     let portalUrl = `${api.url}/sharing/rest`;
     if (so.authentication?.portal) {
       portalUrl = so.authentication.portal;

--- a/packages/common/test/search/_searchGroups.test.ts
+++ b/packages/common/test/search/_searchGroups.test.ts
@@ -119,6 +119,23 @@ describe("_searchGroups:", () => {
         "https://mysite.com/teams/7d9cc5e39a8f4c0aa29e04a473bf4703/about"
       );
     });
+    it("adds sort fields and sort orders", async () => {
+      const searchGroupsSpy = spyOn(Portal, "searchGroups").and.callFake(() => {
+        return Promise.resolve(cloneObject(SimpleResponse));
+      });
+      const f: Filter<"group"> = {
+        filterType: "group",
+        term: "water",
+      };
+      const o: IHubSearchOptions = {
+        sortField: "title",
+        sortOrder: "asc",
+      };
+      const chk = await _searchGroups(f, o);
+      const g1 = chk.results[0];
+      expect(g1.sortField).toBe("title");
+      expect(g1.sortOrder).toBe("asc");
+    });
   });
 
   describe("hub api:", () => {


### PR DESCRIPTION
1. Description:
Add `sortField` and `sortOrder` to `_searchGroups`
1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
