### PR TITLE
fix: enable searching groups by shared edit

### DIFF
--- a/packages/common/src/search/serializeQueryForPortal.ts
+++ b/packages/common/src/search/serializeQueryForPortal.ts
@@ -98,6 +98,7 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
   const portalAllowList = [
     "access",
     "categories",
+    "capabilities",
     "created",
     "description",
     "disabled",
@@ -131,6 +132,7 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
     "userlicensetype",
     "username",
   ];
+
   let qCount = 0;
   // TODO: Look at using reduce vs .map and remove the `.filter`
   const opts = Object.entries(predicate)

--- a/packages/common/test/search/serializeQueryForPortal.test.ts
+++ b/packages/common/test/search/serializeQueryForPortal.test.ts
@@ -252,6 +252,25 @@ describe("ifilter-utils:", () => {
 
       expect(chk.q).toEqual('tags:"water"');
     });
+    it("handles capabilities filter ", () => {
+      const p: IPredicate = {
+        capabilities: "updateitemcontrol",
+      };
+
+      const query: IQuery = {
+        targetEntity: "group",
+        filters: [
+          {
+            operation: "AND",
+            predicates: [p],
+          },
+        ],
+      };
+
+      const chk = serializeQueryForPortal(query);
+
+      expect(chk.q).toEqual('capabilities:"updateitemcontrol"');
+    });
     it("handles bool filter ", () => {
       const p: IPredicate = {
         isopendata: true,
@@ -293,41 +312,4 @@ describe("ifilter-utils:", () => {
       expect(chk.searchUserName).toEqual("dave");
     });
   });
-
-  // describe("empty filters:", () => {
-  //   it("detects empty filter", () => {
-  //     expect(isEmptyFilter({ filterType: "item" })).toBe(true);
-  //     expect(isEmptyFilter({ filterType: "item", owner: "dave" })).toBe(false);
-  //   });
-
-  //   it("detects empty filtergroup", () => {
-  //     expect(
-  //       isEmptyFilterGroup({ operation: "OR", filters: [], filterType: "item" })
-  //     ).toBe(true);
-  //     expect(
-  //       isEmptyFilterGroup({
-  //         operation: "OR",
-  //         filters: [{ filterType: "item" }],
-  //         filterType: "item",
-  //       })
-  //     ).toBe(true);
-  //     expect(
-  //       isEmptyFilterGroup({
-  //         operation: "OR",
-  //         filters: [{ filterType: "item", owner: "dave" }],
-  //         filterType: "item",
-  //       })
-  //     ).toBe(false);
-  //     expect(
-  //       isEmptyFilterGroup({
-  //         operation: "OR",
-  //         filters: [
-  //           { filterType: "item", owner: "dave" },
-  //           { filterType: "item" },
-  //         ],
-  //         filterType: "item",
-  //       })
-  //     ).toBe(false);
-  //   });
-  // });
 });


### PR DESCRIPTION
1. Description:

During the last refactor I missed enabling `capabilities` as a searchable field for groups

1. Instructions for testing:

- run tests - there is a test specifically for this property now


1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
