### PR TITLE
fix(hub-common): fixed searchProjects to pass provided api

### DIFF
--- a/packages/common/src/projects/HubProjects.ts
+++ b/packages/common/src/projects/HubProjects.ts
@@ -1,4 +1,8 @@
-import { IUserRequestOptions, UserSession } from "@esri/arcgis-rest-auth";
+import {
+  ApiKey,
+  IUserRequestOptions,
+  UserSession,
+} from "@esri/arcgis-rest-auth";
 
 // Note - we separate these imports so we can cleanly spy on things in tests
 import {
@@ -33,6 +37,7 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 
 import { IPropertyMap, PropertyMapper } from "../core/helpers/PropertyMapper";
 import { IHubProject } from "../core/types";
+import { expandApi } from "../search";
 
 export const HUB_PROJECT_ITEM_TYPE = "Hub Project";
 
@@ -290,6 +295,12 @@ export async function searchProjects(
       so[prop as keyof ISearchOptions] = options[prop];
     }
   });
+
+  // Add ArcGIS API
+  if (options.api) {
+    const expandedApi = expandApi(options.api);
+    so.portal = expandedApi.url;
+  }
 
   return searchPortalProjects(so);
 }

--- a/packages/common/test/projects/HubProjects.test.ts
+++ b/packages/common/test/projects/HubProjects.test.ts
@@ -17,6 +17,7 @@ import * as slugUtils from "../../src/items/slugs";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 
 import { IHubSearchOptions } from "../../dist/types";
+import { UserSession } from "@esri/arcgis-rest-auth";
 
 const GUID = "9b77674e43cf4bbd9ecad5189b3f1fdc";
 const PROJECT_ITEM = {
@@ -225,6 +226,7 @@ describe("HubProjects:", () => {
       expect(modelToUpdate.item.properties.slug).toBe("dcdev-wat-blarg-1");
     });
   });
+
   describe("searchProjects:", () => {
     const fakeResults = {
       total: 1,
@@ -272,6 +274,7 @@ describe("HubProjects:", () => {
         sortField: "title",
         sortOrder: "desc",
         site: { item: {}, data: {} },
+        api: "arcgisQA",
       } as IHubSearchOptions;
       const response = await searchProjects(filter, opts);
       expect(response.results.length).toBe(1);
@@ -285,6 +288,8 @@ describe("HubProjects:", () => {
 
       expect(searchOpts.q).toBe("water");
       expect(searchOpts.filter).toBe(`(typekeywords:"HubProject")`);
+      expect(searchOpts.portal).toEqual("https://qaext.arcgis.com");
+      expect(searchOpts.authentication).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
1. Description:
- While `api` was a valid option in the `searchProjects` signature, it was not being propagated to the underlying search request.

2. Instructions for testing:
- Unit tests to ensure it is propagated

3. Closes Issues: #<number> (if appropriate)

4. [X] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
