### PR TITLE
feat(hub-common): add metadata.contact as a possible source for IHubContent's publisher field and add isExternal flag

### DIFF
--- a/packages/common/src/content/_internal.ts
+++ b/packages/common/src/content/_internal.ts
@@ -599,5 +599,10 @@ export const getPublisherInfo = (
     result.organizationSource = PublisherSource.ItemOwner;
   }
 
+  // We assume the item belongs to external org if no org info is available and the item is private
+  result.isExternal =
+    result.organizationSource === PublisherSource.None &&
+    item.access !== "public";
+
   return result;
 };

--- a/packages/common/src/content/_internal.ts
+++ b/packages/common/src/content/_internal.ts
@@ -557,7 +557,11 @@ export const getPublisherInfo = (
     metadata,
     "metadata.dataIdInfo.idCitation.citRespParty"
   );
-  const resourceContact = extractFirstContact(metadata, "metadata.mdContact");
+  const resourceContact = extractFirstContact(
+    metadata,
+    "metadata.dataIdInfo.idPoC"
+  );
+  const metadataContact = extractFirstContact(metadata, "metadata.mdContact");
 
   // Determine publisher name properties
   const ownerFullName = getProp(ownerUser, "fullName");
@@ -568,6 +572,9 @@ export const getPublisherInfo = (
   } else if (resourceContact.individualName) {
     result.name = resourceContact.individualName;
     result.nameSource = PublisherSource.ResourceContact;
+  } else if (metadataContact.individualName) {
+    result.name = metadataContact.individualName;
+    result.nameSource = PublisherSource.MetadataContact;
   } else if (ownerFullName) {
     result.name = ownerFullName;
     result.username = ownerUser.username;
@@ -583,6 +590,9 @@ export const getPublisherInfo = (
   } else if (resourceContact.organizationName) {
     result.organization = resourceContact.organizationName;
     result.organizationSource = PublisherSource.ResourceContact;
+  } else if (metadataContact.organizationName) {
+    result.organization = metadataContact.organizationName;
+    result.organizationSource = PublisherSource.MetadataContact;
   } else if (orgName) {
     result.organization = orgName;
     result.orgId = getItemOrgId(item, ownerUser);

--- a/packages/common/src/core/types/IHubContent.ts
+++ b/packages/common/src/core/types/IHubContent.ts
@@ -9,6 +9,7 @@ import { IHubAdditionalResource } from "./IHubAdditionalResource";
 export enum PublisherSource {
   CitationContact = "metadata.resource.citation.contact",
   ResourceContact = "metadata.resource.contact",
+  MetadataContact = "metadata.contact",
   ItemOwner = "item.owner",
   None = "none",
 }
@@ -95,8 +96,9 @@ export interface IHubContent
    * Info to display about the content's publisher. Follows this fallback pattern:
    * 1) Formal Item Metadata > Resource > Citation > Contact
    * 2) Formal Item Metadata > Resource > Contact
-   * 3) Item’s Owner and Org Name
-   * 4) Undefined (Item Owner / Org are private and we can't access additional info)
+   * 3) Formal Item Metadata > Contact
+   * 4) Item’s Owner and Org Name
+   * 5) Undefined (Item Owner / Org are private and we can't access additional info)
    */
   publisher?: {
     name?: string;

--- a/packages/common/src/core/types/IHubContent.ts
+++ b/packages/common/src/core/types/IHubContent.ts
@@ -107,6 +107,7 @@ export interface IHubContent
     organization?: string;
     orgId?: string; // if organization refers to item owner's org, then this will be that org's orgId
     organizationSource: PublisherSource;
+    isExternal: boolean; // whether the item is published to an external org (can only be set when no org info is available)
   };
 
   // TODO: should portalHomeUrl and portalApiUrl be hoisted to IHubItemEntity?

--- a/packages/common/test/compose.test.ts
+++ b/packages/common/test/compose.test.ts
@@ -380,17 +380,17 @@ describe("composeContent", () => {
         const metadata = {
           metadata: {
             mdContact: {
-              rpIndName: "Resource Name",
-              rpOrgName: "Resource Org",
+              rpIndName: "Metadata Name",
+              rpOrgName: "Metadata Org",
             },
           },
         };
         const content = composeContent(item, { metadata });
         expect(content.publisher).toEqual({
-          name: "Resource Name",
-          nameSource: PublisherSource.ResourceContact,
-          organization: "Resource Org",
-          organizationSource: PublisherSource.ResourceContact,
+          name: "Metadata Name",
+          nameSource: PublisherSource.MetadataContact,
+          organization: "Metadata Org",
+          organizationSource: PublisherSource.MetadataContact,
         });
       });
     });

--- a/packages/common/test/compose.test.ts
+++ b/packages/common/test/compose.test.ts
@@ -391,6 +391,7 @@ describe("composeContent", () => {
           nameSource: PublisherSource.MetadataContact,
           organization: "Metadata Org",
           organizationSource: PublisherSource.MetadataContact,
+          isExternal: false,
         });
       });
     });

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -1294,11 +1294,22 @@ describe("extractFirstContact", () => {
 // Gets branches not covered in compose.test.ts
 describe("getPublisherInfo", () => {
   it("correctly reports when no info is available", () => {
-    const item = { id: "abc" } as unknown as IItem;
+    const item = { id: "abc", access: "public" } as unknown as IItem;
     const result = getPublisherInfo(item, null, null, null);
     expect(result).toEqual({
       nameSource: PublisherSource.None,
       organizationSource: PublisherSource.None,
+      isExternal: false,
+    });
+  });
+
+  it("correctly reports when no info is available and the item is external", () => {
+    const item = { id: "abc", access: "private" } as unknown as IItem;
+    const result = getPublisherInfo(item, null, null, null);
+    expect(result).toEqual({
+      nameSource: PublisherSource.None,
+      organizationSource: PublisherSource.None,
+      isExternal: true,
     });
   });
 
@@ -1342,6 +1353,7 @@ describe("getPublisherInfo", () => {
       nameSource: PublisherSource.CitationContact,
       organization: "Citation Org",
       organizationSource: PublisherSource.CitationContact,
+      isExternal: false,
     });
   });
 
@@ -1378,6 +1390,7 @@ describe("getPublisherInfo", () => {
       nameSource: PublisherSource.ResourceContact,
       organization: "Resource Org",
       organizationSource: PublisherSource.ResourceContact,
+      isExternal: false,
     });
   });
 
@@ -1407,6 +1420,7 @@ describe("getPublisherInfo", () => {
       nameSource: PublisherSource.MetadataContact,
       organization: "Metadata Org",
       organizationSource: PublisherSource.MetadataContact,
+      isExternal: false,
     });
   });
 
@@ -1429,6 +1443,7 @@ describe("getPublisherInfo", () => {
       organization: "Item Org Name",
       orgId: "org_id",
       organizationSource: PublisherSource.ItemOwner,
+      isExternal: false,
     });
   });
 
@@ -1459,6 +1474,7 @@ describe("getPublisherInfo", () => {
       organization: "Org Name",
       orgId: "org_id",
       organizationSource: PublisherSource.ItemOwner,
+      isExternal: false,
     });
   });
 });

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -1306,18 +1306,23 @@ describe("getPublisherInfo", () => {
     const item = { id: "abc" } as unknown as IItem;
     const metadata = {
       metadata: {
-        // Resource Info
+        // Metadata Info
         mdContact: {
-          rpIndName: "Resource Name",
-          rpOrgName: "Resource Org",
+          rpIndName: "Metadata Name",
+          rpOrgName: "Metadata Org",
         },
-        // Citation Info
         dataIdInfo: {
+          // Citation Info
           idCitation: {
             citRespParty: {
               rpIndName: "Citation Name",
               rpOrgName: "Citation Org",
             },
+          },
+          // Resource Info
+          idPoC: {
+            rpIndName: "Resource Name",
+            rpOrgName: "Resource Org",
           },
         },
       },
@@ -1344,10 +1349,17 @@ describe("getPublisherInfo", () => {
     const item = { id: "abc" } as unknown as IItem;
     const metadata = {
       metadata: {
-        // Resource Info
+        // Metadata Info
         mdContact: {
           rpIndName: "Resource Name",
           rpOrgName: "Resource Org",
+        },
+        dataIdInfo: {
+          // Resource Info
+          idPoC: {
+            rpIndName: "Resource Name",
+            rpOrgName: "Resource Org",
+          },
         },
       },
     };
@@ -1366,6 +1378,35 @@ describe("getPublisherInfo", () => {
       nameSource: PublisherSource.ResourceContact,
       organization: "Resource Org",
       organizationSource: PublisherSource.ResourceContact,
+    });
+  });
+
+  it("correctly reports metadata contact info", () => {
+    const item = { id: "abc" } as unknown as IItem;
+    const metadata = {
+      metadata: {
+        // Metadata Info
+        mdContact: {
+          rpIndName: "Metadata Name",
+          rpOrgName: "Metadata Org",
+        },
+      },
+    };
+    const ownerUser = {
+      fullName: "Owner User",
+      username: "username",
+      orgId: "org_id",
+    };
+    const org = {
+      id: "org_id",
+      name: "Org Name",
+    };
+    const result = getPublisherInfo(item, metadata, org, ownerUser);
+    expect(result).toEqual({
+      name: "Metadata Name",
+      nameSource: PublisherSource.MetadataContact,
+      organization: "Metadata Org",
+      organizationSource: PublisherSource.MetadataContact,
     });
   });
 
@@ -1395,10 +1436,10 @@ describe("getPublisherInfo", () => {
     const item = { id: "abc" } as unknown as IItem;
     const metadata = {
       metadata: {
-        // Resource Info
+        // Metadata Info
         mdContact: {
-          rpIndName: "Resource Name",
-          // note that resource org name is omitted
+          rpIndName: "Metadata Name",
+          // note that metadata org name is omitted
         },
       },
     };
@@ -1413,8 +1454,8 @@ describe("getPublisherInfo", () => {
     };
     const result = getPublisherInfo(item, metadata, org, ownerUser);
     expect(result).toEqual({
-      name: "Resource Name",
-      nameSource: PublisherSource.ResourceContact,
+      name: "Metadata Name",
+      nameSource: PublisherSource.MetadataContact,
       organization: "Org Name",
       orgId: "org_id",
       organizationSource: PublisherSource.ItemOwner,


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Missed AC from https://github.com/ArcGIS/opendata-ui/pull/10731
Also fixes issue where I mixed up metadata.contact with metadata.resource.contact

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
