### PR TITLE
feat(hub-downloads): make rest-js packages peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22329,10 +22329,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22347,24 +22346,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22378,10 +22374,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22399,10 +22394,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -63576,7 +63570,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "10.0.0-next.5",
+			"version": "10.0.0-next.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -63609,7 +63603,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "12.0.0-next.5",
+			"version": "12.0.0-next.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -63618,7 +63612,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -63631,23 +63625,23 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "10.0.0-next.5"
+				"@esri/hub-common": "10.0.0-next.6"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "10.0.0-next.5",
+			"version": "10.0.0-next.6",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@esri/arcgis-rest-feature-layer": "^3.1.1",
-				"@esri/arcgis-rest-portal": "^3.4.2",
-				"@esri/arcgis-rest-request": "^3.1.1",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/arcgis-rest-feature-layer": "^3.1.1",
+				"@esri/arcgis-rest-portal": "^3.4.2",
+				"@esri/arcgis-rest-request": "^3.1.1",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -63656,12 +63650,16 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "10.0.0-next.5"
+				"@esri/arcgis-rest-auth": "^3.1.0",
+				"@esri/arcgis-rest-feature-layer": "^3.1.0",
+				"@esri/arcgis-rest-portal": "^3.4.0",
+				"@esri/arcgis-rest-request": "^3.1.0",
+				"@esri/hub-common": "10.0.0-next.6"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "10.0.0-next.5",
+			"version": "10.0.0-next.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -63672,7 +63670,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -63686,12 +63684,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.5"
+				"@esri/hub-common": "10.0.0-next.6"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "10.0.0-next.5",
+			"version": "10.0.0-next.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -63700,7 +63698,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -63713,12 +63711,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.5"
+				"@esri/hub-common": "10.0.0-next.6"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "10.0.0-next.5",
+			"version": "10.0.0-next.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -63729,7 +63727,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -63745,12 +63743,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.5"
+				"@esri/hub-common": "10.0.0-next.6"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "10.0.0-next.5",
+			"version": "10.0.0-next.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -63759,9 +63757,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
-				"@esri/hub-initiatives": "10.0.0-next.5",
-				"@esri/hub-teams": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
+				"@esri/hub-initiatives": "10.0.0-next.6",
+				"@esri/hub-teams": "10.0.0-next.6",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -63774,9 +63772,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.5",
-				"@esri/hub-initiatives": "10.0.0-next.5",
-				"@esri/hub-teams": "10.0.0-next.5"
+				"@esri/hub-common": "10.0.0-next.6",
+				"@esri/hub-initiatives": "10.0.0-next.6",
+				"@esri/hub-teams": "10.0.0-next.6"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -63801,7 +63799,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "10.0.0-next.5",
+			"version": "10.0.0-next.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -63812,7 +63810,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -63826,12 +63824,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.5"
+				"@esri/hub-common": "10.0.0-next.6"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "10.0.0-next.5",
+			"version": "10.0.0-next.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -63841,7 +63839,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -63854,7 +63852,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.5"
+				"@esri/hub-common": "10.0.0-next.6"
 			}
 		}
 	},
@@ -67194,7 +67192,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -67213,7 +67211,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -67232,7 +67230,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -67248,7 +67246,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -67267,7 +67265,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -67285,9 +67283,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
-				"@esri/hub-initiatives": "10.0.0-next.5",
-				"@esri/hub-teams": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
+				"@esri/hub-initiatives": "10.0.0-next.6",
+				"@esri/hub-teams": "10.0.0-next.6",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -67324,7 +67322,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -67341,7 +67339,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.5",
+				"@esri/hub-common": "10.0.0-next.6",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -81969,8 +81967,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -81985,20 +81982,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -82012,8 +82006,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -82030,8 +82023,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -8,17 +8,21 @@
   "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-feature-layer": "^3.1.1",
-    "@esri/arcgis-rest-portal": "^3.4.2",
-    "@esri/arcgis-rest-request": "^3.1.1",
     "eventemitter3": "^4.0.4",
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
+    "@esri/arcgis-rest-auth": "^3.1.0",
+    "@esri/arcgis-rest-feature-layer": "^3.1.0",
+    "@esri/arcgis-rest-portal": "^3.4.0",
+    "@esri/arcgis-rest-request": "^3.1.0",
     "@esri/hub-common": "10.0.0-next.6"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
+    "@esri/arcgis-rest-feature-layer": "^3.1.1",
+    "@esri/arcgis-rest-portal": "^3.4.2",
+    "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/hub-common": "10.0.0-next.6",
     "@rollup/plugin-commonjs": "^15.0.0",
     "@rollup/plugin-json": "^4.1.0",


### PR DESCRIPTION
affects: @esri/hub-downloads

BREAKING CHANGE:
make rest-js packages peer dependencies

1. Description:

1. Instructions for testing:

1. Closes Issues: Part of https://devtopia.esri.com/dc/hub/issues/3851

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
