### PR TITLE
fix: re-export survey utils

### DIFF
--- a/packages/surveys/src/utils/index.ts
+++ b/packages/surveys/src/utils/index.ts
@@ -4,4 +4,5 @@
 export * from "./is-draft";
 export * from "./is-published";
 export * from "./status-utils";
+export * from "./results-availability";
 export { isFieldworkerView } from "@esri/hub-common";


### PR DESCRIPTION
1. Description:

Some exports were mistakenly removed > year ago, but we never noticed b/c opendata-ui was not picking up later versions of `@esri/hub-surveys`. Now that we are doing a breaking chance and bumping all packages, this became a problem

1. Instructions for testing:

- run tests


1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
