### PR TITLE
fix(hub-initiatives): filter group search by title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21602,9 +21602,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -21619,21 +21620,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -21647,9 +21651,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -21667,9 +21672,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -61386,7 +61392,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.31.0",
+			"version": "9.31.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -61419,7 +61425,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.18.0",
+			"version": "11.18.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61428,7 +61434,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61441,12 +61447,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.31.0"
+				"@esri/hub-common": "9.31.3"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.31.0",
+			"version": "9.31.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -61457,7 +61463,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61466,12 +61472,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.31.0"
+				"@esri/hub-common": "9.31.3"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.31.0",
+			"version": "9.31.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61482,7 +61488,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61496,12 +61502,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.31.0"
+				"@esri/hub-common": "9.31.3"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.31.0",
+			"version": "9.31.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61510,7 +61516,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61523,12 +61529,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.31.0"
+				"@esri/hub-common": "9.31.3"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.31.0",
+			"version": "9.31.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61539,7 +61545,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61555,12 +61561,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.31.0"
+				"@esri/hub-common": "9.31.3"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.31.0",
+			"version": "9.31.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61569,9 +61575,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
-				"@esri/hub-initiatives": "9.31.0",
-				"@esri/hub-teams": "9.31.0",
+				"@esri/hub-common": "9.31.3",
+				"@esri/hub-initiatives": "9.31.3",
+				"@esri/hub-teams": "9.31.3",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -61584,9 +61590,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.31.0",
-				"@esri/hub-initiatives": "9.31.0",
-				"@esri/hub-teams": "9.31.0"
+				"@esri/hub-common": "9.31.3",
+				"@esri/hub-initiatives": "9.31.3",
+				"@esri/hub-teams": "9.31.3"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61611,7 +61617,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.31.0",
+			"version": "9.31.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61622,7 +61628,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61636,12 +61642,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.31.0"
+				"@esri/hub-common": "9.31.3"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.31.0",
+			"version": "9.31.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61651,7 +61657,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61664,7 +61670,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.31.0"
+				"@esri/hub-common": "9.31.3"
 			}
 		}
 	},
@@ -65079,7 +65085,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65098,7 +65104,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65117,7 +65123,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65133,7 +65139,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65152,7 +65158,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65170,9 +65176,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
-				"@esri/hub-initiatives": "9.31.0",
-				"@esri/hub-teams": "9.31.0",
+				"@esri/hub-common": "9.31.3",
+				"@esri/hub-initiatives": "9.31.3",
+				"@esri/hub-teams": "9.31.3",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -65209,7 +65215,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65226,7 +65232,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.31.0",
+				"@esri/hub-common": "9.31.3",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -79221,7 +79227,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -79236,17 +79243,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -79260,7 +79270,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -79277,7 +79288,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/initiatives/src/groups.ts
+++ b/packages/initiatives/src/groups.ts
@@ -7,7 +7,7 @@ import {
   searchGroups,
   removeGroup,
   unprotectGroup,
-  IUserGroupOptions
+  IUserGroupOptions,
 } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 
@@ -34,7 +34,7 @@ export function createInitiativeGroup(
     description,
     access: "org",
     sortField: "title",
-    sortOrder: "asc"
+    sortOrder: "asc",
   } as any;
 
   if (options.isOpenData) {
@@ -52,7 +52,7 @@ export function createInitiativeGroup(
 
   const createOpts = {
     group,
-    ...requestOptions
+    ...requestOptions,
   };
 
   // The protect call does not return the groupId, but we need to return it
@@ -66,7 +66,7 @@ export function createInitiativeGroup(
       // protect it
       const protectOpts = {
         id: groupId,
-        ...requestOptions
+        ...requestOptions,
       } as IUserGroupOptions;
       return protectGroup(protectOpts);
     })
@@ -90,13 +90,13 @@ export function removeInitiativeGroup(
 ): Promise<any> {
   const opts = {
     id,
-    ...requestOptions
+    ...requestOptions,
   } as IUserGroupOptions;
   return unprotectGroup(opts).then(
     () => {
       return removeGroup(opts);
     },
-    ex => {
+    (ex) => {
       // check if the failure is b/c the group does not exist...
       if (ex.messageCode === "COM_0003" && ex.code === 400) {
         return Promise.resolve({ success: true });
@@ -122,13 +122,14 @@ export function checkGroupExists(
   requestOptions: IRequestOptions
 ): Promise<any> {
   const options = {
-    q: `("${title}") AND orgid: ${orgId}`,
-    ...requestOptions
+    q: `(orgid: ${orgId}`,
+    filter: `title:"${title}"`,
+    ...requestOptions,
   };
 
   return searchGroups(options).then((response: any) => {
     const result = {
-      exists: false
+      exists: false,
     } as any;
     if (response.total > 0) {
       result.exists = true;
@@ -158,15 +159,17 @@ export function getUniqueGroupName(
   if (step) {
     proposedName = `${title} - ${step}`;
   }
-  return checkGroupExists(proposedName, orgId, requestOptions).then(result => {
-    if (result.exists) {
-      // increment the step...
-      step = step + 1;
-      return getUniqueGroupName(title, orgId, step, requestOptions);
-    } else {
-      return proposedName;
+  return checkGroupExists(proposedName, orgId, requestOptions).then(
+    (result) => {
+      if (result.exists) {
+        // increment the step...
+        step = step + 1;
+        return getUniqueGroupName(title, orgId, step, requestOptions);
+      } else {
+        return proposedName;
+      }
     }
-  });
+  );
 }
 
 export function isSharedEditingGroup(group: any): boolean {

--- a/packages/initiatives/test/groups.test.ts
+++ b/packages/initiatives/test/groups.test.ts
@@ -7,7 +7,7 @@ import {
   ISearchOptions,
   ISearchResult,
   ICreateGroupOptions,
-  IUserGroupOptions
+  IUserGroupOptions,
 } from "@esri/arcgis-rest-portal";
 import { MOCK_REQUEST_OPTIONS } from "./mocks/fake-session";
 import {
@@ -15,7 +15,7 @@ import {
   isSharedEditingGroup,
   createInitiativeGroup,
   getUniqueGroupName,
-  removeInitiativeGroup
+  removeInitiativeGroup,
 } from "../src/groups";
 
 const fakeGroup = {
@@ -32,7 +32,7 @@ const fakeGroup = {
   isFav: false,
   isViewOnly: false,
   autoJoin: true,
-  access: "public"
+  access: "public",
 } as IGroup;
 
 describe("Initiative Groups ::", () => {
@@ -52,13 +52,13 @@ describe("Initiative Groups ::", () => {
   });
 
   describe("createInitiativeGroup ::", () => {
-    it("should create and protect a generic group", done => {
+    it("should create and protect a generic group", (done) => {
       return createInitiativeGroup(
         "generic group",
         "generic description",
         {},
         MOCK_REQUEST_OPTIONS
-      ).then(res => {
+      ).then((res) => {
         expect(createGroupSpy.calls.count()).toEqual(
           1,
           "should make one call to createGroup"
@@ -77,13 +77,13 @@ describe("Initiative Groups ::", () => {
         done();
       });
     });
-    it("should create and protect an Open Data group", done => {
+    it("should create and protect an Open Data group", (done) => {
       return createInitiativeGroup(
         "od group",
         "od description",
         { isOpenData: true },
         MOCK_REQUEST_OPTIONS
-      ).then(res => {
+      ).then((res) => {
         expect(createGroupSpy.calls.count()).toEqual(
           1,
           "should make one call to createGroup"
@@ -106,13 +106,13 @@ describe("Initiative Groups ::", () => {
         done();
       });
     });
-    it("should create and protect a collaboration group", done => {
+    it("should create and protect a collaboration group", (done) => {
       return createInitiativeGroup(
         "generic group",
         "generic description",
         { isSharedEditing: true },
         MOCK_REQUEST_OPTIONS
-      ).then(res => {
+      ).then((res) => {
         expect(createGroupSpy.calls.count()).toEqual(
           1,
           "should make one call to createGroup"
@@ -156,14 +156,14 @@ describe("Initiative Groups ::", () => {
         }
       );
     });
-    it("unprotects and removes the group", done => {
+    it("unprotects and removes the group", (done) => {
       unprotectGroupSpy = spyOn(portal, "unprotectGroup").and.callFake(
         (opts: IUserGroupOptions) => {
           return Promise.resolve({ success: true, id: "3ef" });
         }
       );
       return removeInitiativeGroup("BZ7426", MOCK_REQUEST_OPTIONS).then(
-        result => {
+        (result) => {
           expect(result.success).toBeTruthy();
           expect(unprotectGroupSpy.calls.count()).toEqual(1);
           expect(removeGroupSpy.calls.count()).toEqual(1);
@@ -171,14 +171,14 @@ describe("Initiative Groups ::", () => {
         }
       );
     });
-    it("returns success if group does not exist", done => {
+    it("returns success if group does not exist", (done) => {
       unprotectGroupSpy = spyOn(portal, "unprotectGroup").and.callFake(
         (opts: IUserGroupOptions) => {
           return Promise.reject({ code: 400, messageCode: "COM_0003" });
         }
       );
       return removeInitiativeGroup("BZ7426", MOCK_REQUEST_OPTIONS).then(
-        result => {
+        (result) => {
           expect(result.success).toBeTruthy();
           expect(unprotectGroupSpy.calls.count()).toEqual(1);
           expect(removeGroupSpy.calls.count()).toEqual(0);
@@ -186,21 +186,23 @@ describe("Initiative Groups ::", () => {
         }
       );
     });
-    it("throws on some other error", done => {
+    it("throws on some other error", (done) => {
       unprotectGroupSpy = spyOn(portal, "unprotectGroup").and.callFake(
         (opts: IUserGroupOptions) => {
           return Promise.reject({ code: 502, messageCode: "WAT" });
         }
       );
-      return removeInitiativeGroup("BZ7426", MOCK_REQUEST_OPTIONS).catch(ex => {
-        expect(ex.messageCode).toEqual("WAT");
-        done();
-      });
+      return removeInitiativeGroup("BZ7426", MOCK_REQUEST_OPTIONS).catch(
+        (ex) => {
+          expect(ex.messageCode).toEqual("WAT");
+          done();
+        }
+      );
     });
   });
 
   describe("checkGroupExists ::", () => {
-    it("returns true and the group if it exists", done => {
+    it("returns true and the group if it exists", (done) => {
       const searchSpy = spyOn(portal, "searchGroups").and.callFake(
         (opts: ISearchOptions) => {
           const res = {
@@ -209,7 +211,7 @@ describe("Initiative Groups ::", () => {
             total: 1,
             start: 1,
             num: 1,
-            nextStart: -1
+            nextStart: -1,
           } as ISearchResult<IGroup>;
           return Promise.resolve(res);
         }
@@ -232,7 +234,7 @@ describe("Initiative Groups ::", () => {
         done();
       });
     });
-    it("returns false if group does not exist", done => {
+    it("returns false if group does not exist", (done) => {
       const searchSpy = spyOn(portal, "searchGroups").and.callFake(
         (opts: ISearchOptions) => {
           const res = {
@@ -241,7 +243,7 @@ describe("Initiative Groups ::", () => {
             total: 0,
             start: 0,
             num: 0,
-            nextStart: -1
+            nextStart: -1,
           } as ISearchResult<IGroup>;
           return Promise.resolve(res);
         }
@@ -263,7 +265,7 @@ describe("Initiative Groups ::", () => {
   });
 
   describe("getUniqueGroupName ::", () => {
-    it("return original name of no group exists", done => {
+    it("return original name of no group exists", (done) => {
       const searchSpy = spyOn(portal, "searchGroups").and.callFake(
         (opts: ISearchOptions) => {
           const res = {
@@ -272,7 +274,7 @@ describe("Initiative Groups ::", () => {
             total: 0,
             start: 0,
             num: 0,
-            nextStart: -1
+            nextStart: -1,
           } as ISearchResult<IGroup>;
           return Promise.resolve(res);
         }
@@ -291,7 +293,7 @@ describe("Initiative Groups ::", () => {
         done();
       });
     });
-    it("append a number to original name if group exists", done => {
+    it("append a number to original name if group exists", (done) => {
       const searchSpy = spyOn(portal, "searchGroups").and.callFake(
         (opts: ISearchOptions) => {
           const res = {
@@ -300,12 +302,12 @@ describe("Initiative Groups ::", () => {
             total: 0,
             start: 0,
             num: 0,
-            nextStart: -1
+            nextStart: -1,
           } as ISearchResult<IGroup>;
           // if this is the first call w/ a specific name
           // we want to fake the response to show the group
           // does exist
-          if (opts.q === '("foo bar baz") AND orgid: BZ7426') {
+          if (opts.filter === `title:\"foo bar baz\"`) {
             res.total = 1;
             res.results.push({} as IGroup);
           }
@@ -332,7 +334,7 @@ describe("Initiative Groups ::", () => {
     it("should check for sharedEditing correctly", () => {
       expect(
         isSharedEditingGroup({
-          capabilities: ["foo", "updateitemcontrol", "lala"]
+          capabilities: ["foo", "updateitemcontrol", "lala"],
         })
       ).toBeTruthy();
       expect(


### PR DESCRIPTION
1. Description:
 - adds title filter to the query used by`checkGroupExists`  function to eliminate false positives due to fuzzy agol search

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
