### PR TITLE
feat(hub-common): add defaultOrder and order props to ISortOption

### DIFF
--- a/packages/common/src/search/types.ts
+++ b/packages/common/src/search/types.ts
@@ -271,6 +271,10 @@ export interface ISortOption {
   label: string;
   // attribute to sort by at the API level
   attribute: string;
+  // Default sort order for the sort field
+  defaultOrder: string;
+  // Current sort order for the sort field (mutable)
+  order: string;
 }
 
 /**


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Add defaultOrder and order props to ISortOption

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
