### PR TITLE
fix(hub-common): enrichOrg was fetching the org of the the authenticated user (not the item) in some instances

### DIFF
--- a/packages/common/test/items/_enrichments.test.ts
+++ b/packages/common/test/items/_enrichments.test.ts
@@ -79,6 +79,21 @@ describe("_enrichments", () => {
         expect(result.org).toEqual(org);
       });
 
+      it("performs a no-op if orgId isn't available on the item or the ownerUser", async () => {
+        const orgPortalUrl = "https://myorg.maps.arcgis.com";
+
+        // Simulate fetching the user...
+        const username = item.owner;
+        const ownerUser = { username };
+        fetchMock.once("*", ownerUser);
+
+        const result = await fetchItemEnrichments(item, ["ownerUser", "org"], {
+          portal: orgPortalUrl,
+        });
+        expect(fetchMock.calls().length).toEqual(1); // only the ownerUser call is made
+        expect(result.org).toBeUndefined();
+      });
+
       it("handles errors", async () => {
         // Simulate fetching the user...
         const username = item.owner;


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

To prevent the org of the authenticated user from being fetched as part of `enrichOrg`, we simply do a no-op if `orgId` is not available on the item or on the ownerUser.

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
