### PR TITLE
fix(hub-common): fix issues composing proxied csvs

### DIFF
--- a/packages/common/src/content/fetch.ts
+++ b/packages/common/src/content/fetch.ts
@@ -20,7 +20,12 @@ import {
   getContentEnrichments,
 } from "./_fetch";
 import { canUseHubApiForItem } from "./_internal";
-import { composeContent, getItemLayer, isLayerView } from "./compose";
+import {
+  composeContent,
+  getItemLayer,
+  getProxyUrl,
+  isLayerView,
+} from "./compose";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 
 const hasFeatures = (contentType: string) =>
@@ -84,6 +89,12 @@ const fetchItemAndEnrichments = async (
 ) => {
   // fetch the item
   const item = await getItem(itemId, options);
+
+  // The Hub Application expects the item url of proxied CSVs to point to the
+  // proxying feature service. Stabbing it on here maintains that consistency
+  // and also helps us fetch and calculate the correct reference layer
+  item.url = getProxyUrl(item, options) || item.url;
+
   // fetch the enrichments
   const enrichmentsToFetch =
     options?.enrichments || getContentEnrichments(item);

--- a/packages/content/src/enrichments.ts
+++ b/packages/content/src/enrichments.ts
@@ -615,6 +615,7 @@ export const enrichContent = (
         groupIds,
         org,
         server,
+        // TODO: fetch and pass in extent enrichment
         layers,
         recordCount,
         boundary,

--- a/packages/content/test/hub.test.ts
+++ b/packages/content/test/hub.test.ts
@@ -4,7 +4,7 @@ import {
   parseDatasetId,
   getContentFromHub,
 } from "../src/index";
-import { IHubRequestOptions, IHubContent } from "@esri/hub-common";
+import { IHubRequestOptions, IHubContent, isBBox } from "@esri/hub-common";
 import * as featureLayerJson from "./mocks/datasets/feature-layer.json";
 import * as itemJson from "./mocks/items/map-service.json";
 import { mockUserSession } from "./test-helpers/fake-user-session";
@@ -46,8 +46,11 @@ function validateContentFromDataset(
   expect(content.name).toBe(attributes.name);
   // should include derived properties
   expect(content.hubId).toBe(id);
-  const { itemExtent, extent } = attributes;
-  expect(content.extent).toEqual(itemExtent || (extent && extent.coordinates));
+  // verify extent fallback
+  const { itemExtent } = attributes;
+  isBBox(itemExtent)
+    ? expect(content.extent).toEqual(itemExtent)
+    : expect(content.extent).toBeUndefined();
   expect(content.family).toBe(expectedFamily);
   expect(content.summary).toBe(attributes.searchDescription);
   expect(content.publisher).toEqual({

--- a/packages/content/test/portal.test.ts
+++ b/packages/content/test/portal.test.ts
@@ -1,7 +1,7 @@
 import * as fetchMock from "fetch-mock";
 import * as arcgisRestPortal from "@esri/arcgis-rest-portal";
 import { IItem } from "@esri/arcgis-rest-portal";
-import { IHubRequestOptions, IHubContent } from "@esri/hub-common";
+import { IHubRequestOptions, IHubContent, isBBox } from "@esri/hub-common";
 import { getContentFromPortal } from "../src/portal";
 import * as metadataModule from "../src/metadata";
 import * as documentItem from "./mocks/items/document.json";
@@ -12,8 +12,8 @@ import { mockUserSession } from "./test-helpers/fake-user-session";
 function validateContentFromPortal(content: IHubContent, item: IItem) {
   // should include all item properties
   Object.keys(item).forEach((key) => {
-    // we check name below
-    if (key === "name") {
+    // we check name  and extent below
+    if (["name", "extent"].includes(key)) {
       return;
     }
     const contentValue = content[key];
@@ -22,6 +22,10 @@ function validateContentFromPortal(content: IHubContent, item: IItem) {
   });
   // name should be title
   expect(content.name).toBe(item.title);
+  // extent will be undefined if item extent is invalid bbox
+  isBBox(item.extent)
+    ? expect(content.extent).toEqual(item.extent)
+    : expect(content.extent).toBeUndefined();
   // should not set hubId when in portal
   expect(content.hubId).toBeUndefined();
   // should include derived properties


### PR DESCRIPTION
affects: @esri/hub-common, @esri/hub-content

1. Description:
Part of https://devtopia.esri.com/dc/hub/issues/3512

Fixes incorrect fetching and composing of Proxied CSVs. These changes include:
- `fetchContent` sets the `item.url` of proxied csvs to point to the proxying feature service
- `fetchContent` grabs layer and server enrichments for proxied csvs
- `composeContent` sets the `hubId` of proxied csvs to the `item.id`
- `composeContent` correctly handles `extent` fallback scenarios and sets `extent` to be a bbox

1. [x] ran commit script (`npm run c`)