### PR TITLE
feat(hub-common): add convertCatalog function

### DIFF
--- a/packages/common/src/search/convertCatalog.ts
+++ b/packages/common/src/search/convertCatalog.ts
@@ -1,0 +1,27 @@
+import { getProp } from "..";
+import { Filter, ICatalog } from "./types";
+
+/**
+ * Convert the original site catalog structure into a formal ICatalog
+ * @param original
+ */
+export function convertCatalog(original: any): ICatalog {
+  const filter: Filter<"content"> = {
+    filterType: "content",
+  };
+
+  const groups = getProp(original, "groups");
+
+  if (Array.isArray(groups) && groups.length) {
+    filter.group = groups;
+  } else if (typeof groups === "string") {
+    filter.group = [groups];
+  }
+
+  const catalog: ICatalog = {
+    title: "Default Catalog",
+    filter,
+  };
+
+  return catalog;
+}

--- a/packages/common/src/search/index.ts
+++ b/packages/common/src/search/index.ts
@@ -8,3 +8,4 @@ export * from "./_searchGroups";
 export * from "./_searchUsers";
 export * from "./types";
 export * from "./collectionState";
+export * from "./convertCatalog";

--- a/packages/common/test/search/convertCatalog.test.ts
+++ b/packages/common/test/search/convertCatalog.test.ts
@@ -1,0 +1,45 @@
+import { convertCatalog, Filter } from "../../src/search";
+
+describe("convertCatalog", () => {
+  it("returns default catalog if null", () => {
+    const chk = convertCatalog(null);
+    expect(chk.title).toBe("Default Catalog");
+    expect(chk.filter.filterType).toBe("content");
+    const filter = chk.filter as Filter<"content">;
+    expect(filter.group).not.toBeDefined();
+  });
+
+  it("returns default catalog if passed empty object", () => {
+    const chk = convertCatalog({});
+    expect(chk.title).toBe("Default Catalog");
+    expect(chk.filter.filterType).toBe("content");
+    const filter = chk.filter as Filter<"content">;
+    expect(filter.group).not.toBeDefined();
+  });
+
+  it("does not return groups if passed empty array", () => {
+    const chk = convertCatalog({ groups: [] });
+    expect(chk.title).toBe("Default Catalog");
+    expect(chk.filter.filterType).toBe("content");
+    const filter = chk.filter as Filter<"content">;
+    expect(filter.group).not.toBeDefined();
+  });
+
+  it("returns groups if passed a string", () => {
+    const chk = convertCatalog({ groups: "3ef" });
+    expect(chk.title).toBe("Default Catalog");
+    expect(chk.filter.filterType).toBe("content");
+    const filter = chk.filter as Filter<"content">;
+    expect(filter.group).toBeDefined();
+    expect(filter.group).toEqual(["3ef"]);
+  });
+
+  it("returns groups if passed a array", () => {
+    const chk = convertCatalog({ groups: ["3ef", "bc4"] });
+    expect(chk.title).toBe("Default Catalog");
+    expect(chk.filter.filterType).toBe("content");
+    const filter = chk.filter as Filter<"content">;
+    expect(filter.group).toBeDefined();
+    expect(filter.group).toEqual(["3ef", "bc4"]);
+  });
+});


### PR DESCRIPTION
1. Description:

Simple function to convert the existing site.data.catalog structure into an `ICatalog`

Based on a number of production sites I checked, the only property on the current catalog structure is `groups`

1. Instructions for testing:

- run tests

1. Closes Issues: #<number> (if appropriate)

1. [x] semantic commit message?
