### PR TITLE
chore: fix broken docs:build script

### DIFF
--- a/packages/common/src/resources/_internal/_validate-url-helpers.ts
+++ b/packages/common/src/resources/_internal/_validate-url-helpers.ts
@@ -111,18 +111,9 @@ export function getFeatureServiceTitle(url: string): string {
  * Gets item info out of a feature layer item.
  *
  * @export
- * @param {string} url Item URL
- * @param {{
- *     name: string,
- *     description: string,
- *     extent: any
- *   }} body Item body.
- * @return {*}  {{
- *   title: string,
- *   description: string,
- *   extent: any,
- *   url: string
- * }}
+ * @param url Item URL
+ * @param body Item body.
+ * @return Item info (title, description, extent, url)
  */
 export function getFeatureLayerItem(
   url: string,


### PR DESCRIPTION

1. Description:

seems typedoc doesn't like double curlies in type comments

1. Instructions for testing:

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
