### PR TITLE
feat(hub-discussions): add IWithEditor interface

### DIFF
--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -208,13 +208,22 @@ export enum PostSort {
 // mixins
 
 /**
- * authoring properties
+ * author property
  *
  * @export
  * @interface IWithAuthor
  */
 export interface IWithAuthor {
   creator: string;
+}
+
+/**
+ * editor property
+ *
+ * @export
+ * @interface IWithEditor
+ */
+export interface IWithEditor {
   editor: string;
 }
 
@@ -346,9 +355,10 @@ export interface IRemoveReactionResponse {
  * @export
  * @interface IPost
  * @extends {IWithAuthor}
+ * @extends {IWithEditor}
  * @extends {IWithTimestamps}
  */
-export interface IPost extends IWithAuthor, IWithTimestamps {
+export interface IPost extends IWithAuthor, IWithEditor, IWithTimestamps {
   id: string;
   title?: string;
   body: string;
@@ -409,12 +419,14 @@ export interface IFetchPost {
  * @export
  * @interface ISearchChannelPosts
  * @extends {Partial<IWithAuthor>}
+ * @extends {Partial<IWithEditor>}
  * @extends {Partial<IPagingParams>}
  * @extends {Partial<IWithSorting<PostSort>>}
  * @extends {Partial<IWithTimeQueries>}
  */
 export interface ISearchPosts
   extends Partial<IWithAuthor>,
+    Partial<IWithEditor>,
     Partial<IPagingParams>,
     Partial<IWithSorting<PostSort>>,
     Partial<IWithTimeQueries> {
@@ -469,12 +481,14 @@ export interface IUpdatePost
  * @extends {IWithSettings}
  * @extends {IWithSharing}
  * @extends {IWithAuthor}
+ * @extends {IWithEditor}
  * @extends {IWithTimestamps}
  */
 export interface IChannel
   extends IWithSettings,
     IWithSharing,
     IWithAuthor,
+    IWithEditor,
     IWithTimestamps {
   id: string;
 }
@@ -535,9 +549,10 @@ export interface IUpdateChannel extends Partial<IWithSettings> {}
  * @export
  * @interface IReaction
  * @extends {IWithAuthor}
+ * @extends {IWithEditor}
  * @extends {IWithTimestamps}
  */
-export interface IReaction extends IWithAuthor, IWithTimestamps {
+export interface IReaction extends IWithAuthor, IWithEditor, IWithTimestamps {
   id: string;
   value: PostReaction;
   postId?: string;

--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -208,7 +208,7 @@ export enum PostSort {
 // mixins
 
 /**
- * author property
+ * creator property
  *
  * @export
  * @interface IWithAuthor
@@ -538,8 +538,11 @@ export interface ISearchChannels
  * @export
  * @interface IUpdateChannel
  * @extends {Partial<IWithSettings>}
+ * @extends {Partial<IWithAuthor>}
  */
-export interface IUpdateChannel extends Partial<IWithSettings> {}
+export interface IUpdateChannel
+  extends Partial<IWithSettings>,
+    Partial<IWithAuthor> {}
 
 // // reactions
 


### PR DESCRIPTION
BREAKING CHANGE: move editor from IWithAuthor to IWithEditor

1. Description:
Decomposes IWithAuthor into IWithAuthor and IWithEditor (https://devtopia.esri.com/dc/hub/issues/3006)

1. Instructions for testing:
N/A

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
