### PR TITLE
feat: fetch org limits functions

### DIFF
--- a/packages/common/e2e/entity-search.e2e.ts
+++ b/packages/common/e2e/entity-search.e2e.ts
@@ -4,6 +4,7 @@ import {
   expandContentFilter,
   failSafe,
   fetchModelFromItem,
+  fetchOrgLimits,
   IModel,
   IQuery,
   serializeContentFilterForPortal,
@@ -19,6 +20,19 @@ describe("Entity Search", () => {
     factory = new Artifactory(config);
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
   });
+
+  // Just used to verify the request works and the QA API is working
+  // it("fetchOrgLimits", async () => {
+  //   const ctxMgr = await factory.getContextManager("hubBasic", "admin");
+  //   const result = await fetchOrgLimits(
+  //     "self",
+  //     "Groups",
+  //     "MaxNumUserGroups",
+  //     ctxMgr.context.userRequestOptions
+  //   );
+  //   debugger;
+  //   expect(result.limitValue).toBe(512);
+  // });
 
   it("validate createEntitySearchFn", async () => {
     // create session

--- a/packages/common/src/org/fetchOrgLimits.ts
+++ b/packages/common/src/org/fetchOrgLimits.ts
@@ -1,0 +1,67 @@
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import { request } from "@esri/arcgis-rest-request";
+
+export type OrgLimitType =
+  | "ScheduleTask"
+  | "Collaboration"
+  | "Community"
+  | "Groups"
+  | "Content";
+
+/**
+ * Definiton of the org limits response.
+ */
+export interface IOrgLimit {
+  /**
+   * Preset limit types
+   */
+  type: OrgLimitType;
+  /**
+   * Not constrained as there are too many to list
+   */
+  name: string;
+  /**
+   * value of the limit
+   */
+  limitValue: number;
+}
+
+/**
+ * Generic function to fetch org limits
+ * @param orgId
+ * @param limitsType
+ * @param limitName
+ * @param options
+ * @returns
+ */
+export function fetchOrgLimits(
+  orgId: string,
+  limitsType: OrgLimitType,
+  limitName: string,
+  options: IUserRequestOptions
+): Promise<IOrgLimit> {
+  const portal = options.authentication.portal;
+  const url = `${portal}/portals/${orgId}/limits?limitsType=${limitsType}&limitName=${limitName}&f=json`;
+  return request(url, options);
+}
+
+/**
+ * Fetch the maximum number of groups a user can create in an org
+ * @param orgId
+ * @param options
+ * @returns
+ */
+export function fetchMaxNumUserGroupsLimit(
+  orgId: string,
+  options: IUserRequestOptions
+): Promise<number> {
+  return fetchOrgLimits(orgId, "Groups", "MaxNumUserGroups", options)
+    .then((response) => {
+      return response.limitValue;
+    })
+    .catch((_) => {
+      // it's possible that the org doesn't have this property set, and
+      // the api will return a 500 error. So we just return the default value
+      return 512;
+    });
+}

--- a/packages/common/src/org/index.ts
+++ b/packages/common/src/org/index.ts
@@ -1,1 +1,2 @@
 export * from "./fetch-org";
+export * from "./fetchOrgLimits";

--- a/packages/common/test/org/fetchOrgLimits.test.ts
+++ b/packages/common/test/org/fetchOrgLimits.test.ts
@@ -1,0 +1,72 @@
+import * as LimitsModule from "../../src/org/fetchOrgLimits";
+import { MOCK_AUTH } from "../mocks/mock-auth";
+import * as RequestModule from "@esri/arcgis-rest-request";
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+
+describe("fetchOrgLimits module:", () => {
+  describe("fetching any limits", () => {
+    it("sends request and returns response", async () => {
+      const reqSpy = spyOn(RequestModule, "request").and.callFake(() => {
+        return Promise.resolve({
+          type: "Groups",
+          name: "MaxNumUserGroups",
+          limitValue: 672,
+        });
+      });
+      const uro: IUserRequestOptions = {
+        authentication: MOCK_AUTH,
+      };
+      const result = await LimitsModule.fetchOrgLimits(
+        "self",
+        "Groups",
+        "MaxNumUserGroups",
+        uro
+      );
+      expect(result.type).toBe("Groups");
+      expect(reqSpy.calls.count()).toBe(1);
+      const [url, opts] = reqSpy.calls.argsFor(0);
+      expect(url).toBe(
+        "https://myorg.maps.arcgis.com/sharing/rest/portals/self/limits?limitsType=Groups&limitName=MaxNumUserGroups&f=json"
+      );
+    });
+  });
+
+  describe("fetch max user groups", () => {
+    it("fetches group limit", async () => {
+      const reqSpy = spyOn(RequestModule, "request").and.callFake(() => {
+        return Promise.resolve({
+          type: "Groups",
+          name: "MaxNumUserGroups",
+          limitValue: 672,
+        });
+      });
+      const uro: IUserRequestOptions = {
+        authentication: MOCK_AUTH,
+      };
+      const result = await LimitsModule.fetchMaxNumUserGroupsLimit("self", uro);
+      expect(result).toBe(672);
+      expect(reqSpy.calls.count()).toBe(1);
+      const [url, opts] = reqSpy.calls.argsFor(0);
+      expect(url).toBe(
+        "https://myorg.maps.arcgis.com/sharing/rest/portals/self/limits?limitsType=Groups&limitName=MaxNumUserGroups&f=json"
+      );
+    });
+    it("returns 512 on failure", async () => {
+      const reqSpy = spyOn(RequestModule, "request").and.callFake(() => {
+        return Promise.reject({
+          zomg: "error",
+        });
+      });
+      const uro: IUserRequestOptions = {
+        authentication: MOCK_AUTH,
+      };
+      const result = await LimitsModule.fetchMaxNumUserGroupsLimit("self", uro);
+      expect(result).toBe(512);
+      expect(reqSpy.calls.count()).toBe(1);
+      const [url, opts] = reqSpy.calls.argsFor(0);
+      expect(url).toBe(
+        "https://myorg.maps.arcgis.com/sharing/rest/portals/self/limits?limitsType=Groups&limitName=MaxNumUserGroups&f=json"
+      );
+    });
+  });
+});


### PR DESCRIPTION
1. Description:

Adds low-level functions to fetch org limits generally and to fetch the specific MaxNumUserGroups limit. This will be needed for upcoming work

1. Instructions for testing:

1. Part of Issues:  https://devtopia.esri.com/dc/hub/issues/4389

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
