### PR TITLE
fix: Add "state" to ArcGISContext to enable Frameworks to "react" to changes

### DIFF
--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -1,21 +1,10 @@
 import { getSelf, IPortal } from "@esri/arcgis-rest-portal";
+import { IUser, UserSession } from "@esri/arcgis-rest-auth";
 import {
-  IUser,
-  IUserRequestOptions,
-  UserSession,
-} from "@esri/arcgis-rest-auth";
-import { getProp, getWithDefault, IHubRequestOptions } from ".";
-import { IRequestOptions } from "@esri/arcgis-rest-request";
-
-/**
- * Hash of Hub API end points so updates
- * are centralized
- */
-const hubApiEndpoints = {
-  domains: "/api/v3/domains",
-  search: "/api/v3/datasets",
-  discussions: "/api/discussions/v1",
-};
+  ArcGISContextState,
+  IArcGISContextState,
+  IArcGISContextStateOptions,
+} from "./ArcGISContextState";
 
 /**
  * Options that can be passed into `ArcGISContext.create`
@@ -65,6 +54,8 @@ export class ArcGISContext {
    * contexts getting created
    */
   public id: number;
+
+  private _state: IArcGISContextState;
 
   private _authentication: UserSession;
 
@@ -124,19 +115,65 @@ export class ArcGISContext {
    * store that along with current user
    */
   async initialize(): Promise<void> {
+    let stateOpts: IArcGISContextStateOptions = {
+      id: this.id,
+      portalUrl: this._portalUrl,
+      hubUrl: this._hubUrl,
+    };
     if (this._authentication) {
       this.log(`ArcGISContext-${this.id}: Initializing`);
       const ps = await getSelf({ authentication: this._authentication });
       this._portalSelf = ps;
       this._currentUser = ps.user;
+      stateOpts = {
+        id: this.id,
+        portalUrl: this._portalUrl,
+        hubUrl: this._hubUrl,
+        portalSelf: this._portalSelf,
+        currentUser: this._currentUser,
+        authentication: this._authentication,
+      };
     }
+    // update the state
+    this._state = new ArcGISContextState(stateOpts);
   }
 
-  // Set authentication after the instance is up and running
+  /**
+   * Set the Authentication (UserSession) for the context.
+   * This should be called when a user signs into a running
+   * application.
+   * @param auth
+   */
   async setAuthentication(auth: UserSession): Promise<void> {
     this._authentication = auth;
     this._portalUrl = auth.portal.replace("/sharing/rest", "");
     await this.initialize();
+  }
+
+  /**
+   * Clear the Authentication (UserSession). This should be
+   * called when a user signs out of an application, but
+   * the application continues running
+   */
+  clearAuthentication(): void {
+    // Reset the portalUrl from the org url to the base url
+    // for ArcGIS Enterprise, we just leave the _portalUrl as-is
+    if (!this._state.isPortal) {
+      this._portalUrl = getPortalBaseFromOrgUrl(this._portalUrl);
+    }
+    // Clear the auth, portalSelf and currentUser props
+    this._authentication = null;
+    this._portalSelf = null;
+    this._currentUser = null;
+    this._state = new ArcGISContextState({
+      id: this.id,
+      portalUrl: this._portalUrl,
+      hubUrl: this._hubUrl,
+    });
+  }
+
+  get state(): IArcGISContextState {
+    return this._state;
   }
 
   /**
@@ -149,203 +186,6 @@ export class ArcGISContext {
       // tslint:disable-next-line:no-console
       console.info(message);
     }
-  }
-
-  /**
-   * Return the UserSession if authenticated
-   */
-  public get session(): UserSession {
-    return this._authentication;
-  }
-
-  /**
-   * Return boolean indicating if authenticatio is present
-   */
-  public get isAuthenticated(): boolean {
-    return !!this._authentication;
-  }
-
-  /**
-   * Return `IUserRequestOptions`, which is used for REST-JS
-   * functions which require authentication information.
-   *
-   * If context is not authenticated, this function will throw
-   */
-  public get userRequestOptions(): IUserRequestOptions {
-    if (this.isAuthenticated) {
-      return {
-        authentication: this._authentication,
-        portal: this.sharingApiUrl,
-      };
-    }
-  }
-
-  /**
-   * Return `IRequestOptions`, which is used by REST-JS functions
-   * which *may* use authentication information if provided.
-   *
-   * If context is not authenticated, this function just returns
-   * the `portal` property, which informs REST-JS what Sharing API
-   * instance to use (i.e. AGO, Enterprise etc)
-   */
-  public get requestOptions(): IRequestOptions {
-    let ro: any = {
-      portal: this.sharingApiUrl,
-    };
-    if (this.isAuthenticated) {
-      ro = {
-        authentication: this._authentication,
-        portal: this.sharingApiUrl,
-      };
-    }
-    return ro;
-  }
-
-  /**
-   * Return a `IHubRequestOptions` object
-   */
-  public get hubRequestOptions(): IHubRequestOptions {
-    // We may add more logic around what is returned in some corner cases
-    return {
-      authentication: this.session,
-      isPortal: this.isPortal,
-      portalSelf: this.portal,
-      hubApiUrl: this.hubUrl,
-    };
-  }
-
-  // ==============================
-  // Getters / Computed Properties
-  // ==============================
-
-  /**
-   * Return the portal url.
-   *
-   * If authenticated @ ArcGIS Online, it will return
-   * the https://org.env.arcgis.com
-   *
-   * If authenticated @ ArcGIS Enterprise, it will return
-   * https://portalHostname, which includes the web adaptor
-   */
-  public get portalUrl(): string {
-    if (this.isAuthenticated) {
-      if (this.isPortal) {
-        return `https://${this._portalSelf.portalHostname}`;
-      } else {
-        return `https://${this._portalSelf.urlKey}.${this._portalSelf.customBaseUrl}`;
-      }
-    } else {
-      return this._portalUrl;
-    }
-  }
-
-  /**
-   * Returns the url to the sharing api
-   * i.e. https://myorg.maps.arcgis.com/sharing/rest
-   */
-  public get sharingApiUrl(): string {
-    return `${this.portalUrl}/sharing/rest`;
-  }
-
-  public get hubUrl(): string {
-    return this._hubUrl;
-  }
-
-  /**
-   * Returns boolean indicating if the backing system
-   * is ArcGIS Enterprise (formerly ArcGIS Portal) or not
-   */
-  public get isPortal(): boolean {
-    return this._portalSelf
-      ? this._portalSelf.isPortal
-      : this._portalUrl.indexOf("arcgis.com") === -1;
-  }
-
-  // Hub APIs
-  // ----------
-  // Discussions
-  public get discussionsServiceUrl(): string {
-    if (this._hubUrl) {
-      return `${this._hubUrl}${hubApiEndpoints.discussions}`;
-    }
-  }
-
-  // Hub Search
-  public get hubSearchServiceUrl(): string {
-    if (this._hubUrl) {
-      return `${this._hubUrl}${hubApiEndpoints.search}`;
-    }
-  }
-
-  // Domain
-  public get domainServiceUrl(): string {
-    if (this._hubUrl) {
-      return `${this._hubUrl}${hubApiEndpoints.domains}`;
-    }
-  }
-
-  // Events
-  // returns `{serviceId: '3ef..', publicViewId: 'bc3...'}
-  public get eventsConfig(): any {
-    if (this._portalSelf) {
-      return getProp(this._portalSelf, "portalProperties.hub.settings.events");
-    }
-  }
-
-  /**
-   * Returns boolean indicating if the current user
-   * belongs to an organization that has licensed
-   * ArcGIS Hub
-   */
-  public get hubEnabled(): boolean {
-    return getWithDefault(
-      this._portalSelf,
-      "portalProperties.hub.enabled",
-      false
-    );
-  }
-
-  /**
-   * Return Hub Community Org Id, if defined
-   */
-  public get communityOrgId(): string {
-    if (this._portalSelf) {
-      return getProp(
-        this._portalSelf,
-        "portalProperties.hub.settings.communityOrg.orgId"
-      );
-    }
-  }
-
-  public get communityOrgHostname(): string {
-    if (this._portalSelf) {
-      return getProp(
-        this._portalSelf,
-        "portalProperties.hub.settings.communityOrg.portalHostname"
-      );
-    }
-  }
-
-  public get communityOrgUrl(): string {
-    if (this.communityOrgHostname) {
-      return `https://${this.communityOrgHostname}`;
-    }
-  }
-
-  // Platform API service urls are all in helperServices
-  // and not consistent to expose as urls
-  public get helperServices(): any {
-    if (this._portalSelf) {
-      return this._portalSelf.helperServices;
-    }
-  }
-
-  public get currentUser(): IUser {
-    return this._currentUser;
-  }
-
-  public get portal(): IPortal {
-    return this._portalSelf;
   }
 }
 
@@ -365,6 +205,23 @@ function getHubApiFromPortalUrl(portalUrl: string): string {
     result = "https://hubdev.arcgis.com";
   } else if (portalUrl.match(/(www|\.maps)\.arcgis.com/)) {
     result = "https://hub.arcgis.com";
+  }
+
+  return result;
+}
+
+function getPortalBaseFromOrgUrl(orgUrl: string): string {
+  let result;
+
+  if (orgUrl.match(/(qaext|\.mapsqa)\.arcgis.com/)) {
+    result = "https://qaext.arcgis.com";
+  } else if (orgUrl.match(/(devext|\.mapsdevext)\.arcgis.com/)) {
+    result = "https://devext.arcgis.com";
+  } else {
+    /* istanbul ignore else */
+    if (orgUrl.match(/(www|\.maps)\.arcgis.com/)) {
+      result = "https://www.arcgis.com";
+    }
   }
 
   return result;

--- a/packages/common/src/ArcGISContextState.ts
+++ b/packages/common/src/ArcGISContextState.ts
@@ -1,0 +1,295 @@
+import {
+  IUser,
+  IUserRequestOptions,
+  UserSession,
+} from "@esri/arcgis-rest-auth";
+import { IPortal } from "@esri/arcgis-rest-portal";
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { getProp, getWithDefault, IHubRequestOptions } from ".";
+
+/**
+ * Hash of Hub API end points so updates
+ * are centralized
+ */
+const hubApiEndpoints = {
+  domains: "/api/v3/domains",
+  search: "/api/v3/datasets",
+  discussions: "/api/discussions/v1",
+};
+
+/**
+ * Defined the properties of the ArcGISContext.state
+ * object. This wll be a class instance, and when authentication
+ * changes, the instance will be replaced. This is done to allow
+ * frameworks like React or Ember to bind into the .state property
+ * and react when it changes.
+ */
+export interface IArcGISContextState {
+  id: number;
+  session: UserSession;
+  isAuthenticated: boolean;
+  userRequestOptions: IUserRequestOptions;
+  requestOptions: IRequestOptions;
+  hubRequestOptions: IHubRequestOptions;
+  portalUrl: string;
+  sharingApiUrl: string;
+  hubUrl: string;
+  isPortal: boolean;
+  discussionsServiceUrl: string;
+  hubSearchServiceUrl: string;
+  domainServiceUrl: string;
+  eventsConfig: any;
+  hubEnabled: boolean;
+  communityOrgId: string;
+  communityOrgHostname: string;
+  communityOrgUrl: string;
+  helperServices: any;
+  currentUser: IUser;
+  portal: IPortal;
+}
+
+/**
+ * @internal
+ */
+export interface IArcGISContextStateOptions {
+  id: number;
+  portalUrl: string;
+  hubUrl: string;
+  authentication?: UserSession;
+  portalSelf?: IPortal;
+  currentUser?: IUser;
+}
+
+/**
+ * @internal
+ * Thin class just used to enable getters
+ *
+ * This class should not be used by anything other than
+ * the ArcGISContext class
+ */
+export class ArcGISContextState implements IArcGISContextState {
+  public id: number;
+  private _authentication: UserSession;
+
+  private _portalUrl: string = "https://www.arcgis.com";
+
+  private _hubUrl: string;
+
+  private _portalSelf: IPortal;
+
+  private _currentUser: IUser;
+
+  constructor(opts: IArcGISContextStateOptions) {
+    this.id = opts.id;
+    this._portalUrl = opts.portalUrl;
+    this._hubUrl = opts.hubUrl;
+    if (opts.authentication) {
+      this._authentication = opts.authentication;
+    }
+
+    if (opts.portalSelf) {
+      this._portalSelf = opts.portalSelf;
+    }
+
+    if (opts.currentUser) {
+      this._currentUser = opts.currentUser;
+    }
+  }
+
+  /**
+   * Return the UserSession if authenticated
+   */
+  public get session(): UserSession {
+    return this._authentication;
+  }
+
+  /**
+   * Return boolean indicating if authenticatio is present
+   */
+  public get isAuthenticated(): boolean {
+    return !!this._authentication;
+  }
+
+  /**
+   * Return `IUserRequestOptions`, which is used for REST-JS
+   * functions which require authentication information.
+   *
+   * If context is not authenticated, this function will throw
+   */
+  public get userRequestOptions(): IUserRequestOptions {
+    if (this.isAuthenticated) {
+      return {
+        authentication: this._authentication,
+        portal: this.sharingApiUrl,
+      };
+    }
+  }
+
+  /**
+   * Return `IRequestOptions`, which is used by REST-JS functions
+   * which *may* use authentication information if provided.
+   *
+   * If context is not authenticated, this function just returns
+   * the `portal` property, which informs REST-JS what Sharing API
+   * instance to use (i.e. AGO, Enterprise etc)
+   */
+  public get requestOptions(): IRequestOptions {
+    let ro: any = {
+      portal: this.sharingApiUrl,
+    };
+    if (this.isAuthenticated) {
+      ro = {
+        authentication: this._authentication,
+        portal: this.sharingApiUrl,
+      };
+    }
+    return ro;
+  }
+
+  /**
+   * Return a `IHubRequestOptions` object
+   */
+  public get hubRequestOptions(): IHubRequestOptions {
+    // We may add more logic around what is returned in some corner cases
+    return {
+      authentication: this.session,
+      isPortal: this.isPortal,
+      portalSelf: this.portal,
+      hubApiUrl: this.hubUrl,
+    };
+  }
+
+  // ==============================
+  // Getters / Computed Properties
+  // ==============================
+
+  /**
+   * Return the portal url.
+   *
+   * If authenticated @ ArcGIS Online, it will return
+   * the https://org.env.arcgis.com
+   *
+   * If authenticated @ ArcGIS Enterprise, it will return
+   * https://portalHostname, which includes the web adaptor
+   */
+  public get portalUrl(): string {
+    if (this.isAuthenticated) {
+      if (this.isPortal) {
+        return `https://${this._portalSelf.portalHostname}`;
+      } else {
+        return `https://${this._portalSelf.urlKey}.${this._portalSelf.customBaseUrl}`;
+      }
+    } else {
+      return this._portalUrl;
+    }
+  }
+
+  /**
+   * Returns the url to the sharing api
+   * i.e. https://myorg.maps.arcgis.com/sharing/rest
+   */
+  public get sharingApiUrl(): string {
+    return `${this.portalUrl}/sharing/rest`;
+  }
+
+  public get hubUrl(): string {
+    return this._hubUrl;
+  }
+
+  /**
+   * Returns boolean indicating if the backing system
+   * is ArcGIS Enterprise (formerly ArcGIS Portal) or not
+   */
+  public get isPortal(): boolean {
+    return this._portalSelf
+      ? this._portalSelf.isPortal
+      : this._portalUrl.indexOf("arcgis.com") === -1;
+  }
+
+  // Hub APIs
+  // ----------
+  // Discussions
+  public get discussionsServiceUrl(): string {
+    if (this._hubUrl) {
+      return `${this._hubUrl}${hubApiEndpoints.discussions}`;
+    }
+  }
+
+  // Hub Search
+  public get hubSearchServiceUrl(): string {
+    if (this._hubUrl) {
+      return `${this._hubUrl}${hubApiEndpoints.search}`;
+    }
+  }
+
+  // Domain
+  public get domainServiceUrl(): string {
+    if (this._hubUrl) {
+      return `${this._hubUrl}${hubApiEndpoints.domains}`;
+    }
+  }
+
+  // Events
+  // returns `{serviceId: '3ef..', publicViewId: 'bc3...'}
+  public get eventsConfig(): any {
+    if (this._portalSelf) {
+      return getProp(this._portalSelf, "portalProperties.hub.settings.events");
+    }
+  }
+
+  /**
+   * Returns boolean indicating if the current user
+   * belongs to an organization that has licensed
+   * ArcGIS Hub
+   */
+  public get hubEnabled(): boolean {
+    return getWithDefault(
+      this._portalSelf,
+      "portalProperties.hub.enabled",
+      false
+    );
+  }
+
+  /**
+   * Return Hub Community Org Id, if defined
+   */
+  public get communityOrgId(): string {
+    if (this._portalSelf) {
+      return getProp(
+        this._portalSelf,
+        "portalProperties.hub.settings.communityOrg.orgId"
+      );
+    }
+  }
+
+  public get communityOrgHostname(): string {
+    if (this._portalSelf) {
+      return getProp(
+        this._portalSelf,
+        "portalProperties.hub.settings.communityOrg.portalHostname"
+      );
+    }
+  }
+
+  public get communityOrgUrl(): string {
+    if (this.communityOrgHostname) {
+      return `https://${this.communityOrgHostname}`;
+    }
+  }
+
+  // Platform API service urls are all in helperServices
+  // and not consistent to expose as urls
+  public get helperServices(): any {
+    if (this._portalSelf) {
+      return this._portalSelf.helperServices;
+    }
+  }
+
+  public get currentUser(): IUser {
+    return this._currentUser;
+  }
+
+  public get portal(): IPortal {
+    return this._portalSelf;
+  }
+}

--- a/packages/common/test/ArcGISContext.test.ts
+++ b/packages/common/test/ArcGISContext.test.ts
@@ -62,26 +62,28 @@ describe("ArcGISContext:", () => {
     it("verify props when passed nothing", async () => {
       const t = new Date().getTime();
       const ctx = await ArcGISContext.create();
-      expect(ctx.id).toBeGreaterThanOrEqual(t);
+      expect(ctx.state.id).toBeGreaterThanOrEqual(t);
 
-      expect(ctx.portalUrl).toBe("https://www.arcgis.com");
-      expect(ctx.isPortal).toBe(false);
-      expect(ctx.hubUrl).toBe("https://hub.arcgis.com");
-      expect(ctx.requestOptions).toEqual({
-        portal: ctx.sharingApiUrl,
+      expect(ctx.state.portalUrl).toBe("https://www.arcgis.com");
+      expect(ctx.state.isPortal).toBe(false);
+      expect(ctx.state.hubUrl).toBe("https://hub.arcgis.com");
+      expect(ctx.state.requestOptions).toEqual({
+        portal: ctx.state.sharingApiUrl,
       });
-      expect(ctx.userRequestOptions).toBeUndefined();
-      expect(ctx.communityOrgId).toBeUndefined();
-      expect(ctx.communityOrgHostname).toBeUndefined();
-      expect(ctx.communityOrgUrl).toBeUndefined();
-      expect(ctx.eventsConfig).toBeUndefined();
-      expect(ctx.helperServices).toBeUndefined();
-      expect(ctx.hubEnabled).toBeFalsy();
+      expect(ctx.state.userRequestOptions).toBeUndefined();
+      expect(ctx.state.communityOrgId).toBeUndefined();
+      expect(ctx.state.communityOrgHostname).toBeUndefined();
+      expect(ctx.state.communityOrgUrl).toBeUndefined();
+      expect(ctx.state.eventsConfig).toBeUndefined();
+      expect(ctx.state.helperServices).toBeUndefined();
+      expect(ctx.state.hubEnabled).toBeFalsy();
       // Hub Urls
-      const base = ctx.hubUrl;
-      expect(ctx.discussionsServiceUrl).toBe(`${base}/api/discussions/v1`);
-      expect(ctx.hubSearchServiceUrl).toBe(`${base}/api/v3/datasets`);
-      expect(ctx.domainServiceUrl).toBe(`${base}/api/v3/domains`);
+      const base = ctx.state.hubUrl;
+      expect(ctx.state.discussionsServiceUrl).toBe(
+        `${base}/api/discussions/v1`
+      );
+      expect(ctx.state.hubSearchServiceUrl).toBe(`${base}/api/v3/datasets`);
+      expect(ctx.state.domainServiceUrl).toBe(`${base}/api/v3/domains`);
     });
     it("verify props when passed portalUrl", async () => {
       const t = new Date().getTime();
@@ -89,11 +91,11 @@ describe("ArcGISContext:", () => {
         portalUrl: "https://myserver.com/gis",
         debug: true,
       });
-      expect(ctx.id).toBeGreaterThanOrEqual(t);
+      expect(ctx.state.id).toBeGreaterThanOrEqual(t);
 
       // RequestOptions
-      expect(ctx.requestOptions.portal).toBe(ctx.sharingApiUrl);
-      expect(ctx.requestOptions.authentication).not.toBeDefined();
+      expect(ctx.state.requestOptions.portal).toBe(ctx.state.sharingApiUrl);
+      expect(ctx.state.requestOptions.authentication).not.toBeDefined();
     });
     it("verify props when passed session", async () => {
       const t = new Date().getTime();
@@ -104,50 +106,60 @@ describe("ArcGISContext:", () => {
       const ctx = await ArcGISContext.create({ authentication: MOCK_AUTH });
 
       // assertions
-      expect(ctx.id).toBeGreaterThanOrEqual(t);
-      expect(ctx.portalUrl).toBe(MOCK_AUTH.portal.replace(`/sharing/rest`, ""));
-      expect(ctx.sharingApiUrl).toBe(MOCK_AUTH.portal);
-      expect(ctx.hubUrl).toBe("https://hub.arcgis.com");
-      expect(ctx.session).toBe(MOCK_AUTH);
-      expect(ctx.isAuthenticated).toBe(true);
+      expect(ctx.state.id).toBeGreaterThanOrEqual(t);
+      expect(ctx.state.portalUrl).toBe(
+        MOCK_AUTH.portal.replace(`/sharing/rest`, "")
+      );
+      expect(ctx.state.sharingApiUrl).toBe(MOCK_AUTH.portal);
+      expect(ctx.state.hubUrl).toBe("https://hub.arcgis.com");
+      expect(ctx.state.session).toBe(MOCK_AUTH);
+      expect(ctx.state.isAuthenticated).toBe(true);
       // RequestOptions
-      expect(ctx.requestOptions.portal).toBe(ctx.sharingApiUrl);
-      expect(ctx.requestOptions.authentication).toBe(MOCK_AUTH);
+      expect(ctx.state.requestOptions.portal).toBe(ctx.state.sharingApiUrl);
+      expect(ctx.state.requestOptions.authentication).toBe(MOCK_AUTH);
       // UserRequestOptions
-      expect(ctx.userRequestOptions.authentication).toBe(MOCK_AUTH);
-      expect(ctx.userRequestOptions.portal).toBe(ctx.sharingApiUrl);
+      expect(ctx.state.userRequestOptions.authentication).toBe(MOCK_AUTH);
+      expect(ctx.state.userRequestOptions.portal).toBe(ctx.state.sharingApiUrl);
 
       // Hub Request Options
-      expect(ctx.hubRequestOptions.authentication).toBe(MOCK_AUTH);
-      expect(ctx.hubRequestOptions.isPortal).toBe(false);
-      expect(ctx.hubRequestOptions.portalSelf).toEqual(
+      expect(ctx.state.hubRequestOptions.authentication).toBe(MOCK_AUTH);
+      expect(ctx.state.hubRequestOptions.isPortal).toBe(false);
+      expect(ctx.state.hubRequestOptions.portalSelf).toEqual(
         onlinePortalSelfResponse as unknown as IHubRequestOptionsPortalSelf
       );
-      expect(ctx.hubRequestOptions.hubApiUrl).toBe("https://hub.arcgis.com");
+      expect(ctx.state.hubRequestOptions.hubApiUrl).toBe(
+        "https://hub.arcgis.com"
+      );
 
       // Hub Urls
-      const base = ctx.hubUrl;
-      expect(ctx.discussionsServiceUrl).toBe(`${base}/api/discussions/v1`);
-      expect(ctx.hubSearchServiceUrl).toBe(`${base}/api/v3/datasets`);
-      expect(ctx.domainServiceUrl).toBe(`${base}/api/v3/domains`);
+      const base = ctx.state.hubUrl;
+      expect(ctx.state.discussionsServiceUrl).toBe(
+        `${base}/api/discussions/v1`
+      );
+      expect(ctx.state.hubSearchServiceUrl).toBe(`${base}/api/v3/datasets`);
+      expect(ctx.state.domainServiceUrl).toBe(`${base}/api/v3/domains`);
 
       // Community
-      expect(ctx.communityOrgId).toBe("FAKE_C_ORGID");
-      expect(ctx.communityOrgHostname).toBe("my-community.maps.arcgis.com");
-      expect(ctx.communityOrgUrl).toBe("https://my-community.maps.arcgis.com");
+      expect(ctx.state.communityOrgId).toBe("FAKE_C_ORGID");
+      expect(ctx.state.communityOrgHostname).toBe(
+        "my-community.maps.arcgis.com"
+      );
+      expect(ctx.state.communityOrgUrl).toBe(
+        "https://my-community.maps.arcgis.com"
+      );
 
-      expect(ctx.eventsConfig).toEqual(
+      expect(ctx.state.eventsConfig).toEqual(
         onlinePortalSelfResponse.portalProperties.hub.settings.events
       );
-      expect(ctx.hubEnabled).toEqual(
+      expect(ctx.state.hubEnabled).toEqual(
         onlinePortalSelfResponse.portalProperties.hub.enabled
       );
 
-      expect(ctx.helperServices).toEqual(
+      expect(ctx.state.helperServices).toEqual(
         onlinePortalSelfResponse.helperServices
       );
-      expect(ctx.currentUser).toEqual(onlinePortalSelfResponse.user);
-      expect(ctx.portal).toEqual(
+      expect(ctx.state.currentUser).toEqual(onlinePortalSelfResponse.user);
+      expect(ctx.state.portal).toEqual(
         onlinePortalSelfResponse as unknown as IPortal
       );
     });
@@ -157,9 +169,26 @@ describe("ArcGISContext:", () => {
       });
 
       const ctx = await ArcGISContext.create();
-      expect(ctx.portalUrl).toBe("https://www.arcgis.com");
+      expect(ctx.state.portalUrl).toBe("https://www.arcgis.com");
       await ctx.setAuthentication(MOCK_AUTH);
-      expect(ctx.portalUrl).toBe(MOCK_AUTH.portal.replace(`/sharing/rest`, ""));
+      expect(ctx.state.portalUrl).toBe(
+        MOCK_AUTH.portal.replace(`/sharing/rest`, "")
+      );
+    });
+    it("verify props after clearing session", async () => {
+      spyOn(portalModule, "getSelf").and.callFake(() => {
+        return Promise.resolve(cloneObject(onlinePortalSelfResponse));
+      });
+
+      const ctx = await ArcGISContext.create({ authentication: MOCK_AUTH });
+      expect(ctx.state.portalUrl).toBe(
+        MOCK_AUTH.portal.replace(`/sharing/rest`, "")
+      );
+      await ctx.clearAuthentication();
+      expect(ctx.state.portalUrl).toBe("https://www.arcgis.com");
+      expect(ctx.state.portal).toBeUndefined();
+      expect(ctx.state.currentUser).toBeUndefined();
+      expect(ctx.state.session).toBeUndefined();
     });
   });
 
@@ -169,17 +198,17 @@ describe("ArcGISContext:", () => {
       const ctx = await ArcGISContext.create({
         portalUrl: "https://myenterprise.com/gis",
       });
-      expect(ctx.id).toBeGreaterThanOrEqual(t);
-      expect(ctx.portalUrl).toBe("https://myenterprise.com/gis");
-      expect(ctx.sharingApiUrl).toBe(
+      expect(ctx.state.id).toBeGreaterThanOrEqual(t);
+      expect(ctx.state.portalUrl).toBe("https://myenterprise.com/gis");
+      expect(ctx.state.sharingApiUrl).toBe(
         "https://myenterprise.com/gis/sharing/rest"
       );
-      expect(ctx.isPortal).toBe(true);
+      expect(ctx.state.isPortal).toBe(true);
 
-      expect(ctx.hubUrl).toBeUndefined();
-      expect(ctx.discussionsServiceUrl).toBeUndefined();
-      expect(ctx.hubSearchServiceUrl).toBeUndefined();
-      expect(ctx.domainServiceUrl).toBeUndefined();
+      expect(ctx.state.hubUrl).toBeUndefined();
+      expect(ctx.state.discussionsServiceUrl).toBeUndefined();
+      expect(ctx.state.hubSearchServiceUrl).toBeUndefined();
+      expect(ctx.state.domainServiceUrl).toBeUndefined();
     });
     it("verify props when passed session", async () => {
       const t = new Date().getTime();
@@ -192,11 +221,31 @@ describe("ArcGISContext:", () => {
       });
 
       // assertions
-      expect(ctx.id).toBeGreaterThanOrEqual(t);
-      expect(ctx.portalUrl).toBe(
+      expect(ctx.state.id).toBeGreaterThanOrEqual(t);
+      expect(ctx.state.portalUrl).toBe(
         MOCK_ENTERPRISE_AUTH.portal.replace(`/sharing/rest`, "")
       );
-      expect(ctx.sharingApiUrl).toBe(MOCK_ENTERPRISE_AUTH.portal);
+      expect(ctx.state.sharingApiUrl).toBe(MOCK_ENTERPRISE_AUTH.portal);
+    });
+    it("verify props after clearing session", async () => {
+      const t = new Date().getTime();
+      spyOn(portalModule, "getSelf").and.callFake(() => {
+        return Promise.resolve(cloneObject(enterprisePortalSelfResponse));
+      });
+
+      const ctx = await ArcGISContext.create({
+        authentication: MOCK_ENTERPRISE_AUTH,
+      });
+
+      // assertions
+      expect(ctx.state.id).toBeGreaterThanOrEqual(t);
+      expect(ctx.state.portalUrl).toBe(
+        MOCK_ENTERPRISE_AUTH.portal.replace(`/sharing/rest`, "")
+      );
+      await ctx.clearAuthentication();
+      expect(ctx.state.portalUrl).toBe(
+        MOCK_ENTERPRISE_AUTH.portal.replace(`/sharing/rest`, "")
+      );
     });
   });
   describe("extra coverage:", () => {
@@ -204,13 +253,31 @@ describe("ArcGISContext:", () => {
       const ctx = await ArcGISContext.create({
         portalUrl: "https://qaext.arcgis.com",
       });
-      expect(ctx.hubUrl).toBe("https://hubqa.arcgis.com");
+      expect(ctx.state.hubUrl).toBe("https://hubqa.arcgis.com");
     });
     it("handles devext hubUrl", async () => {
       const ctx = await ArcGISContext.create({
         portalUrl: "https://devext.arcgis.com",
       });
-      expect(ctx.hubUrl).toBe("https://hubdev.arcgis.com");
+      expect(ctx.state.hubUrl).toBe("https://hubdev.arcgis.com");
+    });
+    it("sign out on qa, resets portalUrl correctly", async () => {
+      const ctx = await ArcGISContext.create({
+        portalUrl: "https://org.mapsqa.arcgis.com",
+      });
+      expect(ctx.state.hubUrl).toBe("https://hubqa.arcgis.com");
+      await ctx.clearAuthentication();
+      expect(ctx.state.hubUrl).toBe("https://hubqa.arcgis.com");
+      expect(ctx.state.portalUrl).toBe("https://qaext.arcgis.com");
+    });
+    it("sign out on dev, resets portalUrl correctly", async () => {
+      const ctx = await ArcGISContext.create({
+        portalUrl: "https://org.mapsdevext.arcgis.com",
+      });
+      expect(ctx.state.hubUrl).toBe("https://hubdev.arcgis.com");
+      await ctx.clearAuthentication();
+      expect(ctx.state.hubUrl).toBe("https://hubdev.arcgis.com");
+      expect(ctx.state.portalUrl).toBe("https://devext.arcgis.com");
     });
   });
 });


### PR DESCRIPTION
1. Description:

In order to have frameworks like Ember or React or Vue "react" when the state of the ArcGISContext changes is to expose the state on a property of the ArcGISContext instance, and when the context is modified, the state is replaced with a new reference.

So - this PR creates the `ArcGISContextState` class, which is exposed on `ArcGISContext.state`. When we addAuth or clearAuth, we replace the `ArcGISContextState` instance.

Have verified that this works in Ember

1. Instructions for testing:

Run tests

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
