### PR TITLE
feat: add scope to ICatalog and ICollection

### DIFF
--- a/packages/common/src/search/collectionState.ts
+++ b/packages/common/src/search/collectionState.ts
@@ -74,7 +74,7 @@ export function serializeCollectionState(
     state.sort = serializeSortState(collection.sortOption);
   }
 
-  const facetState = collection.facets.reduce((s, facet) => {
+  const facetState = (collection.facets || []).reduce((s, facet) => {
     return { ...s, ...serializeFacetState(facet) };
   }, {} as IFacetState);
 

--- a/packages/common/src/search/convertCatalog.ts
+++ b/packages/common/src/search/convertCatalog.ts
@@ -1,26 +1,35 @@
 import { getProp } from "..";
-import { Filter, ICatalog } from "./types";
+import { ICatalog, IFilterGroup } from "./types";
 
 /**
  * Convert the original site catalog structure into a formal ICatalog
  * @param original
  */
 export function convertCatalog(original: any): ICatalog {
-  const filter: Filter<"content"> = {
-    filterType: "content",
+  const filterGroup: IFilterGroup<"item"> = {
+    filterType: "item",
+    operation: "OR",
+    filters: [],
   };
 
   const groups = getProp(original, "groups");
 
   if (Array.isArray(groups) && groups.length) {
-    filter.group = groups;
+    filterGroup.filters.push({
+      filterType: "item",
+      group: groups,
+    });
   } else if (typeof groups === "string") {
-    filter.group = [groups];
+    filterGroup.filters.push({
+      filterType: "item",
+      group: [groups],
+    });
   }
 
   const catalog: ICatalog = {
     title: "Default Catalog",
-    filter,
+    scope: [filterGroup],
+    collections: [],
   };
 
   return catalog;

--- a/packages/common/src/search/types/ICatalog.ts
+++ b/packages/common/src/search/types/ICatalog.ts
@@ -1,6 +1,6 @@
 import { ICollection } from "./ICollection";
 import { IFacet } from "./IFacet";
-import { Filter, FilterType, ISortOption } from "./types";
+import { Filter, FilterType, IFilterGroup, ISortOption } from "./types";
 
 /**
  * Catalog is the definition which powers what options
@@ -14,7 +14,11 @@ import { Filter, FilterType, ISortOption } from "./types";
  * ```ts
  * const simpleCatalog:Catalog = {
  *   title: "Select Map",
- *   filter: {
+ *   filters: [
+ *    {
+ *     fitlerType: "item",
+ *      operation: "AND",
+ *      fitlers
  *     filterType: "content",
  *     type: "Web Map",
  *     owner: "jsmith"
@@ -59,9 +63,16 @@ export interface ICatalog {
    */
   title?: string;
   /**
-   * Filter defines the "scope" of the Catalog, typically a set of groups or orgids
+   * Scope is a set of FilterGroups which define the limits of the Catalog.
+   * Typically it is just a set of group ids, but it may be arbitrarily complex.
+   * If one was to "search a catalog", this is the description of what would be returned.
    */
-  filter: Filter<FilterType>;
+  scope?: Array<IFilterGroup<FilterType>>;
+  /**
+   * Filter defines the "scope" of the Catalog, typically a set of groups or orgids
+   * DEPRECATED: Use `scope`
+   */
+  filter?: Filter<FilterType>;
   /**
    * Sort options to be shown in the Gallery
    */

--- a/packages/common/src/search/types/ICollection.ts
+++ b/packages/common/src/search/types/ICollection.ts
@@ -1,5 +1,5 @@
 import { IFacet } from "./IFacet";
-import { Filter, FilterType, ISortOption } from "./types";
+import { Filter, FilterType, IFilterGroup, ISortOption } from "./types";
 
 /**
  * A Collection is a subset of a Catalog, but can be used independently
@@ -15,15 +15,26 @@ export interface ICollection {
    */
   filterType?: FilterType;
   /**
+   * Scope is a set of FilterGroups which define the limits of the Collection.
+   * Typically it is just a set of group ids, but it may be arbitrarily complex.
+   * If one was to "search the collection", this is the description of what would be returned.
+   */
+  scope?: Array<IFilterGroup<FilterType>>;
+  /**
    * Specify the includes to be requested when working with this collection
    */
   include?: string[];
-  // Default query for the Collection
-  defaultQuery?: string;
+
   // Default Sorts
   sortOption: ISortOption;
-  // Filter defines the "scope" of the Collection, typically a set of groups or orgids
-  filter: Filter<FilterType>;
   // Facets available for this Collection
   facets?: IFacet[];
+
+  // Filter defines the "scope" of the Collection, typically a set of groups or orgids
+  // DEPRECATED: Use `scope`
+  filter?: Filter<FilterType>;
+
+  // Default query for the Collection
+  // DEPRECATED: use `scope`
+  defaultQuery?: string;
 }

--- a/packages/common/test/search/collectionState.test.ts
+++ b/packages/common/test/search/collectionState.test.ts
@@ -11,9 +11,21 @@ describe("collection state:", () => {
     collection = {
       label: "fake collection",
       key: "fake",
+      scope: [
+        {
+          filterType: "content",
+          operation: "AND",
+          filters: [
+            {
+              filterType: "content",
+              owner: "vader",
+            },
+          ],
+        },
+      ],
       filter: {
         filterType: "content",
-        owner: "vader",
+        owner: "luke",
       },
       sortOption: {
         label: "Title",
@@ -131,6 +143,13 @@ describe("collection state:", () => {
       const chk = serializeCollectionState(clone);
       expect(chk.type).toEqual("map");
       expect(chk.tags).toEqual("water,river");
+    });
+    it("can handle undefined facets", () => {
+      const clone = cloneObject(collection);
+      delete clone.facets;
+      const chk = serializeCollectionState(clone);
+      expect(chk.type).not.toBeDefined();
+      expect(chk.tags).not.toBeDefined();
     });
   });
 });

--- a/packages/common/test/search/convertCatalog.test.ts
+++ b/packages/common/test/search/convertCatalog.test.ts
@@ -1,45 +1,49 @@
-import { convertCatalog, Filter } from "../../src/search";
+import { convertCatalog, Filter, IFilterGroup } from "../../src/search";
 
 describe("convertCatalog", () => {
   it("returns default catalog if null", () => {
     const chk = convertCatalog(null);
     expect(chk.title).toBe("Default Catalog");
-    expect(chk.filter.filterType).toBe("content");
-    const filter = chk.filter as Filter<"content">;
-    expect(filter.group).not.toBeDefined();
+    expect(chk.scope.length).toBe(1);
+    const fg = chk.scope[0] as IFilterGroup<"item">;
+    expect(fg.filters.length).toBe(0);
   });
 
   it("returns default catalog if passed empty object", () => {
     const chk = convertCatalog({});
     expect(chk.title).toBe("Default Catalog");
-    expect(chk.filter.filterType).toBe("content");
-    const filter = chk.filter as Filter<"content">;
-    expect(filter.group).not.toBeDefined();
+    expect(chk.scope.length).toBe(1);
+    expect(chk.scope[0].filterType).toBe("item");
+    const fg = chk.scope[0] as IFilterGroup<"item">;
+    expect(fg.filters.length).toBe(0);
   });
 
   it("does not return groups if passed empty array", () => {
     const chk = convertCatalog({ groups: [] });
     expect(chk.title).toBe("Default Catalog");
-    expect(chk.filter.filterType).toBe("content");
-    const filter = chk.filter as Filter<"content">;
-    expect(filter.group).not.toBeDefined();
+    expect(chk.scope.length).toBe(1);
+    expect(chk.scope[0].filterType).toBe("item");
+    const fg = chk.scope[0] as IFilterGroup<"item">;
+    expect(fg.filters.length).toBe(0);
   });
 
   it("returns groups if passed a string", () => {
     const chk = convertCatalog({ groups: "3ef" });
     expect(chk.title).toBe("Default Catalog");
-    expect(chk.filter.filterType).toBe("content");
-    const filter = chk.filter as Filter<"content">;
-    expect(filter.group).toBeDefined();
-    expect(filter.group).toEqual(["3ef"]);
+    expect(chk.scope.length).toBe(1);
+    expect(chk.scope[0].filterType).toBe("item");
+    const fg = chk.scope[0] as IFilterGroup<"item">;
+    expect(fg.filters[0].group).toBeDefined();
+    expect(fg.filters[0].group).toEqual(["3ef"]);
   });
 
-  it("returns groups if passed a array", () => {
+  it("returns groups if passed an array", () => {
     const chk = convertCatalog({ groups: ["3ef", "bc4"] });
     expect(chk.title).toBe("Default Catalog");
-    expect(chk.filter.filterType).toBe("content");
-    const filter = chk.filter as Filter<"content">;
-    expect(filter.group).toBeDefined();
-    expect(filter.group).toEqual(["3ef", "bc4"]);
+    expect(chk.scope.length).toBe(1);
+    expect(chk.scope[0].filterType).toBe("item");
+    const fg = chk.scope[0] as IFilterGroup<"item">;
+    expect(fg.filters[0].group).toBeDefined();
+    expect(fg.filters[0].group).toEqual(["3ef", "bc4"]);
   });
 });


### PR DESCRIPTION
1. Description:

For the gallery card use-case, we need `ICollection` to support an arbitrarily complex "scoping filter". However, the current `.filter` is to simple to meet this need. This, this adds `scope?: Array<IFilterGroup<FilterType>>;` to both `ICollection` and `ICatalog`. This enables the required level of complexity.

Also fixes an issue where the collection state serializer would fail if the collection did not have `.filters:[]`. 

1. Instructions for testing:

- run tests


1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
