### PR TITLE
fix(hub-common): only fetch record count for feature layers and tables (e.g. not raster layers)

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -22,13 +22,15 @@
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.14.0 || 3",
-    "@esri/arcgis-rest-portal": "^2.15.0 || 3",
+    "@esri/arcgis-rest-feature-layer": "^3.2.0",
+    "@esri/arcgis-rest-portal": "^2.18.0 || 3",
     "@esri/arcgis-rest-request": "^2.14.0 || 3",
     "@esri/arcgis-rest-types": "^2.15.0 || 3"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
-    "@esri/arcgis-rest-portal": "^3.4.2",
+    "@esri/arcgis-rest-feature-layer": "^3.4.3",
+    "@esri/arcgis-rest-portal": "^3.4.3",
     "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/arcgis-rest-types": "^3.1.1",
     "@rollup/plugin-commonjs": "^15.0.0",

--- a/packages/common/src/content/fetch.ts
+++ b/packages/common/src/content/fetch.ts
@@ -126,14 +126,19 @@ const fetchContentBySlug = async (
       options
     );
   }
-  const { slug, boundary, extent, searchDescription, statistics } =
-    hubEnrichments;
+  // Note that we are not extracting the slug for the specified layer.
+  // It seems that the old client composer code always populated the slug
+  // field with the slug that was passed into the function (typically the
+  // slug of the parent service). To maintain parity, we do the same here.
+  //
+  // TODO: should we prefer the slug of the fetched layer instead?
+  const { boundary, extent, searchDescription, statistics } = hubEnrichments;
   // return a new content object composed from the item and enrichments we fetched
   return composeContent(item, {
     requestOptions: options,
     ...itemEnrichments,
     layerId,
-    slug,
+    slug: fullyQualifiedSlug,
     boundary,
     extent,
     searchDescription,
@@ -174,9 +179,14 @@ export const fetchContent = async (
         options
       )
     : await fetchContentById(identifier, options);
-  // fetch record count for layers, tables, or proxied CSVs
-  const { isProxied, layer } = content;
+  // fetch record count for content that has features (e.g. layers, tables, or proxied CSVs)
+  const { layer, type } = content;
   content.recordCount =
-    isProxied || !!layer ? await fetchContentRecordCount(content) : undefined;
+    !!layer && hasFeatures(type)
+      ? await fetchContentRecordCount(content)
+      : undefined;
   return content;
 };
+
+const hasFeatures = (contentType: string) =>
+  ["Feature Layer", "Table"].includes(contentType);

--- a/packages/common/src/content/fetch.ts
+++ b/packages/common/src/content/fetch.ts
@@ -18,6 +18,9 @@ import {
 import { canUseHubApiForItem } from "./_internal";
 import { composeContent, getItemLayer, isLayerView } from "./compose";
 
+const hasFeatures = (contentType: string) =>
+  ["Feature Layer", "Table"].includes(contentType);
+
 interface IFetchItemAndEnrichmentsOptions extends IHubRequestOptions {
   enrichments?: ItemOrServerEnrichment[];
 }
@@ -187,6 +190,3 @@ export const fetchContent = async (
       : undefined;
   return content;
 };
-
-const hasFeatures = (contentType: string) =>
-  ["Feature Layer", "Table"].includes(contentType);

--- a/packages/common/test/content/fetch.test.ts
+++ b/packages/common/test/content/fetch.test.ts
@@ -15,8 +15,16 @@ import * as multiLayerFeatureServiceItem from "../mocks/items/multi-layer-featur
 
 // mock the item enrichments that would be returned for a multi-layer service
 const getMultiLayerItemEnrichments = () => {
-  const layer = { id: 0, name: "layer0 " };
-  const table = { id: 1, name: "table1 " };
+  const layer = {
+    id: 0,
+    type: "Feature Layer" as "Feature Layer" | "Table", // casting needed by compiler
+    name: "layer0 ",
+  };
+  const table = {
+    id: 1,
+    type: "Table" as "Feature Layer" | "Table", // casting needed by compiler
+    name: "table1 ",
+  };
   const item = multiLayerFeatureServiceItem as unknown as portalModule.IItem;
   return {
     item,
@@ -200,7 +208,8 @@ describe("fetchContent", () => {
         expect(result.item).toEqual(
           multiLayerFeatureServiceItem as unknown as portalModule.IItem
         );
-        expect(result.slug).toBe(layerHubEnrichments.slug);
+        // Default to slug that was passed in, not the slug of the fetched layer
+        expect(result.slug).toBe(slug);
         // expect(result.boundary).toEqual(layerHubEnrichments.boundary)
         expect(result.boundary).toBe(layerHubEnrichments.boundary);
         expect(result.boundary).not.toBe(hubEnrichments.boundary);
@@ -227,6 +236,7 @@ describe("fetchContent", () => {
         // expected layer
         itemEnrichments.layers.push({
           id: layerId,
+          type: "Feature Layer",
           isView: true,
           name: "layerView",
         } as any);


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Part of [2866](https://devtopia.esri.com/dc/hub/issues/2866)
Also fixes a parity issue where slugs passed in to fetch content were not respected (i.e. the slug of the specified layer was populated instead).

1. [x] ran commit script (`npm run c`)
