### PR TITLE
fix(hub-common): fix export of a serialization function

### DIFF
--- a/packages/common/src/search/_internal/index.ts
+++ b/packages/common/src/search/_internal/index.ts
@@ -4,4 +4,3 @@ export * from "./portalSearchItems";
 export * from "./hubSearchItems";
 export * from "./portalSearchGroups";
 export * from "./portalSearchUsers";
-export * from "./ifilter-utils";

--- a/packages/common/src/search/_internal/portalSearchGroups.ts
+++ b/packages/common/src/search/_internal/portalSearchGroups.ts
@@ -3,7 +3,7 @@ import { IGroup } from "@esri/arcgis-rest-types";
 import { HubError } from "../../index";
 import { enrichGroupSearchResult } from "../../groups/HubGroups";
 import { IHubRequestOptions } from "../../types";
-import { serializeQueryForPortal } from "./ifilter-utils";
+import { serializeQueryForPortal } from "../ifilter-utils";
 import {
   IHubSearchOptions,
   IHubSearchResponse,

--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -6,7 +6,7 @@ import {
   HubError,
 } from "../..";
 
-import { serializeQueryForPortal } from "./ifilter-utils";
+import { serializeQueryForPortal } from "../ifilter-utils";
 
 import { enrichPageSearchResult } from "../../pages/HubPages";
 import { enrichProjectSearchResult } from "../../projects";

--- a/packages/common/src/search/_internal/portalSearchUsers.ts
+++ b/packages/common/src/search/_internal/portalSearchUsers.ts
@@ -5,7 +5,7 @@ import {
 } from "@esri/arcgis-rest-portal";
 import { IUser } from "@esri/arcgis-rest-types";
 import { enrichUserSearchResult } from "../..";
-import { serializeQueryForPortal } from "./ifilter-utils";
+import { serializeQueryForPortal } from "../ifilter-utils";
 import HubError from "../../HubError";
 import { IHubRequestOptions } from "../../types";
 import {

--- a/packages/common/src/search/ifilter-utils.ts
+++ b/packages/common/src/search/ifilter-utils.ts
@@ -5,8 +5,8 @@ import {
   IMatchOptions,
   IPredicate,
   IQuery,
-} from "../types";
-import { expandPredicate } from "./ipredicate-utils";
+} from "./types";
+import { expandPredicate } from "./_internal/ipredicate-utils";
 
 export function serializeQueryForPortal(query: IQuery): ISearchOptions {
   const filterSearchOptions = query.filters.map(serializeFilter);

--- a/packages/common/src/search/index.ts
+++ b/packages/common/src/search/index.ts
@@ -10,4 +10,5 @@ export * from "./types";
 export * from "./collectionState";
 export * from "./convertCatalog";
 export * from "./filter-utils";
+export * from "./ifilter-utils";
 export * from "./hubSearch";

--- a/packages/common/test/search/ifilter-utils.test.ts
+++ b/packages/common/test/search/ifilter-utils.test.ts
@@ -1,5 +1,5 @@
-import { IPredicate, IQuery } from "../../../src";
-import { serializeQueryForPortal } from "../../../src/search/_internal/ifilter-utils";
+import { IPredicate, IQuery } from "../../src";
+import { serializeQueryForPortal } from "../../src/search/ifilter-utils";
 
 describe("ifilter-utils:", () => {
   describe("serialize query for Portal:", () => {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Allow export of a serializer for client use

2. [x] used semantic commit messages
  
3. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
