### PR TITLE
B/set prop undefined

### DIFF
--- a/packages/common/src/content/_internal.ts
+++ b/packages/common/src/content/_internal.ts
@@ -1,0 +1,79 @@
+/**
+ * Use this module for functions that do not need to be used by consumers (yet),
+ * but may be shared between hub.js modules, and/or need to be tested
+ * to get 100% coverage w/o writing cumbersome tests of higher level functions.
+ *
+ * Consuming will not be able to import these functions.
+ *
+ * It's probably a good pattern to add functions here first and then
+ * move them to index.ts only when they are needed by a consumer.
+ */
+
+import {
+  BBox,
+  IHubContent,
+  IHubGeography,
+  GeographyProvenance,
+} from "../types";
+import { bBoxToPolygon, isBBox } from "../extent";
+
+/**
+ * Create a new content with updated boundary properties
+ * @param content original content
+ * @param boundary boundary provenance
+ * @returns
+ */
+export const setContentBoundary = (
+  content: IHubContent,
+  boundary: GeographyProvenance
+) => {
+  // update content's item and boundary
+  const properties = { ...(content.item.properties || {}), boundary };
+  const item = { ...content.item, properties };
+  const updated = { ...content, item };
+  return { ...updated, boundary: getContentBoundary(updated) };
+};
+
+/**
+ * Create a new content with updated extent and derived properties like boundary
+ * @param content original content
+ * @param extent new extent
+ * @returns a new content with the updated extent and boundary
+ */
+export const setContentExtent = (
+  content: IHubContent,
+  extent: BBox
+): IHubContent => {
+  // update content's item and extent
+  const item = { ...content.item, extent };
+  const updated = { ...content, item, extent };
+  // derive boundary from content properties
+  const boundary = getContentBoundary(updated);
+  return { ...updated, boundary };
+};
+
+const getContentBoundary = (content: IHubContent): IHubGeography => {
+  const item = content.item;
+  const extent = item.extent;
+  const isValidItemExtent = isBBox(extent);
+  // user specified provenance is stored in item.properties
+  const provenance: GeographyProvenance =
+    item.properties?.boundary ||
+    // but we default to item if the item has an extent
+    (isValidItemExtent ? "item" : undefined);
+  let geometry;
+  switch (provenance) {
+    case "item":
+      geometry = isValidItemExtent ? bBoxToPolygon(extent) : null;
+      break;
+    case "none":
+      geometry = null;
+      break;
+    // TODO: handle other provenances
+  }
+  // TODO: derive and return center
+  return {
+    provenance,
+    geometry,
+  };
+};

--- a/packages/common/src/objects/deep-set.ts
+++ b/packages/common/src/objects/deep-set.ts
@@ -15,7 +15,7 @@ export function deepSet(
   let worker = target;
   const lastIdx = parts.length - 1;
   parts.forEach((p, idx) => {
-    if (!worker.hasOwnProperty(p) || worker[p] === null) {
+    if (!worker.hasOwnProperty(p) || worker[p] == null) {
       if (idx === lastIdx) {
         worker[p] = value;
       } else {

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -1,12 +1,11 @@
 import { IItem } from "@esri/arcgis-rest-portal";
-import { IEnvelope, IPolygon } from "@esri/arcgis-rest-types";
+import { IPolygon } from "@esri/arcgis-rest-types";
 import {
   DatasetResource,
   datasetToContent,
   datasetToItem,
   getCategory,
   getCollection,
-  setContentBoundary,
   getTypes,
   getTypeCategories,
   normalizeItemType,
@@ -26,6 +25,7 @@ import {
   getFamily,
   setContentType,
 } from "../src/content";
+import { setContentBoundary } from "../src/content/_internal";
 import { IHubContent, IModel } from "../src/types";
 import { cloneObject } from "../src/util";
 import * as documentItem from "./mocks/items/document.json";
@@ -732,6 +732,11 @@ describe("setContentSiteUrls", () => {
       `${site.item.url}/pages/${content.identifier}`
     );
   });
+});
+
+// the tests below of internal functions are
+// usually only added to get to 100% coverage
+describe("internal", () => {
   it("sets boundary to none", () => {
     const content = setContentBoundary(itemToContent(documentItem), "none");
     expect(content.boundary).toEqual({

--- a/packages/common/test/objects/set-prop.test.ts
+++ b/packages/common/test/objects/set-prop.test.ts
@@ -18,4 +18,10 @@ describe("setProp", () => {
     setProp(["foo", "bar"], true, obj);
     expect(obj).toEqual({ foo: { bar: true } });
   });
+
+  it("handles intermediary properties that are explicitly set to undefined", () => {
+    const obj = { foo: undefined as any };
+    setProp("foo.bar", true, obj);
+    expect(obj).toEqual({ foo: { bar: true } });
+  });
 });


### PR DESCRIPTION
1. Description:

fixes `setProp()` bug and refactors recently added `setContnetBoundary()` and `setContentExtent()` to be internal-only (they have not been released yet so that is not a breaking change)

1. Instructions for testing:

if tests pass we good

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

