### PR TITLE
[WIP] feat: add cache manager class and tests

### DIFF
--- a/packages/common/src/CacheManager.ts
+++ b/packages/common/src/CacheManager.ts
@@ -1,0 +1,95 @@
+/**
+ * Singleton Cache Manager
+ */
+export class CacheManager {
+  private static _instance: CacheManager;
+  public hits: number = 0;
+  public requests: number = 0;
+  private cache: Map<string, unknown>;
+
+  private constructor() {
+    this.cache = new Map<string, unknown>();
+  }
+
+  /**
+   * Convenience static method that directs calls to the instance
+   * @param fn
+   * @param args
+   * @returns
+   */
+  public static async call<Fn extends (...args: any) => any>(
+    fn: (...args: any[]) => ReturnType<Fn>,
+    ...args: any[]
+  ): Promise<ReturnType<Fn>> {
+    return CacheManager.instance.callFn(fn, ...args);
+  }
+
+  /**
+   * Reset the cache
+   */
+  public static reset() {
+    CacheManager.instance.cache = new Map<string, unknown>();
+    CacheManager.instance.hits = 0;
+    CacheManager.instance.requests = 0;
+  }
+
+  /**
+   * Stringify arguments into a key
+   * Although map can use objects as keys, that requires sending
+   * the same refs for multiple calls. Converting to strings allows
+   * caching of the effective request without requiring the same ref
+   * @param args
+   * @returns
+   */
+  private createCacheKey(args: any[]): string {
+    return args.reduce(
+      (cacheKey, arg) =>
+        (cacheKey += `_${
+          typeof arg === "object" ? JSON.stringify(args) : `${arg}`
+        }_`),
+      ""
+    );
+  }
+
+  static get instance(): CacheManager {
+    if (!this._instance) {
+      this._instance = new CacheManager();
+    }
+    return this._instance;
+  }
+
+  /**
+   * Cache a function call based on the args passed in
+   * @param fn
+   * @param args
+   * @returns
+   */
+  private async callFn<Fn extends (...args: any) => any>(
+    fn: (...args: any[]) => ReturnType<Fn>,
+    ...args: any[]
+  ): Promise<ReturnType<Fn>> {
+    const cacheKey = this.createCacheKey(args);
+    this.requests++;
+    if (this.cache.has(cacheKey)) {
+      this.hits++;
+      // since the cache contains the actual promises
+      // we can just return it directly
+      return this.cache.get(cacheKey) as ReturnType<Fn>;
+    } else {
+      // to allow for parallel requests, we don't cache the
+      // response, rather we cache the the promise itself
+      const fnPromise = fn.apply(null, args);
+      this.cache.set(cacheKey, fnPromise);
+      // and return it
+      return fnPromise;
+    }
+  }
+
+  /**
+   * Return summary of cache hits as string
+   * @returns
+   */
+  public static get stats(): string {
+    return `Cache used for ${CacheManager.instance.hits} out of ${CacheManager.instance.requests} calls`;
+  }
+}

--- a/packages/common/src/CacheManager.ts
+++ b/packages/common/src/CacheManager.ts
@@ -68,7 +68,13 @@ export class CacheManager {
     fn: (...args: any[]) => ReturnType<Fn>,
     ...args: any[]
   ): Promise<ReturnType<Fn>> {
-    const cacheKey = this.createCacheKey(args);
+    if (!fn.name) {
+      throw new Error(
+        `CacheManager is not reliable with anonymous functions. Please use a named function.`
+      );
+    }
+    const cacheKey = `${fn.name}-${this.createCacheKey(args)}`;
+
     this.requests++;
     if (this.cache.has(cacheKey)) {
       this.hits++;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -6,6 +6,7 @@ export * from "./api";
 export * from "./ArcGISContext";
 export * from "./ArcGISContextManager";
 export * from "./auth";
+export * from "./CacheManager";
 export * from "./categories";
 export * from "./content";
 export * from "./core";

--- a/packages/common/test/CacheManager.test.ts
+++ b/packages/common/test/CacheManager.test.ts
@@ -1,0 +1,60 @@
+import { CacheManager } from "../src";
+
+async function fakeAsyncFn(payload: any): Promise<any> {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return payload;
+}
+
+function fakeFn(payload: any): any {
+  return payload;
+}
+
+describe("CacheManager:", () => {
+  afterEach(() => {
+    // Reset the cache
+    CacheManager.reset();
+  });
+  it("Caches Async Functions by string arg", async () => {
+    // fire off a few calls
+    const restuls = await Promise.all([
+      CacheManager.call(fakeAsyncFn, "one"),
+      CacheManager.call(fakeAsyncFn, "two"),
+      CacheManager.call(fakeAsyncFn, "one"),
+      CacheManager.call(fakeAsyncFn, "one"),
+      CacheManager.call(fakeAsyncFn, "one"),
+      CacheManager.call(fakeAsyncFn, "two"),
+      CacheManager.call(fakeAsyncFn, "three"),
+    ]);
+    // check the hits and requests
+    expect(CacheManager.instance.hits).toBe(4);
+    expect(CacheManager.instance.requests).toBe(7);
+    expect(CacheManager.stats).toBe(`Cache used for 4 out of 7 calls`);
+  });
+  it("Caches Async Functions by string arg", async () => {
+    // fire off a few calls
+    const restuls = await Promise.all([
+      CacheManager.call(fakeAsyncFn, { a: "one" }),
+      CacheManager.call(fakeAsyncFn, { a: "two" }),
+      CacheManager.call(fakeAsyncFn, { a: "one" }),
+      CacheManager.call(fakeAsyncFn, { a: "one" }),
+      CacheManager.call(fakeAsyncFn, { a: "one" }),
+      CacheManager.call(fakeAsyncFn, { a: "two" }),
+      CacheManager.call(fakeAsyncFn, { a: "three" }),
+    ]);
+    // check the hits and requests
+    expect(CacheManager.instance.hits).toBe(4);
+    expect(CacheManager.instance.requests).toBe(7);
+  });
+  it("Caches non-async functions", () => {
+    CacheManager.call(fakeFn, { a: "one" });
+    CacheManager.call(fakeFn, { a: "two" });
+    CacheManager.call(fakeFn, { a: "one" });
+    CacheManager.call(fakeFn, { a: "one" });
+    CacheManager.call(fakeFn, { a: "one" });
+    CacheManager.call(fakeFn, { a: "two" });
+    CacheManager.call(fakeFn, { a: "three" });
+
+    expect(CacheManager.instance.hits).toBe(4);
+    expect(CacheManager.instance.requests).toBe(7);
+  });
+});


### PR DESCRIPTION
1. Description:

Created a `CacheManager` singleton, that can be used anywhere, with any function (async or not), with any number of parameters.

**Usage**: `await CacheManager.call(getModel, "3ef", {authentication});`

I looked at some memoize functors, but that just seemed overly verbose, and difficult to fold into our existing code style. This approach requires a minor change vs the normal a function call.

**CacheKeys**
The function name is used with the serialized arguments as the cache key, ensuring separation of cache entries across functions which take the same arguments. 

i.e. `getItem("3ef")` and `getItemData("3ef")` have separate cache keys despite having the same arguments

Downside is that it can't work with anonymous functions, and will `throw`. I can't see how that's a problem but comment if you do.

While this can work with non-async functions, `CacheManager.call(...)` *always* returns a Promise. I also don't see this being a big limitation, and could likely be surmounted, but given the chatty nature of our platform, I think this will mostly be used for async functions.

```js
// Normal Call
const itm = getItem("3ef");
// Cached
const itm2 = CacheManager.call(getItem, "3ef");
// subsequent calls to getItem through cache manager will return the same response

// since the cache holds the result of the function (i.e. a Promise) cache hits happen even before
// the first promise resolves. 
// e.g. this code below, will make one call, the other 99 are cache hits
const promises = [];
 for (let index = 0; index < 100; index++) {
    promises.push(CacheManager.call(getServiceInfoById, "3ef");
  }
await Promise.all(promises);
```

1. Instructions for testing:

Run Tests

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
