### PR TITLE
feat: add bBoxToExtent(), extentToPolygon(), and getExtentCenter() utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21602,10 +21602,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -21620,24 +21619,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -21651,10 +21647,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -21672,10 +21667,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -61392,7 +61386,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.35.0",
+			"version": "9.36.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -61425,7 +61419,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.22.0",
+			"version": "11.23.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61434,7 +61428,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61447,12 +61441,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.35.0"
+				"@esri/hub-common": "9.36.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.35.0",
+			"version": "9.36.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -61463,7 +61457,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61472,12 +61466,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.35.0"
+				"@esri/hub-common": "9.36.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.35.0",
+			"version": "9.36.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61488,7 +61482,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61502,12 +61496,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.35.0"
+				"@esri/hub-common": "9.36.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.35.0",
+			"version": "9.36.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61516,7 +61510,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61529,12 +61523,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.35.0"
+				"@esri/hub-common": "9.36.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.35.0",
+			"version": "9.36.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61545,7 +61539,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61561,12 +61555,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.35.0"
+				"@esri/hub-common": "9.36.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.35.0",
+			"version": "9.36.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61575,9 +61569,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
-				"@esri/hub-initiatives": "9.35.0",
-				"@esri/hub-teams": "9.35.0",
+				"@esri/hub-common": "9.36.0",
+				"@esri/hub-initiatives": "9.36.0",
+				"@esri/hub-teams": "9.36.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -61590,9 +61584,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.35.0",
-				"@esri/hub-initiatives": "9.35.0",
-				"@esri/hub-teams": "9.35.0"
+				"@esri/hub-common": "9.36.0",
+				"@esri/hub-initiatives": "9.36.0",
+				"@esri/hub-teams": "9.36.0"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61617,7 +61611,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.35.0",
+			"version": "9.36.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61628,7 +61622,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61642,12 +61636,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.35.0"
+				"@esri/hub-common": "9.36.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.35.0",
+			"version": "9.36.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61657,7 +61651,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61670,7 +61664,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.35.0"
+				"@esri/hub-common": "9.36.0"
 			}
 		}
 	},
@@ -65085,7 +65079,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65104,7 +65098,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65123,7 +65117,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65139,7 +65133,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65158,7 +65152,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65176,9 +65170,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
-				"@esri/hub-initiatives": "9.35.0",
-				"@esri/hub-teams": "9.35.0",
+				"@esri/hub-common": "9.36.0",
+				"@esri/hub-initiatives": "9.36.0",
+				"@esri/hub-teams": "9.36.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -65215,7 +65209,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65232,7 +65226,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.35.0",
+				"@esri/hub-common": "9.36.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -79227,8 +79221,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -79243,20 +79236,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -79270,8 +79260,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -79288,8 +79277,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -719,9 +719,10 @@ export const composeContent = (
     },
     // would require us to do client-side projection of server/layer extent
     get boundary() {
-      // TODO: need to be able to handle automatic w/ additional enrichment
-      // that could for example fetch the concave hull from the Hub API or resources
-      return boundary || getContentBoundary(item);
+      // NOTE: the boundary from the Hub API will be undefined if item.properties.boundary === 'none'
+      return boundary?.provenance === "automatic"
+        ? boundary
+        : getContentBoundary(item);
     },
     get summary() {
       return (

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,7 +1,14 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IItem, IUser, IGroup, IGeometry } from "@esri/arcgis-rest-types";
+import {
+  IItem,
+  IUser,
+  IGroup,
+  IPolygon,
+  ISpatialReference,
+  IGeometry,
+} from "@esri/arcgis-rest-types";
 import { IPortal, ISearchResult } from "@esri/arcgis-rest-portal";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
@@ -201,6 +208,16 @@ export type AccessControl = "view" | "edit" | "admin";
 export type GeographyProvenance = "item" | "none" | "automatic";
 
 /**
+ * properties to be used with the ArcGIS API geometry class constructors
+ */
+export interface IGeometryProperties extends IGeometry {
+  type: string;
+}
+export interface IPolygonProperties extends IPolygon, IGeometryProperties {
+  type: "polygon";
+}
+
+/**
  * Location of a Hub resource
  *
  * @export
@@ -208,8 +225,9 @@ export type GeographyProvenance = "item" | "none" | "automatic";
  */
 export interface IHubGeography {
   center?: [number, number];
-  geometry?: IGeometry;
+  geometry?: IPolygonProperties;
   provenance?: GeographyProvenance;
+  spatialReference?: ISpatialReference;
 }
 
 export type SearchableType = IItem | IGroup | IUser;

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -1,5 +1,5 @@
 import { IItem } from "@esri/arcgis-rest-portal";
-import { ILayerDefinition, IPolygon } from "@esri/arcgis-rest-types";
+import { ILayerDefinition } from "@esri/arcgis-rest-types";
 import {
   DatasetResource,
   datasetToContent,
@@ -43,7 +43,6 @@ import { IModel } from "../src/types";
 import { getProxyUrl, IHubContent, IHubRequestOptions } from "../src";
 import { cloneObject } from "../src/util";
 import * as documentItem from "./mocks/items/document.json";
-import * as mapServiceItem from "./mocks/items/map-service.json";
 import * as documentsJson from "./mocks/datasets/document.json";
 import * as featureLayerJson from "./mocks/datasets/feature-layer.json";
 
@@ -536,34 +535,6 @@ describe("item to content", () => {
   it("has a reference to the item", () => {
     const content = itemToContent(item);
     expect(content.item).toEqual(item);
-  });
-  it("handles invalid item boundary set to item extent but item has no extent", () => {
-    // configure item to specify using item extent as boundary
-    // even though the item has an empty extent
-    const properties = { boundary: "item" };
-    const content = itemToContent({ ...item, properties });
-    const boundary = content.boundary;
-    expect(boundary.geometry).toBeNull();
-    expect(boundary.provenance).toBe("item");
-  });
-  it("has a boundary when the item has a valid extent", () => {
-    item = cloneObject(mapServiceItem) as IItem;
-    const content = itemToContent(item);
-    const geometry: IPolygon = {
-      rings: [
-        [
-          [-2.732, 53.4452],
-          [-2.4139, 53.4452],
-          [-2.4139, 53.6093],
-          [-2.732, 53.6093],
-          [-2.732, 53.4452],
-        ],
-      ],
-      spatialReference: {
-        wkid: 4326,
-      },
-    };
-    expect(content.boundary).toEqual({ geometry, provenance: "item" });
   });
   it("gets relative url from type and family", () => {
     const content = itemToContent(item);

--- a/packages/common/test/content/fetch.test.ts
+++ b/packages/common/test/content/fetch.test.ts
@@ -1,4 +1,3 @@
-import { IPolygon } from "@esri/arcgis-rest-types";
 import * as portalModule from "@esri/arcgis-rest-portal";
 import * as featureLayerModule from "@esri/arcgis-rest-feature-layer";
 import {
@@ -7,6 +6,7 @@ import {
   IFetchContentOptions,
   IItemEnrichments,
   cloneObject,
+  IPolygonProperties,
 } from "../../src";
 import * as _enrichmentsModule from "../../src/items/_enrichments";
 import * as _fetchModule from "../../src/content/_fetch";
@@ -101,7 +101,7 @@ describe("fetchContent", () => {
       // inspect the results
       expect(result.item).toEqual(documentItem);
       expect(result.boundary).toEqual({
-        geometry: undefined,
+        geometry: null,
         provenance: undefined,
       });
       expect(result.statistics).toBeUndefined();
@@ -139,8 +139,10 @@ describe("fetchContent", () => {
               spatialReference: {
                 wkid: 4326,
               },
-            } as IPolygon,
-            // "setBy": null
+            } as IPolygonProperties,
+            spatialReference: {
+              wkid: 4326,
+            },
           },
         };
         itemEnrichments = getMultiLayerItemEnrichments();
@@ -211,7 +213,7 @@ describe("fetchContent", () => {
         // Default to slug that was passed in, not the slug of the fetched layer
         expect(result.slug).toBe(slug);
         // expect(result.boundary).toEqual(layerHubEnrichments.boundary)
-        expect(result.boundary).toBe(layerHubEnrichments.boundary);
+        expect(result.boundary).toEqual(layerHubEnrichments.boundary);
         expect(result.boundary).not.toBe(hubEnrichments.boundary);
         expect(result.statistics).toEqual(layerHubEnrichments.statistics);
         expect(result.recordCount).toBe(count);
@@ -483,7 +485,7 @@ describe("fetchContent", () => {
         // inspect the results
         expect(result.item).toEqual(documentItem);
         expect(result.boundary).toEqual({
-          geometry: undefined,
+          geometry: null,
           provenance: undefined,
         });
         expect(result.statistics).toBeUndefined();
@@ -520,7 +522,7 @@ describe("fetchContent", () => {
         // inspect the results
         expect(result.item).toEqual(documentItem);
         expect(result.boundary).toEqual({
-          geometry: undefined,
+          geometry: null,
           provenance: undefined,
         });
         expect(result.statistics).toBeUndefined();
@@ -554,7 +556,7 @@ describe("fetchContent", () => {
       // inspect the results
       expect(result.item).toEqual(documentItem);
       expect(result.boundary).toEqual({
-        geometry: undefined,
+        geometry: null,
         provenance: undefined,
       });
       expect(result.statistics).toBeUndefined();
@@ -591,7 +593,7 @@ describe("fetchContent", () => {
         // inspect the results
         expect(result.item).toEqual(documentItem);
         expect(result.boundary).toEqual({
-          geometry: undefined,
+          geometry: null,
           provenance: undefined,
         });
         expect(result.statistics).toBeUndefined();
@@ -645,7 +647,7 @@ describe("fetchContent", () => {
           expect(result.item).toEqual(
             multiLayerFeatureServiceItem as portalModule.IItem
           );
-          // expect(result.boundary).toEqual({ geometry: undefined, provenance: undefined })
+          // expect(result.boundary).toEqual({ geometry: null, provenance: undefined })
           expect(result.statistics).toBeUndefined();
           expect(result.layer.id).toBe(layerId);
           expect(result.recordCount).toEqual(Infinity);


### PR DESCRIPTION
1. Description:

add some utils for working with extents, and 
also add center and spatialReference to content.boundary
also add missing content.boundary.geometry.type

1. Instructions for testing:

1. Closes Issues: part of [2154](https://devtopia.esri.com/dc/hub/issues/2154)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
