### PR TITLE
feat(hub-discussions): adding support for ACL in hub.js discussions p…

### DIFF
--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -227,6 +227,27 @@ export interface IWithEditor {
   editor: string;
 }
 
+export interface IPermission {
+  role: string;
+  createdAt: string;
+  updatedAt: string;
+  accessibleAfter: string;
+}
+
+export interface IACL {
+  anonymous?: IPermission;
+  authenticated?: IPermission;
+  groups?: {
+    [key: string]: IPermission;
+  };
+  orgs?: {
+    [key: string]: IPermission;
+  };
+  users: {
+    [key: string]: IPermission;
+  };
+}
+
 /**
  * channel settings properties
  *
@@ -241,6 +262,7 @@ export interface IWithSettings {
   allowReaction: boolean;
   allowedReactions?: PostReaction[];
   blockwords?: string[];
+  acl?: ACL;
 }
 
 /**


### PR DESCRIPTION
Notes For @rgwozdz : I added the interfaces that we need to support ACL and added ACL to the IWithSettings interface. I'm a little confused on how to make it so that we let the developers know that they can only pass in access/groups OR acl. I'm not sure if that's something we need to document to let the user know how to use it or if we need to gate that here somewhere in Hub.js


…ackage

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
