### PR TITLE
feat(hub-common): add titleize to utils

### DIFF
--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -17,3 +17,4 @@ export * from "./is-update-group";
 export * from "./revertable-tasks";
 export * from "./sessionLocalStorage";
 export * from "./dasherize";
+export * from "./titleize";

--- a/packages/common/src/utils/titleize.ts
+++ b/packages/common/src/utils/titleize.ts
@@ -1,0 +1,13 @@
+import { capitalize } from "../util";
+
+/**
+ * Capitalize every word in a sentence
+ * @param {string} value
+ * @returns {string} a sentence with every word being capitalized
+ */
+export function titleize(value: string) {
+  return value
+    .split(" ")
+    .map((k) => capitalize(k))
+    .join(" ");
+}

--- a/packages/common/src/utils/titleize.ts
+++ b/packages/common/src/utils/titleize.ts
@@ -7,6 +7,7 @@ import { capitalize } from "../util";
  */
 export function titleize(value: string) {
   return value
+    .replace(/\s\s+/g, " ")
     .split(" ")
     .map((k) => capitalize(k))
     .join(" ");

--- a/packages/common/test/utils/titleize.test.ts
+++ b/packages/common/test/utils/titleize.test.ts
@@ -4,6 +4,7 @@ describe("titleize", function () {
   it("capitalizes every word in a sentence", function () {
     expect(titleize("hello")).toBe("Hello");
     expect(titleize("hello world")).toBe("Hello World");
+    expect(titleize("hello    world")).toBe("Hello World");
     expect(titleize("helloworld")).toBe("Helloworld");
     expect(titleize("hello-world")).toBe("Hello-world");
   });

--- a/packages/common/test/utils/titleize.test.ts
+++ b/packages/common/test/utils/titleize.test.ts
@@ -1,0 +1,10 @@
+import { titleize } from "../../src";
+
+describe("titleize", function () {
+  it("capitalizes every word in a sentence", function () {
+    expect(titleize("hello")).toBe("Hello");
+    expect(titleize("hello world")).toBe("Hello World");
+    expect(titleize("helloworld")).toBe("Helloworld");
+    expect(titleize("hello-world")).toBe("Hello-world");
+  });
+});


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Add titleize to utils

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
