### PR TITLE
fix(): update discussion auth methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61115,7 +61115,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "13.5.0",
+			"version": "13.6.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/discussions/src/index.ts
+++ b/packages/discussions/src/index.ts
@@ -7,6 +7,6 @@ export * from "./reactions";
 export * from "./types";
 
 export * from "./utils/posts";
-export * from "./utils/channels";
+export * from "./utils/channels/";
 export * from "./utils/reactions";
 export * from "./utils/platform";

--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -2,6 +2,7 @@ import { IHubRequestOptions as _IHubRequestOptions } from "@esri/hub-common";
 import {
   IPagedResponse as IRestPagedResponse,
   IPagingParams,
+  IUser,
 } from "@esri/arcgis-rest-types";
 import { Geometry } from "geojson";
 
@@ -243,6 +244,20 @@ export interface IWithSettings {
   blockwords?: string[];
 }
 
+export interface IChannelACL {
+  anonymous?: IPermission;
+  authenticated?: IPermission;
+  groups?: {
+    [key: string]: IPermission;
+  };
+  orgs?: {
+    [key: string]: IPermission;
+  };
+  users: {
+    [key: string]: IPermission;
+  };
+}
+
 /**
  * channel definition properties, mirroring AGOL sharing ACL & IPlatformSharing
  *
@@ -253,6 +268,7 @@ export interface IWithSharing {
   access: SharingAccess;
   groups?: string[];
   orgs?: string[];
+  acl?: IChannelACL;
 }
 
 /**
@@ -835,4 +851,8 @@ export interface IDiscussionsMentionMeta {
   discussion: string;
   postId: string;
   replyId?: string;
+}
+
+export interface IDiscussionsUser extends IUser {
+  username?: string | null;
 }

--- a/packages/discussions/src/utils/channels/can-post-to-channel.ts
+++ b/packages/discussions/src/utils/channels/can-post-to-channel.ts
@@ -1,0 +1,179 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import {
+  IChannel,
+  IChannelACL,
+  IDiscussionsUser,
+  Role,
+  SharingAccess,
+} from "../../types";
+
+const ALLOWED_GROUP_ROLES = Object.freeze(["owner", "admin", "member"]);
+
+const ALLOWED_ROLES_FOR_POSTING = Object.freeze([
+  Role.WRITE,
+  Role.READWRITE,
+  Role.MANAGE,
+  Role.MODERATE,
+  Role.OWNER,
+]);
+
+interface ILegacyChannelPermissions
+  extends Pick<IChannel, "groups" | "orgs" | "access" | "allowAnonymous"> {}
+
+export function canPostToChannel(
+  channel: IChannel,
+  user: IDiscussionsUser
+): boolean {
+  const { acl, access, groups, orgs, allowAnonymous } = channel;
+
+  if (acl) {
+    return isAuthorizedToPostByAcl(user, acl);
+  }
+
+  // Once ACL usage is enforce, we will remove authorization by legacy permissions
+  return isAuthorizedToPostByLegacyPermissions(user, {
+    access,
+    groups,
+    orgs,
+    allowAnonymous,
+  });
+}
+
+function isAuthorizedToPostByAcl(
+  user: IDiscussionsUser,
+  acl: IChannelACL
+): boolean {
+  if (channelAllowsAnyUserToPost(acl)) {
+    return true;
+  }
+
+  if (user.username === null) {
+    return false;
+  }
+
+  return (
+    channelAllowsAnyAuthenticatedUserToPost(acl) ||
+    channelAllowsThisUserToPost(user, acl) ||
+    channelAllowsPostsByThisUsersGroups(user, acl) ||
+    channelAllowsPostsByThisUsersOrg(user, acl)
+  );
+}
+
+function channelAllowsAnyUserToPost(channelAcl: IChannelACL) {
+  return (
+    channelAcl.anonymous &&
+    ALLOWED_ROLES_FOR_POSTING.includes(channelAcl.anonymous.role)
+  );
+}
+
+function channelAllowsAnyAuthenticatedUserToPost(channelAcl: IChannelACL) {
+  return (
+    channelAcl.authenticated &&
+    ALLOWED_ROLES_FOR_POSTING.includes(channelAcl.authenticated.role)
+  );
+}
+
+function channelAllowsThisUserToPost(user: IDiscussionsUser, acl: IChannelACL) {
+  // TODO: migrate to userId instead of username
+  const { username } = user;
+
+  const userLookup = acl.users || {};
+  const userPermission = userLookup[username];
+
+  if (!userPermission) {
+    return false;
+  }
+
+  return ALLOWED_ROLES_FOR_POSTING.includes(userPermission.role);
+}
+
+function channelAllowsPostsByThisUsersGroups(
+  user: IDiscussionsUser,
+  acl: IChannelACL
+) {
+  if (!acl.groups) {
+    return false;
+  }
+
+  return user.groups.some((userGroup: IGroup) => {
+    const {
+      id: userGroupId,
+      userMembership: { memberType: userMemberType },
+    } = userGroup;
+
+    const channelGroupPermission = acl.groups[userGroupId];
+
+    if (!channelGroupPermission) {
+      return false;
+    }
+
+    return ALLOWED_GROUP_ROLES.includes(userMemberType);
+  });
+}
+
+function channelAllowsPostsByThisUsersOrg(
+  user: IDiscussionsUser,
+  acl: IChannelACL
+) {
+  if (!acl.orgs) {
+    return false;
+  }
+
+  const channelOrgPermission = acl.orgs[user.orgId];
+
+  if (!channelOrgPermission) {
+    return false;
+  }
+
+  return ALLOWED_ROLES_FOR_POSTING.includes(channelOrgPermission.role);
+}
+
+function isAuthorizedToPostByLegacyPermissions(
+  user: IDiscussionsUser,
+  channelParams: ILegacyChannelPermissions
+): boolean {
+  const { username, groups: userGroups, orgId: userOrgId } = user;
+  const { allowAnonymous, access, groups, orgs } = channelParams;
+
+  // order is important here
+  if (allowAnonymous === true) {
+    return true;
+  }
+
+  if (username === null) {
+    return false;
+  }
+
+  if (access === SharingAccess.PUBLIC) {
+    return true;
+  }
+
+  if (access === SharingAccess.PRIVATE) {
+    return isAuthorizedToPostByLegacyGroup(groups, userGroups);
+  }
+
+  if (access === SharingAccess.ORG) {
+    return orgs.includes(userOrgId);
+  }
+
+  return false;
+}
+
+function isAuthorizedToPostByLegacyGroup(
+  channelGroups: string[] = [],
+  userGroups: IGroup[] = []
+) {
+  return channelGroups.some((channelGroupId: string) => {
+    return userGroups.some((group: IGroup) => {
+      const {
+        id: userGroupId,
+        userMembership: { memberType: userMemberType },
+      } = group;
+
+      return (
+        channelGroupId === userGroupId &&
+        ALLOWED_GROUP_ROLES.includes(userMemberType)
+      );
+    });
+  });
+}

--- a/packages/discussions/src/utils/channels/index.ts
+++ b/packages/discussions/src/utils/channels/index.ts
@@ -1,7 +1,7 @@
 import { IUser } from "@esri/arcgis-rest-auth";
 import { GroupMembership } from "@esri/arcgis-rest-portal";
-import { IChannel, IPlatformSharing } from "../types";
-import { isOrgAdmin, reduceByGroupMembership } from "./platform";
+import { IChannel, IPlatformSharing } from "../../types";
+import { isOrgAdmin, reduceByGroupMembership } from "../platform";
 
 function intersectGroups(
   membershipTypes: GroupMembership[],
@@ -86,25 +86,7 @@ export function canCreateChannel(channel: IChannel, user: IUser): boolean {
   return isChannelOrgAdmin(channel, user);
 }
 
-/**
- * Utility to determine whether User can create posts to Channel
- *
- * @export
- * @param {IChannel} channel
- * @param {IUser} user
- * @return {*}  {boolean}
- */
-export function canPostToChannel(channel: IChannel, user: IUser): boolean {
-  if (channel.access === "private") {
-    // ensure user is member of at least one
-    return intersectGroups(["owner", "admin", "member"])(user, channel);
-  } else if (channel.access === "org") {
-    return isChannelOrgMember(channel, user);
-  } else if (user.username === "anonymous") {
-    return channel.allowAnonymous;
-  }
-  return true;
-}
+export { canPostToChannel } from "./can-post-to-channel";
 
 /**
  * Utility to determine whether a Channel definition (inner) is encapsulated by another Channel's definition (outer)

--- a/packages/discussions/src/utils/posts.ts
+++ b/packages/discussions/src/utils/posts.ts
@@ -58,18 +58,25 @@ export function isDiscussable(subject: IGroup | IItem | IHubContent) {
 }
 
 /**
- * Determines if the given user has sufficient privileges to modify the given post
+ * Determines if the given user has sufficient privileges to modify a post's editable attributes
  * @param post An IPost object
  * @param channel An IChannel object
  * @param user An IUser object
  * @returns true if the user can modify the post
  */
-export function canModifyPost(
-  post: IPost,
-  channel: IChannel,
-  user: IUser
-): boolean {
-  return post.creator === user.username || canModifyChannel(channel, user);
+export function canModifyPost(post: IPost, user: IUser): boolean {
+  return post.creator === user.username;
+}
+
+/**
+ * Determines if the given user has sufficient privileges to modify a post's status
+ * @param post An IPost object
+ * @param channel An IChannel object
+ * @param user An IUser object
+ * @returns true if the user can modify the post
+ */
+export function canModifyPostStatus(channel: IChannel, user: IUser): boolean {
+  return canModifyChannel(channel, user);
 }
 
 /**
@@ -84,7 +91,7 @@ export function canDeletePost(
   channel: IChannel,
   user: IUser
 ): boolean {
-  return canModifyPost(post, channel, user);
+  return canModifyPost(post, user) || canModifyChannel(channel, user);
 }
 
 export const MENTION_ATTRIBUTE = "data-mention";

--- a/packages/discussions/test/utils/channels/can-post-to-channel.spec.ts
+++ b/packages/discussions/test/utils/channels/can-post-to-channel.spec.ts
@@ -1,0 +1,415 @@
+import { IChannel, IDiscussionsUser } from "../../../src/types";
+import { canPostToChannel } from "../../../src/utils/channels/can-post-to-channel";
+
+describe("canPostToChannel", () => {
+  describe("with ACL", () => {
+    describe("anonymous user", () => {
+      it("returns true if anonymous user attempts to create post in acl.anonymous.role === readWrite", () => {
+        const user: IDiscussionsUser = { username: null };
+        const channel = {
+          acl: {
+            anonymous: {
+              role: "readWrite",
+            },
+          },
+        } as any;
+
+        expect(canPostToChannel(channel, user)).toBe(true);
+      });
+
+      it("returns true if anonymous user attempts to create post in acl.anonymous.role === write", () => {
+        const user: IDiscussionsUser = { username: null };
+        const channel = {
+          acl: {
+            anonymous: {
+              role: "write",
+            },
+          },
+        } as any;
+
+        expect(canPostToChannel(channel, user)).toBe(true);
+      });
+
+      it("returns false if anonymous user attempts to create post in acl.anonymous.role === read", () => {
+        const user: IDiscussionsUser = { username: null };
+        const channel = {
+          acl: {
+            anonymous: {
+              role: "read",
+            },
+          },
+        } as any;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+
+      it("returns false if anonymous user attempts to create post in a channel without anonymous access", () => {
+        const user: IDiscussionsUser = { username: null };
+        const channel = {
+          acl: {},
+        } as any;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+    });
+
+    describe("authenticated user but otherwise unauthorized", () => {
+      it("returns true if authenticated user attempts to create post in acl.authenticated.role === readWrite", () => {
+        const user: IDiscussionsUser = { username: "Slughorn" };
+        const channel = {
+          acl: {
+            authenticated: {
+              role: "readWrite",
+            },
+          },
+        } as any;
+
+        expect(canPostToChannel(channel, user)).toBe(true);
+      });
+
+      it("returns true if authenticated user attempts to create post in acl.authenticated.role === write", () => {
+        const user: IDiscussionsUser = { username: "Slughorn" };
+        const channel = {
+          acl: {
+            authenticated: {
+              role: "write",
+            },
+          },
+        } as any;
+
+        expect(canPostToChannel(channel, user)).toBe(true);
+      });
+
+      it("returns false if authenticated user attempts to create post in acl.authenticated.role === read", () => {
+        const user: IDiscussionsUser = { username: "Slughorn" };
+        const channel = {
+          acl: {
+            authenticated: {
+              role: "read",
+            },
+          },
+        } as any;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+
+      it("returns false if authenticated user attempts to create post in a channel without authenticated access", () => {
+        const user: IDiscussionsUser = { username: null };
+        const channel = {
+          acl: {},
+        } as any;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+    });
+
+    describe("authenticated user authorized in ACL", () => {
+      it("returns true if user found in acl.users with allowed roles", () => {
+        ["readWrite", "write", "manage", "moderate", "owner"].forEach(
+          (allowedRole) => {
+            const channel = {
+              acl: {
+                users: {
+                  Slughorn: {
+                    role: allowedRole,
+                  },
+                },
+              },
+            } as any;
+
+            const user: IDiscussionsUser = {
+              username: "Slughorn",
+            } as any;
+
+            expect(canPostToChannel(channel, user)).toBe(true);
+          }
+        );
+      });
+
+      it("returns false if authenticated user attempts to create post and is found in acl.users  with role === read", () => {
+        const user: IDiscussionsUser = { username: "Slughorn" };
+        const channel = {
+          acl: {
+            users: {
+              Slughorn: {
+                role: "read",
+              },
+            },
+          },
+        } as any;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+
+      it("returns false if user attempts to create post in a channel without user authorization", () => {
+        const user: IDiscussionsUser = { username: "Slughorn" };
+        const channel = {
+          acl: {},
+        } as any;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+    });
+
+    describe("authorization by group", () => {
+      it("returns true if user has group overlap with acl.groups with allowed roles", () => {
+        ["readWrite", "write", "manage", "moderate", "owner"].forEach(
+          (allowedRole) => {
+            const channel = {
+              acl: {
+                groups: {
+                  abc: {
+                    role: allowedRole,
+                  },
+                },
+              },
+            } as any;
+
+            ["owner", "admin", "member"].forEach((memberType) => {
+              const user: IDiscussionsUser = {
+                username: "Slughorn",
+                groups: [
+                  {
+                    id: "abc",
+                    userMembership: { memberType },
+                  },
+                ],
+              } as any;
+
+              expect(canPostToChannel(channel, user)).toBe(true);
+            });
+          }
+        );
+      });
+
+      it("returns false if user has group membership not allowed", () => {
+        ["readWrite", "write", "manage", "moderate", "owner"].forEach(
+          (allowedRole) => {
+            const channel = {
+              acl: {
+                groups: {
+                  abc: {
+                    role: allowedRole,
+                  },
+                },
+              },
+            } as any;
+
+            const user: IDiscussionsUser = {
+              username: "Slughorn",
+              groups: [
+                {
+                  id: "abc",
+                  userMembership: { memberType: "wuzzles" },
+                },
+              ],
+            } as any;
+
+            expect(canPostToChannel(channel, user)).toBe(false);
+          }
+        );
+      });
+
+      it("returns false if group does not exist in acl", () => {
+        const channel = {
+          acl: {
+            groups: {
+              xyz: {
+                role: "read",
+              },
+            },
+          },
+        } as any;
+
+        ["owner", "admin", "member"].forEach((memberType) => {
+          const user: IDiscussionsUser = {
+            username: "Slughorn",
+            groups: [
+              {
+                id: "abc",
+                userMembership: { memberType },
+              },
+            ],
+          } as any;
+
+          expect(canPostToChannel(channel, user)).toBe(false);
+        });
+      });
+    });
+
+    describe("authorization by org", () => {
+      it("returns true if user is part of org in acl.orgs with allowed roles", () => {
+        ["readWrite", "write", "manage", "moderate", "owner"].forEach(
+          (allowedRole) => {
+            const channel = {
+              acl: {
+                orgs: {
+                  abc: {
+                    role: allowedRole,
+                  },
+                },
+              },
+            } as any;
+
+            const user: IDiscussionsUser = {
+              username: "Slughorn",
+              orgId: "abc",
+            } as any;
+
+            expect(canPostToChannel(channel, user)).toBe(true);
+          }
+        );
+      });
+
+      it("returns false if user is not part of org", () => {
+        ["readWrite", "write", "manage", "moderate", "owner"].forEach(
+          (allowedRole) => {
+            const channel = {
+              acl: {
+                orgs: {
+                  abc: {
+                    role: allowedRole,
+                  },
+                },
+              },
+            } as any;
+
+            const user: IDiscussionsUser = {
+              username: "Slughorn",
+              orgId: "xyz",
+            } as any;
+
+            expect(canPostToChannel(channel, user)).toBe(false);
+          }
+        );
+      });
+
+      it("returns false if org does not have post writing privledge", () => {
+        const channel = {
+          acl: {
+            orgs: {
+              abc: {
+                role: "read",
+              },
+            },
+          },
+        } as any;
+
+        const user: IDiscussionsUser = {
+          username: "Slughorn",
+          orgId: "abc",
+        } as any;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+    });
+  });
+
+  describe("with legacy permissions", () => {
+    it("returns true if anonymous user attempts to create post in allowAnonymous === true channel", () => {
+      const user: IDiscussionsUser = { username: null };
+      const channel = {
+        allowAnonymous: true,
+      } as IChannel;
+
+      expect(canPostToChannel(channel, user)).toBe(true);
+    });
+
+    it("returns false if anonymous user attempts to create post in allowAnonymous === false channel", () => {
+      const user: IDiscussionsUser = { username: null };
+      const channel = {
+        allowAnonymous: false,
+      } as IChannel;
+
+      expect(canPostToChannel(channel, user)).toBe(false);
+    });
+
+    it("returns true if authenticated user attempts to create post in public-access channel", () => {
+      const user: IDiscussionsUser = { username: "Slughorn" };
+      const channel = {
+        access: "public",
+        allowAnonymous: false,
+      } as IChannel;
+
+      expect(canPostToChannel(channel, user)).toBe(true);
+    });
+
+    it("returns true if group authorized user attempts to create post in private-access channel", () => {
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        groups: [
+          {
+            id: "abc",
+            userMembership: { memberType: "member" },
+          },
+        ],
+      } as any;
+      const channel = {
+        access: "private",
+        allowAnonymous: false,
+        groups: ["abc"],
+      } as any;
+
+      expect(canPostToChannel(channel, user)).toBe(true);
+    });
+
+    it("returns false if group unauthorized user attempts to create post in private-access channel", () => {
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        groups: [
+          {
+            id: "abc",
+            userMembership: { memberType: "member" },
+          },
+        ],
+      } as any;
+      const channel = {
+        access: "private",
+        allowAnonymous: false,
+        groups: ["xyz"],
+      } as any;
+
+      expect(canPostToChannel(channel, user)).toBe(false);
+    });
+
+    it("handles missing user/channel groups", () => {
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+      } as any;
+      const channel = {
+        access: "private",
+        allowAnonymous: false,
+      } as any;
+
+      expect(canPostToChannel(channel, user)).toBe(false);
+    });
+
+    it("returns true if org authorized user attempts to create post in org-access channel", () => {
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        orgId: "abc",
+      } as any;
+      const channel = {
+        access: "org",
+        allowAnonymous: false,
+        orgs: ["abc"],
+      } as any;
+
+      expect(canPostToChannel(channel, user)).toBe(true);
+    });
+
+    it("returns false if unknown access value", () => {
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        orgId: "abc",
+      } as any;
+      const channel = {
+        access: "foo",
+        allowAnonymous: false,
+        orgs: ["abc"],
+      } as any;
+
+      expect(canPostToChannel(channel, user)).toBe(false);
+    });
+  });
+});

--- a/packages/discussions/test/utils/channels/index.spec.ts
+++ b/packages/discussions/test/utils/channels/index.spec.ts
@@ -1,13 +1,12 @@
 import { IUser } from "@esri/arcgis-rest-auth";
 import { IGroup } from "@esri/arcgis-rest-types";
-import { SharingAccess, IChannel } from "../../src/types";
+import { SharingAccess, IChannel } from "../../../src/types";
 import {
   canCreateChannel,
   canModifyChannel,
-  canPostToChannel,
   canReadFromChannel,
   isChannelInclusive,
-} from "../../src/utils/channels";
+} from "../../../src/utils/channels";
 
 const orgId1 = "3ef";
 const orgId2 = "4dc";
@@ -315,75 +314,6 @@ describe("Util: Channel Access", () => {
       user.role = "org_admin";
       user.roleId = "123abc";
       expect(canCreateChannel(channel, user)).toBeFalsy();
-    });
-  });
-
-  describe("canPostToChannel", () => {
-    it("returns true for users included within private channel access", () => {
-      const channel = fakeChannel({
-        access: SharingAccess.PRIVATE,
-        orgs: [orgId1],
-        groups: [groupId1],
-      });
-      expect(canPostToChannel(channel, user)).toBeTruthy();
-    });
-    it("returns false for users not included within private channel access", () => {
-      const channel = fakeChannel({
-        access: SharingAccess.PRIVATE,
-        orgs: [orgId1],
-        groups: [groupId3],
-      });
-      expect(canPostToChannel(channel, user)).toBeFalsy();
-    });
-    it("returns true if user is org member of channel with org access", () => {
-      const channel = fakeChannel({
-        access: SharingAccess.ORG,
-        orgs: [orgId1],
-      });
-      expect(canPostToChannel(channel, user)).toBeTruthy();
-    });
-    it("returns false if user is not org member of channel with org access", () => {
-      const channel = fakeChannel({
-        access: SharingAccess.ORG,
-        orgs: [orgId2],
-      });
-      expect(canPostToChannel(channel, user)).toBeFalsy();
-    });
-    it("[GATE]: returns false if user supplies multiple orgs to channel with org access", () => {
-      const channel = fakeChannel({
-        access: SharingAccess.ORG,
-        orgs: [orgId1, orgId2],
-      });
-      expect(canPostToChannel(channel, user)).toBeFalsy();
-    });
-    it("returns true if user is anonymous and channel is public and allows anonymous posts", () => {
-      const channel = fakeChannel({
-        access: SharingAccess.PUBLIC,
-        orgs: [orgId2],
-        allowAnonymous: true,
-      });
-      const _user = fakeUser({
-        username: "anonymous",
-      });
-      expect(canPostToChannel(channel, _user)).toBeTruthy();
-    });
-    it("returns false is user is anonymous and channel is public and does not allow anonymous posts", () => {
-      const channel = fakeChannel({
-        access: SharingAccess.PUBLIC,
-        orgs: [orgId2],
-        allowAnonymous: false,
-      });
-      const _user = fakeUser({
-        username: "anonymous",
-      });
-      expect(canPostToChannel(channel, _user)).toBeFalsy();
-    });
-    it("returns true if channel is public", () => {
-      const channel = fakeChannel({
-        access: SharingAccess.PUBLIC,
-        orgs: [orgId2],
-      });
-      expect(canPostToChannel(channel, user)).toBeTruthy();
     });
   });
 });

--- a/packages/discussions/test/utils/posts.test.ts
+++ b/packages/discussions/test/utils/posts.test.ts
@@ -6,6 +6,7 @@ import {
   isDiscussable,
   parseDiscussionURI,
   canModifyPost,
+  canModifyPostStatus,
   canDeletePost,
   parseMentionedUsers,
   MENTION_ATTRIBUTE,
@@ -83,38 +84,42 @@ describe("isDiscussable", () => {
 
 describe("canModifyPost", () => {
   it("returns true when the user created the post", () => {
-    const canModifyChannelSpy = spyOn(channelUtils, "canModifyChannel");
     const post = { id: "post1", creator: "user1" } as IPost;
     const user = { username: "user1" } as IUser;
-    const channel = { id: "channel1" } as IChannel;
-    const result = canModifyPost(post, channel, user);
+    const result = canModifyPost(post, user);
     expect(result).toBe(true);
-    expect(canModifyChannelSpy).not.toHaveBeenCalled();
   });
 
-  it("returns when user can modify channel", () => {
+  it("returns false when user did not create the post", () => {
+    const post = { id: "post1", creator: "user1" } as IPost;
+    const user = { username: "user2" } as IUser;
+    const result = canModifyPost(post, user);
+    expect(result).toBe(false);
+  });
+});
+
+describe("canModifyPostStatus", () => {
+  it("returns true when user can modify channel", () => {
     const canModifyChannelSpy = spyOn(
       channelUtils,
       "canModifyChannel"
     ).and.returnValue(true);
-    const post = { id: "post1", creator: "user1" } as IPost;
     const user = { username: "user2" } as IUser;
     const channel = { id: "channel1" } as IChannel;
-    const result = canModifyPost(post, channel, user);
+    const result = canModifyPostStatus(channel, user);
     expect(result).toBe(true);
     expect(canModifyChannelSpy).toHaveBeenCalledTimes(1);
     expect(canModifyChannelSpy).toHaveBeenCalledWith(channel, user);
   });
 
-  it("returns false when user did not create the post and user cannot modify channel", () => {
+  it("returns false when user cannot modify channel", () => {
     const canModifyChannelSpy = spyOn(
       channelUtils,
       "canModifyChannel"
     ).and.returnValue(false);
-    const post = { id: "post1", creator: "user1" } as IPost;
     const user = { username: "user2" } as IUser;
     const channel = { id: "channel1" } as IChannel;
-    const result = canModifyPost(post, channel, user);
+    const result = canModifyPostStatus(channel, user);
     expect(result).toBe(false);
     expect(canModifyChannelSpy).toHaveBeenCalledTimes(1);
     expect(canModifyChannelSpy).toHaveBeenCalledWith(channel, user);


### PR DESCRIPTION


1. Description:
* fix(): canModifyPost should match creator to username.
* feat(): canModifyPostStatus - a specific auth method for modifying a post's status
* refactor(): canPostToChannel to partially leverage channel ACL
* BREAKING CHANGE: changed signature of canModifyPost, because it no longer requires the `channel` param
* 
1. Instructions for testing:
Run unit tests

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
