### PR TITLE
feat(hub-common): get content type icon and content type label in itemToContent

### DIFF
--- a/packages/common/src/content/index.ts
+++ b/packages/common/src/content/index.ts
@@ -738,8 +738,8 @@ export const setContentType = (
   // get family and normalized type based on new type
   const normalizedType = normalizeItemType({ ...content.item, type });
   const family = getFamily(normalizedType);
-  const contentTypeIcon = setContentTypeIcon(normalizedType);
-  const contentTypeLabel = setContentTypeLabel(
+  const contentTypeIcon = getContentTypeIcon(normalizedType);
+  const contentTypeLabel = getContentTypeLabel(
     normalizedType,
     content.isProxied
   );
@@ -760,11 +760,15 @@ export const setContentType = (
 };
 
 /**
+ * Compute the content type icon based on the normalizedType
  * @param normalizedType
- * @returns content type icon based on the normalizedType
+ * @returns content type icon
  */
-export const setContentTypeIcon = (normalizedType: string) => {
-  const type = camelize(normalizedType);
+export const getContentTypeIcon = (normalizedType: string) => {
+  let type;
+  if (normalizedType) {
+    type = camelize(normalizedType);
+  }
   const iconMap = {
     appbuilderExtension: "file",
     appbuilderWidgetPackage: "widgets-source",
@@ -866,15 +870,16 @@ export const setContentTypeIcon = (normalizedType: string) => {
 };
 
 /**
+ * Compute the content type label
  * @param normalizedType
  * @param isProxied
- * @returns content type label (typically placed next to the content type icon)
+ * @returns content type label
  */
-export const setContentTypeLabel = (
+export const getContentTypeLabel = (
   normalizedType: string,
   isProxied: boolean
 ) => {
-  return isProxied ? "CSV" : camelize(normalizedType);
+  return isProxied ? "CSV" : camelize(normalizedType || "");
 };
 
 /**

--- a/packages/common/src/content/index.ts
+++ b/packages/common/src/content/index.ts
@@ -765,10 +765,7 @@ export const setContentType = (
  * @returns content type icon
  */
 export const getContentTypeIcon = (normalizedType: string) => {
-  let type;
-  if (normalizedType) {
-    type = camelize(normalizedType);
-  }
+  const type = camelize(normalizedType || "");
   const iconMap = {
     appbuilderExtension: "file",
     appbuilderWidgetPackage: "widgets-source",

--- a/packages/common/src/content/index.ts
+++ b/packages/common/src/content/index.ts
@@ -12,6 +12,7 @@ import { getProp } from "../objects";
 import { getStructuredLicense } from "../items/get-structured-license";
 import { getServiceTypeFromUrl } from "../urls";
 import { setContentExtent } from "./_internal";
+import { camelize } from "../util";
 
 /**
  * JSONAPI dataset resource returned by the Hub API
@@ -737,13 +738,143 @@ export const setContentType = (
   // get family and normalized type based on new type
   const normalizedType = normalizeItemType({ ...content.item, type });
   const family = getFamily(normalizedType);
+  const contentTypeIcon = setContentTypeIcon(normalizedType);
+  const contentTypeLabel = setContentTypeLabel(
+    normalizedType,
+    content.isProxied
+  );
   // TODO: don't we need to update content.item.type too?
-  const updated = { ...content, type, family, normalizedType };
+  const updated = {
+    ...content,
+    type,
+    family,
+    normalizedType,
+    contentTypeIcon,
+    contentTypeLabel,
+  };
   // update the relative URL to the content
   // which is based on type and family
   return appendContentUrls(updated, {
     relative: getContentRelativeUrl(updated),
   });
+};
+
+/**
+ * @param normalizedType
+ * @returns content type icon based on the normalizedType
+ */
+export const setContentTypeIcon = (normalizedType: string) => {
+  const type = camelize(normalizedType);
+  const iconMap = {
+    appbuilderExtension: "file",
+    appbuilderWidgetPackage: "widgets-source",
+    application: "web",
+    arcgisProMap: "desktop",
+    cadDrawing: "file-cad",
+    cityEngineWebScene: "urban-model",
+    codeAttachment: "file-code",
+    colorSet: "palette",
+    contentCategorySet: "label",
+    cSV: "file-csv",
+    cSVCollection: "file-csv",
+    dashboard: "dashboard",
+    desktopApplication: "desktop",
+    documentLink: "link",
+    excaliburImageryProject: "file",
+    explorerMap: "file",
+    exportPackage: "file",
+    featureCollection: "data",
+    featureCollectionTemplate: "file",
+    featureLayer: "data",
+    featureService: "collection",
+    fileGeodatabase: "data",
+    form: "survey",
+    geocodingService: "file",
+    geodataService: "file",
+    geometryService: "file",
+    geopackage: "file",
+    geoprocessingService: "file",
+    globeLayer: "layers",
+    globeService: "file",
+    hubInitiative: "mountain-summit-nocap",
+    hubInitiativeTemplate: "initiative-template-outlines-thick",
+    hubPage: "browser",
+    hubSiteApplication: "web",
+    image: "file-image",
+    imageService: "data",
+    insightsModel: "file",
+    insightsPage: "graph-moving-average",
+    insightsTheme: "palette",
+    insightsWorkbook: "graph-moving-average",
+    iWorkPages: "file-text",
+    iWorkKeynote: "presentation",
+    iWorkNumbers: "file-report",
+    kML: "data",
+    kMLCollection: "data",
+    layer: "layers",
+    layerPackage: "layers",
+    locatorPackage: "file",
+    mapArea: "file",
+    mapDocument: "map-contents",
+    mapImageLayer: "collection",
+    mapPackage: "file",
+    mapService: "collection",
+    microsoftExcel: "file-report",
+    microsoftPowerpoint: "presentation",
+    microsoftWord: "file-text",
+    mission: "file",
+    mobileMapPackage: "map-contents",
+    nativeApplication: "mobile",
+    nativeApplicationInstaller: "file",
+    nativeApplicationTemplate: "file",
+    mobileApplication: "mobile",
+    networkAnalysisService: "file",
+    notebook: "code",
+    orientedImageryCatalog: "file",
+    orthoMappingProject: "file",
+    orthoMappingTemplate: "file",
+    pDF: "file-pdf",
+    quickCaptureProject: "mobile",
+    rasterLayer: "map",
+    realTimeAnalytic: "file",
+    relationalDatabaseConnection: "file",
+    reportTemplate: "file",
+    sceneLayer: "data",
+    sceneService: "urban-model",
+    serviceDefinition: "file",
+    shapefile: "data",
+    solution: "solutions",
+    sqliteGeodatabase: "file",
+    statisticalDataCollection: "file",
+    storyMap: "tour",
+    symbolSet: "file",
+    table: "table",
+    urbanModel: "urban-model",
+    vectorTileService: "map",
+    visioDocument: "conditional-rules",
+    webExperience: "apps",
+    webMap: "map",
+    webMappingApplication: "apps",
+    webScene: "urban-model",
+    wFS: "map",
+    wMS: "map",
+    wMTS: "map",
+    workflowManagerService: "file",
+    workforceProject: "list-check",
+  } as any;
+  return iconMap[type] ?? "file";
+};
+
+/**
+ * @param normalizedType
+ * @param isProxied
+ * @returns content type label (typically placed next to the content type icon)
+ */
+export const setContentTypeLabel = (
+  normalizedType: string,
+  isProxied: boolean
+) => {
+  return isProxied ? "CSV" : camelize(normalizedType);
 };
 
 /**

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -24,8 +24,8 @@ import {
   getItemHubType,
   getFamily,
   setContentType,
-  setContentTypeIcon,
-  setContentTypeLabel,
+  getContentTypeIcon,
+  getContentTypeLabel,
 } from "../src/content";
 import { setContentBoundary } from "../src/content/_internal";
 import { IHubContent, IModel } from "../src/types";
@@ -696,24 +696,24 @@ describe("setContentType", () => {
     const updated = setContentType(oldInitiativeTemplate, "Hub Initiative");
     expect(updated.family).toBe("template");
   });
-});
-describe("setContentTypeIcon", () => {
-  it("sets content type icons", () => {
-    expect(setContentTypeIcon("Application")).toEqual("web");
-    expect(setContentTypeIcon("Feature Service")).toEqual("collection");
-    expect(setContentTypeIcon("Mobile Application")).toEqual("mobile");
-    expect(setContentTypeIcon("Web Map")).toEqual("map");
+  describe("getContentTypeIcon", () => {
+    it("sets content type icons", () => {
+      expect(getContentTypeIcon("Application")).toEqual("web");
+      expect(getContentTypeIcon("Feature Service")).toEqual("collection");
+      expect(getContentTypeIcon("Mobile Application")).toEqual("mobile");
+      expect(getContentTypeIcon("Web Map")).toEqual("map");
+    });
+    it("sets non-existing type icon to file", () => {
+      expect(getContentTypeIcon("fooBar")).toEqual("file");
+    });
   });
-  it("sets non-existing type icon to file", () => {
-    expect(setContentTypeIcon("fooBar")).toEqual("file");
-  });
-});
-describe("setContentTypeLabel", () => {
-  it("sets content type label to the normalized type if is not proxied", () => {
-    expect(setContentTypeLabel("Application", false)).toEqual("application");
-  });
-  it("sets content type label to CSV if is proxied", () => {
-    expect(setContentTypeLabel("fooBar", true)).toEqual("CSV");
+  describe("getContentTypeLabel", () => {
+    it("sets content type label to the normalized type if is not proxied", () => {
+      expect(getContentTypeLabel("Application", false)).toEqual("application");
+    });
+    it("sets content type label to CSV if is proxied", () => {
+      expect(getContentTypeLabel("Application", true)).toEqual("CSV");
+    });
   });
 });
 describe("setContentSiteUrls", () => {

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -24,6 +24,8 @@ import {
   getItemHubType,
   getFamily,
   setContentType,
+  setContentTypeIcon,
+  setContentTypeLabel,
 } from "../src/content";
 import { setContentBoundary } from "../src/content/_internal";
 import { IHubContent, IModel } from "../src/types";
@@ -693,6 +695,25 @@ describe("setContentType", () => {
 
     const updated = setContentType(oldInitiativeTemplate, "Hub Initiative");
     expect(updated.family).toBe("template");
+  });
+});
+describe("setContentTypeIcon", () => {
+  it("sets content type icons", () => {
+    expect(setContentTypeIcon("Application")).toEqual("web");
+    expect(setContentTypeIcon("Feature Service")).toEqual("collection");
+    expect(setContentTypeIcon("Mobile Application")).toEqual("mobile");
+    expect(setContentTypeIcon("Web Map")).toEqual("map");
+  });
+  it("sets non-existing type icon to file", () => {
+    expect(setContentTypeIcon("fooBar")).toEqual("file");
+  });
+});
+describe("setContentTypeLabel", () => {
+  it("sets content type label to the normalized type if is not proxied", () => {
+    expect(setContentTypeLabel("Application", false)).toEqual("application");
+  });
+  it("sets content type label to CSV if is proxied", () => {
+    expect(setContentTypeLabel("fooBar", true)).toEqual("CSV");
   });
 });
 describe("setContentSiteUrls", () => {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
get content type icon and content type label in itemToContent

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
