### PR TITLE
fix(hub-common): fixes removeContextFromSlug to ensure entire context included

### DIFF
--- a/packages/common/src/content/slugs.ts
+++ b/packages/common/src/content/slugs.ts
@@ -60,7 +60,7 @@ export function addContextToSlug(slug: string, context: string): string {
  * @returns slug without context
  */
 export function removeContextFromSlug(slug: string, context: string): string {
-  if (context && slug.match(`${context}::`)) {
+  if (context && slug.match(`^${context}::`)) {
     return slug.split(`${context}::`)[1];
   } else {
     return slug;

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -432,6 +432,15 @@ describe("Slug Helpers", () => {
       const slug = removeContextFromSlug(slugWithContext, "other-org");
       expect(slug).toBe(slugWithContext);
     });
+    it("correctly matches on full context", () => {
+      const slugOne = removeContextFromSlug(slugWithContext, orgKey);
+      expect(slugOne).toBe(title);
+      const slugTwo = removeContextFromSlug(
+        slugWithContext,
+        `another-${orgKey}`
+      );
+      expect(slugTwo).toBe(slugWithContext);
+    });
   });
 });
 


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
- When removing context from slug, there was a very nasty edge case where slug was improperly removed if the underlying item belonged to a different org (context) and the current context and underlying context ended with the same text. This is a regex change to ensure the slug must be matched entirely

2. Instructions for testing:
- See unit tests. Also built and resolved issue in opendata-ui

3. Closes Issues: [3470](https://devtopia.esri.com/dc/hub/issues/3470)

4. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
