### PR TITLE
fix: correct $application well-known-type

### DIFF
--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -372,6 +372,7 @@ export function applyWellKnownItemPredicates(query: IQuery): IQuery {
   // iterate the filters
   queryClone.filters = queryClone.filters.map((filter) => {
     // replace predicates with well-known types
+    let replacedPredicates = false;
     filter.predicates = filter.predicates.reduce(
       (acc: IPredicate[], predicate) => {
         // if the predicate has a well-known type
@@ -382,6 +383,7 @@ export function applyWellKnownItemPredicates(query: IQuery): IQuery {
             predicate.type as keyof typeof WellKnownItemFilters
           );
           acc = [...acc, ...replacements];
+          replacedPredicates = true;
         } else {
           // this predicate does not have a well-known type
           // so we just keep it
@@ -391,6 +393,12 @@ export function applyWellKnownItemPredicates(query: IQuery): IQuery {
       },
       []
     );
+    if (replacedPredicates) {
+      // Any filter who's predicates were replaced with
+      // well-known predicates, needs to use "OR" to ensure
+      // correct query logic
+      filter.operation = "OR";
+    }
     return filter;
   });
 

--- a/packages/common/test/search/_internal/portalSearchItems.test.ts
+++ b/packages/common/test/search/_internal/portalSearchItems.test.ts
@@ -243,12 +243,14 @@ describe("portalSearchItems Module:", () => {
 
         const chk = applyWellKnownItemPredicates(qry);
         expect(chk.filters.length).toBe(2);
+        expect(chk.filters[0].operation).toBe("OR");
 
         expect(chk.filters[0].predicates.length).toBe(1);
         expect(chk.filters[0].predicates[0].type).toEqual(
           WellKnownItemFilters.$dashboard[0].type
         );
         expect(chk.filters[1].predicates.length).toBe(2);
+        expect(chk.filters[1].operation).toBe("OR");
         expect(chk.filters[1].predicates[0].type).toEqual(
           WellKnownItemFilters.$storymap[0].type
         );
@@ -261,6 +263,7 @@ describe("portalSearchItems Module:", () => {
           targetEntity: "item",
           filters: [
             {
+              operation: "AND",
               predicates: [
                 {
                   type: "Web Map",
@@ -273,6 +276,7 @@ describe("portalSearchItems Module:", () => {
         const chk = applyWellKnownItemPredicates(qry);
         expect(chk.filters.length).toBe(1);
         expect(chk.filters).toEqual(qry.filters);
+        expect(chk.filters[0].operation).toBe("AND");
       });
       it("skips non-well-known keys", () => {
         const qry: IQuery = {
@@ -297,7 +301,7 @@ describe("portalSearchItems Module:", () => {
           targetEntity: "item",
           filters: [
             {
-              operation: "OR",
+              operation: "AND",
               predicates: [
                 {
                   type: "$dashboard",
@@ -314,6 +318,7 @@ describe("portalSearchItems Module:", () => {
         expect(chk.filters.length).toBe(1);
 
         expect(chk.filters[0].predicates.length).toBe(3);
+        expect(chk.filters[0].operation).toBe("OR");
         expect(chk.filters[0].predicates[0].type).toEqual(
           WellKnownItemFilters.$dashboard[0].type
         );
@@ -344,7 +349,7 @@ describe("portalSearchItems Module:", () => {
         const chk = applyWellKnownItemPredicates(qry);
         expect(chk.filters.length).toBe(1);
         const expected = cloneObject(WellKnownItemFilters.$dashboard[0].type);
-
+        expect(chk.filters[0].operation).toBe("OR");
         expect(chk.filters[0].predicates[0].type).toEqual(expected);
         expect(chk.filters[0].predicates[0].owner).not.toBeDefined();
       });


### PR DESCRIPTION
1. Description:

While working with the `arcgis-hub-catalog` component, I noticed the `$application` well known type query was incorrect. The issue was that the `filter` needs to use the `OR` operation in order for the well-known-type predicates to work.

This simply ensures that is the case.

1. Instructions for testing:

- run tests

1. Closes Issues: Just fixed it

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
