### PR TITLE
fix: projects do not have a default description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61188,7 +61188,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "11.14.2",
+			"version": "11.16.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -61218,7 +61218,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "14.10.2",
+			"version": "14.12.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61227,19 +61227,19 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "11.14.2"
+				"@esri/hub-common": "11.16.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "11.14.2",
+			"version": "11.16.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -61250,7 +61250,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61258,12 +61258,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "11.14.2"
+				"@esri/hub-common": "11.16.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "11.14.2",
+			"version": "11.16.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61274,7 +61274,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61283,12 +61283,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.14.2"
+				"@esri/hub-common": "11.16.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "11.14.2",
+			"version": "11.16.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61297,7 +61297,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -61305,12 +61305,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "11.14.2"
+				"@esri/hub-common": "11.16.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "11.14.2",
+			"version": "11.16.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61321,7 +61321,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -61332,12 +61332,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.14.2"
+				"@esri/hub-common": "11.16.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "11.14.2",
+			"version": "11.16.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61346,9 +61346,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
-				"@esri/hub-initiatives": "11.14.2",
-				"@esri/hub-teams": "11.14.2",
+				"@esri/hub-common": "11.16.0",
+				"@esri/hub-initiatives": "11.16.0",
+				"@esri/hub-teams": "11.16.0",
 				"@esri/hub-types": "^6.10.0",
 				"typescript": "^3.8.1"
 			},
@@ -61356,9 +61356,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "11.14.2",
-				"@esri/hub-initiatives": "11.14.2",
-				"@esri/hub-teams": "11.14.2"
+				"@esri/hub-common": "11.16.0",
+				"@esri/hub-initiatives": "11.16.0",
+				"@esri/hub-teams": "11.16.0"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61380,7 +61380,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "11.14.2",
+			"version": "11.16.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61391,7 +61391,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61400,12 +61400,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.14.2"
+				"@esri/hub-common": "11.16.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "11.14.2",
+			"version": "11.16.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61415,7 +61415,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61423,7 +61423,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.14.2"
+				"@esri/hub-common": "11.16.0"
 			}
 		}
 	},
@@ -64829,7 +64829,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64842,7 +64842,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64856,7 +64856,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -64867,7 +64867,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64881,7 +64881,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -64894,9 +64894,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
-				"@esri/hub-initiatives": "11.14.2",
-				"@esri/hub-teams": "11.14.2",
+				"@esri/hub-common": "11.16.0",
+				"@esri/hub-initiatives": "11.16.0",
+				"@esri/hub-teams": "11.16.0",
 				"@esri/hub-types": "^6.10.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64924,7 +64924,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -64936,7 +64936,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.14.2",
+				"@esri/hub-common": "11.16.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/common/src/projects/defaults.ts
+++ b/packages/common/src/projects/defaults.ts
@@ -23,7 +23,7 @@ export const DEFAULT_PROJECT_MODEL: IModel = {
   item: {
     type: HUB_PROJECT_ITEM_TYPE,
     title: "No Title Provided",
-    description: "No Description Provided",
+    description: "",
     snippet: "",
     tags: [],
     typeKeywords: ["Hub Project"],


### PR DESCRIPTION
For https://devtopia.esri.com/dc/hub/issues/4906

New projects should not have a default description.

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
