### PR TITLE
feat: serialize categories into q, add support for categoryFilter and categoryAsParam

### DIFF
--- a/packages/common/src/search/_internal/expandPredicate.ts
+++ b/packages/common/src/search/_internal/expandPredicate.ts
@@ -14,7 +14,8 @@ export function expandPredicate(predicate: IPredicate): IPredicate {
   const dateProps = ["created", "modified", "lastlogin"];
   const copyProps = [
     "filterType",
-    "categories",
+    "categoriesAsParam",
+    "categoryFilter",
     "term",
     "searchUserAccess",
     "isopendata",

--- a/packages/common/src/search/serializeQueryForPortal.ts
+++ b/packages/common/src/search/serializeQueryForPortal.ts
@@ -87,7 +87,12 @@ function serializeFilter(filter: IFilter): ISearchOptions {
 function serializePredicate(predicate: IPredicate): ISearchOptions {
   const dateProps = ["created", "modified"];
   const boolProps = ["isopendata"];
-  const passThroughProps = ["searchUserAccess", "searchUserName", "categories"];
+  const passThroughProps = [
+    "searchUserAccess",
+    "searchUserName",
+    "categoriesAsParam",
+    "categoryFilter",
+  ];
   const specialProps = [
     "filterType",
     "term",
@@ -100,6 +105,8 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
     "capabilities",
     "created",
     "categories",
+    "categoriesAsParam",
+    "categoryFilter",
     "description",
     "disabled",
     "email",

--- a/packages/common/test/search/serializeQueryForPortal.test.ts
+++ b/packages/common/test/search/serializeQueryForPortal.test.ts
@@ -33,7 +33,12 @@ describe("ifilter-utils:", () => {
     it("handles categories", () => {
       const p: IPredicate = {
         term: "water",
-        categories: "/Categories/Lakes",
+        categories: { any: ["Lakes", "Rivers"] },
+        categoriesAsParam: [
+          ["/Categories/Lakes", "/Categories/Rivers"],
+          ["/Categories/Land"],
+        ],
+        categoryFilter: "WAT",
       };
 
       const query: IQuery = {
@@ -48,8 +53,14 @@ describe("ifilter-utils:", () => {
 
       const chk = serializeQueryForPortal(query);
 
-      expect(chk.q).toEqual("(water)");
-      expect(chk.categories).toEqual("/Categories/Lakes");
+      expect(chk.q).toEqual(
+        `(water AND (categories:"Lakes" OR categories:"Rivers"))`
+      );
+      expect(chk.categoriesAsParam).toEqual([
+        ["/Categories/Lakes", "/Categories/Rivers"],
+        ["/Categories/Land"],
+      ]);
+      expect(chk.categoryFilter).toEqual("WAT");
     });
     it("blocks props not in portal allow list", () => {
       const p: IPredicate = {


### PR DESCRIPTION
1. Description:

Turns out `categories` can be sent as a top level param (peer to `q`) OR in the `q`.

This changes the behavior so that a predicate like `{categories: "Land"}` will add that to the `q`.

If you want to send it as a param, use `{categoriesAsParam: "/Categories/Whatever/Deep/Path"}`. And it also adds support for the `categoryFilter` param.

1. Instructions for testing:

Run tests

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
