### PR TITLE
fix(hub-common): defaults q param of fetchItemsBySlug to be slug and adds portal

### DIFF
--- a/packages/common/src/items/slugs.ts
+++ b/packages/common/src/items/slugs.ts
@@ -79,9 +79,6 @@ export function findItemsBySlug(
   requestOptions: IRequestOptions
 ): Promise<IItem[]> {
   const opts = {
-    // Necessary because underlying searchItems does not yet pass the filter
-    // TODO - remove "q" when searchItems passes filter
-    q: `typekeywords:"slug|${slugInfo.slug}"`,
     filter: `typekeywords:"slug|${slugInfo.slug}"`,
   } as ISearchOptions;
 

--- a/packages/common/src/items/slugs.ts
+++ b/packages/common/src/items/slugs.ts
@@ -1,4 +1,4 @@
-import { searchItems } from "@esri/arcgis-rest-portal";
+import { ISearchOptions, searchItems } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IItem } from "@esri/arcgis-rest-types";
 import { slugify } from "..";
@@ -79,10 +79,18 @@ export function findItemsBySlug(
   requestOptions: IRequestOptions
 ): Promise<IItem[]> {
   const opts = {
-    q: "",
+    // Necessary because underlying searchItems does not yet pass the filter
+    // TODO - remove "q" when searchItems passes filter
+    q: `typekeywords:"slug|${slugInfo.slug}"`,
     filter: `typekeywords:"slug|${slugInfo.slug}"`,
-    authentication: requestOptions.authentication,
-  };
+  } as ISearchOptions;
+
+  if (requestOptions.authentication) {
+    opts.authentication = requestOptions.authentication;
+  } else if (requestOptions.portal) {
+    opts.portal = requestOptions.portal;
+  }
+
   // We need to check for other items w/ a slug during
   // the update calls. For those scenarios we are interested
   // in any _other_ items which may have a specific slug
@@ -95,7 +103,7 @@ export function findItemsBySlug(
       return response.results;
     })
     .catch((e) => {
-      throw Error(`Error in getItemBySlug ${e}`);
+      throw e;
     });
 }
 

--- a/packages/common/src/projects/HubProjects.ts
+++ b/packages/common/src/projects/HubProjects.ts
@@ -214,6 +214,7 @@ export function fetchProject(
     getPrms = getItemBySlug(identifier, requestOptions);
   }
   return getPrms.then((item) => {
+    if (!item) return null;
     return convertItemToProject(item, requestOptions);
   });
 }

--- a/packages/common/test/items/slugs.test.ts
+++ b/packages/common/test/items/slugs.test.ts
@@ -155,6 +155,26 @@ describe("slug utils: ", () => {
       expect(args.portal).toBe("mock-portal");
     });
 
+    it("handles when neither portal nor auth are provided", async () => {
+      const searchSpy = spyOn(portalModule, "searchItems").and.returnValue(
+        Promise.resolve({
+          results: [
+            { id: "3ef", title: "Fake", typeKeywords: ["one", "slug|foo-bar"] },
+          ],
+        })
+      );
+
+      const results = await slugModule.findItemsBySlug({ slug: "foo-bar" }, {});
+      expect(results[0].id).toBe("3ef");
+      // check if
+      expect(searchSpy.calls.count()).toBe(1);
+      const args = searchSpy.calls.argsFor(0)[0] as unknown as ISearchOptions;
+      expect(args.filter).toBe(`typekeywords:"slug|foo-bar"`);
+      expect(args.q).toBe(`typekeywords:"slug|foo-bar"`);
+      expect(args.authentication).toBe(undefined);
+      expect(args.portal).toBe(undefined);
+    });
+
     it("can re-throw original error", async () => {
       const searchSpy = spyOn(portalModule, "searchItems").and.throwError(
         "Error occurred"

--- a/packages/common/test/items/slugs.test.ts
+++ b/packages/common/test/items/slugs.test.ts
@@ -106,7 +106,7 @@ describe("slug utils: ", () => {
       expect(args.authentication).toBe(MOCK_AUTH);
     });
 
-    it("passes a q query when no exclusion is provided", async () => {
+    it("passes an undefined q query when no exclusion is provided", async () => {
       const searchSpy = spyOn(portalModule, "searchItems").and.returnValue(
         Promise.resolve({
           results: [
@@ -126,7 +126,7 @@ describe("slug utils: ", () => {
       expect(searchSpy.calls.count()).toBe(1);
       const args = searchSpy.calls.argsFor(0)[0] as unknown as ISearchOptions;
       expect(args.filter).toBe(`typekeywords:"slug|foo-bar"`);
-      expect(args.q).toBe(`typekeywords:"slug|foo-bar"`);
+      expect(args.q).toBe(undefined);
       expect(args.authentication).toBe(MOCK_AUTH);
     });
 
@@ -150,7 +150,6 @@ describe("slug utils: ", () => {
       expect(searchSpy.calls.count()).toBe(1);
       const args = searchSpy.calls.argsFor(0)[0] as unknown as ISearchOptions;
       expect(args.filter).toBe(`typekeywords:"slug|foo-bar"`);
-      expect(args.q).toBe(`typekeywords:"slug|foo-bar"`);
       expect(args.authentication).toBe(undefined);
       expect(args.portal).toBe("mock-portal");
     });
@@ -170,7 +169,6 @@ describe("slug utils: ", () => {
       expect(searchSpy.calls.count()).toBe(1);
       const args = searchSpy.calls.argsFor(0)[0] as unknown as ISearchOptions;
       expect(args.filter).toBe(`typekeywords:"slug|foo-bar"`);
-      expect(args.q).toBe(`typekeywords:"slug|foo-bar"`);
       expect(args.authentication).toBe(undefined);
       expect(args.portal).toBe(undefined);
     });

--- a/packages/common/test/items/slugs.test.ts
+++ b/packages/common/test/items/slugs.test.ts
@@ -66,7 +66,7 @@ describe("slug utils: ", () => {
     });
     it("throws lower level errors", async () => {
       const searchSpy = spyOn(portalModule, "searchItems").and.returnValue(
-        Promise.reject()
+        Promise.reject(new Error("An error occurred"))
       );
 
       try {
@@ -75,6 +75,7 @@ describe("slug utils: ", () => {
         });
       } catch (ex) {
         expect(ex).toBeDefined();
+        expect(ex.message).toBe("An error occurred");
         expect(searchSpy.calls.count()).toBe(1);
       }
     });
@@ -103,6 +104,75 @@ describe("slug utils: ", () => {
       expect(args.filter).toBe(`typekeywords:"slug|foo-bar"`);
       expect(args.q).toBe(`NOT id:bc3`);
       expect(args.authentication).toBe(MOCK_AUTH);
+    });
+
+    it("passes a q query when no exclusion is provided", async () => {
+      const searchSpy = spyOn(portalModule, "searchItems").and.returnValue(
+        Promise.resolve({
+          results: [
+            { id: "3ef", title: "Fake", typeKeywords: ["one", "slug|foo-bar"] },
+          ],
+        })
+      );
+
+      const results = await slugModule.findItemsBySlug(
+        { slug: "foo-bar" },
+        {
+          authentication: MOCK_AUTH,
+        }
+      );
+      expect(results[0].id).toBe("3ef");
+      // check if
+      expect(searchSpy.calls.count()).toBe(1);
+      const args = searchSpy.calls.argsFor(0)[0] as unknown as ISearchOptions;
+      expect(args.filter).toBe(`typekeywords:"slug|foo-bar"`);
+      expect(args.q).toBe(`typekeywords:"slug|foo-bar"`);
+      expect(args.authentication).toBe(MOCK_AUTH);
+    });
+
+    it("passes a portal url when no auth is provided", async () => {
+      const searchSpy = spyOn(portalModule, "searchItems").and.returnValue(
+        Promise.resolve({
+          results: [
+            { id: "3ef", title: "Fake", typeKeywords: ["one", "slug|foo-bar"] },
+          ],
+        })
+      );
+
+      const results = await slugModule.findItemsBySlug(
+        { slug: "foo-bar" },
+        {
+          portal: "mock-portal",
+        }
+      );
+      expect(results[0].id).toBe("3ef");
+      // check if
+      expect(searchSpy.calls.count()).toBe(1);
+      const args = searchSpy.calls.argsFor(0)[0] as unknown as ISearchOptions;
+      expect(args.filter).toBe(`typekeywords:"slug|foo-bar"`);
+      expect(args.q).toBe(`typekeywords:"slug|foo-bar"`);
+      expect(args.authentication).toBe(undefined);
+      expect(args.portal).toBe("mock-portal");
+    });
+
+    it("can re-throw original error", async () => {
+      const searchSpy = spyOn(portalModule, "searchItems").and.throwError(
+        "Error occurred"
+      );
+
+      try {
+        await slugModule.findItemsBySlug(
+          { slug: "foo-bar" },
+          {
+            portal: "mock-portal",
+          }
+        );
+        // Never reach here
+        expect(true).toBe(false);
+      } catch (err) {
+        expect(err).toBeDefined();
+        expect(err.message).toBe("Error occurred");
+      }
     });
   });
 

--- a/packages/common/test/projects/HubProjects.test.ts
+++ b/packages/common/test/projects/HubProjects.test.ts
@@ -107,6 +107,20 @@ describe("HubProjects:", () => {
       expect(chk.id).toBe(GUID);
       expect(chk.owner).toBe("vader");
     });
+
+    it("returns null if no id found", async () => {
+      const getItemBySlugSpy = spyOn(
+        slugUtils,
+        "getItemBySlug"
+      ).and.returnValue(Promise.resolve(null));
+
+      const chk = await fetchProject("dcdev-34th-street", {
+        authentication: MOCK_AUTH,
+      });
+      expect(getItemBySlugSpy.calls.count()).toBe(1);
+      expect(getItemBySlugSpy.calls.argsFor(0)[0]).toBe("dcdev-34th-street");
+      expect(chk).toBe(null);
+    });
   });
 
   describe("destroyProject:", () => {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description - This PR does the following.
  - Ensures any portal is passed on in case no auth is provided.
  - Removes a wrapped error to maintain original error status code and message
  - Handles null pointer when no project matching an identifier is found.

3. Instructions for testing:
Modified code in Hub Project API and saw proper responses.

4. [x] ran commit script (`npm run c`)
_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.
