### PR TITLE
perf(hub-common): fetchContent returns cached recordCount when it can

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61386,7 +61386,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.43.0",
+			"version": "9.43.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -61419,7 +61419,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.31.0",
+			"version": "11.30.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61428,7 +61428,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.43.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61441,12 +61441,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.43.0"
+				"@esri/hub-common": "9.43.1"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.42.0",
+			"version": "9.42.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -61457,7 +61457,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.42.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61466,32 +61466,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.42.0"
-			}
-		},
-		"packages/downloads/node_modules/@esri/hub-common": {
-			"version": "9.42.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.42.0.tgz",
-			"integrity": "sha512-so1qxJYPbZk/l7eTKSE6jCTy1rhyB25+DXb8Fcd4HhoP9pWytZAl7FQeYtrYbYUgG1YLfg6vM0M5lqOGpemGKw==",
-			"dev": true,
-			"dependencies": {
-				"abab": "^2.0.5",
-				"adlib": "^3.0.7",
-				"fast-xml-parser": "^3.21.0",
-				"jsonapi-typescript": "^0.1.3",
-				"tslib": "^1.13.0"
-			},
-			"peerDependencies": {
-				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
-				"@esri/arcgis-rest-feature-layer": "^3.2.0",
-				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
-				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/arcgis-rest-types": "^2.15.0 || 3"
+				"@esri/hub-common": "9.43.1"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.42.0",
+			"version": "9.42.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61502,7 +61482,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.42.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61516,32 +61496,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.42.0"
-			}
-		},
-		"packages/events/node_modules/@esri/hub-common": {
-			"version": "9.42.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.42.0.tgz",
-			"integrity": "sha512-so1qxJYPbZk/l7eTKSE6jCTy1rhyB25+DXb8Fcd4HhoP9pWytZAl7FQeYtrYbYUgG1YLfg6vM0M5lqOGpemGKw==",
-			"dev": true,
-			"dependencies": {
-				"abab": "^2.0.5",
-				"adlib": "^3.0.7",
-				"fast-xml-parser": "^3.21.0",
-				"jsonapi-typescript": "^0.1.3",
-				"tslib": "^1.13.0"
-			},
-			"peerDependencies": {
-				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
-				"@esri/arcgis-rest-feature-layer": "^3.2.0",
-				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
-				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/arcgis-rest-types": "^2.15.0 || 3"
+				"@esri/hub-common": "9.43.1"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.42.0",
+			"version": "9.43.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61550,7 +61510,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.42.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61563,32 +61523,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.42.0"
-			}
-		},
-		"packages/initiatives/node_modules/@esri/hub-common": {
-			"version": "9.42.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.42.0.tgz",
-			"integrity": "sha512-so1qxJYPbZk/l7eTKSE6jCTy1rhyB25+DXb8Fcd4HhoP9pWytZAl7FQeYtrYbYUgG1YLfg6vM0M5lqOGpemGKw==",
-			"dev": true,
-			"dependencies": {
-				"abab": "^2.0.5",
-				"adlib": "^3.0.7",
-				"fast-xml-parser": "^3.21.0",
-				"jsonapi-typescript": "^0.1.3",
-				"tslib": "^1.13.0"
-			},
-			"peerDependencies": {
-				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
-				"@esri/arcgis-rest-feature-layer": "^3.2.0",
-				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
-				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/arcgis-rest-types": "^2.15.0 || 3"
+				"@esri/hub-common": "9.43.1"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.42.0",
+			"version": "9.42.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61599,7 +61539,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.42.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61615,32 +61555,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.42.0"
-			}
-		},
-		"packages/search/node_modules/@esri/hub-common": {
-			"version": "9.42.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.42.0.tgz",
-			"integrity": "sha512-so1qxJYPbZk/l7eTKSE6jCTy1rhyB25+DXb8Fcd4HhoP9pWytZAl7FQeYtrYbYUgG1YLfg6vM0M5lqOGpemGKw==",
-			"dev": true,
-			"dependencies": {
-				"abab": "^2.0.5",
-				"adlib": "^3.0.7",
-				"fast-xml-parser": "^3.21.0",
-				"jsonapi-typescript": "^0.1.3",
-				"tslib": "^1.13.0"
-			},
-			"peerDependencies": {
-				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
-				"@esri/arcgis-rest-feature-layer": "^3.2.0",
-				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
-				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/arcgis-rest-types": "^2.15.0 || 3"
+				"@esri/hub-common": "9.43.1"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.42.0",
+			"version": "9.43.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61649,9 +61569,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.42.0",
-				"@esri/hub-initiatives": "9.42.0",
-				"@esri/hub-teams": "9.42.0",
+				"@esri/hub-common": "9.43.1",
+				"@esri/hub-initiatives": "9.43.1",
+				"@esri/hub-teams": "9.42.1",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -61664,9 +61584,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.42.0",
-				"@esri/hub-initiatives": "9.42.0",
-				"@esri/hub-teams": "9.42.0"
+				"@esri/hub-common": "9.43.1",
+				"@esri/hub-initiatives": "9.43.1",
+				"@esri/hub-teams": "9.42.1"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61675,26 +61595,6 @@
 			"integrity": "sha512-2iMwX8tUVTImpoyKjNVsigc0JCUM8hTlyIu/hF2NnehyetvsefSut8njMObwHy872zfBzZ+kOMyulGGzdHvLxg==",
 			"dev": true,
 			"peer": true
-		},
-		"packages/sites/node_modules/@esri/hub-common": {
-			"version": "9.42.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.42.0.tgz",
-			"integrity": "sha512-so1qxJYPbZk/l7eTKSE6jCTy1rhyB25+DXb8Fcd4HhoP9pWytZAl7FQeYtrYbYUgG1YLfg6vM0M5lqOGpemGKw==",
-			"dev": true,
-			"dependencies": {
-				"abab": "^2.0.5",
-				"adlib": "^3.0.7",
-				"fast-xml-parser": "^3.21.0",
-				"jsonapi-typescript": "^0.1.3",
-				"tslib": "^1.13.0"
-			},
-			"peerDependencies": {
-				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
-				"@esri/arcgis-rest-feature-layer": "^3.2.0",
-				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
-				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/arcgis-rest-types": "^2.15.0 || 3"
-			}
 		},
 		"packages/sites/node_modules/@esri/hub-types": {
 			"version": "6.10.0",
@@ -61711,7 +61611,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.43.0",
+			"version": "9.43.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61722,7 +61622,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.43.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61736,12 +61636,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.43.0"
+				"@esri/hub-common": "9.43.1"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.42.0",
+			"version": "9.42.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61751,7 +61651,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.42.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61764,27 +61664,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.42.0"
-			}
-		},
-		"packages/teams/node_modules/@esri/hub-common": {
-			"version": "9.42.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.42.0.tgz",
-			"integrity": "sha512-so1qxJYPbZk/l7eTKSE6jCTy1rhyB25+DXb8Fcd4HhoP9pWytZAl7FQeYtrYbYUgG1YLfg6vM0M5lqOGpemGKw==",
-			"dev": true,
-			"dependencies": {
-				"abab": "^2.0.5",
-				"adlib": "^3.0.7",
-				"fast-xml-parser": "^3.21.0",
-				"jsonapi-typescript": "^0.1.3",
-				"tslib": "^1.13.0"
-			},
-			"peerDependencies": {
-				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
-				"@esri/arcgis-rest-feature-layer": "^3.2.0",
-				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
-				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/arcgis-rest-types": "^2.15.0 || 3"
+				"@esri/hub-common": "9.43.1"
 			}
 		}
 	},
@@ -65199,7 +65079,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.43.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65218,7 +65098,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.42.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65227,21 +65107,6 @@
 				"rollup-plugin-filesize": "^9.0.2",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
-			},
-			"dependencies": {
-				"@esri/hub-common": {
-					"version": "9.42.0",
-					"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.42.0.tgz",
-					"integrity": "sha512-so1qxJYPbZk/l7eTKSE6jCTy1rhyB25+DXb8Fcd4HhoP9pWytZAl7FQeYtrYbYUgG1YLfg6vM0M5lqOGpemGKw==",
-					"dev": true,
-					"requires": {
-						"abab": "^2.0.5",
-						"adlib": "^3.0.7",
-						"fast-xml-parser": "^3.21.0",
-						"jsonapi-typescript": "^0.1.3",
-						"tslib": "^1.13.0"
-					}
-				}
 			}
 		},
 		"@esri/hub-events": {
@@ -65252,7 +65117,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.42.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65260,21 +65125,6 @@
 				"rollup-plugin-filesize": "^9.0.2",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
-			},
-			"dependencies": {
-				"@esri/hub-common": {
-					"version": "9.42.0",
-					"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.42.0.tgz",
-					"integrity": "sha512-so1qxJYPbZk/l7eTKSE6jCTy1rhyB25+DXb8Fcd4HhoP9pWytZAl7FQeYtrYbYUgG1YLfg6vM0M5lqOGpemGKw==",
-					"dev": true,
-					"requires": {
-						"abab": "^2.0.5",
-						"adlib": "^3.0.7",
-						"fast-xml-parser": "^3.21.0",
-						"jsonapi-typescript": "^0.1.3",
-						"tslib": "^1.13.0"
-					}
-				}
 			}
 		},
 		"@esri/hub-initiatives": {
@@ -65283,7 +65133,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.42.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65292,21 +65142,6 @@
 				"rollup-plugin-filesize": "^9.0.2",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
-			},
-			"dependencies": {
-				"@esri/hub-common": {
-					"version": "9.42.0",
-					"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.42.0.tgz",
-					"integrity": "sha512-so1qxJYPbZk/l7eTKSE6jCTy1rhyB25+DXb8Fcd4HhoP9pWytZAl7FQeYtrYbYUgG1YLfg6vM0M5lqOGpemGKw==",
-					"dev": true,
-					"requires": {
-						"abab": "^2.0.5",
-						"adlib": "^3.0.7",
-						"fast-xml-parser": "^3.21.0",
-						"jsonapi-typescript": "^0.1.3",
-						"tslib": "^1.13.0"
-					}
-				}
 			}
 		},
 		"@esri/hub-search": {
@@ -65317,7 +65152,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.42.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65327,21 +65162,6 @@
 				"rollup-plugin-filesize": "^9.0.2",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
-			},
-			"dependencies": {
-				"@esri/hub-common": {
-					"version": "9.42.0",
-					"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.42.0.tgz",
-					"integrity": "sha512-so1qxJYPbZk/l7eTKSE6jCTy1rhyB25+DXb8Fcd4HhoP9pWytZAl7FQeYtrYbYUgG1YLfg6vM0M5lqOGpemGKw==",
-					"dev": true,
-					"requires": {
-						"abab": "^2.0.5",
-						"adlib": "^3.0.7",
-						"fast-xml-parser": "^3.21.0",
-						"jsonapi-typescript": "^0.1.3",
-						"tslib": "^1.13.0"
-					}
-				}
 			}
 		},
 		"@esri/hub-sites": {
@@ -65350,9 +65170,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.42.0",
-				"@esri/hub-initiatives": "9.42.0",
-				"@esri/hub-teams": "9.42.0",
+				"@esri/hub-common": "9.43.1",
+				"@esri/hub-initiatives": "9.43.1",
+				"@esri/hub-teams": "9.42.1",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -65369,19 +65189,6 @@
 					"integrity": "sha512-2iMwX8tUVTImpoyKjNVsigc0JCUM8hTlyIu/hF2NnehyetvsefSut8njMObwHy872zfBzZ+kOMyulGGzdHvLxg==",
 					"dev": true,
 					"peer": true
-				},
-				"@esri/hub-common": {
-					"version": "9.42.0",
-					"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.42.0.tgz",
-					"integrity": "sha512-so1qxJYPbZk/l7eTKSE6jCTy1rhyB25+DXb8Fcd4HhoP9pWytZAl7FQeYtrYbYUgG1YLfg6vM0M5lqOGpemGKw==",
-					"dev": true,
-					"requires": {
-						"abab": "^2.0.5",
-						"adlib": "^3.0.7",
-						"fast-xml-parser": "^3.21.0",
-						"jsonapi-typescript": "^0.1.3",
-						"tslib": "^1.13.0"
-					}
 				},
 				"@esri/hub-types": {
 					"version": "6.10.0",
@@ -65402,7 +65209,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.43.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65419,7 +65226,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.42.0",
+				"@esri/hub-common": "9.43.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65427,21 +65234,6 @@
 				"rollup-plugin-filesize": "^9.0.2",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
-			},
-			"dependencies": {
-				"@esri/hub-common": {
-					"version": "9.42.0",
-					"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.42.0.tgz",
-					"integrity": "sha512-so1qxJYPbZk/l7eTKSE6jCTy1rhyB25+DXb8Fcd4HhoP9pWytZAl7FQeYtrYbYUgG1YLfg6vM0M5lqOGpemGKw==",
-					"dev": true,
-					"requires": {
-						"abab": "^2.0.5",
-						"adlib": "^3.0.7",
-						"fast-xml-parser": "^3.21.0",
-						"jsonapi-typescript": "^0.1.3",
-						"tslib": "^1.13.0"
-					}
-				}
 			}
 		},
 		"@evocateur/libnpmaccess": {

--- a/packages/common/src/content/_fetch.ts
+++ b/packages/common/src/content/_fetch.ts
@@ -82,6 +82,9 @@ export interface IDatasetEnrichments {
    */
   extent?: IHubExtent;
 
+  /** The count of records for the layer referenced by this content */
+  recordCount?: number | null;
+
   /**
    * The appropriate summary to show for the item, coming from either
    * the item's data (for pages or initiatives) or the item's description
@@ -111,7 +114,9 @@ const getHubEnrichmentsOptions = (
   opts.params = {
     ...opts.params,
     // TODO: we should fetch errors too
-    "fields[datasets]": "slug,boundary,extent,searchDescription,statistics",
+    // TODO: stop fetching recordCount at next breaking change
+    "fields[datasets]":
+      "slug,boundary,extent,recordCount,searchDescription,statistics",
   };
   if (slug) {
     opts.params["filter[slug]"] = slug;
@@ -123,7 +128,7 @@ const getHubEnrichmentsOptions = (
 const getDatasetEnrichments = (dataset: DatasetResource) => {
   const { itemId, layerId: layerIdString } = parseDatasetId(dataset.id);
   const layerId = layerIdString && parseInt(layerIdString, 10);
-  const { slug, boundary, extent, searchDescription, statistics } =
+  const { slug, boundary, extent, recordCount, searchDescription, statistics } =
     dataset.attributes;
   return {
     itemId,
@@ -131,6 +136,7 @@ const getDatasetEnrichments = (dataset: DatasetResource) => {
     slug,
     boundary,
     extent,
+    recordCount,
     searchDescription,
     statistics,
   } as IDatasetEnrichments;

--- a/packages/common/src/core/types/IServerEnrichments.ts
+++ b/packages/common/src/core/types/IServerEnrichments.ts
@@ -10,8 +10,9 @@ export interface IServerEnrichments {
   /** Detailed information about the service's layers (geometryType, fields, etc) for related layers in the service */
   layers?: Array<Partial<ILayerDefinition>>;
 
+  // TODO: should we remove this once fetchContent() no longer fetches it?
   /** The count of records for the layer referenced by this content */
-  recordCount?: number;
+  recordCount?: number | null;
 }
 
 // DEPRECATED: remove this alias at the next breaking change

--- a/packages/common/test/content/_fetch.test.ts
+++ b/packages/common/test/content/_fetch.test.ts
@@ -65,6 +65,9 @@ describe("_fetch", () => {
         boundary: null,
       },
     } as DatasetResource;
+    // expected dataset fields to be fetched from the Hub API
+    const datasetFields =
+      "slug,boundary,extent,recordCount,searchDescription,statistics";
     let requestOpts: IHubRequestOptions;
     beforeEach(() => {
       requestOpts = {
@@ -87,9 +90,7 @@ describe("_fetch", () => {
         const { searchParams } = new URL(url);
         expect(calls.length).toBe(1);
         expect(searchParams.get("filter[slug]")).toEqual(slug);
-        expect(searchParams.get("fields[datasets]")).toEqual(
-          "slug,boundary,extent,searchDescription,statistics"
-        );
+        expect(searchParams.get("fields[datasets]")).toEqual(datasetFields);
         expect(result.itemId).toEqual(id);
         expect(result.layerId).toBeUndefined();
         expect(result.slug).toBe(slug);
@@ -120,9 +121,7 @@ describe("_fetch", () => {
         const [url] = calls[0];
         const { searchParams } = new URL(url);
         expect(calls.length).toBe(1);
-        expect(searchParams.get("fields[datasets]")).toEqual(
-          "slug,boundary,extent,searchDescription,statistics"
-        );
+        expect(searchParams.get("fields[datasets]")).toEqual(datasetFields);
         expect(result.itemId).toEqual(id);
         expect(result.layerId).toBeUndefined();
         expect(result.slug).toBe(slug);
@@ -154,9 +153,7 @@ describe("_fetch", () => {
         const [url] = calls[0];
         const { searchParams } = new URL(url);
         expect(calls.length).toBe(1);
-        expect(searchParams.get("fields[datasets]")).toEqual(
-          "slug,boundary,extent,searchDescription,statistics"
-        );
+        expect(searchParams.get("fields[datasets]")).toEqual(datasetFields);
         expect(result.itemId).toBe(itemId);
         expect(result.layerId).toBe(0);
         expect(result.slug).toBe(slug);


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Always fetching the live record count is proving very costly for some feature servers. In the long run, we will remove this from `fetchContent()` so that the fetch can be deferred and not block page load. For now, `fetchContent()` will still return a `recordCount`, but we'll rely on the cached value from the Hub API when it's available, which should be for any non-enterprise public layer.

1. Instructions for testing:

1. Closes Issues:  addresses [3976](https://devtopia.esri.com/dc/hub/issues/3976)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
