### PR TITLE
feat: add well-known-type filter expansions

### DIFF
--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -1,5 +1,6 @@
 import { IItem, ISearchOptions, searchItems } from "@esri/arcgis-rest-portal";
 import {
+  cloneObject,
   convertPortalItemResponseToFacets,
   enrichContentSearchResult,
   HubError,
@@ -9,12 +10,19 @@ import { enrichPageSearchResult } from "../../pages/HubPages";
 import { enrichProjectSearchResult } from "../../projects";
 import { enrichSiteSearchResult } from "../../sites";
 import { IHubRequestOptions } from "../../types";
-import { expandFilter, serializeFilterGroupsForPortal } from "../filter-utils";
 import {
+  expandFilter,
+  isEmptyFilter,
+  isEmptyFilterGroup,
+  serializeFilterGroupsForPortal,
+} from "../filter-utils";
+import {
+  Filter,
   IFilterGroup,
   IHubSearchOptions,
   IHubSearchResponse,
   IHubSearchResult,
+  IMatchOptions,
 } from "../types";
 import { getNextFunction } from "../utils";
 
@@ -35,8 +43,10 @@ export async function portalSearchItems(
       "requestOptions: IHubRequestOptions is required."
     );
   }
+  // Expand well-known filterGroups
+  const replaced = applyWellKnownItemFilters(filterGroups);
   // Expand the individual filters in each of the groups
-  const expandedGroups = filterGroups.map((fg) => {
+  const expandedGroups = replaced.map((fg) => {
     fg.filters = fg.filters.map(expandFilter);
     return fg;
   });
@@ -146,4 +156,258 @@ async function itemToSearchResult(
       break;
   }
   return fn(item, includes, requestOptions);
+}
+
+interface IWellKnownItemFilters {
+  $application: Array<Filter<"item">>;
+  $feedback: Array<Filter<"item">>;
+  $dashboard: Array<Filter<"item">>;
+  $dataset: Array<Filter<"item">>;
+  $experience: Array<Filter<"item">>;
+  $site: Array<Filter<"item">>;
+  $storymap: Array<Filter<"item">>;
+  $initiative: Array<Filter<"item">>;
+  $document: Array<Filter<"item">>;
+  $webmap: Array<Filter<"item">>;
+  $template: Array<Filter<"item">>;
+  $pageforcurrentsite: Array<Filter<"item">>;
+}
+
+export const WellKnownItemFilters: IWellKnownItemFilters = {
+  $application: [
+    {
+      filterType: "item",
+      type: {
+        any: [
+          "Web Mapping Application",
+          "Application",
+          "Insights",
+          "Web Experience",
+        ],
+        not: ["Insights Theme", "Insights Model"],
+      },
+      typekeywords: {
+        not: ["hubSite", "Story Map"],
+      },
+    },
+    {
+      filterType: "item",
+      type: "Web Mapping Experience",
+      typekeywords: "EXB Experience",
+    },
+  ],
+  $dashboard: [
+    {
+      filterType: "item",
+      type: {
+        any: ["Dashboard"],
+        not: ["Operation View"],
+      },
+      typekeywords: {
+        not: ["Extension", "ArcGIS Operation View"],
+      },
+    },
+  ],
+  $dataset: [
+    {
+      filterType: "item",
+      type: {
+        any: [
+          "Scene Service",
+          "Feature Collection",
+          "Route Layer",
+          "Layer",
+          "Explorer Layer",
+          "Tile Package",
+          "Vector Tile Package",
+          "Scene Package",
+          "Layer Package",
+          "Feature Service",
+          "Stream Service",
+          "Map Service",
+          "Vector Tile Service",
+          "Image Service",
+          "WMS",
+          "WFS",
+          "WMTS",
+          "KML",
+          "KML Collection",
+          "Globe Service",
+          "CSV",
+          "Shapefile",
+          "GeoJson",
+          "Service Definition",
+          "File Geodatabase",
+          "CAD Drawing",
+          "Relational Database Connection",
+        ],
+        not: ["Web Mapping Application", "Geodata Service"],
+      },
+    },
+    {
+      filterType: "item",
+      typekeywords: ["OGC", "Geodata Service"],
+    },
+  ],
+  $document: [
+    {
+      filterType: "item",
+      type: [
+        "PDF",
+        "Microsoft Excel",
+        "Microsoft Word",
+        "Microsoft Powerpoint",
+        "iWork Keynote",
+        "iWork Pages",
+        "iWork Numbers",
+        "Visio Document",
+        "Document Link",
+      ],
+    },
+  ],
+  $initiative: [
+    {
+      filterType: "item",
+      type: "Hub Initiative",
+    },
+  ],
+  $experience: [
+    {
+      filterType: "item",
+      type: "Web Experience",
+    },
+  ],
+  $feedback: [
+    {
+      filterType: "item",
+      type: "Form",
+    },
+  ],
+  $pageforcurrentsite: [
+    {
+      filterType: "item",
+      typekeywords: "hubPage",
+    },
+  ],
+  $site: [
+    {
+      filterType: "item",
+      type: ["Hub Site Application", "Site Application"],
+    },
+  ],
+  $storymap: [
+    {
+      filterType: "item",
+      type: "Storymap",
+    },
+    {
+      filterType: "item",
+      type: "Web Mapping Application",
+      typekeywords: "Story Map",
+    },
+  ],
+  $template: [
+    {
+      filterType: "item",
+      type: [
+        "Web Mapping Application",
+        "Hub Initiative",
+        "Hub Initiative Template",
+        "Solution",
+      ],
+      typekeywords: {
+        any: ["hubInitiativeTemplate", "hubSolutionTemplate", "Template"],
+        not: "Deployed",
+      },
+    },
+  ],
+  $webmap: [
+    {
+      filterType: "item",
+      type: {
+        any: ["Web Map", "Web Scene"],
+        not: "Web Mapping Application",
+      },
+    },
+  ],
+};
+
+/**
+ * @private
+ * Convert a Filter Group to expand well-known type filters
+ *
+ * The purpose of this function is to allow for the use of short-hand
+ * names for commonly used, complex queries.
+ *
+ * It works by looking for filters using the .type property, the value
+ * of which is a key in the WellKnownItemFilters hash. If found in the
+ * hash, the filters array of the active filterGroup is replaced with the
+ * filters specified in the hash.
+ *
+ * NOTE: Any other properties specified in a filter will be removed
+ *
+ * Only exported to enable extensive testing
+ * @param filterGroups
+ */
+export function applyWellKnownItemFilters(
+  filterGroups: Array<IFilterGroup<"item">>
+): Array<IFilterGroup<"item">> {
+  const clone = cloneObject(filterGroups);
+  // iterate the filterGroups
+  const result = clone.map((filterGroup) => {
+    filterGroup.filters = filterGroup.filters.reduce((updated, filter) => {
+      // check if the filter.type is a well-known type
+      if (isWellKnownTypeFilter(filter.type)) {
+        // get the set of filters to replace the current filter with
+        const typeFilters = lookupTypeFilters(
+          filter.type as keyof typeof WellKnownItemFilters
+        );
+        // Note: At this point we could try to "merge" in the other
+        // props on the filter, into all the filters returned from
+        // the well-known hash. The problem with this is that the
+        // combination may yield unexpected results; For now, if a filter
+        // includes `.type is keyof WellKnownItemFilters` we simply
+        // replace the entire filter with the array of filters returne
+        // from the hash
+        updated = [...updated, ...typeFilters];
+      } else {
+        // filter does not have a well-known type entry so keep it
+        updated.push(filter);
+      }
+      return updated;
+    }, []);
+    return filterGroup;
+  });
+
+  return result;
+}
+
+/**
+ * Is the argument a well-known type "key"
+ *
+ * Accepts `string`, `string[]` or `IMatchOptions`
+ * but only string values can possibly be keys
+ * on `WellKnownItemFilters`
+ * @param key
+ * @returns
+ */
+function isWellKnownTypeFilter(
+  key: string | string[] | IMatchOptions
+): boolean {
+  let result = false;
+  if (typeof key === "string") {
+    result = key in WellKnownItemFilters;
+  }
+  return result;
+}
+
+/**
+ * Fetch the array of fitlers from the well-known hash
+ * @param key
+ * @returns
+ */
+function lookupTypeFilters(
+  key: keyof typeof WellKnownItemFilters
+): Array<Filter<"item">> {
+  return WellKnownItemFilters[key];
 }

--- a/packages/common/src/search/filter-utils.ts
+++ b/packages/common/src/search/filter-utils.ts
@@ -225,3 +225,38 @@ function serializeStringOrArray(
   }
   return q;
 }
+
+/**
+ * Determine if a Filter is "empty"
+ * @param filter
+ * @returns
+ */
+export function isEmptyFilter(filter: Filter<FilterType>): boolean {
+  // if it has one property, filterType, it's empty
+  return (
+    Object.keys(filter).length === 1 && filter.hasOwnProperty("filterType")
+  );
+}
+
+/**
+ * Determine if a filterGroup is "empty"
+ * @param filterGroup
+ * @returns
+ */
+export function isEmptyFilterGroup(
+  filterGroup: IFilterGroup<FilterType>
+): boolean {
+  // if filters array is empty
+  if (filterGroup.filters.length === 0) {
+    return true;
+  } else {
+    // if all filters are empty
+    const result = filterGroup.filters.reduce((acc, entry) => {
+      if (acc) {
+        acc = isEmptyFilter(entry);
+      }
+      return acc;
+    }, true);
+    return result;
+  }
+}

--- a/packages/common/test/search/filter-utils.test.ts
+++ b/packages/common/test/search/filter-utils.test.ts
@@ -5,6 +5,8 @@ import {
   IDateRange,
   IFilterGroup,
   serializeFilterGroupsForPortal,
+  isEmptyFilter,
+  isEmptyFilterGroup,
 } from "../../src";
 
 describe("filter-utils:", () => {
@@ -290,6 +292,43 @@ describe("filter-utils:", () => {
 
       expect(chk.searchUserAccess).toEqual("groupMember");
       expect(chk.searchUserName).toEqual("dave");
+    });
+  });
+
+  describe("empty filters:", () => {
+    it("detects empty filter", () => {
+      expect(isEmptyFilter({ filterType: "item" })).toBe(true);
+      expect(isEmptyFilter({ filterType: "item", owner: "dave" })).toBe(false);
+    });
+
+    it("detects empty filtergroup", () => {
+      expect(
+        isEmptyFilterGroup({ operation: "OR", filters: [], filterType: "item" })
+      ).toBe(true);
+      expect(
+        isEmptyFilterGroup({
+          operation: "OR",
+          filters: [{ filterType: "item" }],
+          filterType: "item",
+        })
+      ).toBe(true);
+      expect(
+        isEmptyFilterGroup({
+          operation: "OR",
+          filters: [{ filterType: "item", owner: "dave" }],
+          filterType: "item",
+        })
+      ).toBe(false);
+      expect(
+        isEmptyFilterGroup({
+          operation: "OR",
+          filters: [
+            { filterType: "item", owner: "dave" },
+            { filterType: "item" },
+          ],
+          filterType: "item",
+        })
+      ).toBe(false);
     });
   });
 });


### PR DESCRIPTION
1. Description:

Enable use of well-known type expansions for filters.

A filterGroup like..
```
      {
          filterType: "item",
          operation: "OR",
          filters: [
            {
              filterType: "item",
              type: "$dashboard"
            },
          ],
        },
```
will be expanded into

```
{
  filterType: "item",
  operation: "OR",
  filters: [
    {
      filterType: "item",
      type: {
        any: ["Dashboard"],
        not: ["Operation View"],
      },
      typekeywords: {
        not: ["Extension", "ArcGIS Operation View"],
      },
    },
  ],
},
```

**Note** This will replace any filter with a well-known type value (`$application` for example) with the 1 or more filters that make up the definition for that type. **Any other properties specified along with the type will be lost**. This is done to ensure deterministic behavior.


1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
