### PR TITLE
fix(hub-common): fix issue where enrichServer actually fetched the layer for reference layer items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61569,7 +61569,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.29.0",
+			"version": "9.30.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -61602,7 +61602,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.16.0",
+			"version": "11.17.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61611,7 +61611,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61624,12 +61624,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.29.0"
+				"@esri/hub-common": "9.30.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.29.0",
+			"version": "9.30.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -61640,7 +61640,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61649,12 +61649,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.29.0"
+				"@esri/hub-common": "9.30.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.29.0",
+			"version": "9.30.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61665,7 +61665,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61679,12 +61679,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.29.0"
+				"@esri/hub-common": "9.30.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.29.0",
+			"version": "9.30.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61693,7 +61693,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61706,12 +61706,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.29.0"
+				"@esri/hub-common": "9.30.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.29.0",
+			"version": "9.30.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61722,7 +61722,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61738,12 +61738,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.29.0"
+				"@esri/hub-common": "9.30.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.29.0",
+			"version": "9.30.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61752,9 +61752,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
-				"@esri/hub-initiatives": "9.29.0",
-				"@esri/hub-teams": "9.29.0",
+				"@esri/hub-common": "9.30.0",
+				"@esri/hub-initiatives": "9.30.0",
+				"@esri/hub-teams": "9.30.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -61767,9 +61767,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.29.0",
-				"@esri/hub-initiatives": "9.29.0",
-				"@esri/hub-teams": "9.29.0"
+				"@esri/hub-common": "9.30.0",
+				"@esri/hub-initiatives": "9.30.0",
+				"@esri/hub-teams": "9.30.0"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61794,7 +61794,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.29.0",
+			"version": "9.30.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61805,7 +61805,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61819,12 +61819,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.29.0"
+				"@esri/hub-common": "9.30.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.29.0",
+			"version": "9.30.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61834,7 +61834,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61847,7 +61847,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.29.0"
+				"@esri/hub-common": "9.30.0"
 			}
 		}
 	},
@@ -65262,7 +65262,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65281,7 +65281,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65300,7 +65300,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65316,7 +65316,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65335,7 +65335,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65353,9 +65353,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
-				"@esri/hub-initiatives": "9.29.0",
-				"@esri/hub-teams": "9.29.0",
+				"@esri/hub-common": "9.30.0",
+				"@esri/hub-initiatives": "9.30.0",
+				"@esri/hub-teams": "9.30.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -65392,7 +65392,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65409,7 +65409,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.29.0",
+				"@esri/hub-common": "9.30.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/common/src/items/_enrichments.ts
+++ b/packages/common/src/items/_enrichments.ts
@@ -7,6 +7,7 @@ import {
 import {
   getAllLayersAndTables,
   getService,
+  parseServiceUrl,
 } from "@esri/arcgis-rest-feature-layer";
 import { IItemEnrichments, IServerEnrichments } from "../core";
 import { IEnrichmentErrorInfo, IHubRequestOptions } from "../types";
@@ -147,7 +148,7 @@ const enrichServer = (
 ): Promise<IPipeable<IItemAndEnrichments>> => {
   const { data, stack, requestOptions } = input;
   const opId = stack.start("enrichServer");
-  const url = data.item.url;
+  const url = parseServiceUrl(data.item.url);
   const options = {
     ...requestOptions,
     url,

--- a/packages/common/test/items/_enrichments.test.ts
+++ b/packages/common/test/items/_enrichments.test.ts
@@ -78,6 +78,16 @@ describe("_enrichments", () => {
         const result = await fetchItemEnrichments(item, ["server"]);
         expect(result.server).toEqual(server);
       });
+      it("removes /:layer from url", async () => {
+        fetchMock.once("*", {});
+        const serviceRootUrl =
+          "https://servicesqa.arcgis.com/Xj56SBi2udA78cC9/arcgis/rest/services/survey123_a5db32e043f14f6a9edfec7075288df6/FeatureServer";
+        await fetchItemEnrichments({ ...item, url: `${serviceRootUrl}/5` }, [
+          "server",
+        ]);
+        expect(fetchMock.calls().length).toEqual(1);
+        expect(fetchMock.lastUrl()).toEqual(serviceRootUrl);
+      });
       it("handles errors", async () => {
         fetchMock.once("*", 404);
         const result = await fetchItemEnrichments(item, ["server"]);


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Part of https://devtopia.esri.com/dc/hub/issues/3861

`enrichServer` was returning the layer definition instead of the server definition for items that had a reference layer url (i.e. `.../FeatureServer/:layer`). This is because we mistakenly assumed that Rest.js' `getService` function stripped `/:layer` from the url before making the call. It does not, so we have to do it on our own.

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
