### PR TITLE
chore(hub-common): no longer publish es5 build

### DIFF
--- a/demos/ember-app/README.md
+++ b/demos/ember-app/README.md
@@ -4,7 +4,7 @@ This demo is used to verify that ember-auto-import dynamic and static imports wo
 
 ## Running this demo
 
-1. Make sure you run `npm run build` in the monorepo root to setup the dependencies
+1. Make sure you run `npm i && npm run build` in the monorepo root to setup the dependencies
 1. cd into `demos/ember-app`
 1. Run `npm start`
 1. Load `http://localhost:4200/` in a web browser.

--- a/demos/ember-app/ember-cli-build.js
+++ b/demos/ember-app/ember-cli-build.js
@@ -7,10 +7,6 @@ module.exports = function (defaults) {
     // see the README for information on 
     // how to configure this for additional Hub.js packages
     autoImport: {
-      alias: {
-        // use the es2017 build of Hub.js packages
-        '@esri/hub-common': '@esri/hub-common/dist/es2017'
-      },
       // live reload on changes to these Hub.js packages
       watchDependencies: ['@esri/hub-common']
     }

--- a/demos/ember-app/package.json
+++ b/demos/ember-app/package.json
@@ -27,7 +27,7 @@
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-portal": "^3.3.1",
     "@esri/arcgis-rest-request": "^3.1.1",
-    "@esri/hub-common": "^9.10.0"
+    "@esri/hub-common": "10.0.0-next.4"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/demos/node/package.json
+++ b/demos/node/package.json
@@ -15,7 +15,7 @@
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-portal": "^3.3.1",
     "@esri/arcgis-rest-request": "^3.1.1",
-    "@esri/hub-common": "^9.10.0",
+    "@esri/hub-common": "10.0.0-next.4",
     "cross-fetch": "^3.0.0",
     "isomorphic-form-data": "^2.0.0"
   }

--- a/demos/webpack/README.md
+++ b/demos/webpack/README.md
@@ -4,7 +4,7 @@ This demo shows how to have webpack [tree shake](https://rollupjs.org/guide/en#t
 
 ## Running this demo
 
-1. Make sure you run `npm run build` in the root folder to setup the dependencies
+1. Make sure you run `npm i && npm run build` in the root folder to setup the dependencies
 1. cd into `demos/webpack`
 1. Run `npm run build`
 1. Load `index.html` in a web browser.

--- a/demos/webpack/package.json
+++ b/demos/webpack/package.json
@@ -15,7 +15,7 @@
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-portal": "^3.3.1",
     "@esri/arcgis-rest-request": "^3.1.1",
-    "@esri/hub-common": "^9.10.0"
+    "@esri/hub-common": "10.0.0-next.4"
   },
   "devDependencies": {
     "webpack": "^4.46.0",

--- a/demos/webpack/webpack.config.js
+++ b/demos/webpack/webpack.config.js
@@ -3,12 +3,6 @@ const path = require('path');
 module.exports = {
   mode: 'development',
   entry: './src/index.js',
-  resolve: {
-    alias: {
-      // use the es2017 build of Hub.js packages
-      '@esri/hub-common': '@esri/hub-common/dist/es2017'
-    }
-  },
   output: {
     filename: 'main.js',
     path: path.resolve(__dirname, 'dist'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.3.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "^9.10.0"
+				"@esri/hub-common": "10.0.0-next.4"
 			},
 			"devDependencies": {
 				"@ember/optional-features": "^2.0.0",
@@ -152,25 +152,6 @@
 				"node": "10.* || >= 12"
 			}
 		},
-		"demos/ember-app/node_modules/@esri/hub-common": {
-			"version": "9.49.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.49.0.tgz",
-			"integrity": "sha512-0R5pY84+PJVgNf/vsV9vZJel0CLc/z0OpMAQGwWKJBc/Sz1Vo5oW6tuxNDfLDqV76CzTSg7gEF7IWdmL6ReyBQ==",
-			"dependencies": {
-				"abab": "^2.0.5",
-				"adlib": "^3.0.7",
-				"fast-xml-parser": "^3.21.0",
-				"jsonapi-typescript": "^0.1.3",
-				"tslib": "^1.13.0"
-			},
-			"peerDependencies": {
-				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
-				"@esri/arcgis-rest-feature-layer": "^3.2.0",
-				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
-				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/arcgis-rest-types": "^2.15.0 || 3"
-			}
-		},
 		"demos/ember-app/node_modules/eslint-plugin-prettier": {
 			"version": "3.4.1",
 			"dev": true,
@@ -199,28 +180,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.3.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "^9.10.0",
+				"@esri/hub-common": "10.0.0-next.4",
 				"cross-fetch": "^3.0.0",
 				"isomorphic-form-data": "^2.0.0"
-			}
-		},
-		"demos/node/node_modules/@esri/hub-common": {
-			"version": "9.49.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.49.0.tgz",
-			"integrity": "sha512-0R5pY84+PJVgNf/vsV9vZJel0CLc/z0OpMAQGwWKJBc/Sz1Vo5oW6tuxNDfLDqV76CzTSg7gEF7IWdmL6ReyBQ==",
-			"dependencies": {
-				"abab": "^2.0.5",
-				"adlib": "^3.0.7",
-				"fast-xml-parser": "^3.21.0",
-				"jsonapi-typescript": "^0.1.3",
-				"tslib": "^1.13.0"
-			},
-			"peerDependencies": {
-				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
-				"@esri/arcgis-rest-feature-layer": "^3.2.0",
-				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
-				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/arcgis-rest-types": "^2.15.0 || 3"
 			}
 		},
 		"demos/node/node_modules/form-data": {
@@ -250,30 +212,11 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.3.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "^9.10.0"
+				"@esri/hub-common": "10.0.0-next.4"
 			},
 			"devDependencies": {
 				"webpack": "^4.46.0",
 				"webpack-cli": "^4.6.0"
-			}
-		},
-		"demos/webpack/node_modules/@esri/hub-common": {
-			"version": "9.49.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.49.0.tgz",
-			"integrity": "sha512-0R5pY84+PJVgNf/vsV9vZJel0CLc/z0OpMAQGwWKJBc/Sz1Vo5oW6tuxNDfLDqV76CzTSg7gEF7IWdmL6ReyBQ==",
-			"dependencies": {
-				"abab": "^2.0.5",
-				"adlib": "^3.0.7",
-				"fast-xml-parser": "^3.21.0",
-				"jsonapi-typescript": "^0.1.3",
-				"tslib": "^1.13.0"
-			},
-			"peerDependencies": {
-				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
-				"@esri/arcgis-rest-feature-layer": "^3.2.0",
-				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
-				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/arcgis-rest-types": "^2.15.0 || 3"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -61442,7 +61385,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "10.0.0-next.3",
+			"version": "10.0.0-next.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -61475,7 +61418,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "12.0.0-next.3",
+			"version": "12.0.0-next.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61484,7 +61427,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61497,12 +61440,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "10.0.0-next.3"
+				"@esri/hub-common": "10.0.0-next.4"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "10.0.0-next.3",
+			"version": "10.0.0-next.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -61513,7 +61456,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61522,12 +61465,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "10.0.0-next.3"
+				"@esri/hub-common": "10.0.0-next.4"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "10.0.0-next.3",
+			"version": "10.0.0-next.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61538,7 +61481,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61552,12 +61495,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.3"
+				"@esri/hub-common": "10.0.0-next.4"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "10.0.0-next.3",
+			"version": "10.0.0-next.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61566,7 +61509,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61579,12 +61522,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.3"
+				"@esri/hub-common": "10.0.0-next.4"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "10.0.0-next.3",
+			"version": "10.0.0-next.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61595,7 +61538,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61611,12 +61554,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.3"
+				"@esri/hub-common": "10.0.0-next.4"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "10.0.0-next.3",
+			"version": "10.0.0-next.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61625,9 +61568,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
-				"@esri/hub-initiatives": "10.0.0-next.3",
-				"@esri/hub-teams": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
+				"@esri/hub-initiatives": "10.0.0-next.4",
+				"@esri/hub-teams": "10.0.0-next.4",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -61640,9 +61583,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.3",
-				"@esri/hub-initiatives": "10.0.0-next.3",
-				"@esri/hub-teams": "10.0.0-next.3"
+				"@esri/hub-common": "10.0.0-next.4",
+				"@esri/hub-initiatives": "10.0.0-next.4",
+				"@esri/hub-teams": "10.0.0-next.4"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61667,7 +61610,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "10.0.0-next.3",
+			"version": "10.0.0-next.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61678,7 +61621,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61692,12 +61635,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.3"
+				"@esri/hub-common": "10.0.0-next.4"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "10.0.0-next.3",
+			"version": "10.0.0-next.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61707,7 +61650,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61720,7 +61663,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.3"
+				"@esri/hub-common": "10.0.0-next.4"
 			}
 		}
 	},
@@ -65135,7 +65078,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65154,7 +65097,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65173,7 +65116,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65189,7 +65132,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65208,7 +65151,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65226,9 +65169,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
-				"@esri/hub-initiatives": "10.0.0-next.3",
-				"@esri/hub-teams": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
+				"@esri/hub-initiatives": "10.0.0-next.4",
+				"@esri/hub-teams": "10.0.0-next.4",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -65265,7 +65208,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65282,7 +65225,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.3",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -82089,7 +82032,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.3.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "^9.10.0",
+				"@esri/hub-common": "10.0.0-next.4",
 				"@glimmer/component": "^1.0.3",
 				"@glimmer/tracking": "^1.0.3",
 				"babel-eslint": "^10.1.0",
@@ -82126,18 +82069,6 @@
 				"qunit-dom": "^1.6.0"
 			},
 			"dependencies": {
-				"@esri/hub-common": {
-					"version": "9.49.0",
-					"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.49.0.tgz",
-					"integrity": "sha512-0R5pY84+PJVgNf/vsV9vZJel0CLc/z0OpMAQGwWKJBc/Sz1Vo5oW6tuxNDfLDqV76CzTSg7gEF7IWdmL6ReyBQ==",
-					"requires": {
-						"abab": "^2.0.5",
-						"adlib": "^3.0.7",
-						"fast-xml-parser": "^3.21.0",
-						"jsonapi-typescript": "^0.1.3",
-						"tslib": "^1.13.0"
-					}
-				},
 				"eslint-plugin-prettier": {
 					"version": "3.4.1",
 					"dev": true,
@@ -96713,23 +96644,11 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.3.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "^9.10.0",
+				"@esri/hub-common": "10.0.0-next.4",
 				"cross-fetch": "^3.0.0",
 				"isomorphic-form-data": "^2.0.0"
 			},
 			"dependencies": {
-				"@esri/hub-common": {
-					"version": "9.49.0",
-					"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.49.0.tgz",
-					"integrity": "sha512-0R5pY84+PJVgNf/vsV9vZJel0CLc/z0OpMAQGwWKJBc/Sz1Vo5oW6tuxNDfLDqV76CzTSg7gEF7IWdmL6ReyBQ==",
-					"requires": {
-						"abab": "^2.0.5",
-						"adlib": "^3.0.7",
-						"fast-xml-parser": "^3.21.0",
-						"jsonapi-typescript": "^0.1.3",
-						"tslib": "^1.13.0"
-					}
-				},
 				"form-data": {
 					"version": "2.5.1",
 					"requires": {
@@ -108345,23 +108264,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.3.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "^9.10.0",
+				"@esri/hub-common": "10.0.0-next.4",
 				"webpack": "^4.46.0",
 				"webpack-cli": "^4.6.0"
-			},
-			"dependencies": {
-				"@esri/hub-common": {
-					"version": "9.49.0",
-					"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.49.0.tgz",
-					"integrity": "sha512-0R5pY84+PJVgNf/vsV9vZJel0CLc/z0OpMAQGwWKJBc/Sz1Vo5oW6tuxNDfLDqV76CzTSg7gEF7IWdmL6ReyBQ==",
-					"requires": {
-						"abab": "^2.0.5",
-						"adlib": "^3.0.7",
-						"fast-xml-parser": "^3.21.0",
-						"jsonapi-typescript": "^0.1.3",
-						"tslib": "^1.13.0"
-					}
-				}
 			}
 		},
 		"webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -96,12 +96,11 @@
 		"ultra-runner": "^3.10.5"
 	},
 	"scripts": {
-		"build:esm:es5": "npx ultra --build -r filter=\"packages/*\" build:esm:es5",
 		"build:esm": "npx ultra --build -r filter=\"packages/*\"  build:esm",
 		"build:node": "npx ultra --build -r filter=\"packages/*\"  build:node",
 		"build:tests": "npm run build:esm && npm run build:node",
 		"build:umd": "npx ultra --build -r filter=\"packages/*\"  build:umd",
-		"build": "npm run build:esm && npm run build:esm:es5 && npm run build:node",
+		"build": "npm run build:esm && npm run build:node",
 		"c": "npm run precommit && git-cz",
 		"clean:deps": "rm -rf node_modules && rm -rf packages/*/node_modules/",
 		"clean:dist": "rm -rf packages/*/dist/",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -4,7 +4,6 @@
   "description": "Common TypeScript types and utility functions for @esri/hub.js.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",
-  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
   "types": "dist/types/index.d.ts",
   "author": "",
@@ -42,8 +41,7 @@
   },
   "scripts": {
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --outDir ./dist/es2017  --declaration --declarationDir ./dist/types",
-    "build:esm:es5": "tsc --module es2015 --target es5 --outDir ./dist/esm",
+    "build:esm": "tsc --outDir ./dist/esm  --declaration --declarationDir ./dist/types",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "dev:esm": "npm run build:esm -- -w",

--- a/packages/discussions/package.json
+++ b/packages/discussions/package.json
@@ -4,7 +4,6 @@
   "description": "Module to interact with ArcGIS Hub Discussions API in Node.js and modern browsers.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",
-  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
   "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
@@ -36,8 +35,7 @@
   "scripts": {
     "build": "npm run build:node && npm run build:esm",
     "local_build": "npm run build:node && npm run build:esm && npm run build:umd",
-    "build:esm": "tsc --outDir ./dist/es2017  --declaration --declarationDir ./dist/types",
-    "build:esm:es5": "tsc --module es2015 --target es5 --outDir ./dist/esm",
+    "build:esm": "tsc --outDir ./dist/esm  --declaration --declarationDir ./dist/types",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "dev:esm": "npm run build:esm -- -w",

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -4,7 +4,6 @@
   "description": "Service for Hub downloads",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",
-  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
   "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
@@ -33,8 +32,7 @@
   ],
   "scripts": {
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --outDir ./dist/es2017  --declaration --declarationDir ./dist/types",
-    "build:esm:es5": "tsc --module es2015 --target es5 --outDir ./dist/esm",
+    "build:esm": "tsc --outDir ./dist/esm  --declaration --declarationDir ./dist/types",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "dev:esm": "npm run build:esm -- -w",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -4,7 +4,6 @@
   "description": "Module to interact with ArcGIS Hub Events in Node.js and modern browsers.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",
-  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
   "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
@@ -38,8 +37,7 @@
   ],
   "scripts": {
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --outDir ./dist/es2017  --declaration --declarationDir ./dist/types",
-    "build:esm:es5": "tsc --module es2015 --target es5 --outDir ./dist/esm",
+    "build:esm": "tsc --outDir ./dist/esm  --declaration --declarationDir ./dist/types",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "dev:esm": "npm run build:esm -- -w",

--- a/packages/initiatives/package.json
+++ b/packages/initiatives/package.json
@@ -4,7 +4,6 @@
   "description": "Module to interact with ArcGIS Hub Initiatives in Node.js and modern browsers.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",
-  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
   "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
@@ -35,8 +34,7 @@
   ],
   "scripts": {
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --outDir ./dist/es2017  --declaration --declarationDir ./dist/types",
-    "build:esm:es5": "tsc --module es2015 --target es5 --outDir ./dist/esm",
+    "build:esm": "tsc --outDir ./dist/esm  --declaration --declarationDir ./dist/types",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "dev:esm": "npm run build:esm -- -w",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -4,7 +4,6 @@
   "description": "Module to search for ArcGIS items and format them for display in ArcGIS Hub.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",
-  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
   "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
@@ -40,8 +39,7 @@
   ],
   "scripts": {
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --outDir ./dist/es2017  --declaration --declarationDir ./dist/types",
-    "build:esm:es5": "tsc --module es2015 --target es5 --outDir ./dist/esm",
+    "build:esm": "tsc --outDir ./dist/esm  --declaration --declarationDir ./dist/types",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "dev:esm": "npm run build:esm -- -w",

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -4,7 +4,6 @@
   "description": "Module to interact with ArcGIS Hub Sites in Node.js and modern browsers.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",
-  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
   "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
@@ -39,8 +38,7 @@
   ],
   "scripts": {
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --outDir ./dist/es2017  --declaration --declarationDir ./dist/types",
-    "build:esm:es5": "tsc --module es2015 --target es5 --outDir ./dist/esm",
+    "build:esm": "tsc --outDir ./dist/esm  --declaration --declarationDir ./dist/types",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "dev:esm": "npm run build:esm -- -w",

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -4,7 +4,6 @@
   "description": "Module to interact with ArcGIS Hub Surveys in Node.js and modern browsers.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",
-  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
   "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
@@ -38,8 +37,7 @@
   ],
   "scripts": {
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --outDir ./dist/es2017  --declaration --declarationDir ./dist/types",
-    "build:esm:es5": "tsc --module es2015 --target es5 --outDir ./dist/esm",
+    "build:esm": "tsc --outDir ./dist/esm  --declaration --declarationDir ./dist/types",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "dev:esm": "npm run build:esm -- -w",

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -4,7 +4,6 @@
   "description": "Module to interact with ArcGIS Hub Teams in Node.js and modern browsers.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",
-  "es2017": "dist/es2017/index.js",
   "sideEffects": false,
   "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
@@ -36,8 +35,7 @@
   ],
   "scripts": {
     "build": "npm run build:node && npm run build:esm",
-    "build:esm": "tsc --outDir ./dist/es2017  --declaration --declarationDir ./dist/types",
-    "build:esm:es5": "tsc --module es2015 --target es5 --outDir ./dist/esm",
+    "build:esm": "tsc --outDir ./dist/esm  --declaration --declarationDir ./dist/types",
     "build:node": "tsc --module commonjs --outDir ./dist/node",
     "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
     "dev:esm": "npm run build:esm -- -w",

--- a/umd-base-profile.js
+++ b/umd-base-profile.js
@@ -79,7 +79,7 @@ arcgisRestJsPackageNames.reduce((globals, p) => {
  * Now we can export the Rollup config!
  */
 export default {
-  // NOTE: you must run the ESM ES5 build before running the UMD build
+  // NOTE: you must run the ESM build before running the UMD build
   input: "./dist/esm/index.js",
   output: {
     file: `./dist/umd/${name.replace("@esri/hub-", "")}.umd.js`,


### PR DESCRIPTION
affects: ember-app, webpack-demo, @esri/hub-common, @esri/hub-discussions, @esri/hub-downloads,
@esri/hub-events, @esri/hub-initiatives, @esri/hub-search, @esri/hub-sites, @esri/hub-surveys,
@esri/hub-teams

BREAKING CHANGE:
no longer publish es5 build

1. Description:

no longer publish es5 build

1. Instructions for testing:

if tests pass, let'r rip

1. Closes Issues: Part of https://devtopia.esri.com/dc/hub/issues/3851

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
