### PR TITLE
fix(hub-common): strip _ from content name and title; content.layer i…

### DIFF
--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -36,8 +36,8 @@ import { getFamily } from "./get-family";
 
 // helper fns - move this to _internal if needed elsewhere
 const getOnlyQueryLayer = (layers: ILayerDefinition[]) => {
-  const layer = layers && layers.length === 1 && layers[0];
-  return layer && layer.capabilities.includes("Query") && layer;
+  const layer = layers && layers.length === 1 ? layers[0] : undefined;
+  return layer && layer.capabilities.includes("Query") ? layer : undefined;
 };
 
 const shouldUseLayerInfo = (
@@ -52,6 +52,18 @@ const shouldUseLayerInfo = (
     // we use item info instead of layer info for single layer items
     !getLayerIdFromUrl(url)
   );
+};
+
+// this logic adapted from hub-indexer's determineName(), see
+// https://github.com/ArcGIS/hub-indexer/blob/8f4dd6f928124c1f35dd02bc11bd996191ee1160/packages/duke/compose/common.js#L7-L34
+const getContentName = (
+  item: IItem,
+  layer?: Partial<ILayerDefinition>,
+  _shouldUseLayerInfo = false
+) => {
+  return (
+    (_shouldUseLayerInfo ? layer.name : item.title || item.name) || ""
+  ).replace(/_/g, " ");
 };
 
 /**
@@ -583,7 +595,7 @@ export const composeContent = (
   const identifier = slug || hubId || item.id;
   // whether or not we should show layer info for name, description, etc
   const _shouldUseLayerInfo = shouldUseLayerInfo(layer, layers, item.url);
-  const name = _shouldUseLayerInfo ? layer.name : item.title;
+  const name = getContentName(item, layer, _shouldUseLayerInfo);
   const _layerDescription = _shouldUseLayerInfo && layer.description;
   // so much depends on type
   const type = layer

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -59,10 +59,12 @@ const shouldUseLayerInfo = (
 const getContentName = (
   item: IItem,
   layer?: Partial<ILayerDefinition>,
-  _shouldUseLayerInfo = false
+  layers?: Array<Partial<ILayerDefinition>>
 ) => {
   return (
-    (_shouldUseLayerInfo ? layer.name : item.title || item.name) || ""
+    (shouldUseLayerInfo(layer, layers, item.url)
+      ? layer.name
+      : item.title || item.name) || ""
   ).replace(/_/g, " ");
 };
 
@@ -594,9 +596,9 @@ export const composeContent = (
     : undefined;
   const identifier = slug || hubId || item.id;
   // whether or not we should show layer info for name, description, etc
-  const _shouldUseLayerInfo = shouldUseLayerInfo(layer, layers, item.url);
-  const name = getContentName(item, layer, _shouldUseLayerInfo);
-  const _layerDescription = _shouldUseLayerInfo && layer.description;
+  const name = getContentName(item, layer, layers);
+  const _layerDescription =
+    shouldUseLayerInfo(layer, layers, item.url) && layer.description;
   // so much depends on type
   const type = layer
     ? // use layer type (Feature Layer, Table, etc) for layer content

--- a/packages/common/test/compose.test.ts
+++ b/packages/common/test/compose.test.ts
@@ -332,21 +332,21 @@ describe("composeContent", () => {
     const layers = [
       {
         id: 0,
-        name: "layer0",
+        name: "layer_0",
         type: "Feature Layer",
         description: "Layer description",
         capabilities: "Query",
       },
       {
         id: 1,
-        name: "layer1",
+        name: "layer_1",
         type: "Feature Layer",
         description: "",
         capabilities: "Query",
       },
       {
         id: 2,
-        name: "table2",
+        name: "table_2",
         type: "Table",
         description: "",
         capabilities: "Query",
@@ -364,7 +364,7 @@ describe("composeContent", () => {
       expect(layerContent.hubId).toBeUndefined("should not set hubId");
       expect(layerContent.type).toBe(layer.type, "should set type");
       expect(layerContent.family).toBe("dataset", "should set family");
-      expect(layerContent.title).toEqual(layer.name, "should set title");
+      expect(layerContent.title).toEqual("layer 0", "should set title");
       expect(layerContent.description).toEqual(
         layer.description,
         "should set description"
@@ -382,7 +382,7 @@ describe("composeContent", () => {
       layerContent = composeContent(item, { layerId, layers });
       layer = layers[1];
       expect(layerContent.layer).toEqual(layer, "should set layer");
-      expect(layerContent.title).toEqual(layer.name, "should set title");
+      expect(layerContent.title).toEqual("layer 1", "should set title");
       expect(layerContent.description).toEqual(
         item.description,
         "should set description"
@@ -392,6 +392,17 @@ describe("composeContent", () => {
         `${item.url}/${layerId}`,
         "should set url"
       );
+    });
+    it("public, multi-layer feature service w/o layerId", () => {
+      const layerContent = composeContent(item, { layers });
+      expect(layerContent.layer).toBeUndefined();
+      expect(layerContent.hubId).toBe(item.id);
+      expect(layerContent.type).toBe(item.type);
+      expect(layerContent.family).toBe("map");
+      expect(layerContent.url).toEqual(item.url);
+      expect(layerContent.title).toEqual(item.title);
+      expect(layerContent.description).toEqual(item.description);
+      expect(layerContent.summary).toEqual(item.snippet);
     });
     it("public, single-layer feature service w/o layerId", () => {
       const layer = layers[0];


### PR DESCRIPTION
…s never false

affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)
