### PR TITLE
fix(hub-common): fixed icon name for hub projects

### DIFF
--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -257,7 +257,7 @@ export const getContentTypeIcon = (contentType: string) => {
     hubInitiative: "initiative",
     hubInitiativeTemplate: "initiative-template",
     hubPage: "browser",
-    hubProject: "briefcase",
+    hubProject: "projects",
     hubSiteApplication: "web",
     image: "file-image",
     imageService: "data",

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -715,7 +715,7 @@ describe("setContentType", () => {
       expect(getContentTypeIcon("Feature Service")).toEqual("collection");
       expect(getContentTypeIcon("Mobile Application")).toEqual("mobile");
       expect(getContentTypeIcon("Web Map")).toEqual("map");
-      expect(getContentTypeIcon("Hub Project")).toEqual("briefcase");
+      expect(getContentTypeIcon("Hub Project")).toEqual("projects");
     });
     it("sets non-existing type icon to file", () => {
       expect(getContentTypeIcon("fooBar")).toEqual("file");


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Part of https://devtopia.esri.com/dc/hub/issues/3872
The old 'briefcase' alias seems to be broken in opendata-ui. Switching to the standard 'projects' icon name.
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
