### PR TITLE
fix: more optional params to ArcGISContext

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,12 +19,29 @@ module.exports = function(config) {
 
     karmaTypescriptConfig: {
       coverageOptions: {
+        // uncomment the next flag to disable coverage, and
+        // enable debugging in the browser
+        // if left true, the source maps won't actually match up
+        // instrumentation: false,
+
+        // don't report coverage on fixtures or tests
+        exclude: [
+          /\.(d|spec|test|e2e|node-utils)\.ts$/i,
+          /fixture*/,
+          /mocks*/, 
+          /test*/
+        ],
         threshold: {
           global: {
-              statements: 100,
-              branches: 100,
-              functions: 100,
-              lines: 100
+            statements: 100,
+            branches: 100,
+            functions: 100,
+            lines: 100,
+            // don't compute coverage for the tests themselves
+            excludes: [
+              'packages/*/test/**/*.ts',
+              'packages/*/e2e/**/*.ts',
+            ]
           }
         }
       },

--- a/packages/common/test/mocks/ExceptionFactory.ts
+++ b/packages/common/test/mocks/ExceptionFactory.ts
@@ -1,0 +1,33 @@
+import { ArcGISRequestError } from "@esri/arcgis-rest-request";
+
+export default class ExceptionFactory {
+  public static createItemMissingError(
+    props: Record<string, unknown> = {}
+  ): unknown {
+    const response = Object.assign({}, rawItemNotFoundResponse.error, props);
+    return new ArcGISRequestError(response.message, response.code, response);
+  }
+  public static createInvalidTokenError(
+    props: Record<string, unknown> = {}
+  ): unknown {
+    const response = Object.assign({}, rawInvalidTokenResponse.error, props);
+    return new ArcGISRequestError(response.message, response.code, response);
+  }
+}
+
+const rawItemNotFoundResponse = {
+  error: {
+    code: 400,
+    messageCode: "CONT_0001",
+    message: "Item does not exist or is inaccessible.",
+    details: [] as unknown[],
+  },
+};
+
+const rawInvalidTokenResponse = {
+  error: {
+    code: 498,
+    message: "Invalid token.",
+    details: [] as string[],
+  },
+};


### PR DESCRIPTION
1. Description:

`ArcGISContext.create(...)` can now take  `portal:IPortal` and `currentUser:IUser` and will skip fetching those during initialization if passed in. This allows apps which already have this information to skip additional xhrs.

1. Instructions for testing:
- runs tests
