### PR TITLE
fix: resolve null predicate issue; rename file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61386,7 +61386,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.45.3",
+			"version": "9.45.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -61419,7 +61419,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.32.3",
+			"version": "11.32.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61428,7 +61428,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61441,12 +61441,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.45.3"
+				"@esri/hub-common": "9.45.5"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.44.3",
+			"version": "9.44.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -61457,7 +61457,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61466,12 +61466,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.45.3"
+				"@esri/hub-common": "9.45.5"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.44.3",
+			"version": "9.44.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61482,7 +61482,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61496,12 +61496,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.45.3"
+				"@esri/hub-common": "9.45.5"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.45.3",
+			"version": "9.45.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61510,7 +61510,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61523,12 +61523,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.45.3"
+				"@esri/hub-common": "9.45.5"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.44.3",
+			"version": "9.44.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61539,7 +61539,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61555,12 +61555,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.45.3"
+				"@esri/hub-common": "9.45.5"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.45.3",
+			"version": "9.45.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61569,9 +61569,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
-				"@esri/hub-initiatives": "9.45.3",
-				"@esri/hub-teams": "9.44.3",
+				"@esri/hub-common": "9.45.5",
+				"@esri/hub-initiatives": "9.45.5",
+				"@esri/hub-teams": "9.44.5",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -61584,9 +61584,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.45.3",
-				"@esri/hub-initiatives": "9.45.3",
-				"@esri/hub-teams": "9.44.3"
+				"@esri/hub-common": "9.45.5",
+				"@esri/hub-initiatives": "9.45.5",
+				"@esri/hub-teams": "9.44.5"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61611,7 +61611,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.45.3",
+			"version": "9.45.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61622,7 +61622,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61636,12 +61636,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.45.3"
+				"@esri/hub-common": "9.45.5"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.44.3",
+			"version": "9.44.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61651,7 +61651,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61664,7 +61664,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.45.3"
+				"@esri/hub-common": "9.45.5"
 			}
 		}
 	},
@@ -65079,7 +65079,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65098,7 +65098,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65117,7 +65117,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65133,7 +65133,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65152,7 +65152,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65170,9 +65170,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
-				"@esri/hub-initiatives": "9.45.3",
-				"@esri/hub-teams": "9.44.3",
+				"@esri/hub-common": "9.45.5",
+				"@esri/hub-initiatives": "9.45.5",
+				"@esri/hub-teams": "9.44.5",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -65209,7 +65209,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65226,7 +65226,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.45.3",
+				"@esri/hub-common": "9.45.5",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/common/src/search/_internal/portalSearchGroups.ts
+++ b/packages/common/src/search/_internal/portalSearchGroups.ts
@@ -3,7 +3,7 @@ import { IGroup } from "@esri/arcgis-rest-types";
 import { HubError } from "../../index";
 import { enrichGroupSearchResult } from "../../groups/HubGroups";
 import { IHubRequestOptions } from "../../types";
-import { serializeQueryForPortal } from "../ifilter-utils";
+import { serializeQueryForPortal } from "../serializeQueryForPortal";
 import {
   IHubSearchOptions,
   IHubSearchResponse,

--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -6,7 +6,7 @@ import {
   HubError,
 } from "../..";
 
-import { serializeQueryForPortal } from "../ifilter-utils";
+import { serializeQueryForPortal } from "../serializeQueryForPortal";
 
 import { enrichPageSearchResult } from "../../pages/HubPages";
 import { enrichProjectSearchResult } from "../../projects";

--- a/packages/common/src/search/_internal/portalSearchUsers.ts
+++ b/packages/common/src/search/_internal/portalSearchUsers.ts
@@ -5,7 +5,7 @@ import {
 } from "@esri/arcgis-rest-portal";
 import { IUser } from "@esri/arcgis-rest-types";
 import { enrichUserSearchResult } from "../..";
-import { serializeQueryForPortal } from "../ifilter-utils";
+import { serializeQueryForPortal } from "../serializeQueryForPortal";
 import HubError from "../../HubError";
 import { IHubRequestOptions } from "../../types";
 import {

--- a/packages/common/src/search/index.ts
+++ b/packages/common/src/search/index.ts
@@ -10,5 +10,5 @@ export * from "./types";
 export * from "./collectionState";
 export * from "./convertCatalog";
 export * from "./filter-utils";
-export * from "./ifilter-utils";
+export * from "./serializeQueryForPortal";
 export * from "./hubSearch";

--- a/packages/common/src/search/serializeQueryForPortal.ts
+++ b/packages/common/src/search/serializeQueryForPortal.ts
@@ -16,10 +16,19 @@ import { expandPredicate } from "./_internal/ipredicate-utils";
 export function serializeQueryForPortal(query: IQuery): ISearchOptions {
   const filterSearchOptions = query.filters.map(serializeFilter);
   // remove any empty entries
-  const nonEmptyOptions = filterSearchOptions.filter((e) => e !== undefined);
+  const nonEmptyOptions = filterSearchOptions.filter(removeEmptyEntries);
   const result = mergeSearchOptions(nonEmptyOptions, "AND");
 
   return result;
+}
+
+/**
+ * Predicate to remove things from array
+ * @param e
+ * @returns
+ */
+function removeEmptyEntries(e: any): boolean {
+  return !(typeof e === "undefined" || e === null || e === "");
 }
 
 function mergeSearchOptions(
@@ -30,12 +39,12 @@ function mergeSearchOptions(
     (acc, entry) => {
       // walk the props
       Object.entries(entry).forEach(([key, value]) => {
-        // if prop exists
+        // if prop exists and is not empty string
         if (acc[key] && value !== "") {
           // combine via operation
           acc[key] = `${acc[key]} ${operation} ${value}`;
         } else {
-          // just copy the value if it's not ""
+          // just copy the value if it's not empty string
           if (value !== "") {
             acc[key] = value;
           }
@@ -156,7 +165,7 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
         return so;
       }
     })
-    .filter((e) => e !== undefined);
+    .filter(removeEmptyEntries);
 
   // merge up all the searchOptions
   if (opts.length) {

--- a/packages/common/test/search/serializeQueryForPortal.test.ts
+++ b/packages/common/test/search/serializeQueryForPortal.test.ts
@@ -1,5 +1,5 @@
 import { IPredicate, IQuery } from "../../src";
-import { serializeQueryForPortal } from "../../src/search/ifilter-utils";
+import { serializeQueryForPortal } from "../../src/search/serializeQueryForPortal";
 
 describe("ifilter-utils:", () => {
   describe("serialize query for Portal:", () => {
@@ -57,6 +57,58 @@ describe("ifilter-utils:", () => {
       expect(chk.q).toEqual(
         '(water AND modified:[1689716790912 TO 1652808629198] AND (type:"Web Map" OR type:"Hub Project"))'
       );
+    });
+    it("it drops empty predicates", () => {
+      const p: IPredicate = {
+        searchUserAccess: "groupMember",
+      };
+      const p2: IPredicate = {
+        owner: "dave",
+      };
+      const p3: IPredicate = {
+        filterType: "foo",
+      };
+
+      const query: IQuery = {
+        targetEntity: "group",
+        filters: [
+          {
+            operation: "AND",
+            predicates: [p, p2, p3],
+          },
+        ],
+      };
+
+      const chk = serializeQueryForPortal(query);
+
+      expect(chk.q).toEqual(`(owner:"dave")`);
+      expect(chk.searchUserAccess).toBe("groupMember");
+    });
+    it("it drops empty predicates: different order", () => {
+      const p: IPredicate = {
+        searchUserAccess: "groupMember",
+      };
+      const p2: IPredicate = {
+        owner: "dave",
+      };
+      const p3: IPredicate = {
+        filterType: "foo",
+      };
+
+      const query: IQuery = {
+        targetEntity: "group",
+        filters: [
+          {
+            operation: "AND",
+            predicates: [p2, p3, p],
+          },
+        ],
+      };
+
+      const chk = serializeQueryForPortal(query);
+
+      expect(chk.q).toEqual(`(owner:"dave")`);
+      expect(chk.searchUserAccess).toBe("groupMember");
     });
     it("handles complex filter", () => {
       const p: IPredicate = {


### PR DESCRIPTION
1. Description:

In some scenarios, the serialization of some predicates would result in having `AND AND` in the `q`. This PR resolve that problem, and renamed `ifilter-utils.ts` to `serializeQueryForPortal.ts` as that's the only exported function.

1. Instructions for testing:

- Run tests

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
