### PR TITLE
feat(hub-common): introduces a getFamilyTypes function

### DIFF
--- a/packages/common/src/collections.ts
+++ b/packages/common/src/collections.ts
@@ -142,6 +142,20 @@ export const getCollection = (type?: string) => {
   });
 };
 
+/**
+ * The converse of getCollection, returns associated types of provided collection
+ * @param collection The Hub collection
+ * @returns An array of types or undefined if collection is not found
+ * @private
+ */
+export const getCollectionTypes = (collection?: string) => {
+  if (!collection) {
+    return;
+  }
+  const lowerCaseCollection = collection.toLocaleLowerCase();
+  return collections[lowerCaseCollection];
+};
+
 // TODO: remove this when we remove the deprecated categories
 // and then move the above arrays and getCollection() logic to get-family
 export const collections: { [key: string]: string[] } = {

--- a/packages/common/src/content/get-family.ts
+++ b/packages/common/src/content/get-family.ts
@@ -1,5 +1,5 @@
 import { HubFamily } from "../types";
-import { getCollection } from "../collections";
+import { getCollection, getCollectionTypes } from "../collections";
 
 // private helper functions
 function collectionToFamily(collection: string): string {
@@ -44,4 +44,57 @@ export function getFamily(type: string) {
       family = collectionToFamily(getCollection(type));
   }
   return family as HubFamily;
+}
+
+/**
+ * return the types associated with a provided Hub Family
+ * Overrides are provided to match getFamily implementation
+ * @param type item type
+ * @returns Hub family
+ */
+export function getFamilyTypes(family: HubFamily): string[] {
+  let types;
+  // override default behavior for the rows that are highlighted in yellow here:
+  // https://esriis.sharepoint.com/:x:/r/sites/ArcGISHub/_layouts/15/Doc.aspx?sourcedoc=%7BADA1C9DC-4F6C-4DE4-92C6-693EF9571CFA%7D&file=Hub%20Routes.xlsx&nav=MTBfe0VENEREQzI4LUZFMDctNEI0Ri04NjcyLThCQUE2MTA0MEZGRn1fezIwMTIwMEJFLTA4MEQtNEExRC05QzA4LTE5MTAzOUQwMEE1RH0&action=default&mobileredirect=true&cid=df1c874b-c367-4cea-bc13-7bebfad3f2ac
+  switch (family.toLowerCase()) {
+    case "content":
+      types = getCollectionTypes("other");
+      types = types.concat([
+        "CAD Drawing",
+        "Feature Collection Template",
+        "Report Template",
+      ]);
+      break;
+    case "template":
+      types = getCollectionTypes("solution");
+      break;
+    case "dataset":
+      types = getCollectionTypes(family.toLowerCase()).filter(
+        (type) =>
+          type !== "Feature Collection Template" &&
+          type !== "Feature Service" &&
+          type !== "Raster Layer" &&
+          type !== "Microsoft Excel"
+      );
+      types = types.concat("Image Service");
+      break;
+    case "map":
+      types = getCollectionTypes(family.toLowerCase()).filter(
+        (type) => type !== "Image Service"
+      );
+      types = types.concat(["Feature Service", "Raster Layer"]);
+      break;
+    case "document":
+      types = getCollectionTypes(family.toLowerCase()).filter(
+        (type) => type !== "CAD Drawing" && type !== "Report Template"
+      );
+      types = types.concat("Microsoft Excel");
+      break;
+    case "project":
+      types = ["Hub Project"];
+      break;
+    default:
+      types = getCollectionTypes(family.toLowerCase());
+  }
+  return types;
 }

--- a/packages/common/test/collections.test.ts
+++ b/packages/common/test/collections.test.ts
@@ -1,15 +1,34 @@
-import { getCollection } from "../src/collections";
+import { getCollection, getCollectionTypes } from "../src/collections";
 
-describe("getCollection", () => {
-  it("can abort", () => {
-    expect(getCollection()).toBe(undefined);
+describe("collections", () => {
+  describe("getCollections", () => {
+    it("can abort", () => {
+      expect(getCollection()).toBe(undefined);
+    });
+
+    it("can retrieve a single category", () => {
+      expect(getCollection("Feature Layer")).toBe("dataset");
+    });
+
+    it("can retrieve a single category (from cache)", () => {
+      expect(getCollection("Feature Layer")).toBe("dataset");
+    });
   });
 
-  it("can retrieve a single category", () => {
-    expect(getCollection("Feature Layer")).toBe("dataset");
-  });
+  describe("getTypesFromCollection", () => {
+    it("can abort", () => {
+      expect(getCollectionTypes()).toBe(undefined);
+    });
 
-  it("can retrieve a single category (from cache)", () => {
-    expect(getCollection("Feature Layer")).toBe("dataset");
+    it("can retrieve types from a collection", () => {
+      expect(getCollectionTypes("feedback")).toEqual([
+        "Form",
+        "Quick Capture Project",
+      ]);
+    });
+
+    it("returns undefined with unknown collection", () => {
+      expect(getCollectionTypes("dummy")).toBe(undefined);
+    });
   });
 });

--- a/packages/common/test/content/get-family.test.ts
+++ b/packages/common/test/content/get-family.test.ts
@@ -1,0 +1,68 @@
+import { getFamilyTypes } from "../../src";
+
+describe("getFamily", () => {
+  describe("getFamilyTypes", () => {
+    it("can get 'content' types", () => {
+      const types = getFamilyTypes("content");
+      expect(Array.isArray(types)).toBeTruthy();
+      expect(types.length > 0).toBeTruthy();
+      expect(types.includes("CAD Drawing")).toBeTruthy();
+      expect(types.includes("Feature Collection Template")).toBeTruthy();
+      expect(types.includes("Report Template")).toBeTruthy();
+    });
+
+    it("can get 'template' types", () => {
+      const types = getFamilyTypes("template");
+      expect(Array.isArray(types)).toBeTruthy();
+      expect(types.length).toBe(1);
+      expect(types.includes("Solution")).toBeTruthy();
+    });
+
+    it("can get 'dataset' types", () => {
+      const types = getFamilyTypes("dataset");
+      expect(Array.isArray(types)).toBeTruthy();
+      expect(types.length > 0).toBeTruthy();
+      expect(types.includes("Image Service")).toBeTruthy();
+      expect(types.includes("Feature Collection Template")).toBeFalsy();
+      expect(types.includes("Feature Service")).toBeFalsy();
+      expect(types.includes("Raster Layer")).toBeFalsy();
+      expect(types.includes("Microsoft Excel")).toBeFalsy();
+    });
+
+    it("can get 'map' types", () => {
+      const types = getFamilyTypes("map");
+      expect(Array.isArray(types)).toBeTruthy();
+      expect(types.length > 0).toBeTruthy();
+      expect(types.includes("Image Service")).toBeFalsy();
+      expect(types.includes("Feature Service")).toBeTruthy();
+      expect(types.includes("Raster Layer")).toBeTruthy();
+    });
+
+    it("can get 'document' types", () => {
+      const types = getFamilyTypes("document");
+      expect(Array.isArray(types)).toBeTruthy();
+      expect(types.length > 0).toBeTruthy();
+      expect(types.includes("CAD Drawing")).toBeFalsy();
+      expect(types.includes("Report Template")).toBeFalsy();
+      expect(types.includes("Microsoft Excel")).toBeTruthy();
+    });
+
+    it("can get 'project' types", () => {
+      const types = getFamilyTypes("project");
+      expect(Array.isArray(types)).toBeTruthy();
+      expect(types.length).toBe(1);
+      expect(types.includes("Hub Project")).toBeTruthy();
+    });
+
+    it("can get types any other valid family", () => {
+      const types = getFamilyTypes("site");
+      expect(Array.isArray(types)).toBeTruthy();
+      expect(types.length > 0).toBeTruthy();
+    });
+
+    it("can returns undefined for an invalid family", () => {
+      const types = getFamilyTypes("dummy" as any);
+      expect(types).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
[4533](https://devtopia.esri.com/dc/hub/issues/4533). Hub Site OGC APIs currently can return (and search using) user-defined collections that are scoped to the site's catalog. However, Hub also currently has "default" collections on the search route, with each collection as a bucket of different types. The story represents the effort to introduce these collections as default collections that are automatically returned from Site OGC APIs.

While the terminology of this story refers to collections (which are defined and recognized resources within the OGC spec), the _actual_ collections we plan to include are MUCH more akin to non-configurable Hub Families than configurable collections. They are more aligned with resource types that will have their own defined API (and UI) resource path.

In order to get the types associated with a given Hub Family, represented as an OGC collection, this PR introduces a function that returns the types associated with a given family. It is the converse of `getFamily`, and takes the same overrides into account.

2. Instructions for testing:
Unit tests have been included

3. Closes Issues: #<number> (if appropriate)

4. [x] used semantic commit messages
  
5. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
