### PR TITLE
fix(hub-common): fix composeContent to prefer layer spatialReference to item spatialReference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2064,7 +2064,6 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.4.3.tgz",
 			"integrity": "sha512-YT44Dmh/3K0ldVNA3T6oyBFmM1UqtPwildTL4v2FU4a33WiRxiGncxGbZ5lmurgy4z+ibFDd6Dp5Ge6W2BjCdQ==",
-			"dev": true,
 			"dependencies": {
 				"@esri/arcgis-rest-types": "^3.4.3",
 				"tslib": "^1.13.0"
@@ -36814,7 +36813,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.24.2",
+			"version": "9.25.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -36848,7 +36847,7 @@
 		},
 		"packages/content": {
 			"name": "@esri/hub-content",
-			"version": "9.24.2",
+			"version": "9.25.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"fast-xml-parser": "~3.2.4",
@@ -36859,7 +36858,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36873,12 +36872,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.0",
 				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.24.2"
+				"@esri/hub-common": "9.25.1"
 			}
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.10.2",
+			"version": "11.11.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -36887,7 +36886,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36901,12 +36900,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.24.2"
+				"@esri/hub-common": "9.25.1"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.24.2",
+			"version": "9.25.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -36917,7 +36916,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36927,12 +36926,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.24.2"
+				"@esri/hub-common": "9.25.1"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.24.2",
+			"version": "9.25.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -36943,7 +36942,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36958,12 +36957,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.24.2"
+				"@esri/hub-common": "9.25.1"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.24.2",
+			"version": "9.25.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -36972,7 +36971,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36986,12 +36985,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.24.2"
+				"@esri/hub-common": "9.25.1"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.24.2",
+			"version": "9.25.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37002,7 +37001,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -37019,12 +37018,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.24.2"
+				"@esri/hub-common": "9.25.1"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.24.2",
+			"version": "9.25.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37033,9 +37032,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
-				"@esri/hub-initiatives": "9.24.2",
-				"@esri/hub-teams": "9.24.2",
+				"@esri/hub-common": "9.25.1",
+				"@esri/hub-initiatives": "9.25.1",
+				"@esri/hub-teams": "9.25.1",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -37049,14 +37048,14 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.24.2",
-				"@esri/hub-initiatives": "9.24.2",
-				"@esri/hub-teams": "9.24.2"
+				"@esri/hub-common": "9.25.1",
+				"@esri/hub-initiatives": "9.25.1",
+				"@esri/hub-teams": "9.25.1"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.24.2",
+			"version": "9.25.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37067,7 +37066,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -37082,12 +37081,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.24.2"
+				"@esri/hub-common": "9.25.1"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.24.2",
+			"version": "9.25.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37097,7 +37096,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -37111,7 +37110,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.24.2"
+				"@esri/hub-common": "9.25.1"
 			}
 		}
 	},
@@ -38516,7 +38515,6 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.4.3.tgz",
 			"integrity": "sha512-YT44Dmh/3K0ldVNA3T6oyBFmM1UqtPwildTL4v2FU4a33WiRxiGncxGbZ5lmurgy4z+ibFDd6Dp5Ge6W2BjCdQ==",
-			"dev": true,
 			"requires": {
 				"@esri/arcgis-rest-types": "^3.4.3",
 				"tslib": "^1.13.0"
@@ -38583,7 +38581,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38601,7 +38599,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38621,7 +38619,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38641,7 +38639,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38658,7 +38656,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38678,7 +38676,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38697,9 +38695,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
-				"@esri/hub-initiatives": "9.24.2",
-				"@esri/hub-teams": "9.24.2",
+				"@esri/hub-common": "9.25.1",
+				"@esri/hub-initiatives": "9.25.1",
+				"@esri/hub-teams": "9.25.1",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -38719,7 +38717,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38737,7 +38735,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.24.2",
+				"@esri/hub-common": "9.25.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -41879,7 +41877,8 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
 			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
 			"version": "2.4.0",
@@ -51831,7 +51830,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
 			"integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"karma-spec-reporter": {
 			"version": "0.0.32",
@@ -62891,7 +62891,8 @@
 					"version": "1.9.1",
 					"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
 					"integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=",
-					"dev": true
+					"dev": true,
+					"requires": {}
 				}
 			}
 		},
@@ -64400,7 +64401,8 @@
 			"version": "8.2.3",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
 			"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"xdg-basedir": {
 			"version": "3.0.0",

--- a/packages/common/src/content/_internal.ts
+++ b/packages/common/src/content/_internal.ts
@@ -292,26 +292,12 @@ export function parseISODateString(isoString: string) {
   return date && precision && { date, precision };
 }
 
-/**
- * Get the spatial reference from layer or server info
- * @param server
- * @param layer
- * @returns
- * @private
- */
-export const getServerSpatialReference = (
-  server: Partial<IFeatureServiceDefinition>,
-  layer?: ILayerDefinition
-) => {
-  const layerSpatialReference = layer?.extent?.spatialReference;
-  return layerSpatialReference || server?.spatialReference;
-};
-
 // NOTE: IItem has spatialRefernce: ISpatialReference, but
 // the portal REST API returns spatialReference as as string
-// that is always either WKID like "102100" or
-// WKT like "NAD_1983_HARN_StatePlane_Hawaii_3_FIPS_5103_Feet"
-// so we coerce those string into a ISpatialReference object
+// that is always either WKID like "102100" or the name of a
+// WKT like "NAD_1983_HARN_StatePlane_Hawaii_3_FIPS_5103_Feet".
+// We only coerce WKIDs into a ISpatialReference objects since we
+// can't easily lookup a complete WKT.
 /**
  * Get the spatial reference as an object for an item
  * @param item
@@ -329,8 +315,9 @@ export const getItemSpatialReference = (item: IItem): ISpatialReference => {
   const spatialReferenceString = spatialReference + "";
   const wkid = parseInt(spatialReferenceString, 10);
   return isNaN(wkid)
-    ? // string is not a number, assume it is WKT
-      { wkt: spatialReferenceString }
+    ? // It looks like the portal api returns the name of a WKT, but we'd
+      // need to perform a lookup to get the full WKT. Return null for now.
+      null
     : //
       { wkid };
 };

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -25,7 +25,6 @@ import {
   getContentBoundary,
   getHubRelativeUrl,
   getItemSpatialReference,
-  getServerSpatialReference,
   getValueFromMetadata,
   getMetadataPath,
   isProxiedCSV,
@@ -792,9 +791,7 @@ export const composeContent = (
       // NOTE: I had to add || null just so packages/content/test/portal.test.ts would pass
       // we can remove that when that package is deprecated
       return (
-        getItemSpatialReference(item) ||
-        getServerSpatialReference(server, layer) ||
-        null
+        layer?.extent?.spatialReference || getItemSpatialReference(item) || null
       );
     },
     get viewDefinition() {

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -31,7 +31,6 @@ import {
   isProxiedCSV,
   setContentBoundary,
   parseISODateString,
-  getServerSpatialReference,
   getItemSpatialReference,
   getAdditionalResources,
   isDataSourceOfItem,
@@ -924,21 +923,13 @@ describe("internal", () => {
     });
   });
 
-  describe("getServerSpatialReference", () => {
-    it("should get it from the server when no layer", () => {
-      const spatialReference = { wkid: 4326 };
-      const result = getServerSpatialReference({ spatialReference });
-      expect(result).toEqual(spatialReference);
-    });
-  });
-
   describe("getItemSpatialReference", () => {
-    it("should handle wkt", () => {
+    it("should handle wkt name", () => {
       const spatialReference =
         "NAD_1983_HARN_StatePlane_Hawaii_3_FIPS_5103_Feet";
       const item = { spatialReference } as unknown as IItem;
       const result = getItemSpatialReference(item);
-      expect(result).toEqual({ wkt: spatialReference });
+      expect(result).toBeNull();
     });
   });
 });

--- a/packages/content/test/hub.test.ts
+++ b/packages/content/test/hub.test.ts
@@ -129,7 +129,8 @@ describe("hub", () => {
         // since we are authed, we will fetch the item and get this stuff from it
         expect(content.contentStatus).toEqual("org_authoritative");
         expect(content.spatialReference).toEqual({
-          wkid: parseInt(itemJson.spatialReference as string, 10),
+          latestWkid: 27700,
+          wkid: 27700,
         });
 
         // TODO: content type specific properties
@@ -206,7 +207,8 @@ describe("hub", () => {
         // since we are authed, we will fetch the item and get this stuff from it
         expect(content.contentStatus).toEqual("org_authoritative");
         expect(content.spatialReference).toEqual({
-          wkid: parseInt(itemJson.spatialReference as string, 10),
+          latestWkid: 27700,
+          wkid: 27700,
         });
 
         // TODO: content type specific properties


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Part of [2866](https://devtopia.esri.com/dc/hub/issues/2866).

It turns out that `item.spatialReference` isn't always a wkid. Sometimes, it is the name of a wkt (but not the full wkt itself). This is problematic since we don't currently have a way in our applications to lookup the full wkt that we would need for geospatial operations.

As such, we decided to give preference to the layer spatial reference, since it is a more predictable source of truth.
We also eliminated referencing the server's spatial reference since we are unsure if different layers can have different spatial references.

1. [x] ran commit script (`npm run c`)