### PR TITLE
feat(hub-common): add removeDomainsBySiteId()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39250,7 +39250,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -39281,7 +39281,7 @@
 		},
 		"packages/content": {
 			"name": "@esri/hub-content",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"fast-xml-parser": "~3.2.4",
@@ -39292,7 +39292,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39306,12 +39306,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.0",
 				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.2.1",
+			"version": "11.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39320,7 +39320,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39334,12 +39334,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -39350,7 +39350,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39360,12 +39360,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39376,7 +39376,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39391,12 +39391,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39405,7 +39405,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39419,12 +39419,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39435,7 +39435,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39452,12 +39452,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39466,9 +39466,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
-				"@esri/hub-initiatives": "9.17.1",
-				"@esri/hub-teams": "9.17.1",
+				"@esri/hub-common": "9.19.0",
+				"@esri/hub-initiatives": "9.19.0",
+				"@esri/hub-teams": "9.19.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -39482,14 +39482,14 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1",
-				"@esri/hub-initiatives": "9.17.1",
-				"@esri/hub-teams": "9.17.1"
+				"@esri/hub-common": "9.19.0",
+				"@esri/hub-initiatives": "9.19.0",
+				"@esri/hub-teams": "9.19.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39500,7 +39500,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39515,12 +39515,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39530,7 +39530,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39544,7 +39544,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		}
 	},
@@ -41591,7 +41591,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41609,7 +41609,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41629,7 +41629,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41649,7 +41649,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41666,7 +41666,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41686,7 +41686,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41705,9 +41705,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
-				"@esri/hub-initiatives": "9.17.1",
-				"@esri/hub-teams": "9.17.1",
+				"@esri/hub-common": "9.19.0",
+				"@esri/hub-initiatives": "9.19.0",
+				"@esri/hub-teams": "9.19.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -41727,7 +41727,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41745,7 +41745,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/common/src/sites/domains/index.ts
+++ b/packages/common/src/sites/domains/index.ts
@@ -13,6 +13,7 @@ export * from "./is-domain-used-elsewhere";
 export * from "./is-valid-domain";
 export * from "./lookup-domain";
 export * from "./remove-domain";
+export * from "./remove-domains-by-site-id";
 export * from "./update-domain";
 export * from "./_ensure-safe-domain-length";
 export * from "./ensure-unique-domain-name";

--- a/packages/common/src/sites/domains/remove-domains-by-site-id.ts
+++ b/packages/common/src/sites/domains/remove-domains-by-site-id.ts
@@ -1,0 +1,33 @@
+import { IHubRequestOptions } from "../../types";
+import { _getAuthHeader } from "./_get-auth-header";
+import { _getDomainServiceUrl } from "./_get-domain-service-url";
+import { _checkStatusAndParseJson } from "./_check-status-and-parse-json";
+
+/**
+ * Remove all domain entries by site id.
+ * User must be a member of the org that owns the domain entry.
+ * @param {int} domainSiteId of the domain entries to remove
+ * @param {IHubRequestOptions} hubRequestOptions`dom
+ */
+export function removeDomainsBySiteId(
+  domainSiteId: string,
+  hubRequestOptions: IHubRequestOptions
+) {
+  // TODO: Can remove this if no longer required
+  if (hubRequestOptions.isPortal) {
+    throw new Error(
+      `removeDomainsBySiteId is not available in ArcGIS Enterprise. Instead, edit the hubdomain typekeyword on the item`
+    );
+  }
+
+  const headers = _getAuthHeader(hubRequestOptions);
+  headers["Content-Type"] = "application/json";
+
+  const url = `${_getDomainServiceUrl(
+    hubRequestOptions.hubApiUrl
+  )}/?siteId=${domainSiteId}`;
+
+  return fetch(url, { method: "DELETE", headers, mode: "cors" }).then(
+    _checkStatusAndParseJson
+  );
+}

--- a/packages/common/test/sites/domains/remove-domains-by-site-id.test.ts
+++ b/packages/common/test/sites/domains/remove-domains-by-site-id.test.ts
@@ -1,0 +1,43 @@
+import { IHubRequestOptions } from "../../../src";
+import { removeDomainsBySiteId } from "../../../src/sites/domains";
+import * as fetchMock from "fetch-mock";
+import * as _checkStatusAndParseJsonModule from "../../../src/sites/domains/_check-status-and-parse-json";
+
+describe("removeDomainsBySiteId", function () {
+  const domainSiteId = "foobarbaz1234";
+
+  it("removes domains", async () => {
+    const ro = { isPortal: false } as IHubRequestOptions;
+
+    spyOn(
+      _checkStatusAndParseJsonModule,
+      "_checkStatusAndParseJson"
+    ).and.returnValue(Promise.resolve({ success: true }));
+
+    fetchMock.delete(`end:api/v3/domains/?siteId=${domainSiteId}`, {});
+
+    const res = await removeDomainsBySiteId(domainSiteId, ro);
+    expect(fetchMock.done()).toBeTruthy("fetch should have been called once");
+    expect(res.success).toEqual(true);
+  });
+
+  it("throws error on portal", async () => {
+    const ro = { isPortal: true } as IHubRequestOptions;
+
+    spyOn(
+      _checkStatusAndParseJsonModule,
+      "_checkStatusAndParseJson"
+    ).and.returnValue(Promise.resolve({ success: true }));
+
+    fetchMock.put(`end:api/v3/domains/?siteId=${domainSiteId}`, {});
+
+    expect(() => removeDomainsBySiteId(domainSiteId, ro)).toThrowError(
+      Error,
+      "removeDomainsBySiteId is not available in ArcGIS Enterprise. Instead, edit the hubdomain typekeyword on the item"
+    );
+    expect(fetchMock.calls().length).toBe(
+      0,
+      "fetch should NOT have been called"
+    );
+  });
+});

--- a/packages/sites/src/_remove-site-domains.ts
+++ b/packages/sites/src/_remove-site-domains.ts
@@ -1,8 +1,7 @@
-import { IHubRequestOptions } from "@esri/hub-common";
-import { getDomainsForSite, removeDomain } from "@esri/hub-common";
+import { IHubRequestOptions, removeDomainsBySiteId } from "@esri/hub-common";
 
 /**
- * Remove the Domain entries for a Site
+ * Remove the domain entries for a site
  * @param {string} siteId Item Id of the site to remove the domain entries for
  * @param {IHubRequestOptions} hubRequestOptions
  * @private
@@ -13,13 +12,9 @@ export function _removeSiteDomains(
 ) {
   if (hubRequestOptions.isPortal) {
     return Promise.resolve([]);
-  } else {
-    return getDomainsForSite(siteId, hubRequestOptions).then((domains) => {
-      return Promise.all(
-        domains.map((domainEntry) => {
-          return removeDomain(domainEntry.id, hubRequestOptions);
-        })
-      );
-    });
   }
+
+  return removeDomainsBySiteId(siteId, hubRequestOptions).then(
+    (response) => response
+  );
 }

--- a/packages/sites/test/_remove-site-domains.test.ts
+++ b/packages/sites/test/_remove-site-domains.test.ts
@@ -2,13 +2,19 @@ import { _removeSiteDomains } from "../src";
 import * as commonModule from "@esri/hub-common";
 import { IHubRequestOptions } from "@esri/hub-common";
 
+let removeDomainsBySiteIdSpy: jasmine.Spy;
+
+beforeEach(() => {
+  removeDomainsBySiteIdSpy = spyOn(commonModule, "removeDomainsBySiteId");
+});
+
+afterEach(() => {
+  removeDomainsBySiteIdSpy.calls.reset();
+});
+
 describe("_removeSiteDomains", () => {
   it("removes the domains", async () => {
-    const removeSpy = spyOn(commonModule, "removeDomain").and.returnValue(
-      Promise.resolve({})
-    );
-
-    spyOn(commonModule, "getDomainsForSite").and.returnValue(
+    removeDomainsBySiteIdSpy.and.returnValue(
       Promise.resolve([{ id: "foo" }, { id: "baz" }, { id: "bar" }])
     );
 
@@ -18,25 +24,16 @@ describe("_removeSiteDomains", () => {
     const res = await _removeSiteDomains(siteId, ro);
 
     expect(res.length).toEqual(3, "removed correct number of domains");
-    expect(removeSpy.calls.count()).toBe(
-      3,
-      "removeDomain called correct number of times"
+    expect(removeDomainsBySiteIdSpy.calls.count()).toBe(
+      1,
+      "removeDomainsBySiteId called correct number of times"
     );
 
-    // check the ids
-    expect(removeSpy.calls.argsFor(0)[0]).toBe("foo");
-    expect(removeSpy.calls.argsFor(1)[0]).toBe("baz");
-    expect(removeSpy.calls.argsFor(2)[0]).toBe("bar");
+    expect(removeDomainsBySiteIdSpy.calls.argsFor(0)[0]).toBe("foobarbaz");
   });
 
   it("does nothing on portal", async function () {
-    const removeSpy = spyOn(commonModule, "removeDomain").and.returnValue(
-      Promise.resolve({})
-    );
-
-    spyOn(commonModule, "getDomainsForSite").and.returnValue(
-      Promise.resolve([{ id: "foo" }, { id: "baz" }, { id: "bar" }])
-    );
+    removeDomainsBySiteIdSpy.and.returnValue(Promise.resolve({}));
 
     const ro = { isPortal: true } as IHubRequestOptions;
     const siteId = "foobarbaz";
@@ -44,7 +41,6 @@ describe("_removeSiteDomains", () => {
     const res = await _removeSiteDomains(siteId, ro);
 
     expect(res).toEqual([]);
-    expect(removeSpy).not.toHaveBeenCalled();
-    expect(commonModule.getDomainsForSite).not.toHaveBeenCalled();
+    expect(removeDomainsBySiteIdSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
affects: @esri/hub-common, @esri/hub-sites

rename `removeDomain()` to `removeDomainById()`
add `removeDomainsBySiteId()` to delete all domains associated with a site

BREAKING CHANGE:
`removeDomain()` renamed to `removeDomainById()`

ISSUES CLOSED: [#3230](https://devtopia.esri.com/dc/hub/issues/3230)

1. Description:

- Update `_removeSiteDomains()` to use the new Domains DELETE endpoint `deleteBySiteId()`
  - This allows `_removeSiteDomains()` to make a single request instead of requesting get all domain records by `siteId` and then sending parallel requests to delete each record

1. Instructions for testing:

1. Closes Issues: [#3230](https://devtopia.esri.com/dc/hub/issues/3230)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
