### PR TITLE
fix: project status defaults

### DIFF
--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -1,4 +1,5 @@
 import { IConfigurationSchema, IUiSchema, UiSchemaRuleEffects } from "./types";
+import { PROJECT_STATUSES } from "../types";
 
 export const HubProjectSchema: IConfigurationSchema = {
   required: ["name"],
@@ -24,7 +25,7 @@ export const HubProjectSchema: IConfigurationSchema = {
     status: {
       type: "string",
       default: "notStarted",
-      enum: ["notStarted", "inProgress", "complete"],
+      enum: Object.keys(PROJECT_STATUSES),
     },
   },
 } as unknown as IConfigurationSchema;

--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -23,7 +23,7 @@ export const HubProjectSchema: IConfigurationSchema = {
     },
     status: {
       type: "string",
-      default: "not_started",
+      default: "notStarted",
       enum: ["notStarted", "inProgress", "complete"],
     },
   },

--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -24,7 +24,7 @@ export const HubProjectSchema: IConfigurationSchema = {
     },
     status: {
       type: "string",
-      default: "notStarted",
+      default: PROJECT_STATUSES.notStarted,
       enum: Object.keys(PROJECT_STATUSES),
     },
   },

--- a/packages/common/src/core/types/IHubProject.ts
+++ b/packages/common/src/core/types/IHubProject.ts
@@ -18,5 +18,5 @@ export interface IHubProject
   /**
    * Project Status
    */
-  status: "inactive" | "active";
+  status: "notStarted" | "inProgress" | "complete";
 }

--- a/packages/common/src/core/types/IHubProject.ts
+++ b/packages/common/src/core/types/IHubProject.ts
@@ -18,5 +18,11 @@ export interface IHubProject
   /**
    * Project Status
    */
-  status: "notStarted" | "inProgress" | "complete";
+  status: PROJECT_STATUSES;
+}
+
+export enum PROJECT_STATUSES {
+  notStarted = "notStarted",
+  inProgress = "inProgress",
+  complete = "complete",
 }

--- a/packages/common/src/projects/defaults.ts
+++ b/packages/common/src/projects/defaults.ts
@@ -10,7 +10,7 @@ export const DEFAULT_PROJECT: Partial<IHubProject> = {
   name: "No title provided",
   tags: [],
   typeKeywords: ["Hub Project"],
-  status: "inactive",
+  status: "notStarted",
   catalog: { schemaVersion: 0 },
   permissions: [],
   schemaVersion: 1,
@@ -35,7 +35,7 @@ export const DEFAULT_PROJECT_MODEL: IModel = {
   data: {
     display: "about",
     timeline: {},
-    status: "inactive",
+    status: "notStarted",
     contacts: [],
   },
 } as unknown as IModel;

--- a/packages/common/src/projects/defaults.ts
+++ b/packages/common/src/projects/defaults.ts
@@ -35,7 +35,7 @@ export const DEFAULT_PROJECT_MODEL: IModel = {
   data: {
     display: "about",
     timeline: {},
-    status: "notStarted",
+    status: PROJECT_STATUSES.notStarted,
     contacts: [],
   },
 } as unknown as IModel;

--- a/packages/common/src/projects/defaults.ts
+++ b/packages/common/src/projects/defaults.ts
@@ -1,4 +1,4 @@
-import { IHubProject } from "../core";
+import { IHubProject, PROJECT_STATUSES } from "../core";
 import { IModel } from "../types";
 
 export const HUB_PROJECT_ITEM_TYPE = "Hub Project";
@@ -10,7 +10,7 @@ export const DEFAULT_PROJECT: Partial<IHubProject> = {
   name: "No title provided",
   tags: [],
   typeKeywords: ["Hub Project"],
-  status: "notStarted",
+  status: PROJECT_STATUSES.notStarted,
   catalog: { schemaVersion: 0 },
   permissions: [],
   schemaVersion: 1,

--- a/packages/common/test/projects/HubProjects.test.ts
+++ b/packages/common/test/projects/HubProjects.test.ts
@@ -14,6 +14,7 @@ import {
   UiSchemaElementOptions,
   HubProjectSchema,
   deepFind,
+  PROJECT_STATUSES,
 } from "../../src";
 
 import { MOCK_AUTH } from "../mocks/mock-auth";
@@ -300,7 +301,7 @@ describe("HubProjects:", () => {
         createdDateSource: "item.created",
         updatedDate: new Date(1595878750000),
         updatedDateSource: "item.modified",
-        status: "active",
+        status: PROJECT_STATUSES.inProgress,
         thumbnailUrl: "",
         permissions: [],
         catalog: {
@@ -336,7 +337,7 @@ describe("HubProjects:", () => {
       ).and.callFake(() => {
         return Promise.resolve({
           data: {
-            status: "active",
+            status: PROJECT_STATUSES.inProgress,
           },
         });
       });
@@ -393,7 +394,7 @@ describe("HubProjects:", () => {
       );
 
       // verify the response
-      expect(chk.projectStatus).toBe("active");
+      expect(chk.projectStatus).toBe(PROJECT_STATUSES.inProgress);
 
       // verify the spy
       expect(enrichmentSpy.calls.count()).toBe(1, "should fetch enrichments");


### PR DESCRIPTION
1. Description:

update Hub Project status defaults and interface enum values

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
