### PR TITLE
fix: switch to final item type for hub projects

### DIFF
--- a/packages/common/src/projects/HubProjects.ts
+++ b/packages/common/src/projects/HubProjects.ts
@@ -34,7 +34,7 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IPropertyMap, PropertyMapper } from "../core/helpers/PropertyMapper";
 import { IHubProject } from "../core/types";
 
-export const HUB_PROJECT_ITEM_TYPE = "Web Mapping Application";
+export const HUB_PROJECT_ITEM_TYPE = "Hub Project";
 
 /**
  * Default values of a IHubProject
@@ -42,7 +42,7 @@ export const HUB_PROJECT_ITEM_TYPE = "Web Mapping Application";
 const DEFAULT_PROJECT: Partial<IHubProject> = {
   name: "No title provided",
   tags: [],
-  typeKeywords: ["IHubProject", "HubProject"],
+  typeKeywords: ["Hub Project"],
   status: "inactive",
 };
 

--- a/packages/common/test/projects/HubProjects.test.ts
+++ b/packages/common/test/projects/HubProjects.test.ts
@@ -137,6 +137,7 @@ describe("HubProjects:", () => {
       expect(createSpy.calls.count()).toBe(1);
       const modelToCreate = createSpy.calls.argsFor(0)[0];
       expect(modelToCreate.item.title).toBe("Hello World");
+      expect(modelToCreate.item.type).toBe("Hub Project");
       expect(modelToCreate.item.properties.slug).toBe("dcdev-hello-world");
       expect(modelToCreate.item.properties.orgUrlKey).toBe("dcdev");
     });


### PR DESCRIPTION
1. Description:

The `Hub Project` item type landed on QAEXT so we can now switch the code to use that vs `Web Mapping Application`

1. Instructions for testing:

Run tests

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
