### PR TITLE
fix: return aggregations in hub format

### DIFF
--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -24,6 +24,7 @@ import {
   IQuery,
 } from "../types";
 import { getNextFunction } from "../utils";
+import { convertPortalAggregations } from "./portalSearchUtils";
 
 /**
  * @private
@@ -164,14 +165,17 @@ async function searchPortal(
   // map over results
   const results = await Promise.all(resp.results.map(fn));
 
-  // convert aggregations into facets
+  // TODO Remove this call
   const facets = convertPortalItemResponseToFacets(resp);
+  // convert portal  aggregations into hub aggregations
+  const aggregations = convertPortalAggregations(resp);
 
   // Construct the return
   return {
     total: resp.total,
     results,
     facets,
+    aggregations,
     hasNext: resp.nextStart > -1,
     next: getNextFunction<IHubSearchResult>(
       searchOptions,

--- a/packages/common/src/search/_internal/portalSearchUtils.ts
+++ b/packages/common/src/search/_internal/portalSearchUtils.ts
@@ -1,0 +1,24 @@
+import { ISearchResult } from "@esri/arcgis-rest-portal";
+import { IHubAggregation } from "../types";
+
+/**
+ * @private
+ * Convert a portal aggregation structure into the HubAggregations structure
+ * @param searchResults
+ * @returns
+ */
+export function convertPortalAggregations<T>(
+  searchResults: ISearchResult<T>
+): IHubAggregation[] {
+  if (searchResults.aggregations?.counts) {
+    return searchResults.aggregations.counts.map((entry) => {
+      return {
+        mode: "terms",
+        field: entry.fieldName,
+        values: entry.fieldValues,
+      };
+    });
+  } else {
+    return [];
+  }
+}

--- a/packages/common/src/search/hubSearch.ts
+++ b/packages/common/src/search/hubSearch.ts
@@ -88,6 +88,15 @@ export async function hubSearch(
   return fn(cloneObject(filterGroups), options);
 }
 
+/**
+ * Main entrypoint for searching via Hub
+ *
+ * Default's to search ArcGIS Portal but can delegate
+ * to Hub API when it's available.
+ * @param query
+ * @param options
+ * @returns
+ */
 export async function hubSearchQuery(
   query: IQuery,
   options: IHubSearchOptions

--- a/packages/common/src/search/types/IHubAggregation.ts
+++ b/packages/common/src/search/types/IHubAggregation.ts
@@ -1,0 +1,11 @@
+/**
+ * Structure for Search Aggregations in ArcGIS Hub
+ */
+export interface IHubAggregation {
+  mode: string;
+  field: string;
+  values: Array<{
+    value: any;
+    count: number;
+  }>;
+}

--- a/packages/common/src/search/types/IHubSearchResponse.ts
+++ b/packages/common/src/search/types/IHubSearchResponse.ts
@@ -1,4 +1,5 @@
 import { IFacet } from "./IFacet";
+import { IHubAggregation } from "./IHubAggregation";
 
 /**
  * Defines a generic search response interface with parameterized result type
@@ -14,5 +15,8 @@ export interface IHubSearchResponse<T> {
   results: T[];
   hasNext: boolean;
   next: (params?: any) => Promise<IHubSearchResponse<T>>;
+  aggregations?: IHubAggregation[];
+  // DEPRECATED - hub.js no longer computes facets; consumers need to
+  // construct them from aggregations
   facets?: IFacet[];
 }

--- a/packages/common/src/search/types/index.ts
+++ b/packages/common/src/search/types/index.ts
@@ -2,6 +2,7 @@ export * from "./ICatalog";
 export * from "./ICollection";
 export * from "./IFacet";
 export * from "./IFacetOption";
+export * from "./IHubAggregation";
 export * from "./IHubApiSearchRequest";
 export * from "./IHubSearchOptions";
 export * from "./IHubSearchResult";

--- a/packages/common/test/search/_internal/portalSearchUtils.test.ts
+++ b/packages/common/test/search/_internal/portalSearchUtils.test.ts
@@ -1,0 +1,50 @@
+import { IItem, ISearchResult } from "@esri/arcgis-rest-portal";
+import { convertPortalAggregations } from "../../../src/search/_internal/portalSearchUtils";
+describe("portalSearchUtils module", () => {
+  describe("convertPortalAggregations:", () => {
+    it("returns empty array if no aggregations are present", () => {
+      const sr: ISearchResult<IItem> = {
+        query: "",
+        total: 0,
+        start: 0,
+        num: 0,
+        nextStart: 0,
+        results: [],
+      };
+      const chk = convertPortalAggregations(sr);
+      expect(chk.length).toBe(0);
+    });
+
+    it("converts portal aggregations", () => {
+      const sr: ISearchResult<IItem> = {
+        query: "",
+        total: 0,
+        start: 0,
+        num: 0,
+        nextStart: 0,
+        results: [],
+        aggregations: {
+          counts: [
+            {
+              fieldName: "tags",
+              fieldValues: [
+                { value: "hub site", count: 4 },
+                { value: "hubproject", count: 2 },
+                { value: "marks projects", count: 2 },
+              ],
+            },
+          ],
+        },
+      };
+      const chk = convertPortalAggregations(sr);
+      expect(chk.length).toBe(1);
+      expect(chk[0].mode).toBe("terms");
+      expect(chk[0].values.length).toBe(3);
+      expect(chk[0].values).toEqual([
+        { value: "hub site", count: 4 },
+        { value: "hubproject", count: 2 },
+        { value: "marks projects", count: 2 },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
1. Description:

Return aggregations, formatted as `IHubAggregation[]` and let the UI layer construct the facets.

Will remove the facet fns once we've removed the need for it in hub-components

1. Instructions for testing:

- run tests

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
