### PR TITLE
fix(hub-common): fix missing extent in datasetToContent()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38516,7 +38516,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.19.0",
+			"version": "9.21.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -38547,7 +38547,7 @@
 		},
 		"packages/content": {
 			"name": "@esri/hub-content",
-			"version": "9.19.0",
+			"version": "9.21.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"fast-xml-parser": "~3.2.4",
@@ -38558,7 +38558,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38572,12 +38572,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.0",
 				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.19.0"
+				"@esri/hub-common": "9.21.1"
 			}
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.4.0",
+			"version": "11.6.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -38586,7 +38586,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38600,12 +38600,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.19.0"
+				"@esri/hub-common": "9.21.1"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.19.0",
+			"version": "9.21.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -38616,7 +38616,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38626,12 +38626,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.19.0"
+				"@esri/hub-common": "9.21.1"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.19.0",
+			"version": "9.21.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -38642,7 +38642,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38657,12 +38657,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.19.0"
+				"@esri/hub-common": "9.21.1"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.19.0",
+			"version": "9.21.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -38671,7 +38671,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38685,12 +38685,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.19.0"
+				"@esri/hub-common": "9.21.1"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.19.0",
+			"version": "9.21.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -38701,7 +38701,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38718,12 +38718,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.19.0"
+				"@esri/hub-common": "9.21.1"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.19.0",
+			"version": "9.21.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -38732,9 +38732,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
-				"@esri/hub-initiatives": "9.19.0",
-				"@esri/hub-teams": "9.19.0",
+				"@esri/hub-common": "9.21.1",
+				"@esri/hub-initiatives": "9.21.1",
+				"@esri/hub-teams": "9.21.1",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -38748,14 +38748,14 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.19.0",
-				"@esri/hub-initiatives": "9.19.0",
-				"@esri/hub-teams": "9.19.0"
+				"@esri/hub-common": "9.21.1",
+				"@esri/hub-initiatives": "9.21.1",
+				"@esri/hub-teams": "9.21.1"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.19.0",
+			"version": "9.21.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -38766,7 +38766,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38781,12 +38781,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.19.0"
+				"@esri/hub-common": "9.21.1"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.19.0",
+			"version": "9.21.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -38796,7 +38796,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38810,7 +38810,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.19.0"
+				"@esri/hub-common": "9.21.1"
 			}
 		}
 	},
@@ -40857,7 +40857,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -40875,7 +40875,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -40895,7 +40895,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -40915,7 +40915,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -40932,7 +40932,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -40952,7 +40952,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -40971,9 +40971,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
-				"@esri/hub-initiatives": "9.19.0",
-				"@esri/hub-teams": "9.19.0",
+				"@esri/hub-common": "9.21.1",
+				"@esri/hub-initiatives": "9.21.1",
+				"@esri/hub-teams": "9.21.1",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -40993,7 +40993,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41011,7 +41011,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.19.0",
+				"@esri/hub-common": "9.21.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -634,6 +634,8 @@ export const composeContent = (
         // TODO: groups?
       };
     },
+    // TODO: do we want to add dataset extent logic as a getter here?
+    // would require us to do client-side projection of server/layer extent
     get boundary() {
       // TODO: need to be able to handle automatic w/ additional enrichment
       // that could for example fetch the concave hull from the Hub API or resources

--- a/packages/common/src/content/index.ts
+++ b/packages/common/src/content/index.ts
@@ -5,6 +5,7 @@ import { IItem } from "@esri/arcgis-rest-portal";
 import { HubType, IModel } from "../types";
 import { getCollection } from "../collections";
 import { categories as allCategories } from "../categories";
+import { isBBox } from "../extent";
 import { includes, isGuid } from "../utils";
 import { IHubContent } from "../core";
 import { getProp } from "../objects";
@@ -287,6 +288,8 @@ export function datasetToContent(dataset: DatasetResource): IHubContent {
     recordCount,
     statistics,
     // additional attributes needed
+    extent,
+    itemExtent,
     searchDescription,
   } = dataset.attributes;
 
@@ -317,9 +320,18 @@ export function datasetToContent(dataset: DatasetResource): IHubContent {
   });
 
   // TODO: need to add searchDescription logic to composeContent()
+  // or fetch it as a Hub enrichment like boundary
   if (searchDescription) {
     // overwrite default summary (from snippet) w/ search description
     content.summary = searchDescription;
+  }
+  // TODO: need to add extent logic to composeContent()
+  // or fetch it as a Hub enrichment like boundary
+  if (!isBBox(item.extent) && extent && isBBox(extent.coordinates)) {
+    // we fall back to the extent derived by the API
+    // which prefers layer or service extents and ultimately
+    // falls back to the org's extent
+    content.extent = extent.coordinates;
   }
   return content;
 }

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -660,6 +660,11 @@ describe("dataset to content", () => {
     // NOTE: the document JSON does not have org attributes
     expect(content.org).toBeUndefined();
   });
+  it("has extent returned from hub API", () => {
+    const dataset = cloneObject(featureLayerJson.data) as DatasetResource;
+    const content = datasetToContent(dataset);
+    expect(content.extent).toEqual(dataset.attributes.extent.coordinates);
+  });
   // NOTE: other use cases are covered by getContent() tests
 });
 describe("setContentType", () => {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

I should not have removed the extent enrichment logic from `datasetToContent()` 

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
