### PR TITLE
feat(hub-common): createItemFromUrlOrFile can also share created item…

### DIFF
--- a/packages/common/src/items/create-item-from-url-or-file.ts
+++ b/packages/common/src/items/create-item-from-url-or-file.ts
@@ -1,5 +1,9 @@
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
-import { ICreateItemResponse, setItemAccess } from "@esri/arcgis-rest-portal";
+import {
+  ICreateItemResponse,
+  setItemAccess,
+  shareItemWithGroup,
+} from "@esri/arcgis-rest-portal";
 import { IItemAdd } from "@esri/arcgis-rest-types";
 import { createItemFromFile } from "./create-item-from-file";
 import { createItemFromUrl } from "./create-item-from-url";
@@ -12,12 +16,14 @@ import { _waitForItemReady } from "./_internal/_wait-for-item-ready";
  *
  * @export
  * @param {IItemAdd} item Item to be uploaded into online
+ * @param {string[]} groupIds Group ids for the item to be shared to.
  * @param {IUserRequestOptions} requestOptions
  * @return {*}  {Promise<string>} AGO item id
  */
 export async function createItemFromUrlOrFile(
   item: IItemAdd,
-  requestOptions: IUserRequestOptions
+  requestOptions: IUserRequestOptions,
+  groupIds?: string[]
 ): Promise<ICreateItemResponse> {
   // Is there a file or data url?
   const shouldWaitForItemReady = item.dataUrl || item.file;
@@ -45,6 +51,18 @@ export async function createItemFromUrlOrFile(
       owner: item.owner,
       access: item.access,
       ...requestOptions,
+    });
+  }
+
+  // If group ids were passedd in then make share calls to each.
+  if (groupIds && groupIds.length) {
+    groupIds.forEach(async (groupId) => {
+      await shareItemWithGroup({
+        id: createdItem.id,
+        owner: item.owner,
+        groupId,
+        ...requestOptions,
+      });
     });
   }
 

--- a/packages/common/src/items/create-item-from-url-or-file.ts
+++ b/packages/common/src/items/create-item-from-url-or-file.ts
@@ -4,10 +4,16 @@ import {
   setItemAccess,
   shareItemWithGroup,
 } from "@esri/arcgis-rest-portal";
-import { IItemAdd } from "@esri/arcgis-rest-types";
+import { IGroup, IItemAdd } from "@esri/arcgis-rest-types";
+import { failSafe, isUpdateGroup } from "../utils";
 import { createItemFromFile } from "./create-item-from-file";
 import { createItemFromUrl } from "./create-item-from-url";
 import { _waitForItemReady } from "./_internal/_wait-for-item-ready";
+
+interface ICreateItemFromUrlOrFileOptions extends IUserRequestOptions {
+  item: IItemAdd;
+  groups?: IGroup[];
+}
 
 /**
  * Creates an item in online from either url or file.
@@ -21,10 +27,10 @@ import { _waitForItemReady } from "./_internal/_wait-for-item-ready";
  * @return {*}  {Promise<string>} AGO item id
  */
 export async function createItemFromUrlOrFile(
-  item: IItemAdd,
-  requestOptions: IUserRequestOptions,
-  groupIds?: string[]
+  createItemFromUrlOrFileOptions: ICreateItemFromUrlOrFileOptions
 ): Promise<ICreateItemResponse> {
+  const { item, groups, ...userRequestOptions } =
+    createItemFromUrlOrFileOptions;
   // Is there a file or data url?
   const shouldWaitForItemReady = item.dataUrl || item.file;
   let createdItem: ICreateItemResponse;
@@ -32,15 +38,15 @@ export async function createItemFromUrlOrFile(
   // If there is a file then we create the item and chunk the file
   // while multithread uploading it
   if (item.file) {
-    createdItem = await createItemFromFile(item, requestOptions);
+    createdItem = await createItemFromFile(item, userRequestOptions);
     // Otherwise it's being created from a url.
   } else {
-    createdItem = await createItemFromUrl(item, requestOptions);
+    createdItem = await createItemFromUrl(item, userRequestOptions);
   }
 
   // If there is a file or data url we want to check to see if / when the item is ready.
   if (shouldWaitForItemReady) {
-    await _waitForItemReady(createdItem.id, requestOptions);
+    await _waitForItemReady(createdItem.id, userRequestOptions);
   }
 
   // If the item access is NOT private (which is the sharing access level by default)
@@ -50,20 +56,24 @@ export async function createItemFromUrlOrFile(
       id: createdItem.id,
       owner: item.owner,
       access: item.access,
-      ...requestOptions,
+      ...userRequestOptions,
     });
   }
 
   // If group ids were passedd in then make share calls to each.
-  if (groupIds && groupIds.length) {
-    groupIds.forEach(async (groupId) => {
-      await shareItemWithGroup({
-        id: createdItem.id,
-        owner: item.owner,
-        groupId,
-        ...requestOptions,
-      });
-    });
+  if (groups?.length) {
+    const failSafeShare = failSafe(shareItemWithGroup);
+    await Promise.all(
+      groups.map((group: IGroup) =>
+        failSafeShare({
+          id: createdItem.id,
+          owner: item.owner,
+          groupId: group.id,
+          confirmItemControl: isUpdateGroup(group),
+          ...userRequestOptions,
+        })
+      )
+    );
   }
 
   return createdItem;

--- a/packages/common/src/items/create-item-from-url-or-file.ts
+++ b/packages/common/src/items/create-item-from-url-or-file.ts
@@ -21,9 +21,7 @@ interface ICreateItemFromUrlOrFileOptions extends IUserRequestOptions {
  * If access is not private then we make a call to update that.
  *
  * @export
- * @param {IItemAdd} item Item to be uploaded into online
- * @param {string[]} groupIds Group ids for the item to be shared to.
- * @param {IUserRequestOptions} requestOptions
+ * @param {ICreateItemFromUrlOrFileOptions} createItemFromUrlOrFileOptions Input params (item, groups?, requestoptions)
  * @return {*}  {Promise<string>} AGO item id
  */
 export async function createItemFromUrlOrFile(

--- a/packages/common/test/items/create-item-from-url-or-file.test.ts
+++ b/packages/common/test/items/create-item-from-url-or-file.test.ts
@@ -1,12 +1,12 @@
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
-import { IItemAdd } from "@esri/arcgis-rest-types";
+import { IGroup, IItemAdd } from "@esri/arcgis-rest-types";
 import { createItemFromUrlOrFile } from "../../src/items/create-item-from-url-or-file";
 import * as createItemFromFileModule from "../../src/items/create-item-from-file";
 import * as createItemFromUrlModule from "../../src/items/create-item-from-url";
 import * as _waitForItemReadyModule from "../../src/items/_internal/_wait-for-item-ready";
 import * as portal from "@esri/arcgis-rest-portal";
 
-describe("createContent", () => {
+describe("createItemFromUrlOrFile", () => {
   it("creates an item from url", async () => {
     // request options
     const ro = {
@@ -49,12 +49,16 @@ describe("createContent", () => {
       "shareItemWithGroup"
     ).and.callFake(() => Promise.resolve());
 
-    const result = await createItemFromUrlOrFile(item, ro, [
-      "123",
-      "abc",
-      "456",
-      "def",
-    ]);
+    const result = await createItemFromUrlOrFile({
+      item,
+      groups: [
+        { id: "123", capabilities: ["updateitemcontrol"] } as unknown as IGroup,
+        { id: "abc", capabilities: [] } as unknown as IGroup,
+        { id: "456", capabilities: [] } as unknown as IGroup,
+        { id: "def", capabilities: [] } as unknown as IGroup,
+      ],
+      ...ro,
+    });
 
     expect(result).toEqual({ id: "123abc", success: true, folder: "test" });
     expect(createItemFromFileSpy).not.toHaveBeenCalled();
@@ -104,7 +108,7 @@ describe("createContent", () => {
       "shareItemWithGroup"
     ).and.callFake(() => Promise.resolve());
 
-    const result = await createItemFromUrlOrFile(item, ro, []);
+    const result = await createItemFromUrlOrFile({ item, groups: [], ...ro });
 
     expect(result).toEqual({ id: "123abc", success: true, folder: "test" });
     expect(createItemFromFileSpy).not.toHaveBeenCalled();
@@ -154,7 +158,7 @@ describe("createContent", () => {
       Promise.resolve()
     );
 
-    const result = await createItemFromUrlOrFile(item, ro);
+    const result = await createItemFromUrlOrFile({ item, ...ro });
 
     expect(result).toEqual({ id: "123abc", success: true, folder: "test" });
     expect(createItemFromFileSpy).toHaveBeenCalledTimes(1);

--- a/packages/common/test/items/create-item-from-url-or-file.test.ts
+++ b/packages/common/test/items/create-item-from-url-or-file.test.ts
@@ -44,14 +44,24 @@ describe("createContent", () => {
     const setItemAccessSpy = spyOn(portal, "setItemAccess").and.callFake(() =>
       Promise.resolve()
     );
+    const shareItemWithGroupSpy = spyOn(
+      portal,
+      "shareItemWithGroup"
+    ).and.callFake(() => Promise.resolve());
 
-    const result = await createItemFromUrlOrFile(item, ro);
+    const result = await createItemFromUrlOrFile(item, ro, [
+      "123",
+      "abc",
+      "456",
+      "def",
+    ]);
 
     expect(result).toEqual({ id: "123abc", success: true, folder: "test" });
     expect(createItemFromFileSpy).not.toHaveBeenCalled();
     expect(createItemFromUrlSpy).toHaveBeenCalledTimes(1);
     expect(_waitForItemReadySpy).toHaveBeenCalledTimes(1);
     expect(setItemAccessSpy).toHaveBeenCalledTimes(1);
+    expect(shareItemWithGroupSpy).toHaveBeenCalledTimes(4);
   });
   it("creates an item from url without dataUrl", async () => {
     // request options
@@ -89,14 +99,19 @@ describe("createContent", () => {
     const setItemAccessSpy = spyOn(portal, "setItemAccess").and.callFake(() =>
       Promise.resolve()
     );
+    const shareItemWithGroupSpy = spyOn(
+      portal,
+      "shareItemWithGroup"
+    ).and.callFake(() => Promise.resolve());
 
-    const result = await createItemFromUrlOrFile(item, ro);
+    const result = await createItemFromUrlOrFile(item, ro, []);
 
     expect(result).toEqual({ id: "123abc", success: true, folder: "test" });
     expect(createItemFromFileSpy).not.toHaveBeenCalled();
     expect(createItemFromUrlSpy).toHaveBeenCalledTimes(1);
     expect(_waitForItemReadySpy).not.toHaveBeenCalled();
     expect(setItemAccessSpy).toHaveBeenCalledTimes(1);
+    expect(shareItemWithGroupSpy).not.toHaveBeenCalled();
   });
   it("creates an item from file", async () => {
     // request options


### PR DESCRIPTION
… to n groups

1. Description: Forgot to add in share item with group calls for createItemFromUrlOrFile. This remedies that.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
