### PR TITLE
fix(hub-common): pass item owner name to shareItemToGroups and unshar…

### DIFF
--- a/packages/common/src/items/share-item-to-groups.ts
+++ b/packages/common/src/items/share-item-to-groups.ts
@@ -8,22 +8,25 @@ import {
  * Share an item to a set of groups
  * @param {String} itemId Iten Id to share to the groups
  * @param {Array} groups Array of group id's to which the item will be shared
- * @param {String} owner Owner username to determine which endpoint to hit
+ * @param {String} owner optional Owner username to determine which endpoint to hit
  * @param {*} requestOptions
  */
 export function shareItemToGroups(
   itemId: string,
   groups: string[],
   requestOptions: IRequestOptions,
-  owner: string
+  owner?: string
 ) {
   return Promise.all(
     groups.map((groupId: string) => {
       const opt = Object.assign(
         {},
-        { id: itemId, groupId, owner },
+        { id: itemId, groupId },
         requestOptions
       ) as IGroupSharingOptions;
+      if (owner) {
+        opt.owner = owner;
+      }
       return shareItemWithGroup(opt);
     })
   );

--- a/packages/common/src/items/share-item-to-groups.ts
+++ b/packages/common/src/items/share-item-to-groups.ts
@@ -1,25 +1,27 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import {
   shareItemWithGroup,
-  IGroupSharingOptions
+  IGroupSharingOptions,
 } from "@esri/arcgis-rest-portal";
 
 /**
  * Share an item to a set of groups
  * @param {String} itemId Iten Id to share to the groups
  * @param {Array} groups Array of group id's to which the item will be shared
+ * @param {String} owner Owner username to determine which endpoint to hit
  * @param {*} requestOptions
  */
 export function shareItemToGroups(
   itemId: string,
   groups: string[],
-  requestOptions: IRequestOptions
+  requestOptions: IRequestOptions,
+  owner: string
 ) {
   return Promise.all(
     groups.map((groupId: string) => {
       const opt = Object.assign(
         {},
-        { id: itemId, groupId },
+        { id: itemId, groupId, owner },
         requestOptions
       ) as IGroupSharingOptions;
       return shareItemWithGroup(opt);

--- a/packages/common/src/items/unshare-item-from-groups.ts
+++ b/packages/common/src/items/unshare-item-from-groups.ts
@@ -9,22 +9,25 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
  * Unshare an item from a set of groups
  * @param {String} itemId Item Id to unshare from groups
  * @param {Array} groups Array of group id's from which the item will be unshared
- * @param {String} owner Owner username to determine which endpoint to hit
+ * @param {String} owner optional Owner username to determine which endpoint to hit
  * @param {IRequestOptions} requestOptions
  */
 export function unshareItemFromGroups(
   itemId: string,
   groups: string[],
   requestOptions: IRequestOptions,
-  owner: string
+  owner?: string
 ): Promise<ISharingResponse[]> {
   return Promise.all(
     groups.map((groupId) => {
       const opt = Object.assign(
         {},
-        { id: itemId, groupId, owner },
+        { id: itemId, groupId },
         requestOptions
       ) as IGroupSharingOptions;
+      if (owner) {
+        opt.owner = owner;
+      }
       return unshareItemWithGroup(opt);
     })
   );

--- a/packages/common/src/items/unshare-item-from-groups.ts
+++ b/packages/common/src/items/unshare-item-from-groups.ts
@@ -1,7 +1,7 @@
 import {
   unshareItemWithGroup,
   IGroupSharingOptions,
-  ISharingResponse
+  ISharingResponse,
 } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 
@@ -9,18 +9,20 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
  * Unshare an item from a set of groups
  * @param {String} itemId Item Id to unshare from groups
  * @param {Array} groups Array of group id's from which the item will be unshared
+ * @param {String} owner Owner username to determine which endpoint to hit
  * @param {IRequestOptions} requestOptions
  */
 export function unshareItemFromGroups(
   itemId: string,
   groups: string[],
-  requestOptions: IRequestOptions
+  requestOptions: IRequestOptions,
+  owner: string
 ): Promise<ISharingResponse[]> {
   return Promise.all(
-    groups.map(groupId => {
+    groups.map((groupId) => {
       const opt = Object.assign(
         {},
-        { id: itemId, groupId },
+        { id: itemId, groupId, owner },
         requestOptions
       ) as IGroupSharingOptions;
       return unshareItemWithGroup(opt);

--- a/packages/common/test/items/share-item-to-groups.test.ts
+++ b/packages/common/test/items/share-item-to-groups.test.ts
@@ -3,7 +3,7 @@ import * as portal from "@esri/arcgis-rest-portal";
 import { mockUserSession } from "../test-helpers/fake-user-session";
 
 describe("shareItemToGroups", function () {
-  it("delegates to arcgis-rest-js", async function () {
+  it("delegates to arcgis-rest-js with owner", async function () {
     const shareItemSpy = spyOn(portal, "shareItemWithGroup").and.callFake(
       (itemId: string) =>
         Promise.resolve({
@@ -20,6 +20,25 @@ describe("shareItemToGroups", function () {
       },
       "bob"
     );
+
+    expect(shareItemSpy.calls.count()).toEqual(2);
+    expect(shareItemSpy.calls.argsFor(0)[0].groupId).toEqual("grp1");
+    expect(shareItemSpy.calls.argsFor(1)[0].groupId).toEqual("grp2");
+    expect(responses.length).toBe(2);
+    expect(responses[0].notSharedWith.length).toBe(0);
+  });
+  it("delegates to arcgis-rest-js without owner", async function () {
+    const shareItemSpy = spyOn(portal, "shareItemWithGroup").and.callFake(
+      (itemId: string) =>
+        Promise.resolve({
+          notSharedWith: [],
+          itemId,
+        })
+    );
+
+    const responses = await shareItemToGroups("item-id", ["grp1", "grp2"], {
+      authentication: mockUserSession,
+    });
 
     expect(shareItemSpy.calls.count()).toEqual(2);
     expect(shareItemSpy.calls.argsFor(0)[0].groupId).toEqual("grp1");

--- a/packages/common/test/items/share-item-to-groups.test.ts
+++ b/packages/common/test/items/share-item-to-groups.test.ts
@@ -2,19 +2,24 @@ import { shareItemToGroups } from "../../src";
 import * as portal from "@esri/arcgis-rest-portal";
 import { mockUserSession } from "../test-helpers/fake-user-session";
 
-describe("shareItemToGroups", function() {
-  it("delegates to arcgis-rest-js", async function() {
+describe("shareItemToGroups", function () {
+  it("delegates to arcgis-rest-js", async function () {
     const shareItemSpy = spyOn(portal, "shareItemWithGroup").and.callFake(
       (itemId: string) =>
         Promise.resolve({
           notSharedWith: [],
-          itemId
+          itemId,
         })
     );
 
-    const responses = await shareItemToGroups("item-id", ["grp1", "grp2"], {
-      authentication: mockUserSession
-    });
+    const responses = await shareItemToGroups(
+      "item-id",
+      ["grp1", "grp2"],
+      {
+        authentication: mockUserSession,
+      },
+      "bob"
+    );
 
     expect(shareItemSpy.calls.count()).toEqual(2);
     expect(shareItemSpy.calls.argsFor(0)[0].groupId).toEqual("grp1");

--- a/packages/common/test/items/unshare-item-from-groups.test.ts
+++ b/packages/common/test/items/unshare-item-from-groups.test.ts
@@ -3,7 +3,7 @@ import * as portal from "@esri/arcgis-rest-portal";
 import { mockUserSession } from "../test-helpers/fake-user-session";
 
 describe("unshareItemFromGroups", function () {
-  it("delegates to arcgis-rest-js", async function () {
+  it("delegates to arcgis-rest-js with owner", async function () {
     const unshareItemSpy = spyOn(portal, "unshareItemWithGroup").and.callFake(
       (itemId: string) =>
         Promise.resolve({
@@ -20,6 +20,25 @@ describe("unshareItemFromGroups", function () {
       },
       "bob"
     );
+
+    expect(unshareItemSpy.calls.count()).toEqual(2);
+    expect(unshareItemSpy.calls.argsFor(0)[0].groupId).toEqual("grp1");
+    expect(unshareItemSpy.calls.argsFor(1)[0].groupId).toEqual("grp2");
+    expect(responses.length).toBe(2);
+    expect(responses[0].notUnsharedFrom.length).toBe(0);
+  });
+  it("delegates to arcgis-rest-js without owner", async function () {
+    const unshareItemSpy = spyOn(portal, "unshareItemWithGroup").and.callFake(
+      (itemId: string) =>
+        Promise.resolve({
+          notUnsharedFrom: [],
+          itemId,
+        })
+    );
+
+    const responses = await unshareItemFromGroups("item-id", ["grp1", "grp2"], {
+      authentication: mockUserSession,
+    });
 
     expect(unshareItemSpy.calls.count()).toEqual(2);
     expect(unshareItemSpy.calls.argsFor(0)[0].groupId).toEqual("grp1");

--- a/packages/common/test/items/unshare-item-from-groups.test.ts
+++ b/packages/common/test/items/unshare-item-from-groups.test.ts
@@ -2,19 +2,24 @@ import { unshareItemFromGroups } from "../../src";
 import * as portal from "@esri/arcgis-rest-portal";
 import { mockUserSession } from "../test-helpers/fake-user-session";
 
-describe("unshareItemFromGroups", function() {
-  it("delegates to arcgis-rest-js", async function() {
+describe("unshareItemFromGroups", function () {
+  it("delegates to arcgis-rest-js", async function () {
     const unshareItemSpy = spyOn(portal, "unshareItemWithGroup").and.callFake(
       (itemId: string) =>
         Promise.resolve({
           notUnsharedFrom: [],
-          itemId
+          itemId,
         })
     );
 
-    const responses = await unshareItemFromGroups("item-id", ["grp1", "grp2"], {
-      authentication: mockUserSession
-    });
+    const responses = await unshareItemFromGroups(
+      "item-id",
+      ["grp1", "grp2"],
+      {
+        authentication: mockUserSession,
+      },
+      "bob"
+    );
 
     expect(unshareItemSpy.calls.count()).toEqual(2);
     expect(unshareItemSpy.calls.argsFor(0)[0].groupId).toEqual("grp1");


### PR DESCRIPTION
…eItemFromGroups

1. Description: We neglected to pass item owner down into unshareItemFromGroups / shareItemToGroups...which further passes the item owner down into the rest.js functions that are called. This fixes an issue where any share/unshare calls made through this path will be as if the current user is the items owner.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
