### PR TITLE
docs(hub-content): deprecate hub-content package

### DIFF
--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -14,6 +14,8 @@
 
 # @esri/hub-content
 
+> DEPRECATED: This package has been deprecated. `getContent()` has been replaced by `fetchContent()` in `@esri/hub-common`, and all related functions such as `datasetToContent()` have moved to that package.
+
 > Module to interact with ArcGIS Hub Content in Node.js and modern browsers.
 
 ### Example


### PR DESCRIPTION
affects: @esri/hub-content

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
