### PR TITLE
fix(hub-common): added title to portal allow list

### DIFF
--- a/packages/common/src/search/ifilter-utils.ts
+++ b/packages/common/src/search/ifilter-utils.ts
@@ -105,6 +105,7 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
     "snippet",
     "tags",
     "term",
+    "title",
     "type",
     "typekeywords",
     "userlicensetype",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Adds `title` to portal allow list

2. [x] used semantic commit messages
  
3. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
