### PR TITLE
fix(hub-common): fixes a type error when checking if additional resource is an item data source

### DIFF
--- a/packages/common/src/content/_internal.ts
+++ b/packages/common/src/content/_internal.ts
@@ -419,7 +419,9 @@ export const isDataSourceOfItem = (
   item: IItem
 ) => {
   const serviceUrl = item.url && parseServiceUrl(item.url);
-  return serviceUrl && resource.linkage.includes(serviceUrl);
+  return (
+    serviceUrl && resource.linkage && resource.linkage.includes(serviceUrl)
+  );
 };
 
 /**


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: fixes a type error when checking if additional resource is an item data source

2. Instructions for testing:

3. Closes Issues: #3860 (if appropriate)

4. [x] used semantic commit messages - ran `npm run c`
  
5. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!) - ran `npm run c`
