### PR TITLE
fix(hub-common): fetchContentRecordCount did not pass auth nor handle…

### DIFF
--- a/packages/common/test/content/fetch.test.ts
+++ b/packages/common/test/content/fetch.test.ts
@@ -494,10 +494,12 @@ describe("fetchContent", () => {
             "fetchItemEnrichments"
           ).and.returnValue(Promise.resolve(itemEnrichments));
           const count = 1000;
+          // NOTE: for coverage sake we're going to emulate
+          // that the feature service is down and doesn't return record count
           const queryFeaturesSpy = spyOn(
             featureLayerModule,
             "queryFeatures"
-          ).and.returnValue(Promise.resolve({ count }));
+          ).and.returnValue(Promise.reject());
           // call fetch content
           const options = {
             ...requestOpts,
@@ -525,7 +527,7 @@ describe("fetchContent", () => {
           // expect(result.boundary).toEqual({ geometry: undefined, provenance: undefined })
           expect(result.statistics).toBeUndefined();
           expect(result.layer.id).toBe(layerId);
-          expect(result.recordCount).toEqual(count);
+          expect(result.recordCount).toEqual(Infinity);
         });
       });
     });

--- a/packages/common/test/content/fetch.test.ts
+++ b/packages/common/test/content/fetch.test.ts
@@ -306,6 +306,7 @@ describe("fetchContent", () => {
         expect(queryFeaturesArg.url).toEqual(result.url);
         expect(queryFeaturesArg.returnCountOnly).toBeTruthy();
         expect(queryFeaturesArg.where).toBe(definitionExpression);
+        expect(queryFeaturesArg.portal).toBe(requestOpts.portal);
         // inspect the results
         expect(result.item).toEqual(
           multiLayerFeatureServiceItem as unknown as portalModule.IItem
@@ -493,7 +494,6 @@ describe("fetchContent", () => {
             _enrichmentsModule,
             "fetchItemEnrichments"
           ).and.returnValue(Promise.resolve(itemEnrichments));
-          const count = 1000;
           // NOTE: for coverage sake we're going to emulate
           // that the feature service is down and doesn't return record count
           const queryFeaturesSpy = spyOn(
@@ -520,6 +520,7 @@ describe("fetchContent", () => {
           expect(queryFeaturesArg.url).toEqual(result.url);
           expect(queryFeaturesArg.returnCountOnly).toBeTruthy();
           expect(queryFeaturesArg.where).toBeUndefined();
+          expect(queryFeaturesArg.portal).toBe(requestOpts.portal);
           // inspect the results
           expect(result.item).toEqual(
             multiLayerFeatureServiceItem as portalModule.IItem


### PR DESCRIPTION
… errors

affects: @esri/hub-common

1. Description:

Pass authentication and other request options when fetching record count. Also implement existing error handling logic from composer (i.e. return infinity)

1. Instructions for testing:

1. Closes Issues: n/a

1. [x] ran commit script (`npm run c`)
