### PR TITLE
feat: allow custom org group limits

### DIFF
--- a/packages/teams/src/utils/can-user-create-team-in-product.ts
+++ b/packages/teams/src/utils/can-user-create-team-in-product.ts
@@ -2,6 +2,7 @@ import { IUser } from "@esri/arcgis-rest-auth";
 import { hasAllPrivileges } from "./has-all-privileges";
 import { getProp, HubProduct, includes } from "@esri/hub-common";
 import { IGroupTemplate } from "../types";
+import { getOrgGroupLimit } from "./getOrgGroupLimit";
 
 /**
  * Predicate for filtering group templates based on product
@@ -17,10 +18,11 @@ export function canUserCreateTeamInProduct(
   template: IGroupTemplate
 ) {
   let result = false;
+  const userGroupLimit = getOrgGroupLimit(user.orgId) - 5;
   const userGroups = getProp(user, "groups") || [];
   // can this be created in the current environment?
   if (
-    userGroups.length < 507 &&
+    userGroups.length <= userGroupLimit &&
     includes(template.config.availableIn, product)
   ) {
     // and user has required privs...

--- a/packages/teams/src/utils/can-user-create-team.ts
+++ b/packages/teams/src/utils/can-user-create-team.ts
@@ -7,6 +7,7 @@ import {
 } from "@esri/hub-common";
 import { HubTeamType } from "../types";
 import { getUserCreatableTeams } from "./get-user-creatable-teams";
+import { getOrgGroupLimit } from "./getOrgGroupLimit";
 
 /**
  * Determine if the current user can create a specific type of team
@@ -20,7 +21,8 @@ export function canUserCreateTeam(
   hubRequestOptions: IHubRequestOptions
 ) {
   const userGroups = getProp(user, "groups") || [];
-  if (userGroups.length > 510) {
+  const userGroupLimit = getOrgGroupLimit(user.orgId) - 2;
+  if (userGroups.length > userGroupLimit) {
     return false;
   } else {
     const portalSelf = hubRequestOptions.portalSelf;

--- a/packages/teams/src/utils/getOrgGroupLimit.ts
+++ b/packages/teams/src/utils/getOrgGroupLimit.ts
@@ -1,0 +1,17 @@
+/**
+ * Hash of orgs with custom max group limits
+ */
+export const limitsHash: Record<string, number> = {
+  default: 512,
+  xW49QhDgcgjm4BU0: 700,
+  q5DTBtIqgaEcBe1j: 700,
+};
+
+/**
+ * Return the max number of groups a user can be part of
+ * @param orgId
+ * @returns
+ */
+export function getOrgGroupLimit(orgId: string): number {
+  return limitsHash[orgId] || limitsHash.default;
+}

--- a/packages/teams/test/utils/can-user-create-team-in-product.test.ts
+++ b/packages/teams/test/utils/can-user-create-team-in-product.test.ts
@@ -8,14 +8,14 @@ describe("teams:utils:canUserCreateTeamInProduct:", () => {
   const tmpl = {
     config: {
       requiredPrivs: ["baz"],
-      availableIn: ["basic"]
-    }
+      availableIn: ["basic"],
+    },
   } as IGroupTemplate;
 
   it("returns false if user lacks privs", () => {
     const user = {
       privileges: ["foo"],
-      groups: [] as any[]
+      groups: [] as any[],
     };
 
     const result = canUserCreateTeamInProduct(user, "basic", tmpl);
@@ -26,7 +26,7 @@ describe("teams:utils:canUserCreateTeamInProduct:", () => {
   it("returns false if team not availble in product", () => {
     const user = {
       privileges: ["foo"],
-      groups: [] as any[]
+      groups: [] as any[],
     };
 
     const result = canUserCreateTeamInProduct(user, "premium", tmpl);
@@ -36,7 +36,7 @@ describe("teams:utils:canUserCreateTeamInProduct:", () => {
   it("returns false if user has 507 or more groups", () => {
     const user = {
       privileges: ["baz"],
-      groups: new Array(508)
+      groups: new Array(508),
     };
 
     const result = canUserCreateTeamInProduct(user, "basic", tmpl);
@@ -46,10 +46,24 @@ describe("teams:utils:canUserCreateTeamInProduct:", () => {
   it("returns true if user has privs and less than 511 groups", () => {
     const user = {
       privileges: ["baz"],
-      groups: [] as any[]
+      groups: [] as any[],
     };
 
     const result = canUserCreateTeamInProduct(user, "basic", tmpl);
     expect(result).toBeTruthy("user can creat team if they have privs");
+  });
+
+  it("allows more groups for some orgs", () => {
+    const user = {
+      orgId: "xW49QhDgcgjm4BU0",
+      privileges: ["baz"],
+      groups: new Array(645),
+    };
+    const result = canUserCreateTeamInProduct(user, "basic", tmpl);
+    expect(result).toBeTruthy("user can creat team if they have privs");
+
+    user.orgId = "q5DTBtIqgaEcBe1j";
+    const result2 = canUserCreateTeamInProduct(user, "basic", tmpl);
+    expect(result2).toBeTruthy("user can creat team if they have privs");
   });
 });


### PR DESCRIPTION
1. Description:

Allow for customized group limits for some orgs. Hub team must be informed of group limit changes, but this enables simple per-org limit customization; includes the two initial orgs.

1. Instructions for testing:

- run tests

1. Closes Issues: #4389 (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
