### PR TITLE
feat(hub-common) project access and share/unshare groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22063,10 +22063,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22081,24 +22080,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22112,10 +22108,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22133,10 +22128,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -62703,7 +62697,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "9.49.1",
+			"version": "10.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -62736,7 +62730,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "11.36.1",
+			"version": "12.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62745,7 +62739,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62758,12 +62752,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "9.49.1"
+				"@esri/hub-common": "10.0.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "9.48.1",
+			"version": "10.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -62771,7 +62765,10 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/arcgis-rest-feature-layer": "^3.1.1",
+				"@esri/arcgis-rest-portal": "^3.4.2",
+				"@esri/arcgis-rest-request": "^3.1.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62780,12 +62777,16 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/hub-common": "9.49.1"
+				"@esri/arcgis-rest-auth": "^3.1.0",
+				"@esri/arcgis-rest-feature-layer": "^3.1.0",
+				"@esri/arcgis-rest-portal": "^3.4.0",
+				"@esri/arcgis-rest-request": "^3.1.0",
+				"@esri/hub-common": "10.0.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "9.48.1",
+			"version": "10.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62796,7 +62797,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62810,12 +62811,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.49.1"
+				"@esri/hub-common": "10.0.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "9.49.1",
+			"version": "10.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62824,7 +62825,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62837,12 +62838,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.49.1"
+				"@esri/hub-common": "10.0.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "9.48.1",
+			"version": "10.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62853,7 +62854,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62869,12 +62870,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.49.1"
+				"@esri/hub-common": "10.0.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "9.50.2",
+			"version": "10.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62883,9 +62884,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
-				"@esri/hub-initiatives": "9.49.1",
-				"@esri/hub-teams": "9.49.2",
+				"@esri/hub-common": "10.0.0",
+				"@esri/hub-initiatives": "10.0.0",
+				"@esri/hub-teams": "10.0.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -62898,9 +62899,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "9.49.1",
-				"@esri/hub-initiatives": "9.49.1",
-				"@esri/hub-teams": "9.49.2"
+				"@esri/hub-common": "10.0.0",
+				"@esri/hub-initiatives": "10.0.0",
+				"@esri/hub-teams": "10.0.0"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -62925,7 +62926,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "9.49.1",
+			"version": "10.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62936,7 +62937,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62950,12 +62951,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.49.1"
+				"@esri/hub-common": "10.0.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "9.49.2",
+			"version": "10.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62965,7 +62966,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62978,7 +62979,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "9.49.1"
+				"@esri/hub-common": "10.0.0"
 			}
 		}
 	},
@@ -66386,7 +66387,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -66405,7 +66406,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -66424,7 +66425,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -66440,7 +66441,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -66459,7 +66460,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -66477,9 +66478,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
-				"@esri/hub-initiatives": "9.49.1",
-				"@esri/hub-teams": "9.49.2",
+				"@esri/hub-common": "10.0.0",
+				"@esri/hub-initiatives": "10.0.0",
+				"@esri/hub-teams": "10.0.0",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -66516,7 +66517,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -66533,7 +66534,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "9.49.1",
+				"@esri/hub-common": "10.0.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -80854,8 +80855,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -80870,20 +80870,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -80897,8 +80894,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -80915,8 +80911,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62703,7 +62703,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "10.0.0-next.7",
+			"version": "9.49.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -62736,7 +62736,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "12.0.0-next.7",
+			"version": "11.36.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62745,7 +62745,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62758,12 +62758,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "10.0.0-next.7"
+				"@esri/hub-common": "9.49.1"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "10.0.0-next.8",
+			"version": "9.48.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -62771,10 +62771,7 @@
 			},
 			"devDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.1",
-				"@esri/arcgis-rest-feature-layer": "^3.1.1",
-				"@esri/arcgis-rest-portal": "^3.4.2",
-				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62783,16 +62780,12 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/arcgis-rest-auth": "^3.1.0",
-				"@esri/arcgis-rest-feature-layer": "^3.1.0",
-				"@esri/arcgis-rest-portal": "^3.4.0",
-				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "10.0.0-next.7"
+				"@esri/hub-common": "9.49.1"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "10.0.0-next.7",
+			"version": "9.48.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62803,7 +62796,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62817,12 +62810,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.7"
+				"@esri/hub-common": "9.49.1"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "10.0.0-next.7",
+			"version": "9.49.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62831,7 +62824,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62844,12 +62837,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.7"
+				"@esri/hub-common": "9.49.1"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "10.0.0-next.7",
+			"version": "9.48.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62860,7 +62853,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62876,12 +62869,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.7"
+				"@esri/hub-common": "9.49.1"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "10.0.0-next.8",
+			"version": "9.50.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62890,9 +62883,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
-				"@esri/hub-initiatives": "10.0.0-next.7",
-				"@esri/hub-teams": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
+				"@esri/hub-initiatives": "9.49.1",
+				"@esri/hub-teams": "9.49.2",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -62905,9 +62898,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.7",
-				"@esri/hub-initiatives": "10.0.0-next.7",
-				"@esri/hub-teams": "10.0.0-next.7"
+				"@esri/hub-common": "9.49.1",
+				"@esri/hub-initiatives": "9.49.1",
+				"@esri/hub-teams": "9.49.2"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -62932,7 +62925,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "10.0.0-next.8",
+			"version": "9.49.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62943,7 +62936,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62957,12 +62950,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.7"
+				"@esri/hub-common": "9.49.1"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "10.0.0-next.7",
+			"version": "9.49.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62972,7 +62965,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -62985,7 +62978,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "10.0.0-next.7"
+				"@esri/hub-common": "9.49.1"
 			}
 		}
 	},
@@ -66393,7 +66386,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -66412,7 +66405,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -66431,7 +66424,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -66447,7 +66440,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -66466,7 +66459,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -66484,9 +66477,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
-				"@esri/hub-initiatives": "10.0.0-next.7",
-				"@esri/hub-teams": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
+				"@esri/hub-initiatives": "9.49.1",
+				"@esri/hub-teams": "9.49.2",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -66523,7 +66516,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",
@@ -66540,7 +66533,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "10.0.0-next.7",
+				"@esri/hub-common": "9.49.1",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/common/src/core/types/IHubItemEntity.ts
+++ b/packages/common/src/core/types/IHubItemEntity.ts
@@ -1,5 +1,6 @@
 import { IHubEntityBase } from "./IHubEntityBase";
 import { IHubGeography } from "../../types";
+import { AccessLevel } from "./types";
 
 /**
  * Properties exposed by Entities that are backed by Items
@@ -41,4 +42,8 @@ export interface IHubItemEntity extends IHubEntityBase {
    * Canonical Url for the Entity
    */
   url?: string;
+  /**
+   * Access level of the item ("private" | "org" | "public")
+   */
+  access?: AccessLevel;
 }

--- a/packages/common/src/projects/HubProjectManager.ts
+++ b/packages/common/src/projects/HubProjectManager.ts
@@ -287,7 +287,7 @@ export class HubProjectManager
     project: IHubProject,
     group: IGroup,
     requestOptions?: IUserRequestOptions
-  ) {
+  ): Promise<ISharingResponse> {
     if (requestOptions || this.context.isAuthenticated) {
       const ro = requestOptions || this.context.userRequestOptions;
       return shareItemWithGroup({
@@ -317,11 +317,13 @@ export class HubProjectManager
     project: IHubProject,
     groups: IGroup[],
     requestOptions?: IUserRequestOptions
-  ) {
+  ): Promise<ISharingResponse[]> {
     if (requestOptions || this.context.isAuthenticated) {
       const failSafeShare = failSafe(this.shareToGroup);
-      return groups.map((group: IGroup) =>
-        failSafeShare(project, group, requestOptions)
+      return Promise.all(
+        groups.map((group: IGroup) =>
+          failSafeShare(project, group, requestOptions)
+        )
       );
     } else {
       throw new HubError(
@@ -343,7 +345,7 @@ export class HubProjectManager
     project: IHubProject,
     group: IGroup,
     requestOptions?: IUserRequestOptions
-  ) {
+  ): Promise<ISharingResponse> {
     if (requestOptions || this.context.isAuthenticated) {
       const ro = requestOptions || this.context.userRequestOptions;
       return unshareItemWithGroup({
@@ -372,11 +374,13 @@ export class HubProjectManager
     project: IHubProject,
     groups: IGroup[],
     requestOptions?: IUserRequestOptions
-  ) {
+  ): Promise<ISharingResponse[]> {
     if (requestOptions || this.context.isAuthenticated) {
       const failSafeUnshare = failSafe(this.unshareFromGroup);
-      return groups.map((group: IGroup) =>
-        failSafeUnshare(project, group, requestOptions)
+      return Promise.all(
+        groups.map((group: IGroup) =>
+          failSafeUnshare(project, group, requestOptions)
+        )
       );
     } else {
       throw new HubError(

--- a/packages/common/src/projects/HubProjectManager.ts
+++ b/packages/common/src/projects/HubProjectManager.ts
@@ -20,7 +20,14 @@ import {
 import { IHubEntityManager, IHubProject } from "../core/types";
 import { IHubItemEntityManager } from "../core/types/IHubItemEntityManager";
 import { setItemThumbnail as updateItemThumbnail } from "../items/setItemThumbnail";
-import { IItem } from "@esri/arcgis-rest-types";
+import { IGroup, IItem } from "@esri/arcgis-rest-types";
+import {
+  ISharingResponse,
+  setItemAccess,
+  shareItemWithGroup,
+  unshareItemWithGroup,
+} from "@esri/arcgis-rest-portal";
+import { failSafe, isUpdateGroup } from "../utils";
 
 /**
  * Centralized functions used to manage IHubProject instances
@@ -237,5 +244,145 @@ export class HubProjectManager
   ): Promise<IHubProject> {
     const ro = requestOptions || this.context.userRequestOptions;
     return convertItemToProject(item, ro);
+  }
+
+  /**
+   * Sets the access level of a Hub Project
+   *
+   * @param {IHubProject} project
+   * @param {("public" | "org" | "private")} accessLevel
+   * @param {IUserRequestOptions} [requestOptions]
+   * @returns
+   */
+  async setAccess(
+    project: IHubProject,
+    accessLevel: "public" | "org" | "private",
+    requestOptions?: IUserRequestOptions
+  ): Promise<ISharingResponse> {
+    if (requestOptions || this.context.isAuthenticated) {
+      const ro = requestOptions || this.context.userRequestOptions;
+      return setItemAccess({
+        id: project.id,
+        owner: project.owner,
+        access: accessLevel,
+        ...ro,
+      });
+    } else {
+      throw new HubError(
+        "Set Project Access",
+        "Setting Hub Projects access level requires authentication."
+      );
+    }
+  }
+
+  /**
+   * Shares a Hub Project to a group
+   *
+   * @param {IHubProject} project
+   * @param {IGroup} group
+   * @param {IUserRequestOptions} [requestOptions]
+   * @returns
+   */
+  async shareToGroup(
+    project: IHubProject,
+    group: IGroup,
+    requestOptions?: IUserRequestOptions
+  ) {
+    if (requestOptions || this.context.isAuthenticated) {
+      const ro = requestOptions || this.context.userRequestOptions;
+      return shareItemWithGroup({
+        id: project.id,
+        owner: project.owner,
+        groupId: group.id,
+        confirmItemControl: isUpdateGroup(group),
+        ...ro,
+      });
+    } else {
+      throw new HubError(
+        "Share Project to Group",
+        "Sharing Hub Projects to group requires authentication."
+      );
+    }
+  }
+
+  /**
+   * Shares a Hub Project to N Groups.
+   *
+   * @param {IHubProject} project
+   * @param {IGroup[]} groups
+   * @param {IUserRequestOptions} [requestOptions]
+   * @returns
+   */
+  async shareToGroups(
+    project: IHubProject,
+    groups: IGroup[],
+    requestOptions?: IUserRequestOptions
+  ) {
+    if (requestOptions || this.context.isAuthenticated) {
+      const failSafeShare = failSafe(this.shareToGroup);
+      return groups.map((group: IGroup) =>
+        failSafeShare(project, group, requestOptions)
+      );
+    } else {
+      throw new HubError(
+        "Share Project to Groups",
+        "Sharing Hub Projects to groups requires authentication."
+      );
+    }
+  }
+
+  /**
+   * Unshares a Hub Project from a group
+   *
+   * @param {IHubProject} project
+   * @param {IGroup} group
+   * @param {IUserRequestOptions} [requestOptions]
+   * @returns
+   */
+  async unshareFromGroup(
+    project: IHubProject,
+    group: IGroup,
+    requestOptions?: IUserRequestOptions
+  ) {
+    if (requestOptions || this.context.isAuthenticated) {
+      const ro = requestOptions || this.context.userRequestOptions;
+      return unshareItemWithGroup({
+        id: project.id,
+        owner: project.owner,
+        groupId: group.id,
+        ...ro,
+      });
+    } else {
+      throw new HubError(
+        "Unshare Project from Group",
+        "Unsharing Hub Project from group requires authentication."
+      );
+    }
+  }
+
+  /**
+   * Unshares a Hub Project from N groups.
+   *
+   * @param {IHubProject} project
+   * @param {IGroup[]} groups
+   * @param {IUserRequestOptions} [requestOptions]
+   * @returns
+   */
+  async unshareFromGroups(
+    project: IHubProject,
+    groups: IGroup[],
+    requestOptions?: IUserRequestOptions
+  ) {
+    if (requestOptions || this.context.isAuthenticated) {
+      const failSafeUnshare = failSafe(this.unshareFromGroup);
+      return groups.map((group: IGroup) =>
+        failSafeUnshare(project, group, requestOptions)
+      );
+    } else {
+      throw new HubError(
+        "Unshare Project from Groups",
+        "Unsharing Hub Project from groups requires authentication."
+      );
+    }
   }
 }

--- a/packages/common/src/projects/HubProjects.ts
+++ b/packages/common/src/projects/HubProjects.ts
@@ -105,6 +105,7 @@ function getProjectPropertyMap(): IPropertyMap[] {
     "typeKeywords",
     "url",
     "type",
+    "access",
   ];
   const dataProps = [
     "contacts",

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -212,6 +212,7 @@ function getSitePropertyMap(): IPropertyMap[] {
     "typeKeywords",
     "url",
     "type",
+    "access",
   ];
 
   const map: IPropertyMap[] = [];

--- a/packages/common/test/projects/HubProjectManager.test.ts
+++ b/packages/common/test/projects/HubProjectManager.test.ts
@@ -1,5 +1,6 @@
 import { IUser, UserSession } from "@esri/arcgis-rest-auth";
 import { IItem, IPortal } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 // For node jasmine tests to work, contextmanager & context need
 // to be imported with a full path
 import { ArcGISContextManager } from "../../src/ArcGISContextManager";
@@ -9,6 +10,7 @@ import { getProp, IArcGISContextOptions, IHubProject, IQuery } from "../../src";
 import * as HubProjects from "../../src/projects/HubProjects";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as ThumbnailModule from "../../src/items/setItemThumbnail";
+import * as portal from "@esri/arcgis-rest-portal";
 
 describe("HubProjectManager:", () => {
   // Setup the store
@@ -114,6 +116,238 @@ describe("HubProjectManager:", () => {
         await unauthdMgr.update({
           name: "Fake project",
         } as unknown as IHubProject);
+      } catch (err) {
+        expect(getProp(err, "name")).toBe("HubError");
+        expect(getProp(err, "message")).toContain("requires authentication");
+      }
+    });
+  });
+
+  describe("access:", () => {
+    let accessSpy: jasmine.Spy;
+    beforeEach(() => {
+      accessSpy = spyOn(portal, "setItemAccess").and.returnValue(
+        Promise.resolve({
+          id: "3ef",
+        })
+      );
+    });
+    it("uses context by default", async () => {
+      await authdMgr.setAccess(
+        { id: "3ef", owner: "test" } as unknown as IHubProject,
+        "org"
+      );
+      const ro = accessSpy.calls.argsFor(0)[0];
+      expect(ro.authentication).toBe(MOCK_AUTH);
+    });
+    it("uses reqOpts if passed", async () => {
+      const fakeSession = {
+        username: "vader",
+      } as unknown as UserSession;
+      await authdMgr.setAccess(
+        { id: "3ef", owner: "test" } as unknown as IHubProject,
+        "org",
+        { authentication: fakeSession }
+      );
+      const ro = accessSpy.calls.argsFor(0)[0];
+      expect(ro.authentication).toBe(fakeSession);
+    });
+    it("throws HubError if not authd", async () => {
+      try {
+        await unauthdMgr.setAccess(
+          { id: "3ef", owner: "test" } as unknown as IHubProject,
+          "org"
+        );
+      } catch (err) {
+        expect(getProp(err, "name")).toBe("HubError");
+        expect(getProp(err, "message")).toContain("requires authentication");
+      }
+    });
+  });
+
+  describe("shareToGroup:", () => {
+    let groupSpy: jasmine.Spy;
+    beforeEach(() => {
+      groupSpy = spyOn(portal, "shareItemWithGroup").and.returnValue(
+        Promise.resolve({
+          id: "3ef",
+        })
+      );
+    });
+    it("uses context by default", async () => {
+      await authdMgr.shareToGroup(
+        { id: "3ef", owner: "test" } as unknown as IHubProject,
+        {
+          id: "abc123",
+          capabilities: ["updateitemcontrol"],
+        } as unknown as IGroup
+      );
+      const ro = groupSpy.calls.argsFor(0)[0];
+      expect(ro.authentication).toBe(MOCK_AUTH);
+    });
+    it("uses reqOpts if passed", async () => {
+      const fakeSession = {
+        username: "vader",
+      } as unknown as UserSession;
+      await authdMgr.shareToGroup(
+        { id: "3ef", owner: "test" } as unknown as IHubProject,
+        {
+          id: "abc123",
+          capabilities: ["updateitemcontrol"],
+        } as unknown as IGroup,
+        { authentication: fakeSession }
+      );
+      const ro = groupSpy.calls.argsFor(0)[0];
+      expect(ro.authentication).toBe(fakeSession);
+    });
+    it("throws HubError if not authd", async () => {
+      try {
+        await unauthdMgr.shareToGroup(
+          { id: "3ef", owner: "test" } as unknown as IHubProject,
+          {
+            id: "abc123",
+            capabilities: ["updateitemcontrol"],
+          } as unknown as IGroup
+        );
+      } catch (err) {
+        expect(getProp(err, "name")).toBe("HubError");
+        expect(getProp(err, "message")).toContain("requires authentication");
+      }
+    });
+  });
+
+  describe("shareToGroups:", () => {
+    let groupsSpy: jasmine.Spy;
+    beforeEach(() => {
+      groupsSpy = spyOn(portal, "shareItemWithGroup").and.returnValue(
+        Promise.resolve({
+          id: "3ef",
+        })
+      );
+    });
+    it("uses reqOpts if passed", async () => {
+      const fakeSession = {
+        username: "vader",
+      } as unknown as UserSession;
+      await authdMgr.shareToGroups(
+        { id: "3ef", owner: "test" } as unknown as IHubProject,
+        [
+          {
+            id: "abc123",
+            capabilities: ["updateitemcontrol"],
+          } as unknown as IGroup,
+        ],
+        { authentication: fakeSession }
+      );
+      const ro = groupsSpy.calls.argsFor(0)[0];
+      expect(ro.authentication).toBe(fakeSession);
+    });
+    it("throws HubError if not authd", async () => {
+      try {
+        await unauthdMgr.shareToGroups(
+          { id: "3ef", owner: "test" } as unknown as IHubProject,
+          [
+            {
+              id: "abc123",
+              capabilities: ["updateitemcontrol"],
+            } as unknown as IGroup,
+          ]
+        );
+      } catch (err) {
+        expect(getProp(err, "name")).toBe("HubError");
+        expect(getProp(err, "message")).toContain("requires authentication");
+      }
+    });
+  });
+
+  describe("unshareFromGroup:", () => {
+    let groupSpy: jasmine.Spy;
+    beforeEach(() => {
+      groupSpy = spyOn(portal, "unshareItemWithGroup").and.returnValue(
+        Promise.resolve({
+          id: "3ef",
+        })
+      );
+    });
+    it("uses context by default", async () => {
+      await authdMgr.unshareFromGroup(
+        { id: "3ef", owner: "test" } as unknown as IHubProject,
+        {
+          id: "abc123",
+          capabilities: ["updateitemcontrol"],
+        } as unknown as IGroup
+      );
+      const ro = groupSpy.calls.argsFor(0)[0];
+      expect(ro.authentication).toBe(MOCK_AUTH);
+    });
+    it("uses reqOpts if passed", async () => {
+      const fakeSession = {
+        username: "vader",
+      } as unknown as UserSession;
+      await authdMgr.unshareFromGroup(
+        { id: "3ef", owner: "test" } as unknown as IHubProject,
+        {
+          id: "abc123",
+          capabilities: ["updateitemcontrol"],
+        } as unknown as IGroup,
+        { authentication: fakeSession }
+      );
+      const ro = groupSpy.calls.argsFor(0)[0];
+      expect(ro.authentication).toBe(fakeSession);
+    });
+    it("throws HubError if not authd", async () => {
+      try {
+        await unauthdMgr.unshareFromGroup(
+          { id: "3ef", owner: "test" } as unknown as IHubProject,
+          {
+            id: "abc123",
+            capabilities: ["updateitemcontrol"],
+          } as unknown as IGroup
+        );
+      } catch (err) {
+        expect(getProp(err, "name")).toBe("HubError");
+        expect(getProp(err, "message")).toContain("requires authentication");
+      }
+    });
+  });
+
+  describe("unshareFromGroups:", () => {
+    let groupSpy: jasmine.Spy;
+    beforeEach(() => {
+      groupSpy = spyOn(portal, "unshareItemWithGroup").and.returnValue(
+        Promise.resolve({
+          id: "3ef",
+        })
+      );
+    });
+    it("uses reqOpts if passed", async () => {
+      const fakeSession = {
+        username: "vader",
+      } as unknown as UserSession;
+      await authdMgr.unshareFromGroups(
+        { id: "3ef", owner: "test" } as unknown as IHubProject,
+        [
+          {
+            id: "abc123",
+            capabilities: ["updateitemcontrol"],
+          } as unknown as IGroup,
+        ],
+        { authentication: fakeSession }
+      );
+      const ro = groupSpy.calls.argsFor(0)[0];
+      expect(ro.authentication).toBe(fakeSession);
+    });
+    it("throws HubError if not authd", async () => {
+      try {
+        await unauthdMgr.unshareFromGroups(
+          { id: "3ef", owner: "test" } as unknown as IHubProject,
+          [
+            {
+              id: "abc123",
+              capabilities: ["updateitemcontrol"],
+            } as unknown as IGroup,
+          ]
+        );
       } catch (err) {
         expect(getProp(err, "name")).toBe("HubError");
         expect(getProp(err, "message")).toContain("requires authentication");


### PR DESCRIPTION
1. Description:
- [x] Adds access to `IHubItemEntity`
- [x] Adds methods to `HubProjectManager` for setting a projects access level and share/unshare from groups.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
