### PR TITLE
feat: add editor config static method to HubProject class

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -94,7 +94,7 @@ module.exports = function(config) {
     specReporter: {
       // useful for identifying long-running tests
       showSpecTiming: true,
-      // useful when using describe() or fit()
+      // useful when using fdescribe() or fit()
       // suppressSkipped: true
     },
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -94,7 +94,7 @@ module.exports = function(config) {
     specReporter: {
       // useful for identifying long-running tests
       showSpecTiming: true,
-      // useful when using fdescribe() or fit()
+      // useful when using describe() or fit()
       // suppressSkipped: true
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,30 +294,30 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.18.8",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
-			"integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.1.tgz",
+			"integrity": "sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
-			"integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
+			"integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.10",
-				"@babel/helper-compilation-targets": "^7.18.9",
-				"@babel/helper-module-transforms": "^7.18.9",
-				"@babel/helpers": "^7.18.9",
-				"@babel/parser": "^7.18.10",
+				"@babel/generator": "^7.19.0",
+				"@babel/helper-compilation-targets": "^7.19.1",
+				"@babel/helper-module-transforms": "^7.19.0",
+				"@babel/helpers": "^7.19.0",
+				"@babel/parser": "^7.19.1",
 				"@babel/template": "^7.18.10",
-				"@babel/traverse": "^7.18.10",
-				"@babel/types": "^7.18.10",
+				"@babel/traverse": "^7.19.1",
+				"@babel/types": "^7.19.0",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -342,12 +342,12 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.18.12",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
-			"integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
+			"integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.10",
+				"@babel/types": "^7.19.0",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"jsesc": "^2.5.1"
 			},
@@ -395,14 +395,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
-			"integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.1.tgz",
+			"integrity": "sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.18.8",
+				"@babel/compat-data": "^7.19.1",
 				"@babel/helper-validator-option": "^7.18.6",
-				"browserslist": "^4.20.2",
+				"browserslist": "^4.21.3",
 				"semver": "^6.3.0"
 			},
 			"engines": {
@@ -422,14 +422,14 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.9.tgz",
-			"integrity": "sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.19.0.tgz",
+			"integrity": "sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/helper-member-expression-to-functions": "^7.18.9",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
 				"@babel/helper-replace-supers": "^7.18.9",
@@ -443,9 +443,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-regexp-features-plugin": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.18.6.tgz",
-			"integrity": "sha512-7LcpH1wnQLGrI+4v+nPp+zUvIkF9x0ddv1Hkdue10tg3gmRnLy97DXh4STiOf1qeIInyD69Qv5kKSZzKD8B/7A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.19.0.tgz",
+			"integrity": "sha512-htnV+mHX32DF81amCDrwIDr8nrp1PTm+3wfBN9/v8QJOLEioOCOG7qNyq0nHeFiWbT3Eb7gsPwEmV64UCQ1jzw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
@@ -459,9 +459,9 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.2.tgz",
-			"integrity": "sha512-r9QJJ+uDWrd+94BSPcP6/de67ygLtvVy6cK4luE6MOuDsZIdoaPBnfSpbO/+LTifjPckbKXRuI9BB/Z2/y3iTg==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz",
+			"integrity": "sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-compilation-targets": "^7.17.7",
@@ -506,13 +506,13 @@
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
-			"integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+			"integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.18.6",
-				"@babel/types": "^7.18.9"
+				"@babel/template": "^7.18.10",
+				"@babel/types": "^7.19.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -555,9 +555,9 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
-			"integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
+			"integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.18.9",
@@ -565,9 +565,9 @@
 				"@babel/helper-simple-access": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
 				"@babel/helper-validator-identifier": "^7.18.6",
-				"@babel/template": "^7.18.6",
-				"@babel/traverse": "^7.18.9",
-				"@babel/types": "^7.18.9"
+				"@babel/template": "^7.18.10",
+				"@babel/traverse": "^7.19.0",
+				"@babel/types": "^7.19.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -586,9 +586,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
-			"integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
+			"integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -613,16 +613,16 @@
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.18.9.tgz",
-			"integrity": "sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.19.1.tgz",
+			"integrity": "sha512-T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.18.9",
 				"@babel/helper-member-expression-to-functions": "^7.18.9",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
-				"@babel/traverse": "^7.18.9",
-				"@babel/types": "^7.18.9"
+				"@babel/traverse": "^7.19.1",
+				"@babel/types": "^7.19.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -674,9 +674,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -692,29 +692,29 @@
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.18.11.tgz",
-			"integrity": "sha512-oBUlbv+rjZLh2Ks9SKi4aL7eKaAXBWleHzU89mP0G6BMUlRxSckk9tSIkgDGydhgFxHuGSlBQZfnaD47oBEB7w==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.19.0.tgz",
+			"integrity": "sha512-txX8aN8CZyYGTwcLhlk87KRqncAzhh5TpQamZUa0/u3an36NtDpUP6bQgBCBcLeBs09R/OwQu3OjK0k/HwfNDg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/template": "^7.18.10",
-				"@babel/traverse": "^7.18.11",
-				"@babel/types": "^7.18.10"
+				"@babel/traverse": "^7.19.0",
+				"@babel/types": "^7.19.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
-			"integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
+			"integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.18.6",
-				"@babel/traverse": "^7.18.9",
-				"@babel/types": "^7.18.9"
+				"@babel/template": "^7.18.10",
+				"@babel/traverse": "^7.19.0",
+				"@babel/types": "^7.19.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -797,9 +797,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
-			"integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
+			"integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -841,13 +841,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.18.10.tgz",
-			"integrity": "sha512-1mFuY2TOsR1hxbjCo4QL+qlIjV07p4H4EUYw2J/WCqsvFV6V9X9z9YhXbWndc/4fw+hYGlDT7egYxliMp5O6Ew==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.19.1.tgz",
+			"integrity": "sha512-0yu8vNATgLy4ivqMNBIwb1HebCelqN7YX8SL3FDXORv/RqT0zEEWUCH4GH44JsSrvCu6GqnAdR5EBFAPeNBB4Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-remap-async-to-generator": "^7.18.9",
 				"@babel/plugin-syntax-async-generators": "^7.8.4"
 			},
@@ -892,16 +892,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-decorators": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.18.10.tgz",
-			"integrity": "sha512-wdGTwWF5QtpTY/gbBtQLAiCnoxfD4qMbN87NYZle1dOZ9Os8Y6zXcKrIaOU8W+TIvFUWVGG9tUgNww3CjXRVVw==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.19.1.tgz",
+			"integrity": "sha512-LfIKNBBY7Q1OX5C4xAgRQffOg2OnhAo9fnbcOHgOC9Yytm2Sw+4XqHufRYU86tHomzepxtvuVaNO+3EVKR4ivw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
-				"@babel/helper-replace-supers": "^7.18.9",
+				"@babel/helper-create-class-features-plugin": "^7.19.0",
+				"@babel/helper-plugin-utils": "^7.19.0",
+				"@babel/helper-replace-supers": "^7.19.1",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/plugin-syntax-decorators": "^7.18.6"
+				"@babel/plugin-syntax-decorators": "^7.19.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1148,12 +1148,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-decorators": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.18.6.tgz",
-			"integrity": "sha512-fqyLgjcxf/1yhyZ6A+yo1u9gJ7eleFQod2lkaUsF9DQ7sbbY3Ligym3L0+I2c0WmqNKDpoD9UTb1AKP3qRMOAQ==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.19.0.tgz",
+			"integrity": "sha512-xaBZUEDntt4faL1yN8oIFlhfXeQAWJW7CLKYsHTUqriCUbj8xOra8bfxxKGi/UwExPFBuPdH4XfHc9rGQhrVkQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.19.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1393,16 +1393,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.18.9.tgz",
-			"integrity": "sha512-EkRQxsxoytpTlKJmSPYrsOMjCILacAjtSVkd4gChEe2kXjFCun3yohhW5I7plXJhCemM0gKsaGMcO8tinvCA5g==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.19.0.tgz",
+			"integrity": "sha512-YfeEE9kCjqTS9IitkgfJuxjcEtLUHMqa8yUJ6zdz8vR7hKuo6mOy2C05P0F1tdMmDCeuyidKnlrw/iTppHcr2A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
+				"@babel/helper-compilation-targets": "^7.19.0",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-replace-supers": "^7.18.9",
 				"@babel/helper-split-export-declaration": "^7.18.6",
 				"globals": "^11.1.0"
@@ -1430,9 +1431,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.9.tgz",
-			"integrity": "sha512-p5VCYNddPLkZTq4XymQIaIfZNJwT9YsjkPOhkVEqt6QIpQFZVM9IltqqYpOEkJoN1DPznmxUDyZ5CTZs/ZCuHA==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.13.tgz",
+			"integrity": "sha512-TodpQ29XekIsex2A+YJPj5ax2plkGa8YYY6mFjCohk/IG9IY42Rtuj1FuDeemfg2ipxIFLzPeA83SIBnlhSIow==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.18.9"
@@ -1589,14 +1590,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.18.9.tgz",
-			"integrity": "sha512-zY/VSIbbqtoRoJKo2cDTewL364jSlZGvn0LKOf9ntbfxOvjfmyrdtEEOAdswOswhZEb8UH3jDkCKHd1sPgsS0A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.19.0.tgz",
+			"integrity": "sha512-x9aiR0WXAWmOWsqcsnrzGR+ieaTMVyGyffPVA7F8cXAGt/UxefYv6uSHZLkAFChN5M5Iy1+wjE+xJuPt22H39A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-module-transforms": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-module-transforms": "^7.19.0",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-validator-identifier": "^7.18.6",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			},
@@ -1624,13 +1625,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.18.6.tgz",
-			"integrity": "sha512-UmEOGF8XgaIqD74bC8g7iV3RYj8lMf0Bw7NJzvnS9qQhM4mg+1WHKotUIdjxgD2RGrgFLZZPCFPFj3P/kVDYhg==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.19.1.tgz",
+			"integrity": "sha512-oWk9l9WItWBQYS4FgXD4Uyy5kq898lvkXpXQxoJEY1RnvPk4R/Dvu2ebXU9q8lP+rlMwUQTFf2Ok6d78ODa0kw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-create-regexp-features-plugin": "^7.19.0",
+				"@babel/helper-plugin-utils": "^7.19.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1747,16 +1748,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.18.10.tgz",
-			"integrity": "sha512-q5mMeYAdfEbpBAgzl7tBre/la3LeCxmDO1+wMXRdPWbcoMjR3GiXlCLk7JBZVVye0bqTGNMbt0yYVXX1B1jEWQ==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.19.1.tgz",
+			"integrity": "sha512-2nJjTUFIzBMP/f/miLxEK9vxwW/KUXsdvN4sR//TmuDhe6yU2h57WmIOE12Gng3MDP/xpjUV/ToZRdcf8Yj4fA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.9",
-				"babel-plugin-polyfill-corejs2": "^0.3.2",
-				"babel-plugin-polyfill-corejs3": "^0.5.3",
-				"babel-plugin-polyfill-regenerator": "^0.4.0",
+				"@babel/helper-plugin-utils": "^7.19.0",
+				"babel-plugin-polyfill-corejs2": "^0.3.3",
+				"babel-plugin-polyfill-corejs3": "^0.6.0",
+				"babel-plugin-polyfill-regenerator": "^0.4.1",
 				"semver": "^6.3.0"
 			},
 			"engines": {
@@ -1791,12 +1792,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-spread": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.18.9.tgz",
-			"integrity": "sha512-39Q814wyoOPtIB/qGopNIL9xDChOE1pNU0ZY5dO0owhiVt/5kFm4li+/bBtwc7QotG0u5EPzqhZdjMtmqBqyQA==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.19.0.tgz",
+			"integrity": "sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.18.9"
 			},
 			"engines": {
@@ -1852,13 +1853,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.18.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.12.tgz",
-			"integrity": "sha512-2vjjam0cum0miPkenUbQswKowuxs/NjMwIKEq0zwegRxXk12C9YOF9STXnaUptITOtOJHKHpzvvWYOjbm6tc0w==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.19.1.tgz",
+			"integrity": "sha512-+ILcOU+6mWLlvCwnL920m2Ow3wWx3Wo8n2t5aROQmV55GZt+hOiLvBaa3DNzRjSEHa1aauRs4/YLmkCfFkhhRQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-create-class-features-plugin": "^7.19.0",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/plugin-syntax-typescript": "^7.18.6"
 			},
 			"engines": {
@@ -1919,18 +1920,18 @@
 			"hasInstallScript": true
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.18.10.tgz",
-			"integrity": "sha512-wVxs1yjFdW3Z/XkNfXKoblxoHgbtUF7/l3PvvP4m02Qz9TZ6uZGxRVYjSQeR87oQmHco9zWitW5J82DJ7sCjvA==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.19.1.tgz",
+			"integrity": "sha512-c8B2c6D16Lp+Nt6HcD+nHl0VbPKVnNPTpszahuxJJnurfMtKeZ80A+qUv48Y7wqvS+dTFuLuaM9oYxyNHbCLWA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.18.8",
-				"@babel/helper-compilation-targets": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/compat-data": "^7.19.1",
+				"@babel/helper-compilation-targets": "^7.19.1",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-validator-option": "^7.18.6",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.18.9",
-				"@babel/plugin-proposal-async-generator-functions": "^7.18.10",
+				"@babel/plugin-proposal-async-generator-functions": "^7.19.1",
 				"@babel/plugin-proposal-class-properties": "^7.18.6",
 				"@babel/plugin-proposal-class-static-block": "^7.18.6",
 				"@babel/plugin-proposal-dynamic-import": "^7.18.6",
@@ -1964,9 +1965,9 @@
 				"@babel/plugin-transform-async-to-generator": "^7.18.6",
 				"@babel/plugin-transform-block-scoped-functions": "^7.18.6",
 				"@babel/plugin-transform-block-scoping": "^7.18.9",
-				"@babel/plugin-transform-classes": "^7.18.9",
+				"@babel/plugin-transform-classes": "^7.19.0",
 				"@babel/plugin-transform-computed-properties": "^7.18.9",
-				"@babel/plugin-transform-destructuring": "^7.18.9",
+				"@babel/plugin-transform-destructuring": "^7.18.13",
 				"@babel/plugin-transform-dotall-regex": "^7.18.6",
 				"@babel/plugin-transform-duplicate-keys": "^7.18.9",
 				"@babel/plugin-transform-exponentiation-operator": "^7.18.6",
@@ -1976,9 +1977,9 @@
 				"@babel/plugin-transform-member-expression-literals": "^7.18.6",
 				"@babel/plugin-transform-modules-amd": "^7.18.6",
 				"@babel/plugin-transform-modules-commonjs": "^7.18.6",
-				"@babel/plugin-transform-modules-systemjs": "^7.18.9",
+				"@babel/plugin-transform-modules-systemjs": "^7.19.0",
 				"@babel/plugin-transform-modules-umd": "^7.18.6",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.18.6",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.19.1",
 				"@babel/plugin-transform-new-target": "^7.18.6",
 				"@babel/plugin-transform-object-super": "^7.18.6",
 				"@babel/plugin-transform-parameters": "^7.18.8",
@@ -1986,18 +1987,18 @@
 				"@babel/plugin-transform-regenerator": "^7.18.6",
 				"@babel/plugin-transform-reserved-words": "^7.18.6",
 				"@babel/plugin-transform-shorthand-properties": "^7.18.6",
-				"@babel/plugin-transform-spread": "^7.18.9",
+				"@babel/plugin-transform-spread": "^7.19.0",
 				"@babel/plugin-transform-sticky-regex": "^7.18.6",
 				"@babel/plugin-transform-template-literals": "^7.18.9",
 				"@babel/plugin-transform-typeof-symbol": "^7.18.9",
 				"@babel/plugin-transform-unicode-escapes": "^7.18.10",
 				"@babel/plugin-transform-unicode-regex": "^7.18.6",
 				"@babel/preset-modules": "^0.1.5",
-				"@babel/types": "^7.18.10",
-				"babel-plugin-polyfill-corejs2": "^0.3.2",
-				"babel-plugin-polyfill-corejs3": "^0.5.3",
-				"babel-plugin-polyfill-regenerator": "^0.4.0",
-				"core-js-compat": "^3.22.1",
+				"@babel/types": "^7.19.0",
+				"babel-plugin-polyfill-corejs2": "^0.3.3",
+				"babel-plugin-polyfill-corejs3": "^0.6.0",
+				"babel-plugin-polyfill-regenerator": "^0.4.1",
+				"core-js-compat": "^3.25.1",
 				"semver": "^6.3.0"
 			},
 			"engines": {
@@ -2033,9 +2034,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-			"integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
+			"integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
 			"dev": true,
 			"dependencies": {
 				"regenerator-runtime": "^0.13.4"
@@ -2059,19 +2060,19 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz",
-			"integrity": "sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
+			"integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.10",
+				"@babel/generator": "^7.19.0",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/helper-hoist-variables": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.18.11",
-				"@babel/types": "^7.18.10",
+				"@babel/parser": "^7.19.1",
+				"@babel/types": "^7.19.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -2080,9 +2081,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
-			"integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
+			"integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.18.10",
@@ -6198,6 +6199,16 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/@lerna/create/node_modules/@types/glob": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"dev": true,
+			"dependencies": {
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@lerna/create/node_modules/braces": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
@@ -7295,6 +7306,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/@lerna/project/node_modules/@types/glob": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"dev": true,
+			"dependencies": {
+				"@types/minimatch": "*",
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@lerna/project/node_modules/braces": {
@@ -8623,9 +8644,9 @@
 			}
 		},
 		"node_modules/@octokit/core/node_modules/@octokit/endpoint": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.1.tgz",
-			"integrity": "sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.2.tgz",
+			"integrity": "sha512-8/AUACfE9vpRpehE6ZLfEtzkibe5nfsSwFZVMsG8qabqRt1M81qZYUFRZa1B8w8lP6cdfDJfRq9HWS+MbmR7tw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -8638,9 +8659,9 @@
 			}
 		},
 		"node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
-			"version": "13.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.0.1.tgz",
-			"integrity": "sha512-40U39YoFBhJhmkAg6gbJnh9U8aueJwCuiTW0mXY2pNl9/+E7dUxXiMPOrIUGT12XqLinroaXYA3FUiw3BMeNfg==",
+			"version": "13.11.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.11.0.tgz",
+			"integrity": "sha512-Y5LdQm7dFJLJdAp/KTZx40h/gFF3tRKDO78L4MlDd5KUwLuySRE4or9CQuaeMho5yYwQMoKjVDyt7louorZhvw==",
 			"dev": true,
 			"peer": true
 		},
@@ -8678,13 +8699,13 @@
 			}
 		},
 		"node_modules/@octokit/core/node_modules/@octokit/types": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.0.0.tgz",
-			"integrity": "sha512-8uSDc66p6+wADn6lh6lA7I3ZTIapn7F/dfpsiDztVjEr6kkyKR3qPqa4lgEX92O/8iJoDeGcscKRXGAjCSR/zg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.0.tgz",
+			"integrity": "sha512-aHm+olfIZjQpzoODpl+RCZzchKOrdSLJs+yfI7pMMcmB19Li6vidgx0DwUDO/Ic4Q3fq/lOjJORVCcLZefcrJw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@octokit/openapi-types": "^13.0.0"
+				"@octokit/openapi-types": "^13.11.0"
 			}
 		},
 		"node_modules/@octokit/core/node_modules/universal-user-agent": {
@@ -8727,9 +8748,9 @@
 			}
 		},
 		"node_modules/@octokit/graphql/node_modules/@octokit/endpoint": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.1.tgz",
-			"integrity": "sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.2.tgz",
+			"integrity": "sha512-8/AUACfE9vpRpehE6ZLfEtzkibe5nfsSwFZVMsG8qabqRt1M81qZYUFRZa1B8w8lP6cdfDJfRq9HWS+MbmR7tw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -8742,9 +8763,9 @@
 			}
 		},
 		"node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
-			"version": "13.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.0.1.tgz",
-			"integrity": "sha512-40U39YoFBhJhmkAg6gbJnh9U8aueJwCuiTW0mXY2pNl9/+E7dUxXiMPOrIUGT12XqLinroaXYA3FUiw3BMeNfg==",
+			"version": "13.11.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.11.0.tgz",
+			"integrity": "sha512-Y5LdQm7dFJLJdAp/KTZx40h/gFF3tRKDO78L4MlDd5KUwLuySRE4or9CQuaeMho5yYwQMoKjVDyt7louorZhvw==",
 			"dev": true,
 			"peer": true
 		},
@@ -8782,13 +8803,13 @@
 			}
 		},
 		"node_modules/@octokit/graphql/node_modules/@octokit/types": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.0.0.tgz",
-			"integrity": "sha512-8uSDc66p6+wADn6lh6lA7I3ZTIapn7F/dfpsiDztVjEr6kkyKR3qPqa4lgEX92O/8iJoDeGcscKRXGAjCSR/zg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.0.tgz",
+			"integrity": "sha512-aHm+olfIZjQpzoODpl+RCZzchKOrdSLJs+yfI7pMMcmB19Li6vidgx0DwUDO/Ic4Q3fq/lOjJORVCcLZefcrJw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@octokit/openapi-types": "^13.0.0"
+				"@octokit/openapi-types": "^13.11.0"
 			}
 		},
 		"node_modules/@octokit/graphql/node_modules/universal-user-agent": {
@@ -8829,9 +8850,9 @@
 			}
 		},
 		"node_modules/@octokit/plugin-paginate-rest/node_modules/@types/node": {
-			"version": "18.7.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.4.tgz",
-			"integrity": "sha512-RzRcw8c0B8LzryWOR4Wj7YOTFXvdYKwvrb6xQQyuDfnlTxwYXGCV5RZ/TEbq5L5kn+w3rliHAUyRcG1RtbmTFg==",
+			"version": "18.7.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+			"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
 			"dev": true
 		},
 		"node_modules/@octokit/plugin-request-log": {
@@ -8863,9 +8884,9 @@
 			}
 		},
 		"node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@types/node": {
-			"version": "18.7.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.4.tgz",
-			"integrity": "sha512-RzRcw8c0B8LzryWOR4Wj7YOTFXvdYKwvrb6xQQyuDfnlTxwYXGCV5RZ/TEbq5L5kn+w3rliHAUyRcG1RtbmTFg==",
+			"version": "18.7.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+			"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
 			"dev": true
 		},
 		"node_modules/@octokit/request": {
@@ -8903,9 +8924,9 @@
 			}
 		},
 		"node_modules/@octokit/request-error/node_modules/@types/node": {
-			"version": "18.7.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.4.tgz",
-			"integrity": "sha512-RzRcw8c0B8LzryWOR4Wj7YOTFXvdYKwvrb6xQQyuDfnlTxwYXGCV5RZ/TEbq5L5kn+w3rliHAUyRcG1RtbmTFg==",
+			"version": "18.7.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+			"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
 			"dev": true
 		},
 		"node_modules/@octokit/request/node_modules/@octokit/request-error": {
@@ -9043,14 +9064,14 @@
 			}
 		},
 		"node_modules/@semantic-release/github": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.5.tgz",
-			"integrity": "sha512-9pGxRM3gv1hgoZ/muyd4pWnykdIUVfCiev6MXE9lOyGQof4FQy95GFE26nDcifs9ZG7bBzV8ue87bo/y1zVf0g==",
+			"version": "8.0.6",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.6.tgz",
+			"integrity": "sha512-ZxgaxYCeqt9ylm2x3OPqUoUqBw1p60LhxzdX6BqJlIBThupGma98lttsAbK64T6L6AlNa2G5T66BbiG8y0PIHQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@octokit/rest": "^19.0.0",
-				"@semantic-release/error": "^2.2.0",
+				"@semantic-release/error": "^3.0.0",
 				"aggregate-error": "^3.0.0",
 				"bottleneck": "^2.18.1",
 				"debug": "^4.0.0",
@@ -9074,20 +9095,20 @@
 			}
 		},
 		"node_modules/@semantic-release/github/node_modules/@octokit/openapi-types": {
-			"version": "13.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.0.1.tgz",
-			"integrity": "sha512-40U39YoFBhJhmkAg6gbJnh9U8aueJwCuiTW0mXY2pNl9/+E7dUxXiMPOrIUGT12XqLinroaXYA3FUiw3BMeNfg==",
+			"version": "13.11.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.11.0.tgz",
+			"integrity": "sha512-Y5LdQm7dFJLJdAp/KTZx40h/gFF3tRKDO78L4MlDd5KUwLuySRE4or9CQuaeMho5yYwQMoKjVDyt7louorZhvw==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/@semantic-release/github/node_modules/@octokit/plugin-paginate-rest": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.0.0.tgz",
-			"integrity": "sha512-g4GJMt/7VDmIMMdQenN6bmsmRoZca1c7IxOdF2yMiMwQYrE2bmmypGQeQSD5rsaffsFMCUS7Br4pMVZamareYA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.0.tgz",
+			"integrity": "sha512-4V8hWMoXuxb03xPs3s3RjUb5Bzx4HmVRhG+gvbO08PB48ag6G8mk6/HDFKlAXz9XEorDIkc0pXcXnaOz8spHgg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@octokit/types": "^7.0.0"
+				"@octokit/types": "^7.4.0"
 			},
 			"engines": {
 				"node": ">= 14"
@@ -9097,13 +9118,13 @@
 			}
 		},
 		"node_modules/@semantic-release/github/node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.3.0.tgz",
-			"integrity": "sha512-qEu2wn6E7hqluZwIEUnDxWROvKjov3zMIAi4H4d7cmKWNMeBprEXZzJe8pE5eStUYC1ysGhD0B7L6IeG1Rfb+g==",
+			"version": "6.6.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.1.tgz",
+			"integrity": "sha512-hkD9agR36fAeatWiT96Re7ZpyO4OzNrls5ZQxGxo9DeNxEKXGWSdziZ2GtWykpNOdf3Z/zjugIDLI2fUKuOYSQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@octokit/types": "^7.0.0",
+				"@octokit/types": "^7.4.0",
 				"deprecation": "^2.3.1"
 			},
 			"engines": {
@@ -9130,21 +9151,14 @@
 			}
 		},
 		"node_modules/@semantic-release/github/node_modules/@octokit/types": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.0.0.tgz",
-			"integrity": "sha512-8uSDc66p6+wADn6lh6lA7I3ZTIapn7F/dfpsiDztVjEr6kkyKR3qPqa4lgEX92O/8iJoDeGcscKRXGAjCSR/zg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.0.tgz",
+			"integrity": "sha512-aHm+olfIZjQpzoODpl+RCZzchKOrdSLJs+yfI7pMMcmB19Li6vidgx0DwUDO/Ic4Q3fq/lOjJORVCcLZefcrJw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@octokit/openapi-types": "^13.0.0"
+				"@octokit/openapi-types": "^13.11.0"
 			}
-		},
-		"node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
-			"integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/@semantic-release/github/node_modules/agent-base": {
 			"version": "6.0.2",
@@ -9612,12 +9626,6 @@
 				"@types/chai": "*"
 			}
 		},
-		"node_modules/@types/component-emitter": {
-			"version": "1.2.11",
-			"resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
-			"integrity": "sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==",
-			"dev": true
-		},
 		"node_modules/@types/connect": {
 			"version": "3.4.35",
 			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -9652,9 +9660,9 @@
 			"dev": true
 		},
 		"node_modules/@types/express": {
-			"version": "4.17.13",
-			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-			"integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+			"version": "4.17.14",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+			"integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
 			"dev": true,
 			"dependencies": {
 				"@types/body-parser": "*",
@@ -9664,9 +9672,9 @@
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "4.17.30",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
-			"integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
+			"version": "4.17.31",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
+			"integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
@@ -9702,9 +9710,9 @@
 			"dev": true
 		},
 		"node_modules/@types/glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.0.tgz",
+			"integrity": "sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==",
 			"dev": true,
 			"dependencies": {
 				"@types/minimatch": "*",
@@ -9746,9 +9754,9 @@
 			"dev": true
 		},
 		"node_modules/@types/lodash": {
-			"version": "4.14.182",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-			"integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
+			"version": "4.14.185",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.185.tgz",
+			"integrity": "sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==",
 			"dev": true
 		},
 		"node_modules/@types/marked": {
@@ -10660,6 +10668,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
 			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+			"deprecated": "This is probably built in to whatever tool you're using. If you still need it... idk",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^5.0.0"
@@ -10744,7 +10753,6 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -11998,13 +12006,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.2.tgz",
-			"integrity": "sha512-LPnodUl3lS0/4wN3Rb+m+UK8s7lj2jcLRrjho4gLw+OJs+I4bvGXshINesY5xx/apM+biTnQ9reDI8yj+0M5+Q==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
+			"integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.17.7",
-				"@babel/helper-define-polyfill-provider": "^0.3.2",
+				"@babel/helper-define-polyfill-provider": "^0.3.3",
 				"semver": "^6.1.1"
 			},
 			"peerDependencies": {
@@ -12021,25 +12029,25 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.3.tgz",
-			"integrity": "sha512-zKsXDh0XjnrUEW0mxIHLfjBfnXSMr5Q/goMe/fxpQnLm07mcOZiIZHBNWCMx60HmdvjxfXcalac0tfFg0wqxyw==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
+			"integrity": "sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.3.2",
-				"core-js-compat": "^3.21.0"
+				"@babel/helper-define-polyfill-provider": "^0.3.3",
+				"core-js-compat": "^3.25.1"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.0.tgz",
-			"integrity": "sha512-RW1cnryiADFeHmfLS+WW/G431p1PsW5qdRdz0SDRi7TKcUgc7Oh/uXkT7MZ/+tGsT1BkczEAmD5XjUyJ5SWDTw==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz",
+			"integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.3.2"
+				"@babel/helper-define-polyfill-provider": "^0.3.3"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
@@ -14674,9 +14682,9 @@
 			}
 		},
 		"node_modules/browser-sync-client/node_modules/typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "4.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -14914,9 +14922,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-			"integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+			"version": "4.21.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
 			"dev": true,
 			"funding": [
 				{
@@ -14929,10 +14937,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001370",
-				"electron-to-chromium": "^1.4.202",
+				"caniuse-lite": "^1.0.30001400",
+				"electron-to-chromium": "^1.4.251",
 				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.5"
+				"update-browserslist-db": "^1.0.9"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -15343,9 +15351,9 @@
 			"dev": true
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001376",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001376.tgz",
-			"integrity": "sha512-I27WhtOQ3X3v3it9gNs/oTpoE5KpwmqKR5oKPA8M0G7uMXh9Ty81Q904HpKUrM30ei7zfcL5jE7AXefgbOfMig==",
+			"version": "1.0.30001400",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz",
+			"integrity": "sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA==",
 			"dev": true,
 			"funding": [
 				{
@@ -17703,9 +17711,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.24.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.24.1.tgz",
-			"integrity": "sha512-0QTBSYSUZ6Gq21utGzkfITDylE8jWC9Ne1D2MrhvlsZBI1x39OdDIVbzSqtgMndIy6BlHxBXpMGqzZmnztg2rg==",
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.1.tgz",
+			"integrity": "sha512-sr0FY4lnO1hkQ4gLDr24K0DGnweGO1QwSj5BpfQjpSJPdqWalja4cTps29Y/PJVG/P7FYlPDkH3hO+Tr0CvDgQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -17714,26 +17722,16 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.24.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.24.1.tgz",
-			"integrity": "sha512-XhdNAGeRnTpp8xbD+sR/HFDK9CbeeeqXT6TuofXh3urqEevzkWmLRgrVoykodsw8okqo2pu1BOmuCKrHx63zdw==",
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.1.tgz",
+			"integrity": "sha512-pOHS7O0i8Qt4zlPW/eIFjwp+NrTPx+wTL0ctgI2fHn31sZOq89rDsmtc/A2vAX7r6shl+bmVI+678He46jgBlw==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.21.3",
-				"semver": "7.0.0"
+				"browserslist": "^4.21.3"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/core-js"
-			}
-		},
-		"node_modules/core-js-compat/node_modules/semver": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-			"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/core-object": {
@@ -18460,6 +18458,17 @@
 			},
 			"peerDependencies": {
 				"semantic-release": ">=15.8.0 <16.0.0 || >=16.0.0-beta <17.0.0"
+			}
+		},
+		"node_modules/cz-lerna-changelog/node_modules/@types/glob": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@types/minimatch": "*",
+				"@types/node": "*"
 			}
 		},
 		"node_modules/cz-lerna-changelog/node_modules/agent-base": {
@@ -21568,9 +21577,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -21585,21 +21595,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -21613,9 +21626,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -21633,9 +21647,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -25070,9 +25085,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.219",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.219.tgz",
-			"integrity": "sha512-zoQJsXOUw0ZA0YxbjkmzBumAJRtr6je5JySuL/bAoFs0DuLiLJ+5FzRF7/ZayihxR2QcewlRZVm5QZdUhwjOgA==",
+			"version": "1.4.251",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.251.tgz",
+			"integrity": "sha512-k4o4cFrWPv4SoJGGAydd07GmlRVzmeDIJ6MaEChTUjk4Dmomn189tCicSzil2oyvbPoGgg2suwPDNWq4gWRhoQ==",
 			"dev": true
 		},
 		"node_modules/elegant-spinner": {
@@ -26001,9 +26016,9 @@
 			}
 		},
 		"node_modules/ember-cli-htmlbars/node_modules/broccoli-persistent-filter": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
-			"integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
+			"integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
 			"dev": true,
 			"dependencies": {
 				"async-disk-cache": "^2.0.0",
@@ -27449,9 +27464,9 @@
 			}
 		},
 		"node_modules/ember-fetch": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-8.1.1.tgz",
-			"integrity": "sha512-Xi1wNmPtVmfIoFH675AA0ELIdYUcoZ2p+6j9c8eDFjiGJiFesyp01bDtl5ryBI/1VPOByJLsDkT+4C11HixsJw==",
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-8.1.2.tgz",
+			"integrity": "sha512-TVx24/jrvDIuPL296DV0hBwp7BWLcSMf0I8464KGz01sPytAB+ZAePbc9ooBTJDkKZEGFgatJa4nj3yF1S9Bpw==",
 			"dev": true,
 			"dependencies": {
 				"abortcontroller-polyfill": "^1.7.3",
@@ -29085,9 +29100,9 @@
 			}
 		},
 		"node_modules/engine.io/node_modules/@types/node": {
-			"version": "18.7.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.4.tgz",
-			"integrity": "sha512-RzRcw8c0B8LzryWOR4Wj7YOTFXvdYKwvrb6xQQyuDfnlTxwYXGCV5RZ/TEbq5L5kn+w3rliHAUyRcG1RtbmTFg==",
+			"version": "18.7.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+			"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
 			"dev": true
 		},
 		"node_modules/enhanced-resolve": {
@@ -29129,9 +29144,9 @@
 			"dev": true
 		},
 		"node_modules/entities": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-			"integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+			"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.12"
@@ -29224,16 +29239,16 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-			"integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.2.tgz",
+			"integrity": "sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.1",
+				"get-intrinsic": "^1.1.2",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
@@ -29245,9 +29260,9 @@
 				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
 				"is-weakref": "^1.0.2",
-				"object-inspect": "^1.12.0",
+				"object-inspect": "^1.12.2",
 				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.2",
+				"object.assign": "^4.1.4",
 				"regexp.prototype.flags": "^1.4.3",
 				"string.prototype.trimend": "^1.0.5",
 				"string.prototype.trimstart": "^1.0.5",
@@ -30464,8 +30479,7 @@
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"node_modules/fast-diff": {
 			"version": "1.2.0",
@@ -30474,9 +30488,9 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -30491,8 +30505,7 @@
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
@@ -31283,9 +31296,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-			"integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
 		"node_modules/flush-write-stream": {
@@ -31335,9 +31348,9 @@
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-			"integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
 			"dev": true,
 			"funding": [
 				{
@@ -31838,9 +31851,9 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-			"integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+			"integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
 			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.1",
@@ -35033,9 +35046,9 @@
 			"dev": true
 		},
 		"node_modules/is-callable": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.6.tgz",
+			"integrity": "sha512-krO72EO2NptOGAX2KYyqbP9vYMlNAXdB53rq6f8LXY6RY7JdSR/3BD6wLUlPHSAesmY9vstNrjvqGaCiRK/91Q==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
@@ -36132,9 +36145,9 @@
 			}
 		},
 		"node_modules/jquery": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
+			"integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
 			"dev": true
 		},
 		"node_modules/js-string-escape": {
@@ -36210,8 +36223,12 @@
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+		},
+		"node_modules/json-schema-typed": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
+			"integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
 		},
 		"node_modules/json-stable-stringify": {
 			"version": "1.0.1",
@@ -38611,9 +38628,9 @@
 			"dev": true
 		},
 		"node_modules/marked": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
-			"integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
 			"dev": true,
 			"peer": true,
 			"bin": {
@@ -38812,6 +38829,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/mem-fs-editor/node_modules/@types/glob": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"dev": true,
+			"dependencies": {
+				"@types/minimatch": "*",
+				"@types/node": "*"
 			}
 		},
 		"node_modules/mem-fs-editor/node_modules/array-differ": {
@@ -43698,6 +43725,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.4.tgz",
 			"integrity": "sha512-iOuIQDWDyjhv9qSDrj9aq/klt6F9z1p2otB3AV7v3zBDcL/x+OfGsvGQZZCcMZbUf4Ujw1xGNQkjvGnVT22cKg==",
+			"deprecated": "This module is not used anymore, npm uses minipass-fetch for its fetch implementation now",
 			"dev": true,
 			"dependencies": {
 				"encoding": "^0.1.11",
@@ -44115,9 +44143,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "8.17.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.17.0.tgz",
-			"integrity": "sha512-tIcfZd541v86Sqrf+t/GW6ivqiT8b/2b3EAjNw3vRe+eVnL4mlkVwu17hjCOrsPVntLb5C6tQG4jPUE5Oveeyw==",
+			"version": "8.19.2",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.19.2.tgz",
+			"integrity": "sha512-MWkISVv5f7iZbfNkry5/5YBqSYJEDAKSJdL+uzSQuyLg+hgLQUyZynu3SH6bOZlvR9ZvJYk2EiJO6B1r+ynwHg==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -44126,6 +44154,7 @@
 				"@npmcli/fs",
 				"@npmcli/map-workspaces",
 				"@npmcli/package-json",
+				"@npmcli/promise-spawn",
 				"@npmcli/run-script",
 				"abbrev",
 				"archy",
@@ -44136,6 +44165,7 @@
 				"cli-table3",
 				"columnify",
 				"fastest-levenshtein",
+				"fs-minipass",
 				"glob",
 				"graceful-fs",
 				"hosted-git-info",
@@ -44155,6 +44185,7 @@
 				"libnpmteam",
 				"libnpmversion",
 				"make-fetch-happen",
+				"minimatch",
 				"minipass",
 				"minipass-pipeline",
 				"mkdirp",
@@ -44195,41 +44226,44 @@
 			"peer": true,
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^5.0.4",
+				"@npmcli/arborist": "^5.6.2",
 				"@npmcli/ci-detect": "^2.0.0",
 				"@npmcli/config": "^4.2.1",
 				"@npmcli/fs": "^2.1.0",
 				"@npmcli/map-workspaces": "^2.0.3",
 				"@npmcli/package-json": "^2.0.0",
+				"@npmcli/promise-spawn": "*",
 				"@npmcli/run-script": "^4.2.1",
 				"abbrev": "~1.1.1",
 				"archy": "~1.0.0",
-				"cacache": "^16.1.1",
+				"cacache": "^16.1.3",
 				"chalk": "^4.1.2",
 				"chownr": "^2.0.0",
 				"cli-columns": "^4.0.0",
 				"cli-table3": "^0.6.2",
 				"columnify": "^1.6.0",
 				"fastest-levenshtein": "^1.0.12",
+				"fs-minipass": "*",
 				"glob": "^8.0.1",
 				"graceful-fs": "^4.2.10",
-				"hosted-git-info": "^5.0.0",
-				"ini": "^3.0.0",
+				"hosted-git-info": "^5.1.0",
+				"ini": "^3.0.1",
 				"init-package-json": "^3.0.2",
 				"is-cidr": "^4.0.2",
 				"json-parse-even-better-errors": "^2.3.1",
-				"libnpmaccess": "^6.0.2",
-				"libnpmdiff": "^4.0.2",
-				"libnpmexec": "^4.0.2",
-				"libnpmfund": "^3.0.1",
-				"libnpmhook": "^8.0.2",
-				"libnpmorg": "^4.0.2",
-				"libnpmpack": "^4.0.2",
-				"libnpmpublish": "^6.0.2",
-				"libnpmsearch": "^5.0.2",
-				"libnpmteam": "^4.0.2",
-				"libnpmversion": "^3.0.1",
+				"libnpmaccess": "^6.0.4",
+				"libnpmdiff": "^4.0.5",
+				"libnpmexec": "^4.0.13",
+				"libnpmfund": "^3.0.4",
+				"libnpmhook": "^8.0.4",
+				"libnpmorg": "^4.0.4",
+				"libnpmpack": "^4.1.3",
+				"libnpmpublish": "^6.0.5",
+				"libnpmsearch": "^5.0.4",
+				"libnpmteam": "^4.0.4",
+				"libnpmversion": "^3.0.7",
 				"make-fetch-happen": "^10.2.0",
+				"minimatch": "*",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
@@ -44240,19 +44274,19 @@
 				"npm-audit-report": "^3.0.0",
 				"npm-install-checks": "^5.0.0",
 				"npm-package-arg": "^9.1.0",
-				"npm-pick-manifest": "^7.0.1",
+				"npm-pick-manifest": "^7.0.2",
 				"npm-profile": "^6.2.0",
-				"npm-registry-fetch": "^13.3.0",
+				"npm-registry-fetch": "^13.3.1",
 				"npm-user-validate": "^1.0.1",
 				"npmlog": "^6.0.2",
 				"opener": "^1.5.2",
 				"p-map": "^4.0.0",
-				"pacote": "^13.6.1",
+				"pacote": "^13.6.2",
 				"parse-conflict-json": "^2.0.2",
 				"proc-log": "^2.0.1",
 				"qrcode-terminal": "^0.12.0",
 				"read": "~1.0.7",
-				"read-package-json": "^5.0.1",
+				"read-package-json": "^5.0.2",
 				"read-package-json-fast": "^2.0.3",
 				"readdir-scoped-modules": "^1.1.0",
 				"rimraf": "^3.0.2",
@@ -44672,7 +44706,7 @@
 			"peer": true
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "5.5.0",
+			"version": "5.6.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -44686,10 +44720,10 @@
 				"@npmcli/name-from-folder": "^1.0.1",
 				"@npmcli/node-gyp": "^2.0.0",
 				"@npmcli/package-json": "^2.0.0",
-				"@npmcli/query": "^1.1.1",
+				"@npmcli/query": "^1.2.0",
 				"@npmcli/run-script": "^4.1.3",
-				"bin-links": "^3.0.0",
-				"cacache": "^16.0.6",
+				"bin-links": "^3.0.3",
+				"cacache": "^16.1.3",
 				"common-ancestor-path": "^1.0.1",
 				"json-parse-even-better-errors": "^2.3.1",
 				"json-stringify-nice": "^1.1.4",
@@ -44699,7 +44733,7 @@
 				"nopt": "^6.0.0",
 				"npm-install-checks": "^5.0.0",
 				"npm-package-arg": "^9.0.0",
-				"npm-pick-manifest": "^7.0.0",
+				"npm-pick-manifest": "^7.0.2",
 				"npm-registry-fetch": "^13.0.0",
 				"npmlog": "^6.0.2",
 				"pacote": "^13.6.1",
@@ -44733,7 +44767,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "4.2.1",
+			"version": "4.2.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -44766,7 +44800,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/fs": {
-			"version": "2.1.1",
+			"version": "2.1.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -44780,7 +44814,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/git": {
-			"version": "3.0.1",
+			"version": "3.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -44817,6 +44851,16 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
+			"version": "1.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"npm-normalize-package-bin": "^1.0.1"
+			}
+		},
 		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
 			"version": "2.0.4",
 			"dev": true,
@@ -44850,7 +44894,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/move-file": {
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -44907,7 +44951,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/query": {
-			"version": "1.1.1",
+			"version": "1.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -45066,7 +45110,7 @@
 			"peer": true
 		},
 		"node_modules/npm/node_modules/bin-links": {
-			"version": "3.0.1",
+			"version": "3.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -45074,11 +45118,21 @@
 			"dependencies": {
 				"cmd-shim": "^5.0.0",
 				"mkdirp-infer-owner": "^2.0.0",
-				"npm-normalize-package-bin": "^1.0.0",
+				"npm-normalize-package-bin": "^2.0.0",
 				"read-cmd-shim": "^3.0.0",
 				"rimraf": "^3.0.0",
 				"write-file-atomic": "^4.0.0"
 			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
@@ -45114,7 +45168,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/cacache": {
-			"version": "16.1.1",
+			"version": "16.1.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -45137,7 +45191,7 @@
 				"rimraf": "^3.0.2",
 				"ssri": "^9.0.0",
 				"tar": "^6.1.11",
-				"unique-filename": "^1.1.1"
+				"unique-filename": "^2.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -45398,7 +45452,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/diff": {
-			"version": "5.0.0",
+			"version": "5.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-3-Clause",
@@ -45554,7 +45608,7 @@
 			"peer": true
 		},
 		"node_modules/npm/node_modules/hosted-git-info": {
-			"version": "5.0.0",
+			"version": "5.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -45563,7 +45617,7 @@
 				"lru-cache": "^7.5.1"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/http-cache-semantics": {
@@ -45685,7 +45739,7 @@
 			"peer": true
 		},
 		"node_modules/npm/node_modules/ini": {
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -45822,7 +45876,7 @@
 			"peer": true
 		},
 		"node_modules/npm/node_modules/libnpmaccess": {
-			"version": "6.0.3",
+			"version": "6.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -45838,7 +45892,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "4.0.4",
+			"version": "4.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -45847,7 +45901,7 @@
 				"@npmcli/disparity-colors": "^2.0.0",
 				"@npmcli/installed-package-contents": "^1.0.7",
 				"binary-extensions": "^2.2.0",
-				"diff": "^5.0.0",
+				"diff": "^5.1.0",
 				"minimatch": "^5.0.1",
 				"npm-package-arg": "^9.0.1",
 				"pacote": "^13.6.1",
@@ -45858,13 +45912,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "4.0.10",
+			"version": "4.0.13",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"peer": true,
 			"dependencies": {
-				"@npmcli/arborist": "^5.0.0",
+				"@npmcli/arborist": "^5.6.2",
 				"@npmcli/ci-detect": "^2.0.0",
 				"@npmcli/fs": "^2.1.1",
 				"@npmcli/run-script": "^4.2.0",
@@ -45884,20 +45938,20 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "3.0.2",
+			"version": "3.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"peer": true,
 			"dependencies": {
-				"@npmcli/arborist": "^5.0.0"
+				"@npmcli/arborist": "^5.6.2"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmhook": {
-			"version": "8.0.3",
+			"version": "8.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -45911,7 +45965,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmorg": {
-			"version": "4.0.3",
+			"version": "4.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -45925,7 +45979,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "4.1.2",
+			"version": "4.1.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -45940,7 +45994,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
-			"version": "6.0.4",
+			"version": "6.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -45957,7 +46011,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmsearch": {
-			"version": "5.0.3",
+			"version": "5.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -45970,7 +46024,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmteam": {
-			"version": "4.0.3",
+			"version": "4.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -45984,7 +46038,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmversion": {
-			"version": "3.0.6",
+			"version": "3.0.7",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -46011,7 +46065,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "10.2.0",
+			"version": "10.2.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -46078,7 +46132,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass-fetch": {
-			"version": "2.1.0",
+			"version": "2.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -46314,7 +46368,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/normalize-package-data": {
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
@@ -46326,7 +46380,7 @@
 				"validate-npm-package-license": "^3.0.4"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-audit-report": {
@@ -46343,13 +46397,26 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-bundled": {
-			"version": "1.1.2",
+			"version": "2.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"peer": true,
 			"dependencies": {
-				"npm-normalize-package-bin": "^1.0.1"
+				"npm-normalize-package-bin": "^2.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-install-checks": {
@@ -46389,7 +46456,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
-			"version": "5.1.1",
+			"version": "5.1.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -46397,8 +46464,8 @@
 			"dependencies": {
 				"glob": "^8.0.1",
 				"ignore-walk": "^5.0.1",
-				"npm-bundled": "^1.1.2",
-				"npm-normalize-package-bin": "^1.0.1"
+				"npm-bundled": "^2.0.0",
+				"npm-normalize-package-bin": "^2.0.0"
 			},
 			"bin": {
 				"npm-packlist": "bin/index.js"
@@ -46407,18 +46474,38 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
+		"node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
 		"node_modules/npm/node_modules/npm-pick-manifest": {
-			"version": "7.0.1",
+			"version": "7.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"peer": true,
 			"dependencies": {
 				"npm-install-checks": "^5.0.0",
-				"npm-normalize-package-bin": "^1.0.1",
+				"npm-normalize-package-bin": "^2.0.0",
 				"npm-package-arg": "^9.0.0",
 				"semver": "^7.3.5"
 			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
@@ -46438,7 +46525,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-registry-fetch": {
-			"version": "13.3.0",
+			"version": "13.3.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -46516,7 +46603,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "13.6.1",
+			"version": "13.6.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -46684,7 +46771,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/read-package-json": {
-			"version": "5.0.1",
+			"version": "5.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -46693,7 +46780,7 @@
 				"glob": "^8.0.1",
 				"json-parse-even-better-errors": "^2.3.1",
 				"normalize-package-data": "^4.0.0",
-				"npm-normalize-package-bin": "^1.0.1"
+				"npm-normalize-package-bin": "^2.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -46711,6 +46798,16 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/readable-stream": {
@@ -47068,23 +47165,29 @@
 			}
 		},
 		"node_modules/npm/node_modules/unique-filename": {
-			"version": "1.1.1",
+			"version": "2.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"peer": true,
 			"dependencies": {
-				"unique-slug": "^2.0.0"
+				"unique-slug": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/unique-slug": {
-			"version": "2.0.2",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"peer": true,
 			"dependencies": {
 				"imurmurhash": "^0.1.4"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/util-deprecate": {
@@ -47169,7 +47272,7 @@
 			"peer": true
 		},
 		"node_modules/npm/node_modules/write-file-atomic": {
-			"version": "4.0.1",
+			"version": "4.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -47179,7 +47282,7 @@
 				"signal-exit": "^3.0.7"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/yallist": {
@@ -47424,9 +47527,9 @@
 			}
 		},
 		"node_modules/object.assign": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
-			"integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
@@ -48547,12 +48650,12 @@
 			"dev": true
 		},
 		"node_modules/parse5": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
-			"integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
+			"integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
 			"dev": true,
 			"dependencies": {
-				"entities": "^4.3.0"
+				"entities": "^4.4.0"
 			},
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -49545,7 +49648,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -50336,9 +50438,9 @@
 			"dev": true
 		},
 		"node_modules/regenerate-unicode-properties": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz",
-			"integrity": "sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
+			"integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
 			"dev": true,
 			"dependencies": {
 				"regenerate": "^1.4.2"
@@ -50417,15 +50519,15 @@
 			}
 		},
 		"node_modules/regexpu-core": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.1.0.tgz",
-			"integrity": "sha512-bb6hk+xWd2PEOkj5It46A16zFMs2mv86Iwpdu94la4S3sJ7C973h2dHpYKwIBGaWSO7cIRJ+UX0IeMaWcO4qwA==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.2.1.tgz",
+			"integrity": "sha512-HrnlNtpvqP1Xkb28tMhBUO2EbyUHdQlsnlAhzWcwHy8WJR53UWr7/MAvqrsQKMbV4qdpv03oTMG8iIhfsPFktQ==",
 			"dev": true,
 			"dependencies": {
 				"regenerate": "^1.4.2",
-				"regenerate-unicode-properties": "^10.0.1",
-				"regjsgen": "^0.6.0",
-				"regjsparser": "^0.8.2",
+				"regenerate-unicode-properties": "^10.1.0",
+				"regjsgen": "^0.7.1",
+				"regjsparser": "^0.9.1",
 				"unicode-match-property-ecmascript": "^2.0.0",
 				"unicode-match-property-value-ecmascript": "^2.0.0"
 			},
@@ -50458,15 +50560,15 @@
 			}
 		},
 		"node_modules/regjsgen": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.6.0.tgz",
-			"integrity": "sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.7.1.tgz",
+			"integrity": "sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA==",
 			"dev": true
 		},
 		"node_modules/regjsparser": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.8.4.tgz",
-			"integrity": "sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==",
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+			"integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
 			"dev": true,
 			"dependencies": {
 				"jsesc": "~0.5.0"
@@ -51379,9 +51481,9 @@
 			}
 		},
 		"node_modules/semantic-release": {
-			"version": "19.0.3",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.3.tgz",
-			"integrity": "sha512-HaFbydST1cDKZHuFZxB8DTrBLJVK/AnDExpK0s3EqLIAAUAHUgnd+VSJCUtTYQKkAkauL8G9CucODrVCc7BuAA==",
+			"version": "19.0.5",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
+			"integrity": "sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -52526,9 +52628,9 @@
 			}
 		},
 		"node_modules/socket.io": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.1.tgz",
-			"integrity": "sha512-0y9pnIso5a9i+lJmsCdtmTTgJFFSvNQKDnPQRz28mGNnxbmqYg2QPtJTLFxhymFZhAIn50eHAKzJeiNaKr+yUQ==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.2.tgz",
+			"integrity": "sha512-6fCnk4ARMPZN448+SQcnn1u8OHUC72puJcNtSgg2xS34Cu7br1gQ09YKkO1PFfDn/wyUE9ZgMAwosJed003+NQ==",
 			"dev": true,
 			"dependencies": {
 				"accepts": "~1.3.4",
@@ -52536,7 +52638,7 @@
 				"debug": "~4.3.2",
 				"engine.io": "~6.2.0",
 				"socket.io-adapter": "~2.4.0",
-				"socket.io-parser": "~4.0.4"
+				"socket.io-parser": "~4.2.0"
 			},
 			"engines": {
 				"node": ">=10.0.0"
@@ -52549,9 +52651,9 @@
 			"dev": true
 		},
 		"node_modules/socket.io-client": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.1.tgz",
-			"integrity": "sha512-e6nLVgiRYatS+AHXnOnGi4ocOpubvOUCGhyWw8v+/FxW8saHkinG6Dfhi9TU0Kt/8mwJIAASxvw6eujQmjdZVA==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.2.tgz",
+			"integrity": "sha512-naqYfFu7CLDiQ1B7AlLhRXKX3gdeaIMfgigwavDzgJoIUYulc1qHH5+2XflTsXTPY7BlPH5rppJyUjhjrKQKLg==",
 			"dev": true,
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
@@ -52563,27 +52665,13 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/socket.io-client/node_modules/socket.io-parser": {
+		"node_modules/socket.io-parser": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
 			"integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
 			"dev": true,
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
-				"debug": "~4.3.1"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/socket.io-parser": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.5.tgz",
-			"integrity": "sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig==",
-			"dev": true,
-			"dependencies": {
-				"@types/component-emitter": "^1.2.10",
-				"component-emitter": "~1.3.0",
 				"debug": "~4.3.1"
 			},
 			"engines": {
@@ -52696,6 +52784,16 @@
 			},
 			"bin": {
 				"sort-package-json": "cli.js"
+			}
+		},
+		"node_modules/sort-package-json/node_modules/@types/glob": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"dev": true,
+			"dependencies": {
+				"@types/minimatch": "*",
+				"@types/node": "*"
 			}
 		},
 		"node_modules/sort-package-json/node_modules/array-union": {
@@ -52947,9 +53045,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-			"integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+			"version": "3.0.12",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
 			"dev": true
 		},
 		"node_modules/speedometer": {
@@ -53803,9 +53901,9 @@
 			}
 		},
 		"node_modules/supports-hyperlinks": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-			"integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
 			"dev": true,
 			"dependencies": {
 				"has-flag": "^4.0.0",
@@ -54549,9 +54647,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.14.2",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-			"integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+			"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.2",
@@ -54794,9 +54892,9 @@
 			}
 		},
 		"node_modules/testem": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/testem/-/testem-3.8.0.tgz",
-			"integrity": "sha512-WEaFOq2ZGqM3IQji+Q2uXHGdln5upKhSZ1pLYe9W4CttDELAo588frNovk8UQmB+Xg2mDI8G2zmm7qKuWsldtw==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/testem/-/testem-3.9.0.tgz",
+			"integrity": "sha512-YTxCYKj0cc8uUSKEziJtSC5T/pw4fQnY0ZXNOyvAFgrijfsN9NxmncJZOHLhPgFOuhbRd5i+DBQxw0Cpe0SEFg==",
 			"dev": true,
 			"dependencies": {
 				"@xmldom/xmldom": "^0.8.0",
@@ -55963,9 +56061,9 @@
 			"dev": true
 		},
 		"node_modules/uglify-js": {
-			"version": "3.16.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
-			"integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
+			"integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
 			"dev": true,
 			"optional": true,
 			"bin": {
@@ -56233,9 +56331,9 @@
 			}
 		},
 		"node_modules/unicode-property-aliases-ecmascript": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
-			"integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+			"integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -56423,9 +56521,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-			"integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
+			"integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
 			"dev": true,
 			"funding": [
 				{
@@ -56574,7 +56672,6 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -59527,6 +59624,16 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/yeoman-generator/node_modules/@types/glob": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"dev": true,
+			"dependencies": {
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
 		"node_modules/yeoman-generator/node_modules/ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -61092,7 +61199,9 @@
 			"dependencies": {
 				"abab": "^2.0.5",
 				"adlib": "^3.0.7",
+				"ajv": "^6.12.6",
 				"fast-xml-parser": "^3.21.0",
+				"json-schema-typed": "^7.0.3",
 				"jsonapi-typescript": "^0.1.3",
 				"tslib": "^1.13.0"
 			},
@@ -61115,7 +61224,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "13.5.0",
+			"version": "13.6.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61260,17 +61369,14 @@
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
 			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.25.0.tgz",
-			"integrity": "sha512-2iMwX8tUVTImpoyKjNVsigc0JCUM8hTlyIu/hF2NnehyetvsefSut8njMObwHy872zfBzZ+kOMyulGGzdHvLxg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"peer": true
 		},
 		"packages/sites/node_modules/@esri/hub-types": {
 			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-types/-/hub-types-6.10.0.tgz",
-			"integrity": "sha512-fv16PUCaLVZY/rRAIg6HV6LxQLxheutaVovcOS3zmyqAgkeNI7keJblz50RrABSmfP7g+N2/XJRTHntze6ZrVA==",
-			"deprecated": "Types have been moved to @esri/hub-common and @esri/hub-teams",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
@@ -61348,27 +61454,27 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.18.8",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
-			"integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.1.tgz",
+			"integrity": "sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==",
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
-			"integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
+			"integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
 			"dev": true,
 			"requires": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.10",
-				"@babel/helper-compilation-targets": "^7.18.9",
-				"@babel/helper-module-transforms": "^7.18.9",
-				"@babel/helpers": "^7.18.9",
-				"@babel/parser": "^7.18.10",
+				"@babel/generator": "^7.19.0",
+				"@babel/helper-compilation-targets": "^7.19.1",
+				"@babel/helper-module-transforms": "^7.19.0",
+				"@babel/helpers": "^7.19.0",
+				"@babel/parser": "^7.19.1",
 				"@babel/template": "^7.18.10",
-				"@babel/traverse": "^7.18.10",
-				"@babel/types": "^7.18.10",
+				"@babel/traverse": "^7.19.1",
+				"@babel/types": "^7.19.0",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -61385,12 +61491,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.18.12",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
-			"integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
+			"integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.10",
+				"@babel/types": "^7.19.0",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"jsesc": "^2.5.1"
 			},
@@ -61428,14 +61534,14 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
-			"integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.1.tgz",
+			"integrity": "sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.18.8",
+				"@babel/compat-data": "^7.19.1",
 				"@babel/helper-validator-option": "^7.18.6",
-				"browserslist": "^4.20.2",
+				"browserslist": "^4.21.3",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
@@ -61448,14 +61554,14 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.9.tgz",
-			"integrity": "sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.19.0.tgz",
+			"integrity": "sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/helper-member-expression-to-functions": "^7.18.9",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
 				"@babel/helper-replace-supers": "^7.18.9",
@@ -61463,9 +61569,9 @@
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.18.6.tgz",
-			"integrity": "sha512-7LcpH1wnQLGrI+4v+nPp+zUvIkF9x0ddv1Hkdue10tg3gmRnLy97DXh4STiOf1qeIInyD69Qv5kKSZzKD8B/7A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.19.0.tgz",
+			"integrity": "sha512-htnV+mHX32DF81amCDrwIDr8nrp1PTm+3wfBN9/v8QJOLEioOCOG7qNyq0nHeFiWbT3Eb7gsPwEmV64UCQ1jzw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
@@ -61473,9 +61579,9 @@
 			}
 		},
 		"@babel/helper-define-polyfill-provider": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.2.tgz",
-			"integrity": "sha512-r9QJJ+uDWrd+94BSPcP6/de67ygLtvVy6cK4luE6MOuDsZIdoaPBnfSpbO/+LTifjPckbKXRuI9BB/Z2/y3iTg==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz",
+			"integrity": "sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-compilation-targets": "^7.17.7",
@@ -61510,13 +61616,13 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
-			"integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+			"integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.18.6",
-				"@babel/types": "^7.18.9"
+				"@babel/template": "^7.18.10",
+				"@babel/types": "^7.19.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
@@ -61547,9 +61653,9 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
-			"integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
+			"integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-environment-visitor": "^7.18.9",
@@ -61557,9 +61663,9 @@
 				"@babel/helper-simple-access": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
 				"@babel/helper-validator-identifier": "^7.18.6",
-				"@babel/template": "^7.18.6",
-				"@babel/traverse": "^7.18.9",
-				"@babel/types": "^7.18.9"
+				"@babel/template": "^7.18.10",
+				"@babel/traverse": "^7.19.0",
+				"@babel/types": "^7.19.0"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -61572,9 +61678,9 @@
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
-			"integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
+			"integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
 			"dev": true
 		},
 		"@babel/helper-remap-async-to-generator": {
@@ -61590,16 +61696,16 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.18.9.tgz",
-			"integrity": "sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.19.1.tgz",
+			"integrity": "sha512-T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-environment-visitor": "^7.18.9",
 				"@babel/helper-member-expression-to-functions": "^7.18.9",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
-				"@babel/traverse": "^7.18.9",
-				"@babel/types": "^7.18.9"
+				"@babel/traverse": "^7.19.1",
+				"@babel/types": "^7.19.0"
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -61636,9 +61742,9 @@
 			"dev": true
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
@@ -61648,26 +61754,26 @@
 			"dev": true
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.18.11.tgz",
-			"integrity": "sha512-oBUlbv+rjZLh2Ks9SKi4aL7eKaAXBWleHzU89mP0G6BMUlRxSckk9tSIkgDGydhgFxHuGSlBQZfnaD47oBEB7w==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.19.0.tgz",
+			"integrity": "sha512-txX8aN8CZyYGTwcLhlk87KRqncAzhh5TpQamZUa0/u3an36NtDpUP6bQgBCBcLeBs09R/OwQu3OjK0k/HwfNDg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/template": "^7.18.10",
-				"@babel/traverse": "^7.18.11",
-				"@babel/types": "^7.18.10"
+				"@babel/traverse": "^7.19.0",
+				"@babel/types": "^7.19.0"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
-			"integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
+			"integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.18.6",
-				"@babel/traverse": "^7.18.9",
-				"@babel/types": "^7.18.9"
+				"@babel/template": "^7.18.10",
+				"@babel/traverse": "^7.19.0",
+				"@babel/types": "^7.19.0"
 			}
 		},
 		"@babel/highlight": {
@@ -61734,9 +61840,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
-			"integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
+			"integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
 			"dev": true
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -61760,13 +61866,13 @@
 			}
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.18.10.tgz",
-			"integrity": "sha512-1mFuY2TOsR1hxbjCo4QL+qlIjV07p4H4EUYw2J/WCqsvFV6V9X9z9YhXbWndc/4fw+hYGlDT7egYxliMp5O6Ew==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.19.1.tgz",
+			"integrity": "sha512-0yu8vNATgLy4ivqMNBIwb1HebCelqN7YX8SL3FDXORv/RqT0zEEWUCH4GH44JsSrvCu6GqnAdR5EBFAPeNBB4Q==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-remap-async-to-generator": "^7.18.9",
 				"@babel/plugin-syntax-async-generators": "^7.8.4"
 			}
@@ -61793,16 +61899,16 @@
 			}
 		},
 		"@babel/plugin-proposal-decorators": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.18.10.tgz",
-			"integrity": "sha512-wdGTwWF5QtpTY/gbBtQLAiCnoxfD4qMbN87NYZle1dOZ9Os8Y6zXcKrIaOU8W+TIvFUWVGG9tUgNww3CjXRVVw==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.19.1.tgz",
+			"integrity": "sha512-LfIKNBBY7Q1OX5C4xAgRQffOg2OnhAo9fnbcOHgOC9Yytm2Sw+4XqHufRYU86tHomzepxtvuVaNO+3EVKR4ivw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
-				"@babel/helper-replace-supers": "^7.18.9",
+				"@babel/helper-create-class-features-plugin": "^7.19.0",
+				"@babel/helper-plugin-utils": "^7.19.0",
+				"@babel/helper-replace-supers": "^7.19.1",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/plugin-syntax-decorators": "^7.18.6"
+				"@babel/plugin-syntax-decorators": "^7.19.0"
 			}
 		},
 		"@babel/plugin-proposal-dynamic-import": {
@@ -61959,12 +62065,12 @@
 			}
 		},
 		"@babel/plugin-syntax-decorators": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.18.6.tgz",
-			"integrity": "sha512-fqyLgjcxf/1yhyZ6A+yo1u9gJ7eleFQod2lkaUsF9DQ7sbbY3Ligym3L0+I2c0WmqNKDpoD9UTb1AKP3qRMOAQ==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.19.0.tgz",
+			"integrity": "sha512-xaBZUEDntt4faL1yN8oIFlhfXeQAWJW7CLKYsHTUqriCUbj8xOra8bfxxKGi/UwExPFBuPdH4XfHc9rGQhrVkQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.19.0"
 			}
 		},
 		"@babel/plugin-syntax-dynamic-import": {
@@ -62123,16 +62229,17 @@
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.18.9.tgz",
-			"integrity": "sha512-EkRQxsxoytpTlKJmSPYrsOMjCILacAjtSVkd4gChEe2kXjFCun3yohhW5I7plXJhCemM0gKsaGMcO8tinvCA5g==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.19.0.tgz",
+			"integrity": "sha512-YfeEE9kCjqTS9IitkgfJuxjcEtLUHMqa8yUJ6zdz8vR7hKuo6mOy2C05P0F1tdMmDCeuyidKnlrw/iTppHcr2A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
+				"@babel/helper-compilation-targets": "^7.19.0",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-replace-supers": "^7.18.9",
 				"@babel/helper-split-export-declaration": "^7.18.6",
 				"globals": "^11.1.0"
@@ -62148,9 +62255,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.9.tgz",
-			"integrity": "sha512-p5VCYNddPLkZTq4XymQIaIfZNJwT9YsjkPOhkVEqt6QIpQFZVM9IltqqYpOEkJoN1DPznmxUDyZ5CTZs/ZCuHA==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.13.tgz",
+			"integrity": "sha512-TodpQ29XekIsex2A+YJPj5ax2plkGa8YYY6mFjCohk/IG9IY42Rtuj1FuDeemfg2ipxIFLzPeA83SIBnlhSIow==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.18.9"
@@ -62247,14 +62354,14 @@
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.18.9.tgz",
-			"integrity": "sha512-zY/VSIbbqtoRoJKo2cDTewL364jSlZGvn0LKOf9ntbfxOvjfmyrdtEEOAdswOswhZEb8UH3jDkCKHd1sPgsS0A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.19.0.tgz",
+			"integrity": "sha512-x9aiR0WXAWmOWsqcsnrzGR+ieaTMVyGyffPVA7F8cXAGt/UxefYv6uSHZLkAFChN5M5Iy1+wjE+xJuPt22H39A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-module-transforms": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-module-transforms": "^7.19.0",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-validator-identifier": "^7.18.6",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
@@ -62270,13 +62377,13 @@
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.18.6.tgz",
-			"integrity": "sha512-UmEOGF8XgaIqD74bC8g7iV3RYj8lMf0Bw7NJzvnS9qQhM4mg+1WHKotUIdjxgD2RGrgFLZZPCFPFj3P/kVDYhg==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.19.1.tgz",
+			"integrity": "sha512-oWk9l9WItWBQYS4FgXD4Uyy5kq898lvkXpXQxoJEY1RnvPk4R/Dvu2ebXU9q8lP+rlMwUQTFf2Ok6d78ODa0kw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-create-regexp-features-plugin": "^7.19.0",
+				"@babel/helper-plugin-utils": "^7.19.0"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
@@ -62345,16 +62452,16 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.18.10.tgz",
-			"integrity": "sha512-q5mMeYAdfEbpBAgzl7tBre/la3LeCxmDO1+wMXRdPWbcoMjR3GiXlCLk7JBZVVye0bqTGNMbt0yYVXX1B1jEWQ==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.19.1.tgz",
+			"integrity": "sha512-2nJjTUFIzBMP/f/miLxEK9vxwW/KUXsdvN4sR//TmuDhe6yU2h57WmIOE12Gng3MDP/xpjUV/ToZRdcf8Yj4fA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.9",
-				"babel-plugin-polyfill-corejs2": "^0.3.2",
-				"babel-plugin-polyfill-corejs3": "^0.5.3",
-				"babel-plugin-polyfill-regenerator": "^0.4.0",
+				"@babel/helper-plugin-utils": "^7.19.0",
+				"babel-plugin-polyfill-corejs2": "^0.3.3",
+				"babel-plugin-polyfill-corejs3": "^0.6.0",
+				"babel-plugin-polyfill-regenerator": "^0.4.1",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
@@ -62376,12 +62483,12 @@
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.18.9.tgz",
-			"integrity": "sha512-39Q814wyoOPtIB/qGopNIL9xDChOE1pNU0ZY5dO0owhiVt/5kFm4li+/bBtwc7QotG0u5EPzqhZdjMtmqBqyQA==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.19.0.tgz",
+			"integrity": "sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.18.9"
 			}
 		},
@@ -62413,13 +62520,13 @@
 			}
 		},
 		"@babel/plugin-transform-typescript": {
-			"version": "7.18.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.12.tgz",
-			"integrity": "sha512-2vjjam0cum0miPkenUbQswKowuxs/NjMwIKEq0zwegRxXk12C9YOF9STXnaUptITOtOJHKHpzvvWYOjbm6tc0w==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.19.1.tgz",
+			"integrity": "sha512-+ILcOU+6mWLlvCwnL920m2Ow3wWx3Wo8n2t5aROQmV55GZt+hOiLvBaa3DNzRjSEHa1aauRs4/YLmkCfFkhhRQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-create-class-features-plugin": "^7.19.0",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/plugin-syntax-typescript": "^7.18.6"
 			}
 		},
@@ -62461,18 +62568,18 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.18.10.tgz",
-			"integrity": "sha512-wVxs1yjFdW3Z/XkNfXKoblxoHgbtUF7/l3PvvP4m02Qz9TZ6uZGxRVYjSQeR87oQmHco9zWitW5J82DJ7sCjvA==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.19.1.tgz",
+			"integrity": "sha512-c8B2c6D16Lp+Nt6HcD+nHl0VbPKVnNPTpszahuxJJnurfMtKeZ80A+qUv48Y7wqvS+dTFuLuaM9oYxyNHbCLWA==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.18.8",
-				"@babel/helper-compilation-targets": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/compat-data": "^7.19.1",
+				"@babel/helper-compilation-targets": "^7.19.1",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-validator-option": "^7.18.6",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.18.9",
-				"@babel/plugin-proposal-async-generator-functions": "^7.18.10",
+				"@babel/plugin-proposal-async-generator-functions": "^7.19.1",
 				"@babel/plugin-proposal-class-properties": "^7.18.6",
 				"@babel/plugin-proposal-class-static-block": "^7.18.6",
 				"@babel/plugin-proposal-dynamic-import": "^7.18.6",
@@ -62506,9 +62613,9 @@
 				"@babel/plugin-transform-async-to-generator": "^7.18.6",
 				"@babel/plugin-transform-block-scoped-functions": "^7.18.6",
 				"@babel/plugin-transform-block-scoping": "^7.18.9",
-				"@babel/plugin-transform-classes": "^7.18.9",
+				"@babel/plugin-transform-classes": "^7.19.0",
 				"@babel/plugin-transform-computed-properties": "^7.18.9",
-				"@babel/plugin-transform-destructuring": "^7.18.9",
+				"@babel/plugin-transform-destructuring": "^7.18.13",
 				"@babel/plugin-transform-dotall-regex": "^7.18.6",
 				"@babel/plugin-transform-duplicate-keys": "^7.18.9",
 				"@babel/plugin-transform-exponentiation-operator": "^7.18.6",
@@ -62518,9 +62625,9 @@
 				"@babel/plugin-transform-member-expression-literals": "^7.18.6",
 				"@babel/plugin-transform-modules-amd": "^7.18.6",
 				"@babel/plugin-transform-modules-commonjs": "^7.18.6",
-				"@babel/plugin-transform-modules-systemjs": "^7.18.9",
+				"@babel/plugin-transform-modules-systemjs": "^7.19.0",
 				"@babel/plugin-transform-modules-umd": "^7.18.6",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.18.6",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.19.1",
 				"@babel/plugin-transform-new-target": "^7.18.6",
 				"@babel/plugin-transform-object-super": "^7.18.6",
 				"@babel/plugin-transform-parameters": "^7.18.8",
@@ -62528,18 +62635,18 @@
 				"@babel/plugin-transform-regenerator": "^7.18.6",
 				"@babel/plugin-transform-reserved-words": "^7.18.6",
 				"@babel/plugin-transform-shorthand-properties": "^7.18.6",
-				"@babel/plugin-transform-spread": "^7.18.9",
+				"@babel/plugin-transform-spread": "^7.19.0",
 				"@babel/plugin-transform-sticky-regex": "^7.18.6",
 				"@babel/plugin-transform-template-literals": "^7.18.9",
 				"@babel/plugin-transform-typeof-symbol": "^7.18.9",
 				"@babel/plugin-transform-unicode-escapes": "^7.18.10",
 				"@babel/plugin-transform-unicode-regex": "^7.18.6",
 				"@babel/preset-modules": "^0.1.5",
-				"@babel/types": "^7.18.10",
-				"babel-plugin-polyfill-corejs2": "^0.3.2",
-				"babel-plugin-polyfill-corejs3": "^0.5.3",
-				"babel-plugin-polyfill-regenerator": "^0.4.0",
-				"core-js-compat": "^3.22.1",
+				"@babel/types": "^7.19.0",
+				"babel-plugin-polyfill-corejs2": "^0.3.3",
+				"babel-plugin-polyfill-corejs3": "^0.6.0",
+				"babel-plugin-polyfill-regenerator": "^0.4.1",
+				"core-js-compat": "^3.25.1",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
@@ -62565,9 +62672,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-			"integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
+			"integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
@@ -62585,27 +62692,27 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz",
-			"integrity": "sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
+			"integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.10",
+				"@babel/generator": "^7.19.0",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/helper-hoist-variables": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.18.11",
-				"@babel/types": "^7.18.10",
+				"@babel/parser": "^7.19.1",
+				"@babel/types": "^7.19.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
-			"integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
+			"integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-string-parser": "^7.18.10",
@@ -64714,7 +64821,9 @@
 				"@types/adlib": "^3.0.1",
 				"abab": "^2.0.5",
 				"adlib": "^3.0.7",
+				"ajv": "^6.12.6",
 				"fast-xml-parser": "^3.21.0",
+				"json-schema-typed": "^7.0.3",
 				"jsonapi-typescript": "^0.1.3",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64801,15 +64910,11 @@
 			"dependencies": {
 				"@esri/arcgis-rest-types": {
 					"version": "2.25.0",
-					"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.25.0.tgz",
-					"integrity": "sha512-2iMwX8tUVTImpoyKjNVsigc0JCUM8hTlyIu/hF2NnehyetvsefSut8njMObwHy872zfBzZ+kOMyulGGzdHvLxg==",
 					"dev": true,
 					"peer": true
 				},
 				"@esri/hub-types": {
 					"version": "6.10.0",
-					"resolved": "https://registry.npmjs.org/@esri/hub-types/-/hub-types-6.10.0.tgz",
-					"integrity": "sha512-fv16PUCaLVZY/rRAIg6HV6LxQLxheutaVovcOS3zmyqAgkeNI7keJblz50RrABSmfP7g+N2/XJRTHntze6ZrVA==",
 					"dev": true,
 					"requires": {
 						"tslib": "^1.13.0"
@@ -65982,6 +66087,16 @@
 					"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 					"dev": true
 				},
+				"@types/glob": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+					"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+					"dev": true,
+					"requires": {
+						"@types/minimatch": "*",
+						"@types/node": "*"
+					}
+				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
@@ -66935,6 +67050,16 @@
 					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
 					"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 					"dev": true
+				},
+				"@types/glob": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+					"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+					"dev": true,
+					"requires": {
+						"@types/minimatch": "*",
+						"@types/node": "*"
+					}
 				},
 				"braces": {
 					"version": "2.3.2",
@@ -68026,9 +68151,9 @@
 					}
 				},
 				"@octokit/endpoint": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.1.tgz",
-					"integrity": "sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==",
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.2.tgz",
+					"integrity": "sha512-8/AUACfE9vpRpehE6ZLfEtzkibe5nfsSwFZVMsG8qabqRt1M81qZYUFRZa1B8w8lP6cdfDJfRq9HWS+MbmR7tw==",
 					"dev": true,
 					"peer": true,
 					"requires": {
@@ -68038,9 +68163,9 @@
 					}
 				},
 				"@octokit/openapi-types": {
-					"version": "13.0.1",
-					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.0.1.tgz",
-					"integrity": "sha512-40U39YoFBhJhmkAg6gbJnh9U8aueJwCuiTW0mXY2pNl9/+E7dUxXiMPOrIUGT12XqLinroaXYA3FUiw3BMeNfg==",
+					"version": "13.11.0",
+					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.11.0.tgz",
+					"integrity": "sha512-Y5LdQm7dFJLJdAp/KTZx40h/gFF3tRKDO78L4MlDd5KUwLuySRE4or9CQuaeMho5yYwQMoKjVDyt7louorZhvw==",
 					"dev": true,
 					"peer": true
 				},
@@ -68072,13 +68197,13 @@
 					}
 				},
 				"@octokit/types": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.0.0.tgz",
-					"integrity": "sha512-8uSDc66p6+wADn6lh6lA7I3ZTIapn7F/dfpsiDztVjEr6kkyKR3qPqa4lgEX92O/8iJoDeGcscKRXGAjCSR/zg==",
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.0.tgz",
+					"integrity": "sha512-aHm+olfIZjQpzoODpl+RCZzchKOrdSLJs+yfI7pMMcmB19Li6vidgx0DwUDO/Ic4Q3fq/lOjJORVCcLZefcrJw==",
 					"dev": true,
 					"peer": true,
 					"requires": {
-						"@octokit/openapi-types": "^13.0.0"
+						"@octokit/openapi-types": "^13.11.0"
 					}
 				},
 				"universal-user-agent": {
@@ -68122,9 +68247,9 @@
 			},
 			"dependencies": {
 				"@octokit/endpoint": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.1.tgz",
-					"integrity": "sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==",
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.2.tgz",
+					"integrity": "sha512-8/AUACfE9vpRpehE6ZLfEtzkibe5nfsSwFZVMsG8qabqRt1M81qZYUFRZa1B8w8lP6cdfDJfRq9HWS+MbmR7tw==",
 					"dev": true,
 					"peer": true,
 					"requires": {
@@ -68134,9 +68259,9 @@
 					}
 				},
 				"@octokit/openapi-types": {
-					"version": "13.0.1",
-					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.0.1.tgz",
-					"integrity": "sha512-40U39YoFBhJhmkAg6gbJnh9U8aueJwCuiTW0mXY2pNl9/+E7dUxXiMPOrIUGT12XqLinroaXYA3FUiw3BMeNfg==",
+					"version": "13.11.0",
+					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.11.0.tgz",
+					"integrity": "sha512-Y5LdQm7dFJLJdAp/KTZx40h/gFF3tRKDO78L4MlDd5KUwLuySRE4or9CQuaeMho5yYwQMoKjVDyt7louorZhvw==",
 					"dev": true,
 					"peer": true
 				},
@@ -68168,13 +68293,13 @@
 					}
 				},
 				"@octokit/types": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.0.0.tgz",
-					"integrity": "sha512-8uSDc66p6+wADn6lh6lA7I3ZTIapn7F/dfpsiDztVjEr6kkyKR3qPqa4lgEX92O/8iJoDeGcscKRXGAjCSR/zg==",
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.0.tgz",
+					"integrity": "sha512-aHm+olfIZjQpzoODpl+RCZzchKOrdSLJs+yfI7pMMcmB19Li6vidgx0DwUDO/Ic4Q3fq/lOjJORVCcLZefcrJw==",
 					"dev": true,
 					"peer": true,
 					"requires": {
-						"@octokit/openapi-types": "^13.0.0"
+						"@octokit/openapi-types": "^13.11.0"
 					}
 				},
 				"universal-user-agent": {
@@ -68217,9 +68342,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "18.7.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.4.tgz",
-					"integrity": "sha512-RzRcw8c0B8LzryWOR4Wj7YOTFXvdYKwvrb6xQQyuDfnlTxwYXGCV5RZ/TEbq5L5kn+w3rliHAUyRcG1RtbmTFg==",
+					"version": "18.7.18",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+					"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
 					"dev": true
 				}
 			}
@@ -68251,9 +68376,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "18.7.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.4.tgz",
-					"integrity": "sha512-RzRcw8c0B8LzryWOR4Wj7YOTFXvdYKwvrb6xQQyuDfnlTxwYXGCV5RZ/TEbq5L5kn+w3rliHAUyRcG1RtbmTFg==",
+					"version": "18.7.18",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+					"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
 					"dev": true
 				}
 			}
@@ -68312,9 +68437,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "18.7.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.4.tgz",
-					"integrity": "sha512-RzRcw8c0B8LzryWOR4Wj7YOTFXvdYKwvrb6xQQyuDfnlTxwYXGCV5RZ/TEbq5L5kn+w3rliHAUyRcG1RtbmTFg==",
+					"version": "18.7.18",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+					"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
 					"dev": true
 				}
 			}
@@ -68412,14 +68537,14 @@
 			}
 		},
 		"@semantic-release/github": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.5.tgz",
-			"integrity": "sha512-9pGxRM3gv1hgoZ/muyd4pWnykdIUVfCiev6MXE9lOyGQof4FQy95GFE26nDcifs9ZG7bBzV8ue87bo/y1zVf0g==",
+			"version": "8.0.6",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.6.tgz",
+			"integrity": "sha512-ZxgaxYCeqt9ylm2x3OPqUoUqBw1p60LhxzdX6BqJlIBThupGma98lttsAbK64T6L6AlNa2G5T66BbiG8y0PIHQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
 				"@octokit/rest": "^19.0.0",
-				"@semantic-release/error": "^2.2.0",
+				"@semantic-release/error": "^3.0.0",
 				"aggregate-error": "^3.0.0",
 				"bottleneck": "^2.18.1",
 				"debug": "^4.0.0",
@@ -68437,30 +68562,30 @@
 			},
 			"dependencies": {
 				"@octokit/openapi-types": {
-					"version": "13.0.1",
-					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.0.1.tgz",
-					"integrity": "sha512-40U39YoFBhJhmkAg6gbJnh9U8aueJwCuiTW0mXY2pNl9/+E7dUxXiMPOrIUGT12XqLinroaXYA3FUiw3BMeNfg==",
+					"version": "13.11.0",
+					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.11.0.tgz",
+					"integrity": "sha512-Y5LdQm7dFJLJdAp/KTZx40h/gFF3tRKDO78L4MlDd5KUwLuySRE4or9CQuaeMho5yYwQMoKjVDyt7louorZhvw==",
 					"dev": true,
 					"peer": true
 				},
 				"@octokit/plugin-paginate-rest": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.0.0.tgz",
-					"integrity": "sha512-g4GJMt/7VDmIMMdQenN6bmsmRoZca1c7IxOdF2yMiMwQYrE2bmmypGQeQSD5rsaffsFMCUS7Br4pMVZamareYA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.0.tgz",
+					"integrity": "sha512-4V8hWMoXuxb03xPs3s3RjUb5Bzx4HmVRhG+gvbO08PB48ag6G8mk6/HDFKlAXz9XEorDIkc0pXcXnaOz8spHgg==",
 					"dev": true,
 					"peer": true,
 					"requires": {
-						"@octokit/types": "^7.0.0"
+						"@octokit/types": "^7.4.0"
 					}
 				},
 				"@octokit/plugin-rest-endpoint-methods": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.3.0.tgz",
-					"integrity": "sha512-qEu2wn6E7hqluZwIEUnDxWROvKjov3zMIAi4H4d7cmKWNMeBprEXZzJe8pE5eStUYC1ysGhD0B7L6IeG1Rfb+g==",
+					"version": "6.6.1",
+					"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.1.tgz",
+					"integrity": "sha512-hkD9agR36fAeatWiT96Re7ZpyO4OzNrls5ZQxGxo9DeNxEKXGWSdziZ2GtWykpNOdf3Z/zjugIDLI2fUKuOYSQ==",
 					"dev": true,
 					"peer": true,
 					"requires": {
-						"@octokit/types": "^7.0.0",
+						"@octokit/types": "^7.4.0",
 						"deprecation": "^2.3.1"
 					}
 				},
@@ -68478,21 +68603,14 @@
 					}
 				},
 				"@octokit/types": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.0.0.tgz",
-					"integrity": "sha512-8uSDc66p6+wADn6lh6lA7I3ZTIapn7F/dfpsiDztVjEr6kkyKR3qPqa4lgEX92O/8iJoDeGcscKRXGAjCSR/zg==",
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.0.tgz",
+					"integrity": "sha512-aHm+olfIZjQpzoODpl+RCZzchKOrdSLJs+yfI7pMMcmB19Li6vidgx0DwUDO/Ic4Q3fq/lOjJORVCcLZefcrJw==",
 					"dev": true,
 					"peer": true,
 					"requires": {
-						"@octokit/openapi-types": "^13.0.0"
+						"@octokit/openapi-types": "^13.11.0"
 					}
-				},
-				"@semantic-release/error": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
-					"integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
-					"dev": true,
-					"peer": true
 				},
 				"agent-base": {
 					"version": "6.0.2",
@@ -68863,12 +68981,6 @@
 				"@types/chai": "*"
 			}
 		},
-		"@types/component-emitter": {
-			"version": "1.2.11",
-			"resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
-			"integrity": "sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==",
-			"dev": true
-		},
 		"@types/connect": {
 			"version": "3.4.35",
 			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -68903,9 +69015,9 @@
 			"dev": true
 		},
 		"@types/express": {
-			"version": "4.17.13",
-			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-			"integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+			"version": "4.17.14",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+			"integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
 			"dev": true,
 			"requires": {
 				"@types/body-parser": "*",
@@ -68915,9 +69027,9 @@
 			}
 		},
 		"@types/express-serve-static-core": {
-			"version": "4.17.30",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
-			"integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
+			"version": "4.17.31",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
+			"integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -68953,9 +69065,9 @@
 			"dev": true
 		},
 		"@types/glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.0.tgz",
+			"integrity": "sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==",
 			"dev": true,
 			"requires": {
 				"@types/minimatch": "*",
@@ -68996,9 +69108,9 @@
 			"dev": true
 		},
 		"@types/lodash": {
-			"version": "4.14.182",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-			"integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
+			"version": "4.14.185",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.185.tgz",
+			"integrity": "sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==",
 			"dev": true
 		},
 		"@types/marked": {
@@ -69870,7 +69982,6 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -70917,13 +71028,13 @@
 			}
 		},
 		"babel-plugin-polyfill-corejs2": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.2.tgz",
-			"integrity": "sha512-LPnodUl3lS0/4wN3Rb+m+UK8s7lj2jcLRrjho4gLw+OJs+I4bvGXshINesY5xx/apM+biTnQ9reDI8yj+0M5+Q==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
+			"integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
 			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.17.7",
-				"@babel/helper-define-polyfill-provider": "^0.3.2",
+				"@babel/helper-define-polyfill-provider": "^0.3.3",
 				"semver": "^6.1.1"
 			},
 			"dependencies": {
@@ -70936,22 +71047,22 @@
 			}
 		},
 		"babel-plugin-polyfill-corejs3": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.3.tgz",
-			"integrity": "sha512-zKsXDh0XjnrUEW0mxIHLfjBfnXSMr5Q/goMe/fxpQnLm07mcOZiIZHBNWCMx60HmdvjxfXcalac0tfFg0wqxyw==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
+			"integrity": "sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-define-polyfill-provider": "^0.3.2",
-				"core-js-compat": "^3.21.0"
+				"@babel/helper-define-polyfill-provider": "^0.3.3",
+				"core-js-compat": "^3.25.1"
 			}
 		},
 		"babel-plugin-polyfill-regenerator": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.0.tgz",
-			"integrity": "sha512-RW1cnryiADFeHmfLS+WW/G431p1PsW5qdRdz0SDRi7TKcUgc7Oh/uXkT7MZ/+tGsT1BkczEAmD5XjUyJ5SWDTw==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz",
+			"integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-define-polyfill-provider": "^0.3.2"
+				"@babel/helper-define-polyfill-provider": "^0.3.3"
 			}
 		},
 		"babel-plugin-syntax-async-functions": {
@@ -73413,9 +73524,9 @@
 			},
 			"dependencies": {
 				"typescript": {
-					"version": "4.7.4",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-					"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+					"version": "4.8.3",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+					"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
 					"dev": true
 				}
 			}
@@ -73521,15 +73632,15 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-			"integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+			"version": "4.21.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001370",
-				"electron-to-chromium": "^1.4.202",
+				"caniuse-lite": "^1.0.30001400",
+				"electron-to-chromium": "^1.4.251",
 				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.5"
+				"update-browserslist-db": "^1.0.9"
 			}
 		},
 		"bs-recipes": {
@@ -73861,9 +73972,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001376",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001376.tgz",
-			"integrity": "sha512-I27WhtOQ3X3v3it9gNs/oTpoE5KpwmqKR5oKPA8M0G7uMXh9Ty81Q904HpKUrM30ei7zfcL5jE7AXefgbOfMig==",
+			"version": "1.0.30001400",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz",
+			"integrity": "sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -75777,27 +75888,18 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "3.24.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.24.1.tgz",
-			"integrity": "sha512-0QTBSYSUZ6Gq21utGzkfITDylE8jWC9Ne1D2MrhvlsZBI1x39OdDIVbzSqtgMndIy6BlHxBXpMGqzZmnztg2rg==",
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.1.tgz",
+			"integrity": "sha512-sr0FY4lnO1hkQ4gLDr24K0DGnweGO1QwSj5BpfQjpSJPdqWalja4cTps29Y/PJVG/P7FYlPDkH3hO+Tr0CvDgQ==",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.24.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.24.1.tgz",
-			"integrity": "sha512-XhdNAGeRnTpp8xbD+sR/HFDK9CbeeeqXT6TuofXh3urqEevzkWmLRgrVoykodsw8okqo2pu1BOmuCKrHx63zdw==",
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.1.tgz",
+			"integrity": "sha512-pOHS7O0i8Qt4zlPW/eIFjwp+NrTPx+wTL0ctgI2fHn31sZOq89rDsmtc/A2vAX7r6shl+bmVI+678He46jgBlw==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.21.3",
-				"semver": "7.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-					"dev": true
-				}
+				"browserslist": "^4.21.3"
 			}
 		},
 		"core-object": {
@@ -76401,6 +76503,17 @@
 						"into-stream": "^5.0.0",
 						"lodash": "^4.17.4",
 						"read-pkg-up": "^7.0.0"
+					}
+				},
+				"@types/glob": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+					"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"@types/minimatch": "*",
+						"@types/node": "*"
 					}
 				},
 				"agent-base": {
@@ -78801,7 +78914,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -78816,17 +78930,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -78840,7 +78957,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -78857,7 +78975,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",
@@ -81572,9 +81691,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.219",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.219.tgz",
-			"integrity": "sha512-zoQJsXOUw0ZA0YxbjkmzBumAJRtr6je5JySuL/bAoFs0DuLiLJ+5FzRF7/ZayihxR2QcewlRZVm5QZdUhwjOgA==",
+			"version": "1.4.251",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.251.tgz",
+			"integrity": "sha512-k4o4cFrWPv4SoJGGAydd07GmlRVzmeDIJ6MaEChTUjk4Dmomn189tCicSzil2oyvbPoGgg2suwPDNWq4gWRhoQ==",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -82799,9 +82918,9 @@
 					}
 				},
 				"broccoli-persistent-filter": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
-					"integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
+					"integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
 					"dev": true,
 					"requires": {
 						"async-disk-cache": "^2.0.0",
@@ -83589,9 +83708,9 @@
 			}
 		},
 		"ember-fetch": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-8.1.1.tgz",
-			"integrity": "sha512-Xi1wNmPtVmfIoFH675AA0ELIdYUcoZ2p+6j9c8eDFjiGJiFesyp01bDtl5ryBI/1VPOByJLsDkT+4C11HixsJw==",
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-8.1.2.tgz",
+			"integrity": "sha512-TVx24/jrvDIuPL296DV0hBwp7BWLcSMf0I8464KGz01sPytAB+ZAePbc9ooBTJDkKZEGFgatJa4nj3yF1S9Bpw==",
 			"dev": true,
 			"requires": {
 				"abortcontroller-polyfill": "^1.7.3",
@@ -84916,9 +85035,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "18.7.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.4.tgz",
-					"integrity": "sha512-RzRcw8c0B8LzryWOR4Wj7YOTFXvdYKwvrb6xQQyuDfnlTxwYXGCV5RZ/TEbq5L5kn+w3rliHAUyRcG1RtbmTFg==",
+					"version": "18.7.18",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+					"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
 					"dev": true
 				}
 			}
@@ -84975,9 +85094,9 @@
 			"dev": true
 		},
 		"entities": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-			"integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+			"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
 			"dev": true
 		},
 		"env-ci": {
@@ -85043,16 +85162,16 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-			"integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.2.tgz",
+			"integrity": "sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.1",
+				"get-intrinsic": "^1.1.2",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
@@ -85064,9 +85183,9 @@
 				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
 				"is-weakref": "^1.0.2",
-				"object-inspect": "^1.12.0",
+				"object-inspect": "^1.12.2",
 				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.2",
+				"object.assign": "^4.1.4",
 				"regexp.prototype.flags": "^1.4.3",
 				"string.prototype.trimend": "^1.0.5",
 				"string.prototype.trimstart": "^1.0.5",
@@ -86002,8 +86121,7 @@
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-diff": {
 			"version": "1.2.0",
@@ -86012,9 +86130,9 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -86026,8 +86144,7 @@
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -86674,9 +86791,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-			"integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
 		"flush-write-stream": {
@@ -86728,9 +86845,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-			"integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
 			"dev": true
 		},
 		"for-each": {
@@ -87115,9 +87232,9 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
 		},
 		"get-intrinsic": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-			"integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+			"integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
 			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
@@ -89686,9 +89803,9 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.6.tgz",
+			"integrity": "sha512-krO72EO2NptOGAX2KYyqbP9vYMlNAXdB53rq6f8LXY6RY7JdSR/3BD6wLUlPHSAesmY9vstNrjvqGaCiRK/91Q==",
 			"dev": true
 		},
 		"is-ci": {
@@ -90508,9 +90625,9 @@
 			}
 		},
 		"jquery": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
+			"integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
 			"dev": true
 		},
 		"js-string-escape": {
@@ -90574,8 +90691,12 @@
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+		},
+		"json-schema-typed": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
+			"integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
@@ -92564,9 +92685,9 @@
 			}
 		},
 		"marked": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
-			"integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
 			"dev": true,
 			"peer": true
 		},
@@ -92739,6 +92860,16 @@
 					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
 					"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 					"dev": true
+				},
+				"@types/glob": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+					"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+					"dev": true,
+					"requires": {
+						"@types/minimatch": "*",
+						"@types/node": "*"
+					}
 				},
 				"array-differ": {
 					"version": "3.0.0",
@@ -96812,48 +96943,51 @@
 			}
 		},
 		"npm": {
-			"version": "8.17.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.17.0.tgz",
-			"integrity": "sha512-tIcfZd541v86Sqrf+t/GW6ivqiT8b/2b3EAjNw3vRe+eVnL4mlkVwu17hjCOrsPVntLb5C6tQG4jPUE5Oveeyw==",
+			"version": "8.19.2",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.19.2.tgz",
+			"integrity": "sha512-MWkISVv5f7iZbfNkry5/5YBqSYJEDAKSJdL+uzSQuyLg+hgLQUyZynu3SH6bOZlvR9ZvJYk2EiJO6B1r+ynwHg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^5.0.4",
+				"@npmcli/arborist": "^5.6.2",
 				"@npmcli/ci-detect": "^2.0.0",
 				"@npmcli/config": "^4.2.1",
 				"@npmcli/fs": "^2.1.0",
 				"@npmcli/map-workspaces": "^2.0.3",
 				"@npmcli/package-json": "^2.0.0",
+				"@npmcli/promise-spawn": "*",
 				"@npmcli/run-script": "^4.2.1",
 				"abbrev": "~1.1.1",
 				"archy": "~1.0.0",
-				"cacache": "^16.1.1",
+				"cacache": "^16.1.3",
 				"chalk": "^4.1.2",
 				"chownr": "^2.0.0",
 				"cli-columns": "^4.0.0",
 				"cli-table3": "^0.6.2",
 				"columnify": "^1.6.0",
 				"fastest-levenshtein": "^1.0.12",
+				"fs-minipass": "*",
 				"glob": "^8.0.1",
 				"graceful-fs": "^4.2.10",
-				"hosted-git-info": "^5.0.0",
-				"ini": "^3.0.0",
+				"hosted-git-info": "^5.1.0",
+				"ini": "^3.0.1",
 				"init-package-json": "^3.0.2",
 				"is-cidr": "^4.0.2",
 				"json-parse-even-better-errors": "^2.3.1",
-				"libnpmaccess": "^6.0.2",
-				"libnpmdiff": "^4.0.2",
-				"libnpmexec": "^4.0.2",
-				"libnpmfund": "^3.0.1",
-				"libnpmhook": "^8.0.2",
-				"libnpmorg": "^4.0.2",
-				"libnpmpack": "^4.0.2",
-				"libnpmpublish": "^6.0.2",
-				"libnpmsearch": "^5.0.2",
-				"libnpmteam": "^4.0.2",
-				"libnpmversion": "^3.0.1",
+				"libnpmaccess": "^6.0.4",
+				"libnpmdiff": "^4.0.5",
+				"libnpmexec": "^4.0.13",
+				"libnpmfund": "^3.0.4",
+				"libnpmhook": "^8.0.4",
+				"libnpmorg": "^4.0.4",
+				"libnpmpack": "^4.1.3",
+				"libnpmpublish": "^6.0.5",
+				"libnpmsearch": "^5.0.4",
+				"libnpmteam": "^4.0.4",
+				"libnpmversion": "^3.0.7",
 				"make-fetch-happen": "^10.2.0",
+				"minimatch": "*",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
@@ -96864,19 +96998,19 @@
 				"npm-audit-report": "^3.0.0",
 				"npm-install-checks": "^5.0.0",
 				"npm-package-arg": "^9.1.0",
-				"npm-pick-manifest": "^7.0.1",
+				"npm-pick-manifest": "^7.0.2",
 				"npm-profile": "^6.2.0",
-				"npm-registry-fetch": "^13.3.0",
+				"npm-registry-fetch": "^13.3.1",
 				"npm-user-validate": "^1.0.1",
 				"npmlog": "^6.0.2",
 				"opener": "^1.5.2",
 				"p-map": "^4.0.0",
-				"pacote": "^13.6.1",
+				"pacote": "^13.6.2",
 				"parse-conflict-json": "^2.0.2",
 				"proc-log": "^2.0.1",
 				"qrcode-terminal": "^0.12.0",
 				"read": "~1.0.7",
-				"read-package-json": "^5.0.1",
+				"read-package-json": "^5.0.2",
 				"read-package-json-fast": "^2.0.3",
 				"readdir-scoped-modules": "^1.1.0",
 				"rimraf": "^3.0.2",
@@ -96911,7 +97045,7 @@
 					"peer": true
 				},
 				"@npmcli/arborist": {
-					"version": "5.5.0",
+					"version": "5.6.2",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -96924,10 +97058,10 @@
 						"@npmcli/name-from-folder": "^1.0.1",
 						"@npmcli/node-gyp": "^2.0.0",
 						"@npmcli/package-json": "^2.0.0",
-						"@npmcli/query": "^1.1.1",
+						"@npmcli/query": "^1.2.0",
 						"@npmcli/run-script": "^4.1.3",
-						"bin-links": "^3.0.0",
-						"cacache": "^16.0.6",
+						"bin-links": "^3.0.3",
+						"cacache": "^16.1.3",
 						"common-ancestor-path": "^1.0.1",
 						"json-parse-even-better-errors": "^2.3.1",
 						"json-stringify-nice": "^1.1.4",
@@ -96937,7 +97071,7 @@
 						"nopt": "^6.0.0",
 						"npm-install-checks": "^5.0.0",
 						"npm-package-arg": "^9.0.0",
-						"npm-pick-manifest": "^7.0.0",
+						"npm-pick-manifest": "^7.0.2",
 						"npm-registry-fetch": "^13.0.0",
 						"npmlog": "^6.0.2",
 						"pacote": "^13.6.1",
@@ -96961,7 +97095,7 @@
 					"peer": true
 				},
 				"@npmcli/config": {
-					"version": "4.2.1",
+					"version": "4.2.2",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -96986,7 +97120,7 @@
 					}
 				},
 				"@npmcli/fs": {
-					"version": "2.1.1",
+					"version": "2.1.2",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -96996,7 +97130,7 @@
 					}
 				},
 				"@npmcli/git": {
-					"version": "3.0.1",
+					"version": "3.0.2",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97020,6 +97154,17 @@
 					"requires": {
 						"npm-bundled": "^1.1.1",
 						"npm-normalize-package-bin": "^1.0.1"
+					},
+					"dependencies": {
+						"npm-bundled": {
+							"version": "1.1.2",
+							"bundled": true,
+							"dev": true,
+							"peer": true,
+							"requires": {
+								"npm-normalize-package-bin": "^1.0.1"
+							}
+						}
 					}
 				},
 				"@npmcli/map-workspaces": {
@@ -97047,7 +97192,7 @@
 					}
 				},
 				"@npmcli/move-file": {
-					"version": "2.0.0",
+					"version": "2.0.1",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97087,7 +97232,7 @@
 					}
 				},
 				"@npmcli/query": {
-					"version": "1.1.1",
+					"version": "1.2.0",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97202,17 +97347,25 @@
 					"peer": true
 				},
 				"bin-links": {
-					"version": "3.0.1",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
 					"requires": {
 						"cmd-shim": "^5.0.0",
 						"mkdirp-infer-owner": "^2.0.0",
-						"npm-normalize-package-bin": "^1.0.0",
+						"npm-normalize-package-bin": "^2.0.0",
 						"read-cmd-shim": "^3.0.0",
 						"rimraf": "^3.0.0",
 						"write-file-atomic": "^4.0.0"
+					},
+					"dependencies": {
+						"npm-normalize-package-bin": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"peer": true
+						}
 					}
 				},
 				"binary-extensions": {
@@ -97240,7 +97393,7 @@
 					}
 				},
 				"cacache": {
-					"version": "16.1.1",
+					"version": "16.1.3",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97262,7 +97415,7 @@
 						"rimraf": "^3.0.2",
 						"ssri": "^9.0.0",
 						"tar": "^6.1.11",
-						"unique-filename": "^1.1.1"
+						"unique-filename": "^2.0.0"
 					}
 				},
 				"chalk": {
@@ -97441,7 +97594,7 @@
 					}
 				},
 				"diff": {
-					"version": "5.0.0",
+					"version": "5.1.0",
 					"bundled": true,
 					"dev": true,
 					"peer": true
@@ -97558,7 +97711,7 @@
 					"peer": true
 				},
 				"hosted-git-info": {
-					"version": "5.0.0",
+					"version": "5.1.0",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97656,7 +97809,7 @@
 					"peer": true
 				},
 				"ini": {
-					"version": "3.0.0",
+					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
 					"peer": true
@@ -97755,7 +97908,7 @@
 					"peer": true
 				},
 				"libnpmaccess": {
-					"version": "6.0.3",
+					"version": "6.0.4",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97767,7 +97920,7 @@
 					}
 				},
 				"libnpmdiff": {
-					"version": "4.0.4",
+					"version": "4.0.5",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97775,7 +97928,7 @@
 						"@npmcli/disparity-colors": "^2.0.0",
 						"@npmcli/installed-package-contents": "^1.0.7",
 						"binary-extensions": "^2.2.0",
-						"diff": "^5.0.0",
+						"diff": "^5.1.0",
 						"minimatch": "^5.0.1",
 						"npm-package-arg": "^9.0.1",
 						"pacote": "^13.6.1",
@@ -97783,12 +97936,12 @@
 					}
 				},
 				"libnpmexec": {
-					"version": "4.0.10",
+					"version": "4.0.13",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
 					"requires": {
-						"@npmcli/arborist": "^5.0.0",
+						"@npmcli/arborist": "^5.6.2",
 						"@npmcli/ci-detect": "^2.0.0",
 						"@npmcli/fs": "^2.1.1",
 						"@npmcli/run-script": "^4.2.0",
@@ -97805,16 +97958,16 @@
 					}
 				},
 				"libnpmfund": {
-					"version": "3.0.2",
+					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
 					"requires": {
-						"@npmcli/arborist": "^5.0.0"
+						"@npmcli/arborist": "^5.6.2"
 					}
 				},
 				"libnpmhook": {
-					"version": "8.0.3",
+					"version": "8.0.4",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97824,7 +97977,7 @@
 					}
 				},
 				"libnpmorg": {
-					"version": "4.0.3",
+					"version": "4.0.4",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97834,7 +97987,7 @@
 					}
 				},
 				"libnpmpack": {
-					"version": "4.1.2",
+					"version": "4.1.3",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97845,7 +97998,7 @@
 					}
 				},
 				"libnpmpublish": {
-					"version": "6.0.4",
+					"version": "6.0.5",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97858,7 +98011,7 @@
 					}
 				},
 				"libnpmsearch": {
-					"version": "5.0.3",
+					"version": "5.0.4",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97867,7 +98020,7 @@
 					}
 				},
 				"libnpmteam": {
-					"version": "4.0.3",
+					"version": "4.0.4",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97877,7 +98030,7 @@
 					}
 				},
 				"libnpmversion": {
-					"version": "3.0.6",
+					"version": "3.0.7",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97896,7 +98049,7 @@
 					"peer": true
 				},
 				"make-fetch-happen": {
-					"version": "10.2.0",
+					"version": "10.2.1",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -97947,7 +98100,7 @@
 					}
 				},
 				"minipass-fetch": {
-					"version": "2.1.0",
+					"version": "2.1.1",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -98112,7 +98265,7 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "4.0.0",
+					"version": "4.0.1",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -98133,12 +98286,20 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.1.2",
+					"version": "2.0.1",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
 					"requires": {
-						"npm-normalize-package-bin": "^1.0.1"
+						"npm-normalize-package-bin": "^2.0.0"
+					},
+					"dependencies": {
+						"npm-normalize-package-bin": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"peer": true
+						}
 					}
 				},
 				"npm-install-checks": {
@@ -98169,27 +98330,43 @@
 					}
 				},
 				"npm-packlist": {
-					"version": "5.1.1",
+					"version": "5.1.3",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
 					"requires": {
 						"glob": "^8.0.1",
 						"ignore-walk": "^5.0.1",
-						"npm-bundled": "^1.1.2",
-						"npm-normalize-package-bin": "^1.0.1"
+						"npm-bundled": "^2.0.0",
+						"npm-normalize-package-bin": "^2.0.0"
+					},
+					"dependencies": {
+						"npm-normalize-package-bin": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"peer": true
+						}
 					}
 				},
 				"npm-pick-manifest": {
-					"version": "7.0.1",
+					"version": "7.0.2",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
 					"requires": {
 						"npm-install-checks": "^5.0.0",
-						"npm-normalize-package-bin": "^1.0.1",
+						"npm-normalize-package-bin": "^2.0.0",
 						"npm-package-arg": "^9.0.0",
 						"semver": "^7.3.5"
+					},
+					"dependencies": {
+						"npm-normalize-package-bin": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"peer": true
+						}
 					}
 				},
 				"npm-profile": {
@@ -98203,7 +98380,7 @@
 					}
 				},
 				"npm-registry-fetch": {
-					"version": "13.3.0",
+					"version": "13.3.1",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -98260,7 +98437,7 @@
 					}
 				},
 				"pacote": {
-					"version": "13.6.1",
+					"version": "13.6.2",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -98380,7 +98557,7 @@
 					"peer": true
 				},
 				"read-package-json": {
-					"version": "5.0.1",
+					"version": "5.0.2",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -98388,7 +98565,15 @@
 						"glob": "^8.0.1",
 						"json-parse-even-better-errors": "^2.3.1",
 						"normalize-package-data": "^4.0.0",
-						"npm-normalize-package-bin": "^1.0.1"
+						"npm-normalize-package-bin": "^2.0.0"
+					},
+					"dependencies": {
+						"npm-normalize-package-bin": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"peer": true
+						}
 					}
 				},
 				"read-package-json-fast": {
@@ -98658,16 +98843,16 @@
 					"peer": true
 				},
 				"unique-filename": {
-					"version": "1.1.1",
+					"version": "2.0.1",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
 					"requires": {
-						"unique-slug": "^2.0.0"
+						"unique-slug": "^3.0.0"
 					}
 				},
 				"unique-slug": {
-					"version": "2.0.2",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -98740,7 +98925,7 @@
 					"peer": true
 				},
 				"write-file-atomic": {
-					"version": "4.0.1",
+					"version": "4.0.2",
 					"bundled": true,
 					"dev": true,
 					"peer": true,
@@ -99236,9 +99421,9 @@
 			}
 		},
 		"object.assign": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
-			"integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
@@ -100125,12 +100310,12 @@
 			}
 		},
 		"parse5": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
-			"integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
+			"integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
 			"dev": true,
 			"requires": {
-				"entities": "^4.3.0"
+				"entities": "^4.4.0"
 			}
 		},
 		"parse5-htmlparser2-tree-adapter": {
@@ -100927,8 +101112,7 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"q": {
 			"version": "1.5.1",
@@ -101565,9 +101749,9 @@
 			"dev": true
 		},
 		"regenerate-unicode-properties": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz",
-			"integrity": "sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
+			"integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.2"
@@ -101625,15 +101809,15 @@
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.1.0.tgz",
-			"integrity": "sha512-bb6hk+xWd2PEOkj5It46A16zFMs2mv86Iwpdu94la4S3sJ7C973h2dHpYKwIBGaWSO7cIRJ+UX0IeMaWcO4qwA==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.2.1.tgz",
+			"integrity": "sha512-HrnlNtpvqP1Xkb28tMhBUO2EbyUHdQlsnlAhzWcwHy8WJR53UWr7/MAvqrsQKMbV4qdpv03oTMG8iIhfsPFktQ==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.2",
-				"regenerate-unicode-properties": "^10.0.1",
-				"regjsgen": "^0.6.0",
-				"regjsparser": "^0.8.2",
+				"regenerate-unicode-properties": "^10.1.0",
+				"regjsgen": "^0.7.1",
+				"regjsparser": "^0.9.1",
 				"unicode-match-property-ecmascript": "^2.0.0",
 				"unicode-match-property-value-ecmascript": "^2.0.0"
 			}
@@ -101657,15 +101841,15 @@
 			}
 		},
 		"regjsgen": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.6.0.tgz",
-			"integrity": "sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.7.1.tgz",
+			"integrity": "sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA==",
 			"dev": true
 		},
 		"regjsparser": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.8.4.tgz",
-			"integrity": "sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==",
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+			"integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
 			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
@@ -102384,9 +102568,9 @@
 			"dev": true
 		},
 		"semantic-release": {
-			"version": "19.0.3",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.3.tgz",
-			"integrity": "sha512-HaFbydST1cDKZHuFZxB8DTrBLJVK/AnDExpK0s3EqLIAAUAHUgnd+VSJCUtTYQKkAkauL8G9CucODrVCc7BuAA==",
+			"version": "19.0.5",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
+			"integrity": "sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -103321,9 +103505,9 @@
 			}
 		},
 		"socket.io": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.1.tgz",
-			"integrity": "sha512-0y9pnIso5a9i+lJmsCdtmTTgJFFSvNQKDnPQRz28mGNnxbmqYg2QPtJTLFxhymFZhAIn50eHAKzJeiNaKr+yUQ==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.2.tgz",
+			"integrity": "sha512-6fCnk4ARMPZN448+SQcnn1u8OHUC72puJcNtSgg2xS34Cu7br1gQ09YKkO1PFfDn/wyUE9ZgMAwosJed003+NQ==",
 			"dev": true,
 			"requires": {
 				"accepts": "~1.3.4",
@@ -103331,7 +103515,7 @@
 				"debug": "~4.3.2",
 				"engine.io": "~6.2.0",
 				"socket.io-adapter": "~2.4.0",
-				"socket.io-parser": "~4.0.4"
+				"socket.io-parser": "~4.2.0"
 			}
 		},
 		"socket.io-adapter": {
@@ -103341,37 +103525,24 @@
 			"dev": true
 		},
 		"socket.io-client": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.1.tgz",
-			"integrity": "sha512-e6nLVgiRYatS+AHXnOnGi4ocOpubvOUCGhyWw8v+/FxW8saHkinG6Dfhi9TU0Kt/8mwJIAASxvw6eujQmjdZVA==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.2.tgz",
+			"integrity": "sha512-naqYfFu7CLDiQ1B7AlLhRXKX3gdeaIMfgigwavDzgJoIUYulc1qHH5+2XflTsXTPY7BlPH5rppJyUjhjrKQKLg==",
 			"dev": true,
 			"requires": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.2",
 				"engine.io-client": "~6.2.1",
 				"socket.io-parser": "~4.2.0"
-			},
-			"dependencies": {
-				"socket.io-parser": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
-					"integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
-					"dev": true,
-					"requires": {
-						"@socket.io/component-emitter": "~3.1.0",
-						"debug": "~4.3.1"
-					}
-				}
 			}
 		},
 		"socket.io-parser": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.5.tgz",
-			"integrity": "sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
+			"integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
 			"dev": true,
 			"requires": {
-				"@types/component-emitter": "^1.2.10",
-				"component-emitter": "~1.3.0",
+				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.1"
 			}
 		},
@@ -103462,6 +103633,16 @@
 				"sort-object-keys": "^1.1.3"
 			},
 			"dependencies": {
+				"@types/glob": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+					"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+					"dev": true,
+					"requires": {
+						"@types/minimatch": "*",
+						"@types/node": "*"
+					}
+				},
 				"array-union": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -103686,9 +103867,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-			"integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+			"version": "3.0.12",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
 			"dev": true
 		},
 		"speedometer": {
@@ -104382,9 +104563,9 @@
 			}
 		},
 		"supports-hyperlinks": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-			"integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
 			"dev": true,
 			"requires": {
 				"has-flag": "^4.0.0",
@@ -104987,9 +105168,9 @@
 			}
 		},
 		"terser": {
-			"version": "5.14.2",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-			"integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+			"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/source-map": "^0.3.2",
@@ -105176,9 +105357,9 @@
 			}
 		},
 		"testem": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/testem/-/testem-3.8.0.tgz",
-			"integrity": "sha512-WEaFOq2ZGqM3IQji+Q2uXHGdln5upKhSZ1pLYe9W4CttDELAo588frNovk8UQmB+Xg2mDI8G2zmm7qKuWsldtw==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/testem/-/testem-3.9.0.tgz",
+			"integrity": "sha512-YTxCYKj0cc8uUSKEziJtSC5T/pw4fQnY0ZXNOyvAFgrijfsN9NxmncJZOHLhPgFOuhbRd5i+DBQxw0Cpe0SEFg==",
 			"dev": true,
 			"requires": {
 				"@xmldom/xmldom": "^0.8.0",
@@ -106078,9 +106259,9 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.16.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
-			"integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
+			"integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
 			"dev": true,
 			"optional": true
 		},
@@ -106286,9 +106467,9 @@
 			"dev": true
 		},
 		"unicode-property-aliases-ecmascript": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
-			"integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+			"integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
 			"dev": true
 		},
 		"union-value": {
@@ -106438,9 +106619,9 @@
 			"dev": true
 		},
 		"update-browserslist-db": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-			"integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
+			"integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
 			"dev": true,
 			"requires": {
 				"escalade": "^3.1.1",
@@ -106551,7 +106732,6 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -108936,6 +109116,16 @@
 					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
 					"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 					"dev": true
+				},
+				"@types/glob": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+					"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+					"dev": true,
+					"requires": {
+						"@types/minimatch": "*",
+						"@types/node": "*"
+					}
 				},
 				"ansi-styles": {
 					"version": "3.2.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,8 +14,10 @@
   "dependencies": {
     "abab": "^2.0.5",
     "adlib": "^3.0.7",
+    "ajv": "^6.12.6",
     "fast-xml-parser": "^3.21.0",
     "jsonapi-typescript": "^0.1.3",
+    "json-schema-typed": "^7.0.3",
     "tslib": "^1.13.0"
   },
   "peerDependencies": {

--- a/packages/common/src/core/HubItemEntity.ts
+++ b/packages/common/src/core/HubItemEntity.ts
@@ -12,6 +12,7 @@ import { getItemThumbnailUrl, IThumbnailOptions } from "../resources";
 import { cloneObject } from "../util";
 import { mapBy } from "../utils";
 import { IWithSharingBehavior, IWithStoreBehavior } from "./behaviors";
+
 import { IWithThumbnailBehavior } from "./behaviors/IWithThumbnailBehavior";
 import { IHubItemEntity, SettableAccessLevel } from "./types";
 import { sharedWith } from "./_internal/sharedWith";

--- a/packages/common/src/core/behaviors/IWithEditorBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithEditorBehavior.ts
@@ -1,0 +1,88 @@
+import { JSONSchema } from "json-schema-typed";
+import Ajv from "ajv";
+
+export enum UiSchemaRuleEffects {
+  SHOW = "SHOW",
+  HIDE = "HIDE",
+  DISABLE = "DISABLE",
+  NONE = "",
+}
+
+export enum UiSchemaElementTypes {
+  section = "Section",
+  step = "Step",
+  control = "Control",
+  layout = "Layout",
+  slot = "Slot",
+}
+
+export enum UiSchemaSectionTypes {
+  accordion = "accordion",
+  stepper = "stepper",
+}
+export interface IConfigurationSchema extends JSONSchema {
+  type?: "object";
+}
+
+export interface IConfigurationValues {
+  [key: string]: unknown;
+}
+
+export interface IChangeEventDetail {
+  valid: boolean;
+  values?: {
+    [key: string]: any;
+  };
+}
+
+export interface IValidationResult {
+  valid: boolean;
+  errors?: Ajv.ErrorObject[];
+}
+
+export interface IUiSchemaRule {
+  effect: UiSchemaRuleEffects;
+  condition: {
+    scope: string;
+    schema: IConfigurationSchema;
+  };
+}
+
+export interface IUiSchemaElement {
+  type: string;
+  labelKey?: string;
+  label?: string;
+  options?: {
+    [key: string]: any;
+  };
+  scope?: string;
+  rule?: IUiSchemaRule;
+  elements?: IUiSchemaElement[];
+  tooltip?: string;
+}
+export interface IUiSchema extends IUiSchemaElement {
+  elements?: IUiSchemaElement[];
+}
+
+export type EditorConfigType = "complete" | "minimal";
+
+export interface IEditorConfig {
+  schema: IConfigurationSchema;
+  uiSchema: IUiSchema;
+}
+
+/**
+ *
+ */
+export type SchemaElementOptions = Pick<IUiSchemaElement, "scope" | "options">;
+
+/**
+ *
+ */
+export interface IWithEditorBehavior {
+  getEditorConfig(
+    i18nScope: string,
+    type: EditorConfigType,
+    options: SchemaElementOptions[]
+  ): Promise<IEditorConfig>;
+}

--- a/packages/common/src/core/behaviors/IWithEditorBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithEditorBehavior.ts
@@ -1,70 +1,10 @@
-import { JSONSchema } from "json-schema-typed";
-import Ajv from "ajv";
+import {
+  IConfigurationSchema,
+  IUiSchema,
+  UiSchemaElementOptions,
+} from "../schemas";
 
-export enum UiSchemaRuleEffects {
-  SHOW = "SHOW",
-  HIDE = "HIDE",
-  DISABLE = "DISABLE",
-  NONE = "",
-}
-
-export enum UiSchemaElementTypes {
-  section = "Section",
-  step = "Step",
-  control = "Control",
-  layout = "Layout",
-  slot = "Slot",
-}
-
-export enum UiSchemaSectionTypes {
-  accordion = "accordion",
-  stepper = "stepper",
-}
-export interface IConfigurationSchema extends JSONSchema {
-  type?: "object";
-}
-
-export interface IConfigurationValues {
-  [key: string]: unknown;
-}
-
-export interface IChangeEventDetail {
-  valid: boolean;
-  values?: {
-    [key: string]: any;
-  };
-}
-
-export interface IValidationResult {
-  valid: boolean;
-  errors?: Ajv.ErrorObject[];
-}
-
-export interface IUiSchemaRule {
-  effect: UiSchemaRuleEffects;
-  condition: {
-    scope: string;
-    schema: IConfigurationSchema;
-  };
-}
-
-export interface IUiSchemaElement {
-  type: string;
-  labelKey?: string;
-  label?: string;
-  options?: {
-    [key: string]: any;
-  };
-  scope?: string;
-  rule?: IUiSchemaRule;
-  elements?: IUiSchemaElement[];
-  tooltip?: string;
-}
-export interface IUiSchema extends IUiSchemaElement {
-  elements?: IUiSchemaElement[];
-}
-
-export type EditorConfigType = "complete" | "minimal";
+export type EditorConfigType = "create" | "edit";
 
 export interface IEditorConfig {
   schema: IConfigurationSchema;
@@ -74,15 +14,10 @@ export interface IEditorConfig {
 /**
  *
  */
-export type SchemaElementOptions = Pick<IUiSchemaElement, "scope" | "options">;
-
-/**
- *
- */
 export interface IWithEditorBehavior {
   getEditorConfig(
     i18nScope: string,
     type: EditorConfigType,
-    options: SchemaElementOptions[]
+    options: UiSchemaElementOptions[]
   ): Promise<IEditorConfig>;
 }

--- a/packages/common/src/core/behaviors/index.ts
+++ b/packages/common/src/core/behaviors/index.ts
@@ -2,3 +2,4 @@ export * from "./IWithPermissionBehavior";
 export * from "./IWithCatalogBehavior";
 export * from "./IWithStoreBehavior";
 export * from "./IWithSharingBehavior";
+export * from "./IWithEditorBehavior";

--- a/packages/common/src/core/index.ts
+++ b/packages/common/src/core/index.ts
@@ -2,3 +2,4 @@ export * from "./traits";
 export * from "./types";
 export * from "./behaviors";
 export * from "./PermissionManager";
+export * from "./schemas";

--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -1,4 +1,4 @@
-import { IConfigurationSchema, IUiSchema } from "../core";
+import { IConfigurationSchema, IUiSchema } from "./types";
 
 export const HubProjectSchema: IConfigurationSchema = {
   required: ["name"],
@@ -27,7 +27,7 @@ export const HubProjectSchema: IConfigurationSchema = {
 /**
  * Minimal UI Schema for Hub Project
  */
-export const HubProjectMinimalUiSchema: IUiSchema = {
+export const HubProjectCreateUiSchema: IUiSchema = {
   type: "Layout",
   elements: [
     {
@@ -41,7 +41,7 @@ export const HubProjectMinimalUiSchema: IUiSchema = {
 /**
  * Complete UI Schema for Hub Project
  */
-export const HubProjectCompleteUiSchema: IUiSchema = {
+export const HubProjectEditUiSchema: IUiSchema = {
   type: "Layout",
   elements: [
     {

--- a/packages/common/src/core/schemas/index.ts
+++ b/packages/common/src/core/schemas/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./hubproject";

--- a/packages/common/src/core/schemas/internal/applyUiSchemaElementOptions.ts
+++ b/packages/common/src/core/schemas/internal/applyUiSchemaElementOptions.ts
@@ -25,7 +25,7 @@ export function applyUiSchemaElementOptions(
       // we dont want to apply this to rules
       // Note: If this logic becomes more complex, we may need to
       // write a function that's more specific to the uiSchema
-      return !entry.schema && entry.scope === elementOptions.scope;
+      return !entry?.schema && entry?.scope === elementOptions.scope;
     });
     if (elConfig) {
       elConfig.options = {

--- a/packages/common/src/core/schemas/internal/applyUiSchemaElementOptions.ts
+++ b/packages/common/src/core/schemas/internal/applyUiSchemaElementOptions.ts
@@ -22,7 +22,10 @@ export function applyUiSchemaElementOptions(
     // find the entry in the uiSchema for the elementOptions.scope,
     // and extend the elementOptions.options into the .options property
     const elConfig = deepFind(cloneSchema, (entry) => {
-      return entry.scope === elementOptions.scope;
+      // we dont want to apply this to rules
+      // Note: If this logic becomes more complex, we may need to
+      // write a function that's more specific to the uiSchema
+      return !entry.schema && entry.scope === elementOptions.scope;
     });
     if (elConfig) {
       elConfig.options = {

--- a/packages/common/src/core/schemas/internal/applyUiSchemaElementOptions.ts
+++ b/packages/common/src/core/schemas/internal/applyUiSchemaElementOptions.ts
@@ -1,0 +1,35 @@
+import { deepFind } from "../../../objects/deepFind";
+import { cloneObject } from "../../../util";
+import { IUiSchema, UiSchemaElementOptions } from "../types";
+
+/**
+ * Apply a set of run-time configurations into the UI schema so
+ * the controls can be configured for the current environment.
+ * TODO: Add Example
+ * @param schema
+ * @param options
+ * @returns
+ */
+export function applyUiSchemaElementOptions(
+  schema: IUiSchema,
+  options: UiSchemaElementOptions[] = []
+): IUiSchema {
+  // return a clone so we don't mutate the passed in schema
+  const cloneSchema = cloneObject(schema);
+  // merge the options into the uiSchema
+  // hoist into applyElementOptions fn
+  options.forEach((elementOptions) => {
+    // find the entry in the uiSchema for the elementOptions.scope,
+    // and extend the elementOptions.options into the .options property
+    const elConfig = deepFind(cloneSchema, (entry) => {
+      return entry.scope === elementOptions.scope;
+    });
+    if (elConfig) {
+      elConfig.options = {
+        ...(elConfig.options || {}),
+        ...elementOptions.options,
+      };
+    }
+  });
+  return cloneSchema;
+}

--- a/packages/common/src/core/schemas/internal/filterSchemaToUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/filterSchemaToUiSchema.ts
@@ -1,0 +1,18 @@
+import { getUiSchemaProps } from "./getUiSchemaProps";
+import { IConfigurationSchema, IUiSchema } from "../types";
+import { subsetSchema } from "./subsetSchema";
+
+/**
+ * Subset a json schema to only those properties needed by the uiSchema
+ * @param schema
+ * @param uiSchema
+ * @returns
+ */
+export function filterSchemaToUiSchema(
+  schema: IConfigurationSchema,
+  uiSchema: IUiSchema
+): IConfigurationSchema {
+  const propsToKeep = getUiSchemaProps(uiSchema);
+  schema = subsetSchema(schema, propsToKeep);
+  return schema;
+}

--- a/packages/common/src/core/schemas/internal/getUiSchemaProps.ts
+++ b/packages/common/src/core/schemas/internal/getUiSchemaProps.ts
@@ -1,0 +1,15 @@
+import { deepGetPropValues } from "../../../objects/deepGetPropValues";
+import { IUiSchema } from "../types";
+
+/**
+ * Get all the property names from a UI schema.
+ *
+ * Used to subset a json schema to only those properties used in a UI Schema
+ * @param uiSchema
+ * @returns
+ */
+export function getUiSchemaProps(uiSchema: IUiSchema): string[] {
+  return deepGetPropValues(uiSchema, "scope").map((scope: string) => {
+    return scope.split("/").pop();
+  });
+}

--- a/packages/common/src/core/schemas/internal/getUiSchemaProps.ts
+++ b/packages/common/src/core/schemas/internal/getUiSchemaProps.ts
@@ -1,4 +1,5 @@
 import { deepGetPropValues } from "../../../objects/deepGetPropValues";
+import { unique } from "../../../util";
 import { IUiSchema } from "../types";
 
 /**
@@ -9,7 +10,9 @@ import { IUiSchema } from "../types";
  * @returns
  */
 export function getUiSchemaProps(uiSchema: IUiSchema): string[] {
-  return deepGetPropValues(uiSchema, "scope").map((scope: string) => {
-    return scope.split("/").pop();
-  });
+  return deepGetPropValues(uiSchema, "scope")
+    .map((scope: string) => {
+      return scope.split("/")[2];
+    })
+    .filter(unique);
 }

--- a/packages/common/src/core/schemas/internal/index.ts
+++ b/packages/common/src/core/schemas/internal/index.ts
@@ -1,0 +1,4 @@
+export * from "./getUiSchemaProps";
+export * from "./subsetSchema";
+export * from "./filterSchemaToUiSchema";
+export * from "./applyUiSchemaElementOptions";

--- a/packages/common/src/core/schemas/internal/subsetSchema.ts
+++ b/packages/common/src/core/schemas/internal/subsetSchema.ts
@@ -1,0 +1,21 @@
+import { cloneObject } from "../../../util";
+import { IConfigurationSchema } from "../types";
+
+/**
+ * Subset a json schema to only those properties specified.
+ * @param schema
+ * @param props
+ * @returns
+ */
+export function subsetSchema(
+  schema: IConfigurationSchema,
+  props: string[]
+): IConfigurationSchema {
+  const subset: IConfigurationSchema = cloneObject(schema);
+  Object.keys(subset.properties).forEach((key) => {
+    if (props.indexOf(key) === -1) {
+      delete subset.properties[key];
+    }
+  });
+  return subset;
+}

--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -1,0 +1,74 @@
+import { JSONSchema } from "json-schema-typed";
+import Ajv from "ajv";
+
+export enum UiSchemaRuleEffects {
+  SHOW = "SHOW",
+  HIDE = "HIDE",
+  DISABLE = "DISABLE",
+  NONE = "",
+}
+
+export enum UiSchemaElementTypes {
+  section = "Section",
+  step = "Step",
+  control = "Control",
+  layout = "Layout",
+  slot = "Slot",
+}
+
+export enum UiSchemaSectionTypes {
+  accordion = "accordion",
+  stepper = "stepper",
+}
+export interface IConfigurationSchema extends JSONSchema {
+  type?: "object";
+}
+
+export interface IConfigurationValues {
+  [key: string]: unknown;
+}
+
+export interface IChangeEventDetail {
+  valid: boolean;
+  values?: {
+    [key: string]: any;
+  };
+}
+
+export interface IValidationResult {
+  valid: boolean;
+  errors?: Ajv.ErrorObject[];
+}
+
+export interface IUiSchemaRule {
+  effect: UiSchemaRuleEffects;
+  condition: {
+    scope: string;
+    schema: IConfigurationSchema;
+  };
+}
+
+export interface IUiSchemaElement {
+  type: string;
+  labelKey?: string;
+  label?: string;
+  options?: {
+    [key: string]: any;
+  };
+  scope?: string;
+  rule?: IUiSchemaRule;
+  elements?: IUiSchemaElement[];
+  tooltip?: string;
+}
+
+export interface IUiSchema extends IUiSchemaElement {
+  elements?: IUiSchema[] | IUiSchemaElement[];
+}
+
+/**
+ * Run-time configuration for UiSchema Elements
+ */
+export type UiSchemaElementOptions = Pick<
+  IUiSchemaElement,
+  "scope" | "options"
+>;

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -7,6 +7,9 @@ import {
   PermissionManager,
   IWithStoreBehavior,
   IWithSharingBehavior,
+  EditorConfigType,
+  SchemaElementOptions,
+  IEditorConfig,
 } from "../core";
 
 import {
@@ -124,6 +127,21 @@ export class HubInitiative
         throw ex;
       }
     }
+  }
+
+  /**
+   * Static method to get the editor config for for the HubProject entity.
+   * @param i18nScope Translation scope to be interpolated into the schemas
+   * @param type
+   * @param options Optional hash of Element component options
+   */
+  static async getEditorConfig(
+    i18nScope: string,
+    type: EditorConfigType,
+    options: SchemaElementOptions[] = []
+  ): Promise<IEditorConfig> {
+    // Delegate to module fn
+    throw new Error("getEditorConfig Not Implemented for Initiatives");
   }
 
   private static applyDefaults(

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -8,7 +8,7 @@ import {
   IWithStoreBehavior,
   IWithSharingBehavior,
   EditorConfigType,
-  SchemaElementOptions,
+  UiSchemaElementOptions,
   IEditorConfig,
 } from "../core";
 
@@ -135,14 +135,14 @@ export class HubInitiative
    * @param type
    * @param options Optional hash of Element component options
    */
-  static async getEditorConfig(
-    i18nScope: string,
-    type: EditorConfigType,
-    options: SchemaElementOptions[] = []
-  ): Promise<IEditorConfig> {
-    // Delegate to module fn
-    throw new Error("getEditorConfig Not Implemented for Initiatives");
-  }
+  // static async getEditorConfig(
+  //   i18nScope: string,
+  //   type: EditorConfigType,
+  //   options: UiSchemaElementOptions[] = []
+  // ): Promise<IEditorConfig> {
+  //   // Delegate to module fn
+  //   throw new Error("getEditorConfig Not Implemented for Initiatives");
+  // }
 
   private static applyDefaults(
     partialInitiative: Partial<IHubInitiative>,

--- a/packages/common/src/objects/deepGetPropValues.ts
+++ b/packages/common/src/objects/deepGetPropValues.ts
@@ -1,0 +1,22 @@
+import { _deepMapValues } from ".";
+
+/**
+ * Extract all the propertie names from a UI schema so we can subset the
+ * json schema to only those properties.
+ * @param obj
+ */
+
+export function deepGetPropValues(
+  obj: Record<string, any>,
+  prop: string
+): string[] {
+  const props: string[] = [];
+  _deepMapValues(obj, (value, path) => {
+    // if the path ends with the property we're looking for then add it to the list
+    if (path.split(".").pop() === prop) {
+      props.push(value);
+    }
+    return value;
+  });
+  return props;
+}

--- a/packages/common/src/objects/deepGetPropValues.ts
+++ b/packages/common/src/objects/deepGetPropValues.ts
@@ -1,8 +1,9 @@
 import { _deepMapValues } from ".";
+import { unique } from "../util";
 
 /**
- * Extract all the propertie names from a UI schema so we can subset the
- * json schema to only those properties.
+ * For a given property name, extract an array of the unique values of that property
+ * This was designed to work with string values, so no promises about other types
  * @param obj
  */
 
@@ -18,5 +19,5 @@ export function deepGetPropValues(
     }
     return value;
   });
-  return props;
+  return props.filter(unique);
 }

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -137,7 +137,7 @@ export class HubProject
    * Static method to get the editor config for for the HubProject entity.
    * @param i18nScope Translation scope to be interpolated into the schemas
    * @param type
-   * @param options Optional hash of Element component options
+   * @param options Optional hash of uiSchema element option overrides
    * Note: typescript does not have a means to specify static methods in interfaces
    * so while this is the implementation of IWithEditorBehavior, it is not enforced
    * by the compiler.

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -13,12 +13,18 @@ import {
   createProject,
   deleteProject,
   fetchProject,
+  getHubProjectEditorConfig,
   updateProject,
 } from "./HubProjects";
 
 import { Catalog } from "../search/Catalog";
 import { IArcGISContext } from "../ArcGISContext";
 import { HubItemEntity } from "../core/HubItemEntity";
+import {
+  EditorConfigType,
+  SchemaElementOptions,
+  IEditorConfig,
+} from "../core/behaviors/IWithEditorBehavior";
 
 /**
  * Hub Project Class
@@ -31,6 +37,7 @@ export class HubProject
     IWithCatalogBehavior,
     IWithSharingBehavior
 {
+  // static IWithEditorBehavior
   private _catalog: Catalog;
   private _permissionManager: PermissionManager;
   /**
@@ -124,6 +131,24 @@ export class HubProject
         throw ex;
       }
     }
+  }
+
+  /**
+   * Static method to get the editor config for for the HubProject entity.
+   * @param i18nScope Translation scope to be interpolated into the schemas
+   * @param type
+   * @param options Optional hash of Element component options
+   * Note: typescript does not have a means to specify static methods in interfaces
+   * so while this is the implementation of IWithEditorBehavior, it is not enforced
+   * by the compiler.
+   */
+  static async getEditorConfig(
+    i18nScope: string,
+    type: EditorConfigType,
+    options: SchemaElementOptions[] = []
+  ): Promise<IEditorConfig> {
+    // Delegate to module fn
+    return getHubProjectEditorConfig(i18nScope, type, options);
   }
 
   private static applyDefaults(

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -7,6 +7,7 @@ import {
   PermissionManager,
   IWithStoreBehavior,
   IWithSharingBehavior,
+  UiSchemaElementOptions,
 } from "../core";
 
 import {
@@ -22,7 +23,6 @@ import { IArcGISContext } from "../ArcGISContext";
 import { HubItemEntity } from "../core/HubItemEntity";
 import {
   EditorConfigType,
-  SchemaElementOptions,
   IEditorConfig,
 } from "../core/behaviors/IWithEditorBehavior";
 
@@ -145,7 +145,7 @@ export class HubProject
   static async getEditorConfig(
     i18nScope: string,
     type: EditorConfigType,
-    options: SchemaElementOptions[] = []
+    options: UiSchemaElementOptions[] = []
   ): Promise<IEditorConfig> {
     // Delegate to module fn
     return getHubProjectEditorConfig(i18nScope, type, options);

--- a/packages/common/src/projects/schemas.ts
+++ b/packages/common/src/projects/schemas.ts
@@ -1,0 +1,73 @@
+import { IConfigurationSchema, IUiSchema } from "../core";
+
+export const HubProjectSchema: IConfigurationSchema = {
+  required: ["name"],
+  type: "object",
+  properties: {
+    name: {
+      type: "string",
+      minLength: 1,
+      maxLength: 250,
+    },
+    summary: {
+      type: "string",
+      // TODO: Remove reliance on subtype as it's not valid json schema
+      // Issue https://devtopia.esri.com/dc/hub/issues/3725
+      subtype: "long-text",
+    },
+    description: {
+      type: "string",
+      // TODO: Remove reliance on subtype as it's not valid json schema
+      // Issue https://devtopia.esri.com/dc/hub/issues/3725
+      subtype: "long-text",
+    },
+  },
+} as unknown as IConfigurationSchema;
+
+/**
+ * Minimal UI Schema for Hub Project
+ */
+export const HubProjectMinimalUiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      labelKey: "routes.projects.project.edit.name",
+      scope: "/properties/name",
+      type: "Control",
+    },
+  ],
+};
+
+/**
+ * Complete UI Schema for Hub Project
+ */
+export const HubProjectCompleteUiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      labelKey: "{{i18nScope}}.name.label",
+      scope: "/properties/name",
+      type: "Control",
+    },
+    {
+      labelKey: "{{i18nScope}}.summary.label",
+      scope: "/properties/summary",
+      type: "Control",
+      options: {
+        helperText: {
+          labelKey: "{{i18nScope}}.summary.helperText",
+        },
+      },
+    },
+    {
+      labelKey: "{{i18nScope}}.description.label",
+      scope: "/properties/description",
+      type: "Control",
+      options: {
+        helperText: {
+          labelKey: "{{i18nScope}}.description.helperText",
+        },
+      },
+    },
+  ],
+};

--- a/packages/common/test/core/schemas/internal/applyUiSchemaElemetOptions.test.ts
+++ b/packages/common/test/core/schemas/internal/applyUiSchemaElemetOptions.test.ts
@@ -46,7 +46,7 @@ describe("applySchemaElementOptions util:", () => {
     const chk = applyUiSchemaElementOptions(cloneSchema, opts);
     // get the property2 element out of the deep graph
     const target = deepFind(chk, (entry) => {
-      return entry.scope === "/properties/property2";
+      return entry?.scope === "/properties/property2";
     });
     // verify that .options has been merged into the element
     expect(target.options).toEqual(opts[0].options);
@@ -68,7 +68,7 @@ describe("applySchemaElementOptions util:", () => {
     const chk = applyUiSchemaElementOptions(cloneSchema, opts);
     // get the property3 element out of the deep graph
     const target = deepFind(chk, (entry) => {
-      return !entry.schema && entry.scope === opts[0].scope;
+      return !entry?.schema && entry?.scope === opts[0].scope;
     });
 
     // verify that .options has been merged into the element
@@ -116,6 +116,13 @@ const SteppedUiSchema: IUiSchema = {
               type: "Control",
               options: {
                 existing: "prop",
+              },
+              rule: {
+                effect: UiSchemaRuleEffects.DISABLE,
+                condition: {
+                  scope: "/properties/property3",
+                  schema: { enum: [undefined, ""] },
+                },
               },
             },
             {

--- a/packages/common/test/core/schemas/internal/applyUiSchemaElemetOptions.test.ts
+++ b/packages/common/test/core/schemas/internal/applyUiSchemaElemetOptions.test.ts
@@ -2,11 +2,12 @@ import { applyUiSchemaElementOptions } from "../../../../src/core/schemas/intern
 import {
   IUiSchema,
   UiSchemaElementOptions,
+  UiSchemaRuleEffects,
 } from "../../../../src/core/schemas/types";
 import { deepFind, getProp } from "../../../../src/objects";
 import { cloneObject } from "../../../../src/util";
 
-describe("appluSchemaElementOptions util:", () => {
+describe("applySchemaElementOptions util:", () => {
   it("returns a clone with out changes if no options passed", () => {
     const cloneSchema = cloneObject(SteppedUiSchema);
     expect(applyUiSchemaElementOptions(cloneSchema)).toEqual(cloneSchema);
@@ -65,10 +66,11 @@ describe("appluSchemaElementOptions util:", () => {
     ];
     const cloneSchema = cloneObject(SteppedUiSchema);
     const chk = applyUiSchemaElementOptions(cloneSchema, opts);
-    // get the property2 element out of the deep graph
+    // get the property3 element out of the deep graph
     const target = deepFind(chk, (entry) => {
-      return entry.scope === "/properties/property3";
+      return !entry.schema && entry.scope === opts[0].scope;
     });
+
     // verify that .options has been merged into the element
     expect(target.options).toEqual({
       ...{ existing: "prop" },
@@ -120,6 +122,13 @@ const SteppedUiSchema: IUiSchema = {
               labelKey: "property4.label.key",
               scope: "/properties/property4",
               type: "Control",
+              rule: {
+                effect: UiSchemaRuleEffects.DISABLE,
+                condition: {
+                  scope: "/properties/property3",
+                  schema: { enum: ["hello"] },
+                },
+              },
             },
           ],
         },

--- a/packages/common/test/core/schemas/internal/applyUiSchemaElemetOptions.test.ts
+++ b/packages/common/test/core/schemas/internal/applyUiSchemaElemetOptions.test.ts
@@ -1,0 +1,129 @@
+import { applyUiSchemaElementOptions } from "../../../../src/core/schemas/internal/applyUiSchemaElementOptions";
+import {
+  IUiSchema,
+  UiSchemaElementOptions,
+} from "../../../../src/core/schemas/types";
+import { deepFind, getProp } from "../../../../src/objects";
+import { cloneObject } from "../../../../src/util";
+
+describe("appluSchemaElementOptions util:", () => {
+  it("returns a clone with out changes if no options passed", () => {
+    const cloneSchema = cloneObject(SteppedUiSchema);
+    expect(applyUiSchemaElementOptions(cloneSchema)).toEqual(cloneSchema);
+  });
+  it("works if element not found", () => {
+    const opts: UiSchemaElementOptions[] = [
+      {
+        scope: "/properties/doesnotexist",
+        options: {
+          color: "red",
+          parent: "3ef",
+          deep: {
+            object: "is deep",
+          },
+        },
+      },
+    ];
+    const cloneSchema = cloneObject(SteppedUiSchema);
+    const chk = applyUiSchemaElementOptions(cloneSchema, opts);
+    expect(chk).toEqual(cloneSchema);
+  });
+  it("injects configuration into deep schema", () => {
+    const opts: UiSchemaElementOptions[] = [
+      {
+        scope: "/properties/property2",
+        options: {
+          color: "red",
+          parent: "3ef",
+          deep: {
+            object: "is deep",
+          },
+        },
+      },
+    ];
+    const cloneSchema = cloneObject(SteppedUiSchema);
+    const chk = applyUiSchemaElementOptions(cloneSchema, opts);
+    // get the property2 element out of the deep graph
+    const target = deepFind(chk, (entry) => {
+      return entry.scope === "/properties/property2";
+    });
+    // verify that .options has been merged into the element
+    expect(target.options).toEqual(opts[0].options);
+  });
+  it("injects configuration into deep schema, preserving other props", () => {
+    const opts: UiSchemaElementOptions[] = [
+      {
+        scope: "/properties/property3",
+        options: {
+          color: "red",
+          parent: "3ef",
+          deep: {
+            object: "is deep",
+          },
+        },
+      },
+    ];
+    const cloneSchema = cloneObject(SteppedUiSchema);
+    const chk = applyUiSchemaElementOptions(cloneSchema, opts);
+    // get the property2 element out of the deep graph
+    const target = deepFind(chk, (entry) => {
+      return entry.scope === "/properties/property3";
+    });
+    // verify that .options has been merged into the element
+    expect(target.options).toEqual({
+      ...{ existing: "prop" },
+      ...opts[0].options,
+    });
+  });
+});
+
+const SteppedUiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      type: "Section",
+      labelKey: "section1.label.key",
+      options: {
+        section: "stepper",
+        open: true,
+      },
+      elements: [
+        {
+          type: "Step",
+          labelKey: "step1.label.key",
+          elements: [
+            {
+              labelKey: "property1.label.key",
+              scope: "/properties/property1",
+              type: "Control",
+            },
+            {
+              labelKey: "property2.label.key",
+              scope: "/properties/property2",
+              type: "Control",
+            },
+          ],
+        },
+        {
+          type: "Step",
+          labelKey: "step2.label.key",
+          elements: [
+            {
+              labelKey: "property3.label.key",
+              scope: "/properties/property3",
+              type: "Control",
+              options: {
+                existing: "prop",
+              },
+            },
+            {
+              labelKey: "property4.label.key",
+              scope: "/properties/property4",
+              type: "Control",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/common/test/core/schemas/internal/filterSchemaToUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/filterSchemaToUiSchema.test.ts
@@ -1,0 +1,62 @@
+import { filterSchemaToUiSchema } from "../../../../src/core/schemas/internal/filterSchemaToUiSchema";
+import {
+  IConfigurationSchema,
+  IUiSchema,
+} from "../../../../src/core/schemas/types";
+
+describe("filterSchemaToUiSchema util:", () => {
+  it("returns schema limited to props in UiSchema", () => {
+    const chk = filterSchemaToUiSchema(schema, SteppedUiSchema);
+    expect(chk.properties?.description).not.toBeDefined();
+  });
+});
+
+const schema: IConfigurationSchema = {
+  required: ["name"],
+  type: "object",
+  properties: {
+    name: {
+      type: "string",
+      minLength: 1,
+      maxLength: 250,
+    },
+    summary: {
+      type: "string",
+    },
+    description: {
+      type: "string",
+    },
+  },
+};
+
+const SteppedUiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      type: "Section",
+      labelKey: "section1.label.key",
+      options: {
+        section: "stepper",
+        open: true,
+      },
+      elements: [
+        {
+          type: "Step",
+          labelKey: "step1.label.key",
+          elements: [
+            {
+              labelKey: "property1.label.key",
+              scope: "/properties/name",
+              type: "Control",
+            },
+            {
+              labelKey: "property2.label.key",
+              scope: "/properties/summary",
+              type: "Control",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/common/test/core/schemas/internal/getUiSchemaProps.test.ts
+++ b/packages/common/test/core/schemas/internal/getUiSchemaProps.test.ts
@@ -2,9 +2,15 @@ import { getUiSchemaProps } from "../../../../src/core/schemas/internal/getUiSch
 import { IUiSchema } from "../../../../src/core/schemas/types";
 
 describe("getUiSchemaProps util:", () => {
-  it("returns prop names from a sectioned schema", () => {
+  it("returns unique prop names from a sectioned schema with deep props", () => {
     const chk = getUiSchemaProps(SectionedUiSchema);
-    expect(chk).toEqual(["property1", "property2", "property3", "property4"]);
+    expect(chk).toEqual([
+      "property1",
+      "property2",
+      "link", // there are two entries for link b/c it's an object
+      "property3",
+      "property4",
+    ]);
   });
   it("returns prop names from accordion schema", () => {
     const chk = getUiSchemaProps(AccordionUiSchema);
@@ -33,6 +39,16 @@ const SectionedUiSchema: IUiSchema = {
         {
           labelKey: "property2.label.key",
           scope: "/properties/property2",
+          type: "Control",
+        },
+        {
+          labelKey: "link.href",
+          scope: "/properties/link/properties/href",
+          type: "Control",
+        },
+        {
+          labelKey: "link.title",
+          scope: "/properties/link/properties/title",
           type: "Control",
         },
       ],

--- a/packages/common/test/core/schemas/internal/getUiSchemaProps.test.ts
+++ b/packages/common/test/core/schemas/internal/getUiSchemaProps.test.ts
@@ -1,0 +1,150 @@
+import { getUiSchemaProps } from "../../../../src/core/schemas/internal/getUiSchemaProps";
+import { IUiSchema } from "../../../../src/core/schemas/types";
+
+describe("getUiSchemaProps util:", () => {
+  it("returns prop names from a sectioned schema", () => {
+    const chk = getUiSchemaProps(SectionedUiSchema);
+    expect(chk).toEqual(["property1", "property2", "property3", "property4"]);
+  });
+  it("returns prop names from accordion schema", () => {
+    const chk = getUiSchemaProps(AccordionUiSchema);
+    expect(chk).toEqual(["property1", "property2", "property3", "property4"]);
+  });
+
+  it("returns prop names from stepped schema", () => {
+    const chk = getUiSchemaProps(SteppedUiSchema);
+    expect(chk).toEqual(["property1", "property2", "property3", "property4"]);
+  });
+});
+
+const SectionedUiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      type: "Section",
+      options: { headerTag: "h4" },
+      labelKey: "section1.label.key",
+      elements: [
+        {
+          labelKey: "property1.label.key",
+          scope: "/properties/property1",
+          type: "Control",
+        },
+        {
+          labelKey: "property2.label.key",
+          scope: "/properties/property2",
+          type: "Control",
+        },
+      ],
+    },
+    {
+      type: "Section",
+      labelKey: "section2.label.key",
+      elements: [
+        {
+          labelKey: "property3.label.key",
+          scope: "/properties/property3",
+          type: "Control",
+        },
+        {
+          labelKey: "property4.label.key",
+          scope: "/properties/property4",
+          type: "Control",
+        },
+      ],
+    },
+  ],
+};
+
+const AccordionUiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      type: "Section",
+      labelKey: "section1.label.key",
+      options: {
+        section: "accordion",
+        open: true,
+      },
+      elements: [
+        {
+          labelKey: "property1.label.key",
+          scope: "/properties/property1",
+          type: "Control",
+        },
+        {
+          labelKey: "property2.label.key",
+          scope: "/properties/property2",
+          type: "Control",
+        },
+      ],
+    },
+    {
+      type: "Section",
+      labelKey: "section2.label.key",
+      options: {
+        section: "accordion",
+      },
+      elements: [
+        {
+          labelKey: "property3.label.key",
+          scope: "/properties/property3",
+          type: "Control",
+        },
+        {
+          labelKey: "property4.label.key",
+          scope: "/properties/property4",
+          type: "Control",
+        },
+      ],
+    },
+  ],
+};
+
+const SteppedUiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      type: "Section",
+      labelKey: "section1.label.key",
+      options: {
+        section: "stepper",
+        open: true,
+      },
+      elements: [
+        {
+          type: "Step",
+          labelKey: "step1.label.key",
+          elements: [
+            {
+              labelKey: "property1.label.key",
+              scope: "/properties/property1",
+              type: "Control",
+            },
+            {
+              labelKey: "property2.label.key",
+              scope: "/properties/property2",
+              type: "Control",
+            },
+          ],
+        },
+        {
+          type: "Step",
+          labelKey: "step2.label.key",
+          elements: [
+            {
+              labelKey: "property3.label.key",
+              scope: "/properties/property3",
+              type: "Control",
+            },
+            {
+              labelKey: "property4.label.key",
+              scope: "/properties/property4",
+              type: "Control",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/common/test/core/schemas/internal/subsetSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/subsetSchema.test.ts
@@ -1,0 +1,62 @@
+import { subsetSchema } from "../../../../src/core/schemas/internal/subsetSchema";
+import {
+  IConfigurationSchema,
+  IUiSchema,
+} from "../../../../src/core/schemas/types";
+
+describe("subsetSchema util:", () => {
+  it("returns schema limited to props passed in", () => {
+    const chk = subsetSchema(schema, ["name", "summary"]);
+    expect(chk.properties?.description).not.toBeDefined();
+  });
+});
+
+const schema: IConfigurationSchema = {
+  required: ["name"],
+  type: "object",
+  properties: {
+    name: {
+      type: "string",
+      minLength: 1,
+      maxLength: 250,
+    },
+    summary: {
+      type: "string",
+    },
+    description: {
+      type: "string",
+    },
+  },
+};
+
+const SteppedUiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      type: "Section",
+      labelKey: "section1.label.key",
+      options: {
+        section: "stepper",
+        open: true,
+      },
+      elements: [
+        {
+          type: "Step",
+          labelKey: "step1.label.key",
+          elements: [
+            {
+              labelKey: "property1.label.key",
+              scope: "/properties/name",
+              type: "Control",
+            },
+            {
+              labelKey: "property2.label.key",
+              scope: "/properties/summary",
+              type: "Control",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/common/test/objects/deepGetPropValues.test.ts
+++ b/packages/common/test/objects/deepGetPropValues.test.ts
@@ -1,0 +1,56 @@
+import { deepGetPropValues } from "../../src/objects/deepGetPropValues";
+import { cloneObject } from "../../src/util";
+
+describe("deepGetPropValues util:", () => {
+  it("returns array of all values of a specified prop at all levels of the graph", () => {
+    const schema = cloneObject(testObject);
+    const chk = deepGetPropValues(schema, "scope");
+    expect(chk).toEqual([
+      "topLevel",
+      "/properties/property1",
+      "/properties/property2",
+      "/properties/property3",
+      "/properties/property4",
+    ]);
+  });
+});
+
+const testObject = {
+  type: "Layout",
+  scope: "topLevel",
+  elements: [
+    {
+      type: "Section",
+      options: { headerTag: "h4" },
+      labelKey: "section1.label.key",
+      elements: [
+        {
+          labelKey: "property1.label.key",
+          scope: "/properties/property1",
+          type: "Control",
+        },
+        {
+          labelKey: "property2.label.key",
+          scope: "/properties/property2",
+          type: "Control",
+        },
+      ],
+    },
+    {
+      type: "Section",
+      labelKey: "section2.label.key",
+      elements: [
+        {
+          labelKey: "property3.label.key",
+          scope: "/properties/property3",
+          type: "Control",
+        },
+        {
+          labelKey: "property4.label.key",
+          scope: "/properties/property4",
+          type: "Control",
+        },
+      ],
+    },
+  ],
+};

--- a/packages/common/test/objects/deepGetPropValues.test.ts
+++ b/packages/common/test/objects/deepGetPropValues.test.ts
@@ -1,3 +1,4 @@
+import { UiSchemaRuleEffects } from "../../src";
 import { deepGetPropValues } from "../../src/objects/deepGetPropValues";
 import { cloneObject } from "../../src/util";
 
@@ -49,6 +50,13 @@ const testObject = {
           labelKey: "property4.label.key",
           scope: "/properties/property4",
           type: "Control",
+          rule: {
+            effect: UiSchemaRuleEffects.DISABLE,
+            condition: {
+              scope: "/properties/property3",
+              schema: { enum: ["hello"] },
+            },
+          },
         },
       ],
     },

--- a/packages/common/test/projects/HubProject.test.ts
+++ b/packages/common/test/projects/HubProject.test.ts
@@ -1,10 +1,14 @@
 import * as PortalModule from "@esri/arcgis-rest-portal";
-import { Catalog, IHubProject, PermissionManager } from "../../src";
+import {
+  Catalog,
+  IHubProject,
+  PermissionManager,
+  UiSchemaElementOptions,
+} from "../../src";
 import { ArcGISContextManager } from "../../src/ArcGISContextManager";
 import { HubProject } from "../../src/projects/HubProject";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as HubProjectsModule from "../../src/projects/HubProjects";
-import * as SharedWithModule from "../../src/core/_internal/sharedWith";
 
 describe("HubProject Class:", () => {
   let authdCtxMgr: ArcGISContextManager;
@@ -28,7 +32,7 @@ describe("HubProject Class:", () => {
     });
   });
 
-  describe("ctor:", () => {
+  describe("static methods:", () => {
     it("loads from minimal json", () => {
       const createSpy = spyOn(HubProjectsModule, "createProject");
       const chk = HubProject.fromJson(
@@ -89,6 +93,34 @@ describe("HubProject Class:", () => {
         expect(fetchSpy).toHaveBeenCalledTimes(1);
         expect(ex.message).toBe("ZOMG!");
       }
+    });
+
+    it("returns editorConfig", async () => {
+      const spy = spyOn(
+        HubProjectsModule,
+        "getHubProjectEditorConfig"
+      ).and.callFake(() => {
+        return Promise.resolve({ schema: {}, uiSchema: {} });
+      });
+
+      await HubProject.getEditorConfig("test.scope", "edit");
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith("test.scope", "edit", []);
+    });
+
+    it("returns editorConfig integrating options", async () => {
+      const spy = spyOn(
+        HubProjectsModule,
+        "getHubProjectEditorConfig"
+      ).and.callFake(() => {
+        return Promise.resolve({ schema: {}, uiSchema: {} });
+      });
+
+      const opts: UiSchemaElementOptions[] = [];
+
+      await HubProject.getEditorConfig("test.scope", "edit", opts);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith("test.scope", "edit", opts);
     });
   });
 

--- a/packages/common/test/projects/HubProjects.test.ts
+++ b/packages/common/test/projects/HubProjects.test.ts
@@ -12,6 +12,10 @@ import {
   enrichProjectSearchResult,
   IQuery,
   IHubSearchOptions,
+  getHubProjectEditorConfig,
+  UiSchemaElementOptions,
+  HubProjectSchema,
+  deepFind,
 } from "../../src";
 
 import { MOCK_AUTH } from "../mocks/mock-auth";
@@ -397,6 +401,43 @@ describe("HubProjects:", () => {
       expect(item).toEqual(PROJECT_ITEM_ENRICH);
       expect(enrichments).toEqual(["data"]);
       expect(ro).toBe(hubRo);
+    });
+  });
+
+  describe("getEditorConfig:", () => {
+    // TODO: Decide how deep to verify the return structures
+    it("returns create schema", async () => {
+      const chk = await getHubProjectEditorConfig("test.scope", "create");
+      expect(chk.schema).toBeDefined();
+      expect(chk.schema).not.toEqual(HubProjectSchema);
+      expect(chk.uiSchema).toBeDefined();
+    });
+
+    it("returns edit schema with overrides", async () => {
+      const opts: UiSchemaElementOptions[] = [
+        {
+          scope: "/properties/name",
+          options: {
+            color: "red",
+          },
+        },
+      ];
+      const chk = await getHubProjectEditorConfig("test.scope", "edit", opts);
+      expect(chk.schema).toBeDefined();
+      expect(chk.schema).toEqual(HubProjectSchema);
+      expect(chk.uiSchema).toBeDefined();
+
+      const target = deepFind(chk, (entry) => {
+        return entry.scope === "/properties/name";
+      });
+      expect(target.options.color).toBe("red");
+    });
+
+    it("returns edit schema", async () => {
+      const chk = await getHubProjectEditorConfig("test.scope", "edit");
+      expect(chk.schema).toBeDefined();
+      expect(chk.schema).toEqual(HubProjectSchema);
+      expect(chk.uiSchema).toBeDefined();
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,8 +54,8 @@
     "types": [
       "node",
       "jasmine"
-    ]                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    ],                           /* Type declaration files to be included in compilation. */
+    "allowSyntheticDefaultImports": true  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
 
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */


### PR DESCRIPTION
1. Description:

Expose `.getEditorConfig(...)` as static method on Hub entity classes.

This is a rough first pass implementation to get feedback. Will polish once assumptions have been validated.

Some things to consider:
- adding schemas to hub.js required importing Ajv and json-schema-typed. Since we're just using those for types, I *hope* nothing else gets bundled into the build - @tomwayson should/could we make these devDeps?
- another solution here is to put all this into a util fn in hub-components, and fiddle with adding static methods to the classes. While nominally less ergonomic, I'm not sure it's ZOMG worse, and keeps UI layer concerns in the UI layer.


1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
