### PR TITLE
fix(hub-search): fix not chunking countFields

### DIFF
--- a/packages/search/src/ago/get-items.ts
+++ b/packages/search/src/ago/get-items.ts
@@ -20,13 +20,16 @@ export async function getItems(
       MAX_COUNTFIELDS
     ).map((fieldArrayChunk) => fieldArrayChunk.join(","));
     const promises = chunkedCountFields.map((chunk) => {
+      const countFields = chunk;
       return searchItems({
         ...agoParams,
         params: {
+          // NOTE: we shouldn't need this since we pass in authentication below
           token,
-          countFields: chunk,
+          countFields,
           countSize: agoParams.countSize,
         },
+        countFields,
         portal,
         authentication,
         httpMethod: "POST",
@@ -55,9 +58,8 @@ export async function getItems(
     return searchItems({
       ...agoParams,
       params: {
+        // NOTE: we shouldn't need this since we pass in authentication below
         token,
-        countFields: agoParams.countFields,
-        countSize: agoParams.countSize,
       },
       portal,
       httpMethod: "POST",

--- a/packages/search/test/ago/get-items.test.ts
+++ b/packages/search/test/ago/get-items.test.ts
@@ -41,7 +41,7 @@ describe("getItems test", () => {
       q: "long ago query",
       start: 1,
       num: 10,
-      params: { token, countFields: undefined, countSize: undefined },
+      params: { token },
       portal,
       httpMethod: "POST",
       authentication: undefined,
@@ -184,7 +184,7 @@ describe("getItems test", () => {
         portal,
         httpMethod: "POST",
         authentication: undefined,
-        countFields: "a,b,c,d,e,f,g",
+        countFields: "a,b,c",
         countSize: 10,
       },
     ];
@@ -200,7 +200,7 @@ describe("getItems test", () => {
         portal,
         httpMethod: "POST",
         authentication: undefined,
-        countFields: "a,b,c,d,e,f,g",
+        countFields: "d,e,f",
         countSize: 10,
       },
     ];
@@ -216,7 +216,7 @@ describe("getItems test", () => {
         portal,
         httpMethod: "POST",
         authentication: undefined,
-        countFields: "a,b,c,d,e,f,g",
+        countFields: "g",
         countSize: 10,
       },
     ];
@@ -298,7 +298,7 @@ describe("getItems test", () => {
         portal,
         httpMethod: "POST",
         authentication: undefined,
-        countFields: "a,b,c,d",
+        countFields: "a,b,c",
         countSize: 10,
       },
     ];
@@ -314,7 +314,7 @@ describe("getItems test", () => {
         portal,
         httpMethod: "POST",
         authentication: undefined,
-        countFields: "a,b,c,d",
+        countFields: "d",
         countSize: 10,
       },
     ];


### PR DESCRIPTION
affects: @esri/hub-search

1. Description:

top level countFields had all (unchunked) countFields
and overrides params.countFields

1. Instructions for testing:

1. Closes Issues: [#3258](https://devtopia.esri.com/dc/hub/issues/3258)

1. [x] ran commit script (`npm run c`)

