### PR TITLE
feat: prototype canEdit and canDelete props

### DIFF
--- a/packages/common/src/core/behaviors/IWithPermissionBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithPermissionBehavior.ts
@@ -7,6 +7,18 @@ import { IHubPermission, HubPermission } from "../types/IHubPermission";
  */
 export interface IWithPermissionBehavior {
   permissions: PermissionManager;
+  /**
+   * Can the current user edit the Entity?
+   * User must be owner, or member of a shared editing group, to which the item is shared
+   * @param useCache by default, this method will use cached user groups and item groups. Passing false will force a re-caching of this information
+   */
+  canEdit(useCache: boolean): Promise<boolean>;
+  /**
+   * Can the current user delete the Entity?
+   * User must own the entiry or be an org admin in the owner's org
+   * @param useCache by default, this method will use cached user groups and item groups. Passing false will force a re-caching of this information
+   */
+  canDelete(useCache: boolean): Promise<boolean>;
 }
 
 // Permission util functions

--- a/packages/common/src/core/behaviors/IWithSharingBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithSharingBehavior.ts
@@ -24,5 +24,5 @@ export interface IWithSharingBehavior {
    * Get the list of groups that the item is shared to.
    * Limited to Groups that the user has access to
    */
-  sharedWith(): Promise<IGroup[]>;
+  sharedWith(useCache: boolean): Promise<IGroup[]>;
 }


### PR DESCRIPTION
1. Description:

Prototype of one option for adding `.canEdit` and `.canDelete` to Hub classes

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
