### PR TITLE
fix(hub-common): use accordionClosed instead of accordionOpen

### DIFF
--- a/packages/common/src/search/types.ts
+++ b/packages/common/src/search/types.ts
@@ -179,8 +179,8 @@ export interface IFacet {
   // if dynamic the code must construct these
   // from the API response
   options?: IFacetOption[];
-  // whether to keep the accordion open
-  accordionOpen?: boolean;
+  // whether to keep the accordion closed
+  accordionClosed?: boolean;
   // number of facet options to show
   pageSize?: number;
 }


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Fix for https://github.com/Esri/hub.js/pull/750

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
