### PR TITLE
feat(hub-common): add additional resources to IHubContent composition logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39250,7 +39250,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -39281,7 +39281,7 @@
 		},
 		"packages/content": {
 			"name": "@esri/hub-content",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"fast-xml-parser": "~3.2.4",
@@ -39292,7 +39292,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39306,12 +39306,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.0",
 				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.2.1",
+			"version": "11.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39320,7 +39320,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39334,12 +39334,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -39350,7 +39350,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39360,12 +39360,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39376,7 +39376,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39391,12 +39391,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39405,7 +39405,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39419,12 +39419,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39435,7 +39435,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39452,12 +39452,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39466,9 +39466,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
-				"@esri/hub-initiatives": "9.17.1",
-				"@esri/hub-teams": "9.17.1",
+				"@esri/hub-common": "9.19.0",
+				"@esri/hub-initiatives": "9.19.0",
+				"@esri/hub-teams": "9.19.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -39482,14 +39482,14 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1",
-				"@esri/hub-initiatives": "9.17.1",
-				"@esri/hub-teams": "9.17.1"
+				"@esri/hub-common": "9.19.0",
+				"@esri/hub-initiatives": "9.19.0",
+				"@esri/hub-teams": "9.19.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39500,7 +39500,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39515,12 +39515,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.17.1",
+			"version": "9.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -39530,7 +39530,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -39544,7 +39544,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.17.1"
+				"@esri/hub-common": "9.19.0"
 			}
 		}
 	},
@@ -41591,7 +41591,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41609,7 +41609,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41629,7 +41629,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41649,7 +41649,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41666,7 +41666,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41686,7 +41686,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41705,9 +41705,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
-				"@esri/hub-initiatives": "9.17.1",
-				"@esri/hub-teams": "9.17.1",
+				"@esri/hub-common": "9.19.0",
+				"@esri/hub-initiatives": "9.19.0",
+				"@esri/hub-teams": "9.19.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -41727,7 +41727,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41745,7 +41745,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.17.1",
+				"@esri/hub-common": "9.19.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/common/src/content/_internal.ts
+++ b/packages/common/src/content/_internal.ts
@@ -11,12 +11,12 @@
 import {
   ILayerDefinition,
   IFeatureServiceDefinition,
+  parseServiceUrl,
 } from "@esri/arcgis-rest-feature-layer";
 import { IItem } from "@esri/arcgis-rest-portal";
 import { ISpatialReference } from "@esri/arcgis-rest-types";
 import { IHubContent } from "../core";
 import {
-  BBox,
   IHubGeography,
   GeographyProvenance,
   IHubRequestOptions,
@@ -24,6 +24,7 @@ import {
 import { bBoxToPolygon, isBBox } from "../extent";
 import { getFamily } from "./get-family";
 import { getProp } from "../objects";
+import { IHubAdditionalResource } from "../core/types/IHubAdditionalResource";
 
 /**
  * Create a new content with updated boundary properties
@@ -255,4 +256,63 @@ export const getItemSpatialReference = (item: IItem): ISpatialReference => {
       { wkt: spatialReferenceString }
     : //
       { wkid };
+};
+
+/**
+ * Data model for additional resources that are extracted
+ * directly from formal item metadata (with no transformation)
+ */
+interface IAGOAdditionalResource {
+  orName?: string; // Name of the resource
+  linkage: string; // URL to the resource
+}
+
+/**
+ * Extracts additional resources from the provided metadata
+ * and transforms them into a hub-friendly format.
+ *
+ * Returns null if no resources are available
+ *
+ * @param item
+ * @param metadata formal metadata
+ * @returns
+ */
+export const getAdditionalResources = (
+  item: IItem,
+  metadata?: any
+): IHubAdditionalResource[] => {
+  let rawResources: IAGOAdditionalResource | IAGOAdditionalResource[] =
+    getProp(metadata, "metadata.distInfo.distTranOps.onLineSrc") || null;
+
+  if (rawResources === null) {
+    return null;
+  }
+
+  // Coerce to array since rawResources will be an object if only 1 resource is available
+  rawResources = Array.isArray(rawResources) ? rawResources : [rawResources];
+
+  return rawResources.map(
+    (resource: IAGOAdditionalResource): IHubAdditionalResource => ({
+      name: resource.orName,
+      url: resource.linkage,
+      isDataSource: isDataSourceOfItem(resource, item),
+    })
+  );
+};
+
+/**
+ * Determines whether a raw additional resource (i.e. extracted out of formal
+ * metadata with no transformation) references the underlying service that backs
+ * the item.
+ *
+ * @param resource raw additional resource of an item
+ * @param item
+ * @returns
+ */
+export const isDataSourceOfItem = (
+  resource: IAGOAdditionalResource,
+  item: IItem
+) => {
+  const serviceUrl = item.url && parseServiceUrl(item.url);
+  return serviceUrl && resource.linkage.includes(serviceUrl);
 };

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -27,6 +27,7 @@ import {
   isProxiedCSV,
   isPortal,
   parseISODateString,
+  getAdditionalResources,
 } from "./_internal";
 import { getFamily } from "./get-family";
 import { getHubApiUrl } from "../api";
@@ -750,6 +751,9 @@ export const composeContent = (
       console.warn("DEPRECATED: use family instead");
       /* tslint:enable no-console */
       return getFamily(type);
+    },
+    get additionalResources() {
+      return getAdditionalResources(item, metadata);
     },
   } as IHubContent;
 };

--- a/packages/common/src/content/index.ts
+++ b/packages/common/src/content/index.ts
@@ -12,8 +12,6 @@ import { getServiceTypeFromUrl } from "../urls";
 import { getHubRelativeUrl, isPageType } from "./_internal";
 import { camelize } from "../util";
 import {
-  getLayerIdFromUrl,
-  isFeatureService,
   normalizeItemType,
   getContentTypeIcon,
   composeContent,

--- a/packages/common/src/core/types/IHubAdditionalResource.ts
+++ b/packages/common/src/core/types/IHubAdditionalResource.ts
@@ -1,0 +1,10 @@
+/**
+ * Data model for additional resources that are pulled from formal item metadata
+ * and transformed into a hub-friendly interface
+ */
+export interface IHubAdditionalResource {
+  name?: string;
+  url: string;
+  /** whether the url points to the service of the related item */
+  isDataSource: boolean;
+}

--- a/packages/common/src/core/types/IHubContent.ts
+++ b/packages/common/src/core/types/IHubContent.ts
@@ -1,14 +1,10 @@
 import { IItem, IGroup } from "@esri/arcgis-rest-portal";
 import { ILayerDefinition } from "@esri/arcgis-rest-feature-layer";
-import {
-  Visibility,
-  AccessControl,
-  HubFamily,
-  IActionLink,
-  IStructuredLicense,
-} from "../..";
+import { AccessControl, HubFamily, IActionLink, Visibility } from "../../types";
+import { IStructuredLicense } from "../../items/get-structured-license";
 import { IHubItemEntity } from ".";
 import { IHubContentEnrichments } from "./IHubContentEnrichments";
+import { IHubAdditionalResource } from "./IHubAdditionalResource";
 
 // TODO: at next breaking change, IHubContent should no longer extend IItem
 /**
@@ -114,6 +110,9 @@ export interface IHubContent
 
   /** Whether or not the layer or table is actually a proxied CSV */
   isProxied?: boolean;
+
+  /** links to additional resources specified in the formal item metadata */
+  additionalResources?: IHubAdditionalResource[];
 
   ///////////
   // TODO: remove these deprecated props at the next breaking version

--- a/packages/common/test/compose.test.ts
+++ b/packages/common/test/compose.test.ts
@@ -236,83 +236,83 @@ describe("composeContent", () => {
         ]);
       });
     });
-  });
-  describe("publishedDate", () => {
-    it("should return the correct value when pubDate metadata present", () => {
-      const pubDate = "1970-02-07";
-      const metadata = {
-        metadata: {
-          Esri: {
-            ArcGISProfile: "ISO19139",
-          },
-          dataIdInfo: {
-            idCitation: {
-              date: {
-                pubDate,
+    describe("publishedDate", () => {
+      it("should return the correct value when pubDate metadata present", () => {
+        const pubDate = "1970-02-07";
+        const metadata = {
+          metadata: {
+            Esri: {
+              ArcGISProfile: "ISO19139",
+            },
+            dataIdInfo: {
+              idCitation: {
+                date: {
+                  pubDate,
+                },
               },
             },
           },
-        },
-      };
-      const result = composeContent(item, { metadata });
-      const dateParts = pubDate.split("-").map((part) => +part);
-      expect(result.publishedDate).toEqual(
-        new Date(dateParts[0], dateParts[1] - 1, dateParts[2])
-      );
-      expect(result.publishedDatePrecision).toEqual("day");
-      expect(result.publishedDateSource).toEqual(
-        "metadata.metadata.dataIdInfo.idCitation.date.pubDate"
-      );
-    });
-    it("should return the correct value when createDate metadata present", () => {
-      const createDate = "1970-02-07";
-      const metadata = {
-        metadata: {
-          Esri: {
-            ArcGISProfile: "ISO19139",
-          },
-          dataIdInfo: {
-            idCitation: {
-              date: {
-                createDate,
+        };
+        const result = composeContent(item, { metadata });
+        const dateParts = pubDate.split("-").map((part) => +part);
+        expect(result.publishedDate).toEqual(
+          new Date(dateParts[0], dateParts[1] - 1, dateParts[2])
+        );
+        expect(result.publishedDatePrecision).toEqual("day");
+        expect(result.publishedDateSource).toEqual(
+          "metadata.metadata.dataIdInfo.idCitation.date.pubDate"
+        );
+      });
+      it("should return the correct value when createDate metadata present", () => {
+        const createDate = "1970-02-07";
+        const metadata = {
+          metadata: {
+            Esri: {
+              ArcGISProfile: "ISO19139",
+            },
+            dataIdInfo: {
+              idCitation: {
+                date: {
+                  createDate,
+                },
               },
             },
           },
-        },
-      };
-      const result = composeContent(item, { metadata });
-      const dateParts = createDate.split("-").map((part) => +part);
-      expect(result.publishedDate).toEqual(
-        new Date(dateParts[0], dateParts[1] - 1, dateParts[2])
-      );
-      expect(result.publishedDatePrecision).toEqual("day");
-      expect(result.publishedDateSource).toEqual(
-        "metadata.metadata.dataIdInfo.idCitation.date.createDate"
-      );
-    });
-    it("should return the correct value when createDate & pubDate metadata present", () => {
-      const pubDate = "02/07/1970";
-      const metadata = {
-        metadata: {
-          Esri: {
-            ArcGISProfile: "ISO19139",
-          },
-          dataIdInfo: {
-            idCitation: {
-              date: {
-                createDate: "1970-11-17T00:00:00.000Z",
-                pubDate,
+        };
+        const result = composeContent(item, { metadata });
+        const dateParts = createDate.split("-").map((part) => +part);
+        expect(result.publishedDate).toEqual(
+          new Date(dateParts[0], dateParts[1] - 1, dateParts[2])
+        );
+        expect(result.publishedDatePrecision).toEqual("day");
+        expect(result.publishedDateSource).toEqual(
+          "metadata.metadata.dataIdInfo.idCitation.date.createDate"
+        );
+      });
+      it("should return the correct value when createDate & pubDate metadata present", () => {
+        const pubDate = "02/07/1970";
+        const metadata = {
+          metadata: {
+            Esri: {
+              ArcGISProfile: "ISO19139",
+            },
+            dataIdInfo: {
+              idCitation: {
+                date: {
+                  createDate: "1970-11-17T00:00:00.000Z",
+                  pubDate,
+                },
               },
             },
           },
-        },
-      };
-      const result = composeContent(item, { metadata });
-      expect(result.publishedDate).toEqual(new Date(1970, 1, 7));
-      expect(result.publishedDatePrecision).toEqual("day");
-      expect(result.publishedDateSource).toEqual(
-        "metadata.metadata.dataIdInfo.idCitation.date.pubDate"
-      );
+        };
+        const result = composeContent(item, { metadata });
+        expect(result.publishedDate).toEqual(new Date(1970, 1, 7));
+        expect(result.publishedDatePrecision).toEqual("day");
+        expect(result.publishedDateSource).toEqual(
+          "metadata.metadata.dataIdInfo.idCitation.date.pubDate"
+        );
+      });
     });
   });
   describe("with layers", () => {

--- a/packages/common/test/compose.test.ts
+++ b/packages/common/test/compose.test.ts
@@ -196,6 +196,46 @@ describe("composeContent", () => {
         );
       });
     });
+    describe("additionalResources", () => {
+      it("should return null if metadata doesn't contain additional resources", () => {
+        const metadata = {};
+        const result = composeContent(item, { metadata });
+        expect(result.additionalResources).toBeNull();
+      });
+      it("should return correct structure when metadata contain additional resources", () => {
+        const metadata = {
+          metadata: {
+            distInfo: {
+              distTranOps: {
+                onLineSrc: [
+                  {
+                    linkage: "unnamed-resource-url",
+                  },
+                  {
+                    orName: "Named Resource",
+                    linkage: "named-resource-url",
+                  },
+                ],
+              },
+            },
+          },
+        };
+        const result = composeContent(item, { metadata });
+        expect(result.additionalResources.length).toEqual(2);
+        expect(result.additionalResources).toEqual([
+          {
+            name: undefined,
+            url: "unnamed-resource-url",
+            isDataSource: false,
+          },
+          {
+            name: "Named Resource",
+            url: "named-resource-url",
+            isDataSource: false,
+          },
+        ]);
+      });
+    });
   });
   describe("publishedDate", () => {
     it("should return the correct value when pubDate metadata present", () => {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Part of [3304](https://devtopia.esri.com/dc/hub/issues/3304)
Added to the IHubContent interface and created additional helpers to parse and transform additional resources from formal item metadata

1. [x] ran commit script (`npm run c`)