### PR TITLE
fix(hub-sites): ignore draft resources when clone a site or page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36813,7 +36813,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.25.6",
+			"version": "9.26.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -36847,7 +36847,7 @@
 		},
 		"packages/content": {
 			"name": "@esri/hub-content",
-			"version": "9.25.6",
+			"version": "9.26.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"fast-xml-parser": "~3.2.4",
@@ -36858,7 +36858,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36872,12 +36872,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.0",
 				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.6"
+				"@esri/hub-common": "9.26.1"
 			}
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.11.6",
+			"version": "11.13.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -36886,7 +36886,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36900,12 +36900,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.25.6"
+				"@esri/hub-common": "9.26.1"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.25.6",
+			"version": "9.26.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -36916,7 +36916,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36926,12 +36926,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.25.6"
+				"@esri/hub-common": "9.26.1"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.25.6",
+			"version": "9.26.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -36942,7 +36942,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36957,12 +36957,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.6"
+				"@esri/hub-common": "9.26.1"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.25.6",
+			"version": "9.26.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -36971,7 +36971,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -36985,12 +36985,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.6"
+				"@esri/hub-common": "9.26.1"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.25.6",
+			"version": "9.26.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37001,7 +37001,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -37018,12 +37018,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.6"
+				"@esri/hub-common": "9.26.1"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.25.6",
+			"version": "9.26.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37032,9 +37032,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
-				"@esri/hub-initiatives": "9.25.6",
-				"@esri/hub-teams": "9.25.6",
+				"@esri/hub-common": "9.26.1",
+				"@esri/hub-initiatives": "9.26.1",
+				"@esri/hub-teams": "9.26.1",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -37048,14 +37048,14 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.6",
-				"@esri/hub-initiatives": "9.25.6",
-				"@esri/hub-teams": "9.25.6"
+				"@esri/hub-common": "9.26.1",
+				"@esri/hub-initiatives": "9.26.1",
+				"@esri/hub-teams": "9.26.1"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.25.6",
+			"version": "9.26.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37066,7 +37066,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -37081,12 +37081,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.6"
+				"@esri/hub-common": "9.26.1"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.25.6",
+			"version": "9.26.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -37096,7 +37096,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -37110,7 +37110,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.25.6"
+				"@esri/hub-common": "9.26.1"
 			}
 		}
 	},
@@ -38581,7 +38581,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.2.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38599,7 +38599,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38619,7 +38619,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38639,7 +38639,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38656,7 +38656,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38676,7 +38676,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38695,9 +38695,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
-				"@esri/hub-initiatives": "9.25.6",
-				"@esri/hub-teams": "9.25.6",
+				"@esri/hub-common": "9.26.1",
+				"@esri/hub-initiatives": "9.26.1",
+				"@esri/hub-teams": "9.26.1",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -38717,7 +38717,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -38735,7 +38735,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.25.6",
+				"@esri/hub-common": "9.26.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/sites/test/convert-site-to-template.test.ts
+++ b/packages/sites/test/convert-site-to-template.test.ts
@@ -3,7 +3,7 @@ import { cloneObject, deepSet } from "@esri/hub-common";
 import {
   SITE_ITEM_RESPONSE,
   SITE_DATA_RESPONSE,
-  SITE_RESOURCES_RESPONSE
+  SITE_RESOURCES_RESPONSE,
 } from "./site-responses.test";
 import { MOCK_HUB_REQOPTS } from "./test-helpers.test";
 import * as fetchMock from "fetch-mock";
@@ -13,14 +13,14 @@ describe("convertSiteToTemplate", () => {
     // construct a model
     const model = {
       item: cloneObject(SITE_ITEM_RESPONSE),
-      data: cloneObject(SITE_DATA_RESPONSE)
+      data: cloneObject(SITE_DATA_RESPONSE),
     };
     // make some changes so we can ensure some operations occur
     model.data.chkIdConvert = `this has the ${model.item.id} item id`;
     // setup the fetch mocks
     fetchMock.post(`glob:*/${SITE_ITEM_RESPONSE.id}/resources`, {
       status: 200,
-      body: JSON.stringify(SITE_RESOURCES_RESPONSE)
+      body: JSON.stringify(SITE_RESOURCES_RESPONSE),
     });
 
     const response = await convertSiteToTemplate(model, MOCK_HUB_REQOPTS);
@@ -39,7 +39,11 @@ describe("convertSiteToTemplate", () => {
       "192c341d37b04e35a017402491bec6ea",
       "should pull a dependency"
     );
-    expect(response.assets.length).toBe(9, "should have 9 assets");
+    expect(SITE_RESOURCES_RESPONSE.total).toBe(
+      10,
+      "should have 10 resources from site"
+    );
+    expect(response.assets.length).toBe(9, "should ignore draft resources");
     expect(response.item.hasOwnProperty("url")).toBeFalsy(
       "item.url should be removed"
     );
@@ -57,7 +61,7 @@ describe("convertSiteToTemplate", () => {
     // construct a model
     const model = {
       item: cloneObject(SITE_ITEM_RESPONSE),
-      data: cloneObject(SITE_DATA_RESPONSE)
+      data: cloneObject(SITE_DATA_RESPONSE),
     };
 
     delete model.data.values.defaultExtent;
@@ -66,7 +70,7 @@ describe("convertSiteToTemplate", () => {
     // setup the fetch mocks
     fetchMock.post(`glob:*/${SITE_ITEM_RESPONSE.id}/resources`, {
       status: 200,
-      body: JSON.stringify(SITE_RESOURCES_RESPONSE)
+      body: JSON.stringify(SITE_RESOURCES_RESPONSE),
     });
 
     const response = await convertSiteToTemplate(model, MOCK_HUB_REQOPTS);

--- a/packages/sites/test/pages/convert-page-to-template.test.ts
+++ b/packages/sites/test/pages/convert-page-to-template.test.ts
@@ -39,6 +39,21 @@ describe("convertPageToTemplate", () => {
       url: "some-url",
       type: "some-type",
     },
+    {
+      mimeType: "image/png",
+      name: "draft-1234123.json",
+      url: "some-url",
+      type: "some-type",
+    },
+  ];
+
+  const expectedAsset: ITemplateAsset[] = [
+    {
+      mimeType: "image/png",
+      name: "some-name",
+      url: "some-url",
+      type: "some-type",
+    },
   ];
 
   beforeEach(() => {
@@ -49,11 +64,10 @@ describe("convertPageToTemplate", () => {
 
   it("convert page to template", async () => {
     const chk = await convertPageToTemplate(cloneObject(model), ro);
-
     expect(chk.type).toBe("Hub Page");
     expect(chk.key).toBeDefined();
     expect(chk.itemId).toBe("page-id");
-    expect(chk.assets).toEqual(assets);
+    expect(chk.assets).toEqual(expectedAsset, "should ignore draft resources");
     expect(chk.dependencies).toEqual([
       "cc2",
       "cc3",

--- a/packages/sites/test/pages/convert-page-to-template.test.ts
+++ b/packages/sites/test/pages/convert-page-to-template.test.ts
@@ -3,16 +3,16 @@ import {
   IModel,
   IHubRequestOptions,
   ITemplateAsset,
-  cloneObject
+  cloneObject,
 } from "@esri/hub-common";
 import * as commonModule from "@esri/hub-common";
 import { testLayout } from "../mock-layout.test";
 
 describe("convertPageToTemplate", () => {
-  const model = ({
+  const model = {
     item: {
       id: "page-id",
-      title: "Some fun page"
+      title: "Some fun page",
     },
     data: {
       values: {
@@ -23,13 +23,13 @@ describe("convertPageToTemplate", () => {
         folderId: "delete",
         slug: "delete",
         testIdReplacement: "page-id",
-        layout: testLayout
-      }
-    }
-  } as unknown) as IModel;
+        layout: testLayout,
+      },
+    },
+  } as unknown as IModel;
 
   const ro = {
-    isPortal: false
+    isPortal: false,
   } as IHubRequestOptions;
 
   const assets: ITemplateAsset[] = [
@@ -37,8 +37,8 @@ describe("convertPageToTemplate", () => {
       mimeType: "image/png",
       name: "some-name",
       url: "some-url",
-      type: "some-type"
-    }
+      type: "some-type",
+    },
   ];
 
   beforeEach(() => {
@@ -53,14 +53,14 @@ describe("convertPageToTemplate", () => {
     expect(chk.type).toBe("Hub Page");
     expect(chk.key).toBeDefined();
     expect(chk.itemId).toBe("page-id");
-    expect(chk.assets).toBe(assets);
+    expect(chk.assets).toEqual(assets);
     expect(chk.dependencies).toEqual([
       "cc2",
       "cc3",
       "0ee0b0a435db49969bbd93a7064a321c",
       "eb173fb9d0084c4bbd19b40ee186965f",
       "e8201f104dca4d8d87cb4ce1c7367257",
-      "5a14dbb7b2f3417fb4a6ea0506c2eb26"
+      "5a14dbb7b2f3417fb4a6ea0506c2eb26",
     ]);
     expect(chk.data.values.sites).toEqual([], "sites are emptied");
     expect(chk.data.values.testIdReplacement).toBe("{{appid}}");

--- a/packages/sites/test/site-responses.test.ts
+++ b/packages/sites/test/site-responses.test.ts
@@ -22,7 +22,7 @@ export const SITE_ITEM_RESPONSE = {
     "Ready To Use",
     "selfConfigured",
     "Web Map",
-    "Registered App"
+    "Registered App",
   ],
   description:
     "Create your own initiative by combining existing applications with a custom site. Use this initiative to form teams around a problem and invite your community to participate.",
@@ -46,7 +46,7 @@ export const SITE_ITEM_RESPONSE = {
     parentInitiativeId: "c36ce9aca1ce4f5598196acdaa73f3e9",
     children: [],
     collaborationGroupId: "7cb00f2cff024747887a0b711c2f02d2",
-    teams: ["6d7bb29366744a16a8c26725f16a6211"]
+    teams: ["6d7bb29366744a16a8c26725f16a6211"],
   },
   url: "https://dave-public-dc.hubqa.arcgis.com",
   proxyFilter: null,
@@ -68,12 +68,12 @@ export const SITE_ITEM_RESPONSE = {
   numViews: 2494,
   itemControl: "admin",
   scoreCompleteness: 45,
-  groupDesignations: null
+  groupDesignations: null,
 } as IItem;
 
 export const SITE_DATA_RESPONSE = {
   catalog: {
-    groups: ["b2ee4e0403c14b9e8c61727a4d24b9b9"]
+    groups: ["b2ee4e0403c14b9e8c61727a4d24b9b9"],
   },
   values: {
     title: "Default Site Template",
@@ -90,16 +90,15 @@ export const SITE_DATA_RESPONSE = {
             {
               id: "World_Imagery_2017",
               layerType: "ArcGISTiledMapServiceLayer",
-              url:
-                "https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer",
+              url: "https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer",
               visibility: true,
               opacity: 1,
-              title: "World Imagery"
-            }
+              title: "World Imagery",
+            },
           ],
-          operationalLayers: []
-        }
-      }
+          operationalLayers: [],
+        },
+      },
     },
     defaultExtent: {
       xmin: -8608122.702602567,
@@ -107,15 +106,15 @@ export const SITE_DATA_RESPONSE = {
       xmax: -8551463.755386196,
       ymax: 4733454.274071424,
       spatialReference: {
-        wkid: 102100
-      }
+        wkid: 102100,
+      },
     },
     pages: [
       {
         id: "192c341d37b04e35a017402491bec6ea",
         title: "gooafsad",
-        slug: "gooafsad"
-      }
+        slug: "gooafsad",
+      },
     ],
     layout: {
       sections: [
@@ -132,47 +131,47 @@ export const SITE_DATA_RESPONSE = {
                   transformAxis: "x",
                   position: {
                     x: 0,
-                    y: 0
+                    y: 0,
                   },
                   scale: {
                     current: 0,
-                    original: 0
+                    original: 0,
                   },
                   container: {
                     left: 20,
                     top: 152,
                     width: 858.0078125,
-                    height: 723.944091796875
+                    height: 723.944091796875,
                   },
                   natural: {
                     width: 800,
-                    height: 675
+                    height: 675,
                   },
                   output: {
                     width: 818.0078125,
-                    height: 446.944091796875
+                    height: 446.944091796875,
                   },
                   version: 2,
                   rendered: {
                     width: 858.0078125,
-                    height: 723.944091796875
-                  }
-                }
+                    height: 723.944091796875,
+                  },
+                },
               },
               transparency: 30,
               position: {
                 x: "center",
-                y: "center"
+                y: "center",
               },
               color: "#000000",
               image:
                 "https://s3.amazonaws.com/geohub-assets/templates/public-engagement/city-architecture.jpg",
               cropId: "i698hohxr",
               fileSrc: "rob-gold.jpg",
-              cropSrc: "hub-image-card-crop-i698hohxr.png"
+              cropSrc: "hub-image-card-crop-i698hohxr.png",
             },
             color: "#ffffff",
-            rowLayout: "box"
+            rowLayout: "box",
           },
           rows: [
             {
@@ -193,46 +192,46 @@ export const SITE_DATA_RESPONSE = {
                       state: "valid",
                       position: {
                         x: "center",
-                        y: "center"
+                        y: "center",
                       },
                       display: {
                         crop: {
                           transformAxis: "x",
                           position: {
                             x: 0,
-                            y: 0
+                            y: 0,
                           },
                           scale: {
                             current: 0,
-                            original: 0
+                            original: 0,
                           },
                           container: {
                             left: 20,
                             top: 31,
                             width: 858.0078125,
-                            height: 482.2624557062561
+                            height: 482.2624557062561,
                           },
                           natural: {
                             width: 1023,
-                            height: 575
+                            height: 575,
                           },
                           output: {
                             width: 818.0078125,
-                            height: 294.2624557062561
+                            height: 294.2624557062561,
                           },
                           version: 2,
                           rendered: {
                             width: 858.0078125,
-                            height: 482.2624557062561
-                          }
-                        }
+                            height: 482.2624557062561,
+                          },
+                        },
                       },
-                      cropId: "iotoe4w50"
-                    }
+                      cropId: "iotoe4w50",
+                    },
                   },
-                  width: 12
-                }
-              ]
+                  width: 12,
+                },
+              ],
             },
             {
               cards: [
@@ -254,49 +253,49 @@ export const SITE_DATA_RESPONSE = {
                       display: {
                         position: {
                           x: "center",
-                          y: "center"
+                          y: "center",
                         },
                         reflow: false,
                         crop: {
                           transformAxis: "x",
                           position: {
                             x: 0,
-                            y: 0
+                            y: 0,
                           },
                           scale: {
                             current: 0,
-                            original: 0
+                            original: 0,
                           },
                           container: {
                             left: 20,
                             top: 75,
                             width: 858.0078125,
-                            height: 643.505859375
+                            height: 643.505859375,
                           },
                           natural: {
                             width: 1024,
-                            height: 768
+                            height: 768,
                           },
                           output: {
                             width: 818.0078125,
-                            height: 337.505859375
+                            height: 337.505859375,
                           },
                           version: 2,
                           rendered: {
                             width: 858.0078125,
-                            height: 643.505859375
-                          }
-                        }
+                            height: 643.505859375,
+                          },
+                        },
                       },
-                      cropId: "i3e7knwx9"
-                    }
+                      cropId: "i3e7knwx9",
+                    },
                   },
-                  width: 12
-                }
-              ]
-            }
-          ]
-        }
+                  width: 12,
+                },
+              ],
+            },
+          ],
+        },
       ],
       header: {
         component: {
@@ -319,19 +318,19 @@ export const SITE_DATA_RESPONSE = {
               isFile: true,
               isUrl: false,
               fileSrc: "dumpsterfire-128.png",
-              cropSrc: "dumpsterfire-128.png"
+              cropSrc: "dumpsterfire-128.png",
             },
             shortTitle: "",
             menuLinks: [],
             socialLinks: {
               facebook: {},
               twitter: {},
-              instagram: {}
+              instagram: {},
             },
-            schemaVersion: 2
-          }
+            schemaVersion: 2,
+          },
         },
-        showEditor: false
+        showEditor: false,
       },
       footer: {
         component: {
@@ -340,44 +339,44 @@ export const SITE_DATA_RESPONSE = {
             footerType: "custom",
             markdown:
               '<div class="footer-background">\n  <div class="container-fluid">\n    <div class="col-xs-12">\n      <img src="https://placehold.it/50x50?text=" class="center-block logo">\n    </div>\n    <div class="col-xs-6 center-block">\n      <ul class="nav nav-pills">\n\n        <li><a href="">URL</a></li>\n\n        <li><a href="">URL</a></li>\n\n        <li><a href="">URL</a></li>\n\n        <li><a href="">URL</a></li>\n\n      </ul>\n    </div>\n    <div class="col-xs-6 center-block">\n      <ul class="nav nav-pills" style="float:right;">\n        <li><a href="#">Terms of Service</a></li>\n        <li><a href="#">Privacy Policy</a></li>\n      </ul>\n    </div>\n    <div class="col-xs-12">\n      <div class="text-white" style="padding-top: 3rem; text-align: center;">\n        <p>&copy; Custom Initiative Template. All photos used on this site are from <a href="https://unsplash.com/">Unsplash</a>.</p>\n      </div>\n    </div>\n  </div>\n</div>\n\n\n<style>\n  .footer-background {\n    background-color: #111;\n    color: #fff;\n    padding: 3rem 0;\n  }\n\n  .footer-background .nav a {\n    background-color: transparent;\n    color: #fff;\n    -webkit-font-smoothing: antialiased;\n  }\n\n  .footer-background .nav a:focus,\n  .footer-background .nav a:hover {\n    background-color: transparent;\n  }\n.mt-0 {\n  margin-top: 0rem; }\n\n.mb-0 {\n  margin-bottom: 0rem; }\n\n.mt-1 {\n  margin-top: 0.5rem; }\n\n.mb-1 {\n  margin-bottom: 0.5rem; }\n\n.mt-2 {\n  margin-top: 1rem; }\n\n.mb-2 {\n  margin-bottom: 1rem; }\n\n.mt-3 {\n  margin-top: 1.5rem; }\n\n.mb-3 {\n  margin-bottom: 1.5rem; }\n\n.mt-4 {\n  margin-top: 2rem; }\n\n.mb-4 {\n  margin-bottom: 2rem; }\n\n.mt-5 {\n  margin-top: 2.5rem; }\n\n.mb-5 {\n  margin-bottom: 2.5rem; }\n\n.mt-6 {\n  margin-top: 3rem; }\n\n.mb-6 {\n  margin-bottom: 3rem; }\n\n.mt-7 {\n  margin-top: 3.5rem; }\n\n.mb-7 {\n  margin-bottom: 3.5rem; }\n\n.mt-8 {\n  margin-top: 4rem; }\n\n.mb-8 {\n  margin-bottom: 4rem; }\n\n.mt-9 {\n  margin-top: 4.5rem; }\n\n.mb-9 {\n  margin-bottom: 4.5rem; }\n\n.mt-10 {\n  margin-top: 5rem; }\n\n.mb-10 {\n  margin-bottom: 5rem; }\n}\n.display-flex {\n  display: flex;\n}\n.flex-middle {\n  align-items: center;\n}\n</style>',
-            schemaVersion: 1
-          }
+            schemaVersion: 1,
+          },
         },
-        showEditor: false
-      }
+        showEditor: false,
+      },
     },
     theme: {
       header: {
         background: "#004da8",
-        text: "#a3ff73"
+        text: "#a3ff73",
       },
       body: {
         background: "#ffffff",
         text: "#e82e2e",
-        link: "#ff00c5"
+        link: "#ff00c5",
       },
       button: {
         background: "#0079c1",
-        text: "#ffffff"
+        text: "#ffffff",
       },
       logo: {
         small:
-          "https://user-images.githubusercontent.com/1218/34112930-11865eba-e3dc-11e7-82d6-4010f818e926.png"
+          "https://user-images.githubusercontent.com/1218/34112930-11865eba-e3dc-11e7-82d6-4010f818e926.png",
       },
       fonts: {
         base: {
           url: "",
-          family: "Avenir Next"
+          family: "Avenir Next",
         },
         heading: {
           url: "",
-          family: "Avenir Next"
-        }
+          family: "Avenir Next",
+        },
       },
       globalNav: {
         background: "#004da8",
-        text: "#a3ff73"
-      }
+        text: "#a3ff73",
+      },
     },
     headerSass:
       ".custom-header {\n  .first-tier {\n    height: 80px;\n    margin-bottom: 0px;\n    background-color:green;\n  }\n\n  .first-tier .nav>li>a {\n    margin-top: 5px;\n    padding: 3px 6px;\n    color: #fff;\n  }\n\n  .first-tier .nav>li>a:focus,\n  .first-tier .nav>li>a:hover {\n    background-color: #136fbf;\n    color: #fff;\n  }\n\n  .first-tier .site-logo img {\n    vertical-align: middle;\n  }\n\n  .first-tier h1 {\n    display: inline;\n    font-size: 25px;\n  }\n\n  .second-tier {\n    margin-bottom: 0px;\n    background-color: #05466c;\n  } \n\n .site-header .navbar-header img {\n    vertical-align: middle;\n    height: 50px;\n    padding: 5px;\n  }\n\n  .header-container {\n    top: 80px;\n    margin: 0 auto;\n    max-width: 1440px;\n    position: absolute;\n    width: 100%;\n    transform: translateX(-50%);\n    left: 50%;\n    z-index: 10;\n    transition: max-width 250ms linear;\n  } \n\n  .header-container .navbar .container-fluid {\n    display: flex;\n  }\n\n  .header-container .navbar.navbar-default {\n    background-color: #fff;\n    border-color: transparent !important;\n    border-radius: 0;\n  }\n\n  .header-container .navbar.navbar-default .navbar-collapse.collapse {\n    display: flex !important;\n    flex: 1;\n    padding-right: 0;\n  }\n\n  .header-container .navbar.navbar-default .navbar-brand {\n    color: #333;\n    height: auto;\n    padding: 1rem;\n  }\n\n  .header-container .navbar.navbar-default .navbar-brand-img {\n    display: inline-block;\n  }\n\n  .header-container .navbar.navbar-default .navbar-nav {\n    flex: 2;\n    align-items: center;\n    justify-content: center;\n    margin: auto;\n    float: none;\n  }\n\n  .header-container .navbar.navbar-default .navbar-nav>li {\n    float: none;\n    display: inline-block;\n  }\n\n  .header-container .navbar.navbar-default .navbar-nav>li>a {\n    background: transparent;\n    color: #333;\n    font-size: 15px;\n    transition: all 250ms linear;\n  }\n\n  .header-container .navbar.navbar-default .navbar-nav>li>a:focus,\n  .header-container .navbar.navbar-default .navbar-nav>li>a:hover {\n    background: #3276AE;\n    color: #fff;\n  }\n\n  .header-container .navbar.navbar-default .navbar-right {\n    margin-right: 0;\n    flex: 1;\n    text-align: right;\n  }\n\n  .is-sticky {\n    position: relative;\n    z-index: 10;\n  }\n\n  .is-sticky .header-container {\n    max-width: 100%;\n  }\n\n  @media screen and (max-width: 768px) {\n    .header-container .navbar-header {\n      width: 100%;\n    }\n    .header-container .navbar-default .navbar-toggle {\n      margin-top: 18px;\n    }\n    .header-container .navbar .container-fluid {\n      display: block !important;\n    }\n    .header-container .navbar.navbar-default .navbar-collapse.collapse {\n      overflow: hidden;\n      display: none !important;\n    }\n    .header-container .navbar.navbar-default .navbar-collapse.collapse.in {\n      display: block !important;\n    }\n    .header-container .navbar.navbar-default .navbar-nav {\n      display: inherit;\n      padding: 0 0 1rem 0;\n    }\n    .header-container .navbar.navbar-default .navbar-nav > li {\n      display: block;\n    }\n  }\n\n/* Editor adjustment for absolute positioned header */\n  header ~ .body-editor section:first-child { padding-top: 100px; }}",
@@ -397,7 +396,7 @@ export const SITE_DATA_RESPONSE = {
       "document_iframes",
       "items_view",
       "app_page",
-      "globalNav"
+      "globalNav",
     ],
     clientId: "aMsMKCkCQZ5V5124",
     siteId: "72084",
@@ -405,69 +404,75 @@ export const SITE_DATA_RESPONSE = {
     footerCss: "",
     customHostname: "",
     internalUrl: "",
-    gacode: null
-  }
+    gacode: null,
+  },
 } as any;
 
 export const SITE_RESOURCES_RESPONSE = {
-  total: 7,
+  total: 10,
   start: 1,
-  num: 7,
+  num: 10,
   nextStart: -1,
   resources: [
     {
       resource: "abstract-art-background-1020317.jpg",
       created: 1581433698000,
       size: 1208686,
-      access: "inherit"
+      access: "inherit",
     },
     {
       resource: "dave-in-the-cave.png",
       created: 1581379037000,
       size: 1582485,
-      access: "inherit"
+      access: "inherit",
     },
     {
       resource: "hub-image-card-crop-i698hohxr.png",
       created: 1581433721000,
       size: 1352569,
-      access: "inherit"
+      access: "inherit",
     },
     {
       resource: "test-detail-image.jpg",
       created: 1570740649000,
       size: 62554,
-      access: "inherit"
+      access: "inherit",
     },
     {
       resource: "test-icon-dark.png",
       created: 1570740649000,
       size: 2228,
-      access: "inherit"
+      access: "inherit",
     },
     {
       resource: "test-icon-light.png",
       created: 1570740649000,
       size: 4083,
-      access: "inherit"
+      access: "inherit",
     },
     {
       resource: "theme.json",
       created: 1570740646000,
       size: 380,
-      access: "inherit"
+      access: "inherit",
     },
     {
       resource: "hub-image-card-crop-NOTUSEDWILLBEREMOVED.png",
       created: 1581433721000,
       size: 1352569,
-      access: "inherit"
+      access: "inherit",
     },
     {
       resource: "abstract-art-background-1020317.jpg",
       created: 1581433721000,
       size: 1352569,
-      access: "inherit"
-    }
-  ]
+      access: "inherit",
+    },
+    {
+      resource: "draft-1898989948560.json",
+      created: 1581433798560,
+      size: 125863,
+      access: "inherit",
+    },
+  ],
 };


### PR DESCRIPTION
affects: @esri/hub-sites

1. Description:
Ignore draft resources when clone a site or page

1. Instructions for testing:
Clone a site or page, you should see the cloned version doesn't have the draft resources information

1. Closes Issues: #<3546> [3546](https://zentopia.esri.com/workspaces/collaboration-sprint-board-614f9bfc0946c40011ef574e/issues/dc/hub/3546)

1. [x] ran commit script (`npm run c`)

_Note_ If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `npm run c` and follow the prompts.

For more information see the README
