### PR TITLE
fix(hub-common): revert unintended breaking change: getFamily() requi…

### DIFF
--- a/packages/common/src/content/get-family.ts
+++ b/packages/common/src/content/get-family.ts
@@ -15,11 +15,13 @@ function collectionToFamily(collection: string): string {
  * @param type item type
  * @returns Hub family
  */
-export function getFamily(type: string) {
+export function getFamily(type?: string) {
   let family;
   // override default behavior for the rows that are highlighted in yellow here:
   // https://esriis.sharepoint.com/:x:/r/sites/ArcGISHub/_layouts/15/Doc.aspx?sourcedoc=%7BADA1C9DC-4F6C-4DE4-92C6-693EF9571CFA%7D&file=Hub%20Routes.xlsx&nav=MTBfe0VENEREQzI4LUZFMDctNEI0Ri04NjcyLThCQUE2MTA0MEZGRn1fezIwMTIwMEJFLTA4MEQtNEExRC05QzA4LTE5MTAzOUQwMEE1RH0&action=default&mobileredirect=true&cid=df1c874b-c367-4cea-bc13-7bebfad3f2ac
-  switch (type.toLowerCase()) {
+  // DEPRECATED: we should make type a required parameter
+  // and just do type.toLowerCase() at the next breaking change
+  switch ((type || "").toLowerCase()) {
     case "image service":
       family = "dataset";
       break;

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -467,6 +467,10 @@ describe("get item family", () => {
   it("returns content for collection other", () => {
     expect(getFamily("360 VR Experience")).toBe("content");
   });
+  // DEPRECATED: remove this test at the next breaking chagne
+  it("should handle falsey values", () => {
+    expect(getFamily()).toBeUndefined();
+  });
 });
 
 describe("get item hub type", () => {


### PR DESCRIPTION
…res type

affects: @esri/hub-common

1. Description:

Reverts a change that caused errors in opendata-ui

1. Instructions for testing:

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
