### PR TITLE
fix(hub-common): fix circular import dependency in HubError

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39250,7 +39250,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.15.0",
+			"version": "9.17.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -39281,7 +39281,7 @@
 		},
 		"packages/content": {
 			"name": "@esri/hub-content",
-			"version": "9.15.0",
+			"version": "9.17.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"fast-xml-parser": "~3.2.4",
@@ -39292,7 +39292,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39306,12 +39306,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.0",
 				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.15.0"
+				"@esri/hub-common": "9.17.0"
 			}
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "10.1.0",
+			"version": "11.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39320,7 +39320,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39334,12 +39334,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.15.0"
+				"@esri/hub-common": "9.17.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.15.0",
+			"version": "9.17.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -39350,7 +39350,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39360,12 +39360,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.15.0"
+				"@esri/hub-common": "9.17.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.15.0",
+			"version": "9.17.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39376,7 +39376,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39391,12 +39391,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.15.0"
+				"@esri/hub-common": "9.17.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.15.0",
+			"version": "9.17.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39405,7 +39405,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39419,12 +39419,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.15.0"
+				"@esri/hub-common": "9.17.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.15.0",
+			"version": "9.17.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39435,7 +39435,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39452,12 +39452,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.15.0"
+				"@esri/hub-common": "9.17.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.15.0",
+			"version": "9.17.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39466,9 +39466,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
-				"@esri/hub-initiatives": "9.15.0",
-				"@esri/hub-teams": "9.15.0",
+				"@esri/hub-common": "9.17.0",
+				"@esri/hub-initiatives": "9.17.0",
+				"@esri/hub-teams": "9.17.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -39482,14 +39482,14 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.15.0",
-				"@esri/hub-initiatives": "9.15.0",
-				"@esri/hub-teams": "9.15.0"
+				"@esri/hub-common": "9.17.0",
+				"@esri/hub-initiatives": "9.17.0",
+				"@esri/hub-teams": "9.17.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.15.0",
+			"version": "9.17.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39500,7 +39500,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39515,12 +39515,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.15.0"
+				"@esri/hub-common": "9.17.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.15.0",
+			"version": "9.17.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39530,7 +39530,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39544,7 +39544,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.15.0"
+				"@esri/hub-common": "9.17.0"
 			}
 		}
 	},
@@ -41591,7 +41591,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41609,7 +41609,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41629,7 +41629,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41649,7 +41649,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41666,7 +41666,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41686,7 +41686,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41705,9 +41705,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
-				"@esri/hub-initiatives": "9.15.0",
-				"@esri/hub-teams": "9.15.0",
+				"@esri/hub-common": "9.17.0",
+				"@esri/hub-initiatives": "9.17.0",
+				"@esri/hub-teams": "9.17.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -41727,7 +41727,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41745,7 +41745,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.15.0",
+				"@esri/hub-common": "9.17.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/common/src/HubError.ts
+++ b/packages/common/src/HubError.ts
@@ -1,4 +1,5 @@
-import { getWithDefault, OperationError } from ".";
+import { getWithDefault } from "./objects/get-with-default";
+import OperationError from "./OperationError";
 
 /**
  * Generic Hub Error with an Error stack as well


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
There was a circular dependency in HubError that was included in 9.15.0. However, the error didn't surface until we integrated the new hub-common into the dcat output plugins. This PR fixes that circular dependency.

1. [x] ran commit script (`npm run c`)
