### PR TITLE
feat(hub-common): migrate validateUrl function from ember application

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36813,7 +36813,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.25.5",
+			"version": "9.25.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -36847,7 +36847,7 @@
 		},
 		"packages/content": {
 			"name": "@esri/hub-content",
-			"version": "9.25.5",
+			"version": "9.25.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"fast-xml-parser": "~3.2.4",
@@ -36858,7 +36858,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36872,12 +36872,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.0",
 				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.5"
+				"@esri/hub-common": "9.25.6"
 			}
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.11.5",
+			"version": "11.11.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -36886,7 +36886,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36900,12 +36900,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.25.5"
+				"@esri/hub-common": "9.25.6"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.25.5",
+			"version": "9.25.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -36916,7 +36916,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36926,12 +36926,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.25.5"
+				"@esri/hub-common": "9.25.6"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.25.5",
+			"version": "9.25.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -36942,7 +36942,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36957,12 +36957,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.5"
+				"@esri/hub-common": "9.25.6"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.25.5",
+			"version": "9.25.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -36971,7 +36971,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36985,12 +36985,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.5"
+				"@esri/hub-common": "9.25.6"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.25.5",
+			"version": "9.25.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37001,7 +37001,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -37018,12 +37018,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.5"
+				"@esri/hub-common": "9.25.6"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.25.5",
+			"version": "9.25.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37032,9 +37032,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
-				"@esri/hub-initiatives": "9.25.5",
-				"@esri/hub-teams": "9.25.5",
+				"@esri/hub-common": "9.25.6",
+				"@esri/hub-initiatives": "9.25.6",
+				"@esri/hub-teams": "9.25.6",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -37048,14 +37048,14 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.5",
-				"@esri/hub-initiatives": "9.25.5",
-				"@esri/hub-teams": "9.25.5"
+				"@esri/hub-common": "9.25.6",
+				"@esri/hub-initiatives": "9.25.6",
+				"@esri/hub-teams": "9.25.6"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.25.5",
+			"version": "9.25.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37066,7 +37066,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -37081,12 +37081,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.5"
+				"@esri/hub-common": "9.25.6"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.25.5",
+			"version": "9.25.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37096,7 +37096,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -37110,7 +37110,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.5"
+				"@esri/hub-common": "9.25.6"
 			}
 		}
 	},
@@ -38581,7 +38581,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38599,7 +38599,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38619,7 +38619,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38639,7 +38639,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38656,7 +38656,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38676,7 +38676,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38695,9 +38695,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
-				"@esri/hub-initiatives": "9.25.5",
-				"@esri/hub-teams": "9.25.5",
+				"@esri/hub-common": "9.25.6",
+				"@esri/hub-initiatives": "9.25.6",
+				"@esri/hub-teams": "9.25.6",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -38717,7 +38717,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38735,7 +38735,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.5",
+				"@esri/hub-common": "9.25.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/common/src/resources/_internal/_validate-url-helpers.ts
+++ b/packages/common/src/resources/_internal/_validate-url-helpers.ts
@@ -1,0 +1,279 @@
+import {
+  IExtent,
+  IFeatureServiceDefinition,
+  ILayerDefinition,
+} from "@esri/arcgis-rest-types";
+import { ItemType } from "../../types";
+import { Logger } from "../../utils";
+
+const FEATURE_SERVICE_URL_REGEX = /(feature)server(\/|\/(\d+))?$/i;
+const SERVICE_URL_REGEX = /\/[a-zA-Z]+server(\/|\/(\d+))?$/i;
+
+/**
+ * Feature service / Doc Links Should not have data urls. Let"s exclude them from that.
+ *
+ * @export
+ * @param {string} itemType What type of item is it?
+ * @return {*}  {boolean}
+ */
+export function shouldHaveDataUrl(itemType: string): boolean {
+  // Specifically we want to avoid FS / DL from having a data url.
+  return !["Feature Service", "Document Link"].includes(itemType);
+}
+
+/**
+ * Get the file name out of a url. Will return either the
+ * hostname, or the pathname if it exists
+ *
+ * @export
+ * @param {string} url Url to get a file name out of
+ * @return {*}  {string}
+ */
+export function getFileName(url: string): string {
+  let filename: string;
+
+  try {
+    const parsed = new URL(url);
+
+    // If the URL pathname exists, return its last segment,
+    // otherwise return the hostname
+    filename =
+      parsed.pathname !== "/"
+        ? parsed.pathname.split("/").pop()
+        : parsed.hostname;
+  } catch (e) {
+    throw new Error(`Error getting file name from data url`);
+  }
+
+  return filename;
+}
+
+/**
+ * Is this a valid url?
+ *
+ * @param {string} url Url to validate
+ * @return {*}  {boolean}
+ */
+export function isUrl(url: string): boolean {
+  // Use try / catch as a simple string "test" will cause new URL() to throw an error.
+  try {
+    const result = new URL(url);
+    // Cast to bool.
+    return !!result;
+  } catch (e) {
+    Logger.error(`Error parsing data url`);
+    return false;
+  }
+}
+
+/**
+ * Tests if url string is a feature service / layer.
+ *
+ * @param {string} url URL to test
+ * @return {*}  {boolean}
+ */
+export function isFeatureService(url: string): boolean {
+  return FEATURE_SERVICE_URL_REGEX.test(url);
+}
+
+/**
+ * Tests if url string is a service (map, feature, image, etc)
+ *
+ * @param {string} url Url to test
+ * @return {*}  {boolean}
+ */
+export function isService(url: string): boolean {
+  return SERVICE_URL_REGEX.test(url);
+}
+
+/**
+ * Is the service a feature service AND is it a layer specifically
+ *
+ * @param {string} url
+ * @return {*}  {boolean}
+ */
+export function isFeatureLayer(url: string): boolean {
+  const results = url.match(FEATURE_SERVICE_URL_REGEX);
+  return results && !!results[3];
+}
+
+/**
+ * Gets item title from url as a fall back
+ *
+ * @param {string} url item url
+ * @return {*}  {string}
+ */
+export function getFeatureServiceTitle(url: string): string {
+  return url.match(/\/services\/(.+)\/(feature|map|image)server/i)[1];
+}
+
+/**
+ * Gets item info out of a feature layer item.
+ *
+ * @export
+ * @param {string} url Item URL
+ * @param {{
+ *     name: string,
+ *     description: string,
+ *     extent: any
+ *   }} body Item body.
+ * @return {*}  {{
+ *   title: string,
+ *   description: string,
+ *   extent: any,
+ *   url: string
+ * }}
+ */
+export function getFeatureLayerItem(
+  url: string,
+  body: Partial<ILayerDefinition>
+): {
+  title: string;
+  description: string;
+  extent: IExtent;
+  url: string;
+} {
+  return {
+    title: body.name,
+    description: body.description,
+    extent: body.extent,
+    url,
+  };
+}
+
+/**
+ * Gets item info out of a feature service response (which is not a specific layer)
+ *
+ * @export
+ * @param {*} url
+ * @param {*} body
+ * @return {*}
+ */
+export function getFeatureServiceItem(
+  url: string,
+  body: Partial<IFeatureServiceDefinition>
+): {
+  title: string;
+  description: string;
+  extent: IExtent;
+  url: string;
+} {
+  const description = body.serviceDescription || body.description;
+  const title = getFeatureServiceTitle(url);
+  const extent: IExtent = body.fullExtent || body.initialExtent;
+
+  return { title, description, extent, url };
+}
+
+/**
+ * Ping a non FS url and return response status && headers
+ *
+ * @export
+ * @param {string} url Non FS URL
+ * @return {*}  {Promise<{ ok: boolean, headers: Headers }>}
+ */
+export async function pingUrl(
+  url: string
+): Promise<{ ok: boolean; headers?: Headers }> {
+  const response = await fetch(url, { method: "HEAD" });
+
+  return {
+    ok: response.ok,
+    headers: response.headers,
+  };
+}
+
+/**
+ * Ping a FS URL and handle matters such as "hidden" success failures.
+ *
+ * @export
+ * @param {string} url
+ * @return {*}  {Promise<{ ok: boolean, item?: any }>}
+ */
+export async function pingFeatureService(
+  url: string
+): Promise<{ ok: boolean; item?: any }> {
+  // make sure the response is in json format
+  const parsed = new URL(url);
+  parsed.searchParams.set("f", "json");
+
+  // Since the feature service can return a 200 response with error (e.g. for
+  // non-existing layer), we can only request the full metadata by a GET, not HEAD
+  // request
+  const response = await fetch(parsed.href);
+
+  if (!response.ok) {
+    return { ok: false };
+  }
+
+  const body = await response.json();
+
+  // Exit if the request returns an error
+  if (body.error) {
+    return { ok: false };
+  }
+
+  const getItem = isFeatureLayer(url)
+    ? getFeatureLayerItem
+    : getFeatureServiceItem;
+  const item = getItem(url, body);
+
+  return {
+    ok: true,
+    item,
+  };
+}
+
+export function detectDataTypeFromHeader(headers: Headers): ItemType {
+  let contentType = headers.get("Content-Type");
+  let dataType: ItemType;
+
+  if (!contentType) {
+    return;
+  }
+  // Only get the "media-type"
+  contentType = contentType.split(";").shift();
+
+  if (contentType === "text/csv") {
+    dataType = ItemType.CSV;
+  } else if (
+    contentType === "application/vnd.ms-excel" ||
+    contentType ===
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+  ) {
+    dataType = ItemType["Microsoft Excel"];
+  } else if (contentType === "application/pdf") {
+    dataType = ItemType.PDF;
+  } else if (
+    contentType === "image/jpeg" ||
+    contentType === "image/jpg" ||
+    contentType === "image/png"
+  ) {
+    dataType = ItemType.Image;
+  } else if (contentType === "application/geo+json") {
+    dataType = ItemType.GeoJson;
+  }
+  return dataType;
+}
+
+export function detectDataTypeFromExtension(url: string): ItemType {
+  const contentType = url.toLowerCase().split(".").pop();
+  let dataType;
+
+  if (contentType === "csv") {
+    dataType = ItemType.CSV;
+  } else if (contentType === "xls" || contentType === "xlsx") {
+    dataType = ItemType["Microsoft Excel"];
+  } else if (contentType === "pdf") {
+    dataType = ItemType.PDF;
+  } else if (
+    contentType === "jpeg" ||
+    contentType === "jpg" ||
+    contentType === "png"
+  ) {
+    dataType = ItemType.Image;
+  } else if (contentType === "geojson") {
+    dataType = ItemType.GeoJson;
+  }
+  return dataType;
+}

--- a/packages/common/src/resources/index.ts
+++ b/packages/common/src/resources/index.ts
@@ -9,3 +9,4 @@ export * from "./string-to-blob";
 export * from "./upload-resources-from-url";
 export * from "./add-solution-resource-url-to-assets";
 export * from "./object-to-json-blob";
+export * from "./validate-url";

--- a/packages/common/src/resources/validate-url.ts
+++ b/packages/common/src/resources/validate-url.ts
@@ -1,0 +1,105 @@
+import { ItemType } from "../types";
+import { Logger } from "../utils";
+import {
+  isUrl,
+  isFeatureService,
+  isService,
+  pingFeatureService,
+  pingUrl,
+  detectDataTypeFromHeader,
+  getFileName,
+  detectDataTypeFromExtension,
+  shouldHaveDataUrl,
+} from "./_internal/_validate-url-helpers";
+
+/**
+ * Takes in a URL and validates it based on valid url, type of item, etc
+ *
+ * @export
+ * @param {string} url
+ * @return {*}  {Promise<any>}
+ */
+export async function validateUrl(url: string): Promise<any> {
+  // If URL doesn't pass then exit out immediately.
+  if (!isUrl(url)) {
+    return {
+      pass: false,
+      error: "invalidFormat",
+    };
+  }
+
+  // Check if it's a FS, Map service, or image service
+  const isFeatureServiceUrl = isFeatureService(url);
+  const isServiceUrl = isService(url);
+
+  if (isServiceUrl && !isFeatureServiceUrl) {
+    return {
+      pass: false,
+      error: "invalidFormat",
+    };
+  }
+
+  // Content type which can be determined bby the url file extnesion or the request response header
+  let type;
+
+  let item;
+
+  let pingResult: { ok?: boolean; headers?: any; body?: any; item?: any } = {};
+
+  try {
+    pingResult = isFeatureServiceUrl
+      ? await pingFeatureService(url)
+      : await pingUrl(url);
+
+    // return an error if the response is not okay
+    if (!pingResult.ok) {
+      return {
+        pass: false,
+        error: "invalidUrl",
+      };
+    }
+  } catch (e) {
+    // TODO: This is tricky. The fetch() API rejects when a network error
+    // happens. This error can be a CORS error, or a 404 error, or a timeout
+    // error. While an error like 404 does suggest a bad URL, the CORS occurs
+    // because this is a front-end request and the file is likely accessible by
+    // the server. Unfortunately, the error doesn't have any information about
+    // underline failure type. For now, the network failure is ignored, so the
+    // user can paste a URL from any domain and avoid the CORS issue.
+    Logger.error(`error requesting url`);
+  }
+  // Use the metadata from the ping response if exists, otherwise guess the file
+  // name from the URL
+  if (pingResult.item) {
+    item = pingResult.item;
+  } else {
+    item = { title: getFileName(url), url };
+  }
+
+  if (pingResult.headers) {
+    type = detectDataTypeFromHeader(pingResult.headers);
+  }
+
+  if (isFeatureServiceUrl) {
+    type = ItemType["Feature Service"];
+  } else if (!type) {
+    // Guess the data type from the extension
+    type = detectDataTypeFromExtension(url);
+  }
+
+  if (type) {
+    item.type = type;
+  }
+
+  if (item.type && shouldHaveDataUrl(item.type)) {
+    item.dataUrl = item.url;
+  }
+
+  return {
+    pass: true,
+    // The type may or may not be true
+    type,
+    // fetched / calculated item
+    item,
+  };
+}

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -193,7 +193,7 @@ export type HubFamily =
 export type Visibility = "private" | "org" | "public";
 
 /**
- * User's access level to a Hub resource
+ * User"s access level to a Hub resource
  */
 export type AccessControl = "view" | "edit" | "admin";
 
@@ -249,11 +249,11 @@ export interface IHubResource {
    * the item key, e.g. `item.modified` or `item.metadata.modified_date`
    */
   updatedDateSource?: string;
-  /** URL of the resource's page in the Portal Home application */
+  /** URL of the resource"s page in the Portal Home application */
   portalHomeUrl?: string;
   /** URL of the Portal API endpoint for the resource */
   portalApiUrl?: string;
-  /** Fully qualified URL for the item's thumbnail, including current user's token if authenticated and required */
+  /** Fully qualified URL for the item"s thumbnail, including current user"s token if authenticated and required */
   thumbnailUrl?: string; // Full URL. item.thumbnail with host + path
 
   /**
@@ -371,7 +371,7 @@ export interface IDomainEntry {
 
 /**
  * The catalog object found on Hub Site Application items.
- * It defines a selection of content to show up in the site's
+ * It defines a selection of content to show up in the site"s
  * search context.
  */
 export interface ISiteCatalog {
@@ -408,3 +408,883 @@ export interface ISearchResponse<T> {
   next: (params?: any) => Promise<ISearchResponse<T>>;
   facets?: IFacet[];
 }
+
+/**
+ * ENUM which defines File extensions.
+ */
+export enum FileExtension {
+  aptx = "aptx",
+  bpk = "bpk",
+  csv = "csv",
+  eaz = "eaz",
+  esriaddin = "esriaddin",
+  esriaddinx = "esriaddinx",
+  doc = "doc",
+  docx = "docx",
+  dlpk = "dlpk",
+  featurecollection = "featurecollection",
+  geojson = "geojson",
+  gcpk = "gcpk",
+  gpk = "gpk",
+  gpkg = "gpkg",
+  gpkx = "gpkx",
+  insightswbk = "insightswbk",
+  ipynb = "ipynb",
+  jpg = "jpg",
+  jpeg = "jpeg",
+  json = "json",
+  key = "key",
+  kml = "kml",
+  kmz = "kmz",
+  lpk = "lpk",
+  lpkx = "lpkx",
+  lyr = "lyr",
+  lyrx = "lyrx",
+  mapx = "mapx",
+  mmpk = "mmpk",
+  mpk = "mpk",
+  mpkx = "mpkx",
+  msd = "msd",
+  mspk = "mspk",
+  mxd = "mxd",
+  ncfg = "ncfg",
+  nmc = "nmc",
+  nmf = "nmf",
+  numbers = "numbers",
+  pages = "pages",
+  pagx = "pagx",
+  parquet = "parquet",
+  pdf = "pdf",
+  pmf = "pmf",
+  png = "png",
+  ppkx = "ppkx",
+  ppt = "ppt",
+  pptx = "pptx",
+  proconfigx = "proconfigx",
+  rpk = "rpk",
+  rptx = "rptx",
+  sd = "sd",
+  slpk = "slpk",
+  spk = "spk",
+  stylx = "stylx",
+  surveyaddin = "surveyaddin",
+  sxd = "sxd",
+  tif = "tif",
+  tiff = "tiff",
+  tpk = "tpk",
+  tpkx = "tpkx",
+  vsd = "vsd",
+  vtpk = "vtpk",
+  wmpk = "wmpk",
+  wpk = "wpk",
+  xls = "xls",
+  xml = "xml",
+  xlsx = "xlsx",
+  zip = "zip",
+  "3dd" = "3dd",
+  "3vr" = "3vr",
+  "3ws" = "3ws",
+  "rft.json" = "rft.json",
+  "rft.xml" = "rft.xml",
+}
+
+/**
+ * ENUM which defines human readable Item Type names
+ */
+export enum ItemType {
+  "360 VR Experience" = "360 VR Experience",
+  "Apache Parquet" = "Apache Parquet",
+  "AppBuilder Widget Package" = "AppBuilder Widget Package",
+  "Desktop Add In" = "Desktop Add In",
+  "Explorer Add In" = "Explorer Add In",
+  "Explorer Map" = "Explorer Map",
+  "Explorer Layer" = "Explorer Layer",
+  "Windows Mobile Package" = "Windows Mobile Package",
+  "ArcGIS Pro Add In" = "ArcGIS Pro Add In",
+  "ArcGIS Pro Configuration" = "ArcGIS Pro Configuration",
+  "Globe Document" = "Globe Document",
+  "Map Document" = "Map Document",
+  "ArcPad Package" = "ArcPad Package",
+  "Published Map" = "Published Map",
+  "Scene Document" = "Scene Document",
+  "CityEngine Web Scene" = "CityEngine Web Scene",
+  "Code Sample" = "Code Sample",
+  "CSV Collection" = "CSV Collection",
+  "CSV" = "CSV",
+  "CAD Drawing" = "CAD Drawing",
+  "Deep Learning Package" = "Deep Learning Package",
+  "Desktop Application" = "Desktop Application",
+  "Desktop Application Template" = "Desktop Application Template",
+  "Desktop Style" = "Desktop Style",
+  "Earth Configuration" = "Earth Configuration",
+  "Feature Collection" = "Feature Collection",
+  "File Geodatabase" = "File Geodatabase",
+  "GeoJson" = "GeoJson",
+  "Geoprocessing Package" = "Geoprocessing Package",
+  "GeoPackage" = "GeoPackage",
+  "Geoprocessing Sample" = "Geoprocessing Sample",
+  "GML" = "GML",
+  "Image Collection" = "Image Collection",
+  "Image" = "Image",
+  "iWork Keynote" = "iWork Keynote",
+  "iWork Numbers" = "iWork Numbers",
+  "iWork Pages" = "iWork Pages",
+  "KML Collection" = "KML Collection",
+  "KML" = "KML",
+  "Layer" = "Layer",
+  "Layer Package" = "Layer Package",
+  "Layout" = "Layout",
+  "Locator Package" = "Locator Package",
+  "Map Package" = "Map Package",
+  "Map Template" = "Map Template",
+  "Microsoft Excel" = "Microsoft Excel",
+  "Microsoft Powerpoint" = "Microsoft Powerpoint",
+  "Visio Document" = "Visio Document",
+  "Microsoft Word" = "Microsoft Word",
+  "Mobile Basemap Package" = "Mobile Basemap Package",
+  "Mobile Map Package" = "Mobile Map Package",
+  "Mobile Scene Package" = "Mobile Scene Package",
+  "Notebook" = "Notebook",
+  "PDF" = "PDF",
+  "Pro Map" = "Pro Map",
+  "Pro Report" = "Pro Report",
+  "Project Package" = "Project Package",
+  "Project Template" = "Project Template",
+  "Raster function template" = "Raster function template",
+  "Rule Package" = "Rule Package",
+  "Scene Package" = "Scene Package",
+  "Service Definition" = "Service Definition",
+  "Shapefile" = "Shapefile",
+  "Survey123 Add In" = "Survey123 Add In",
+  "Tile Package" = "Tile Package",
+  "Vector Tile Package" = "Vector Tile Package",
+  "Workflow Manager Package" = "Workflow Manager Package",
+  "Document Link" = "Document Link",
+  "Feature Service" = "Feature Service",
+  "Geocoding Service" = "Geocoding Service",
+  "Geodata Service" = "Geodata Service",
+  "Geometry Service" = "Geometry Service",
+  "Geoprocessing Service" = "Geoprocessing Service",
+  "Geoenrichment Service" = "Geoenrichment Service",
+  "Globe Service" = "Globe Service",
+  "Image Service" = "Image Service",
+  "Map Service" = "Map Service",
+  "Network Analysis Service" = "Network Analysis Service",
+  "Vector Tile Service" = "Vector Tile Service",
+  "WFS" = "WFS",
+  "WMS" = "WMS",
+  "WMTS" = "WMTS",
+  "OGCFeatureServer" = "OGCFeatureServer",
+  "Scene Service" = "Scene Service",
+  "Stream Service" = "Stream Service",
+  "Workflow Manager Service" = "Workflow Manager Service",
+  "Web Mapping Application" = "Web Mapping Application",
+  "Mobile Application" = "Mobile Application",
+  "AppBuilder Extension" = "AppBuilder Extension",
+  "Google Drive" = "Google Drive",
+  "Dropbox" = "Dropbox",
+  "OneDrive" = "OneDrive",
+  "StoryMap" = "StoryMap",
+  "Dashboard" = "Dashboard",
+  "Hub Initiative" = "Hub Initiative",
+  "Hub Site Application" = "Hub Site Application",
+  "Web Experience" = "Web Experience",
+  "Insights Workbook Package" = "Insights Workbook Package",
+  "Application" = "Application",
+  "ArcGIS Explorer Application Configuration" = "ArcGIS Explorer Application Configuration",
+  "ArcMap Document" = "ArcMap Document",
+  "Layer File" = "Layer File",
+  "ogcFeature" = "ogcFeature",
+  FeatureServer = "Feature Service",
+  GeocodeServer = "GeocodeServer",
+  GeoDataServer = "GeoDataServer",
+  GeometryServer = "GeometryServer",
+  GeoenrichmentServer = "GeoenrichmentServer",
+  GPServer = "GPServer",
+  GlobeServer = "GlobeServer",
+  ImageServer = "ImageServer",
+  MapServer = "MapServer",
+  NAServer = "NAServer",
+  ElevationServer = "ElevationServer",
+  VectorTileServer = "VectorTileServer",
+  "Scene Server" = "Scene Server",
+  StreamServer = "StreamServer",
+  WMServer = "WMServer",
+  TiledImageServer = "TiledImageServer",
+}
+
+/**
+ * File type to extension interface
+ */
+export interface IFileType {
+  type: ItemType;
+  typeKeywords: string[];
+  fileExt?: FileExtension[];
+}
+
+/**
+ * Array of ItemTypes and/or array of extensions. Primarily used for the create new content flow
+ */
+export interface IAllowedFileTypes {
+  types?: ItemType[];
+  extensions?: FileExtension[];
+}
+
+/**
+ * Maps human readable file names to extensions IE Image === jpg, png, etc
+ */
+export const addCreateItemTypes: Record<string, IFileType> = {
+  "360 VR Experience": {
+    fileExt: [FileExtension["3dd"]],
+    type: ItemType["360 VR Experience"],
+    typeKeywords: [],
+  },
+  "Apache Parquet": {
+    fileExt: [FileExtension.parquet],
+    type: ItemType["Apache Parquet"],
+    typeKeywords: [],
+  },
+  "AppBuilder Widget Package": {
+    fileExt: [FileExtension.zip],
+    type: ItemType["AppBuilder Widget Package"],
+    typeKeywords: [],
+  },
+  "Desktop Add In": {
+    fileExt: [FileExtension.esriaddin],
+    type: ItemType["Desktop Add In"],
+    typeKeywords: [
+      "Tool",
+      "Add In",
+      "Desktop Add In",
+      "ArcGIS Desktop",
+      "ArcMap",
+      "ArcGlobe",
+      "ArcScene",
+      "esriaddin",
+    ],
+  },
+  "Explorer Add In": {
+    fileExt: [FileExtension.eaz],
+    type: ItemType["Explorer Add In"],
+    typeKeywords: [
+      "Tool",
+      "Add In",
+      "Explorer Add In",
+      "ArcGIS Explorer",
+      "eaz",
+    ],
+  },
+  "Explorer Map": {
+    fileExt: [FileExtension.nmf],
+    type: ItemType["Explorer Map"],
+    typeKeywords: [
+      "Map",
+      "Explorer Map",
+      "Explorer Document",
+      "2D",
+      "3D",
+      "ArcGIS Explorer",
+      "nmf",
+    ],
+  },
+  "ArcGIS Explorer Application Configuration": {
+    fileExt: [FileExtension.ncfg],
+    type: ItemType["Explorer Map"],
+    typeKeywords: [
+      "Map",
+      "Explorer Map",
+      "Explorer Mapping Application",
+      "2D",
+      "3D",
+      "ArcGIS Explorer",
+    ],
+  },
+  "Explorer Layer": {
+    fileExt: [FileExtension.nmc],
+    type: ItemType["Explorer Layer"],
+    typeKeywords: ["Data", "Layer", "Explorer Layer", "ArcGIS Explorer", "nmc"],
+  },
+  "Windows Mobile Package": {
+    fileExt: [FileExtension.wmpk],
+    type: ItemType["Windows Mobile Package"],
+    typeKeywords: [],
+  },
+  "ArcGIS Pro Add In": {
+    fileExt: [FileExtension.esriaddinx],
+    type: ItemType["ArcGIS Pro Add In"],
+    typeKeywords: ["Tool", "Add In", "Pro Add In", "esriaddinx"],
+  },
+  "ArcGIS Pro Configuration": {
+    fileExt: [FileExtension.proconfigx],
+    type: ItemType["ArcGIS Pro Configuration"],
+    typeKeywords: [],
+  },
+  "Globe Document": {
+    fileExt: [FileExtension["3dd"]],
+    type: ItemType["Globe Document"],
+    typeKeywords: [
+      "Map",
+      "Globe Document",
+      "3D",
+      "ArcGlobe",
+      "ArcGIS Server",
+      "3dd",
+    ],
+  },
+  "Map Document": {
+    fileExt: [FileExtension.msd],
+    type: ItemType["Map Document"],
+    typeKeywords: [
+      "Map Document",
+      "Map",
+      "2D",
+      "ArcMap",
+      "ArcGIS Server",
+      "msd",
+    ],
+  },
+  "ArcMap Document": {
+    fileExt: [FileExtension.mxd],
+    type: ItemType["Map Document"],
+    typeKeywords: ["Map Document", "Map", "2D", "ArcMap", "ArcGIS Server"],
+  },
+  "ArcPad Package": {
+    fileExt: [FileExtension.zip],
+    type: ItemType["ArcPad Package"],
+    typeKeywords: ["Map", "Layer", "Data"],
+  },
+  "Published Map": {
+    fileExt: [FileExtension.pmf],
+    type: ItemType["Published Map"],
+    typeKeywords: [
+      "Map",
+      "Published Map",
+      "2D",
+      "ArcReader",
+      "ArcMap",
+      "ArcGIS Server",
+      "pmf",
+    ],
+  },
+  "Scene Document": {
+    fileExt: [FileExtension.sxd],
+    type: ItemType["Scene Document"],
+    typeKeywords: ["Map", "Scene Document", "3D", "ArcScene", "sxd"],
+  },
+  "CityEngine Web Scene": {
+    fileExt: [FileExtension["3ws"]],
+    type: ItemType["CityEngine Web Scene"],
+    typeKeywords: ["3D", "Map", "Scene", "Web"],
+  },
+  "Code Sample": {
+    fileExt: [FileExtension.zip],
+    type: ItemType["Code Sample"],
+    typeKeywords: ["Code", "Sample"],
+  },
+  "CSV Collection": {
+    fileExt: [FileExtension.zip],
+    type: ItemType["CSV Collection"],
+    typeKeywords: [],
+  },
+  CSV: {
+    fileExt: [FileExtension.csv],
+    type: ItemType.CSV,
+    typeKeywords: ["CSV"],
+  },
+  "CAD Drawing": {
+    fileExt: [FileExtension.zip],
+    type: ItemType["CAD Drawing"],
+    typeKeywords: [],
+  },
+  "Deep Learning Package": {
+    fileExt: [FileExtension.zip, FileExtension.dlpk],
+    type: ItemType["Deep Learning Package"],
+    typeKeywords: ["Deep Learning", "Raster"],
+  },
+  "Desktop Application": {
+    type: ItemType["Desktop Application"],
+    typeKeywords: ["Desktop Application"],
+  },
+  "Desktop Application Template": {
+    fileExt: [FileExtension.zip],
+    type: ItemType["Desktop Application Template"],
+    typeKeywords: ["application", "template", "ArcGIS desktop"],
+  },
+  "Desktop Style": {
+    fileExt: [FileExtension.stylx],
+    type: ItemType["Desktop Style"],
+    typeKeywords: ["ArcGIS Pro", "Symbology", "Style", "Symbols"],
+  },
+  "Earth Configuration": {
+    fileExt: [FileExtension.xml],
+    type: ItemType["Earth Configuration"],
+    typeKeywords: ["ArcGIS Earth", "Earth", "Earth Configuration"],
+  },
+  "Feature Collection": {
+    type: ItemType["Feature Collection"],
+    fileExt: [FileExtension.featurecollection],
+    typeKeywords: [],
+  },
+  "File Geodatabase": {
+    fileExt: [FileExtension.zip],
+    type: ItemType["File Geodatabase"],
+    typeKeywords: [],
+  },
+  GeoJson: {
+    fileExt: [FileExtension.geojson, FileExtension.json],
+    type: ItemType.GeoJson,
+    typeKeywords: [
+      "Coordinates Type",
+      "CRS",
+      "Feature",
+      "FeatureCollection",
+      "GeoJSON",
+      "Geometry",
+      "GeometryCollection",
+    ],
+  },
+  "Geoprocessing Package": {
+    fileExt: [FileExtension.gpk, FileExtension.gpkx],
+    type: ItemType["Geoprocessing Package"],
+    typeKeywords: [
+      "ArcGIS Desktop",
+      "ArcGlobe",
+      "ArcMap",
+      "ArcScene",
+      "Geoprocessing Package",
+      "gpk",
+      "Model",
+      "Result",
+      "Script",
+      "Sharing",
+      "Tool",
+      "Toolbox",
+    ],
+  },
+  GeoPackage: {
+    fileExt: [FileExtension.gpkg],
+    type: ItemType.GeoPackage,
+    typeKeywords: ["Data", "GeoPackage", "gpkg"],
+  },
+  "Geoprocessing Sample": {
+    fileExt: [FileExtension.zip],
+    type: ItemType["Geoprocessing Sample"],
+    typeKeywords: ["tool", "geoprocessing", "sample"],
+  },
+  GML: {
+    fileExt: [FileExtension.zip],
+    type: ItemType.GML,
+    typeKeywords: [],
+  },
+  "Image Collection": {
+    fileExt: [FileExtension.zip],
+    type: ItemType["Image Collection"],
+    typeKeywords: [],
+  },
+  Image: {
+    fileExt: [
+      FileExtension.jpg,
+      FileExtension.jpeg,
+      FileExtension.png,
+      FileExtension.tif,
+      FileExtension.tiff,
+    ],
+    type: ItemType.Image,
+    typeKeywords: ["Data", "Image"],
+  },
+  "iWork Keynote": {
+    fileExt: [FileExtension.key],
+    type: ItemType["iWork Keynote"],
+    typeKeywords: ["Data", "Document", "Mac"],
+  },
+  "iWork Numbers": {
+    fileExt: [FileExtension.numbers],
+    type: ItemType["iWork Numbers"],
+    typeKeywords: ["Data", "Document", "Mac"],
+  },
+  "iWork Pages": {
+    fileExt: [FileExtension.pages],
+    type: ItemType["iWork Pages"],
+    typeKeywords: ["Data", "Document", "Mac"],
+  },
+  "KML Collection": {
+    fileExt: [FileExtension.zip],
+    type: ItemType["KML Collection"],
+    typeKeywords: [],
+  },
+  KML: {
+    type: ItemType.KML,
+    fileExt: [FileExtension.kml, FileExtension.kmz],
+    typeKeywords: ["Data", "Map", "kml"],
+  },
+  Layer: {
+    fileExt: [FileExtension.lyr],
+    type: ItemType.Layer,
+    typeKeywords: [
+      "Data",
+      "Layer",
+      "ArcMap",
+      "ArcGlobe",
+      "ArcGIS Explorer",
+      "lyr",
+    ],
+  },
+  "Layer File": {
+    fileExt: [FileExtension.lyrx],
+    type: ItemType.Layer,
+    typeKeywords: ["ArcGIS Pro", "Layer", "Layer File"],
+  },
+  "Layer Package": {
+    fileExt: [FileExtension.lpk, FileExtension.lpkx],
+    type: ItemType["Layer Package"],
+    typeKeywords: [],
+  },
+  Layout: {
+    fileExt: [FileExtension.pagx],
+    type: ItemType.Layout,
+    typeKeywords: ["ArcGIS Pro", "Layout", "Layout File", "pagx"],
+  },
+  "Locator Package": {
+    fileExt: [FileExtension.gcpk],
+    type: ItemType["Locator Package"],
+    typeKeywords: [],
+  },
+  "Map Package": {
+    fileExt: [FileExtension.mpk, FileExtension.mpkx],
+    type: ItemType["Map Package"],
+    typeKeywords: [],
+  },
+  "Map Template": {
+    fileExt: [FileExtension.zip],
+    type: ItemType["Map Template"],
+    typeKeywords: ["map", "ArcMap", "template", "ArcGIS desktop"],
+  },
+  "Microsoft Excel": {
+    fileExt: [FileExtension.xls, FileExtension.xlsx],
+    type: ItemType["Microsoft Excel"],
+    typeKeywords: ["Data", "Document", "Microsoft Excel"],
+  },
+  "Microsoft Powerpoint": {
+    fileExt: [FileExtension.ppt, FileExtension.pptx],
+    type: ItemType["Microsoft Powerpoint"],
+    typeKeywords: ["Data", "Document", "Microsoft Powerpoint"],
+  },
+  "Visio Document": {
+    fileExt: [FileExtension.vsd],
+    type: ItemType["Visio Document"],
+    typeKeywords: ["Data", "Document", "Visio Document"],
+  },
+  "Microsoft Word": {
+    fileExt: [FileExtension.doc, FileExtension.docx],
+    type: ItemType["Microsoft Word"],
+    typeKeywords: ["Data", "Document"],
+  },
+  "Mobile Basemap Package": {
+    fileExt: [FileExtension.bpk],
+    type: ItemType["Mobile Basemap Package"],
+    typeKeywords: [],
+  },
+  "Mobile Map Package": {
+    fileExt: [FileExtension.mmpk],
+    type: ItemType["Mobile Map Package"],
+    typeKeywords: [],
+  },
+  "Mobile Scene Package": {
+    fileExt: [FileExtension.mspk],
+    type: ItemType["Mobile Scene Package"],
+    typeKeywords: [],
+  },
+  Notebook: {
+    fileExt: [FileExtension.ipynb],
+    type: ItemType.Notebook,
+    typeKeywords: ["Notebook", "Python"],
+  },
+  PDF: {
+    fileExt: [FileExtension.pdf],
+    type: ItemType.PDF,
+    typeKeywords: ["Data", "Document", "PDF"],
+  },
+  "Pro Map": {
+    fileExt: [FileExtension.mapx],
+    type: ItemType["Pro Map"],
+    typeKeywords: ["ArcGIS Pro", "Map", "Map File", "mapx"],
+  },
+  "Pro Report": {
+    fileExt: [FileExtension.rptx],
+    type: ItemType["Pro Report"],
+    typeKeywords: [],
+  },
+  "Project Package": {
+    fileExt: [FileExtension.ppkx],
+    type: ItemType["Project Package"],
+    typeKeywords: [],
+  },
+  "Project Template": {
+    fileExt: [FileExtension.aptx],
+    type: ItemType["Project Template"],
+    typeKeywords: [],
+  },
+  "Raster function template": {
+    fileExt: [FileExtension["rft.json"], FileExtension["rft.xml"]],
+    type: ItemType["Raster function template"],
+    typeKeywords: [
+      "Raster",
+      "Functions",
+      "Processing",
+      "rft",
+      "srf",
+      "function template",
+      "templates",
+      "ArcGIS Pro",
+    ],
+  },
+  "Rule Package": {
+    fileExt: [FileExtension.rpk],
+    type: ItemType["Rule Package"],
+    typeKeywords: [],
+  },
+  "Scene Package": {
+    fileExt: [FileExtension.slpk, FileExtension.spk],
+    type: ItemType["Scene Package"],
+    typeKeywords: [],
+  },
+  "Service Definition": {
+    fileExt: [FileExtension.sd],
+    type: ItemType["Service Definition"],
+    typeKeywords: ["Data", "Service", "Service Definition"],
+  },
+  Shapefile: {
+    fileExt: [FileExtension.zip],
+    type: ItemType.Shapefile,
+    typeKeywords: ["Data", "Layer", "shapefile"],
+  },
+  "Survey123 Add In": {
+    fileExt: [FileExtension.surveyaddin],
+    type: ItemType["Survey123 Add In"],
+    typeKeywords: ["Add In", "Survey123 Add In", "Tool"],
+  },
+  "Tile Package": {
+    fileExt: [FileExtension.tpk, FileExtension.tpkx],
+    type: ItemType["Tile Package"],
+    typeKeywords: [],
+  },
+  "Vector Tile Package": {
+    fileExt: [FileExtension.vtpk],
+    type: ItemType["Vector Tile Package"],
+    typeKeywords: [],
+  },
+  "Workflow Manager Package": {
+    fileExt: [FileExtension.wpk],
+    type: ItemType["Workflow Manager Package"],
+    typeKeywords: [],
+  },
+  "Document Link": {
+    type: ItemType["Document Link"],
+    typeKeywords: ["Data", "Document"],
+  },
+  "Feature Service": {
+    type: ItemType["Feature Service"],
+    typeKeywords: [
+      "ArcGIS Server",
+      "Data",
+      "Feature Access",
+      "Feature Service",
+      "Service",
+      "Singlelayer",
+      "Hosted Service",
+    ],
+  },
+  GeocodeServer: {
+    type: ItemType["Geocoding Service"],
+    typeKeywords: [
+      "ArcGIS Server",
+      "Geocoding Service",
+      "Locator Service",
+      "Service",
+      "Tool",
+      "Service Proxy",
+    ],
+  },
+  GeoDataServer: {
+    type: ItemType["Geodata Service"],
+    typeKeywords: ["Data", "Service", "Geodata Service", "ArcGIS Server"],
+  },
+  GeometryServer: {
+    type: ItemType["Geometry Service"],
+    typeKeywords: ["Tool", "Service", "Geometry Service", "ArcGIS Server"],
+  },
+  GeoenrichmentServer: {
+    type: ItemType["Geoenrichment Service"],
+    typeKeywords: ["Geoenrichment Service", "ArcGIS Server"],
+  },
+  GPServer: {
+    type: ItemType["Geoprocessing Service"],
+    typeKeywords: ["Tool", "Service", "Geoprocessing Service", "ArcGIS Server"],
+  },
+  GlobeServer: {
+    type: ItemType["Globe Service"],
+    typeKeywords: ["Data", "Service", "Globe Service", "ArcGIS Server"],
+  },
+  ImageServer: {
+    type: ItemType["Image Service"],
+    typeKeywords: ["Data", "Service", "Image Service", "ArcGIS Server"],
+  },
+  MapServer: {
+    type: ItemType["Map Service"],
+    typeKeywords: ["Data", "Service", "Map Service", "ArcGIS Server"],
+  },
+  NAServer: {
+    type: ItemType["Network Analysis Service"],
+    typeKeywords: [
+      "Tool",
+      "Service",
+      "Network Analysis Service",
+      "ArcGIS Server",
+    ],
+  },
+  ElevationServer: {
+    type: ItemType["Image Service"],
+    typeKeywords: ["Elevation 3D Layer"],
+  },
+  VectorTileServer: {
+    type: ItemType["Vector Tile Service"],
+    typeKeywords: [],
+  },
+  WFS: {
+    type: ItemType.WFS,
+    typeKeywords: ["Data", "Service", "Web Feature Service", "OGC"],
+  },
+  WMS: {
+    type: ItemType.WMS,
+    typeKeywords: ["Data", "Service", "Web Map Service", "OGC"],
+  },
+  WMTS: {
+    type: ItemType.WMTS,
+    typeKeywords: ["Data", "Service", "OGC"],
+  },
+  ogcFeature: {
+    type: ItemType.OGCFeatureServer,
+    typeKeywords: [
+      "Data",
+      "Service",
+      "Feature Service",
+      "OGC",
+      "OGC Feature Service",
+    ],
+  },
+  SceneServer: {
+    type: ItemType["Scene Service"],
+    typeKeywords: ["Scene Service"],
+  },
+  StreamServer: {
+    type: ItemType["Stream Service"],
+    typeKeywords: ["Data", "Service", "Stream Service", "ArcGIS Server"],
+  },
+  WMServer: {
+    type: ItemType["Workflow Manager Service"],
+    typeKeywords: [
+      "Workflow Manager",
+      "ArcGIS Server",
+      "WMServer",
+      "Workflow",
+      "JTX",
+      "Job Tracking",
+    ],
+  },
+  TiledImageServer: {
+    type: ItemType["Image Service"],
+    typeKeywords: ["Tiled Imagery"],
+  },
+  "Web Mapping Application": {
+    type: ItemType["Web Mapping Application"],
+    typeKeywords: [
+      "JavaScript",
+      "Map",
+      "Mapping Site",
+      "Online Map",
+      "Ready To Use",
+      "Web AppBuilder",
+      "Web Map (+ WAB2D or WAB3D)",
+    ],
+  },
+  "Mobile Application": {
+    type: ItemType["Mobile Application"],
+    typeKeywords: ["ArcGIS Mobile Map", "Mobile Application"],
+  },
+  "AppBuilder Extension": {
+    type: ItemType["AppBuilder Extension"],
+    typeKeywords: ["Widget", "App Builder"],
+  },
+  "Google Drive": {
+    type: ItemType["Google Drive"],
+    typeKeywords: ["CSV", "Shapefile", "GeoJSON", "Excel", "FileGeodatabase"],
+  },
+  Dropbox: {
+    type: ItemType.Dropbox,
+    typeKeywords: ["CSV", "Shapefile", "GeoJSON", "Excel", "FileGeodatabase"],
+  },
+  OneDrive: {
+    type: ItemType.OneDrive,
+    typeKeywords: ["CSV", "Shapefile", "GeoJSON", "Excel", "FileGeodatabase"],
+  },
+  "Map Service": {
+    type: ItemType["Map Service"],
+    typeKeywords: [
+      "ArcGIS Server",
+      "Data",
+      "Map Service",
+      "Service",
+      "Hosted Service",
+    ],
+  },
+  StoryMap: {
+    type: ItemType.StoryMap,
+    typeKeywords: [
+      "arcgis-storymaps",
+      "StoryMap",
+      "Web Application (smstatusdraft or smsstatuspublished)",
+    ],
+  },
+  Dashboard: {
+    type: ItemType.Dashboard,
+    typeKeywords: ["Dashboard", "Operations Dashboard"],
+  },
+  "Hub Initiative": {
+    type: ItemType["Hub Initiative"],
+    typeKeywords: ["Hub", "hubInitiative", "OpenData"],
+  },
+  "Hub Site Application": {
+    type: ItemType["Hub Site Application"],
+    typeKeywords: [
+      "Hub",
+      "hubSite",
+      "hubSolution",
+      "JavaScript",
+      "Map",
+      "Mapping Site",
+      "Online Map",
+      "OpenData",
+      "Ready To Use",
+      "selfConfigured",
+      "Web Map",
+      "Registered App",
+    ],
+  },
+  "Web Experience": {
+    type: ItemType["Web Experience"],
+    typeKeywords: [
+      "EXB Experience",
+      "JavaScript",
+      "Ready To Use Web Application",
+      "Web Experience",
+      "Web Mapping Application",
+      "Web Page",
+      "Web Site",
+    ],
+  },
+  "Insights Workbook Package": {
+    type: ItemType["Insights Workbook Package"],
+    fileExt: [FileExtension.insightswbk],
+    typeKeywords: ["Insights", "Insights Workbook Package"],
+  },
+};

--- a/packages/common/test/resources/_validate-url-helpers.test.ts
+++ b/packages/common/test/resources/_validate-url-helpers.test.ts
@@ -1,0 +1,312 @@
+import {
+  IExtent,
+  IFeatureServiceDefinition,
+  ILayerDefinition,
+} from "@esri/arcgis-rest-types";
+import * as fetchMock from "fetch-mock";
+import { ItemType } from "../../src";
+import {
+  shouldHaveDataUrl,
+  getFileName,
+  isUrl,
+  isFeatureService,
+  isService,
+  isFeatureLayer,
+  getFeatureServiceTitle,
+  getFeatureLayerItem,
+  getFeatureServiceItem,
+  detectDataTypeFromHeader,
+  detectDataTypeFromExtension,
+  pingUrl,
+  pingFeatureService,
+} from "../../src/resources/_internal/_validate-url-helpers";
+
+describe("_validate-url-helpers", () => {
+  it("shouldHaveDataUrl", () => {
+    ["Feature Service", "Document Link"].forEach((type) => {
+      expect(shouldHaveDataUrl(type)).toBeFalsy();
+    });
+    expect(shouldHaveDataUrl("Image")).toBeTruthy();
+  });
+
+  it("getFileName", () => {
+    // If the URL does not have a pathname then it returns hostname.
+    let url = "https://hubqa.arcgis.com";
+    expect(getFileName(url)).toBe("hubqa.arcgis.com");
+    // Otherwise it does return the pathname.
+    url = "https://hubqa.arcgis.com/item-test/test.csv";
+    expect(getFileName(url)).toBe("test.csv");
+    // Throws error
+    try {
+      getFileName("test");
+    } catch (e) {
+      expect(e.message).toBe("Error getting file name from data url");
+    }
+  });
+
+  it("isUrl", () => {
+    expect(isUrl("https://hubqa.arcgis.com")).toBeTruthy("valid url passes");
+    // invalid url
+    expect(isUrl("test")).toBeFalsy("Invalid url returns false");
+  });
+
+  it("isFeatureService", () => {
+    expect(
+      isFeatureService(
+        "https://test.com/test/arcgis/rest/services/2016_Crashes_Florida_view/FeatureServer"
+      )
+    ).toBeTruthy("valid FS returns true");
+    // Image server fails.
+    expect(
+      isFeatureService(
+        "https://test.com/test/arcgis/rest/services/2016_Crashes_Florida_view/ImageServer"
+      )
+    ).toBeFalsy("Image server rejects");
+    // Map server fails
+    expect(
+      isFeatureService(
+        "https://test.com/test/arcgis/rest/services/2016_Crashes_Florida_view/MapServer"
+      )
+    ).toBeFalsy("Map server rejects");
+  });
+
+  it("isService", () => {
+    const servers = [
+      "https://test.com/FeatureServer",
+      "https://test.com/MapServer",
+      "https://test.com/ImageServer",
+    ];
+    servers.forEach((server) => {
+      expect(isService(server)).toBeTruthy("Servers pass");
+    });
+    expect(isService("https://test.com/test")).toBeFalsy(
+      "non server does not pass"
+    );
+  });
+
+  it("isFeatureLayer", () => {
+    expect(
+      isFeatureLayer(
+        "https://test.com/test/arcgis/rest/services/2016_Crashes_Florida_view/FeatureServer/0"
+      )
+    ).toBeTruthy("It has a layer");
+    // no layer
+    expect(
+      isFeatureLayer(
+        "https://test.com/test/arcgis/rest/services/2016_Crashes_Florida_view/FeatureServer"
+      )
+    ).toBeFalsy("It does not have a layer");
+    // Not feature service
+    expect(
+      isFeatureLayer(
+        "https://test.com/test/arcgis/rest/services/2016_Crashes_Florida_view/MapServer/0"
+      )
+    ).toBeFalsy("It is not a FeatureSErvice");
+  });
+
+  it("getFeatureServiceTitle", () => {
+    expect(
+      getFeatureServiceTitle(
+        "https://test.com/test/arcgis/rest/services/2016_Crashes_Florida_view/FeatureServer"
+      )
+    ).toBe("2016_Crashes_Florida_view");
+  });
+
+  it("getFeatureLayerItem", () => {
+    const url =
+      "https://test.com/test/arcgis/rest/services/2016_Crashes_Florida_view/FeatureServer/0";
+    const extent: IExtent = {
+      // autocasts as new Extent()
+      xmin: -9177811,
+      ymin: 4247000,
+      xmax: -9176791,
+      ymax: 4247784,
+      spatialReference: {
+        wkid: 102100,
+      },
+    };
+    const body: Partial<ILayerDefinition> = {
+      name: "test",
+      description: "this is a test",
+      extent,
+    };
+    const result: any = {
+      title: "test",
+      description: "this is a test",
+      extent,
+      url,
+    };
+    expect(getFeatureLayerItem(url, body)).toEqual(result);
+  });
+
+  it("getFeatureServiceItem", () => {
+    const url =
+      "https://test.com/test/arcgis/rest/services/2016_Crashes_Florida_view/FeatureServer/0";
+    const extent: IExtent = {
+      // autocasts as new Extent()
+      xmin: -9177811,
+      ymin: 4247000,
+      xmax: -9176791,
+      ymax: 4247784,
+      spatialReference: {
+        wkid: 102100,
+      },
+    };
+
+    const body: Partial<IFeatureServiceDefinition> = {
+      serviceDescription: "This is a test",
+      fullExtent: extent,
+    };
+    expect(getFeatureServiceItem(url, body)).toEqual({
+      title: "2016_Crashes_Florida_view",
+      description: "This is a test",
+      extent,
+      url,
+    });
+
+    const secondBody: Partial<IFeatureServiceDefinition> = {
+      description: "This is a test",
+      initialExtent: extent,
+    };
+    expect(getFeatureServiceItem(url, secondBody)).toEqual({
+      title: "2016_Crashes_Florida_view",
+      description: "This is a test",
+      extent,
+      url,
+    });
+  });
+
+  it("detectDataTypeFromheader", () => {
+    // if there's no content type....
+    const noContentTypeHeaders = new Headers();
+    expect(detectDataTypeFromHeader(noContentTypeHeaders)).toBeFalsy();
+    // run through expected types.
+    const types = [
+      "text/csv",
+      "application/vnd.ms-excel",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "application/pdf",
+      "image/jpeg",
+      "image/jpg",
+      "image/png",
+      "application/geo+json",
+      "application/test",
+    ];
+    types.forEach((type) => {
+      const headers = new Headers();
+      headers.append("Content-Type", type);
+      const result = detectDataTypeFromHeader(headers);
+      expect(result).toBe(ItemType[result]);
+    });
+  });
+
+  it("detectDataTypeFromExtension", () => {
+    const urls = [
+      "https://notrealurl.com/test.csv",
+      "https://notrealurl.com/test.xls",
+      "https://notrealurl.com/test.xlsx",
+      "https://notrealurl.com/test.pdf",
+      "https://notrealurl.com/test.jpeg",
+      "https://notrealurl.com/test.jpg",
+      "https://notrealurl.com/test.png",
+      "https://notrealurl.com/test.geojson",
+    ];
+    urls.forEach((url) => {
+      expect(detectDataTypeFromExtension(url)).toBeTruthy();
+    });
+    // ensure one not in the list doesn't get through
+    expect(
+      detectDataTypeFromExtension("https://notrealurl.com/test.kml")
+    ).toBeFalsy();
+  });
+
+  describe("ping url and ping feature service", () => {
+    const response = { ok: true };
+    beforeEach(() => {
+      fetchMock.mock("*", { status: 200, body: response });
+    });
+    afterEach(fetchMock.restore);
+
+    it("pingUrl", async () => {
+      const result = await pingUrl("https://notrealurl.com/test.csv");
+      expect(result.ok).toBeTruthy();
+    });
+
+    it("pingFeatureService response fails", async () => {
+      fetchMock.reset();
+      fetchMock.mock("*", { status: 400, body: { ok: false } });
+      const result = await pingFeatureService(
+        "https://notrealurl.com/services/test/FeatureServer"
+      );
+      expect(result.ok).toBeFalsy();
+    });
+
+    it("pingFeatureService status 200 bbut really a failure", async () => {
+      fetchMock.reset();
+      fetchMock.mock("*", { status: 200, body: { ok: true, error: {} } });
+      const result = await pingFeatureService(
+        "https://notrealurl.com/services/test/FeatureServer"
+      );
+      expect(result.ok).toBeFalsy();
+    });
+
+    it("pingFeatureService works for feature layers", async () => {
+      const url = "https://notrealurl.com/services/test/FeatureServer/0";
+      const extent: IExtent = {
+        // autocasts as new Extent()
+        xmin: -9177811,
+        ymin: 4247000,
+        xmax: -9176791,
+        ymax: 4247784,
+        spatialReference: {
+          wkid: 102100,
+        },
+      };
+      const body: Partial<ILayerDefinition> = {
+        name: "test",
+        description: "This is a test",
+        extent,
+      };
+      fetchMock.reset();
+      fetchMock.mock("*", {
+        status: 200,
+        body,
+      });
+      const result = await pingFeatureService(url);
+      expect(result.ok).toBeTruthy();
+      expect(result.item.title).toBe(body.name);
+      expect(result.item.description).toBe(body.description);
+      expect(result.item.extent).toEqual(extent);
+      expect(result.item.url).toBe(url);
+    });
+
+    it("pingFeatureService works for feature servers", async () => {
+      const url = "https://notrealurl.com/services/test/FeatureServer";
+      const extent: IExtent = {
+        // autocasts as new Extent()
+        xmin: -9177811,
+        ymin: 4247000,
+        xmax: -9176791,
+        ymax: 4247784,
+        spatialReference: {
+          wkid: 102100,
+        },
+      };
+      const body: Partial<IFeatureServiceDefinition> = {
+        serviceDescription: "This is a test",
+        fullExtent: extent,
+      };
+      fetchMock.reset();
+      fetchMock.mock("*", {
+        status: 200,
+        body,
+      });
+      const result = await pingFeatureService(url);
+      expect(result.ok).toBeTruthy();
+      expect(result.item.title).toBe("test");
+      expect(result.item.description).toBe(body.serviceDescription);
+      expect(result.item.extent).toEqual(extent);
+      expect(result.item.url).toBe(url);
+    });
+  });
+});

--- a/packages/common/test/resources/validate-url.test.ts
+++ b/packages/common/test/resources/validate-url.test.ts
@@ -1,0 +1,194 @@
+import { IExtent } from "@esri/arcgis-rest-types";
+import * as fetchMock from "fetch-mock";
+import { validateUrl } from "../../src";
+
+describe("validateUrl", () => {
+  const response = { ok: true };
+  beforeEach(() => {
+    fetchMock.mock("*", { status: 200, body: response });
+  });
+  afterEach(fetchMock.restore);
+
+  it("rejects if invalid url", async () => {
+    const result = await validateUrl("test");
+    expect(result.pass).toBeFalsy();
+    expect(result.error).toBe("invalidFormat");
+  });
+
+  it("rejects if null input", async () => {
+    const result = await validateUrl("");
+    expect(result.pass).toBeFalsy();
+    expect(result.error).toBe("invalidFormat");
+  });
+
+  it("rejects for map service", async () => {
+    const result = await validateUrl(
+      "https://test.com/test/arcgis/rest/services/2016_Crashes_Florida_view/MapServer"
+    );
+    expect(result.pass).toBeFalsy();
+    expect(result.error).toBe("invalidFormat");
+  });
+
+  it("rejects for image service", async () => {
+    const result = await validateUrl(
+      "https://test.com/test/arcgis/rest/services/2016_Crashes_Florida_view/ImageServer"
+    );
+    expect(result.pass).toBeFalsy();
+    expect(result.error).toBe("invalidFormat");
+  });
+
+  it("rejects if the response fails", async () => {
+    fetchMock.reset();
+    fetchMock.mock("*", { status: 400, body: { ok: false } });
+    const result = await validateUrl(
+      "https://notrealurl.com/services/test/FeatureServer"
+    );
+    expect(result.pass).toBeFalsy();
+    expect(result.error).toBe("invalidUrl");
+  });
+
+  it("rejects if the service status 200 but really a failure", async () => {
+    fetchMock.reset();
+    fetchMock.mock("*", { status: 200, body: { ok: true, error: {} } });
+    const result = await validateUrl(
+      "https://notrealurl.com/services/test/FeatureServer"
+    );
+    expect(result.pass).toBeFalsy();
+    expect(result.error).toBe("invalidUrl");
+  });
+
+  it("Passes through if error is thrown fetching url (could be cors issue)", async () => {
+    fetchMock.reset();
+    fetchMock.mock("*", () => {
+      throw new Error("Fake CORS err");
+    });
+    const result = await validateUrl(
+      "https://notrealurl.com/services/test/FeatureServer"
+    );
+    expect(result.pass).toBeTruthy();
+    expect(result.item).toEqual({
+      title: "FeatureServer",
+      type: "Feature Service",
+      url: "https://notrealurl.com/services/test/FeatureServer",
+    });
+  });
+
+  it("returns pass===true for data url with headers", async () => {
+    fetchMock.reset();
+    fetchMock.mock("*", {
+      headers: {
+        "Content-Type": "application/pdf",
+      },
+      status: 200,
+    });
+    const result = await validateUrl("https://notrealurl.com");
+    expect(result.pass).toBeTruthy();
+    expect(result.error).toBeFalsy();
+    expect(result.type).toBe("PDF");
+
+    expect(result.item).toEqual({
+      title: "notrealurl.com",
+      url: "https://notrealurl.com",
+      type: "PDF",
+      dataUrl: "https://notrealurl.com",
+    });
+  });
+
+  it("returns pass === true for data url without headers", async () => {
+    fetchMock.reset();
+    fetchMock.mock("*", { status: 200, body: response });
+    const result = await validateUrl("https://notrealurl.com/test.csv");
+    expect(result.pass).toBeTruthy();
+    expect(result.error).toBeFalsy();
+    expect(result.type).toBe("CSV");
+
+    expect(result.item).toEqual({
+      title: "test.csv",
+      url: "https://notrealurl.com/test.csv",
+      type: "CSV",
+      dataUrl: "https://notrealurl.com/test.csv",
+    });
+  });
+
+  it("returns pass === true for data url without headers and with unknown type", async () => {
+    fetchMock.reset();
+    fetchMock.mock("*", { status: 200, body: response });
+    const result = await validateUrl("https://notrealurl.com/test.kml");
+    expect(result.pass).toBeTruthy();
+    expect(result.error).toBeFalsy();
+
+    expect(result.item).toEqual({
+      title: "test.kml",
+      url: "https://notrealurl.com/test.kml",
+    });
+  });
+
+  it("can get item metadata from a feature service", async () => {
+    const url = "https://notrealurl.com/services/test/FeatureServer";
+    const extent: IExtent = {
+      // autocasts as new Extent()
+      xmin: -9177811,
+      ymin: 4247000,
+      xmax: -9176791,
+      ymax: 4247784,
+      spatialReference: {
+        wkid: 102100,
+      },
+    };
+    fetchMock.reset();
+    fetchMock.mock("*", {
+      body: {
+        description: "This is a test",
+        fullExtent: extent,
+      },
+      status: 200,
+    });
+    const result = await validateUrl(url);
+    expect(result.pass).toBeTruthy();
+    expect(result.error).toBeFalsy();
+    expect(result.type).toBe("Feature Service");
+
+    expect(result.item).toEqual({
+      title: "test",
+      description: "This is a test",
+      url,
+      type: "Feature Service",
+      extent,
+    });
+  });
+
+  it("can get item metadata from a feature layer", async () => {
+    const url = "https://notrealurl.com/services/test/FeatureServer/0";
+    const extent: IExtent = {
+      // autocasts as new Extent()
+      xmin: -9177811,
+      ymin: 4247000,
+      xmax: -9176791,
+      ymax: 4247784,
+      spatialReference: {
+        wkid: 102100,
+      },
+    };
+    fetchMock.reset();
+    fetchMock.mock("*", {
+      body: {
+        name: "Test test",
+        description: "This is a test",
+        extent,
+      },
+      status: 200,
+    });
+    const result = await validateUrl(url);
+    expect(result.pass).toBeTruthy();
+    expect(result.error).toBeFalsy();
+    expect(result.type).toBe("Feature Service");
+
+    expect(result.item).toEqual({
+      title: "Test test",
+      description: "This is a test",
+      url,
+      type: "Feature Service",
+      extent,
+    });
+  });
+});


### PR DESCRIPTION
1. Description: Migrates validate url logic from Haoliang over from ember. Will be used by new component in hub-components.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
