### PR TITLE
feat(hub-common): add tags and categories to item-backed search results and to IHubSearchResult

### DIFF
--- a/packages/common/src/content/HubContent.ts
+++ b/packages/common/src/content/HubContent.ts
@@ -31,6 +31,8 @@ export async function enrichContentSearchResult(
     type: item.type,
     name: item.title,
     owner: item.owner,
+    tags: item.tags,
+    categories: item.categories,
     summary: item.snippet || item.description,
     createdDate: new Date(item.created),
     createdDateSource: "item.created",

--- a/packages/common/src/pages/HubPages.ts
+++ b/packages/common/src/pages/HubPages.ts
@@ -30,6 +30,8 @@ export async function enrichPageSearchResult(
     type: item.type,
     name: item.title,
     owner: item.owner,
+    tags: item.tags,
+    categories: item.categories,
     summary: item.snippet || item.description,
     createdDate: new Date(item.created),
     createdDateSource: "item.created",

--- a/packages/common/src/projects/HubProjects.ts
+++ b/packages/common/src/projects/HubProjects.ts
@@ -248,6 +248,8 @@ export async function enrichProjectSearchResult(
     type: item.type,
     name: item.title,
     owner: item.owner,
+    tags: item.tags,
+    categories: item.categories,
     summary: item.snippet || item.description,
     createdDate: new Date(item.created),
     createdDateSource: "item.created",

--- a/packages/common/src/search/types/IHubSearchResult.ts
+++ b/packages/common/src/search/types/IHubSearchResult.ts
@@ -36,6 +36,16 @@ export interface IHubSearchResult extends IHubEntityBase {
   owner?: string;
 
   /**
+   * Tags; Applies to Items
+   */
+  tags?: string[];
+
+  /**
+   * Categories; Applies to Items
+   */
+  categories?: string[];
+
+  /**
    * Links to related things
    */
   links?: {

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -496,6 +496,8 @@ export async function enrichSiteSearchResult(
     type: item.type,
     name: item.title,
     owner: item.owner,
+    tags: item.tags,
+    categories: item.categories,
     summary: item.snippet || item.description,
     createdDate: new Date(item.created),
     createdDateSource: "item.created",

--- a/packages/common/test/content/HubContent.test.ts
+++ b/packages/common/test/content/HubContent.test.ts
@@ -33,7 +33,7 @@ const FEATURE_SERVICE_ITEM: IItem = {
     [20.9847, 37.0075],
     [26.6331, 41.7264],
   ],
-  categories: [],
+  categories: ["category"],
   spatialReference: null,
   accessInformation: null,
   licenseInfo: null,
@@ -106,6 +106,8 @@ describe("HubContent module:", () => {
       expect(chk.updatedDate).toEqual(new Date(ITM.modified));
       expect(chk.updatedDateSource).toEqual("item.modified");
       expect(chk.family).toEqual("map");
+      expect(chk.tags).toEqual(ITM.tags);
+      expect(chk.categories).toEqual(ITM.categories);
       expect(chk.links.self).toEqual(
         `https://some-server.com/gis/home/item.html?id=${ITM.id}`
       );

--- a/packages/common/test/pages/HubPages.test.ts
+++ b/packages/common/test/pages/HubPages.test.ts
@@ -30,12 +30,12 @@ const PAGE_ITEM: IItem = {
   ],
   description:
     "DO NOT DELETE OR MODIFY THIS ITEM. This item is managed by the ArcGIS Hub application. To make changes to this page, please visit https://hub.arcgis.com/admin/",
-  tags: [],
+  tags: ["tag"],
   snippet: null,
   thumbnail: "thumbnail/foo.png",
   documentation: null,
   extent: [],
-  categories: [],
+  categories: ["category"],
   spatialReference: null,
   accessInformation: null,
   licenseInfo: null,
@@ -110,6 +110,8 @@ describe("HubPages Module", () => {
       expect(chk.updatedDate).toEqual(new Date(ITM.modified));
       expect(chk.updatedDateSource).toEqual("item.modified");
       expect(chk.family).toEqual("document");
+      expect(chk.tags).toEqual(ITM.tags);
+      expect(chk.categories).toEqual(ITM.categories);
       expect(chk.links.self).toEqual(
         `https://some-server.com/gis/home/item.html?id=${ITM.id}`
       );

--- a/packages/common/test/projects/HubProjects.test.ts
+++ b/packages/common/test/projects/HubProjects.test.ts
@@ -10,8 +10,6 @@ import {
   updateProject,
   IHubRequestOptions,
   enrichProjectSearchResult,
-  IQuery,
-  IHubSearchOptions,
   getHubProjectEditorConfig,
   UiSchemaElementOptions,
   HubProjectSchema,
@@ -80,7 +78,7 @@ const PROJECT_ITEM_ENRICH: portalModule.IItem = {
   thumbnail: "thumbnail/my-project.png",
   // documentation: null,
   extent: [],
-  categories: [],
+  categories: ["category"],
   // spatialReference: null,
   accessInformation: null,
   licenseInfo: "CC-BY-SA",
@@ -371,6 +369,8 @@ describe("HubProjects:", () => {
       expect(chk.updatedDate).toEqual(new Date(ITM.modified));
       expect(chk.updatedDateSource).toEqual("item.modified");
       expect(chk.family).toEqual("project");
+      expect(chk.tags).toEqual(ITM.tags);
+      expect(chk.categories).toEqual(ITM.categories);
       expect(chk.links?.self).toEqual(
         `https://some-server.com/gis/home/item.html?id=${ITM.id}`
       );

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -116,7 +116,7 @@ const SITE_ITEM_ENRICH: portalModule.IItem = {
   thumbnail: "thumbnail/bar.png",
   // documentation: null,
   extent: [],
-  categories: [],
+  categories: ["category"],
   // spatialReference: null,
   accessInformation: null,
   licenseInfo: null,
@@ -484,6 +484,8 @@ describe("HubSites:", () => {
       expect(chk.updatedDate).toEqual(new Date(ITM.modified));
       expect(chk.updatedDateSource).toEqual("item.modified");
       expect(chk.family).toEqual("site");
+      expect(chk.tags).toEqual(ITM.tags);
+      expect(chk.categories).toEqual(ITM.categories);
       expect(chk.links?.self).toEqual(ITM.url);
       expect(chk.links?.siteRelative).toEqual(`/content/${ITM.id}`);
       expect(chk.links?.thumbnail).toEqual(


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Add tags and categories to item-backed search results and to the IHubSearchResult interfaces.
Part of [4822](https://devtopia.esri.com/dc/hub/issues/4822)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
