### PR TITLE
fix(hub-initiatives): add missing closing paren in checkGroupExists

### DIFF
--- a/packages/initiatives/src/groups.ts
+++ b/packages/initiatives/src/groups.ts
@@ -122,7 +122,7 @@ export function checkGroupExists(
   requestOptions: IRequestOptions
 ): Promise<any> {
   const options = {
-    q: `(orgid: ${orgId}`,
+    q: `(orgid: ${orgId})`,
     filter: `title:"${title}"`,
     ...requestOptions,
   };


### PR DESCRIPTION
1. Description:
- add missing closing paren in `checkGroupExists` query

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
