### PR TITLE
chore: identify and fix slow running tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -83,7 +83,20 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ["jasmine-diff", "dots", "karma-typescript"],
+    reporters: [
+      // replace "dots" with "spec" to get verbose info on tests, including timing
+      "dots",
+      "jasmine-diff",
+      "karma-typescript"
+    ],
+
+    // NOTE: this is only used when when reporters includes "spec"
+    specReporter: {
+      // useful for identifying long-running tests
+      showSpecTiming: true,
+      // useful when using fdescribe() or fit()
+      // suppressSkipped: true
+    },
 
     // web server port
     port: 9876,

--- a/package-lock.json
+++ b/package-lock.json
@@ -62875,7 +62875,7 @@
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "10.0.0",
+			"version": "10.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62886,7 +62886,7 @@
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/hub-common": "10.0.0",
 				"@esri/hub-initiatives": "10.0.0",
-				"@esri/hub-teams": "10.0.0",
+				"@esri/hub-teams": "10.0.1",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -62901,7 +62901,7 @@
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/hub-common": "10.0.0",
 				"@esri/hub-initiatives": "10.0.0",
-				"@esri/hub-teams": "10.0.0"
+				"@esri/hub-teams": "10.0.1"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -62956,7 +62956,7 @@
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "10.0.0",
+			"version": "10.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -66480,7 +66480,7 @@
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/hub-common": "10.0.0",
 				"@esri/hub-initiatives": "10.0.0",
-				"@esri/hub-teams": "10.0.0",
+				"@esri/hub-teams": "10.0.1",
 				"@esri/hub-types": "^6.10.0",
 				"@rollup/plugin-commonjs": "^15.0.0",
 				"@rollup/plugin-json": "^4.1.0",

--- a/packages/common/src/items/_internal/_wait-for-item-ready.ts
+++ b/packages/common/src/items/_internal/_wait-for-item-ready.ts
@@ -18,11 +18,14 @@ function delay(milliseconds: number) {
  */
 export async function _waitForItemReady(
   itemId: string,
-  requestOptions: IUserRequestOptions
+  requestOptions: IUserRequestOptions,
+  milliseconds?: number
 ): Promise<void> {
   let statusResult: IGetItemStatusResponse;
   do {
-    await delay(2000);
+    await delay(
+      milliseconds || /* istanbul ignore next: slows down tests */ 2000
+    );
 
     statusResult = await getItemStatus({
       id: itemId,

--- a/packages/common/src/search/_internal/portalSearchUsers.ts
+++ b/packages/common/src/search/_internal/portalSearchUsers.ts
@@ -4,7 +4,7 @@ import {
   searchUsers,
 } from "@esri/arcgis-rest-portal";
 import { IUser } from "@esri/arcgis-rest-types";
-import { enrichUserSearchResult } from "../..";
+import { enrichUserSearchResult } from "../../users";
 import { serializeQueryForPortal } from "../serializeQueryForPortal";
 import HubError from "../../HubError";
 import { IHubRequestOptions } from "../../types";
@@ -120,18 +120,18 @@ async function searchPortal(
  * Convert an Item to a IHubSearchResult
  * Fetches the includes and attaches them to the item
  * @param item
- * @param includes
+ * @param include
  * @param requestOptions
  * @returns
  */
 async function userToSearchResult(
   user: IUser,
-  includes: string[] = [],
+  include: string[] = [],
   requestOptions?: IHubRequestOptions
 ): Promise<IHubSearchResult> {
   // Delegate to HubGroups module
   // This layer of indirection is not necessary but
   // aligns with how the items search works and
   // allows for future specialization
-  return enrichUserSearchResult(user, includes, requestOptions);
+  return enrichUserSearchResult(user, include, requestOptions);
 }

--- a/packages/common/test/items/_wait-for-item-ready.test.ts
+++ b/packages/common/test/items/_wait-for-item-ready.test.ts
@@ -2,12 +2,8 @@ import * as portal from "@esri/arcgis-rest-portal";
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { _waitForItemReady } from "../../src/items/_internal/_wait-for-item-ready";
 
-function delay(milliseconds: number) {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds));
-}
-
 describe("_waitForItemReady", () => {
-  it("works for success", async (done) => {
+  it("works for success", async () => {
     try {
       // auth
       const ro = {
@@ -17,27 +13,16 @@ describe("_waitForItemReady", () => {
       } as IUserRequestOptions;
 
       spyOn(portal, "getItemStatus").and.returnValues(
-        new Promise((resolve, reject) => {
-          resolve({
-            status: "partial",
-          });
-        }),
-        new Promise((resolve, reject) => {
-          resolve({
-            status: "completed",
-          });
-        })
+        Promise.resolve({ status: "partial" }),
+        Promise.resolve({ status: "completed" })
       );
-      await _waitForItemReady("1234abc", ro);
-      await delay(100);
+      await _waitForItemReady("1234abc", ro, 10);
       expect(portal.getItemStatus).toHaveBeenCalledTimes(2);
     } catch (err) {
       expect(err).toEqual(undefined);
-    } finally {
-      done();
     }
   });
-  it("throws an error when an error occurs", async (done) => {
+  it("throws an error when an error occurs", async () => {
     try {
       // auth
       const ro = {
@@ -47,26 +32,17 @@ describe("_waitForItemReady", () => {
       } as IUserRequestOptions;
 
       spyOn(portal, "getItemStatus").and.returnValues(
-        new Promise((resolve, reject) => {
-          resolve({
-            status: "partial",
-          });
-        }),
-        new Promise((resolve, reject) => {
-          resolve({
-            status: "failed",
-            statusMessage: "Upload failed",
-          });
+        Promise.resolve({ status: "partial" }),
+        Promise.resolve({
+          status: "failed",
+          statusMessage: "Upload failed",
         })
       );
 
-      await _waitForItemReady("1234abc", ro);
-      await delay(100);
+      await _waitForItemReady("1234abc", ro, 10);
       expect(portal.getItemStatus).toHaveBeenCalledTimes(2);
     } catch (err) {
-      expect(err.message).toEqual("Upload failed");
-    } finally {
-      done();
+      expect((err as Error).message).toEqual("Upload failed");
     }
   });
 });

--- a/packages/common/test/search/_internal/portalSearchUsers.test.ts
+++ b/packages/common/test/search/_internal/portalSearchUsers.test.ts
@@ -1,6 +1,7 @@
 import { cloneObject, IHubSearchOptions, IQuery } from "../../../src";
 import { portalSearchUsers } from "../../../src/search/_internal/portalSearchUsers";
 import * as Portal from "@esri/arcgis-rest-portal";
+import * as users from "../../../src/users";
 import { MOCK_AUTH } from "../../mocks/mock-auth";
 import * as SimpleResponse from "../../mocks/user-search/simple-response.json";
 
@@ -60,6 +61,11 @@ describe("portalSearchUsers module:", () => {
       const searchUsersSpy = spyOn(Portal, "searchUsers").and.callFake(() => {
         return Promise.resolve(cloneObject(SimpleResponse));
       });
+      // NOTE: enrichUserSearchResult is tested elsewhere so we don't assert on the results here
+      const enrichUserSearchResultSpy = spyOn(
+        users,
+        "enrichUserSearchResult"
+      ).and.callFake(() => Promise.resolve({}));
       const qry: IQuery = {
         targetEntity: "user",
         filters: [
@@ -79,7 +85,7 @@ describe("portalSearchUsers module:", () => {
         },
       };
 
-      await await portalSearchUsers(qry, opts);
+      await portalSearchUsers(qry, opts);
 
       expect(searchUsersSpy.calls.count()).toBe(1, "should call searchItems");
       const [expectedParams] = searchUsersSpy.calls.argsFor(0);
@@ -89,6 +95,10 @@ describe("portalSearchUsers module:", () => {
         opts.requestOptions?.authentication
       );
       expect(expectedParams.countFields).not.toBeDefined();
+      expect(enrichUserSearchResultSpy.calls.count()).toBe(
+        10,
+        "should call enrichUserSearchResult for each result"
+      );
     });
   });
 });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Tests now run in ~3s for me locally compared w/ ~12s before.

Also cleans up tests that were using `async` and `done()` which was causing warnings in the node output, and documents how to use the spec reported to identify slow-running tests.

1. Instructions for testing:

1. Closes Issues: [4540](https://devtopia.esri.com/dc/hub/issues/4540)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
