### PR TITLE
B/search description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36813,7 +36813,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.25.1",
+			"version": "9.25.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -36847,7 +36847,7 @@
 		},
 		"packages/content": {
 			"name": "@esri/hub-content",
-			"version": "9.25.1",
+			"version": "9.25.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"fast-xml-parser": "~3.2.4",
@@ -36858,7 +36858,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36872,12 +36872,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.0",
 				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.1"
+				"@esri/hub-common": "9.25.2"
 			}
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.11.1",
+			"version": "11.11.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -36886,7 +36886,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36900,12 +36900,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.25.1"
+				"@esri/hub-common": "9.25.2"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.25.1",
+			"version": "9.25.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -36916,7 +36916,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36926,12 +36926,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.25.1"
+				"@esri/hub-common": "9.25.2"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.25.1",
+			"version": "9.25.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -36942,7 +36942,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36957,12 +36957,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.1"
+				"@esri/hub-common": "9.25.2"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.25.1",
+			"version": "9.25.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -36971,7 +36971,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36985,12 +36985,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.1"
+				"@esri/hub-common": "9.25.2"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.25.1",
+			"version": "9.25.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37001,7 +37001,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -37018,12 +37018,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.1"
+				"@esri/hub-common": "9.25.2"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.25.1",
+			"version": "9.25.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37032,9 +37032,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
-				"@esri/hub-initiatives": "9.25.1",
-				"@esri/hub-teams": "9.25.1",
+				"@esri/hub-common": "9.25.2",
+				"@esri/hub-initiatives": "9.25.2",
+				"@esri/hub-teams": "9.25.2",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -37048,14 +37048,14 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.1",
-				"@esri/hub-initiatives": "9.25.1",
-				"@esri/hub-teams": "9.25.1"
+				"@esri/hub-common": "9.25.2",
+				"@esri/hub-initiatives": "9.25.2",
+				"@esri/hub-teams": "9.25.2"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.25.1",
+			"version": "9.25.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37066,7 +37066,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -37081,12 +37081,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.1"
+				"@esri/hub-common": "9.25.2"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.25.1",
+			"version": "9.25.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37096,7 +37096,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -37110,7 +37110,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.1"
+				"@esri/hub-common": "9.25.2"
 			}
 		}
 	},
@@ -38581,7 +38581,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38599,7 +38599,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38619,7 +38619,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38639,7 +38639,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38656,7 +38656,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38676,7 +38676,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38695,9 +38695,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
-				"@esri/hub-initiatives": "9.25.1",
-				"@esri/hub-teams": "9.25.1",
+				"@esri/hub-common": "9.25.2",
+				"@esri/hub-initiatives": "9.25.2",
+				"@esri/hub-teams": "9.25.2",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -38717,7 +38717,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38735,7 +38735,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.1",
+				"@esri/hub-common": "9.25.2",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -659,7 +659,7 @@ export const composeContent = (
       return name;
     },
     get description() {
-      return searchDescription || _layerDescription || item.description;
+      return _layerDescription || item.description;
     },
     type,
     get family() {
@@ -711,12 +711,13 @@ export const composeContent = (
       return boundary || getContentBoundary(item);
     },
     get summary() {
-      return _layerDescription
-        ? _layerDescription
-        : // TODO: this should use the logic for the Hub API's searchDescription
-          // see: https://github.com/ArcGIS/hub-indexer/blob/b352cfded8221a967ac80447879d493db6476d7a/packages/duke/compose/dataset.js#L238-L250
-          // TODO: can we strip HTML from description, and do we need to trim it to a X chars?
-          item.snippet || item.description;
+      return (
+        searchDescription ||
+        // TODO: this should use the logic for the Hub API's searchDescription
+        // see: https://github.com/ArcGIS/hub-indexer/blob/b352cfded8221a967ac80447879d493db6476d7a/packages/duke/compose/dataset.js#L238-L250
+        item.snippet ||
+        item.description
+      );
     },
     urls,
     get portalHomeUrl() {

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -218,6 +218,9 @@ export function relativeDateToDateRange(
       break;
     case "months":
       // get the current month and subtract num
+      // NOTE: when the previous month has fewer days than this month
+      // setMonth() will return a date w/in the current month
+      // example: 3/30 -> 3/2 b/c there is no 2/28
       now.setMonth(now.getMonth() - relative.num);
       result.from = now.getTime();
       break;

--- a/packages/common/test/compose.test.ts
+++ b/packages/common/test/compose.test.ts
@@ -370,8 +370,8 @@ describe("composeContent", () => {
         "should set description"
       );
       expect(layerContent.summary).toEqual(
-        layer.description,
-        "should set summary"
+        item.snippet,
+        "should not set summary"
       );
       expect(layerContent.url).toEqual(
         `${item.url}/${layerId}`,

--- a/packages/common/test/search/utils.test.ts
+++ b/packages/common/test/search/utils.test.ts
@@ -198,6 +198,7 @@ describe("Search Utils:", () => {
         expect(chk.from).toBeLessThan(chk.to);
       });
       it("converts months", () => {
+        const monthDays = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
         const rd: IRelativeDate = {
           type: "relative-date",
           num: 1,
@@ -206,10 +207,19 @@ describe("Search Utils:", () => {
         const chk = relativeDateToDateRange(rd);
         expect(chk.from).toBeLessThan(chk.to);
         const m = new Date(chk.from).getMonth();
-        const curMonth = new Date().getMonth();
+        const now = new Date();
+        const curMonth = now.getMonth();
         // Account for January/December
         if (curMonth > 0) {
-          expect(m).toBeLessThan(curMonth);
+          const prevMonthDays = monthDays[curMonth - 1];
+          const curDay = now.getDate();
+          if (curDay > prevMonthDays) {
+            // see NOTE in relativeDateToDateRange() about why this is
+            // should probably also expect that chk.to - prevMonthDays > chk.from
+            expect(m).toBe(curMonth);
+          } else {
+            expect(m).toBeLessThan(curMonth);
+          }
         } else {
           expect(m).toBe(11);
         }

--- a/packages/content/src/enrichments.ts
+++ b/packages/content/src/enrichments.ts
@@ -601,6 +601,8 @@ export const enrichContent = (
         recordCount,
         boundary,
         statistics,
+        // summary will have searchDescription if coming from getContentFromHub()
+        summary,
       } = fetched;
       // org enrichment is not yet implemented
       const org = orgId && { id: orgId };
@@ -618,6 +620,7 @@ export const enrichContent = (
         boundary,
         statistics,
         requestOptions,
+        searchDescription: summary,
       });
     }
   );

--- a/packages/content/test/hub.test.ts
+++ b/packages/content/test/hub.test.ts
@@ -49,9 +49,7 @@ function validateContentFromDataset(
   const { itemExtent, extent } = attributes;
   expect(content.extent).toEqual(itemExtent || (extent && extent.coordinates));
   expect(content.family).toBe(expectedFamily);
-  expect(content.summary).toBe(
-    /* attributes.searchDescription || */ attributes.snippet
-  );
+  expect(content.summary).toBe(attributes.searchDescription);
   expect(content.publisher).toEqual({
     name: attributes.owner,
     username: attributes.owner,


### PR DESCRIPTION
1. Description:

use searchDescription for content.summary, not content.description

also fixes tests for relativeDateToDateRange() that would only fail at the end of months that are longer than the previous month. Not sure if we consider the underlying logic a bug, but wasn't sure what logic we want. For example: what should be the from date of the range that represents the previous 1 month form 3/30? There is no 2/30. So I kept the existing logic under the assumption that if it's good enough for `Date.setDate()` it's good enough for us, and just updated the test expectations.

1. Instructions for testing:

1. Closes Issues: [3507](https://devtopia.esri.com/dc/hub/issues/3507)

1. [x] ran commit script (`npm run c`)
