### PR TITLE
refactor(hub-common): move getCollection() to collection module

### DIFF
--- a/packages/common/src/collections.ts
+++ b/packages/common/src/collections.ts
@@ -125,6 +125,30 @@ const other: string[] = [
 
 const site: string[] = ["Hub Site Application", "Site Application"];
 
+/**
+ * ```js
+ * import { getCollection } from "@esri/hub-common";
+ * //
+ * getCollection('Feature Layer')
+ * > 'dataset'
+ * ```
+ * Get the Hub collection for a given item type
+ * @param itemType The ArcGIS [item type](https://developers.arcgis.com/rest/users-groups-and-items/items-and-item-types.htm).
+ * @returns the Hub collection of a given item type.
+ */
+export const getCollection = (type?: string) => {
+  if (!type) {
+    return;
+  }
+  const lowerCaseType = type.toLocaleLowerCase();
+  return Object.keys(collections).find((key) => {
+    const collectionTypes = collections[key];
+    return collectionTypes.some((t) => t.toLocaleLowerCase() === lowerCaseType);
+  });
+};
+
+// TODO: remove this at the next breaking change
+// it's only here to support deprecated categories
 export const collections: { [key: string]: string[] } = {
   app,
   dataset,

--- a/packages/common/src/content/index.ts
+++ b/packages/common/src/content/index.ts
@@ -3,7 +3,7 @@
 import { ResourceObject } from "jsonapi-typescript";
 import { IItem } from "@esri/arcgis-rest-portal";
 import { HubType, HubFamily } from "../types";
-import { collections } from "../collections";
+import { getCollection } from "../collections";
 import { categories as allCategories, isDownloadable } from "../categories";
 import { isBBox } from "../extent";
 import { includes, isGuid } from "../utils";
@@ -27,6 +27,7 @@ export type DatasetResource = ResourceObject<
   }
 >;
 
+// private helper functions
 function collectionToFamily(collection: string): string {
   const overrides: any = {
     other: "content",
@@ -34,8 +35,6 @@ function collectionToFamily(collection: string): string {
   };
   return overrides[collection] || collection;
 }
-
-const cache: { [key: string]: string } = {};
 
 // TODO: remove this at next breaking version
 /**
@@ -141,31 +140,6 @@ export function getTypeCategories(item: any = {}): string[] {
     return [chars.join("")];
   } else {
     return ["Other"];
-  }
-}
-
-/**
- * ```js
- * import { getCollection } from "@esri/hub-common";
- * //
- * getCollection('Feature Layer')
- * > 'dataset'
- * ```
- * Get the Hub collection for a given item type
- * @param itemType The ArcGIS [item type](https://developers.arcgis.com/rest/users-groups-and-items/items-and-item-types.htm).
- * @returns the Hub collection of a given item type.
- */
-export function getCollection(itemType: string = ""): string {
-  if (cache[itemType]) {
-    return cache[itemType];
-  }
-  for (const collection of Object.keys(collections)) {
-    for (const type of collections[collection]) {
-      if (itemType.toLowerCase() === type.toLowerCase()) {
-        cache[itemType] = collection;
-        return collection;
-      }
-    }
   }
 }
 

--- a/packages/common/test/collections.test.ts
+++ b/packages/common/test/collections.test.ts
@@ -1,0 +1,15 @@
+import { getCollection } from "../src/collections";
+
+describe("getCollection", () => {
+  it("can abort", () => {
+    expect(getCollection()).toBe(undefined);
+  });
+
+  it("can retrieve a single category", () => {
+    expect(getCollection("Feature Layer")).toBe("dataset");
+  });
+
+  it("can retrieve a single category (from cache)", () => {
+    expect(getCollection("Feature Layer")).toBe("dataset");
+  });
+});

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -4,8 +4,6 @@ import {
   DatasetResource,
   datasetToContent,
   datasetToItem,
-  getCategory,
-  getCollection,
   getTypes,
   getTypeCategories,
   normalizeItemType,
@@ -21,11 +19,13 @@ import {
   itemToContent,
   parseDatasetId,
   parseItemCategories,
-  getItemHubType,
   getFamily,
   setContentType,
   getContentTypeIcon,
   getContentTypeLabel,
+  // deprecated, remove these at the next breaking change
+  getCategory,
+  getItemHubType,
 } from "../src/content";
 import { setContentBoundary } from "../src/content/_internal";
 import { IHubContent, IModel } from "../src/types";
@@ -34,20 +34,6 @@ import * as documentItem from "./mocks/items/document.json";
 import * as mapServiceItem from "./mocks/items/map-service.json";
 import * as documentsJson from "./mocks/datasets/document.json";
 import * as featureLayerJson from "./mocks/datasets/feature-layer.json";
-
-describe("getCollection", () => {
-  it("can abort", () => {
-    expect(getCollection()).toBe(undefined);
-  });
-
-  it("can retrieve a single category", () => {
-    expect(getCollection("Feature Layer")).toBe("dataset");
-  });
-
-  it("can retrieve a single category (from cache)", () => {
-    expect(getCollection("Feature Layer")).toBe("dataset");
-  });
-});
 
 describe("getCategory", () => {
   it("returns 'app' for forms", () => {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
