### PR TITLE
chore(hub-common): remove some logging messages from the test results

### DIFF
--- a/packages/common/src/resources/_internal/_validate-url-helpers.ts
+++ b/packages/common/src/resources/_internal/_validate-url-helpers.ts
@@ -61,7 +61,7 @@ export function isUrl(url: string): boolean {
     // Cast to bool.
     return !!result;
   } catch (e) {
-    Logger.error(`Error parsing data url`);
+    Logger.error(`Error parsing URL`);
     return false;
   }
 }

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -112,7 +112,6 @@ describe("ArcGISContext:", () => {
       const t = new Date().getTime();
       const mgr = await ArcGISContextManager.create({
         portalUrl: "https://myserver.com/gis",
-        logLevel: Level.debug,
       });
       expect(mgr.context.id).toBeGreaterThanOrEqual(t);
 
@@ -128,7 +127,7 @@ describe("ArcGISContext:", () => {
       mgr.setProperties({ hubSite });
       expect(mgr.context.properties.hubSite).toEqual(hubSite);
     });
-    it("verify when passed properties", async () => {
+    it("verify when passed log level and properties", async () => {
       const t = new Date().getTime();
       const site = {
         id: "bc3",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Also updates `isUrl()` error message to be more accurate.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
