### PR TITLE
feat(hub-common): add composeContent()

### DIFF
--- a/packages/common/src/content/_internal.ts
+++ b/packages/common/src/content/_internal.ts
@@ -8,16 +8,22 @@
  * It's probably a good pattern to add functions here first and then
  * move them to index.ts only when they are needed by a consumer.
  */
-
-import { IItem } from "@esri/arcgis-rest-types/dist/types/item";
+import {
+  ILayerDefinition,
+  IFeatureServiceDefinition,
+} from "@esri/arcgis-rest-feature-layer";
+import { IItem } from "@esri/arcgis-rest-portal";
+import { ISpatialReference } from "@esri/arcgis-rest-types";
+import { IHubContent } from "../core";
 import {
   BBox,
-  IHubContent,
   IHubGeography,
   GeographyProvenance,
   IHubRequestOptions,
-} from "..";
+} from "../types";
 import { bBoxToPolygon, isBBox } from "../extent";
+import { getFamily } from "./get-family";
+import { getProp } from "../objects";
 
 /**
  * Create a new content with updated boundary properties
@@ -33,29 +39,11 @@ export const setContentBoundary = (
   const properties = { ...(content.item.properties || {}), boundary };
   const item = { ...content.item, properties };
   const updated = { ...content, item };
-  return { ...updated, boundary: getContentBoundary(updated) };
+  return { ...updated, boundary: getContentBoundary(item) };
 };
 
-/**
- * Create a new content with updated extent and derived properties like boundary
- * @param content original content
- * @param extent new extent
- * @returns a new content with the updated extent and boundary
- */
-export const setContentExtent = (
-  content: IHubContent,
-  extent: BBox
-): IHubContent => {
-  // update content's item and extent
-  const item = { ...content.item, extent };
-  const updated = { ...content, item, extent };
-  // derive boundary from content properties
-  const boundary = getContentBoundary(updated);
-  return { ...updated, boundary };
-};
-
-const getContentBoundary = (content: IHubContent): IHubGeography => {
-  const item = content.item;
+// TODO: this needs to be able to handle "automatic"
+export const getContentBoundary = (item: IItem): IHubGeography => {
   const extent = item.extent;
   const isValidItemExtent = isBBox(extent);
   // user specified provenance is stored in item.properties
@@ -80,7 +68,12 @@ const getContentBoundary = (content: IHubContent): IHubGeography => {
   };
 };
 
-const MAX_SIZE = 5000000;
+// when no request options are provided, the underlying
+// request functions assume that we are online in production
+// so we only want use enterprise logic if isPortal is explicitly defined
+export const isPortal = (requestOptions?: IHubRequestOptions) => {
+  return requestOptions && requestOptions.isPortal;
+};
 
 /**
  * Returns whether or not an item is a proxied csv
@@ -89,8 +82,178 @@ const MAX_SIZE = 5000000;
  * @param requestOptions Hub Request Options (including whether we're in portal)
  * @returns
  */
-export const isProxiedCSV = (item: IItem, requestOptions: IHubRequestOptions) =>
-  !requestOptions.isPortal &&
+export const isProxiedCSV = (
+  item: IItem,
+  requestOptions?: IHubRequestOptions
+) =>
+  !isPortal(requestOptions) &&
   item.access === "public" &&
   item.type === "CSV" &&
-  item.size <= MAX_SIZE;
+  item.size <= 5000000;
+
+export const getHubRelativeUrl = (
+  type: string,
+  identifier: string,
+  typeKeywords?: string[]
+): string => {
+  // solution types have their own logic
+  let contentUrl = getSolutionUrl(type, identifier, typeKeywords);
+  if (!contentUrl) {
+    const family = getFamily(type);
+    const pluralizedFamilies = [
+      "app",
+      "dataset",
+      "document",
+      "map",
+      "template",
+    ];
+    // default to the catchall content route
+    let path = "/content";
+    if (family === "feedback") {
+      // exception
+      path = "/feedback/surveys";
+    } else if (isPageType(type)) {
+      // pages are in the document family,
+      // but instead of showing the page's metadata on /documents/about
+      // but we render the page on the pages route
+      path = "/pages";
+    } else if (pluralizedFamilies.indexOf(family) > -1) {
+      // the rule
+      path = `/${family}s`;
+    }
+    contentUrl = `${path}/${identifier}`;
+  }
+  return contentUrl;
+};
+
+export const isPageType = (type: string) =>
+  ["Hub Page", "Site Page"].includes(type);
+
+const getSolutionUrl = (
+  type: string,
+  identifier: string,
+  typeKeywords?: string[]
+): string => {
+  let hubUrl;
+  if (type === "Solution") {
+    // NOTE: as per the above spreadsheet,
+    // solution types are now in the Template family
+    // but we don't send them to the route for initiative templates
+    if (typeKeywords?.indexOf("Deployed") > 0) {
+      // deployed solutions go to the generic content route
+      hubUrl = `/content/${identifier}`;
+    }
+    // others go to the solution about route
+    hubUrl = `/templates/${identifier}/about`;
+  }
+  return hubUrl;
+};
+
+// metadata
+export interface IMetadataPaths {
+  updateFrequency: string;
+  metadataUpdateFrequency: string;
+  metadataUpdatedDate: string;
+  reviseDate: string;
+  pubDate: string;
+  createDate: string;
+}
+
+export function getMetadataPath(identifier: keyof IMetadataPaths) {
+  // NOTE: i have verified that this will work regardless of the "Metadata Style" set on the org
+  const metadataPaths: IMetadataPaths = {
+    updateFrequency:
+      "metadata.dataIdInfo.resMaint.maintFreq.MaintFreqCd.@_value",
+    reviseDate: "metadata.dataIdInfo.idCitation.date.reviseDate",
+    pubDate: "metadata.dataIdInfo.idCitation.date.pubDate",
+    createDate: "metadata.dataIdInfo.idCitation.date.createDate",
+    metadataUpdateFrequency: "metadata.mdMaint.maintFreq.MaintFreqCd.@_value",
+    metadataUpdatedDate: "metadata.mdDateSt",
+  };
+  return metadataPaths[identifier];
+}
+
+export function getValueFromMetadata(
+  metadata: any,
+  identifier: keyof IMetadataPaths
+) {
+  const path = getMetadataPath(identifier);
+  return path && getProp(metadata, path);
+}
+
+export enum DatePrecision {
+  Year = "year",
+  Month = "month",
+  Day = "day",
+  Time = "time",
+}
+
+// TODO: move this to _internal and copy over tests from hub-content
+/**
+ * Parses an ISO8601 date string into a date and a precision.
+ * This is because a) if somone entered 2018, we want to respect that and not treat it as the same as 2018-01-01
+ * and b) you cannot naively call new Date with an ISO 8601 string that does not include time information
+ * For example, when I, here in mountain time, do new Date('2018').getFullYear() I get "2017".
+ * This is because when you do not provide time or timezone info, UTC is assumed, so new Date('2018') is 2018-01-01T00:00:00 in UTC
+ * which is actually 7 hours earlier here in mountain time.
+ *
+ * @param {string} isoString
+ * @return { date: Date, precision: DatePrecision }
+ */
+export function parseISODateString(isoString: string) {
+  isoString = `${isoString}`;
+  let date;
+  let precision;
+  if (/^\d{4}$/.test(isoString)) {
+    // yyyy
+    date = new Date(+isoString, 0, 1);
+    precision = DatePrecision.Year;
+  } else if (/^\d{4}-\d{1,2}$/.test(isoString)) {
+    // yyyy-mm
+    const parts = isoString.split("-");
+    date = new Date(+parts[0], +parts[1] - 1, 1);
+    precision = DatePrecision.Month;
+  } else if (/^\d{4}-\d{1,2}-\d{1,2}$/.test(isoString)) {
+    // yyyy-mm-dd
+    const parts = isoString.split("-");
+    date = new Date(+parts[0], +parts[1] - 1, +parts[2]);
+    precision = DatePrecision.Day;
+  } else if (!Number.isNaN(Date.parse(isoString))) {
+    // any other string parsable to a valid date
+    date = new Date(isoString);
+    precision = isoString.includes("T")
+      ? DatePrecision.Time
+      : DatePrecision.Day;
+  }
+  return date && precision && { date, precision };
+}
+
+export const getServerSpatialReference = (
+  server: Partial<IFeatureServiceDefinition>,
+  layer?: ILayerDefinition
+) => {
+  const layerSpatialReference = layer?.extent?.spatialReference;
+  return layerSpatialReference || server?.spatialReference;
+};
+
+// NOTE: IItem has spatialRefernce: ISpatialReference, but
+// the portal REST API returns spatialReference as as string
+// that is always either WKID like "102100" or
+// WKT like "NAD_1983_HARN_StatePlane_Hawaii_3_FIPS_5103_Feet"
+// so we coerce those string into a ISpatialReference object
+export const getItemSpatialReference = (item: IItem): ISpatialReference => {
+  const spatialReference = item.spatialReference as unknown;
+  if (!spatialReference || typeof spatialReference === "object") {
+    // no need to try and transform this into an ISpatialReference
+    return spatialReference;
+  }
+  // otherwise it _should_ be a string (if coming form the REST API)
+  // but we force it in case it was set to a number somewhere outside of TS
+  const spatialReferenceString = spatialReference + "";
+  const wkid = parseInt(spatialReferenceString, 10);
+  return isNaN(wkid)
+    ? // string is not a number, assume it is a wkid
+      { wkt: spatialReferenceString }
+    : //
+      { wkid };
+};

--- a/packages/common/src/content/_internal.ts
+++ b/packages/common/src/content/_internal.ts
@@ -100,7 +100,7 @@ export const getHubRelativeUrl = (
   let contentUrl = getSolutionUrl(type, identifier, typeKeywords);
   if (!contentUrl) {
     const family = getFamily(type);
-    const pluralizedFamilies = [
+    const familiesWithPluralizedRoute = [
       "app",
       "dataset",
       "document",
@@ -110,15 +110,15 @@ export const getHubRelativeUrl = (
     // default to the catchall content route
     let path = "/content";
     if (family === "feedback") {
-      // exception
+      // the exception
       path = "/feedback/surveys";
     } else if (isPageType(type)) {
       // pages are in the document family,
       // but instead of showing the page's metadata on /documents/about
       // but we render the page on the pages route
       path = "/pages";
-    } else if (pluralizedFamilies.indexOf(family) > -1) {
-      // the rule
+    } else if (familiesWithPluralizedRoute.indexOf(family) > -1) {
+      // the rule: route name is plural of family name
       path = `/${family}s`;
     }
     contentUrl = `${path}/${identifier}`;
@@ -188,7 +188,6 @@ export enum DatePrecision {
   Time = "time",
 }
 
-// TODO: move this to _internal and copy over tests from hub-content
 /**
  * Parses an ISO8601 date string into a date and a precision.
  * This is because a) if somone entered 2018, we want to respect that and not treat it as the same as 2018-01-01
@@ -252,7 +251,7 @@ export const getItemSpatialReference = (item: IItem): ISpatialReference => {
   const spatialReferenceString = spatialReference + "";
   const wkid = parseInt(spatialReferenceString, 10);
   return isNaN(wkid)
-    ? // string is not a number, assume it is a wkid
+    ? // string is not a number, assume it is WKT
       { wkt: spatialReferenceString }
     : //
       { wkid };

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -1,0 +1,755 @@
+import { IItem } from "@esri/arcgis-rest-portal";
+import {
+  ILayerDefinition,
+  IFeatureServiceDefinition,
+  parseServiceUrl,
+} from "@esri/arcgis-rest-feature-layer";
+import { IHubRequestOptions } from "../types";
+import { isDownloadable } from "../categories";
+import { IHubContentEnrichments, IHubContent } from "../core";
+import { getStructuredLicense } from "../items/get-structured-license";
+import { getProp } from "../objects";
+import { getItemThumbnailUrl } from "../resources/get-item-thumbnail-url";
+import { getItemHomeUrl } from "../urls/get-item-home-url";
+import { getItemApiUrl } from "../urls/get-item-api-url";
+import { getItemDataUrl } from "../urls/get-item-data-url";
+import { camelize, isNil } from "../util";
+import { includes } from "../utils";
+import {
+  DatePrecision,
+  getContentBoundary,
+  getHubRelativeUrl,
+  getItemSpatialReference,
+  getServerSpatialReference,
+  getValueFromMetadata,
+  IMetadataPaths,
+  getMetadataPath,
+  isProxiedCSV,
+  isPortal,
+  parseISODateString,
+} from "./_internal";
+import { getFamily } from "./get-family";
+import { getHubApiUrl } from "..";
+
+// helper fns - move this to _internal if needed elsewhere
+const getOnlyQueryLayer = (layers: ILayerDefinition[]) => {
+  const layer = layers && layers.length === 1 && layers[0];
+  return layer && layer.capabilities.includes("Query") && layer;
+};
+
+const shouldUseLayerInfo = (
+  layer: Partial<ILayerDefinition>,
+  layers: Array<Partial<ILayerDefinition>>,
+  url: string
+) => {
+  return (
+    layer &&
+    layers &&
+    layers.length > 1 &&
+    // we use item info instead of layer info for single layer items
+    !getLayerIdFromUrl(url)
+  );
+};
+
+/**
+ * The possible values for updateFrequency
+ *
+ * @enum {string}
+ */
+export enum UpdateFrequency {
+  Continual = "continual",
+  Daily = "daily",
+  Weekly = "weekly",
+  Fortnightly = "fortnightly",
+  Monthly = "monthly",
+  Quarterly = "quarterly",
+  Biannually = "biannually",
+  Annually = "annually",
+  AsNeeded = "as-needed",
+  Irregular = "irregular",
+  NotPlanned = "not-planned",
+  Unknown = "unknown",
+  Semimonthly = "semimonthly",
+}
+
+const getUpdateFrequencyFromMetadata = (
+  metadata: any,
+  identifier?: keyof IMetadataPaths
+) => {
+  const updateFrequencyMap = {
+    "001": UpdateFrequency.Continual,
+    "002": UpdateFrequency.Daily,
+    "003": UpdateFrequency.Weekly,
+    "004": UpdateFrequency.Fortnightly,
+    "005": UpdateFrequency.Monthly,
+    "006": UpdateFrequency.Quarterly,
+    "007": UpdateFrequency.Biannually,
+    "008": UpdateFrequency.Annually,
+    "009": UpdateFrequency.AsNeeded,
+    "010": UpdateFrequency.Irregular,
+    "011": UpdateFrequency.NotPlanned,
+    "012": UpdateFrequency.Unknown,
+    "013": UpdateFrequency.Semimonthly,
+  } as { [index: string]: UpdateFrequency };
+
+  return updateFrequencyMap[
+    getValueFromMetadata(metadata, identifier || "updateFrequency")
+  ];
+};
+
+interface IDateInfo {
+  date: Date;
+  source: string;
+  precision?: string;
+}
+
+const getDateInfoFromMetadata = (
+  metadata: any,
+  identifier: keyof IMetadataPaths
+): IDateInfo => {
+  const metadataDateInfo = parseISODateString(
+    getValueFromMetadata(metadata, identifier)
+  );
+  return (
+    metadataDateInfo && {
+      ...metadataDateInfo,
+      source: `metadata.${getMetadataPath(identifier)}`,
+    }
+  );
+};
+
+const getLastEditDateInfo = (
+  content: {
+    layer?: Partial<ILayerDefinition>;
+    server?: Partial<IFeatureServiceDefinition>;
+  },
+  layerOrServer: "layer" | "server"
+) => {
+  const source = `${layerOrServer}.editingInfo.lastEditDate`;
+  const lastEditDate = getProp(content, source);
+  return (
+    lastEditDate && {
+      date: new Date(lastEditDate),
+      source,
+      // NOTE: this default was taken from _enrichDates
+      precision: DatePrecision.Day,
+    }
+  );
+};
+
+const getItemDateInfo = (
+  item: IItem,
+  createdOrModified: "created" | "modified"
+) => {
+  return {
+    date: new Date(item[createdOrModified]),
+    // NOTE: this was set to Day in _enrichDates()
+    // but I wonder if it should be Time instead?
+    precision: DatePrecision.Day,
+    source: `item.${createdOrModified}`,
+  };
+};
+
+const getUpdatedDateInfo = (
+  item: IItem,
+  options: {
+    metadata?: any;
+    layer?: Partial<ILayerDefinition>;
+    server?: Partial<IFeatureServiceDefinition>;
+  }
+) => {
+  return (
+    // prefer metadata revise date
+    getDateInfoFromMetadata(options.metadata, "reviseDate") ||
+    // then layer last edit date
+    getLastEditDateInfo(options, "layer") ||
+    // then server last edit date
+    getLastEditDateInfo(options, "server") ||
+    // fall back to item modified date
+    getItemDateInfo(item, "modified")
+  );
+};
+
+const getPublishedDateInfo = (item: IItem, metadata?: any) => {
+  return (
+    // prefer metadata publish date
+    getDateInfoFromMetadata(metadata, "pubDate") ||
+    // then metadata create date
+    getDateInfoFromMetadata(metadata, "createDate") ||
+    // fall back to item created date
+    getItemDateInfo(item, "created")
+  );
+};
+
+const getMetadataUpdatedDateInfo = (item: IItem, metadata?: any) => {
+  // prefer date from metadata
+  return (
+    getDateInfoFromMetadata(metadata, "metadataUpdatedDate") ||
+    // default to when the item was last modified
+    getItemDateInfo(item, "modified")
+  );
+};
+
+// public API
+/**
+ * DEPRECATED: Compute the content type icon based on the content type
+ * @param content type
+ * @returns content type icon
+ */
+export const getContentTypeIcon = (contentType: string) => {
+  const type = camelize(contentType || "");
+  const iconMap = {
+    appbuilderExtension: "file",
+    appbuilderWidgetPackage: "widgets-source",
+    application: "web",
+    applicationConfiguration: "app-gear",
+    arcgisProMap: "desktop",
+    cadDrawing: "file-cad",
+    cityEngineWebScene: "urban-model",
+    codeAttachment: "file-code",
+    codeSample: "file-code",
+    colorSet: "palette",
+    contentCategorySet: "label",
+    csv: "file-csv",
+    cSV: "file-csv",
+    cSVCollection: "file-csv",
+    dashboard: "dashboard",
+    desktopApplication: "desktop",
+    documentLink: "link",
+    excaliburImageryProject: "file",
+    explorerMap: "file",
+    exportPackage: "file",
+    featureCollection: "data",
+    featureCollectionTemplate: "file",
+    featureLayer: "data",
+    featureService: "collection",
+    fileGeodatabase: "data",
+    form: "survey",
+    geocodingService: "file",
+    geodataService: "file",
+    geometryService: "file",
+    geopackage: "file",
+    geoprocessingService: "file",
+    globeLayer: "layers",
+    globeService: "file",
+    hubInitiative: "initiative",
+    hubInitiativeTemplate: "initiative-template",
+    hubPage: "browser",
+    hubSiteApplication: "web",
+    image: "file-image",
+    imageService: "data",
+    insightsModel: "file",
+    insightsPage: "graph-moving-average",
+    insightsTheme: "palette",
+    insightsWorkbook: "graph-moving-average",
+    iWorkPages: "file-text",
+    iWorkKeynote: "presentation",
+    iWorkNumbers: "file-report",
+    kML: "data",
+    kMLCollection: "data",
+    layer: "layers",
+    layerPackage: "layers",
+    layerTemplate: "file",
+    locatorPackage: "file",
+    mapArea: "file",
+    mapDocument: "map-contents",
+    mapImageLayer: "collection",
+    mapPackage: "file",
+    mapService: "collection",
+    microsoftExcel: "file-report",
+    microsoftPowerpoint: "presentation",
+    microsoftWord: "file-text",
+    mission: "file",
+    mobileMapPackage: "map-contents",
+    nativeApplication: "mobile",
+    nativeApplicationInstaller: "file",
+    nativeApplicationTemplate: "file",
+    mobileApplication: "mobile",
+    networkAnalysisService: "file",
+    notebook: "code",
+    orientedImageryCatalog: "file",
+    orthoMappingProject: "file",
+    orthoMappingTemplate: "file",
+    pDF: "file-pdf",
+    quickCaptureProject: "mobile",
+    rasterFunctionTemplate: "file",
+    rasterLayer: "map",
+    realTimeAnalytic: "file",
+    relationalDatabaseConnection: "file",
+    reportTemplate: "file",
+    sceneLayer: "data",
+    sceneService: "urban-model",
+    serviceDefinition: "file",
+    shapefile: "data",
+    solution: "puzzle-piece",
+    sqliteGeodatabase: "file",
+    statisticalDataCollection: "file",
+    storymap: "tour",
+    storyMap: "tour",
+    storymapTheme: "palette",
+    symbolSet: "file",
+    table: "table",
+    urbanModel: "urban-model",
+    vectorTilePackage: "file-shape",
+    vectorTileService: "map",
+    visioDocument: "conditional-rules",
+    webExperience: "apps",
+    webMap: "map",
+    webMappingApplication: "apps",
+    webScene: "urban-model",
+    wfs: "map",
+    wFS: "map",
+    wMS: "map",
+    wMTS: "map",
+    workflowManagerService: "file",
+    workforceProject: "list-check",
+  } as any;
+  return iconMap[type] ?? "file";
+};
+
+/**
+ * get portal URLs (home, API, data, and thumbnail) for an item
+ *
+ * @param item Item
+ * @param requestOptions Request options
+ * @returns a hash with the portal URLs
+ * @export
+ */
+export const getPortalUrls = (
+  item: IItem,
+  requestOptions: IHubRequestOptions
+) => {
+  const authentication = requestOptions.authentication;
+  const token = authentication && authentication.token;
+  // add properties that depend on portal
+  const portalHome = getItemHomeUrl(item.id, requestOptions);
+  // the URL of the item's Portal API end point
+  const portalApi = getItemApiUrl(item, requestOptions, token);
+  // the URL of the item's data API end point
+  const portalData = getItemDataUrl(item, requestOptions, token);
+  // the full URL of the thumbnail
+  const thumbnail = getItemThumbnailUrl(item, requestOptions, {
+    token,
+  });
+  return {
+    portalHome,
+    portalApi,
+    portalData,
+    thumbnail,
+  };
+};
+
+/**
+ * If an item is a proxied csv, returns the url for the proxying feature layer.
+ * If the item is not a proxied csv, returns undefined.
+ *
+ * @param item
+ * @param requestOptions Hub Request Options (including whether we're in portal)
+ * @returns
+ */
+export const getProxyUrl = (
+  item: IItem,
+  requestOptions?: IHubRequestOptions
+) => {
+  let result;
+  if (isProxiedCSV(item, requestOptions)) {
+    result = `${getHubApiUrl(requestOptions)}/datasets/${
+      item.id
+    }_0/FeatureServer/0`;
+  }
+  return result;
+};
+
+/**
+ * parse layer id from a service URL
+ * @param {string} url
+ * @returns {string} layer id
+ */
+export const getLayerIdFromUrl = (url: string) => {
+  const endsWithNumberSegmentRegEx = /\/\d+$/;
+  const matched = url && url.match(endsWithNumberSegmentRegEx);
+  return matched && matched[0].slice(1);
+};
+
+/**
+ * Case-insensitive check if the type is "Feature Service"
+ * @param {string} type - item's type
+ * @returns {boolean}
+ */
+export const isFeatureService = (type: string) => {
+  return type && type.toLowerCase() === "feature service";
+};
+
+/**
+ * ```js
+ * import { normalizeItemType } from "@esri/hub-common";
+ * //
+ * normalizeItemType(item)
+ * > [ 'Hub Site Application' ]
+ * ```
+ * @param item Item object.
+ * @returns type of the input item.
+ *
+ */
+export function normalizeItemType(item: any = {}): string {
+  let ret = item.type;
+  const typeKeywords = item.typeKeywords || [];
+  if (
+    item.type === "Site Application" ||
+    (item.type === "Web Mapping Application" &&
+      includes(typeKeywords, "hubSite"))
+  ) {
+    ret = "Hub Site Application";
+  }
+  if (
+    item.type === "Site Page" ||
+    (item.type === "Web Mapping Application" &&
+      includes(typeKeywords, "hubPage"))
+  ) {
+    ret = "Hub Page";
+  }
+  if (
+    item.type === "Hub Initiative" &&
+    includes(typeKeywords, "hubInitiativeTemplate")
+  ) {
+    ret = "Hub Initiative Template";
+  }
+  if (
+    item.type === "Web Mapping Application" &&
+    includes(typeKeywords, "hubSolutionTemplate")
+  ) {
+    ret = "Solution";
+  }
+  return ret;
+}
+
+/**
+ * return the layerId if we can tell that item is a single layer service
+ * @param {*} item from AGO
+ * @returns {string} layer id
+ */
+export const getItemLayerId = (item: IItem) => {
+  // try to parse it from the URL, but failing that we check for
+  // the Singlelayer typeKeyword, which I think is set when you create the item in AGO
+  // but have not verified that, nor that we should alway return '0' in that case
+  return (
+    getLayerIdFromUrl(item.url) ||
+    (isFeatureService(item.type) &&
+      item.typeKeywords &&
+      includes(item.typeKeywords, "Singlelayer") &&
+      "0")
+  );
+};
+
+/**
+ * given an item, get the id to use w/ the Hub API
+ * @param item
+ * @returns Hub API id (hubId)
+ */
+export const getItemHubId = (item: IItem) => {
+  if (item.access !== "public") {
+    // the hub only indexes public items
+    return;
+  }
+  const id = item.id;
+  const layerId = getItemLayerId(item);
+  return layerId ? `${id}_${layerId}` : id;
+};
+
+/**
+ * Splits item category strings at slashes and discards the "Categories" keyword
+ *
+ * ```
+ * ["/Categories/Boundaries", "/Categories/Planning and cadastre/Property records", "/Categories/Structure"]
+ * ```
+ * Should end up being
+ * ```
+ * ["Boundaries", "Planning and cadastre", "Property records", "Structure"]
+ * ```
+ *
+ * @param categories - an array of strings
+ * @private
+ */
+export function parseItemCategories(categories: string[]) {
+  if (!categories) return categories;
+
+  const exclude = ["categories", ""];
+  const parsed = categories.map((cat) => cat.split("/"));
+  const flattened = parsed.reduce((acc, arr, _) => [...acc, ...arr], []);
+  return flattened.filter((cat) => !includes(exclude, cat.toLowerCase()));
+}
+export interface IComposeContentOptions extends IHubContentEnrichments {
+  layerId?: number;
+  slug?: string;
+  requestOptions?: IHubRequestOptions;
+}
+
+/**
+ * Compose a new content object out of an item, enrichments, and context
+ * @param item
+ * @param options any enrichments, current state (selected layerId), or context (requestOptions)
+ * @returns new content object
+ */
+export const composeContent = (
+  item: IItem,
+  options?: IComposeContentOptions
+) => {
+  // extract enrichments and context out of the options
+  const {
+    slug,
+    requestOptions,
+    data,
+    metadata,
+    groupIds,
+    ownerUser,
+    org,
+    errors,
+    server,
+    layers,
+    recordCount,
+    boundary,
+    statistics,
+  } = options || {};
+
+  // set common variables that we will use in the derived properties below
+  // if item refers to a layer we always want to use that layer id
+  // otherwise use the layer id that was passed in (if any)
+  const _layerIdFromUrl = getLayerIdFromUrl(item.url);
+  const layerId = _layerIdFromUrl
+    ? parseInt(_layerIdFromUrl, 10)
+    : options?.layerId;
+  const layer =
+    layers &&
+    (!isNil(layerId)
+      ? // find the explicitly set layer id
+        layers.find((_layer) => _layer.id === layerId)
+      : // for feature servers with a single layer always show the layer
+        isFeatureService(item.type) && getOnlyQueryLayer(layers));
+  // NOTE: we only set hubId for public items in online
+  const _canUseHubApi = !isPortal(requestOptions) && item.access === "public";
+  const hubId = _canUseHubApi
+    ? layer
+      ? `${item.id}_${layer.id}`
+      : getItemHubId(item)
+    : undefined;
+  const identifier = slug || hubId || item.id;
+  // whether or not we should show layer info for name, description, etc
+  const _shouldUseLayerInfo = shouldUseLayerInfo(layer, layers, item.url);
+  const name = _shouldUseLayerInfo ? layer.name : item.title;
+  const _layerDescription = _shouldUseLayerInfo && layer.description;
+  // so much depends on type
+  const type = layer
+    ? // use layer type (Feature Layer, Table, etc) for layer content
+      layer.type
+    : // otherwise use the normalized item type
+      normalizeItemType(item);
+  // all the urls
+  const urls = {
+    relative: getHubRelativeUrl(type, identifier, item.typeKeywords),
+    ...(requestOptions && getPortalUrls(item, requestOptions)),
+  };
+  const _proxyUrl = getProxyUrl(item, requestOptions);
+  // NOTE: I'd rather not compute these date values up front,
+  // but they are used by several getters below, so we do it here only once
+  const _updatedDateInfo = getUpdatedDateInfo(item, {
+    metadata,
+    layer,
+    server,
+  });
+  const _publishedDateInfo = getPublishedDateInfo(item, metadata);
+  const _metadataUpdatedDateInfo = getMetadataUpdatedDateInfo(item, metadata);
+
+  // return all of the above composed into a content object
+  return {
+    // a reference to underlying item
+    item,
+    // hoisted item properties
+    // NOTE: in the future we should limit this to only
+    // what is needed to satisfy the IHubContent interface, but
+    // for now we just merge in the item to avoid breaking changes :(
+    ...item,
+    // item enrichments
+    slug,
+    data,
+    metadata,
+    groupIds,
+    ownerUser,
+    org,
+    errors: errors || [],
+    // server enrichments
+    server,
+    layers,
+    recordCount,
+    // enrichments from the Hub API (boundary is below)
+    statistics,
+    // derived properties
+    // NOTE: in the getters below you can **not** use this.
+    // these are not meant to provide live updating computed props
+    // their purpose is to avoid computing all these values above
+    // especially where we want to defer computation of less used props
+    hubId,
+    identifier,
+    get isProxied() {
+      return !!_proxyUrl;
+    },
+    layer,
+    name,
+    get title() {
+      return name;
+    },
+    get description() {
+      return _layerDescription || item.description;
+    },
+    type,
+    get family() {
+      return getFamily(type);
+    },
+    get url() {
+      return _proxyUrl
+        ? _proxyUrl
+        : _shouldUseLayerInfo
+        ? `${parseServiceUrl(item.url)}/${layer.id}`
+        : item.url;
+    },
+    get categories() {
+      return parseItemCategories(item.categories);
+    },
+    get actionLinks() {
+      return item.properties && item.properties.links;
+    },
+    get hubActions() {
+      return item.properties && item.properties.actions;
+    },
+    get isDownloadable() {
+      return isDownloadable(item);
+    },
+    get structuredLicense() {
+      return getStructuredLicense(item.licenseInfo);
+    },
+    get permissions() {
+      return {
+        visibility: item.access,
+        control: item.itemControl || "view",
+        // TODO: groups?
+      };
+    },
+    get boundary() {
+      // TODO: need to be able to handle automatic w/ additional enrichment
+      // that could for example fetch the concave hull from the Hub API or resources
+      return boundary || getContentBoundary(item);
+    },
+    get summary() {
+      return _layerDescription
+        ? _layerDescription
+        : // TODO: this should use the logic for the Hub API's searchDescription
+          // see: https://github.com/ArcGIS/hub-indexer/blob/b352cfded8221a967ac80447879d493db6476d7a/packages/duke/compose/dataset.js#L238-L250
+          // TODO: can we strip HTML from description, and do we need to trim it to a X chars?
+          item.snippet || item.description;
+    },
+    urls,
+    get portalHomeUrl() {
+      return urls.portalHome;
+    },
+    get portalDataUrl() {
+      return urls.portalData;
+    },
+    get portalApiUrl() {
+      return urls.portalApi;
+    },
+    get thumbnailUrl() {
+      return urls.thumbnail;
+    },
+    /** The date the item was created */
+    get createdDate() {
+      return new Date(item.created);
+    },
+    createdDateSource: "item.created",
+    get updatedDate() {
+      return _updatedDateInfo.date;
+    },
+    get updatedDateSource() {
+      return _updatedDateInfo.source;
+    },
+    get updatedDatePrecision() {
+      return _updatedDateInfo.precision;
+    },
+    get modified() {
+      return _updatedDateInfo.date.getTime();
+    },
+    get publishedDate() {
+      return _publishedDateInfo.date;
+    },
+    get publishedDateSource() {
+      return _publishedDateInfo.source;
+    },
+    get publishedDatePrecision() {
+      return _publishedDateInfo.precision;
+    },
+    get metadataUpdatedDate() {
+      return _metadataUpdatedDateInfo.date;
+    },
+    get metadataUpdatedDateSource() {
+      return _metadataUpdatedDateInfo.source;
+    },
+    get metadataUpdatedDatePrecision() {
+      return _metadataUpdatedDateInfo.precision;
+    },
+    get updateFrequency() {
+      return getUpdateFrequencyFromMetadata(metadata);
+    },
+    get metadataUpdateFrequency() {
+      return getUpdateFrequencyFromMetadata(
+        metadata,
+        "metadataUpdateFrequency"
+      );
+    },
+    // TODO: add the publisher logic outlined here:
+    // https://devtopia.esri.com/dc/hub/issues/2932#issuecomment-3276309
+    get publisher() {
+      return {
+        name: item.owner,
+        username: item.owner,
+      };
+    },
+    // TODO: is metrics in use?
+    get metrics() {
+      return item.properties && item.properties.metrics;
+    },
+    get spatialReference() {
+      // NOTE: I had to add || null just so packages/content/test/portal.test.ts would pass
+      // we can remove that when that package is deprecated
+      return (
+        getItemSpatialReference(item) ||
+        getServerSpatialReference(server, layer) ||
+        null
+      );
+    },
+    get orgId() {
+      // NOTE: it's undocumented, but the portal API will return orgId for items... sometimes
+      return org ? org.id : item.orgId;
+    },
+    // deprecated properties
+    // TODO: should we add these in legacy wrappers
+    // like itemToContent or datasetToContent instead?
+    get contentTypeIcon() {
+      /* tslint:disable no-console */
+      console.warn(
+        /* tslint:enable no-console */
+        "DEPRECATED: it is now the responsibility of the consuming package to determine the icon"
+      );
+      return getContentTypeIcon(type);
+    },
+    get license() {
+      /* tslint:disable no-console */
+      console.warn("DEPRECATED: use structuredLicense instead");
+      /* tslint:enable no-console */
+      return { name: "Custom License", description: item.accessInformation };
+    },
+    get hubType() {
+      /* tslint:disable no-console */
+      console.warn("DEPRECATED: use family instead");
+      /* tslint:enable no-console */
+      return getFamily(type);
+    },
+  } as IHubContent;
+};

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -29,7 +29,7 @@ import {
   parseISODateString,
 } from "./_internal";
 import { getFamily } from "./get-family";
-import { getHubApiUrl } from "..";
+import { getHubApiUrl } from "../api";
 
 // helper fns - move this to _internal if needed elsewhere
 const getOnlyQueryLayer = (layers: ILayerDefinition[]) => {
@@ -583,7 +583,7 @@ export const composeContent = (
     // enrichments from the Hub API (boundary is below)
     statistics,
     // derived properties
-    // NOTE: in the getters below you can **not** use this.
+    // NOTE: in the getters below you can **not** use `this`
     // these are not meant to provide live updating computed props
     // their purpose is to avoid computing all these values above
     // especially where we want to defer computation of less used props

--- a/packages/common/src/content/get-family.ts
+++ b/packages/common/src/content/get-family.ts
@@ -1,0 +1,44 @@
+import { HubFamily } from "../types";
+import { getCollection } from "../collections";
+
+// private helper functions
+function collectionToFamily(collection: string): string {
+  const overrides: any = {
+    other: "content",
+    solution: "template",
+  };
+  return overrides[collection] || collection;
+}
+
+/**
+ * return the Hub family given an item's type
+ * @param type item type
+ * @returns Hub family
+ */
+export function getFamily(type: string) {
+  let family;
+  // override default behavior for the rows that are highlighted in yellow here:
+  // https://esriis.sharepoint.com/:x:/r/sites/ArcGISHub/_layouts/15/Doc.aspx?sourcedoc=%7BADA1C9DC-4F6C-4DE4-92C6-693EF9571CFA%7D&file=Hub%20Routes.xlsx&nav=MTBfe0VENEREQzI4LUZFMDctNEI0Ri04NjcyLThCQUE2MTA0MEZGRn1fezIwMTIwMEJFLTA4MEQtNEExRC05QzA4LTE5MTAzOUQwMEE1RH0&action=default&mobileredirect=true&cid=df1c874b-c367-4cea-bc13-7bebfad3f2ac
+  switch ((type || "").toLowerCase()) {
+    case "image service":
+      family = "dataset";
+      break;
+    case "feature service":
+    case "raster layer":
+      // TODO: check if feature service has > 1 layer first?
+      family = "map";
+      break;
+    case "microsoft excel":
+      family = "document";
+      break;
+    case "cad drawing":
+    case "feature collection template":
+    case "report template":
+      family = "content";
+      break;
+    default:
+      // by default derive from collection
+      family = collectionToFamily(getCollection(type));
+  }
+  return family as HubFamily;
+}

--- a/packages/common/src/core/types/IHubContent.ts
+++ b/packages/common/src/core/types/IHubContent.ts
@@ -8,7 +8,7 @@ import {
   IStructuredLicense,
 } from "../..";
 import { IHubItemEntity } from ".";
-import { IContentEnrichments } from "./IContentEnrichments";
+import { IHubContentEnrichments } from "./IHubContentEnrichments";
 
 // TODO: at next breaking change, IHubContent should no longer extend IItem
 /**
@@ -16,7 +16,7 @@ import { IContentEnrichments } from "./IContentEnrichments";
  */
 export interface IHubContent
   extends IHubItemEntity,
-    IContentEnrichments,
+    IHubContentEnrichments,
     IItem {
   // NOTE: for content we keep and expose a reference to the underlying item
   // b/c some top-level properties like type and categories have been
@@ -111,6 +111,9 @@ export interface IHubContent
 
   /** Information about the layer referenced by this content (geometryType, fields, etc) */
   layer?: Partial<ILayerDefinition>;
+
+  /** Whether or not the layer or table is actually a proxied CSV */
+  isProxied?: boolean;
 
   ///////////
   // TODO: remove these deprecated props at the next breaking version

--- a/packages/common/src/core/types/IHubContentEnrichments.ts
+++ b/packages/common/src/core/types/IHubContentEnrichments.ts
@@ -1,0 +1,21 @@
+import { IHubGeography } from "../../types";
+
+import { IItemEnrichments } from "./IItemEnrichments";
+import { IServerEnrichments } from "./IServerEnrichments";
+
+export interface IHubContentEnrichments
+  extends IItemEnrichments,
+    IServerEnrichments {
+  /**
+   * boundary will default to the item extent
+   * but can be overwritten by enrichments from the Hub API (inline)
+   * or fetched from a location such as /resources/boundary.json
+   */
+  boundary?: IHubGeography;
+
+  // TODO: a better type than any
+  /**
+   *
+   */
+  statistics?: any;
+}

--- a/packages/common/src/core/types/IHubItemEntity.ts
+++ b/packages/common/src/core/types/IHubItemEntity.ts
@@ -1,5 +1,5 @@
 import { IHubEntityBase } from "./IHubEntityBase";
-import { IHubGeography } from "../..";
+import { IHubGeography } from "../../types";
 
 /**
  * Properties exposed by Entities that are backed by Items

--- a/packages/common/src/core/types/IServerEnrichments.ts
+++ b/packages/common/src/core/types/IServerEnrichments.ts
@@ -3,9 +3,7 @@ import {
   ILayerDefinition,
 } from "@esri/arcgis-rest-feature-layer";
 
-import { IItemEnrichments } from "./IItemEnrichments";
-
-export interface IContentEnrichments extends IItemEnrichments {
+export interface IServerEnrichments {
   /** Information about the service referenced by this content (currentVersion, capabilities, maxRecordCount etc) */
   server?: Partial<IFeatureServiceDefinition>;
 
@@ -15,3 +13,7 @@ export interface IContentEnrichments extends IItemEnrichments {
   /** The count of records for the layer referenced by this content */
   recordCount?: number;
 }
+
+// DEPRECATED: remove this alias at the next breaking change
+// tslint:disable-next-line
+export interface IContentEnrichments extends IServerEnrichments {}

--- a/packages/common/src/core/types/index.ts
+++ b/packages/common/src/core/types/index.ts
@@ -1,5 +1,5 @@
-export * from "./IContentEnrichments";
 export * from "./IItemEnrichments";
+export * from "./IHubContentEnrichments";
 export * from "./IHubContent";
 export * from "./IHubEntityBase";
 export * from "./IHubItemEntity";
@@ -12,3 +12,4 @@ export * from "./IHubPage";
 export * from "./IHubProject";
 export * from "./IHubSite";
 export * from "./IHubTimeline";
+export * from "./IServerEnrichments";

--- a/packages/common/test/compose.test.ts
+++ b/packages/common/test/compose.test.ts
@@ -1,0 +1,266 @@
+import { ILayerDefinition } from "@esri/arcgis-rest-feature-layer";
+import { IItem } from "@esri/arcgis-rest-portal";
+import { cloneObject, composeContent } from "../src";
+import * as documentItem from "./mocks/items/document.json";
+
+const featureServiceItem = {
+  id: "3ae",
+  type: "Feature Service",
+  title: "Item Title",
+  description: "Item description",
+  snippet: "Item snippet",
+  url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+  access: "public",
+  owner: "me",
+  tags: ["test"],
+  created: 1526675011000,
+  modified: 1526675614000,
+  numViews: 1,
+  size: null,
+} as IItem;
+
+describe("composeContent", () => {
+  let item: IItem;
+  // most of compose content is currently covered by
+  // tests of higher level functions like datasetToContent()
+  // the tests below fill the gaps in coverage
+  it("should expose metrics", () => {
+    item = cloneObject(documentItem) as IItem;
+    const properties = {
+      metrics: {},
+    };
+    const content = composeContent({
+      ...item,
+      properties,
+    });
+    expect(content.metrics).toEqual(properties.metrics);
+  });
+  describe("proxied CSV", () => {
+    beforeEach(() => {
+      item = {
+        id: "3ae",
+        type: "CSV",
+        title: "Item Title",
+        description: "Item description",
+        snippet: "Item snippet",
+        url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+        access: "public",
+        owner: "me",
+        tags: ["test"],
+        created: 1526675011000,
+        modified: 1526675614000,
+        numViews: 1,
+        size: 4000000,
+      };
+    });
+    it("should have the proxied CSV URL", () => {
+      // NOTE: we're not passing in request options,
+      // so we expect this to return a prod URL
+      const proxiedContent = composeContent(item);
+      expect(proxiedContent.url).toEqual(
+        "https://hub.arcgis.com/datasets/3ae_0/FeatureServer/0"
+      );
+    });
+  });
+  describe("with metadata", () => {
+    beforeEach(() => {
+      item = cloneObject(featureServiceItem);
+    });
+    // TODO: copy over tests for metadataUpdateFrequency, updatedDate,
+    // and publishedDate from enrichments.test.ts
+    describe("metadataUpdatedDate", () => {
+      it("should return the correct value when metadataUpdatedDate metadata present", () => {
+        const metadataUpdatedDate = "1970";
+        const metadata = {
+          metadata: {
+            Esri: {
+              ArcGISProfile: "ISO19139",
+            },
+            mdDateSt: metadataUpdatedDate,
+          },
+        };
+        const result = composeContent(item, { metadata });
+        expect(result.metadataUpdatedDate).toEqual(
+          new Date(+metadataUpdatedDate, 0, 1)
+        );
+        expect(result.metadataUpdatedDatePrecision).toEqual("year");
+        expect(result.metadataUpdatedDateSource).toEqual(
+          "metadata.metadata.mdDateSt"
+        );
+      });
+    });
+  });
+  describe("with layers", () => {
+    const layers = [
+      {
+        id: 0,
+        name: "layer0",
+        type: "Feature Layer",
+        description: "Layer description",
+        capabilities: "Query",
+      },
+      {
+        id: 1,
+        name: "layer1",
+        type: "Feature Layer",
+        description: "",
+        capabilities: "Query",
+      },
+      {
+        id: 2,
+        name: "table2",
+        type: "Table",
+        description: "",
+        capabilities: "Query",
+      },
+    ] as Array<Partial<ILayerDefinition>>;
+    beforeEach(() => {
+      item = cloneObject(featureServiceItem);
+    });
+    it("non-public, multi-layer feature service w/ layerId", () => {
+      item.access = "private";
+      let layerId = 0;
+      let layerContent = composeContent(item, { layerId, layers });
+      let layer = layers[0];
+      expect(layerContent.layer).toEqual(layer, "should set layer");
+      expect(layerContent.hubId).toBeUndefined("should not set hubId");
+      expect(layerContent.type).toBe(layer.type, "should set type");
+      expect(layerContent.family).toBe("dataset", "should set family");
+      expect(layerContent.title).toEqual(layer.name, "should set title");
+      expect(layerContent.description).toEqual(
+        layer.description,
+        "should set description"
+      );
+      expect(layerContent.summary).toEqual(
+        layer.description,
+        "should set summary"
+      );
+      expect(layerContent.url).toEqual(
+        `${item.url}/${layerId}`,
+        "should set url"
+      );
+      // layer w/ no description
+      layerId = 1;
+      layerContent = composeContent(item, { layerId, layers });
+      layer = layers[1];
+      expect(layerContent.layer).toEqual(layer, "should set layer");
+      expect(layerContent.title).toEqual(layer.name, "should set title");
+      expect(layerContent.description).toEqual(
+        item.description,
+        "should set description"
+      );
+      expect(layerContent.summary).toEqual(item.snippet, "should set summary");
+      expect(layerContent.url).toEqual(
+        `${item.url}/${layerId}`,
+        "should set url"
+      );
+    });
+    it("public, single-layer feature service w/o layerId", () => {
+      const layer = layers[0];
+      const layerContent = composeContent(item, { layers: [layer] });
+      expect(layerContent.layer).toEqual(layer, "should set layer");
+      expect(layerContent.hubId).toBe(
+        `${item.id}_${layer.id}`,
+        "should set hubId"
+      );
+      expect(layerContent.type).toBe(layer.type, "should set type");
+      expect(layerContent.family).toBe("dataset", "should set family");
+      expect(layerContent.title).toEqual(item.title, "should not set title");
+      expect(layerContent.description).toEqual(
+        item.description,
+        "should not set description"
+      );
+      expect(layerContent.summary).toEqual(
+        item.snippet,
+        "should not set summary"
+      );
+      expect(layerContent.url).toEqual(item.url, "should not set url");
+    });
+    // TODO: re-implement these bug scenario tests
+    // /**
+    //  * The following series of tests is to account for occurrences of items that have been uploaded as a
+    //  * type Feature Service, but are actually other types of services that may not have layers. This is a bug.
+    //  * See the PR for link to bug description: https://github.com/Esri/hub.js/pull/633
+    //  */
+    // it("zero-layered image service w/o layerId", () => {
+    //   const content = {
+    //     id: "3ae",
+    //     type: "Image Service",
+    //     title: "Item Title",
+    //     description: "Item description",
+    //     summary: "Item snippet",
+    //     layers: undefined,
+    //     url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+    //   } as IHubContent;
+    //   const layerContent = getLayerContent(content);
+    //   expect(layerContent).toBeFalsy();
+    // });
+    // it("zero-layered feature service w/o layerId", () => {
+    //   const content = {
+    //     id: "3ae",
+    //     type: "Feature Service",
+    //     title: "Item Title",
+    //     description: "Item description",
+    //     summary: "Item snippet",
+    //     layers: null,
+    //     url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+    //   } as IHubContent;
+    //   const layerContent = getLayerContent(content);
+    //   expect(layerContent).toBeFalsy();
+    // });
+    // it("zero-layered image service w/ layerId", () => {
+    //   const content = {
+    //     id: "3ae",
+    //     type: "Image Service",
+    //     title: "Item Title",
+    //     description: "Item description",
+    //     summary: "Item snippet",
+    //     layers: null,
+    //     url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+    //   } as IHubContent;
+    //   const layerId = 0;
+    //   const layerContent = getLayerContent(content, layerId);
+    //   expect(layerContent).toBeFalsy();
+    // });
+    // it("zero-layered feature service w/ layerId", () => {
+    //   const content = {
+    //     id: "3ae",
+    //     type: "Feature Service",
+    //     title: "Item Title",
+    //     description: "Item description",
+    //     summary: "Item snippet",
+    //     layers: null,
+    //     url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+    //   } as IHubContent;
+    //   const layerId = 0;
+    //   const layerContent = getLayerContent(content, layerId);
+    //   expect(layerContent).toBeFalsy();
+    // });
+    // it("image service w/ layerId and undefined layers", () => {
+    //   const content = {
+    //     id: "3ae",
+    //     type: "Image Service",
+    //     title: "Item Title",
+    //     description: "Item description",
+    //     summary: "Item snippet",
+    //     url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+    //   } as IHubContent;
+    //   const layerId = 0;
+    //   const layerContent = getLayerContent(content, layerId);
+    //   expect(layerContent).toBeFalsy();
+    // });
+    // it("feature service w/ layerId and undefined layers", () => {
+    //   const content = {
+    //     id: "3ae",
+    //     type: "Feature Service",
+    //     title: "Item Title",
+    //     description: "Item description",
+    //     summary: "Item snippet",
+    //     url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/LocalGovernment/Recreation/FeatureServer",
+    //   } as IHubContent;
+    //   const layerId = 0;
+    //   const layerContent = getLayerContent(content, layerId);
+    //   expect(layerContent).toBeFalsy();
+    // });
+  });
+});

--- a/packages/content/test/enrichments.test.ts
+++ b/packages/content/test/enrichments.test.ts
@@ -133,12 +133,16 @@ describe("enrichContent", () => {
     const getItemDataSpy = spyOn(arcgisRestPortal, "getItemData");
     const getItemGroupsSpy = spyOn(arcgisRestPortal, "getItemGroups");
     const getContentMetadataSpy = spyOn(metadataModule, "getContentMetadata");
-    const content = {
+    const item = {
       id: "3ae",
       // signature for a Hub created web map would trigger getUser
       type: "Web Map",
       typeKeywords: ["ArcGIS Hub"],
       // missing groupIds, data, and metadata would trigger other fetches
+    } as unknown as arcgisRestPortal.IItem;
+    const content = {
+      item,
+      ...item,
     } as IHubContent;
     const requestOptions: IEnrichContentOptions = {
       isPortal: false,

--- a/packages/content/test/hub.test.ts
+++ b/packages/content/test/hub.test.ts
@@ -46,11 +46,11 @@ function validateContentFromDataset(
   expect(content.name).toBe(attributes.name);
   // should include derived properties
   expect(content.hubId).toBe(id);
-  const extent = attributes.extent;
-  expect(content.extent).toEqual(extent && extent.coordinates);
+  const { itemExtent, extent } = attributes;
+  expect(content.extent).toEqual(itemExtent || (extent && extent.coordinates));
   expect(content.family).toBe(expectedFamily);
   expect(content.summary).toBe(
-    attributes.searchDescription || attributes.snippet
+    /* attributes.searchDescription || */ attributes.snippet
   );
   expect(content.publisher).toEqual({
     name: attributes.owner,
@@ -128,9 +128,9 @@ describe("hub", () => {
 
         // since we are authed, we will fetch the item and get this stuff from it
         expect(content.contentStatus).toEqual("org_authoritative");
-        expect(content.spatialReference as string).toEqual(
-          itemJson.spatialReference
-        );
+        expect(content.spatialReference).toEqual({
+          wkid: parseInt(itemJson.spatialReference as string, 10),
+        });
 
         // TODO: content type specific properties
         // expect(content.recordCount).toBe(attributes.recordCount);
@@ -205,9 +205,9 @@ describe("hub", () => {
 
         // since we are authed, we will fetch the item and get this stuff from it
         expect(content.contentStatus).toEqual("org_authoritative");
-        expect(content.spatialReference as string).toEqual(
-          itemJson.spatialReference
-        );
+        expect(content.spatialReference).toEqual({
+          wkid: parseInt(itemJson.spatialReference as string, 10),
+        });
 
         // TODO: content type specific properties
         // expect(content.recordCount).toBe(attributes.recordCount);

--- a/packages/content/test/portal.test.ts
+++ b/packages/content/test/portal.test.ts
@@ -1,11 +1,7 @@
 import * as fetchMock from "fetch-mock";
 import * as arcgisRestPortal from "@esri/arcgis-rest-portal";
 import { IItem } from "@esri/arcgis-rest-portal";
-import {
-  IHubRequestOptions,
-  IHubContent,
-  datasetToContent,
-} from "@esri/hub-common";
+import { IHubRequestOptions, IHubContent } from "@esri/hub-common";
 import { getContentFromPortal } from "../src/portal";
 import * as metadataModule from "../src/metadata";
 import * as documentItem from "./mocks/items/document.json";
@@ -20,7 +16,9 @@ function validateContentFromPortal(content: IHubContent, item: IItem) {
     if (key === "name") {
       return;
     }
-    expect(content[key]).toEqual(item[key]);
+    const contentValue = content[key];
+    const itemValue = item[key];
+    expect(contentValue).toEqual(itemValue);
   });
   // name should be title
   expect(content.name).toBe(item.title);
@@ -28,7 +26,7 @@ function validateContentFromPortal(content: IHubContent, item: IItem) {
   expect(content.hubId).toBeUndefined();
   // should include derived properties
   expect(content.family).toBe("document");
-  // DEPRECATED: remove hubType check
+  // DEPRECATED: remove hubType check at next breaking change
   expect(content.hubType).toBe("document");
   expect(content.summary).toBe(item.snippet);
   expect(content.publisher).toEqual({
@@ -216,7 +214,8 @@ describe("get content from portal", () => {
     // pass dataset id
     getContentFromPortal(dataset.id, requestOpts).then((content) => {
       expect(content.item).toEqual(item, "set item");
-      expect(content.hubId).toBe(dataset.id, "set hubId");
+      // since we are in portal we should not expect a hubId to be set
+      // expect(content.hubId).toBe(dataset.id, "set hubId");
       // validate that layer and associated properties were set
       expect(content.layer).toEqual(layers[0] as unknown, "set content layer");
       expect(content.type).toBe("Feature Layer", "updated type");


### PR DESCRIPTION
affects: @esri/hub-common, @esri/hub-content

1. Description:

replaces existing implementations of itemToContent(), datasetToContent(), and getLayerContent()

1. Instructions for testing:

If tests pass w/ complete coverage, we good.

1. Part of : [2870](https://devtopia.esri.com/dc/hub/issues/2870)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
