### PR TITLE
fix(hub-common): setContentType() now uses normalizedType to calculate family

### DIFF
--- a/packages/common/src/content.ts
+++ b/packages/common/src/content.ts
@@ -743,7 +743,7 @@ export function datasetToItem(dataset: DatasetResource): IItem {
 }
 
 /**
- * retunrs a new content that has the specified type and
+ * returns a new content that has the specified type and
  * and updated related properties like normalizedType, family, etc
  * @param content orignal content
  * @param type new type
@@ -754,8 +754,8 @@ export const setContentType = (
   type: string
 ): IHubContent => {
   // get family and normalized type based on new type
-  const family = getFamily(type);
   const normalizedType = normalizeItemType({ ...content.item, type });
+  const family = getFamily(normalizedType);
   const updated = { ...content, type, family, normalizedType };
   // update the relative URL to the content
   // which is based on type and family
@@ -765,7 +765,7 @@ export const setContentType = (
 };
 
 /**
- * retunrs a new content that has the specified hubId and updated identifier
+ * returns a new content that has the specified hubId and updated identifier
  * @param content orignal content
  * @param hubId new hubId
  * @returns new content

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -644,24 +644,40 @@ describe("dataset to content", () => {
   // NOTE: other use cases are covered by getContent() tests
 });
 describe("setContentType", () => {
-  // NOTE: these tests are just the most expedient way
-  // to get coverage for getContentRelativeUrl() w/o exporting it
-  let content: IHubContent;
-  beforeEach(() => {
-    content = itemToContent(documentItem);
+  describe("Relative Urls", () => {
+    // NOTE: these tests are just the most expedient way
+    // to get coverage for getContentRelativeUrl() w/o exporting it
+    let content: IHubContent;
+    beforeEach(() => {
+      content = itemToContent(documentItem);
+    });
+    it("sets relative url for feedback", () => {
+      const updated = setContentType(content, "Form");
+      expect(updated.urls.relative).toBe(
+        `/feedback/surveys/${content.identifier}`
+      );
+    });
+    it("sets relative url for deployed solution", () => {
+      content.typeKeywords.push("Deployed");
+      const updated = setContentType(content, "Solution");
+      expect(updated.urls.relative).toBe(
+        `/templates/${content.identifier}/about`
+      );
+    });
   });
-  it("sets relative url for feedback", () => {
-    const updated = setContentType(content, "Form");
-    expect(updated.urls.relative).toBe(
-      `/feedback/surveys/${content.identifier}`
-    );
-  });
-  it("sets relative url for deployed solution", () => {
-    content.typeKeywords.push("Deployed");
-    const updated = setContentType(content, "Solution");
-    expect(updated.urls.relative).toBe(
-      `/templates/${content.identifier}/about`
-    );
+  // NOTE: this test is meant to verify that normalizedType
+  // is passed into getFamily(), not the raw type.
+  it("Sets the family based on the normalizedType", () => {
+    const oldInitiativeTemplate = {
+      identifier: "9001",
+      item: {
+        type: "Hub Initiative",
+        typeKeywords: ["hubInitiativeTemplate"],
+      },
+    } as unknown as IHubContent;
+
+    const updated = setContentType(oldInitiativeTemplate, "Hub Initiative");
+    expect(updated.family).toBe("template");
   });
 });
 describe("setContentSiteUrls", () => {


### PR DESCRIPTION
affects: @esri/hub-common

Resolves https://devtopia.esri.com/dc/hub/issues/2123.

Using normalizedType to calculate family solves the issue of legacy item types. For example, Hub
Initiative Templates used to be designated as type: 'Hub Initiative' with typeKeywords:
['hubInitiativeTemplate']. Running these old initiative templates through setContentType() used to
set family incorrectly as 'initiative'. Now family is correctly set to 'template'.

1. [x] ran commit script (`npm run c`)
