### PR TITLE
feat(hub-common): fetch org enrichment in fetchContent and add fallback logic for publisher in composeContent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21602,9 +21602,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -21619,21 +21620,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -21647,9 +21651,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -21667,9 +21672,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -61386,7 +61392,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.36.0",
+			"version": "9.38.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -61419,7 +61425,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.23.0",
+			"version": "11.25.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61428,7 +61434,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61441,12 +61447,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.36.0"
+				"@esri/hub-common": "9.38.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.36.0",
+			"version": "9.38.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -61457,7 +61463,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61466,12 +61472,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.36.0"
+				"@esri/hub-common": "9.38.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.36.0",
+			"version": "9.38.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61482,7 +61488,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61496,12 +61502,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.36.0"
+				"@esri/hub-common": "9.38.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.36.0",
+			"version": "9.38.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61510,7 +61516,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61523,12 +61529,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.36.0"
+				"@esri/hub-common": "9.38.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.36.0",
+			"version": "9.38.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61539,7 +61545,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61555,12 +61561,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.36.0"
+				"@esri/hub-common": "9.38.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.36.0",
+			"version": "9.38.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61569,9 +61575,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
-				"@esri/hub-initiatives": "9.36.0",
-				"@esri/hub-teams": "9.36.0",
+				"@esri/hub-common": "9.38.0",
+				"@esri/hub-initiatives": "9.38.0",
+				"@esri/hub-teams": "9.38.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -61584,9 +61590,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.36.0",
-				"@esri/hub-initiatives": "9.36.0",
-				"@esri/hub-teams": "9.36.0"
+				"@esri/hub-common": "9.38.0",
+				"@esri/hub-initiatives": "9.38.0",
+				"@esri/hub-teams": "9.38.0"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61611,7 +61617,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.36.0",
+			"version": "9.38.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61622,7 +61628,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61636,12 +61642,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.36.0"
+				"@esri/hub-common": "9.38.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.36.0",
+			"version": "9.38.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61651,7 +61657,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61664,7 +61670,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.36.0"
+				"@esri/hub-common": "9.38.0"
 			}
 		}
 	},
@@ -65079,7 +65085,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65098,7 +65104,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65117,7 +65123,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65133,7 +65139,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65152,7 +65158,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65170,9 +65176,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
-				"@esri/hub-initiatives": "9.36.0",
-				"@esri/hub-teams": "9.36.0",
+				"@esri/hub-common": "9.38.0",
+				"@esri/hub-initiatives": "9.38.0",
+				"@esri/hub-teams": "9.38.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -65209,7 +65215,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65226,7 +65232,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.36.0",
+				"@esri/hub-common": "9.38.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -79221,7 +79227,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -79236,17 +79243,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -79260,7 +79270,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -79277,7 +79288,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -31,6 +31,8 @@ import {
   parseISODateString,
   getAdditionalResources,
   determineExtent,
+  getPublisherInfo,
+  getItemOrgId,
 } from "./_internal";
 import { getFamily } from "./get-family";
 
@@ -790,13 +792,9 @@ export const composeContent = (
         "metadataUpdateFrequency"
       );
     },
-    // TODO: add the publisher logic outlined here:
-    // https://devtopia.esri.com/dc/hub/issues/2932#issuecomment-3276309
+
     get publisher() {
-      return {
-        name: item.owner,
-        username: item.owner,
-      };
+      return getPublisherInfo(item, metadata, org, ownerUser);
     },
     // TODO: is metrics in use?
     get metrics() {
@@ -821,8 +819,7 @@ export const composeContent = (
       return dataLayer ? dataLayer.layerDefinition : undefined;
     },
     get orgId() {
-      // NOTE: it's undocumented, but the portal API will return orgId for items... sometimes
-      return org ? org.id : item.orgId || ownerUser?.orgId;
+      return org ? org.id : getItemOrgId(item, ownerUser);
     },
     get contentTypeIcon() {
       /* Note: only returns calcite-icons */

--- a/packages/common/src/core/types/IHubContent.ts
+++ b/packages/common/src/core/types/IHubContent.ts
@@ -6,6 +6,13 @@ import { IHubItemEntity } from ".";
 import { IHubContentEnrichments } from "./IHubContentEnrichments";
 import { IHubAdditionalResource } from "./IHubAdditionalResource";
 
+export enum PublisherSource {
+  CitationContact = "metadata.resource.citation.contact",
+  ResourceContact = "metadata.resource.contact",
+  ItemOwner = "item.owner",
+  None = "none",
+}
+
 // TODO: at next breaking change, IHubContent should no longer extend IItem
 /**
  * Data model for content
@@ -84,7 +91,21 @@ export interface IHubContent
   /** Frequency at which the content is updated */
   updateFrequency?: string;
 
-  // TODO: publisher?
+  /**
+   * Info to display about the content's publisher. Follows this fallback pattern:
+   * 1) Formal Item Metadata > Resource > Citation > Contact
+   * 2) Formal Item Metadata > Resource > Contact
+   * 3) Item’s Owner and Org Name
+   * 4) Undefined (Item Owner / Org are private and we can't access additional info)
+   */
+  publisher?: {
+    name?: string;
+    username?: string; // if name refers to item owner, then this will be item owner's username, otherwise it will be undefined
+    nameSource: PublisherSource;
+    organization?: string;
+    orgId?: string; // if organization refers to item owner's org, then this will be that org's orgId
+    organizationSource: PublisherSource;
+  };
 
   // TODO: should portalHomeUrl and portalApiUrl be hoisted to IHubItemEntity?
   // previously we had them in IHubResource

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -28,6 +28,7 @@ export * from "./util";
 export * from "./utils";
 export * from "./Hub";
 export * from "./pages";
+export * from "./org";
 
 import OperationStack from "./OperationStack";
 import OperationError from "./OperationError";

--- a/packages/common/src/items/_enrichments.ts
+++ b/packages/common/src/items/_enrichments.ts
@@ -19,6 +19,7 @@ import { getItemMetadata } from "@esri/arcgis-rest-portal";
 import { parse } from "fast-xml-parser";
 import { getPortalBaseFromOrgUrl } from "../urls/getPortalBaseFromOrgUrl";
 import { getItemOrgId } from "../content/_internal";
+import { getProp } from "../objects";
 
 /**
  * An object containing the item and fetched enrichments
@@ -148,12 +149,15 @@ const enrichOrg = (
   const opId = stack.start("enrichOrg");
   const orgId = getItemOrgId(data.item, data.ownerUser);
   // TODO: purposely error / reject when requestOptions.portal isn't passed in.
+  const orgPortalUrl =
+    getProp(requestOptions, "portal") ||
+    getProp(requestOptions, "authentication.portal");
   const options = {
     ...requestOptions,
     // In order to get the correct response, we must pass options.portal
     // as a base portal url (e.g., www.arcgis.com, qaext.arcgis.com, etc)
     // **not** an org portal (i.e. org.maps.arcgis.com).
-    portal: `${getPortalBaseFromOrgUrl(requestOptions.portal)}/sharing/rest`,
+    portal: `${getPortalBaseFromOrgUrl(orgPortalUrl)}/sharing/rest`,
   };
 
   return getPortal(orgId, options)

--- a/packages/common/src/items/_enrichments.ts
+++ b/packages/common/src/items/_enrichments.ts
@@ -3,7 +3,6 @@ import {
   getItemData,
   getItemGroups,
   getUser,
-  getPortal,
 } from "@esri/arcgis-rest-portal";
 import {
   getAllLayersAndTables,
@@ -17,9 +16,8 @@ import OperationStack from "../OperationStack";
 // TODO: move these functions here under /items
 import { getItemMetadata } from "@esri/arcgis-rest-portal";
 import { parse } from "fast-xml-parser";
-import { getPortalBaseFromOrgUrl } from "../urls/getPortalBaseFromOrgUrl";
 import { getItemOrgId } from "../content/_internal";
-import { getProp } from "../objects";
+import { fetchOrg } from "../org";
 
 /**
  * An object containing the item and fetched enrichments
@@ -148,19 +146,8 @@ const enrichOrg = (
   const { data, stack, requestOptions } = input;
   const opId = stack.start("enrichOrg");
   const orgId = getItemOrgId(data.item, data.ownerUser);
-  // TODO: purposely error / reject when requestOptions.portal isn't passed in.
-  const orgPortalUrl =
-    getProp(requestOptions, "portal") ||
-    getProp(requestOptions, "authentication.portal");
-  const options = {
-    ...requestOptions,
-    // In order to get the correct response, we must pass options.portal
-    // as a base portal url (e.g., www.arcgis.com, qaext.arcgis.com, etc)
-    // **not** an org portal (i.e. org.maps.arcgis.com).
-    portal: `${getPortalBaseFromOrgUrl(orgPortalUrl)}/sharing/rest`,
-  };
 
-  return getPortal(orgId, options)
+  return fetchOrg(orgId, requestOptions)
     .then((org) => {
       stack.finish(opId);
       return {

--- a/packages/common/src/org/fetch-org.ts
+++ b/packages/common/src/org/fetch-org.ts
@@ -1,0 +1,24 @@
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { getProp } from "../objects/get-prop";
+import { getPortalBaseFromOrgUrl } from "../urls/getPortalBaseFromOrgUrl";
+import { getPortal } from "@esri/arcgis-rest-portal";
+
+/**
+ * Fetches the portal for a given org.
+ *
+ * @param orgId
+ * @param options request options
+ * @returns
+ */
+export const fetchOrg = (orgId: string, options?: IRequestOptions) => {
+  const orgPortalUrl =
+    getProp(options, "portal") ||
+    getProp(options, "authentication.portal") ||
+    "www.arcgis.com";
+
+  // In order to get the correct response, we must pass options.portal
+  // as a base portal url (e.g., www.arcgis.com, qaext.arcgis.com, etc)
+  // **not** an org portal (i.e. org.maps.arcgis.com).
+  const basePortalUrl = `${getPortalBaseFromOrgUrl(orgPortalUrl)}/sharing/rest`;
+  return getPortal(orgId, { ...options, portal: basePortalUrl });
+};

--- a/packages/common/src/org/index.ts
+++ b/packages/common/src/org/index.ts
@@ -1,0 +1,1 @@
+export * from "./fetch-org";

--- a/packages/common/test/compose.test.ts
+++ b/packages/common/test/compose.test.ts
@@ -7,6 +7,7 @@ import {
   getProxyUrl,
   IHubGeography,
   IHubRequestOptions,
+  PublisherSource,
 } from "../src";
 import * as documentItem from "./mocks/items/document.json";
 import * as mapServiceItem from "./mocks/items/map-service.json";
@@ -372,6 +373,25 @@ describe("composeContent", () => {
         expect(result.publishedDateSource).toEqual(
           "metadata.metadata.dataIdInfo.idCitation.date.pubDate"
         );
+      });
+    });
+    describe("with publisher info", () => {
+      it("should populate publisher", () => {
+        const metadata = {
+          metadata: {
+            mdContact: {
+              rpIndName: "Resource Name",
+              rpOrgName: "Resource Org",
+            },
+          },
+        };
+        const content = composeContent(item, { metadata });
+        expect(content.publisher).toEqual({
+          name: "Resource Name",
+          nameSource: PublisherSource.ResourceContact,
+          organization: "Resource Org",
+          organizationSource: PublisherSource.ResourceContact,
+        });
       });
     });
   });

--- a/packages/common/test/items/_enrichments.test.ts
+++ b/packages/common/test/items/_enrichments.test.ts
@@ -53,7 +53,7 @@ describe("_enrichments", () => {
       });
     });
     describe("enrichOrg", () => {
-      it("fetches the org portal using options.portal", async () => {
+      it("fetches the org portal", async () => {
         const orgPortalUrl = "https://myorg.maps.arcgis.com"; // target we pass in
         const basePortalUrl = "https://www.arcgis.com"; // target that should be hit
 
@@ -61,7 +61,7 @@ describe("_enrichments", () => {
         const username = item.owner;
         const ownerUser = {
           username,
-          orgId: "foo", // should be used to fetch the org
+          orgId: "foo",
         };
         fetchMock.once("*", ownerUser);
 
@@ -71,35 +71,6 @@ describe("_enrichments", () => {
 
         const result = await fetchItemEnrichments(item, ["ownerUser", "org"], {
           portal: orgPortalUrl,
-        });
-        expect(fetchMock.calls().length).toEqual(2);
-        expect(fetchMock.lastUrl()).toMatch(
-          `${basePortalUrl}/sharing/rest/portals/${ownerUser.orgId}`
-        );
-        expect(result.org).toEqual(org);
-      });
-
-      it("fetches the org portal using options.authentication.portal", async () => {
-        const orgPortalUrl = "https://myorg.maps.arcgis.com"; // target we pass in
-        const basePortalUrl = "https://www.arcgis.com"; // target that should be hit
-
-        // Simulate fetching the user...
-        const username = item.owner;
-        const ownerUser = {
-          username,
-          orgId: "foo", // should be used to fetch the org
-        };
-        fetchMock.once("*", ownerUser);
-
-        // then fetch the org
-        const org = { id: "foo", name: "bar" };
-        fetchMock.once("*", org, { overwriteRoutes: false });
-        const result = await fetchItemEnrichments(item, ["ownerUser", "org"], {
-          // add back in org
-          authentication: {
-            getToken: async () => "fake-token",
-            portal: orgPortalUrl,
-          } as any,
         });
         expect(fetchMock.calls().length).toEqual(2);
         expect(fetchMock.lastUrl()).toMatch(

--- a/packages/common/test/org/fetch-org.test.ts
+++ b/packages/common/test/org/fetch-org.test.ts
@@ -1,0 +1,50 @@
+import * as restPortal from "@esri/arcgis-rest-portal";
+import { IPortal } from "@esri/arcgis-rest-portal";
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { fetchOrg } from "../../src";
+
+describe("fetchOrg", () => {
+  let getPortalStub;
+  const orgId = "9001";
+  const mockPortal = {
+    orgId,
+    name: "test",
+  } as unknown as IPortal;
+  beforeEach(() => {
+    getPortalStub = spyOn(restPortal, "getPortal").and.returnValue(
+      Promise.resolve(mockPortal)
+    );
+  });
+  it("Derives base portal from options.portal", async () => {
+    const mockAuth = { portal: "authentication-portal.mapsdevext.arcgis.com" };
+    const requestOptions = {
+      portal: "top-level-portal.mapsqa.arcgis.com",
+      authentication: mockAuth,
+    } as unknown as IRequestOptions;
+
+    const result = await fetchOrg(orgId, requestOptions);
+    expect(getPortalStub).toHaveBeenCalledWith(orgId, {
+      portal: "https://qaext.arcgis.com/sharing/rest",
+      authentication: mockAuth,
+    });
+    expect(result).toBe(mockPortal);
+  });
+  it("Derives base portal from option.authentication.portal", async () => {
+    const mockAuth = { portal: "authentication-portal.mapsdevext.arcgis.com" };
+    const requestOptions = {
+      authentication: mockAuth,
+    } as unknown as IRequestOptions;
+
+    await fetchOrg(orgId, requestOptions);
+    expect(getPortalStub).toHaveBeenCalledWith(orgId, {
+      portal: "https://devext.arcgis.com/sharing/rest",
+      authentication: mockAuth,
+    });
+  });
+  it("Defaults to www.arcgis.com", async () => {
+    await fetchOrg(orgId);
+    expect(getPortalStub).toHaveBeenCalledWith(orgId, {
+      portal: "https://www.arcgis.com/sharing/rest",
+    });
+  });
+});

--- a/packages/common/test/org/fetch-org.test.ts
+++ b/packages/common/test/org/fetch-org.test.ts
@@ -4,7 +4,7 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { fetchOrg } from "../../src";
 
 describe("fetchOrg", () => {
-  let getPortalStub;
+  let getPortalStub: any;
   const orgId = "9001";
   const mockPortal = {
     orgId,


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Part of https://devtopia.esri.com/dc/hub/issues/2932.
Fetch org enrichment in fetchContent and add fallback logic for publisher in composeContent

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
