### PR TITLE
feat: project extents are converted to strings on create/update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61115,7 +61115,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "13.5.0",
+			"version": "13.6.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/src/extent.ts
+++ b/packages/common/src/extent.ts
@@ -13,6 +13,16 @@ export const bBoxToExtent = (bBox: BBox) => {
   return createExtent(xmin, ymin, xmax, ymax);
 };
 
+/**
+ * Given a Bbox, convert it to a string. Some api endpoints expect a string
+ *
+ * @param {BBox} extent
+ * @return {*}  {string}
+ */
+export const bboxToString = (extent: BBox): string => {
+  return extent.map((a) => a.join(", ")).join(", ");
+};
+
 export function createExtent(
   xmin: number,
   ymin: number,

--- a/packages/common/src/models/index.ts
+++ b/packages/common/src/models/index.ts
@@ -12,7 +12,7 @@ import {
   updateItem,
 } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { cloneObject, IModel, getItemBySlug } from "..";
+import { cloneObject, IModel, getItemBySlug, bboxToString } from "..";
 
 /**
  * Gets the full item/data model for an item id
@@ -88,6 +88,13 @@ export function createModel(
   // const clone = cloneObject(model) as IModel;
   const item = cloneObject(model.item);
   item.data = cloneObject(model.data);
+  // Update extent from bbox to string
+  // TODO: remove below logic once rest.js is fixed.
+  if (item.extent && typeof item.extent !== "string") {
+    // THIS IS A HACK TO WORK AROUND REST.JS BUG
+    // and normally should never be done.
+    item.extent = bboxToString(item.extent) as unknown as number[][];
+  }
   const opts = {
     item,
     ...requestOptions,
@@ -120,6 +127,13 @@ export function updateModel(
   // const clone = cloneObject(model);
   const item = cloneObject(model.item);
   item.data = cloneObject(model.data);
+  // Update extent from bbox to string
+  // TODO: remove below logic once rest.js is fixed.
+  if (item.extent && typeof item.extent !== "string") {
+    // THIS IS A HACK TO WORK AROUND REST.JS BUG
+    // and normally should never be done.
+    item.extent = bboxToString(item.extent) as unknown as number[][];
+  }
   const opts = {
     item,
     ...requestOptions,

--- a/packages/common/src/projects/HubProjects.ts
+++ b/packages/common/src/projects/HubProjects.ts
@@ -24,6 +24,7 @@ import {
   getFamily,
   IHubRequestOptions,
   getItemHomeUrl,
+  bboxToString,
 } from "../index";
 import {
   IItem,
@@ -89,6 +90,10 @@ export async function createProject(
   const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
   // create model from object, using the default model as a starting point
   let model = mapper.objectToModel(project, cloneObject(DEFAULT_PROJECT_MODEL));
+  // Update extent from bbox to string
+  if (model.extent) {
+    model.extent = bboxToString(project.extent);
+  }
   // create the item
   model = await createModel(model, requestOptions);
   // map the model back into a IHubProject
@@ -121,6 +126,10 @@ export async function updateProject(
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic
   const modelToUpdate = mapper.objectToModel(project, model);
+  // Update extent from bbox to string
+  if (model.extent) {
+    model.extent = bboxToString(project.extent);
+  }
   // update the backing item
   const updatedModel = await updateModel(modelToUpdate, requestOptions);
   // now map back into a project and return that

--- a/packages/common/src/projects/HubProjects.ts
+++ b/packages/common/src/projects/HubProjects.ts
@@ -24,7 +24,6 @@ import {
   getFamily,
   IHubRequestOptions,
   getItemHomeUrl,
-  bboxToString,
 } from "../index";
 import {
   IItem,
@@ -90,10 +89,6 @@ export async function createProject(
   const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
   // create model from object, using the default model as a starting point
   let model = mapper.objectToModel(project, cloneObject(DEFAULT_PROJECT_MODEL));
-  // Update extent from bbox to string
-  if (model.extent) {
-    model.extent = bboxToString(project.extent);
-  }
   // create the item
   model = await createModel(model, requestOptions);
   // map the model back into a IHubProject
@@ -126,10 +121,6 @@ export async function updateProject(
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic
   const modelToUpdate = mapper.objectToModel(project, model);
-  // Update extent from bbox to string
-  if (model.extent) {
-    model.extent = bboxToString(project.extent);
-  }
   // update the backing item
   const updatedModel = await updateModel(modelToUpdate, requestOptions);
   // now map back into a project and return that

--- a/packages/common/test/models/models.test.ts
+++ b/packages/common/test/models/models.test.ts
@@ -71,6 +71,10 @@ describe("model utils:", () => {
         item: {
           title: "My New Thing",
           type: "Hub Project",
+          extent: [
+            [1, 2],
+            [3, 4],
+          ],
         },
         data: {
           some: "data",
@@ -93,6 +97,51 @@ describe("model utils:", () => {
 
       expect(opts.authentication).toBe(MOCK_AUTH);
       expect(opts.item.data).toBeDefined();
+      expect(opts.item.extent).toBe("1, 2, 3, 4" as unknown as number[][]);
+    });
+    it("creates item and stores it w/ extent as string", async () => {
+      const createItemSpy = spyOn(portalModule, "createItem").and.returnValue(
+        Promise.resolve({ success: true, id: "bc3" })
+      );
+      const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
+        Promise.resolve({
+          id: "bc3",
+          created: new Date().getTime(),
+          modified: new Date().getTime(),
+        })
+      );
+      const getItemDataSpy = spyOn(portalModule, "getItemData").and.returnValue(
+        Promise.resolve({ data: "values" })
+      );
+
+      const m = {
+        item: {
+          title: "My New Thing",
+          type: "Hub Project",
+          extent: "1, 2, 3, 4" as unknown as number[][],
+        },
+        data: {
+          some: "data",
+        },
+      } as unknown as IModel;
+      // depending how fast tests run, the date we're faking may be a bit off
+      const ts = new Date().getTime() - 100;
+      const chk = await createModel(m, {
+        authentication: MOCK_AUTH,
+      });
+      expect(chk.item.id).toBe("bc3");
+      expect(chk.item.created).toBeGreaterThanOrEqual(ts);
+      expect(chk.item.modified).toBeGreaterThanOrEqual(ts);
+      expect(getItemSpy.calls.count()).toBe(1);
+      expect(getItemDataSpy.calls.count()).toBe(1);
+      expect(createItemSpy.calls.count()).toBe(1);
+      const opts = createItemSpy.calls.argsFor(
+        0
+      )[0] as unknown as portalModule.ICreateItemOptions;
+
+      expect(opts.authentication).toBe(MOCK_AUTH);
+      expect(opts.item.data).toBeDefined();
+      expect(opts.item.extent).toBe("1, 2, 3, 4" as unknown as number[][]);
     });
   });
   describe("updateModel: ", () => {
@@ -118,6 +167,10 @@ describe("model utils:", () => {
           type: "Hub Project",
           created: 1643663750004,
           modified: 1643663750007,
+          extent: [
+            [1, 2],
+            [3, 4],
+          ],
         },
         data: {
           some: "data",
@@ -140,6 +193,54 @@ describe("model utils:", () => {
 
       expect(opts.authentication).toBe(MOCK_AUTH);
       expect(opts.item.data).toBeDefined();
+      expect(opts.item.extent).toBe("1, 2, 3, 4" as unknown as number[][]);
+    });
+    it("updates a model w/ extent as string", async () => {
+      const updateItemSpy = spyOn(portalModule, "updateItem").and.returnValue(
+        Promise.resolve({ success: true, id: "00c" })
+      );
+      const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
+        Promise.resolve({
+          id: "00c",
+          created: 1643663750004,
+          modified: new Date().getTime(),
+        })
+      );
+      const getItemDataSpy = spyOn(portalModule, "getItemData").and.returnValue(
+        Promise.resolve({ data: "values" })
+      );
+
+      const m = {
+        item: {
+          id: "00c",
+          title: "My New Thing",
+          type: "Hub Project",
+          created: 1643663750004,
+          modified: 1643663750007,
+          extent: "1, 2, 3, 4" as unknown as number[][],
+        },
+        data: {
+          some: "data",
+        },
+      } as unknown as IModel;
+      // depending how fast tests run, the modified date we're faking may be a bit off
+      const ts = new Date().getTime() - 100;
+      const chk = await updateModel(m, {
+        authentication: MOCK_AUTH,
+      });
+      expect(chk.item.id).toBe("00c");
+      expect(chk.item.created).toBe(1643663750004);
+      expect(chk.item.modified).toBeGreaterThanOrEqual(ts);
+      expect(getItemSpy.calls.count()).toBe(1);
+      expect(getItemDataSpy.calls.count()).toBe(1);
+      expect(updateItemSpy.calls.count()).toBe(1);
+      const opts = updateItemSpy.calls.argsFor(
+        0
+      )[0] as unknown as portalModule.IUpdateItemOptions;
+
+      expect(opts.authentication).toBe(MOCK_AUTH);
+      expect(opts.item.data).toBeDefined();
+      expect(opts.item.extent).toBe("1, 2, 3, 4" as unknown as number[][]);
     });
   });
   describe("fetchModelFromItem:", () => {


### PR DESCRIPTION
1. Description: project create/update call the addItem and update endpoints which both expect extent as a string, not a bbox.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
