### PR TITLE
feat(hub-common): add viewDefinition and recordCount to fetchContent(…

### DIFF
--- a/packages/common/src/content/_fetch.ts
+++ b/packages/common/src/content/_fetch.ts
@@ -1,8 +1,12 @@
 import { IItem } from "@esri/arcgis-rest-portal";
-import { BBox } from "..";
-import { ItemOrServerEnrichment } from "../items/_enrichments";
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { IHubContent } from "../core";
+import {
+  fetchItemEnrichments,
+  ItemOrServerEnrichment,
+} from "../items/_enrichments";
 import { hubApiRequest } from "../request";
-import { IHubRequestOptions, IHubGeography } from "../types";
+import { BBox, IHubRequestOptions, IHubGeography } from "../types";
 import { isMapOrFeatureServerUrl } from "../urls";
 import { cloneObject } from "../util";
 import { includes } from "../utils";

--- a/packages/common/src/content/_fetch.ts
+++ b/packages/common/src/content/_fetch.ts
@@ -1,10 +1,5 @@
 import { IItem } from "@esri/arcgis-rest-portal";
-import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IHubContent } from "../core";
-import {
-  fetchItemEnrichments,
-  ItemOrServerEnrichment,
-} from "../items/_enrichments";
+import { ItemOrServerEnrichment } from "../items/_enrichments";
 import { hubApiRequest } from "../request";
 import { BBox, IHubRequestOptions, IHubGeography } from "../types";
 import { isMapOrFeatureServerUrl } from "../urls";

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -784,15 +784,15 @@ export const composeContent = (
       );
     },
     get viewDefinition() {
-      return layer &&
+      // if this is a layer view and we have the item data
+      // find the definition that corresponds to the current layer
+      const dataLayer =
+        layer &&
         isLayerView(layer) &&
         data &&
-        data.layers &&
-        data.layers.length > 0
-        ? // NOTE: I copied over this logic that
-          // _always_ uses the first layer from composer.js
-          data.layers[0].layerDefinition
-        : undefined;
+        Array.isArray(data.layers) &&
+        data.layers.find((_layer) => _layer.id === layer.id);
+      return dataLayer ? dataLayer.layerDefinition : undefined;
     },
     get orgId() {
       // NOTE: it's undocumented, but the portal API will return orgId for items... sometimes

--- a/packages/common/src/content/fetch.ts
+++ b/packages/common/src/content/fetch.ts
@@ -38,7 +38,11 @@ const maybeFetchLayerEnrichments = async (
   // TODO: add recordCount here too?
   const layerEnrichments =
     layer && isLayerView(layer) && !data
-      ? await fetchItemEnrichments(item, ["data"], options)
+      ? // NOTE: I'm not sure what conditions causes a layer view
+        // to store (at least part of) it's view definition in item data
+        // it seems that most do not, but until we have a reliable signal
+        // we just fetch the item data for all layer views
+        await fetchItemEnrichments(item, ["data"], options)
       : undefined;
   // TODO: merge errors
   return { ...itemAndEnrichments, ...layerEnrichments };

--- a/packages/common/src/core/types/IHubContent.ts
+++ b/packages/common/src/core/types/IHubContent.ts
@@ -114,6 +114,11 @@ export interface IHubContent
   /** links to additional resources specified in the formal item metadata */
   additionalResources?: IHubAdditionalResource[];
 
+  /** definition for content that refers to a client-side layer view */
+  viewDefinition?: { definitionExpression?: string };
+
+  // TODO: metrics, urls, publisher, etc?
+
   ///////////
   // TODO: remove these deprecated props at the next breaking version
   //////////
@@ -126,6 +131,4 @@ export interface IHubContent
 
   /* DEPRECATED: use org.id instead */
   orgId?: string;
-
-  // TODO: metrics, urls, publisher, etc?
 }

--- a/packages/common/test/content/fetch.test.ts
+++ b/packages/common/test/content/fetch.test.ts
@@ -208,6 +208,7 @@ describe("fetchContent", () => {
         expect(result.recordCount).toBe(count);
       });
       it("should fetch view definition for client-side layer views", async () => {
+        const layerId = 2;
         // NOTE: testing edge case here by pretending that
         // this layer view ends up filtering out all records
         const definitionExpression = "1=2";
@@ -216,6 +217,7 @@ describe("fetchContent", () => {
         const data = {
           layers: [
             {
+              id: layerId,
               layerDefinition: {
                 definitionExpression,
               },
@@ -224,11 +226,10 @@ describe("fetchContent", () => {
         };
         // expected layer
         itemEnrichments.layers.push({
-          id: 2,
+          id: layerId,
           isView: true,
           name: "layerView",
         } as any);
-        const layerId = 2;
         // the hub API enrichments that we expect for the above layer
         // see: https://hubqa.arcgis.com/api/v3/datasets/eda6e08848924887b00a67ca319ec1bf_2?fields[datasets]=slug,boundary,statistics
         const layerHubEnrichments = {


### PR DESCRIPTION
…) response

affects: @esri/hub-common

1. Description:

fetchContent now fetches the definition for client-side layer views
and fetches the record count for
layers, tables, and proxied CSVs

1. Instructions for testing:

1. Closes Issues:

#322 (essentially)

There are additional top-level aliases we could add like `geometryType`, `capabilities`, `objectIdField`, however, we've decided for now to update the client-code instead to get those from `layer` or `server`.

1. [x] ran commit script (`npm run c`)
