### PR TITLE
fix(hub-common): fetchContent() handles & returns non-fatal errors

### DIFF
--- a/packages/common/src/content/_fetch.ts
+++ b/packages/common/src/content/_fetch.ts
@@ -1,6 +1,6 @@
 import { IItem } from "@esri/arcgis-rest-portal";
 import {
-  addEnrichmentError,
+  getEnrichmentErrors,
   ItemOrServerEnrichment,
 } from "../items/_enrichments";
 import { hubApiRequest } from "../request";
@@ -177,6 +177,6 @@ export const fetchHubEnrichmentsById = async (
   } catch (e) {
     // dataset record not found, just log the error
     // b/c we can still look up the item and enrichments by id
-    return { errors: addEnrichmentError(e as Error) };
+    return { errors: getEnrichmentErrors(e as Error) };
   }
 };

--- a/packages/common/src/content/_fetch.ts
+++ b/packages/common/src/content/_fetch.ts
@@ -1,7 +1,15 @@
 import { IItem } from "@esri/arcgis-rest-portal";
-import { ItemOrServerEnrichment } from "../items/_enrichments";
+import {
+  addEnrichmentError,
+  ItemOrServerEnrichment,
+} from "../items/_enrichments";
 import { hubApiRequest } from "../request";
-import { BBox, IHubRequestOptions, IHubGeography } from "../types";
+import {
+  BBox,
+  IHubRequestOptions,
+  IHubGeography,
+  IEnrichmentErrorInfo,
+} from "../types";
 import { isMapOrFeatureServerUrl } from "../urls";
 import { cloneObject } from "../util";
 import { includes } from "../utils";
@@ -55,7 +63,9 @@ export interface IHubExtent {
  * The set of enrichments that we fetch from the Hub API
  */
 export interface IDatasetEnrichments {
-  itemId: string;
+  // TODO: I don't think itemId is used
+  // we should remove it at the next breaking change
+  itemId?: string;
   layerId?: number;
   slug?: string;
   // TODO: move these to a common interface shared w/ IHubContentEnrichments
@@ -83,6 +93,12 @@ export interface IDatasetEnrichments {
    * Pre-computed field statistics (min, max, average, etc)
    */
   statistics?: any;
+
+  /**
+   * Any errors encountered when fetching enrichments
+   * see https://github.com/ArcGIS/hub-indexer/blob/master/docs/errors.md#response-formatting-for-errors
+   */
+  errors?: IEnrichmentErrorInfo[];
 }
 
 // build up request options to only include the above enrichments
@@ -94,6 +110,7 @@ const getHubEnrichmentsOptions = (
   const opts = cloneObject(requestOptions);
   opts.params = {
     ...opts.params,
+    // TODO: we should fetch errors too
     "fields[datasets]": "slug,boundary,extent,searchDescription,statistics",
   };
   if (slug) {
@@ -128,8 +145,11 @@ const getDatasetEnrichments = (dataset: DatasetResource) => {
  */
 export const fetchHubEnrichmentsBySlug = async (
   slug: string,
-  requestOptions: IHubRequestOptions
+  requestOptions?: IHubRequestOptions
 ) => {
+  // NOTE: we don't catch errors here b/c
+  // searching by slug is the first step in fetchContent()
+  // and if this fails, we don't have an id to fall back on
   const response = await hubApiRequest(
     `/datasets`,
     getHubEnrichmentsOptions(requestOptions, slug)
@@ -146,11 +166,17 @@ export const fetchHubEnrichmentsBySlug = async (
  */
 export const fetchHubEnrichmentsById = async (
   hubId: string,
-  requestOptions: IHubRequestOptions
+  requestOptions?: IHubRequestOptions
 ) => {
-  const response = await hubApiRequest(
-    `/datasets/${hubId}`,
-    getHubEnrichmentsOptions(requestOptions)
-  );
-  return getDatasetEnrichments(response.data);
+  try {
+    const response = await hubApiRequest(
+      `/datasets/${hubId}`,
+      getHubEnrichmentsOptions(requestOptions)
+    );
+    return getDatasetEnrichments(response.data);
+  } catch (e) {
+    // dataset record not found, just log the error
+    // b/c we can still look up the item and enrichments by id
+    return { errors: addEnrichmentError(e as Error) };
+  }
 };

--- a/packages/common/src/items/_enrichments.ts
+++ b/packages/common/src/items/_enrichments.ts
@@ -201,7 +201,7 @@ const handleEnrichmentError = (
   return {
     data: {
       ...data,
-      errors: addEnrichmentError(error, data.errors),
+      errors: getEnrichmentErrors(error, data.errors),
     },
     stack,
     requestOptions,
@@ -231,7 +231,7 @@ const enrichmentOperations: IEnrichmentOperations = {
  * @returns a new array of enrichment error info
  * @private
  */
-export const addEnrichmentError = (
+export const getEnrichmentErrors = (
   error: Error | string,
   errors: IEnrichmentErrorInfo[] = []
 ) => {

--- a/packages/common/src/items/_enrichments.ts
+++ b/packages/common/src/items/_enrichments.ts
@@ -9,7 +9,7 @@ import {
   getService,
 } from "@esri/arcgis-rest-feature-layer";
 import { IItemEnrichments, IServerEnrichments } from "../core";
-import { IHubRequestOptions } from "../types";
+import { IEnrichmentErrorInfo, IHubRequestOptions } from "../types";
 import { IPipeable, createOperationPipeline } from "../utils";
 import OperationStack from "../OperationStack";
 // TODO: move these functions here under /items
@@ -198,20 +198,14 @@ const handleEnrichmentError = (
 ): IPipeable<IItemAndEnrichments> => {
   const { data, stack, requestOptions } = input;
   stack.finish(opId, { error });
-  const message =
-    typeof error === "string"
-      ? /* istanbul ignore next our tests only throw Error objects */
-        error
-      : error.message;
-  const errors = data.errors || [];
-  errors.push({
-    // NOTE: for now we just return the message and type "Other"
-    // but we could later introspect for HTTP or AGO errors
-    // and/or return the status code if available
-    type: "Other",
-    message,
-  });
-  return { data: { ...data, errors }, stack, requestOptions };
+  return {
+    data: {
+      ...data,
+      errors: addEnrichmentError(error, data.errors),
+    },
+    stack,
+    requestOptions,
+  };
 };
 
 // map of all enrichment operations
@@ -224,10 +218,38 @@ const enrichmentOperations: IEnrichmentOperations = {
   groupIds: enrichGroupIds,
   metadata: enrichMetadata,
   ownerUser: enrichOwnerUser,
-  // TOOD: org
   data: enrichData,
   server: enrichServer,
   layers: enrichLayers,
+};
+
+/**
+ * convert an error to an enrichment error info format
+ * and optionally append it to an existing array of those
+ * @param error
+ * @param errors an array of existing enrichment error info
+ * @returns a new array of enrichment error info
+ * @private
+ */
+export const addEnrichmentError = (
+  error: Error | string,
+  errors: IEnrichmentErrorInfo[] = []
+) => {
+  const message =
+    typeof error === "string"
+      ? /* istanbul ignore next our tests only throw Error objects */
+        error
+      : error.message;
+  return [
+    ...errors,
+    {
+      // NOTE: for now we just return the message and type "Other"
+      // but we could later introspect for HTTP or AGO errors
+      // and/or return the status code if available
+      type: "Other",
+      message,
+    } as IEnrichmentErrorInfo,
+  ];
 };
 
 /**

--- a/packages/common/src/utils/_array.ts
+++ b/packages/common/src/utils/_array.ts
@@ -4,6 +4,7 @@
  * that are not actually arrays
  * @param arrays An array of arrays
  * @returns concatenated array
+ * @private
  */
 export const maybeConcat = (arrays: any[][]) => {
   const result = [].concat.apply([], arrays.filter(Array.isArray));

--- a/packages/common/src/utils/_array.ts
+++ b/packages/common/src/utils/_array.ts
@@ -1,0 +1,11 @@
+/**
+ * concat an array of arrays
+ * excluding any elements of the top level array
+ * that are not actually arrays
+ * @param arrays An array of arrays
+ * @returns concatenated array
+ */
+export const maybeConcat = (arrays: any[][]) => {
+  const result = [].concat.apply([], arrays.filter(Array.isArray));
+  return result.length ? result : undefined;
+};

--- a/packages/common/test/content/_fetch.test.ts
+++ b/packages/common/test/content/_fetch.test.ts
@@ -95,9 +95,21 @@ describe("_fetch", () => {
         expect(result.slug).toBe(slug);
         expect(result.boundary).toEqual(dataset.attributes.boundary);
         expect(result.statistics).toBeUndefined();
+        expect(result.errors).toBeUndefined();
       });
     });
     describe("by id", () => {
+      it("should handle errors", async () => {
+        fetchMock.mock(`begin:${hubApiUrl}/api/v3/datasets/${id}`, 404);
+        const result = await fetchHubEnrichmentsById(id, requestOpts);
+        // inspect the datasets request for the correct parameters
+        const calls = fetchMock.calls();
+        const [url] = calls[0];
+        expect(calls.length).toBe(1);
+        expect(result).toEqual({
+          errors: [{ type: "Other", message: "Not Found" }],
+        });
+      });
       it("should call the hub API with an id and specific fields", async () => {
         fetchMock.mock(`begin:${hubApiUrl}/api/v3/datasets/${id}`, {
           data: dataset,
@@ -116,6 +128,7 @@ describe("_fetch", () => {
         expect(result.slug).toBe(slug);
         expect(result.boundary).toEqual(dataset.attributes.boundary);
         expect(result.statistics).toBeUndefined();
+        expect(result.errors).toBeUndefined();
       });
       it("should return the layerId", async () => {
         const itemId = "4ef";
@@ -149,6 +162,7 @@ describe("_fetch", () => {
         expect(result.slug).toBe(slug);
         expect(result.boundary).toEqual(layerDataset.attributes.boundary);
         expect(result.statistics).toEqual(layerDataset.attributes.statistics);
+        expect(result.errors).toBeUndefined();
       });
     });
   });

--- a/packages/common/test/utils/_array.test.ts
+++ b/packages/common/test/utils/_array.test.ts
@@ -1,0 +1,19 @@
+import { maybeConcat } from "../../src/utils/_array";
+
+describe("maybeConcat", () => {
+  it("returns undefined when no arrays", () => {
+    const result = maybeConcat([undefined, null]);
+    expect(result).toBeUndefined();
+  });
+  it("returns concatenated array of only array elements", () => {
+    const result = maybeConcat([[1, 2], undefined, [3, 4]]);
+    expect(result).toEqual([1, 2, 3, 4]);
+  });
+  it("returns concatenated array of all elements", () => {
+    const result = maybeConcat([
+      [1, 2],
+      [3, 4],
+    ]);
+    expect(result).toEqual([1, 2, 3, 4]);
+  });
+});


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

errors fetching enrichments form the Hub API were causing `fetchContent()` to fail, but instead we should have been catching them and adding them to `content.errors`, which is what this PR does.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)
