### PR TITLE
chore(hub-common): fix flakey test and remove unused imports

### DIFF
--- a/packages/common/src/content/_internal.ts
+++ b/packages/common/src/content/_internal.ts
@@ -16,7 +16,6 @@ import { IItem } from "@esri/arcgis-rest-portal";
 import { ISpatialReference } from "@esri/arcgis-rest-types";
 import { IHubContent } from "../core";
 import {
-  BBox,
   IHubGeography,
   GeographyProvenance,
   IHubRequestOptions,

--- a/packages/common/src/content/index.ts
+++ b/packages/common/src/content/index.ts
@@ -12,8 +12,6 @@ import { getServiceTypeFromUrl } from "../urls";
 import { getHubRelativeUrl, isPageType } from "./_internal";
 import { camelize } from "../util";
 import {
-  getLayerIdFromUrl,
-  isFeatureService,
   normalizeItemType,
   getContentTypeIcon,
   composeContent,

--- a/packages/common/test/compose.test.ts
+++ b/packages/common/test/compose.test.ts
@@ -196,83 +196,83 @@ describe("composeContent", () => {
         );
       });
     });
-  });
-  describe("publishedDate", () => {
-    it("should return the correct value when pubDate metadata present", () => {
-      const pubDate = "1970-02-07";
-      const metadata = {
-        metadata: {
-          Esri: {
-            ArcGISProfile: "ISO19139",
-          },
-          dataIdInfo: {
-            idCitation: {
-              date: {
-                pubDate,
+    describe("publishedDate", () => {
+      it("should return the correct value when pubDate metadata present", () => {
+        const pubDate = "1970-02-07";
+        const metadata = {
+          metadata: {
+            Esri: {
+              ArcGISProfile: "ISO19139",
+            },
+            dataIdInfo: {
+              idCitation: {
+                date: {
+                  pubDate,
+                },
               },
             },
           },
-        },
-      };
-      const result = composeContent(item, { metadata });
-      const dateParts = pubDate.split("-").map((part) => +part);
-      expect(result.publishedDate).toEqual(
-        new Date(dateParts[0], dateParts[1] - 1, dateParts[2])
-      );
-      expect(result.publishedDatePrecision).toEqual("day");
-      expect(result.publishedDateSource).toEqual(
-        "metadata.metadata.dataIdInfo.idCitation.date.pubDate"
-      );
-    });
-    it("should return the correct value when createDate metadata present", () => {
-      const createDate = "1970-02-07";
-      const metadata = {
-        metadata: {
-          Esri: {
-            ArcGISProfile: "ISO19139",
-          },
-          dataIdInfo: {
-            idCitation: {
-              date: {
-                createDate,
+        };
+        const result = composeContent(item, { metadata });
+        const dateParts = pubDate.split("-").map((part) => +part);
+        expect(result.publishedDate).toEqual(
+          new Date(dateParts[0], dateParts[1] - 1, dateParts[2])
+        );
+        expect(result.publishedDatePrecision).toEqual("day");
+        expect(result.publishedDateSource).toEqual(
+          "metadata.metadata.dataIdInfo.idCitation.date.pubDate"
+        );
+      });
+      it("should return the correct value when createDate metadata present", () => {
+        const createDate = "1970-02-07";
+        const metadata = {
+          metadata: {
+            Esri: {
+              ArcGISProfile: "ISO19139",
+            },
+            dataIdInfo: {
+              idCitation: {
+                date: {
+                  createDate,
+                },
               },
             },
           },
-        },
-      };
-      const result = composeContent(item, { metadata });
-      const dateParts = createDate.split("-").map((part) => +part);
-      expect(result.publishedDate).toEqual(
-        new Date(dateParts[0], dateParts[1] - 1, dateParts[2])
-      );
-      expect(result.publishedDatePrecision).toEqual("day");
-      expect(result.publishedDateSource).toEqual(
-        "metadata.metadata.dataIdInfo.idCitation.date.createDate"
-      );
-    });
-    it("should return the correct value when createDate & pubDate metadata present", () => {
-      const pubDate = "02/07/1970";
-      const metadata = {
-        metadata: {
-          Esri: {
-            ArcGISProfile: "ISO19139",
-          },
-          dataIdInfo: {
-            idCitation: {
-              date: {
-                createDate: "1970-11-17T00:00:00.000Z",
-                pubDate,
+        };
+        const result = composeContent(item, { metadata });
+        const dateParts = createDate.split("-").map((part) => +part);
+        expect(result.publishedDate).toEqual(
+          new Date(dateParts[0], dateParts[1] - 1, dateParts[2])
+        );
+        expect(result.publishedDatePrecision).toEqual("day");
+        expect(result.publishedDateSource).toEqual(
+          "metadata.metadata.dataIdInfo.idCitation.date.createDate"
+        );
+      });
+      it("should return the correct value when createDate & pubDate metadata present", () => {
+        const pubDate = "02/07/1970";
+        const metadata = {
+          metadata: {
+            Esri: {
+              ArcGISProfile: "ISO19139",
+            },
+            dataIdInfo: {
+              idCitation: {
+                date: {
+                  createDate: "1970-11-17T00:00:00.000Z",
+                  pubDate,
+                },
               },
             },
           },
-        },
-      };
-      const result = composeContent(item, { metadata });
-      expect(result.publishedDate).toEqual(new Date(1970, 1, 7));
-      expect(result.publishedDatePrecision).toEqual("day");
-      expect(result.publishedDateSource).toEqual(
-        "metadata.metadata.dataIdInfo.idCitation.date.pubDate"
-      );
+        };
+        const result = composeContent(item, { metadata });
+        expect(result.publishedDate).toEqual(new Date(1970, 1, 7));
+        expect(result.publishedDatePrecision).toEqual("day");
+        expect(result.publishedDateSource).toEqual(
+          "metadata.metadata.dataIdInfo.idCitation.date.pubDate"
+        );
+      });
     });
   });
   describe("with layers", () => {


### PR DESCRIPTION
1. Description:

improperly scoped `describe()` was causing tests to intermittently fail.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
