### PR TITLE
fix: rename permission, catalog props and simplify adding permission

### DIFF
--- a/packages/common/e2e/hub-project-class.e2e.ts
+++ b/packages/common/e2e/hub-project-class.e2e.ts
@@ -43,7 +43,7 @@ fdescribe("HubProject Class", () => {
     const group = groups[0];
     if (group) {
       // add the project to the project
-      project.permissions.add("addEvent", {
+      project.permissions.add({
         permission: "addEvent",
         target: "group",
         targetId: group.id,
@@ -57,8 +57,8 @@ fdescribe("HubProject Class", () => {
       await project.save();
 
       const json = project.toJson();
-      expect(json.permissionDefinition).toBeDefined();
-      expect(json.permissionDefinition[0].targetId).toBe(group.id);
+      expect(json.permissions).toBeDefined();
+      expect(json.permissions[0].targetId).toBe(group.id);
     }
 
     // change something else and save it again

--- a/packages/common/src/core/PermissionManager.ts
+++ b/packages/common/src/core/PermissionManager.ts
@@ -57,15 +57,11 @@ export class PermissionManager {
    * Set a permission for the given entity
    * @param permission
    */
-  add(permission: HubPermission, definition: IHubPermission): void {
-    if (!definition.id) {
-      definition.id = createId("p");
+  add(permission: IHubPermission): void {
+    if (!permission.id) {
+      permission.id = createId("p");
     }
-    this._permissions = addPermission(
-      permission,
-      definition,
-      this._permissions
-    );
+    this._permissions = addPermission(permission, this._permissions);
   }
 
   /**

--- a/packages/common/src/core/behaviors/IWithPermissionBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithPermissionBehavior.ts
@@ -69,12 +69,11 @@ export function getPermissions(
  * @returns
  */
 export function addPermission(
-  permission: HubPermission,
   definition: IHubPermission,
   permissions: IHubPermission[]
 ): IHubPermission[] {
   const otherPermissions = removePermission(
-    permission,
+    definition.permission,
     definition.targetId,
     permissions
   );

--- a/packages/common/src/core/traits/IWithCatalogDefinition.ts
+++ b/packages/common/src/core/traits/IWithCatalogDefinition.ts
@@ -1,8 +1,8 @@
 import { IHubCatalog } from "../../search";
 
-export interface IWithCatalogDefinition {
+export interface IWithCatalog {
   /**
    * Catalog
    */
-  catalogDefinition: IHubCatalog;
+  catalog: IHubCatalog;
 }

--- a/packages/common/src/core/traits/IWithPermissions.ts
+++ b/packages/common/src/core/traits/IWithPermissions.ts
@@ -7,5 +7,5 @@ export interface IWithPermissionDefinition {
   /**
    * List of permissions for the entity
    */
-  permissionDefinition: IHubPermission[];
+  permissions: IHubPermission[];
 }

--- a/packages/common/src/core/types/IHubProject.ts
+++ b/packages/common/src/core/types/IHubProject.ts
@@ -4,7 +4,7 @@ import {
   IWithPermissionDefinition,
   IWithSlug,
 } from "../traits/index";
-import { IWithCatalogDefinition } from "../traits/IWithCatalogDefinition";
+import { IWithCatalog } from "../traits/IWithCatalogDefinition";
 
 /**
  * Defines the properties of a Hub Project object
@@ -12,7 +12,7 @@ import { IWithCatalogDefinition } from "../traits/IWithCatalogDefinition";
 export interface IHubProject
   extends IHubItemEntity,
     IWithSlug,
-    IWithCatalogDefinition,
+    IWithCatalog,
     IWithLayout,
     IWithPermissionDefinition {
   /**

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -51,184 +51,12 @@ export class HubProject
   private constructor(project: IHubProject, context: IArcGISContext) {
     this.context = context;
     this.entity = project;
-    this._catalog = Catalog.fromJson(project.catalogDefinition, this.context);
+    this._catalog = Catalog.fromJson(project.catalog, this.context);
     this._permissionManager = PermissionManager.fromJson(
-      project.permissionDefinition,
+      project.permissions,
       this.context
     );
   }
-
-  //#region Properties - coverage skipped for now
-  // TODO: decide if we want ambient dirty tracking or if we
-  // implement that as async check against the server
-
-  // // istanbul ignore next
-  // get permissionDefinition(): IHubPermission[] {
-  //   return this.entity.permissionDefinition;
-  // }
-  // // istanbul ignore next
-  // set permissionDefinition(permissions: IHubPermission[]) {
-  //   this.entity.permissionDefinition = permissions;
-  // }
-
-  // // istanbul ignore next
-  // get timeline(): IHubTimeline | undefined {
-  //   return this.entity.timeline;
-  // }
-  // // istanbul ignore next
-  // set timeline(value: IHubTimeline | undefined) {
-  //   this.entity.timeline = value;
-  // }
-  // // istanbul ignore next
-  // get status(): "inactive" | "active" {
-  //   return this.entity.status;
-  // }
-  // // istanbul ignore next
-  // set status(value: "inactive" | "active") {
-  //   this.entity.status = value;
-  // }
-
-  // // istanbul ignore next
-  // get thumbnailUrl(): string | undefined {
-  //   return this.entity.thumbnailUrl;
-  // }
-  // // istanbul ignore next
-  // set thumbnailUrl(value: string | undefined) {
-  //   this.entity.thumbnailUrl = value;
-  // }
-
-  // // istanbul ignore next
-  // get owner(): string {
-  //   return this.entity.owner;
-  // }
-
-  // // istanbul ignore next
-  // get description(): string | undefined {
-  //   return this.entity.description;
-  // }
-  // // istanbul ignore next
-  // set description(value: string | undefined) {
-  //   this.entity.description = value;
-  // }
-  // // istanbul ignore next
-  // get boundary(): IHubGeography | undefined {
-  //   return this.entity.boundary;
-  // }
-  // // istanbul ignore next
-  // set boundary(value: IHubGeography | undefined) {
-  //   this.entity.boundary = value;
-  // }
-  // // istanbul ignore next
-  // get culture(): string | undefined {
-  //   return this.entity.culture;
-  // }
-  // // istanbul ignore next
-  // set culture(value: string | undefined) {
-  //   this.entity.culture = value;
-  // }
-  // // istanbul ignore next
-  // get tags(): string[] {
-  //   return this.entity.tags;
-  // }
-  // // istanbul ignore next
-  // set tags(value: string[]) {
-  //   this.entity.tags = value;
-  // }
-  // // istanbul ignore next
-  // get typeKeywords(): string[] | undefined {
-  //   return this.entity.typeKeywords;
-  // }
-  // // istanbul ignore next
-  // set typeKeywords(value: string[] | undefined) {
-  //   this.entity.typeKeywords = value;
-  // }
-  // // istanbul ignore next
-  // get url(): string | undefined {
-  //   return this.entity.url;
-  // }
-  // // istanbul ignore next
-  // set url(value: string | undefined) {
-  //   this.entity.url = value;
-  // }
-  // // istanbul ignore next
-  // get id(): string {
-  //   return this.entity.id;
-  // }
-
-  // // istanbul ignore next
-  // get name(): string {
-  //   return this.entity.name;
-  // }
-  // // istanbul ignore next
-  // set name(value: string) {
-  //   this.entity.name = value;
-  // }
-  // // istanbul ignore next
-  // get summary(): string | undefined {
-  //   return this.entity.summary;
-  // }
-  // // istanbul ignore next
-  // set summary(value: string | undefined) {
-  //   this.entity.summary = value;
-  // }
-  // // istanbul ignore next
-  // get createdDate(): Date {
-  //   return this.entity.createdDate;
-  // }
-  // // istanbul ignore next
-  // get createdDateSource(): string {
-  //   return this.entity.createdDateSource;
-  // }
-  // // istanbul ignore next
-  // get updatedDate(): Date {
-  //   return this.entity.updatedDate;
-  // }
-  // // istanbul ignore next
-  // get updatedDateSource(): string {
-  //   return this.entity.updatedDateSource;
-  // }
-  // // istanbul ignore next
-  // get type(): string {
-  //   return this.entity.type;
-  // }
-  // // istanbul ignore next
-  // get source(): string | undefined {
-  //   return this.entity.source;
-  // }
-  // // istanbul ignore next
-  // set source(value: string | undefined) {
-  //   this.entity.source = value;
-  // }
-  // // istanbul ignore next
-  // get slug(): string {
-  //   return this.entity.slug;
-  // }
-  // // istanbul ignore next
-  // set slug(value: string) {
-  //   this.entity.slug = value;
-  // }
-  // // istanbul ignore next
-  // get orgUrlKey(): string {
-  //   return this.entity.orgUrlKey;
-  // }
-  // // istanbul ignore next
-  // get layout(): IHubLayout | undefined {
-  //   return this.entity.layout;
-  // }
-  // // istanbul ignore next
-  // set layout(value: IHubLayout | undefined) {
-  //   this.entity.layout = value;
-  // }
-  // // istanbul ignore next
-  // get catalogDefinition(): IHubCatalog {
-  //   return this.entity.catalogDefinition;
-  // }
-
-  // set catalogDefinition(value: IHubCatalog) {
-  //   this.entity.catalogDefinition = value;
-  //   // update the catalog instance
-  //   this._catalog = Catalog.fromJson(value, this.context);
-  // }
 
   /**
    * @returns Catalog instance for this project. Note: Do not hold direct references to this object; always access it from the project.
@@ -243,8 +71,6 @@ export class HubProject
   get permissions(): PermissionManager {
     return this._permissionManager;
   }
-
-  // #endregion
 
   /**
    * Create an instance from an IHubProject object
@@ -345,15 +171,12 @@ export class HubProject
     this.entity = { ...this.entity, ...changes };
 
     // update internal instances
-    if (changes.catalogDefinition) {
-      this._catalog = Catalog.fromJson(
-        this.entity.catalogDefinition,
-        this.context
-      );
+    if (changes.catalog) {
+      this._catalog = Catalog.fromJson(this.entity.catalog, this.context);
     }
-    if (changes.permissionDefinition) {
+    if (changes.permissions) {
       this._permissionManager = PermissionManager.fromJson(
-        this.entity.permissionDefinition,
+        this.entity.permissions,
         this.context
       );
     }
@@ -367,9 +190,9 @@ export class HubProject
     if (this.isDestroyed) {
       throw new Error("HubProject is already destroyed.");
     }
-    // get the catalog definition out of the instance
-    this.entity.catalogDefinition = this._catalog.toJson();
-    this.entity.permissionDefinition = this._permissionManager.toJson();
+    // get the catalog, and permission configs
+    this.entity.catalog = this._catalog.toJson();
+    this.entity.permissions = this._permissionManager.toJson();
 
     if (this.entity.id) {
       // update it

--- a/packages/common/src/projects/HubProjectManager.ts
+++ b/packages/common/src/projects/HubProjectManager.ts
@@ -30,6 +30,7 @@ import {
 import { failSafe, isUpdateGroup } from "../utils";
 
 /**
+ * @private
  * Centralized functions used to manage IHubProject instances
  *
  * This class is a convenience wrapper over util functions which

--- a/packages/common/src/projects/HubProjects.ts
+++ b/packages/common/src/projects/HubProjects.ts
@@ -74,6 +74,7 @@ function getProjectPropertyMap(): IPropertyMap[] {
   ];
   const dataProps = [
     "contacts",
+    "catalog",
     "display",
     "geometry",
     "headerImage",
@@ -93,10 +94,6 @@ function getProjectPropertyMap(): IPropertyMap[] {
   map.push({
     objectKey: "slug",
     modelKey: "item.properties.slug",
-  });
-  map.push({
-    objectKey: "catalogDefinition",
-    modelKey: "data.catalog",
   });
   map.push({
     objectKey: "orgUrlKey",

--- a/packages/common/src/projects/defaults.ts
+++ b/packages/common/src/projects/defaults.ts
@@ -11,8 +11,8 @@ export const DEFAULT_PROJECT: Partial<IHubProject> = {
   tags: [],
   typeKeywords: ["Hub Project"],
   status: "inactive",
-  catalogDefinition: { schemaVersion: 0 },
-  permissionDefinition: [],
+  catalog: { schemaVersion: 0 },
+  permissions: [],
 };
 
 /**

--- a/packages/common/test/core/PermissionManager.test.ts
+++ b/packages/common/test/core/PermissionManager.test.ts
@@ -84,8 +84,8 @@ describe("PermissionManager Class:", () => {
       targetId: "bchy8ad",
     };
 
-    pm.add(p2.permission, p2);
-    pm.add(p3.permission, p3);
+    pm.add(p2);
+    pm.add(p3);
     expect(addPermissionSpy.calls.count()).toBe(2);
     expect(pm.get("addInitiative").length).toBe(2);
     pm.remove("addInitiative", p2.targetId);

--- a/packages/common/test/core/behaviors/PermissionBehavior.test.ts
+++ b/packages/common/test/core/behaviors/PermissionBehavior.test.ts
@@ -77,7 +77,6 @@ describe("PermissionBehavior module:", () => {
   });
   it("addPermission replaces existing", () => {
     const updates = addPermission(
-      "addInitiative",
       {
         id: "pnew",
         permission: "addInitiative",
@@ -93,7 +92,6 @@ describe("PermissionBehavior module:", () => {
   });
   it("addPermission adds new", () => {
     const updates = addPermission(
-      "createProject",
       {
         id: "p9",
         permission: "createProject",

--- a/packages/common/test/projects/HubProject.test.ts
+++ b/packages/common/test/projects/HubProject.test.ts
@@ -40,8 +40,8 @@ describe("HubProject Class:", () => {
       expect(chk.toJson().name).toEqual("Test Project");
       // adds empty permissions and catalog
       const json = chk.toJson();
-      expect(json.permissionDefinition).toEqual([]);
-      expect(json.catalogDefinition).toEqual({ schemaVersion: 0 });
+      expect(json.permissions).toEqual([]);
+      expect(json.catalog).toEqual({ schemaVersion: 0 });
     });
     it("loads based on identifier", async () => {
       const fetchSpy = spyOn(HubProjectsModule, "fetchProject").and.callFake(
@@ -135,18 +135,18 @@ describe("HubProject Class:", () => {
 
   it("update applies partial chagnes to internal state", () => {
     const chk = HubProject.fromJson(
-      { name: "Test Project", catalogDefinition: { schemaVersion: 0 } },
+      { name: "Test Project", catalog: { schemaVersion: 0 } },
       authdCtxMgr.context
     );
     chk.update({
       name: "Test Project 2",
-      permissionDefinition: [
+      permissions: [
         { permission: "addEvent", target: "group", targetId: "3ef" },
       ],
-      catalogDefinition: { schemaVersion: 2 },
+      catalog: { schemaVersion: 2 },
     });
     expect(chk.toJson().name).toEqual("Test Project 2");
-    expect(chk.toJson().catalogDefinition).toEqual({ schemaVersion: 2 });
+    expect(chk.toJson().catalog).toEqual({ schemaVersion: 2 });
 
     chk.update({ tags: ["one", "two"] });
     expect(chk.toJson().tags).toEqual(["one", "two"]);
@@ -162,7 +162,7 @@ describe("HubProject Class:", () => {
       {
         id: "bc3",
         name: "Test Project",
-        catalogDefinition: { schemaVersion: 0 },
+        catalog: { schemaVersion: 0 },
       },
       authdCtxMgr.context
     );
@@ -207,7 +207,7 @@ describe("HubProject Class:", () => {
 
   it("internal instance accessors", () => {
     const chk = HubProject.fromJson(
-      { name: "Test Project", catalogDefinition: { schemaVersion: 0 } },
+      { name: "Test Project", catalog: { schemaVersion: 0 } },
       authdCtxMgr.context
     );
 
@@ -215,13 +215,13 @@ describe("HubProject Class:", () => {
     expect(chk.permissions instanceof PermissionManager).toBeTruthy();
   });
 
-  it("setting catalogDefinition updates catalog instance", () => {
+  it("setting catalog updates catalog instance", () => {
     const chk = HubProject.fromJson(
-      { name: "Test Project", catalogDefinition: { schemaVersion: 0 } },
+      { name: "Test Project", catalog: { schemaVersion: 0 } },
       authdCtxMgr.context
     );
-    chk.update({ catalogDefinition: { schemaVersion: 2 } });
-    expect(chk.toJson().catalogDefinition).toEqual({ schemaVersion: 2 });
+    chk.update({ catalog: { schemaVersion: 2 } });
+    expect(chk.toJson().catalog).toEqual({ schemaVersion: 2 });
     expect(chk.catalog.schemaVersion).toEqual(2);
   });
 
@@ -233,7 +233,7 @@ describe("HubProject Class:", () => {
           id: "00c",
           name: "Test Project",
           owner: "deke",
-          catalogDefinition: { schemaVersion: 0 },
+          catalog: { schemaVersion: 0 },
         },
         authdCtxMgr.context
       );

--- a/packages/common/test/projects/HubProjects.test.ts
+++ b/packages/common/test/projects/HubProjects.test.ts
@@ -298,8 +298,8 @@ describe("HubProjects:", () => {
         updatedDateSource: "item.modified",
         status: "active",
         thumbnailUrl: "",
-        permissionDefinition: [],
-        catalogDefinition: {
+        permissions: [],
+        catalog: {
           schemaVersion: 0,
         },
       };


### PR DESCRIPTION
1. Description:

- since we are not exposing the underlying entity props on the classes, we can store the catalog and permissions as `.catalog` and `.permissions`
- remove the redundant `HubPermission` param on `addPermission` method

1. Instructions for testing:

- run tests

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
