### PR TITLE
feat(hub-common): rename title to timelineTitle in IHubTimeline

### DIFF
--- a/packages/common/src/core/types/IHubTimeline.ts
+++ b/packages/common/src/core/types/IHubTimeline.ts
@@ -2,7 +2,7 @@
  * Hub Timeline Definition
  */
 export interface IHubTimeline {
-  title: string;
+  timelineTitle: string;
   description: string;
   stages: IHubStage[];
 }


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
 Rename `title` to `timelineTitle` in `IHubTimeline`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
