### PR TITLE
feat(hub-common): add isProxiedCSV and getProxyUrl utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39250,7 +39250,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -39281,7 +39281,7 @@
 		},
 		"packages/content": {
 			"name": "@esri/hub-content",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"fast-xml-parser": "~3.2.4",
@@ -39292,7 +39292,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39306,12 +39306,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.0",
 				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "9.14.0",
+			"version": "10.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39320,7 +39320,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39334,12 +39334,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -39350,7 +39350,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39360,12 +39360,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39376,7 +39376,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39391,12 +39391,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39405,7 +39405,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39419,12 +39419,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39435,7 +39435,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39452,12 +39452,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39466,9 +39466,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
-				"@esri/hub-initiatives": "9.14.0",
-				"@esri/hub-teams": "9.14.0",
+				"@esri/hub-common": "9.15.0",
+				"@esri/hub-initiatives": "9.15.0",
+				"@esri/hub-teams": "9.15.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -39482,14 +39482,14 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0",
-				"@esri/hub-initiatives": "9.14.0",
-				"@esri/hub-teams": "9.14.0"
+				"@esri/hub-common": "9.15.0",
+				"@esri/hub-initiatives": "9.15.0",
+				"@esri/hub-teams": "9.15.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39500,7 +39500,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39515,12 +39515,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39530,7 +39530,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39544,7 +39544,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		}
 	},
@@ -41591,7 +41591,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41609,7 +41609,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41629,7 +41629,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41649,7 +41649,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41666,7 +41666,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41686,7 +41686,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41705,9 +41705,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
-				"@esri/hub-initiatives": "9.14.0",
-				"@esri/hub-teams": "9.14.0",
+				"@esri/hub-common": "9.15.0",
+				"@esri/hub-initiatives": "9.15.0",
+				"@esri/hub-teams": "9.15.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -41727,7 +41727,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41745,7 +41745,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/common/src/content/index.ts
+++ b/packages/common/src/content/index.ts
@@ -2,7 +2,7 @@
  * Apache-2.0 */
 import { ResourceObject } from "jsonapi-typescript";
 import { IItem } from "@esri/arcgis-rest-portal";
-import { HubType, HubFamily, IModel } from "../types";
+import { HubType, HubFamily, IModel, IHubRequestOptions } from "../types";
 import { collections } from "../collections";
 import { categories as allCategories, isDownloadable } from "../categories";
 import { isBBox } from "../extent";
@@ -1016,3 +1016,22 @@ const getSolutionUrl = (content: IHubContent): string => {
 // instead of hardcoding the types here.
 const isPageContent = (content: IHubContent) =>
   includes(["Hub Page", "Site Page"], content.type);
+
+// proxied csv helpers
+const MAX_SIZE = 5000000;
+export const isProxiedCSV = (item: IItem, requestOptions: IHubRequestOptions) =>
+  !requestOptions.isPortal &&
+  item.access === "public" &&
+  item.type === "CSV" &&
+  item.size <= MAX_SIZE;
+
+export const getProxyUrl = (
+  item: IItem,
+  requestOptions: IHubRequestOptions
+) => {
+  let result;
+  if (isProxiedCSV(item, requestOptions)) {
+    result = `${requestOptions.hubApiUrl}/datasets/${item.id}_0/FeatureServer/0`;
+  }
+  return result;
+};

--- a/packages/common/test/content/index.test.ts
+++ b/packages/common/test/content/index.test.ts
@@ -1,0 +1,110 @@
+import { isProxiedCSV, getProxyUrl, IHubRequestOptions } from "../../src";
+import { IItem } from "@esri/arcgis-rest-portal";
+
+describe("isProxiedCSV", () => {
+  it("returns false when in a portal environment", () => {
+    const item = {
+      access: "public",
+      type: "CSV",
+      size: 9001,
+    } as unknown as IItem;
+
+    const requestOptions: IHubRequestOptions = {
+      isPortal: true,
+    };
+
+    expect(isProxiedCSV(item, requestOptions)).toBeFalsy();
+  });
+
+  it("returns false when access is not public", () => {
+    const item = {
+      access: "private",
+      type: "CSV",
+      size: 9001,
+    } as unknown as IItem;
+
+    const requestOptions: IHubRequestOptions = {
+      isPortal: false,
+    };
+
+    expect(isProxiedCSV(item, requestOptions)).toBeFalsy();
+  });
+
+  it("returns false when type is not CSV", () => {
+    const item = {
+      access: "public",
+      type: "Feature Service",
+    } as unknown as IItem;
+
+    const requestOptions: IHubRequestOptions = {
+      isPortal: false,
+    };
+
+    expect(isProxiedCSV(item, requestOptions)).toBeFalsy();
+  });
+
+  it("returns false when size is greater than the max allowed", () => {
+    const item = {
+      access: "public",
+      type: "CSV",
+      size: 5000001,
+    } as unknown as IItem;
+
+    const requestOptions: IHubRequestOptions = {
+      isPortal: false,
+    };
+
+    expect(isProxiedCSV(item, requestOptions)).toBeFalsy();
+  });
+
+  it("returns true when the item is a proxied csv", () => {
+    const item = {
+      access: "public",
+      type: "CSV",
+      size: 500000,
+    } as unknown as IItem;
+
+    const requestOptions: IHubRequestOptions = {
+      isPortal: false,
+    };
+
+    expect(isProxiedCSV(item, requestOptions)).toBeTruthy();
+  });
+});
+
+describe("getProxyUrl", () => {
+  it("returns undefined when item cannot be a proxied csv", () => {
+    const item = {
+      access: "private",
+      type: "CSV",
+      size: 500000,
+    } as unknown as IItem;
+
+    const requestOptions: IHubRequestOptions = {
+      isPortal: false,
+      hubApiUrl: "https://opendata.arcgis.com",
+    };
+
+    const url = getProxyUrl(item, requestOptions);
+    expect(url).toBeUndefined();
+  });
+
+  it("returns url when item is a proxied csv", () => {
+    const item = {
+      access: "public",
+      type: "CSV",
+      size: 500000,
+      id: 0,
+    } as unknown as IItem;
+
+    const requestOptions: IHubRequestOptions = {
+      isPortal: false,
+      hubApiUrl: "https://opendata.arcgis.com",
+    };
+
+    const url = getProxyUrl(item, requestOptions);
+    expect(url).toBe(
+      "https://opendata.arcgis.com/datasets/0_0/FeatureServer/0"
+    );
+  });
+});


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
For [2408](https://devtopia.esri.com/dc/hub/issues/2408), we needed a way to detect whether an item was a proxied csv. However, all proxied csv logic only exists in opendata-ui. This PR lifts a couple of needed utils into hub-common.

1. [x] ran commit script (`npm run c`)
