### PR TITLE
fix: update convertCatalog to return latest structure

### DIFF
--- a/packages/common/src/search/Collection.ts
+++ b/packages/common/src/search/Collection.ts
@@ -1,5 +1,6 @@
 import { hubSearchQuery, IArcGISContext } from "..";
 import {
+  EntityType,
   IHubCatalog,
   IHubCollection,
   IHubSearchOptions,
@@ -51,6 +52,9 @@ export class Collection implements IHubCollection {
   }
   public get sortDirection(): "asc" | "desc" {
     return this._collection.sortDirection || "asc";
+  }
+  public get targetEntity(): EntityType {
+    return this._collection.targetEntity;
   }
 
   public async search(

--- a/packages/common/src/search/convertCatalog.ts
+++ b/packages/common/src/search/convertCatalog.ts
@@ -1,36 +1,36 @@
 import { getProp } from "..";
-import { ICatalog, IFilterGroup } from "./types";
+import { IHubCatalog } from "./types";
 
 /**
  * Convert the original site catalog structure into a formal ICatalog
  * @param original
  */
-export function convertCatalog(original: any): ICatalog {
-  const filterGroup: IFilterGroup<"item"> = {
-    filterType: "item",
-    operation: "OR",
-    filters: [],
-  };
-
-  const groups = getProp(original, "groups");
-
-  if (Array.isArray(groups) && groups.length) {
-    filterGroup.filters.push({
-      filterType: "item",
-      group: groups,
-    });
-  } else if (typeof groups === "string") {
-    filterGroup.filters.push({
-      filterType: "item",
-      group: [groups],
-    });
-  }
-
-  const catalog: ICatalog = {
+export function convertCatalog(original: any): IHubCatalog {
+  const catalog: IHubCatalog = {
+    schemaVersion: 1,
     title: "Default Catalog",
-    scope: [filterGroup],
+    scopes: {
+      item: {
+        targetEntity: "item",
+        filters: [],
+      },
+    },
     collections: [],
   };
+
+  const rawGroups = getProp(original, "groups");
+  let groups = [];
+  if (Array.isArray(rawGroups) && rawGroups.length) {
+    groups = rawGroups;
+  } else if (typeof rawGroups === "string") {
+    groups = [rawGroups];
+  }
+
+  if (groups.length) {
+    catalog.scopes.item.filters.push({
+      predicates: [{ group: groups }],
+    });
+  }
 
   return catalog;
 }

--- a/packages/common/src/search/types/IHubCatalog.ts
+++ b/packages/common/src/search/types/IHubCatalog.ts
@@ -11,9 +11,13 @@ export interface IHubCatalog {
    * Collections within the Catalog
    */
   collections?: IHubCollection[];
+  /**
+   * Schema Version
+   */
+  schemaVersion: number;
 }
 
-export interface ICatalogScope extends Record<EntityType, IQuery> {}
+export interface ICatalogScope extends Partial<Record<EntityType, IQuery>> {}
 
 export interface IHubCollection {
   /**
@@ -40,6 +44,11 @@ export interface IHubCollection {
    * Default sort direction for the Collection
    */
   sortDirection?: "asc" | "desc";
+  /**
+   * What entity is this query targeting. This is used internally to
+   * ensure we query the correct API
+   */
+  targetEntity: EntityType;
 }
 
 export type EntityType = "item" | "group" | "user" | "groupMember" | "event";

--- a/packages/common/test/search/convertCatalog.test.ts
+++ b/packages/common/test/search/convertCatalog.test.ts
@@ -4,46 +4,40 @@ describe("convertCatalog", () => {
   it("returns default catalog if null", () => {
     const chk = convertCatalog(null);
     expect(chk.title).toBe("Default Catalog");
-    expect(chk.scope.length).toBe(1);
-    const fg = chk.scope[0] as IFilterGroup<"item">;
-    expect(fg.filters.length).toBe(0);
+    expect(chk.scopes).toBeDefined();
+    expect(chk.scopes?.item?.filters.length).toBe(0);
   });
 
   it("returns default catalog if passed empty object", () => {
     const chk = convertCatalog({});
     expect(chk.title).toBe("Default Catalog");
-    expect(chk.scope.length).toBe(1);
-    expect(chk.scope[0].filterType).toBe("item");
-    const fg = chk.scope[0] as IFilterGroup<"item">;
-    expect(fg.filters.length).toBe(0);
+    expect(chk.scopes).toBeDefined();
+    expect(chk.scopes?.item?.filters.length).toBe(0);
   });
 
   it("does not return groups if passed empty array", () => {
     const chk = convertCatalog({ groups: [] });
     expect(chk.title).toBe("Default Catalog");
-    expect(chk.scope.length).toBe(1);
-    expect(chk.scope[0].filterType).toBe("item");
-    const fg = chk.scope[0] as IFilterGroup<"item">;
-    expect(fg.filters.length).toBe(0);
+    expect(chk.scopes).toBeDefined();
+    expect(chk.scopes?.item?.filters.length).toBe(0);
   });
 
   it("returns groups if passed a string", () => {
     const chk = convertCatalog({ groups: "3ef" });
     expect(chk.title).toBe("Default Catalog");
-    expect(chk.scope.length).toBe(1);
-    expect(chk.scope[0].filterType).toBe("item");
-    const fg = chk.scope[0] as IFilterGroup<"item">;
-    expect(fg.filters[0].group).toBeDefined();
-    expect(fg.filters[0].group).toEqual(["3ef"]);
+    expect(chk.scopes).toBeDefined();
+    expect(chk.scopes?.item?.filters.length).toBe(1);
+    expect(chk.scopes?.item?.filters[0].predicates[0].group).toEqual(["3ef"]);
   });
 
   it("returns groups if passed an array", () => {
     const chk = convertCatalog({ groups: ["3ef", "bc4"] });
     expect(chk.title).toBe("Default Catalog");
-    expect(chk.scope.length).toBe(1);
-    expect(chk.scope[0].filterType).toBe("item");
-    const fg = chk.scope[0] as IFilterGroup<"item">;
-    expect(fg.filters[0].group).toBeDefined();
-    expect(fg.filters[0].group).toEqual(["3ef", "bc4"]);
+    expect(chk.scopes).toBeDefined();
+    expect(chk.scopes?.item?.filters.length).toBe(1);
+    expect(chk.scopes?.item?.filters[0].predicates[0].group).toEqual([
+      "3ef",
+      "bc4",
+    ]);
   });
 });


### PR DESCRIPTION
1. Description:

- update the `convertCatalog` function to return `IHubCatalog` 
- add `schemaVersion` prop to `IHubCatalog`
- add `targetEntity` to IHubCollection


1. Instructions for testing:

- run tests

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
