### PR TITLE
chore: updated caniuse db & package-lock

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -34,7 +34,7 @@ You can run _all_ the tests with `npm test`.
 * `npm run test:chrome:debug` runs the Karma tests in Chrome and watches for changes. In the opened Chrome window you can click "Debug" and refresh the page to enter the debugger for tests. Note that you will be debugging the compiled JS files until https://github.com/monounity/karma-typescript/issues/144 is resolved.
 * `npm run test:node:debug` run the node tests, automatically opening the Chrome debugger. This is great for debugging the tests while you are working. **REQUIRES CHROME 60+**. This also means you can do you really stupid things like run this in an infinite loop with `while :; do npm run test:node:debug; sleep 1; done` which will reopen the chrome debugger once the current one closes.
 
-### Formatting commit messsages
+### Formatting commit messages
 
 Using [`npm run c`](https://github.com/Esri/hub.js/blob/4aeb8f23c3c91beaf44c05ac32278e5a22b5a69e/package.json#L112) (instead of `git commit`) creates commit messages that our handy [script](https://github.com/Esri/arcgis-rest-js/blob/master/support/changelog.js) can parse to categorize your bug fix, new feature or breaking change and associate it with relevant packages to update our [CHANGELOG](CHANGELOG.md) automatically the next time we :rocket: a release.
 

--- a/docs/DEV-PLAN.md
+++ b/docs/DEV-PLAN.md
@@ -7,9 +7,9 @@ The process of extraction involves:
 
 - determining what functions are core to the CRUD operations of Initiatives & Solutions
 - translating those functions into TypeScript and adding useful jsDoc comments
-- ensuring any platform-level dependant "services" are available in ArcGIS-REST-js 
+- ensuring any platform-level dependent "services" are available in ArcGIS-REST-js 
   - i.e. working with oAuth application registration, image resources etc
-- ensuring any hub-level dependant "services" are available in Hub.js
+- ensuring any hub-level dependent "services" are available in Hub.js
   - i.e. registering site domains w/ the Hub API
 - writing comprehensive unit tests
   - goal is 100% code-coverage
@@ -48,7 +48,7 @@ As we work through this project, the intent is to migrate the Hub applications t
 - utilize the S123 API
 
 ### Coarse-Grained Wrapper Calls
-- these will validate access/priviledges, and orchestrate calls to the fine-grained functions
+- these will validate access/privileges, and orchestrate calls to the fine-grained functions
 - *TODO: they are long-running tasks, and we need to work out how best to return "status" information to the caller*
 
 ### Hub API in Node

--- a/docs/HOW_TO_HUBJS.md
+++ b/docs/HOW_TO_HUBJS.md
@@ -22,7 +22,7 @@ This should be the dominant workflow from July 2021 forward.
 - use existing Hub.js functions, until you need something that's not present yet
 - add util to the `hub-components` repo, where you write function in typescript
 - use Storybook to verify the function and the component work as you want them to
-- add the function to the appropritate package in Hub.js and add tests
+- add the function to the appropriate package in Hub.js and add tests
 - open Hub.js PR, get it approved & merged
 - cut a release (see Releasing section below)
 - bump Hub.js version in `hub-components` and install
@@ -38,7 +38,7 @@ This is the pre-July 2021 workflow [More details here](https://github.com/ArcGIS
 - add a util to the Ember app, write the needed function(s) in there
 - get it working the way you need it to
 - PR feature into Hub app repo
-- add the function to the appropritate package in Hub.js and add tests
+- add the function to the appropriate package in Hub.js and add tests
 - open Hub.js PR, get it approved & merged
 - cut a release (see Releasing section below)
 - bump Hub.js version in Hub App and install
@@ -51,7 +51,7 @@ This is the pre-July 2021 workflow [More details here](https://github.com/ArcGIS
 
 The easiest thing to do is edit the function in the Hub.js package, under `node_modules`. You can then verify it within the ember app, and when its working...
 
-- add/update the function to the appropritate package in Hub.js and add tests
+- add/update the function to the appropriate package in Hub.js and add tests
 - open Hub.hs PR, get it approved & merged
 - cut a release (see Releasing section below)
 - bump Hub.js version in Hub App and `yarn` to install
@@ -72,7 +72,7 @@ This is where things get complex. We have a few options:
 
 Hub.js has e2e test infrastructure, but it is _not_ intended to be run on a regular basis or drive code-coverage. Instead, it's a means to verify the underlying API calls, in a browser, without having to "link" into a UI app (Stencil or Hub app).
 
-# Sematic Commit Messages
+# Semantic Commit Messages
 
 As of June 24th, 2021, pull requests to Hub.js will require at least one [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/#summary) in order to automatically generate the CHANGELOG.md entries during the release process.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9750,9 +9750,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001230",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
-			"integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
+			"version": "1.0.30001312",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+			"integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
 			"dev": true,
 			"funding": {
 				"type": "opencollective",
@@ -39250,7 +39250,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -39281,7 +39281,7 @@
 		},
 		"packages/content": {
 			"name": "@esri/hub-content",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"fast-xml-parser": "~3.2.4",
@@ -39292,7 +39292,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39306,12 +39306,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.0",
 				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "9.14.0",
+			"version": "11.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39320,7 +39320,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39334,12 +39334,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -39350,7 +39350,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39360,12 +39360,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39376,7 +39376,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39391,12 +39391,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39405,7 +39405,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39419,12 +39419,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39435,7 +39435,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39452,12 +39452,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39466,9 +39466,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
-				"@esri/hub-initiatives": "9.14.0",
-				"@esri/hub-teams": "9.14.0",
+				"@esri/hub-common": "9.15.0",
+				"@esri/hub-initiatives": "9.15.0",
+				"@esri/hub-teams": "9.15.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -39482,14 +39482,14 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0",
-				"@esri/hub-initiatives": "9.14.0",
-				"@esri/hub-teams": "9.14.0"
+				"@esri/hub-common": "9.15.0",
+				"@esri/hub-initiatives": "9.15.0",
+				"@esri/hub-teams": "9.15.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39500,7 +39500,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39515,12 +39515,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.14.0",
+			"version": "9.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39530,7 +39530,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39544,7 +39544,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.14.0"
+				"@esri/hub-common": "9.15.0"
 			}
 		}
 	},
@@ -41591,7 +41591,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41609,7 +41609,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41629,7 +41629,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41649,7 +41649,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41666,7 +41666,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41686,7 +41686,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41705,9 +41705,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
-				"@esri/hub-initiatives": "9.14.0",
-				"@esri/hub-teams": "9.14.0",
+				"@esri/hub-common": "9.15.0",
+				"@esri/hub-initiatives": "9.15.0",
+				"@esri/hub-teams": "9.15.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -41727,7 +41727,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41745,7 +41745,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.14.0",
+				"@esri/hub-common": "9.15.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -47556,9 +47556,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001230",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
-			"integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
+			"version": "1.0.30001312",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+			"integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
 			"dev": true
 		},
 		"capture-stack-trace": {


### PR DESCRIPTION
1. Description:

Updated caniuse db, and, as a side effect, the package-lock.json file.

Also minor doc changes as an excuse to run `npm run c`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
