### PR TITLE
fix: predicates need to be wrapped in parens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61386,7 +61386,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.49.0",
+			"version": "9.49.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -61419,7 +61419,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.36.0",
+			"version": "11.36.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61428,7 +61428,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61441,12 +61441,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.49.0"
+				"@esri/hub-common": "9.49.1"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.48.0",
+			"version": "9.48.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
@@ -61457,7 +61457,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61466,12 +61466,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.49.0"
+				"@esri/hub-common": "9.49.1"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.48.0",
+			"version": "9.48.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61482,7 +61482,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61496,12 +61496,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.49.0"
+				"@esri/hub-common": "9.49.1"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.49.0",
+			"version": "9.49.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61510,7 +61510,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61523,12 +61523,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.49.0"
+				"@esri/hub-common": "9.49.1"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.48.0",
+			"version": "9.48.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61539,7 +61539,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61555,12 +61555,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.49.0"
+				"@esri/hub-common": "9.49.1"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.50.0",
+			"version": "9.50.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61569,9 +61569,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
-				"@esri/hub-initiatives": "9.49.0",
-				"@esri/hub-teams": "9.49.0",
+				"@esri/hub-common": "9.49.1",
+				"@esri/hub-initiatives": "9.49.1",
+				"@esri/hub-teams": "9.49.2",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -61584,9 +61584,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.49.0",
-				"@esri/hub-initiatives": "9.49.0",
-				"@esri/hub-teams": "9.49.0"
+				"@esri/hub-common": "9.49.1",
+				"@esri/hub-initiatives": "9.49.1",
+				"@esri/hub-teams": "9.49.2"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61611,7 +61611,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.49.0",
+			"version": "9.49.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61622,7 +61622,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61636,12 +61636,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.49.0"
+				"@esri/hub-common": "9.49.1"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.49.0",
+			"version": "9.49.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61651,7 +61651,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -61664,7 +61664,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.49.0"
+				"@esri/hub-common": "9.49.1"
 			}
 		}
 	},
@@ -65079,7 +65079,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65098,7 +65098,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65117,7 +65117,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65133,7 +65133,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65152,7 +65152,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65170,9 +65170,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
-				"@esri/hub-initiatives": "9.49.0",
-				"@esri/hub-teams": "9.49.0",
+				"@esri/hub-common": "9.49.1",
+				"@esri/hub-initiatives": "9.49.1",
+				"@esri/hub-teams": "9.49.2",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -65209,7 +65209,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -65226,7 +65226,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.0",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/common/src/search/serializeQueryForPortal.ts
+++ b/packages/common/src/search/serializeQueryForPortal.ts
@@ -172,7 +172,7 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
   // merge up all the searchOptions
   if (opts.length) {
     const searchOptions = mergeSearchOptions(opts, "AND");
-    if (qCount > 1) {
+    if (searchOptions.q) {
       searchOptions.q = `(${searchOptions.q})`;
     }
     return searchOptions;

--- a/packages/common/test/projects/HubProjects.test.ts
+++ b/packages/common/test/projects/HubProjects.test.ts
@@ -359,7 +359,7 @@ describe("HubProjects:", () => {
       // verify the query
       const searchOpts = searchSpy.calls.argsFor(0)[0];
 
-      expect(searchOpts.q).toBe(`type:"Hub Project" AND water`);
+      expect(searchOpts.q).toBe(`(type:"Hub Project") AND (water)`);
     });
     it("accepts an IQuery", async () => {
       const qry: IQuery = {
@@ -386,7 +386,7 @@ describe("HubProjects:", () => {
       // verify the query
       const searchOpts = searchSpy.calls.argsFor(0)[0];
 
-      expect(searchOpts.q).toBe(`type:"Hub Project" AND colorado`);
+      expect(searchOpts.q).toBe(`(type:"Hub Project") AND (colorado)`);
     });
 
     it("accepts num, sortField and aggFields", async () => {
@@ -402,7 +402,7 @@ describe("HubProjects:", () => {
       // verify the query
       const searchOpts = searchSpy.calls.argsFor(0)[0];
 
-      expect(searchOpts.q).toBe(`type:"Hub Project" AND water`);
+      expect(searchOpts.q).toBe(`(type:"Hub Project") AND (water)`);
       expect(searchOpts.portal).toEqual(`https://qaext.arcgis.com`);
       expect(searchOpts.num).toBe(4);
       expect(searchOpts.sortField).toBe("created");
@@ -424,7 +424,7 @@ describe("HubProjects:", () => {
       // verify the query
       const searchOpts = searchSpy.calls.argsFor(0)[0];
 
-      expect(searchOpts.q).toBe(`type:"Hub Project" AND water`);
+      expect(searchOpts.q).toBe(`(type:"Hub Project") AND (water)`);
       expect(searchOpts.portal).toEqual(`https://qaext.arcgis.com`);
     });
   });

--- a/packages/common/test/search/_internal/portalSearchGroups.test.ts
+++ b/packages/common/test/search/_internal/portalSearchGroups.test.ts
@@ -32,7 +32,7 @@ describe("portalSearchGroups module:", () => {
       await portalSearchGroups(qry, o);
       expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
       const [expectedParams] = searchGroupsSpy.calls.argsFor(0);
-      expect(expectedParams.q).toEqual("water");
+      expect(expectedParams.q).toEqual("(water)");
       expect(expectedParams.portal).toBe("https://www.arcgis.com/sharing/rest");
       expect(expectedParams.requestOptions).toBeDefined();
     });
@@ -61,7 +61,7 @@ describe("portalSearchGroups module:", () => {
       await portalSearchGroups(qry, o);
       expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
       const [expectedParams] = searchGroupsSpy.calls.argsFor(0);
-      expect(expectedParams.q).toEqual("water");
+      expect(expectedParams.q).toEqual("(water)");
       expect(expectedParams.authentication).toBe(MOCK_ENTERPRISE_AUTH);
       expect(expectedParams.portal).toBeUndefined();
       expect(expectedParams.requestOptions).toBeDefined();
@@ -96,7 +96,7 @@ describe("portalSearchGroups module:", () => {
       await portalSearchGroups(qry, o);
       expect(searchGroupsSpy.calls.count()).toBe(1, "should call searchGroups");
       const [expectedParams] = searchGroupsSpy.calls.argsFor(0);
-      expect(expectedParams.q).toEqual("water");
+      expect(expectedParams.q).toEqual("(water)");
       expect(expectedParams.portal).toBe(
         "https://some-server.com/gis/sharing/rest"
       );

--- a/packages/common/test/search/_internal/portalSearchItems.test.ts
+++ b/packages/common/test/search/_internal/portalSearchItems.test.ts
@@ -66,7 +66,7 @@ describe("portalSearchItems Module:", () => {
       expect(searchItemsSpy.calls.count()).toBe(1, "should call searchItems");
       const [expectedParams] = searchItemsSpy.calls.argsFor(0);
       expect(expectedParams.portal).toEqual(opts.requestOptions?.portal);
-      expect(expectedParams.q).toEqual("water");
+      expect(expectedParams.q).toEqual("(water)");
       expect(expectedParams.countFields).not.toBeDefined();
     });
     it("simple search with auth", async () => {
@@ -97,7 +97,7 @@ describe("portalSearchItems Module:", () => {
       expect(searchItemsSpy.calls.count()).toBe(1, "should call searchItems");
       const [expectedParams] = searchItemsSpy.calls.argsFor(0);
       expect(expectedParams.portal).toBeUndefined();
-      expect(expectedParams.q).toEqual("water");
+      expect(expectedParams.q).toEqual("(water)");
       expect(expectedParams.authentication).toEqual(
         opts.requestOptions?.authentication
       );
@@ -131,7 +131,7 @@ describe("portalSearchItems Module:", () => {
       expect(searchItemsSpy.calls.count()).toBe(1, "should call searchItems");
       const [expectedParams] = searchItemsSpy.calls.argsFor(0);
       // verify q
-      expect(expectedParams.q).toEqual("water");
+      expect(expectedParams.q).toEqual("(water)");
       expect(expectedParams.countFields).toEqual("tags");
       expect(expectedParams.countSize).toEqual(10);
     });
@@ -164,7 +164,7 @@ describe("portalSearchItems Module:", () => {
       expect(searchItemsSpy.calls.count()).toBe(1, "should call searchItems");
       const [expectedParams] = searchItemsSpy.calls.argsFor(0);
       // verify q
-      expect(expectedParams.q).toEqual("water");
+      expect(expectedParams.q).toEqual("(water)");
       expect(expectedParams.countFields).toEqual("tags");
       expect(expectedParams.countSize).toEqual(100);
       expect(expectedParams.portal).toEqual(

--- a/packages/common/test/search/_internal/portalSearchUsers.test.ts
+++ b/packages/common/test/search/_internal/portalSearchUsers.test.ts
@@ -84,7 +84,7 @@ describe("portalSearchUsers module:", () => {
       expect(searchUsersSpy.calls.count()).toBe(1, "should call searchItems");
       const [expectedParams] = searchUsersSpy.calls.argsFor(0);
       expect(expectedParams.portal).toBeUndefined();
-      expect(expectedParams.q).toEqual(`firstname:"Jane"`);
+      expect(expectedParams.q).toEqual(`(firstname:"Jane")`);
       expect(expectedParams.authentication).toEqual(
         opts.requestOptions?.authentication
       );

--- a/packages/common/test/search/serializeQueryForPortal.test.ts
+++ b/packages/common/test/search/serializeQueryForPortal.test.ts
@@ -81,7 +81,7 @@ describe("ifilter-utils:", () => {
 
       const chk = serializeQueryForPortal(query);
 
-      expect(chk.q).toEqual(`(owner:"dave")`);
+      expect(chk.q).toEqual(`((owner:"dave"))`);
       expect(chk.searchUserAccess).toBe("groupMember");
     });
     it("it drops empty predicates: different order", () => {
@@ -107,7 +107,7 @@ describe("ifilter-utils:", () => {
 
       const chk = serializeQueryForPortal(query);
 
-      expect(chk.q).toEqual(`(owner:"dave")`);
+      expect(chk.q).toEqual(`((owner:"dave"))`);
       expect(chk.searchUserAccess).toBe("groupMember");
     });
     it("handles complex filter", () => {
@@ -132,7 +132,7 @@ describe("ifilter-utils:", () => {
       const chk = serializeQueryForPortal(query);
 
       expect(chk.q).toEqual(
-        '(tags:"water" OR tags:"rivers") AND tags:"production" AND (-tags:"preview" OR -tags:"deprecated")'
+        '((tags:"water" OR tags:"rivers") AND tags:"production" AND (-tags:"preview" OR -tags:"deprecated"))'
       );
     });
     it("can pass through props", () => {
@@ -185,7 +185,7 @@ describe("ifilter-utils:", () => {
       const chk = serializeQueryForPortal(query);
 
       expect(chk.q).toEqual(
-        'austin AND (type:"Hub Project" OR type:"Web Map" OR type:"Hub Site Application")'
+        '(austin) AND ((type:"Hub Project") OR (type:"Web Map") OR (type:"Hub Site Application"))'
       );
     });
     it("handles complex filter without any", () => {
@@ -209,7 +209,7 @@ describe("ifilter-utils:", () => {
       const chk = serializeQueryForPortal(query);
 
       expect(chk.q).toEqual(
-        'tags:"production" AND (-tags:"preview" OR -tags:"deprecated")'
+        '(tags:"production" AND (-tags:"preview" OR -tags:"deprecated"))'
       );
     });
     it("handles complex filter without any or all", () => {
@@ -231,7 +231,7 @@ describe("ifilter-utils:", () => {
 
       const chk = serializeQueryForPortal(query);
 
-      expect(chk.q).toEqual('(-tags:"preview" OR -tags:"deprecated")');
+      expect(chk.q).toEqual('((-tags:"preview" OR -tags:"deprecated"))');
     });
     it("handles simple filter ", () => {
       const p: IPredicate = {
@@ -250,7 +250,7 @@ describe("ifilter-utils:", () => {
 
       const chk = serializeQueryForPortal(query);
 
-      expect(chk.q).toEqual('tags:"water"');
+      expect(chk.q).toEqual('(tags:"water")');
     });
     it("handles capabilities filter ", () => {
       const p: IPredicate = {
@@ -269,7 +269,7 @@ describe("ifilter-utils:", () => {
 
       const chk = serializeQueryForPortal(query);
 
-      expect(chk.q).toEqual('capabilities:"updateitemcontrol"');
+      expect(chk.q).toEqual('(capabilities:"updateitemcontrol")');
     });
     it("handles bool filter ", () => {
       const p: IPredicate = {
@@ -288,7 +288,7 @@ describe("ifilter-utils:", () => {
 
       const chk = serializeQueryForPortal(query);
 
-      expect(chk.q).toEqual("isopendata:true");
+      expect(chk.q).toEqual("(isopendata:true)");
     });
     it("handles passthrough props ", () => {
       const p: IPredicate = {


### PR DESCRIPTION
1. Description: Fixes an issue with search. What I was seeing was that when I sent in a query that contained a filter like:

```js
{
  operation: "OR",
  predicates: ['$app', '$webmap']
};
```
The well known type filters would get combined in such a way that they could negate each other or otherwise produce incorrect results. What needed to happen was for each predicate to be wrapped in parens so they would be handled as a block when they were combined with others with an `AND' or an 'OR'.

1. Instructions for testing: run the tests

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
