### PR TITLE
feat(hub-common): remove icon and isEditing from IHubStage

### DIFF
--- a/packages/common/src/core/types/IHubTimeline.ts
+++ b/packages/common/src/core/types/IHubTimeline.ts
@@ -32,12 +32,4 @@ export interface IHubStage {
    * Stage status
    */
   status: string;
-  /**
-   * Icon Name
-   */
-  icon: string;
-
-  // TODO: These should likely be removed as they are not
-  // specific to the Stage itself, but rather the edit UI and never persists
-  isEditing?: boolean; // render editing ui for a stage
 }


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
remove icon and isEditing from IHubStage

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
