### PR TITLE
feat: update IHubStage to optionally include a link property

### DIFF
--- a/packages/common/src/core/types/IHubTimeline.ts
+++ b/packages/common/src/core/types/IHubTimeline.ts
@@ -29,6 +29,14 @@ export interface IHubStage {
    */
   description: string;
   /**
+   * Stage Link
+   */
+  link?: string;
+  /**
+   * Stage Link Display Text
+   */
+  linkText?: string;
+  /**
    * Stage status
    */
   status: string;

--- a/packages/common/src/core/types/IHubTimeline.ts
+++ b/packages/common/src/core/types/IHubTimeline.ts
@@ -2,6 +2,7 @@
  * Hub Timeline Definition
  */
 export interface IHubTimeline {
+  schemaVersion: number;
   title: string;
   description: string;
   stages: IHubStage[];

--- a/packages/common/src/core/types/IHubTimeline.ts
+++ b/packages/common/src/core/types/IHubTimeline.ts
@@ -32,13 +32,20 @@ export interface IHubStage {
   /**
    * Stage Link
    */
-  link?: string;
-  /**
-   * Stage Link Display Text
-   */
-  linkText?: string;
+  link?: IHubStageLink;
   /**
    * Stage status
    */
   status: string;
+}
+
+export interface IHubStageLink {
+  /**
+   * Link href
+   */
+  href: string;
+  /**
+   * Link display title text
+   */
+  title?: string;
 }


### PR DESCRIPTION
see [4362](https://devtopia.esri.com/dc/hub/issues/4362) for more details

see corresponding [PR](https://github.com/Esri/hub-components/pull/564) in `hub-components`
 
1. Description:

- update `IHubStage` to optionally include a `link` property
- update `IHubTimeline` to include a `schemaVersion` property

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
