### PR TITLE
feat(hub-discussions): extends post geometry support in hub-discussions

### DIFF
--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -365,6 +365,7 @@ export interface IPost extends IWithAuthor, IWithEditor, IWithTimestamps {
   discussion?: string;
   status: PostStatus;
   geometry?: Geometry;
+  featureGeometry?: Geometry;
   appInfo?: string; // this is a catch-all field for app-specific information about a post, added for Urban
   channelId?: string;
   channel?: IChannel;
@@ -388,6 +389,7 @@ export interface ICreateChannelPost {
   channelId: string;
   discussion?: string;
   geometry?: Geometry;
+  featureGeometry?: Geometry;
   appInfo?: string;
 }
 
@@ -433,6 +435,8 @@ export interface ISearchPosts
   title?: string;
   body?: string;
   discussion?: string;
+  geometry?: Geometry;
+  featureGeometry?: Geometry;
   parents?: Array<string | null>;
   status?: PostStatus[];
   relations?: PostRelation[];


### PR DESCRIPTION
affects: @esri/hub-discussions

Reflects recent changes in hub-discussions to support spatial filtering of post geometry and new
featureGeometry field

1. Description:

`hub-discussions` has new `post.featureGeometry` column and both `post.geometry` and `post.featureGeometry` are *searchable* by `Geometry`.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
