### PR TITLE
fix(hub-common): allows start param to be passed into Project searches

### DIFF
--- a/packages/common/src/search/_internal/searchContentEntities.ts
+++ b/packages/common/src/search/_internal/searchContentEntities.ts
@@ -51,13 +51,8 @@ export function searchContentEntities<T>(
     "sortField",
     "sortOrder",
     "site",
+    "start",
   ];
-
-  // "start" not included in IHubSearchOptions because Hub v3 API relied on "page"
-  // Hub V4 API, however, will provide "start"
-  if ((options as any).start) {
-    searchOptions.start = (options as any).start;
-  }
 
   // Include "start" here
   // copy the props over

--- a/packages/common/src/search/_internal/searchContentEntities.ts
+++ b/packages/common/src/search/_internal/searchContentEntities.ts
@@ -52,6 +52,14 @@ export function searchContentEntities<T>(
     "sortOrder",
     "site",
   ];
+
+  // "start" not included in IHubSearchOptions because Hub v3 API relied on "page"
+  // Hub V4 API, however, will provide "start"
+  if ((options as any).start) {
+    searchOptions.start = (options as any).start;
+  }
+
+  // Include "start" here
   // copy the props over
   props.forEach((prop) => {
     if (options.hasOwnProperty(prop)) {

--- a/packages/common/src/search/_searchContent.ts
+++ b/packages/common/src/search/_searchContent.ts
@@ -49,6 +49,7 @@ export async function _searchContent(
       "sortField",
       "sortOrder",
       "site",
+      "start",
     ];
     // copy the props over
     props.forEach((prop) => {

--- a/packages/common/src/search/_searchGroups.ts
+++ b/packages/common/src/search/_searchGroups.ts
@@ -42,6 +42,7 @@ export async function _searchGroups(
       "sortField",
       "sortOrder",
       "site",
+      "start",
     ];
     // copy the props over
     props.forEach((prop) => {

--- a/packages/common/src/search/_searchUsers.ts
+++ b/packages/common/src/search/_searchUsers.ts
@@ -68,6 +68,7 @@ export async function _searchUsers(
       "sortField",
       "sortOrder",
       "site",
+      "start",
     ];
     // copy the props over
     props.forEach((prop) => {

--- a/packages/common/src/search/types.ts
+++ b/packages/common/src/search/types.ts
@@ -346,6 +346,7 @@ export interface IHubSearchOptions {
   sortField?: string;
   sortOrder?: "desc" | "asc";
   page?: string;
+  start?: number;
   num?: number;
   aggregations?: string[];
   bbox?: string;

--- a/packages/common/test/projects/HubProjects.test.ts
+++ b/packages/common/test/projects/HubProjects.test.ts
@@ -256,6 +256,7 @@ describe("HubProjects:", () => {
       expect(modelToUpdate.item.properties.slug).toBe("dcdev-wat-blarg-1");
     });
   });
+
   describe("searchProjects:", () => {
     const fakeResults = {
       total: 1,
@@ -326,6 +327,33 @@ describe("HubProjects:", () => {
         sortOrder: "desc",
         site: { item: {}, data: {} },
       } as IHubSearchOptions;
+      const response = await searchProjects(filter, opts);
+      expect(response.results.length).toBe(1);
+      expect(searchSpy.calls.count()).toBe(1);
+      expect(dataSpy.calls.count()).toBe(1);
+      expect(response.results[0].thumbnailUrl).toBe(
+        "https://myorg.maps.arcgis.com/sharing/rest/content/items/bc3/info/zen.jpg?token=fake-token"
+      );
+      // verify the query
+      const searchOpts = searchSpy.calls.argsFor(0)[0];
+
+      expect(searchOpts.q).toBe("water");
+      expect(searchOpts.filter).toBe(`(type:"Hub Project")`);
+    });
+    it("constructs search, including a specific start if required", async () => {
+      const filter: Filter<"content"> = {
+        filterType: "content",
+        term: "water",
+      };
+      const opts = {
+        authentication: MOCK_AUTH,
+        aggregations: ["tags"],
+        num: 10,
+        sortField: "title",
+        sortOrder: "desc",
+        site: { item: {}, data: {} },
+        start: 2,
+      } as any;
       const response = await searchProjects(filter, opts);
       expect(response.results.length).toBe(1);
       expect(searchSpy.calls.count()).toBe(1);

--- a/packages/common/test/search/_searchContent.test.ts
+++ b/packages/common/test/search/_searchContent.test.ts
@@ -118,6 +118,7 @@ describe("_searchContent:", () => {
         aggregations: ["tags", "access"],
         sortField: "title",
         sortOrder: "desc",
+        start: 1,
       };
 
       const res = await _searchContent(f, opts);
@@ -128,6 +129,10 @@ describe("_searchContent:", () => {
       expect(expectedParams.q).toEqual("water");
       // verify countFields
       expect(expectedParams.countFields).toEqual("tags,access");
+      // veryify opts
+      expect(expectedParams.sortField).toEqual("title");
+      expect(expectedParams.sortOrder).toEqual("desc");
+      expect(expectedParams.start).toEqual(1);
       // verify Facets
       expect(res.facets).toBeDefined();
       expect(res.facets?.length).toBe(2, "should have two facets");

--- a/packages/common/test/search/_searchGroups.test.ts
+++ b/packages/common/test/search/_searchGroups.test.ts
@@ -80,6 +80,7 @@ describe("_searchGroups:", () => {
         num: 6,
         sortField: "title",
         sortOrder: "desc",
+        start: 3,
       };
       await _searchGroups(f, o);
       expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
@@ -87,6 +88,7 @@ describe("_searchGroups:", () => {
 
       expect(expectedParams.q).toEqual("water");
       expect(expectedParams.num).toEqual(6);
+      expect(expectedParams.start).toEqual(3);
       expect(expectedParams.portal).toBe(
         "https://qaext.arcgis.com/sharing/rest"
       );

--- a/packages/common/test/search/_searchUsers.test.ts
+++ b/packages/common/test/search/_searchUsers.test.ts
@@ -92,6 +92,7 @@ describe("_searchUsers:", () => {
         sortField: "username",
         num: 11,
         site,
+        start: 2,
       };
 
       const chk = await _searchUsers(f, o);
@@ -101,6 +102,7 @@ describe("_searchUsers:", () => {
       expect(expectedParams.num).toEqual(11);
       expect(expectedParams.sortOrder).toEqual("desc");
       expect(expectedParams.sortField).toEqual("username");
+      expect(expectedParams.start).toEqual(2);
       expect(expectedParams.site).toEqual(site);
       expect(expectedParams.authentication).toBe(MOCK_ENTERPRISE_AUTH);
       const u1 = chk.results[0];


### PR DESCRIPTION
affects: @esri/hub-common

1. Description
The IHubSearchOptions interface was tailored to the Hub V3 API, which did not allow for a start option property. It's predicted to be allowed in the Hub V4 API. This PR does not change the IHubSearchOptions interface, but allows for a valid start property for Project Search

2. See Unit Test

3. Closes Issues: N/A but unblocks [3531](https://devtopia.esri.com/dc/hub/issues/3531)

4. [x] ran commit script (`npm run c`)
_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
