### PR TITLE
Add ArcGISContext class and Session LocalStorage Utils

### DIFF
--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -68,7 +68,7 @@ export class ArcGISContext {
 
   private _authentication: UserSession;
 
-  private _portalUrl: string;
+  private _portalUrl: string = "https://www.arcgis.com";
 
   private _hubUrl: string;
 
@@ -102,7 +102,6 @@ export class ArcGISContext {
       this._portalUrl = opts.portalUrl;
       this._hubUrl = getHubApiFromPortalUrl(this._portalUrl);
     } else {
-      this._portalUrl = "https://www.arcgis.com";
       this._hubUrl = getHubApiFromPortalUrl(this._portalUrl);
     }
   }

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -1,0 +1,394 @@
+import { getSelf, IPortal } from "@esri/arcgis-rest-portal";
+import {
+  IUser,
+  IUserRequestOptions,
+  UserSession,
+} from "@esri/arcgis-rest-auth";
+import { getProp, getWithDefault, IHubRequestOptions } from ".";
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+
+/**
+ * Options that can be passed into `ArcGISContext.create`
+ */
+export interface IArcGISContextOptions {
+  /**
+   * ClientId for use with oAuth. Although this is optional,
+   * it is required to use ArcGISContext with an oAuth flow
+   */
+  clientId?: string;
+
+  /**
+   * Existing user session, which may be created from Identity Manager
+   * `const session = UserSession.fromCredential(idMgr.getCredential());`
+   */
+  authentication?: UserSession;
+
+  /**
+   * ArcGIS Online or ArcGIS Enterprise portal url.
+   * Do not include  `/sharing/rest`
+   * Defaults to `https://www.arcgis.com`
+   * For ArcGIS Enterprise, you must include the webadaptor name.
+   * i.e. https://gis.mytown.gov/portal
+   *
+   * When Authentication is present, the UserSession.portal value is
+   * used instead of this property.
+   */
+  portalUrl?: string;
+
+  /**
+   * If set to `true` additional logging will be sent to the console
+   * Defaults to false.
+   */
+  debug?: boolean;
+}
+
+/**
+ * Application Context Object
+ *
+ * Abstraction that combines a `UserSession` with
+ * the `portal/self` and `user/self` responses to
+ * provide a central lookup of platform information.
+ *
+ * This is a work-in-progress, and will likely expand over time.
+ *
+ * `ArcGISContext` is used in conjuction with the `arcgis-app-identity`
+ * component to orchestrate oAuth.
+ */
+export class ArcGISContext {
+  /**
+   * When a session is persisted to local storage,
+   * the storage key is the combination of the client id
+   * and the SESSION_KEY
+   */
+  private SESSION_KEY = "__CONTEXT_";
+
+  private _authentication: UserSession;
+
+  private _portalUrl: string;
+
+  private _hubUrl: string;
+
+  private _portalSelf: IPortal;
+
+  private _currentUser: IUser;
+
+  private _clientId: string;
+
+  private _debug = false;
+
+  /**
+   * Random identifier useful for debugging issues where race-conditions
+   */
+  public id: number;
+
+  private constructor(opts: IArcGISContextOptions) {
+    // Having a unique id makes debugging easier
+    this.id = new Date().getTime();
+    if (opts.debug) {
+      this._debug = opts.debug;
+    }
+    this.log(`ArcGISContext:ctor: Creating ${this.id}`);
+    // If not passed in, the clientId defaults to arcgisonline
+    // NOTE: this clientid only works for applications hosted by Esri on the arcgis.com domain
+    // Custom applications *must* provide a valid clientId associated with
+    // an Application Item stored in the portal you are connecting to
+    this._clientId = opts.clientId || "arcgisonline";
+    if (opts.authentication) {
+      this._authentication = opts.authentication;
+      this._portalUrl = this._authentication.portal.replace(
+        "/sharing/rest",
+        ""
+      );
+      this._hubUrl = getHubApiFromPortalUrl(this._portalUrl);
+    } else if (opts.portalUrl) {
+      this._portalUrl = opts.portalUrl;
+      this._hubUrl = getHubApiFromPortalUrl(this._portalUrl);
+    } else {
+      this._portalUrl = "https://www.arcgis.com";
+      this._hubUrl = getHubApiFromPortalUrl(this._portalUrl);
+    }
+  }
+
+  /**
+   * @internal
+   * Log debugging messages to the console
+   * @param message
+   */
+  private log(message: string): void {
+    if (this._debug) {
+      console.info(message);
+    }
+  }
+
+  /**
+   * Static async Factory
+   * @param opts
+   * @returns
+   */
+  public static async create(
+    opts: IArcGISContextOptions,
+    win: any = window
+  ): Promise<ArcGISContext> {
+    const ctx = new ArcGISContext(opts);
+    // if auth was not passed in, but we have a clientId, and we have access
+    // to localStorage (i.e. we're in a browser) see if we can re-hydrate an existing session
+    if (!opts.authentication && opts.clientId && win.localStorage) {
+      const serializedSession = win.localStorage.getItem(ctx.sessionKey);
+      if (serializedSession) {
+        if (opts.debug) {
+          console.info(
+            `ArcGISContext-${ctx.id}: Loaded session from localStorage`
+          );
+        }
+        await ctx.setAuthentication(UserSession.deserialize(serializedSession));
+      }
+    }
+    if (opts.debug) {
+      console.info(`ArcGISContext-${ctx.id}: Initializing`);
+    }
+    await ctx.initialize();
+    return ctx;
+  }
+
+  /**
+   * If we have a UserSession, fetch portal/self and
+   * store that along with current user
+   */
+  async initialize(): Promise<void> {
+    if (this._authentication) {
+      const ps = await getSelf({ authentication: this._authentication });
+      this._portalSelf = ps;
+      this._currentUser = ps.user;
+    }
+  }
+
+  // Set authentication after the instance is up and running
+  async setAuthentication(auth: UserSession): Promise<void> {
+    this._authentication = auth;
+    this._portalUrl = auth.portal.replace("/sharing/rest", "");
+    await this.initialize();
+  }
+
+  private get sessionKey(): string {
+    return `${this.SESSION_KEY}${this._clientId}`;
+  }
+
+  public saveSession(win: any = window): void {
+    if (win.localStorage) {
+      win.localStorage.setItem(
+        this.sessionKey,
+        this._authentication.serialize()
+      );
+    }
+  }
+
+  public async clearSession(win: any = window): Promise<void> {
+    // const localStorage = ArcGISContext._getLocalStorage();
+    if (win.localStorage) {
+      win.localStorage.removeItem(this.sessionKey);
+    }
+    this._authentication = null;
+    this._currentUser = null;
+    this._portalSelf = null;
+    this.initialize();
+  }
+
+  public get session(): UserSession {
+    return this._authentication;
+  }
+
+  public get isAuthenticated(): boolean {
+    return !!this._authentication;
+  }
+
+  public get clientId(): string {
+    return this._clientId;
+  }
+
+  /**
+   * Return `IUserRequestOptions`, which is used for REST-JS
+   * functions which require authentication information.
+   *
+   * If context is not authenticated, this function will throw
+   */
+  public get userRequestOptions(): IUserRequestOptions {
+    if (this.isAuthenticated) {
+      return {
+        authentication: this._authentication,
+        portal: this.sharingApiUrl,
+      };
+    }
+  }
+
+  /**
+   * Return `IRequestOptions`, which is used by REST-JS functions
+   * which *may* use authentication information if provided.
+   *
+   * If context is not authenticated, this function just returns
+   * the `portal` property, which informs REST-JS what Sharing API
+   * instance to use (i.e. AGO, Enterprise etc)
+   */
+  public get requestOptions(): IRequestOptions {
+    let ro: any = {
+      portal: this.sharingApiUrl,
+    };
+    if (this.isAuthenticated) {
+      ro = {
+        authentication: this._authentication,
+        portal: this.sharingApiUrl,
+      };
+    }
+    return ro;
+  }
+
+  public get hubRequestOptions(): IHubRequestOptions {
+    // We may add more logic around what is returned in some corner cases
+    return {
+      authentication: this.session,
+      isPortal: this.isPortal,
+      portalSelf: this.portal,
+      hubApiUrl: this.hubUrl,
+    };
+  }
+
+  // ==============================
+  // Getters / Computed Properties
+  // ==============================
+  // All these props should derive their values
+  // based on other state of the object
+  public get portalUrl(): string {
+    if (this.isAuthenticated) {
+      if (this.isPortal) {
+        return `https://${this._portalSelf.portalHostname}`;
+      } else {
+        return `https://${this._portalSelf.urlKey}.${this._portalSelf.customBaseUrl}`;
+      }
+    } else {
+      return this._portalUrl;
+    }
+  }
+
+  public get sharingApiUrl(): string {
+    return `${this.portalUrl}/sharing/rest`;
+  }
+
+  public get hubUrl(): string {
+    return this._hubUrl;
+  }
+
+  // Deprecate isPortal but until we can do that
+  // this is a stand-in and will warn in console
+  // which will be important if/when we rework
+  // session/ArcGISContext service to lean into this class
+  public get isPortal(): boolean {
+    return this._portalSelf
+      ? this._portalSelf.isPortal
+      : this._portalUrl.indexOf("arcgis.com") === -1;
+  }
+
+  // Hub APIs
+  // ----------
+  // Discussions
+  public get discussionsServiceUrl(): string {
+    if (this._hubUrl) {
+      return `${this._hubUrl}${hubApiEndpoints.discussions}`;
+    }
+  }
+
+  // Hub Search
+  public get hubSearchServiceUrl(): string {
+    if (this._hubUrl) {
+      return `${this._hubUrl}${hubApiEndpoints.search}`;
+    }
+  }
+
+  // Domain
+  public get domainServiceUrl(): string {
+    if (this._hubUrl) {
+      return `${this._hubUrl}${hubApiEndpoints.domains}`;
+    }
+  }
+
+  // Events
+  // returns `{serviceId: '3ef..', publicViewId: 'bc3...'}
+  public get eventsConfig(): any {
+    if (this._portalSelf) {
+      return getProp(this._portalSelf, "portalProperties.hub.settings.events");
+    }
+  }
+
+  public get hubEnabled(): boolean {
+    return getWithDefault(
+      this._portalSelf,
+      "portalProperties.hub.enabled",
+      false
+    );
+  }
+
+  public get communityOrgId(): string {
+    if (this._portalSelf) {
+      return getProp(
+        this._portalSelf,
+        "portalProperties.hub.settings.communityOrg.orgId"
+      );
+    }
+  }
+
+  public get communityOrgHostname(): string {
+    if (this._portalSelf) {
+      return getProp(
+        this._portalSelf,
+        "portalProperties.hub.settings.communityOrg.portalHostname"
+      );
+    }
+  }
+
+  public get communityOrgUrl(): string {
+    if (this.communityOrgHostname) {
+      return `https://${this.communityOrgHostname}`;
+    }
+  }
+
+  // Platform API service urls are all in helperServices
+  // and not consistent to expose as urls
+  public get helperServices(): any {
+    if (this._portalSelf) {
+      return this._portalSelf.helperServices;
+    }
+  }
+
+  public get currentUser(): IUser {
+    return this._currentUser;
+  }
+
+  public get portal(): IPortal {
+    return this._portalSelf;
+  }
+}
+
+/**
+ * Cross-walk from a portalUrl to the corresponding Hub.
+ *
+ * If the passed url is not recognized, then this will return `undefined`
+ * @param portalUrl
+ * @returns
+ */
+function getHubApiFromPortalUrl(portalUrl: string): string {
+  let result;
+
+  if (portalUrl.match(/(qaext|\.mapsqa)\.arcgis.com/)) {
+    result = "https://hubqa.arcgis.com";
+  } else if (portalUrl.match(/(devext|\.mapsdevext)\.arcgis.com/)) {
+    result = "https://hubdev.arcgis.com";
+  } else if (portalUrl.match(/(www|\.maps)\.arcgis.com/)) {
+    result = "https://hub.arcgis.com";
+  }
+
+  return result;
+}
+
+const hubApiEndpoints = {
+  domains: "/api/v3/domains",
+  search: "/api/v3/datasets",
+  discussions: "/api/discussions/v1",
+};

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -21,9 +21,11 @@ export * from "./utils";
 export * from "./i18n";
 export * from "./request";
 export * from "./surveys";
+export * from "./ArcGISContext";
 
 import OperationStack from "./OperationStack";
 import OperationError from "./OperationError";
+
 // Re-exports
 export { OperationStack, OperationError };
 export { btoa, atob } from "abab";

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -100,7 +100,11 @@ export interface ISolutionTemplate extends IModel {
 
 export type GenericAsyncFunc = (...args: any) => Promise<any>;
 
-interface IHubRequestOptionsPortalSelf extends IPortal {
+/**
+ * @internal
+ * This just adds user to the IPortal interface
+ */
+export interface IHubRequestOptionsPortalSelf extends IPortal {
   user?: IUser;
 }
 

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -15,3 +15,4 @@ export * from "./increment-string";
 export * from "./logger";
 export * from "./is-update-group";
 export * from "./revertable-tasks";
+export * from "./sessionLocalStorage";

--- a/packages/common/src/utils/sessionLocalStorage.ts
+++ b/packages/common/src/utils/sessionLocalStorage.ts
@@ -1,0 +1,56 @@
+import { UserSession } from "@esri/arcgis-rest-auth";
+
+/**
+ * Remove any serialized sessions associated with the passed clientId
+ * from a browser's local storage
+ * @param clientId oAuth Client Id
+ * @param win optional window (used for testing)
+ */
+export function clearSession(
+  clientId: string,
+  /* istanbul ignore next */
+  win: any = window
+): void {
+  if (win.localStorage) {
+    win.localStorage.removeItem(`__CONTEXT_${clientId}`);
+  }
+}
+
+/**
+ * Re-hydrate a UserSession from a browser's local storage.
+ * If not found,
+ * @param clientId oAuth Client Id
+ * @param win optional window (used for testing)
+ * @returns
+ */
+export function getSession(
+  clientId: string,
+  /* istanbul ignore next */
+  win: any = window
+): UserSession | null {
+  let result: UserSession | null = null;
+  if (win.localStorage) {
+    const serializedSession = win.localStorage.getItem(`__CONTEXT_${clientId}`);
+    if (serializedSession) {
+      result = UserSession.deserialize(serializedSession);
+    }
+  }
+  return result;
+}
+
+/**
+ * Serialize a UserSession into a browser's local storage
+ * @param clientId oAuth Client Id
+ * @param session UserSession
+ * @param win optional window (used for testing)
+ */
+export function saveSession(
+  clientId: string,
+  session: UserSession,
+  /* istanbul ignore next */
+  win: any = window
+): void {
+  if (win.localStorage) {
+    win.localStorage.setItem(`__CONTEXT_${clientId}`, session.serialize());
+  }
+}

--- a/packages/common/test/ArcGISContext.test.ts
+++ b/packages/common/test/ArcGISContext.test.ts
@@ -2,13 +2,7 @@ import { ArcGISContext } from "../src/ArcGISContext";
 import { cloneObject, IHubRequestOptionsPortalSelf } from "../src";
 import * as portalModule from "@esri/arcgis-rest-portal";
 import { MOCK_AUTH, MOCK_ENTERPRISE_AUTH } from "./mocks/mock-auth";
-import { getItem, IPortal } from "@esri/arcgis-rest-portal";
-
-const MOCK_LOCAL_STORAGE = {
-  setItem: () => {},
-  getItem: () => {},
-  removeItem: () => {},
-};
+import { IPortal } from "@esri/arcgis-rest-portal";
 
 const onlinePortalSelfResponse = {
   urlKey: "myorg",
@@ -65,16 +59,11 @@ const enterprisePortalSelfResponse = {
 
 describe("ArcGISContext:", () => {
   describe("AGO:", () => {
-    it("verify props when passed just clientid and not authd", async () => {
+    it("verify props when passed nothing", async () => {
       const t = new Date().getTime();
-      const ctx = await ArcGISContext.create(
-        {
-          clientId: "FAKEID",
-        },
-        {}
-      );
+      const ctx = await ArcGISContext.create();
       expect(ctx.id).toBeGreaterThanOrEqual(t);
-      expect(ctx.clientId).toBe("FAKEID");
+
       expect(ctx.portalUrl).toBe("https://www.arcgis.com");
       expect(ctx.isPortal).toBe(false);
       expect(ctx.hubUrl).toBe("https://hub.arcgis.com");
@@ -94,33 +83,28 @@ describe("ArcGISContext:", () => {
       expect(ctx.hubSearchServiceUrl).toBe(`${base}/api/v3/datasets`);
       expect(ctx.domainServiceUrl).toBe(`${base}/api/v3/domains`);
     });
-    it("verify props when passed clientid and portalUrl", async () => {
+    it("verify props when passed portalUrl", async () => {
       const t = new Date().getTime();
-      const ctx = await ArcGISContext.create(
-        {
-          clientId: "FAKEID",
-          portalUrl: "https://myserver.com/gis",
-          debug: true,
-        },
-        {}
-      );
+      const ctx = await ArcGISContext.create({
+        portalUrl: "https://myserver.com/gis",
+        debug: true,
+      });
       expect(ctx.id).toBeGreaterThanOrEqual(t);
-      expect(ctx.clientId).toBe("FAKEID");
+
       // RequestOptions
       expect(ctx.requestOptions.portal).toBe(ctx.sharingApiUrl);
       expect(ctx.requestOptions.authentication).not.toBeDefined();
     });
     it("verify props when passed session", async () => {
       const t = new Date().getTime();
-      const getSelfSpy = spyOn(portalModule, "getSelf").and.callFake(() => {
+      spyOn(portalModule, "getSelf").and.callFake(() => {
         return Promise.resolve(cloneObject(onlinePortalSelfResponse));
       });
 
-      const ctx = await ArcGISContext.create({ authentication: MOCK_AUTH }, {});
+      const ctx = await ArcGISContext.create({ authentication: MOCK_AUTH });
 
       // assertions
       expect(ctx.id).toBeGreaterThanOrEqual(t);
-      expect(ctx.clientId).toBe("arcgisonline");
       expect(ctx.portalUrl).toBe(MOCK_AUTH.portal.replace(`/sharing/rest`, ""));
       expect(ctx.sharingApiUrl).toBe(MOCK_AUTH.portal);
       expect(ctx.hubUrl).toBe("https://hub.arcgis.com");
@@ -167,142 +151,25 @@ describe("ArcGISContext:", () => {
         onlinePortalSelfResponse as unknown as IPortal
       );
     });
-
-    it("hydrates from localStorage", async () => {
-      const MOCK_WIN = {
-        localStorage: MOCK_LOCAL_STORAGE,
-      };
-      const localStorageGetItemSpy = spyOn(
-        MOCK_LOCAL_STORAGE,
-        "getItem"
-      ).and.returnValue(MOCK_AUTH.serialize());
+    it("verify props update setting session after", async () => {
       spyOn(portalModule, "getSelf").and.callFake(() => {
         return Promise.resolve(cloneObject(onlinePortalSelfResponse));
       });
-      const ctx = await ArcGISContext.create(
-        {
-          clientId: "FAKEID",
-          debug: true,
-        },
-        MOCK_WIN
-      );
 
-      expect(ctx.clientId).toBe("FAKEID");
-      expect(localStorageGetItemSpy.calls.count()).toBe(1);
-      expect(localStorageGetItemSpy.calls.argsFor(0)[0]).toBe(
-        "__CONTEXT_FAKEID"
-      );
-      // Just for coverage when we don't sent debug: true
-      const ctx2 = await ArcGISContext.create(
-        {
-          clientId: "FAKEID",
-        },
-        MOCK_WIN
-      );
-    });
-    it("saves session to localStorage", async () => {
-      const MOCK_WIN = {
-        localStorage: MOCK_LOCAL_STORAGE,
-      };
-      spyOn(portalModule, "getSelf").and.callFake(() => {
-        return Promise.resolve(cloneObject(onlinePortalSelfResponse));
-      });
-      const ctx = await ArcGISContext.create(
-        {
-          clientId: "FAKEID",
-          authentication: MOCK_AUTH,
-        },
-        MOCK_WIN
-      );
-
-      const localStorageSetItemSpy = spyOn(
-        MOCK_LOCAL_STORAGE,
-        "setItem"
-      ).and.callThrough();
-
-      expect(ctx.clientId).toBe("FAKEID");
-      ctx.saveSession(MOCK_WIN);
-      expect(localStorageSetItemSpy.calls.count()).toBe(1);
-      expect(localStorageSetItemSpy.calls.argsFor(0)[0]).toEqual(
-        "__CONTEXT_FAKEID"
-      );
-      expect(localStorageSetItemSpy.calls.argsFor(0)[1]).toEqual(
-        MOCK_AUTH.serialize()
-      );
-    });
-    it("saveSession fails silently if no localStorage present", async () => {
-      spyOn(portalModule, "getSelf").and.callFake(() => {
-        return Promise.resolve(cloneObject(onlinePortalSelfResponse));
-      });
-      const ctx = await ArcGISContext.create(
-        {
-          clientId: "FAKEID",
-          authentication: MOCK_AUTH,
-        },
-        {}
-      );
-      ctx.saveSession({});
-    });
-    describe("clearSession:", () => {
-      it("clears localStorage and props", async () => {
-        const MOCK_WIN = {
-          localStorage: MOCK_LOCAL_STORAGE,
-        };
-        spyOn(portalModule, "getSelf").and.callFake(() => {
-          return Promise.resolve(cloneObject(onlinePortalSelfResponse));
-        });
-        const ctx = await ArcGISContext.create(
-          {
-            clientId: "FAKEID",
-            authentication: MOCK_AUTH,
-          },
-          MOCK_WIN
-        );
-
-        const localStorageRemoveItemSpy = spyOn(
-          MOCK_LOCAL_STORAGE,
-          "removeItem"
-        ).and.callThrough();
-        await ctx.clearSession(MOCK_WIN);
-        expect(localStorageRemoveItemSpy.calls.count()).toBe(1);
-        expect(ctx.isAuthenticated).toBeFalsy();
-        expect(ctx.session).toBeNull();
-        expect(ctx.portal).toBeNull();
-      });
-
-      it("clears props if no localStorage", async () => {
-        spyOn(portalModule, "getSelf").and.callFake(() => {
-          return Promise.resolve(cloneObject(onlinePortalSelfResponse));
-        });
-        const ctx = await ArcGISContext.create(
-          {
-            clientId: "FAKEID",
-            authentication: MOCK_AUTH,
-          },
-          {}
-        );
-
-        await ctx.clearSession({});
-
-        expect(ctx.isAuthenticated).toBeFalsy();
-        expect(ctx.session).toBeNull();
-        expect(ctx.portal).toBeNull();
-      });
+      const ctx = await ArcGISContext.create();
+      expect(ctx.portalUrl).toBe("https://www.arcgis.com");
+      await ctx.setAuthentication(MOCK_AUTH);
+      expect(ctx.portalUrl).toBe(MOCK_AUTH.portal.replace(`/sharing/rest`, ""));
     });
   });
 
   describe("Enterprise:", () => {
     it("verify props when passed just clientid", async () => {
       const t = new Date().getTime();
-      const ctx = await ArcGISContext.create(
-        {
-          clientId: "FAKEID",
-          portalUrl: "https://myenterprise.com/gis",
-        },
-        {}
-      );
+      const ctx = await ArcGISContext.create({
+        portalUrl: "https://myenterprise.com/gis",
+      });
       expect(ctx.id).toBeGreaterThanOrEqual(t);
-      expect(ctx.clientId).toBe("FAKEID");
       expect(ctx.portalUrl).toBe("https://myenterprise.com/gis");
       expect(ctx.sharingApiUrl).toBe(
         "https://myenterprise.com/gis/sharing/rest"
@@ -320,16 +187,12 @@ describe("ArcGISContext:", () => {
         return Promise.resolve(cloneObject(enterprisePortalSelfResponse));
       });
 
-      const ctx = await ArcGISContext.create(
-        {
-          authentication: MOCK_ENTERPRISE_AUTH,
-        },
-        {}
-      );
+      const ctx = await ArcGISContext.create({
+        authentication: MOCK_ENTERPRISE_AUTH,
+      });
 
       // assertions
       expect(ctx.id).toBeGreaterThanOrEqual(t);
-      expect(ctx.clientId).toBe("arcgisonline");
       expect(ctx.portalUrl).toBe(
         MOCK_ENTERPRISE_AUTH.portal.replace(`/sharing/rest`, "")
       );
@@ -338,21 +201,15 @@ describe("ArcGISContext:", () => {
   });
   describe("extra coverage:", () => {
     it("handles qaext hubUrl", async () => {
-      const ctx = await ArcGISContext.create(
-        {
-          portalUrl: "https://qaext.arcgis.com",
-        },
-        {}
-      );
+      const ctx = await ArcGISContext.create({
+        portalUrl: "https://qaext.arcgis.com",
+      });
       expect(ctx.hubUrl).toBe("https://hubqa.arcgis.com");
     });
     it("handles devext hubUrl", async () => {
-      const ctx = await ArcGISContext.create(
-        {
-          portalUrl: "https://devext.arcgis.com",
-        },
-        {}
-      );
+      const ctx = await ArcGISContext.create({
+        portalUrl: "https://devext.arcgis.com",
+      });
       expect(ctx.hubUrl).toBe("https://hubdev.arcgis.com");
     });
   });

--- a/packages/common/test/ArcGISContext.test.ts
+++ b/packages/common/test/ArcGISContext.test.ts
@@ -1,0 +1,359 @@
+import { ArcGISContext } from "../src/ArcGISContext";
+import { cloneObject, IHubRequestOptionsPortalSelf } from "../src";
+import * as portalModule from "@esri/arcgis-rest-portal";
+import { MOCK_AUTH, MOCK_ENTERPRISE_AUTH } from "./mocks/mock-auth";
+import { getItem, IPortal } from "@esri/arcgis-rest-portal";
+
+const MOCK_LOCAL_STORAGE = {
+  setItem: () => {},
+  getItem: () => {},
+  removeItem: () => {},
+};
+
+const onlinePortalSelfResponse = {
+  urlKey: "myorg",
+  customBaseUrl: "maps.arcgis.com",
+  isPortal: false,
+  helperServices: {
+    big: "hash of things",
+  },
+  portalProperties: {
+    hub: {
+      enabled: true,
+      settings: {
+        events: {
+          publicViewId: "54cb8ca07c7e4980a554ce9b2a6b0c0a",
+          serviceId: "bde7428c5199419d9c62f20367a71126",
+        },
+        communityOrg: {
+          orgId: "FAKE_C_ORGID",
+          portalHostname: "my-community.maps.arcgis.com",
+        },
+      },
+    },
+  },
+  user: {
+    username: "jvader",
+    firstName: "Jeff",
+    lastName: "Vader",
+    description: "Runs the Deathstar",
+    email: "jvader@deathstar.com",
+  },
+};
+
+const enterprisePortalSelfResponse = {
+  customBaseUrl: "portal",
+  portalHostname: "my-server.com/portal",
+  isPortal: true,
+  helperServices: {
+    big: "hash of things",
+  },
+  portalProperties: {},
+  user: {
+    username: "lskywalker",
+    firstName: "Leia",
+    lastName: "Skywalker",
+    description: "Runs the Rebels",
+    email: "lskywalker@rebelalliance.com",
+  },
+};
+
+/**
+ * NOTE: Throughout these tests we pass in a second arg to ArcGISContext.create
+ * which is a fake `window`. We do this so these same tests will work in node
+ */
+
+describe("ArcGISContext:", () => {
+  describe("AGO:", () => {
+    it("verify props when passed just clientid and not authd", async () => {
+      const t = new Date().getTime();
+      const ctx = await ArcGISContext.create(
+        {
+          clientId: "FAKEID",
+        },
+        {}
+      );
+      expect(ctx.id).toBeGreaterThanOrEqual(t);
+      expect(ctx.clientId).toBe("FAKEID");
+      expect(ctx.portalUrl).toBe("https://www.arcgis.com");
+      expect(ctx.isPortal).toBe(false);
+      expect(ctx.hubUrl).toBe("https://hub.arcgis.com");
+      expect(ctx.requestOptions).toEqual({
+        portal: ctx.sharingApiUrl,
+      });
+      expect(ctx.userRequestOptions).toBeUndefined();
+      expect(ctx.communityOrgId).toBeUndefined();
+      expect(ctx.communityOrgHostname).toBeUndefined();
+      expect(ctx.communityOrgUrl).toBeUndefined();
+      expect(ctx.eventsConfig).toBeUndefined();
+      expect(ctx.helperServices).toBeUndefined();
+      expect(ctx.hubEnabled).toBeFalsy();
+      // Hub Urls
+      const base = ctx.hubUrl;
+      expect(ctx.discussionsServiceUrl).toBe(`${base}/api/discussions/v1`);
+      expect(ctx.hubSearchServiceUrl).toBe(`${base}/api/v3/datasets`);
+      expect(ctx.domainServiceUrl).toBe(`${base}/api/v3/domains`);
+    });
+    it("verify props when passed clientid and portalUrl", async () => {
+      const t = new Date().getTime();
+      const ctx = await ArcGISContext.create(
+        {
+          clientId: "FAKEID",
+          portalUrl: "https://myserver.com/gis",
+          debug: true,
+        },
+        {}
+      );
+      expect(ctx.id).toBeGreaterThanOrEqual(t);
+      expect(ctx.clientId).toBe("FAKEID");
+      // RequestOptions
+      expect(ctx.requestOptions.portal).toBe(ctx.sharingApiUrl);
+      expect(ctx.requestOptions.authentication).not.toBeDefined();
+    });
+    it("verify props when passed session", async () => {
+      const t = new Date().getTime();
+      const getSelfSpy = spyOn(portalModule, "getSelf").and.callFake(() => {
+        return Promise.resolve(cloneObject(onlinePortalSelfResponse));
+      });
+
+      const ctx = await ArcGISContext.create({ authentication: MOCK_AUTH }, {});
+
+      // assertions
+      expect(ctx.id).toBeGreaterThanOrEqual(t);
+      expect(ctx.clientId).toBe("arcgisonline");
+      expect(ctx.portalUrl).toBe(MOCK_AUTH.portal.replace(`/sharing/rest`, ""));
+      expect(ctx.sharingApiUrl).toBe(MOCK_AUTH.portal);
+      expect(ctx.hubUrl).toBe("https://hub.arcgis.com");
+      expect(ctx.session).toBe(MOCK_AUTH);
+      expect(ctx.isAuthenticated).toBe(true);
+      // RequestOptions
+      expect(ctx.requestOptions.portal).toBe(ctx.sharingApiUrl);
+      expect(ctx.requestOptions.authentication).toBe(MOCK_AUTH);
+      // UserRequestOptions
+      expect(ctx.userRequestOptions.authentication).toBe(MOCK_AUTH);
+      expect(ctx.userRequestOptions.portal).toBe(ctx.sharingApiUrl);
+
+      // Hub Request Options
+      expect(ctx.hubRequestOptions.authentication).toBe(MOCK_AUTH);
+      expect(ctx.hubRequestOptions.isPortal).toBe(false);
+      expect(ctx.hubRequestOptions.portalSelf).toEqual(
+        onlinePortalSelfResponse as unknown as IHubRequestOptionsPortalSelf
+      );
+      expect(ctx.hubRequestOptions.hubApiUrl).toBe("https://hub.arcgis.com");
+
+      // Hub Urls
+      const base = ctx.hubUrl;
+      expect(ctx.discussionsServiceUrl).toBe(`${base}/api/discussions/v1`);
+      expect(ctx.hubSearchServiceUrl).toBe(`${base}/api/v3/datasets`);
+      expect(ctx.domainServiceUrl).toBe(`${base}/api/v3/domains`);
+
+      // Community
+      expect(ctx.communityOrgId).toBe("FAKE_C_ORGID");
+      expect(ctx.communityOrgHostname).toBe("my-community.maps.arcgis.com");
+      expect(ctx.communityOrgUrl).toBe("https://my-community.maps.arcgis.com");
+
+      expect(ctx.eventsConfig).toEqual(
+        onlinePortalSelfResponse.portalProperties.hub.settings.events
+      );
+      expect(ctx.hubEnabled).toEqual(
+        onlinePortalSelfResponse.portalProperties.hub.enabled
+      );
+
+      expect(ctx.helperServices).toEqual(
+        onlinePortalSelfResponse.helperServices
+      );
+      expect(ctx.currentUser).toEqual(onlinePortalSelfResponse.user);
+      expect(ctx.portal).toEqual(
+        onlinePortalSelfResponse as unknown as IPortal
+      );
+    });
+
+    it("hydrates from localStorage", async () => {
+      const MOCK_WIN = {
+        localStorage: MOCK_LOCAL_STORAGE,
+      };
+      const localStorageGetItemSpy = spyOn(
+        MOCK_LOCAL_STORAGE,
+        "getItem"
+      ).and.returnValue(MOCK_AUTH.serialize());
+      spyOn(portalModule, "getSelf").and.callFake(() => {
+        return Promise.resolve(cloneObject(onlinePortalSelfResponse));
+      });
+      const ctx = await ArcGISContext.create(
+        {
+          clientId: "FAKEID",
+          debug: true,
+        },
+        MOCK_WIN
+      );
+
+      expect(ctx.clientId).toBe("FAKEID");
+      expect(localStorageGetItemSpy.calls.count()).toBe(1);
+      expect(localStorageGetItemSpy.calls.argsFor(0)[0]).toBe(
+        "__CONTEXT_FAKEID"
+      );
+      // Just for coverage when we don't sent debug: true
+      const ctx2 = await ArcGISContext.create(
+        {
+          clientId: "FAKEID",
+        },
+        MOCK_WIN
+      );
+    });
+    it("saves session to localStorage", async () => {
+      const MOCK_WIN = {
+        localStorage: MOCK_LOCAL_STORAGE,
+      };
+      spyOn(portalModule, "getSelf").and.callFake(() => {
+        return Promise.resolve(cloneObject(onlinePortalSelfResponse));
+      });
+      const ctx = await ArcGISContext.create(
+        {
+          clientId: "FAKEID",
+          authentication: MOCK_AUTH,
+        },
+        MOCK_WIN
+      );
+
+      const localStorageSetItemSpy = spyOn(
+        MOCK_LOCAL_STORAGE,
+        "setItem"
+      ).and.callThrough();
+
+      expect(ctx.clientId).toBe("FAKEID");
+      ctx.saveSession(MOCK_WIN);
+      expect(localStorageSetItemSpy.calls.count()).toBe(1);
+      expect(localStorageSetItemSpy.calls.argsFor(0)[0]).toEqual(
+        "__CONTEXT_FAKEID"
+      );
+      expect(localStorageSetItemSpy.calls.argsFor(0)[1]).toEqual(
+        MOCK_AUTH.serialize()
+      );
+    });
+    it("saveSession fails silently if no localStorage present", async () => {
+      spyOn(portalModule, "getSelf").and.callFake(() => {
+        return Promise.resolve(cloneObject(onlinePortalSelfResponse));
+      });
+      const ctx = await ArcGISContext.create(
+        {
+          clientId: "FAKEID",
+          authentication: MOCK_AUTH,
+        },
+        {}
+      );
+      ctx.saveSession({});
+    });
+    describe("clearSession:", () => {
+      it("clears localStorage and props", async () => {
+        const MOCK_WIN = {
+          localStorage: MOCK_LOCAL_STORAGE,
+        };
+        spyOn(portalModule, "getSelf").and.callFake(() => {
+          return Promise.resolve(cloneObject(onlinePortalSelfResponse));
+        });
+        const ctx = await ArcGISContext.create(
+          {
+            clientId: "FAKEID",
+            authentication: MOCK_AUTH,
+          },
+          MOCK_WIN
+        );
+
+        const localStorageRemoveItemSpy = spyOn(
+          MOCK_LOCAL_STORAGE,
+          "removeItem"
+        ).and.callThrough();
+        await ctx.clearSession(MOCK_WIN);
+        expect(localStorageRemoveItemSpy.calls.count()).toBe(1);
+        expect(ctx.isAuthenticated).toBeFalsy();
+        expect(ctx.session).toBeNull();
+        expect(ctx.portal).toBeNull();
+      });
+
+      it("clears props if no localStorage", async () => {
+        spyOn(portalModule, "getSelf").and.callFake(() => {
+          return Promise.resolve(cloneObject(onlinePortalSelfResponse));
+        });
+        const ctx = await ArcGISContext.create(
+          {
+            clientId: "FAKEID",
+            authentication: MOCK_AUTH,
+          },
+          {}
+        );
+
+        await ctx.clearSession({});
+
+        expect(ctx.isAuthenticated).toBeFalsy();
+        expect(ctx.session).toBeNull();
+        expect(ctx.portal).toBeNull();
+      });
+    });
+  });
+
+  describe("Enterprise:", () => {
+    it("verify props when passed just clientid", async () => {
+      const t = new Date().getTime();
+      const ctx = await ArcGISContext.create(
+        {
+          clientId: "FAKEID",
+          portalUrl: "https://myenterprise.com/gis",
+        },
+        {}
+      );
+      expect(ctx.id).toBeGreaterThanOrEqual(t);
+      expect(ctx.clientId).toBe("FAKEID");
+      expect(ctx.portalUrl).toBe("https://myenterprise.com/gis");
+      expect(ctx.sharingApiUrl).toBe(
+        "https://myenterprise.com/gis/sharing/rest"
+      );
+      expect(ctx.isPortal).toBe(true);
+
+      expect(ctx.hubUrl).toBeUndefined();
+      expect(ctx.discussionsServiceUrl).toBeUndefined();
+      expect(ctx.hubSearchServiceUrl).toBeUndefined();
+      expect(ctx.domainServiceUrl).toBeUndefined();
+    });
+    it("verify props when passed session", async () => {
+      const t = new Date().getTime();
+      spyOn(portalModule, "getSelf").and.callFake(() => {
+        return Promise.resolve(cloneObject(enterprisePortalSelfResponse));
+      });
+
+      const ctx = await ArcGISContext.create(
+        {
+          authentication: MOCK_ENTERPRISE_AUTH,
+        },
+        {}
+      );
+
+      // assertions
+      expect(ctx.id).toBeGreaterThanOrEqual(t);
+      expect(ctx.clientId).toBe("arcgisonline");
+      expect(ctx.portalUrl).toBe(
+        MOCK_ENTERPRISE_AUTH.portal.replace(`/sharing/rest`, "")
+      );
+      expect(ctx.sharingApiUrl).toBe(MOCK_ENTERPRISE_AUTH.portal);
+    });
+  });
+  describe("extra coverage:", () => {
+    it("handles qaext hubUrl", async () => {
+      const ctx = await ArcGISContext.create(
+        {
+          portalUrl: "https://qaext.arcgis.com",
+        },
+        {}
+      );
+      expect(ctx.hubUrl).toBe("https://hubqa.arcgis.com");
+    });
+    it("handles devext hubUrl", async () => {
+      const ctx = await ArcGISContext.create(
+        {
+          portalUrl: "https://devext.arcgis.com",
+        },
+        {}
+      );
+      expect(ctx.hubUrl).toBe("https://hubdev.arcgis.com");
+    });
+  });
+});

--- a/packages/common/test/utils/sessionLocalStorage.test.ts
+++ b/packages/common/test/utils/sessionLocalStorage.test.ts
@@ -1,0 +1,91 @@
+import { saveSession, clearSession, getSession } from "../../src";
+import { MOCK_AUTH } from "../mocks/mock-auth";
+
+const MOCK_LOCAL_STORAGE = {
+  // tslint:disable-next-line:no-empty
+  setItem: () => {},
+  // tslint:disable-next-line:no-empty
+  getItem: () => {},
+  // tslint:disable-next-line:no-empty
+  removeItem: () => {},
+};
+
+describe("localStorage:", () => {
+  describe("getSession:", () => {
+    it("returns null if window.localStorage is undefined", () => {
+      const chk = getSession("FAKE_ID", {});
+      expect(chk).toBeNull();
+    });
+    it("returns null if localStorage returns null", () => {
+      const MOCK_WIN = {
+        localStorage: MOCK_LOCAL_STORAGE,
+      };
+
+      const chk = getSession("FAKE_ID", MOCK_WIN);
+      expect(chk).toBeNull();
+    });
+
+    it("returns session if localStorage has entry", () => {
+      const MOCK_WIN = {
+        localStorage: MOCK_LOCAL_STORAGE,
+      };
+      const localStorageGetItemSpy = spyOn(
+        MOCK_LOCAL_STORAGE,
+        "getItem"
+      ).and.returnValue(MOCK_AUTH.serialize());
+      const chk = getSession("FAKE_ID", MOCK_WIN);
+      expect(chk.username).toBe("casey");
+      expect(localStorageGetItemSpy.calls.count()).toBe(1);
+      expect(localStorageGetItemSpy.calls.argsFor(0)[0]).toBe(
+        "__CONTEXT_FAKE_ID"
+      );
+    });
+  });
+
+  describe("saveSession:", () => {
+    it("does nothing if window.localStorage is undefined", () => {
+      const chk = saveSession("FAKE_ID", MOCK_AUTH, {});
+      expect(chk).toBeUndefined();
+    });
+    it("stores session if localStorage is present", () => {
+      const MOCK_WIN = {
+        localStorage: MOCK_LOCAL_STORAGE,
+      };
+      const localStorageGetItemSpy = spyOn(
+        MOCK_LOCAL_STORAGE,
+        "setItem"
+      ).and.callThrough();
+      const chk = saveSession("FAKE_ID", MOCK_AUTH, MOCK_WIN);
+      expect(chk).toBeUndefined();
+      expect(localStorageGetItemSpy.calls.count()).toBe(1);
+      expect(localStorageGetItemSpy.calls.argsFor(0)[0]).toBe(
+        "__CONTEXT_FAKE_ID"
+      );
+      expect(localStorageGetItemSpy.calls.argsFor(0)[1]).toEqual(
+        MOCK_AUTH.serialize()
+      );
+    });
+  });
+
+  describe("clearSession:", () => {
+    it("does nothing if window.localStorage is undefined", () => {
+      const chk = clearSession("FAKE_ID", {});
+      expect(chk).toBeUndefined();
+    });
+    it("clears session if localStorage has entry", () => {
+      const MOCK_WIN = {
+        localStorage: MOCK_LOCAL_STORAGE,
+      };
+      const localStorageGetItemSpy = spyOn(
+        MOCK_LOCAL_STORAGE,
+        "removeItem"
+      ).and.callThrough();
+      const chk = clearSession("FAKE_ID", MOCK_WIN);
+      expect(chk).toBeUndefined();
+      expect(localStorageGetItemSpy.calls.count()).toBe(1);
+      expect(localStorageGetItemSpy.calls.argsFor(0)[0]).toBe(
+        "__CONTEXT_FAKE_ID"
+      );
+    });
+  });
+});


### PR DESCRIPTION
1. Description:
- Add ArcGISContext class and Session LocalStorage Utils

ArcGISContext is pretty similar to AppSettings class in hub-components, but more generically named, and moves localStorage from inside the class to separate utils.

Next step will be to pull this into -ui, and expose an instance on the app-settings service so that it is available for use with hub-components. Then, I'll update the hub-components package to use ArcGISContext instead of AppSettings, and finally update UI with latest of all packages, consuming ArcGISContext from the app-settings service.

1. Instructions for testing:
- run tests
1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
