### PR TITLE
chore: upgrade fast-xml-parser for 25% smaller builds of hub-common

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12530,6 +12530,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
 			"dependencies": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
@@ -12540,12 +12541,14 @@
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
 			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
 			"deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+			"dev": true,
 			"hasInstallScript": true
 		},
 		"node_modules/babel-runtime/node_modules/regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
 		},
 		"node_modules/babel-template": {
 			"version": "6.26.0",
@@ -15822,6 +15825,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"dependencies": {
 				"restore-cursor": "^2.0.0"
 			},
@@ -15946,7 +15950,8 @@
 		"node_modules/cli-width": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
+			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+			"dev": true
 		},
 		"node_modules/cliui": {
 			"version": "6.0.0",
@@ -21597,10 +21602,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -21615,24 +21619,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -21646,10 +21647,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -21667,10 +21667,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -29406,6 +29405,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -30744,17 +30744,18 @@
 			"dev": true
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.2.4.tgz",
-			"integrity": "sha512-19R4aaHzqsTe7gyL3wthWiyYyNFqVK1tzO6BMEAQEKRu4R3ptkl4FyuEtUMOPKdYsO6k6C/Ym3YJ6eCL49OdSw==",
-			"hasInstallScript": true,
+			"version": "3.21.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
+			"integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
 			"dependencies": {
-				"he": "~1.1.1",
-				"nimnjs": "^1.1.0",
-				"opencollective": "^1.0.3"
+				"strnum": "^1.0.4"
 			},
 			"bin": {
 				"xml2js": "cli.js"
+			},
+			"funding": {
+				"type": "paypal",
+				"url": "https://paypal.me/naturalintelligence"
 			}
 		},
 		"node_modules/fastest-levenshtein": {
@@ -30836,6 +30837,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"dependencies": {
 				"escape-string-regexp": "^1.0.5"
 			},
@@ -33176,6 +33178,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"dependencies": {
 				"ansi-regex": "^2.0.0"
 			},
@@ -33187,6 +33190,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -33397,14 +33401,6 @@
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
-			}
-		},
-		"node_modules/he": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-			"bin": {
-				"he": "bin/he"
 			}
 		},
 		"node_modules/heimdalljs": {
@@ -33805,6 +33801,7 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			},
@@ -43413,7 +43410,8 @@
 		"node_modules/mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"node_modules/mz": {
 			"version": "2.7.0",
@@ -43487,25 +43485,6 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
-		},
-		"node_modules/nimn_schema_builder": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/nimn_schema_builder/-/nimn_schema_builder-1.1.0.tgz",
-			"integrity": "sha512-DK5/B8CM4qwzG2URy130avcwPev4uO0ev836FbQyKo1ms6I9z/i6EJyiZ+d9xtgloxUri0W+5gfR8YbPq7SheA=="
-		},
-		"node_modules/nimn-date-parser": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/nimn-date-parser/-/nimn-date-parser-1.0.0.tgz",
-			"integrity": "sha512-1Nf+x3EeMvHUiHsVuEhiZnwA8RMeOBVTQWfB1S2n9+i6PYCofHd2HRMD+WOHIHYshy4T4Gk8wQoCol7Hq3av8Q=="
-		},
-		"node_modules/nimnjs": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/nimnjs/-/nimnjs-1.3.2.tgz",
-			"integrity": "sha512-TIOtI4iqkQrUM1tiM76AtTQem0c7e56SkDZ7sj1d1MfUsqRcq2ZWQvej/O+HBTZV7u/VKnwlKTDugK/75IRPPw==",
-			"dependencies": {
-				"nimn_schema_builder": "^1.0.0",
-				"nimn-date-parser": "^1.0.0"
-			}
 		},
 		"node_modules/no-case": {
 			"version": "3.0.4",
@@ -47410,6 +47389,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -47877,23 +47857,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/opencollective": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
-			"integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
-			"dependencies": {
-				"babel-polyfill": "6.23.0",
-				"chalk": "1.1.3",
-				"inquirer": "3.0.6",
-				"minimist": "1.2.0",
-				"node-fetch": "1.6.3",
-				"opn": "4.0.2"
-			},
-			"bin": {
-				"oc": "dist/bin/opencollective.js",
-				"opencollective": "dist/bin/opencollective.js"
-			}
-		},
 		"node_modules/opencollective-postinstall": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
@@ -47901,170 +47864,6 @@
 			"dev": true,
 			"bin": {
 				"opencollective-postinstall": "index.js"
-			}
-		},
-		"node_modules/opencollective/node_modules/ansi-escapes": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/opencollective/node_modules/ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/opencollective/node_modules/babel-polyfill": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-			"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-			"dependencies": {
-				"babel-runtime": "^6.22.0",
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.10.0"
-			}
-		},
-		"node_modules/opencollective/node_modules/chalk": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"dependencies": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/opencollective/node_modules/chardet": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
-		},
-		"node_modules/opencollective/node_modules/core-js": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-			"deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
-			"hasInstallScript": true
-		},
-		"node_modules/opencollective/node_modules/external-editor": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-			"dependencies": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
-				"tmp": "^0.0.33"
-			},
-			"engines": {
-				"node": ">=0.12"
-			}
-		},
-		"node_modules/opencollective/node_modules/inquirer": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
-			"integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
-			"dependencies": {
-				"ansi-escapes": "^1.1.0",
-				"chalk": "^1.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^2.0.1",
-				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
-				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rx": "^4.1.0",
-				"string-width": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"through": "^2.3.6"
-			}
-		},
-		"node_modules/opencollective/node_modules/is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/opencollective/node_modules/is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/opencollective/node_modules/minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-		},
-		"node_modules/opencollective/node_modules/node-fetch": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-			"integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
-			"dependencies": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
-			}
-		},
-		"node_modules/opencollective/node_modules/opn": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-			"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-			"dependencies": {
-				"object-assign": "^4.0.1",
-				"pinkie-promise": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/opencollective/node_modules/regenerator-runtime": {
-			"version": "0.10.5",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-		},
-		"node_modules/opencollective/node_modules/string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dependencies": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/opencollective/node_modules/string-width/node_modules/strip-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-			"dependencies": {
-				"ansi-regex": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/opencollective/node_modules/supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-			"engines": {
-				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/openurl": {
@@ -48247,6 +48046,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -49394,6 +49194,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
 			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -49402,6 +49203,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"dependencies": {
 				"pinkie": "^2.0.0"
 			},
@@ -51408,6 +51210,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"dependencies": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
@@ -51420,6 +51223,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -51428,6 +51232,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"dependencies": {
 				"mimic-fn": "^1.0.0"
 			},
@@ -51669,6 +51474,7 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
 			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -51707,7 +51513,8 @@
 		"node_modules/rx": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+			"dev": true
 		},
 		"node_modules/rx-lite": {
 			"version": "3.1.2",
@@ -52826,7 +52633,8 @@
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
 		},
 		"node_modules/signale": {
 			"version": "1.4.0",
@@ -54167,6 +53975,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"dependencies": {
 				"ansi-regex": "^2.0.0"
 			},
@@ -54178,6 +53987,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -54287,6 +54097,11 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/strnum": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
 		},
 		"node_modules/strong-log-transformer": {
 			"version": "2.1.0",
@@ -55681,7 +55496,8 @@
 		"node_modules/through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"node_modules/through2": {
 			"version": "4.0.2",
@@ -55797,6 +55613,7 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"dependencies": {
 				"os-tmpdir": "~1.0.2"
 			},
@@ -61569,12 +61386,12 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.30.0",
+			"version": "9.30.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
 				"adlib": "^3.0.7",
-				"fast-xml-parser": "~3.2.4",
+				"fast-xml-parser": "^3.21.0",
 				"jsonapi-typescript": "^0.1.3",
 				"tslib": "^1.13.0"
 			},
@@ -61602,7 +61419,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.17.0",
+			"version": "11.17.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61611,7 +61428,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61624,12 +61441,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.30.0"
+				"@esri/hub-common": "9.30.1"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.30.0",
+			"version": "9.30.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -61640,7 +61457,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61649,12 +61466,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.30.0"
+				"@esri/hub-common": "9.30.1"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.30.0",
+			"version": "9.30.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61665,7 +61482,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61679,12 +61496,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.30.0"
+				"@esri/hub-common": "9.30.1"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.30.0",
+			"version": "9.30.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61693,7 +61510,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61706,12 +61523,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.30.0"
+				"@esri/hub-common": "9.30.1"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.30.0",
+			"version": "9.30.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61722,7 +61539,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61738,12 +61555,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.30.0"
+				"@esri/hub-common": "9.30.1"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.30.0",
+			"version": "9.30.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61752,9 +61569,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
-				"@esri/hub-initiatives": "9.30.0",
-				"@esri/hub-teams": "9.30.0",
+				"@esri/hub-common": "9.30.1",
+				"@esri/hub-initiatives": "9.30.1",
+				"@esri/hub-teams": "9.30.1",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -61767,9 +61584,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.30.0",
-				"@esri/hub-initiatives": "9.30.0",
-				"@esri/hub-teams": "9.30.0"
+				"@esri/hub-common": "9.30.1",
+				"@esri/hub-initiatives": "9.30.1",
+				"@esri/hub-teams": "9.30.1"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61794,7 +61611,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.30.0",
+			"version": "9.30.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61805,7 +61622,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61819,12 +61636,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.30.0"
+				"@esri/hub-common": "9.30.1"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.30.0",
+			"version": "9.30.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61834,7 +61651,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61847,7 +61664,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.30.0"
+				"@esri/hub-common": "9.30.1"
 			}
 		}
 	},
@@ -65248,7 +65065,7 @@
 				"@types/adlib": "^3.0.1",
 				"abab": "^2.0.5",
 				"adlib": "^3.0.7",
-				"fast-xml-parser": "~3.2.4",
+				"fast-xml-parser": "^3.21.0",
 				"jsonapi-typescript": "^0.1.3",
 				"rollup": "^2.26.5",
 				"rollup-plugin-filesize": "^9.0.2",
@@ -65262,7 +65079,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65281,7 +65098,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65300,7 +65117,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65316,7 +65133,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65335,7 +65152,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65353,9 +65170,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
-				"@esri/hub-initiatives": "9.30.0",
-				"@esri/hub-teams": "9.30.0",
+				"@esri/hub-common": "9.30.1",
+				"@esri/hub-initiatives": "9.30.1",
+				"@esri/hub-teams": "9.30.1",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -65392,7 +65209,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65409,7 +65226,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.30.0",
+				"@esri/hub-common": "9.30.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -72012,6 +71829,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
@@ -72020,12 +71838,14 @@
 				"core-js": {
 					"version": "2.6.12",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+					"dev": true
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+					"dev": true
 				}
 			}
 		},
@@ -74804,6 +74624,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
@@ -74900,7 +74721,8 @@
 		"cli-width": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
+			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+			"dev": true
 		},
 		"cliui": {
 			"version": "6.0.0",
@@ -79399,8 +79221,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -79415,20 +79236,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -79442,8 +79260,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -79460,8 +79277,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",
@@ -85751,7 +85567,8 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"eslint": {
 			"version": "7.32.0",
@@ -86797,13 +86614,11 @@
 			}
 		},
 		"fast-xml-parser": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.2.4.tgz",
-			"integrity": "sha512-19R4aaHzqsTe7gyL3wthWiyYyNFqVK1tzO6BMEAQEKRu4R3ptkl4FyuEtUMOPKdYsO6k6C/Ym3YJ6eCL49OdSw==",
+			"version": "3.21.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
+			"integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
 			"requires": {
-				"he": "~1.1.1",
-				"nimnjs": "^1.1.0",
-				"opencollective": "^1.0.3"
+				"strnum": "^1.0.4"
 			}
 		},
 		"fastest-levenshtein": {
@@ -86870,6 +86685,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -88751,6 +88567,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			},
@@ -88758,7 +88575,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				}
 			}
 		},
@@ -88929,11 +88747,6 @@
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
 			}
-		},
-		"he": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
 		},
 		"heimdalljs": {
 			"version": "0.2.6",
@@ -89281,6 +89094,7 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -96737,7 +96551,8 @@
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"mz": {
 			"version": "2.7.0",
@@ -96805,25 +96620,6 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
-		},
-		"nimn_schema_builder": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/nimn_schema_builder/-/nimn_schema_builder-1.1.0.tgz",
-			"integrity": "sha512-DK5/B8CM4qwzG2URy130avcwPev4uO0ev836FbQyKo1ms6I9z/i6EJyiZ+d9xtgloxUri0W+5gfR8YbPq7SheA=="
-		},
-		"nimn-date-parser": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/nimn-date-parser/-/nimn-date-parser-1.0.0.tgz",
-			"integrity": "sha512-1Nf+x3EeMvHUiHsVuEhiZnwA8RMeOBVTQWfB1S2n9+i6PYCofHd2HRMD+WOHIHYshy4T4Gk8wQoCol7Hq3av8Q=="
-		},
-		"nimnjs": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/nimnjs/-/nimnjs-1.3.2.tgz",
-			"integrity": "sha512-TIOtI4iqkQrUM1tiM76AtTQem0c7e56SkDZ7sj1d1MfUsqRcq2ZWQvej/O+HBTZV7u/VKnwlKTDugK/75IRPPw==",
-			"requires": {
-				"nimn_schema_builder": "^1.0.0",
-				"nimn-date-parser": "^1.0.0"
-			}
 		},
 		"no-case": {
 			"version": "3.0.4",
@@ -99793,7 +99589,8 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -100154,155 +99951,6 @@
 				}
 			}
 		},
-		"opencollective": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
-			"integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
-			"requires": {
-				"babel-polyfill": "6.23.0",
-				"chalk": "1.1.3",
-				"inquirer": "3.0.6",
-				"minimist": "1.2.0",
-				"node-fetch": "1.6.3",
-				"opn": "4.0.2"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"babel-polyfill": {
-					"version": "6.23.0",
-					"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-					"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-					"requires": {
-						"babel-runtime": "^6.22.0",
-						"core-js": "^2.4.0",
-						"regenerator-runtime": "^0.10.0"
-					}
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"chardet": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-					"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
-				},
-				"core-js": {
-					"version": "2.6.12",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-				},
-				"external-editor": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-					"requires": {
-						"chardet": "^0.4.0",
-						"iconv-lite": "^0.4.17",
-						"tmp": "^0.0.33"
-					}
-				},
-				"inquirer": {
-					"version": "3.0.6",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
-					"integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
-					"requires": {
-						"ansi-escapes": "^1.1.0",
-						"chalk": "^1.0.0",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^2.0.1",
-						"figures": "^2.0.0",
-						"lodash": "^4.3.0",
-						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rx": "^4.1.0",
-						"string-width": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"through": "^2.3.6"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"is-stream": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"node-fetch": {
-					"version": "1.6.3",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-					"integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
-					"requires": {
-						"encoding": "^0.1.11",
-						"is-stream": "^1.0.1"
-					}
-				},
-				"opn": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-					"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-					"requires": {
-						"object-assign": "^4.0.1",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.10.5",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					},
-					"dependencies": {
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
 		"opencollective-postinstall": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
@@ -100450,7 +100098,8 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"osenv": {
 			"version": "0.1.5",
@@ -101346,12 +100995,14 @@
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
@@ -102981,6 +102632,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
@@ -102989,12 +102641,14 @@
 				"mimic-fn": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+					"dev": true
 				},
 				"onetime": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
 					}
@@ -103191,7 +102845,8 @@
 		"run-async": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+			"dev": true
 		},
 		"run-parallel": {
 			"version": "1.2.0",
@@ -103213,7 +102868,8 @@
 		"rx": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+			"dev": true
 		},
 		"rx-lite": {
 			"version": "3.1.2",
@@ -104102,7 +103758,8 @@
 		"signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
 		},
 		"signale": {
 			"version": "1.4.0",
@@ -105235,6 +104892,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			},
@@ -105242,7 +104900,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				}
 			}
 		},
@@ -105323,6 +104982,11 @@
 			"resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
 			"integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
 			"dev": true
+		},
+		"strnum": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
 		},
 		"strong-log-transformer": {
 			"version": "2.1.0",
@@ -106444,7 +106108,8 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"through2": {
 			"version": "4.0.2",
@@ -106543,6 +106208,7 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "abab": "^2.0.5",
     "adlib": "^3.0.7",
-    "fast-xml-parser": "~3.2.4",
+    "fast-xml-parser": "^3.21.0",
     "jsonapi-typescript": "^0.1.3",
     "tslib": "^1.13.0"
   },


### PR DESCRIPTION
1. Description:

[Before](https://github.com/Esri/hub.js/runs/6395049343?check_suite_focus=true#step:5:93)

```bash
[@esri/hub-common::rollup] ┌───────────────────────────────────────────┐
[@esri/hub-common::rollup] │                                           │
[@esri/hub-common::rollup] │   Destination: ./dist/umd/common.umd.js   │
[@esri/hub-common::rollup] │   Bundle Size:  736.18 KB                 │
[@esri/hub-common::rollup] │   Minified Size:  227.17 KB               │
[@esri/hub-common::rollup] │   Gzipped Size:  74.41 KB                 │
[@esri/hub-common::rollup] │                                           │
[@esri/hub-common::rollup] └───────────────────────────────────────────┘
```

After

```bash
      │ ┌───────────────────────────────────────────┐
      │ │                                           │
      │ │   Destination: ./dist/umd/common.umd.js   │
      │ │   Bundle Size:  694.29 KB                 │
      │ │   Minified Size:  191.04 KB               │
      │ │   Gzipped Size:  55.22 KB                 │
      │ │                                           │
      │ └───────────────────────────────────────────┘
```


1. Instructions for testing:

If tests pass we should be good, but I'm going to try and ~~create a preview PR in -ui~~ npm link locally to verify this.

1. Closes Issues: [3850](https://devtopia.esri.com/dc/hub/issues/3850)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
