### PR TITLE
feat(hub-discussions): check groups for cannotDiscuss

### DIFF
--- a/packages/discussions/src/utils/channels/can-post-to-channel.ts
+++ b/packages/discussions/src/utils/channels/can-post-to-channel.ts
@@ -7,6 +7,8 @@ import {
   SharingAccess,
 } from "../../types";
 
+const CANNOT_DISCUSS = "cannotDiscuss";
+
 const ALLOWED_GROUP_ROLES = Object.freeze(["owner", "admin", "member"]);
 
 const ALLOWED_ROLES_FOR_POSTING = Object.freeze([
@@ -99,15 +101,16 @@ function channelAllowsPostsByThisUsersGroups(
     const {
       id: userGroupId,
       userMembership: { memberType: userMemberType },
+      typeKeywords,
     } = userGroup;
 
     const channelGroupPermission = acl.groups[userGroupId];
 
-    if (!channelGroupPermission) {
-      return false;
-    }
-
-    return ALLOWED_GROUP_ROLES.includes(userMemberType);
+    return (
+      channelGroupPermission &&
+      ALLOWED_GROUP_ROLES.includes(userMemberType) &&
+      !typeKeywords.includes(CANNOT_DISCUSS)
+    );
   });
 }
 
@@ -168,11 +171,13 @@ function isAuthorizedToPostByLegacyGroup(
       const {
         id: userGroupId,
         userMembership: { memberType: userMemberType },
+        typeKeywords,
       } = group;
 
       return (
         channelGroupId === userGroupId &&
-        ALLOWED_GROUP_ROLES.includes(userMemberType)
+        ALLOWED_GROUP_ROLES.includes(userMemberType) &&
+        !typeKeywords.includes(CANNOT_DISCUSS)
       );
     });
   });


### PR DESCRIPTION
1. Description:
Alter the canPostToDiscussion util so that during "authorization by group" (i.e. user's group matches channel group), we check that the group has not been tagged with typeKeyword `cannotDiscuss` which is a flag that users of this group are not allowed to participate in discussions.

1. Instructions for testing:
Added units tests, so we are covered.

1. Closes Issues: #<number> (if appropriate)
Doesn't fully close, but contributes to: https://zentopia.esri.com/workspaces/engagement-workspace-61508ae50946c40014ef574f/issues/dc/hub/4751

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
