### PR TITLE
feat: add FilterGroup functions

### DIFF
--- a/packages/common/e2e/hub-projects.e2e.ts
+++ b/packages/common/e2e/hub-projects.e2e.ts
@@ -3,7 +3,7 @@ import config from "./helpers/config";
 import { HubProjectManager, IHubProject } from "../src";
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
 
-fdescribe("Hub Projects", () => {
+describe("Hub Projects", () => {
   let factory: Artifactory;
   beforeAll(() => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;

--- a/packages/common/e2e/hub-sites.e2e.ts
+++ b/packages/common/e2e/hub-sites.e2e.ts
@@ -2,7 +2,7 @@ import Artifactory from "./helpers/Artifactory";
 import config from "./helpers/config";
 import { HubSiteManager, IHubSite } from "../src";
 
-fdescribe("Hub Sites", () => {
+describe("Hub Sites", () => {
   let factory: Artifactory;
   beforeAll(() => {
     factory = new Artifactory(config);

--- a/packages/common/src/search/filter-utils.ts
+++ b/packages/common/src/search/filter-utils.ts
@@ -1,0 +1,167 @@
+import { ISearchOptions } from "@esri/arcgis-rest-portal";
+import { getProp, setProp } from "../objects";
+import { cloneObject } from "../util";
+import {
+  Filter,
+  IFilterGroup,
+  FilterType,
+  IDateRange,
+  IMatchOptions,
+} from "./types";
+import { relativeDateToDateRange, valueToMatchOptions } from "./utils";
+
+/**
+ * Expand a Filter into it's more expressive structure so it can be
+ * serialized deterministically.
+ *
+ * Props with type `string | string[] | MatchOptions` expand into `IMatchOptions`
+ * Props relative-dates are expanded into formal date-ranges
+ * @param filter
+ * @returns
+ */
+export function expandFilter<T>(filter: T): T {
+  const result = {} as typeof filter;
+  const dateProps = ["created", "modified", "lastlogin"];
+  const copyProps = ["filterType", "term", "searchUserAccess"];
+  const nonMatchOptionsFields = [...dateProps, ...copyProps];
+  // Do the conversion
+  Object.entries(filter).forEach(([key, value]) => {
+    // Handle MatchOptions fields
+    if (!nonMatchOptionsFields.includes(key)) {
+      // setProp side-steps typescript complaining
+      setProp(key, valueToMatchOptions(value), result);
+    }
+    // Handle Date fields
+    if (dateProps.includes(key)) {
+      const dateFieldValue = cloneObject(getProp(filter, key));
+      if (getProp(filter, `${key}.type`) === "relative-date") {
+        setProp(key, relativeDateToDateRange(dateFieldValue), result);
+      } else {
+        setProp(key, dateFieldValue, result);
+      }
+    }
+    // Handle fields that are just copied forward
+    if (copyProps.includes(key) && filter.hasOwnProperty(key)) {
+      setProp(key, value, result);
+    }
+  });
+  return result;
+}
+
+/**
+ * Serialize a FilterGroup of any type for Portal
+ * @param filterGroups
+ * @returns
+ */
+export function serializeFilterGroupsForPortal(
+  filterGroups: Array<IFilterGroup<FilterType>>
+): ISearchOptions {
+  const result = {
+    q: "",
+    filter: "",
+  } as ISearchOptions;
+
+  result.q = filterGroups.map(serializeGroup).join(" AND ");
+
+  return result;
+}
+
+/**
+ * Serialize the filters in a FitlerGroup into a Portal Query
+ * @param group
+ * @returns
+ */
+function serializeGroup(group: IFilterGroup<FilterType>): string {
+  const operation = group.operation || "AND";
+  const filters = group.filters.map(expandFilter);
+  return filters.map(serializeFilter).join(` ${operation} `);
+}
+/**
+ * Serialize a Filter into a Portal Query
+ * @param filter
+ * @returns
+ */
+function serializeFilter(filter: Filter<FilterType>): string {
+  const dateProps = ["created", "modified"];
+  const specialProps = ["filterType", "searchUserAccess", "term", ...dateProps];
+  // TODO: Look at using reduce vs .map and remove the `.filter`
+  const stringFilters = Object.entries(filter)
+    .map(([key, value]) => {
+      if (!specialProps.includes(key)) {
+        return serializeMatchOptions(key, value);
+      }
+      if (dateProps.includes(key)) {
+        return serializeDateRange(key, value as unknown as IDateRange<number>);
+      }
+      if (key === "term") {
+        return value;
+      }
+    })
+    .filter((e) => e !== undefined);
+  // eslint-disable-next-line unicorn/prefer-ternary
+  if (stringFilters.length > 1) {
+    return `(${stringFilters.join(" AND ")})`;
+  } else {
+    return stringFilters[0] as string;
+  }
+}
+
+/**
+ * Serialize MatchOptions into portal syntax
+ * @param key
+ * @param value
+ * @returns
+ */
+function serializeMatchOptions(key: string, value: IMatchOptions): string {
+  let result = "";
+  if (value.any) {
+    result = `${serializeStringOrArray("OR", key, value.any)}`;
+  }
+  if (value.all) {
+    result =
+      (result ? result + " AND " : "") +
+      `${serializeStringOrArray("AND", key, value.all)}`;
+  }
+  if (value.not) {
+    // negate the entries if they are not
+    result =
+      (result ? result + " AND " : "") +
+      `${serializeStringOrArray("OR", `-${key}`, value.not)}`;
+  }
+  // TODO HANDLE EXACT
+  return result;
+}
+
+/**
+ * Serialize a date-range into Portal syntax
+ * @param key
+ * @param range
+ * @returns
+ */
+function serializeDateRange(key: string, range: IDateRange<number>): string {
+  return `${key}:[${range.from} TO ${range.to}]`;
+}
+
+/**
+ * Serialize a `string` or `string[]` into a string
+ * @param join
+ * @param key
+ * @param value
+ * @returns
+ */
+function serializeStringOrArray(
+  join: "AND" | "OR",
+  key: string,
+  value: string | string[]
+): string {
+  let q = "";
+  if (Array.isArray(value)) {
+    q = `${key}:"${value.join(`" ${join} ${key}:"`)}"`;
+    if (value.length > 1) {
+      q = `(${q})`;
+    }
+  } else {
+    q = `${key}:"${value}"`;
+  }
+  return q;
+}

--- a/packages/common/src/search/index.ts
+++ b/packages/common/src/search/index.ts
@@ -9,3 +9,4 @@ export * from "./_searchUsers";
 export * from "./types";
 export * from "./collectionState";
 export * from "./convertCatalog";
+export * from "./filter-utils";

--- a/packages/common/src/search/types/IHubSearchResponse.ts
+++ b/packages/common/src/search/types/IHubSearchResponse.ts
@@ -1,0 +1,18 @@
+import { IFacet } from "./IFacet";
+
+/**
+ * Defines a generic search response interface with parameterized result type
+ * for different types of searches
+ *
+ * total - total number of results
+ * results - potentially paginated list of results
+ * hasNext - boolean flag for if there are any more pages ofresults
+ * next - invokable function for obtaining next page of results
+ */
+export interface IHubSearchResponse<T> {
+  total: number;
+  results: T[];
+  hasNext: boolean;
+  next: (params?: any) => Promise<IHubSearchResponse<T>>;
+  facets?: IFacet[];
+}

--- a/packages/common/src/search/types/index.ts
+++ b/packages/common/src/search/types/index.ts
@@ -5,4 +5,5 @@ export * from "./IFacetOption";
 export * from "./IHubApiSearchRequest";
 export * from "./IHubSearchOptions";
 export * from "./IHubSearchResult";
+export * from "./IHubSearchResponse";
 export * from "./types";

--- a/packages/common/src/search/types/types.ts
+++ b/packages/common/src/search/types/types.ts
@@ -26,6 +26,11 @@ export type Filter<T extends FilterType> = IFilterTypeMap[T] & {
   filterType: T;
 };
 
+export interface IFilterGroup<T extends FilterType> {
+  operation?: "AND" | "OR";
+  filters: Array<Filter<T>>;
+}
+
 /**
  * Groups of filters with an operation specifying how the
  * filters should be connected when serialized
@@ -42,6 +47,9 @@ export interface IFilterGroup<T extends FilterType> {
 export interface IFilterTypeMap {
   // any: IAnyFilterDefinition;
   item: IItemFilter;
+  /**
+   * DEPRECATED use item
+   */
   content: IContentFilterDefinition;
   user: IUserFilterDefinition;
   group: IGroupFilterDefinition;

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -273,6 +273,7 @@ export function mergeSearchOptions(
 /**
  * @private
  * Serialize a `MatchOptions` into `q` or `filter` on an `ISearchOptions`
+ * DEPRECATED: Serialization should be handled in filter-utils.ts
  * @param key
  * @param opts
  * @returns
@@ -385,7 +386,10 @@ export function serializeStringOrArray(
 ): string {
   let q = "";
   if (Array.isArray(value)) {
-    q = `(${key}:"${value.join(`" ${join} ${key}:"`)}")`;
+    q = `${key}:"${value.join(`" ${join} ${key}:"`)}"`;
+    if (value.length > 1) {
+      q = `(${q})`;
+    }
   } else {
     q = `${key}:"${value}"`;
   }

--- a/packages/common/test/projects/HubProjects.test.ts
+++ b/packages/common/test/projects/HubProjects.test.ts
@@ -302,7 +302,7 @@ describe("HubProjects:", () => {
       const searchOpts = searchSpy.calls.argsFor(0)[0];
 
       expect(searchOpts.q).toBe("water");
-      expect(searchOpts.filter).toBe(`(type:"Hub Project")`);
+      expect(searchOpts.filter).toBe(`type:"Hub Project"`);
       // Verify facets
       expect(response.facets).toBeDefined();
     });
@@ -326,7 +326,7 @@ describe("HubProjects:", () => {
       const searchOpts = searchSpy.calls.argsFor(0)[0];
 
       expect(searchOpts.q).toBe("water");
-      expect(searchOpts.filter).toBe(`(type:"Hub Project")`);
+      expect(searchOpts.filter).toBe(`type:"Hub Project"`);
       expect(searchOpts.portal).toEqual(`https://qaext.arcgis.com`);
       // Verify facets
       expect(response.facets).toBeDefined();
@@ -357,7 +357,7 @@ describe("HubProjects:", () => {
       expect(searchOpts.q).toBe("water");
       expect(searchOpts.countFields).toBe("tags");
       expect(searchOpts.countSize).toBe(10);
-      expect(searchOpts.filter).toBe(`(type:"Hub Project")`);
+      expect(searchOpts.filter).toBe(`type:"Hub Project"`);
 
       // Verify facets
       expect(response.facets).toBeDefined();
@@ -391,9 +391,8 @@ describe("HubProjects:", () => {
       const searchOpts = searchSpy.calls.argsFor(0)[0];
 
       expect(searchOpts.q).toBe("water");
-      expect(searchOpts.filter).toBe(`(type:"Hub Project")`);
+      expect(searchOpts.filter).toBe(`type:"Hub Project"`);
       expect(searchOpts.countSize).toBe(54);
-      expect(searchOpts.filter).toBe(`(type:"Hub Project")`);
 
       // Verify facets
       expect(response.facets).toBeDefined();

--- a/packages/common/test/search/filter-utils.test.ts
+++ b/packages/common/test/search/filter-utils.test.ts
@@ -1,0 +1,203 @@
+import {
+  Filter,
+  expandFilter,
+  IMatchOptions,
+  IDateRange,
+  IFilterGroup,
+  serializeFilterGroupsForPortal,
+} from "../../src";
+
+describe("filter-utils:", () => {
+  describe("expandFilters;", () => {
+    it("expands group filter", () => {
+      const f: Filter<"group"> = {
+        filterType: "group",
+        term: "Orange",
+        title: "Water",
+        owner: {
+          any: ["Dave", "Mike"],
+          not: ["Andrew"],
+        },
+        created: {
+          type: "relative-date",
+          num: 2,
+          unit: "months",
+        },
+        searchUserAccess: "groupMember",
+      };
+      const chk = expandFilter(f);
+
+      expect((chk.title as IMatchOptions).any).toBeDefined();
+      expect(chk.filterType).toBe("group");
+      expect((chk.owner as IMatchOptions).any).toEqual(["Dave", "Mike"]);
+      expect((chk.owner as IMatchOptions).not).toEqual(["Andrew"]);
+      expect(chk.searchUserAccess).toBeTruthy();
+      expect(chk.term).toBe("Orange");
+      const created = chk.created as IDateRange<number>;
+      expect(created.type).toBe("date-range");
+      expect(created.to).toBeCloseTo(Date.now(), -4);
+    });
+
+    it("expands item filter", () => {
+      const f: Filter<"item"> = {
+        filterType: "item",
+        term: "Orange",
+
+        title: "Water",
+
+        owner: {
+          any: ["Dave", "Mike"],
+          not: ["Andrew"],
+        },
+        type: "Web Map",
+        created: {
+          type: "relative-date",
+          num: 2,
+          unit: "months",
+        },
+        modified: {
+          type: "date-range",
+          from: 1689716790912,
+          to: 1652808629198,
+        },
+        snowcover: {
+          any: ["sparse", "medium"],
+        },
+      };
+      const chk = expandFilter(f);
+
+      expect((chk.title as IMatchOptions).any).toBeDefined();
+      expect(chk.filterType).toBe("item");
+      expect((chk.owner as IMatchOptions).any).toEqual(["Dave", "Mike"]);
+      expect((chk.owner as IMatchOptions).not).toEqual(["Andrew"]);
+      expect(chk.term).toBe("Orange");
+      // Pass through random stuff
+      expect((chk.snowcover as IMatchOptions).any).toEqual([
+        "sparse",
+        "medium",
+      ]);
+      const created = chk.created as IDateRange<number>;
+      expect(created.type).toBe("date-range");
+      expect(created.to).toBeCloseTo(Date.now(), -4);
+    });
+
+    it("expands user filter", () => {
+      const f: Filter<"user"> = {
+        filterType: "user",
+        username: "Dave",
+        term: "Orange",
+        lastlogin: {
+          type: "relative-date",
+          num: 2,
+          unit: "months",
+        },
+      };
+      const chk = expandFilter(f);
+
+      expect((chk.username as IMatchOptions).any).toEqual(["Dave"]);
+      expect(chk.filterType).toBe("user");
+      expect(chk.term).toBe("Orange");
+      const dt = chk.lastlogin as IDateRange<number>;
+      expect(dt.type).toBe("date-range");
+      expect(dt.to).toBeCloseTo(Date.now(), -4);
+    });
+  });
+
+  describe("serialize for Portal:", () => {
+    it("converts item filter", () => {
+      const f: Filter<"item"> = {
+        filterType: "item",
+        term: "water",
+        modified: {
+          type: "date-range",
+          from: 1689716790912,
+          to: 1652808629198,
+        },
+        type: { any: ["Web Map", "Hub Project"] },
+      };
+
+      const group: IFilterGroup<"item"> = {
+        filters: [f],
+      };
+
+      const chk = serializeFilterGroupsForPortal([group]);
+
+      expect(chk.q).toEqual(
+        '(water AND modified:[1689716790912 TO 1652808629198] AND (type:"Web Map" OR type:"Hub Project"))'
+      );
+    });
+    it("handles complex filter", () => {
+      const f: Filter<"item"> = {
+        filterType: "item",
+        tags: {
+          any: ["water", "rivers"],
+          all: "production",
+          not: ["preview", "deprecated"],
+        },
+      };
+
+      const group: IFilterGroup<"item"> = {
+        operation: "AND",
+        filters: [f],
+      };
+
+      const chk = serializeFilterGroupsForPortal([group]);
+
+      expect(chk.q).toEqual(
+        '(tags:"water" OR tags:"rivers") AND tags:"production" AND (-tags:"preview" OR -tags:"deprecated")'
+      );
+    });
+    it("handles complex filter without any", () => {
+      const f: Filter<"item"> = {
+        filterType: "item",
+        tags: {
+          all: "production",
+          not: ["preview", "deprecated"],
+        },
+      };
+
+      const group: IFilterGroup<"item"> = {
+        operation: "AND",
+        filters: [f],
+      };
+
+      const chk = serializeFilterGroupsForPortal([group]);
+
+      expect(chk.q).toEqual(
+        'tags:"production" AND (-tags:"preview" OR -tags:"deprecated")'
+      );
+    });
+    it("handles complex filter without any or all", () => {
+      const f: Filter<"item"> = {
+        filterType: "item",
+        tags: {
+          not: ["preview", "deprecated"],
+        },
+      };
+
+      const group: IFilterGroup<"item"> = {
+        operation: "AND",
+        filters: [f],
+      };
+
+      const chk = serializeFilterGroupsForPortal([group]);
+
+      expect(chk.q).toEqual('(-tags:"preview" OR -tags:"deprecated")');
+    });
+    it("handles simple filter ", () => {
+      const f: Filter<"item"> = {
+        filterType: "item",
+        tags: "water",
+      };
+
+      const group: IFilterGroup<"item"> = {
+        operation: "AND",
+        filters: [f],
+      };
+
+      const chk = serializeFilterGroupsForPortal([group]);
+
+      expect(chk.q).toEqual('tags:"water"');
+    });
+  });
+});

--- a/packages/common/test/search/group-utils.test.ts
+++ b/packages/common/test/search/group-utils.test.ts
@@ -76,7 +76,7 @@ describe("group-utils:", () => {
         };
         const chk = serializeGroupFilterForPortal(f);
         expect(chk.q).toBe(
-          `((((owner:"dbouwman_dc") AND (typekeywords:"one" OR typekeywords:"two")) AND created:[10 TO 100]) AND modified:[2 TO 8])`
+          `(((owner:"dbouwman_dc" AND (typekeywords:"one" OR typekeywords:"two")) AND created:[10 TO 100]) AND modified:[2 TO 8])`
         );
       });
       it("creates q", () => {
@@ -88,7 +88,7 @@ describe("group-utils:", () => {
           searchUserAccess: "groupMember",
         };
         const chk = serializeGroupFilterForPortal(f);
-        expect(chk.q).toBe(`(typekeywords:"Hub Content Group")`);
+        expect(chk.q).toBe(`typekeywords:"Hub Content Group"`);
         expect(chk.searchUserAccess).toBe("groupMember");
       });
     });

--- a/packages/common/test/search/utils.test.ts
+++ b/packages/common/test/search/utils.test.ts
@@ -53,7 +53,7 @@ describe("Search Utils:", () => {
         const chk = serializeMatchOptions("tags", mo);
 
         expect(chk.q).toBe(
-          '(tags:"buildings" OR tags:"tents") AND (tags:"red" AND tags:"blue") AND (-tags:"yellow")'
+          '(tags:"buildings" OR tags:"tents") AND (tags:"red" AND tags:"blue") AND -tags:"yellow"'
         );
         expect(chk.filter).toBe(`(tags:"Rubber" AND tags:"Duck")`);
       });
@@ -97,7 +97,7 @@ describe("Search Utils:", () => {
             exact: "buildings",
           };
           const chk = serializeMatchOptions("metaInfo", mo);
-          expect(chk.q).toBe('(metaInfo:"buildings")');
+          expect(chk.q).toBe('metaInfo:"buildings"');
           expect(chk.filter).toEqual("");
         });
         it("added to .all if both arrays", () => {
@@ -134,7 +134,7 @@ describe("Search Utils:", () => {
             exact: ["buildings"],
           };
           const chk = serializeMatchOptions("metaInfo", mo);
-          expect(chk.q).toBe('(metaInfo:"buildings")');
+          expect(chk.q).toBe('metaInfo:"buildings"');
           expect(chk.filter).toEqual("");
         });
       });

--- a/packages/teams/e2e/create-teams.e2e.ts
+++ b/packages/teams/e2e/create-teams.e2e.ts
@@ -7,7 +7,7 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
 
-fdescribe("Team Creation Validation:", () => {
+describe("Team Creation Validation:", () => {
   let factory: Artifactory;
   beforeAll(() => {
     factory = new Artifactory(config);


### PR DESCRIPTION
1. Description:

Adds generic function for expanding filters `expandFilter<T>(filter: T): T` which takes the flexible Filter<T> structure and "expands" all the props into `IMatchOptions` or `IDateRange<number>` which simplifies deterministic serialization into Hub or Portal API requests.

Also adds function to serialize an array of `IFilterGroup<T>` to `ISearchOptions` for portal

`serializeFilterGroupsForPortal(filterGroups: Array<IFilterGroup<FilterType>>): ISearchOptions`

This is on-going work pulling hacked functions from a spike branch up into robust tested code.

Once everything is done, we can remove *many* of the FilterType specific functions, but we're not there yet.


1. Instructions for testing:
- run tests



1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
