### PR TITLE
feat(hub-common): lazy-load XML parsing library before parsing item m…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21577,10 +21577,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -21595,24 +21594,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -21626,10 +21622,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -21647,10 +21642,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -61194,7 +61188,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "11.5.0",
+			"version": "11.7.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -61224,7 +61218,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "13.6.0",
+			"version": "14.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61233,19 +61227,19 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "11.5.0"
+				"@esri/hub-common": "11.7.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "11.5.0",
+			"version": "11.7.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -61256,7 +61250,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61264,12 +61258,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.4.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "11.5.0"
+				"@esri/hub-common": "11.7.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "11.5.0",
+			"version": "11.7.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61280,7 +61274,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61289,12 +61283,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.5.0"
+				"@esri/hub-common": "11.7.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "11.5.0",
+			"version": "11.7.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61303,7 +61297,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -61311,12 +61305,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "11.5.0"
+				"@esri/hub-common": "11.7.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "11.5.0",
+			"version": "11.7.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61327,7 +61321,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -61338,12 +61332,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.5.0"
+				"@esri/hub-common": "11.7.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "11.5.0",
+			"version": "11.7.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61352,9 +61346,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
-				"@esri/hub-initiatives": "11.5.0",
-				"@esri/hub-teams": "11.5.0",
+				"@esri/hub-common": "11.7.0",
+				"@esri/hub-initiatives": "11.7.0",
+				"@esri/hub-teams": "11.7.0",
 				"@esri/hub-types": "^6.10.0",
 				"typescript": "^3.8.1"
 			},
@@ -61362,9 +61356,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "11.5.0",
-				"@esri/hub-initiatives": "11.5.0",
-				"@esri/hub-teams": "11.5.0"
+				"@esri/hub-common": "11.7.0",
+				"@esri/hub-initiatives": "11.7.0",
+				"@esri/hub-teams": "11.7.0"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61386,7 +61380,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "11.5.0",
+			"version": "11.7.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61397,7 +61391,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61406,12 +61400,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.5.0"
+				"@esri/hub-common": "11.7.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "11.5.0",
+			"version": "11.7.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61421,7 +61415,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61429,7 +61423,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.5.0"
+				"@esri/hub-common": "11.7.0"
 			}
 		}
 	},
@@ -64835,7 +64829,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64848,7 +64842,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64862,7 +64856,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -64873,7 +64867,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64887,7 +64881,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -64900,9 +64894,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
-				"@esri/hub-initiatives": "11.5.0",
-				"@esri/hub-teams": "11.5.0",
+				"@esri/hub-common": "11.7.0",
+				"@esri/hub-initiatives": "11.7.0",
+				"@esri/hub-teams": "11.7.0",
 				"@esri/hub-types": "^6.10.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64930,7 +64924,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -64942,7 +64936,7 @@
 				"@esri/arcgis-rest-portal": "^3.4.2",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.5.0",
+				"@esri/hub-common": "11.7.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -78914,8 +78908,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -78930,20 +78923,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -78957,8 +78947,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -78975,8 +78964,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "es2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
-    "module": "es2015",                     /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "module": "es2020",                     /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": [
       "dom",
       "es2017"


### PR DESCRIPTION
…etadata

affects: @esri/hub-common

1. Description:

lazy-loads the fast-xml-parser library only when needed to parse fetched metadata

@dbouwman this will serve as the basis for how we solve how classes can lazy-load the expensive CUD and schema code.

1. Instructions for testing:

I verified this locally w/ yalc

1. Closes Issues: [3697](https://devtopia.esri.com/dc/hub/issues/3697)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
