### PR TITLE
feat: support serializing categories into separate param

### DIFF
--- a/packages/common/src/search/_internal/expandPredicate.ts
+++ b/packages/common/src/search/_internal/expandPredicate.ts
@@ -14,6 +14,7 @@ export function expandPredicate(predicate: IPredicate): IPredicate {
   const dateProps = ["created", "modified", "lastlogin"];
   const copyProps = [
     "filterType",
+    "categories",
     "term",
     "searchUserAccess",
     "isopendata",

--- a/packages/common/src/search/serializeQueryForPortal.ts
+++ b/packages/common/src/search/serializeQueryForPortal.ts
@@ -87,7 +87,7 @@ function serializeFilter(filter: IFilter): ISearchOptions {
 function serializePredicate(predicate: IPredicate): ISearchOptions {
   const dateProps = ["created", "modified"];
   const boolProps = ["isopendata"];
-  const passThroughProps = ["searchUserAccess", "searchUserName"];
+  const passThroughProps = ["searchUserAccess", "searchUserName", "categories"];
   const specialProps = [
     "filterType",
     "term",
@@ -97,9 +97,9 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
   ];
   const portalAllowList = [
     "access",
-    "categories",
     "capabilities",
     "created",
+    "categories",
     "description",
     "disabled",
     "email",
@@ -133,7 +133,6 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
     "username",
   ];
 
-  let qCount = 0;
   // TODO: Look at using reduce vs .map and remove the `.filter`
   const opts = Object.entries(predicate)
     .map(([key, value]) => {
@@ -143,25 +142,21 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
       if (portalAllowList.includes(key)) {
         const so: ISearchOptions = { q: "" };
         if (!specialProps.includes(key) && key !== "term") {
-          qCount++;
           so.q = serializeMatchOptions(key, value);
         }
         if (dateProps.includes(key)) {
-          qCount++;
           so.q = serializeDateRange(
             key,
             value as unknown as IDateRange<number>
           );
         }
         if (boolProps.includes(key)) {
-          qCount++;
           so.q = `${key}:${value}`;
         }
         if (passThroughProps.includes(key)) {
           so[key] = value;
         }
         if (key === "term") {
-          qCount++;
           so.q = value;
         }
         return so;

--- a/packages/common/test/search/serializeQueryForPortal.test.ts
+++ b/packages/common/test/search/serializeQueryForPortal.test.ts
@@ -30,6 +30,27 @@ describe("ifilter-utils:", () => {
         '(water AND modified:[1689716790912 TO 1652808629198] AND (type:"Web Map" OR type:"Hub Project"))'
       );
     });
+    it("handles categories", () => {
+      const p: IPredicate = {
+        term: "water",
+        categories: "/Categories/Lakes",
+      };
+
+      const query: IQuery = {
+        targetEntity: "item",
+        filters: [
+          {
+            operation: "AND",
+            predicates: [p],
+          },
+        ],
+      };
+
+      const chk = serializeQueryForPortal(query);
+
+      expect(chk.q).toEqual("(water)");
+      expect(chk.categories).toEqual("/Categories/Lakes");
+    });
     it("blocks props not in portal allow list", () => {
       const p: IPredicate = {
         term: "water",


### PR DESCRIPTION
1. Description:

sending a predicate with `categories` was adding that into the `q` which the portal does not respect, and thus ignores. This correctly serializes it into a separate property which is sent as a separate form field in the search request

1. Instructions for testing:

run rests

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
