### PR TITLE
feat: add HubSite class with .contains

### DIFF
--- a/packages/common/e2e/deep-contains.e2e.ts
+++ b/packages/common/e2e/deep-contains.e2e.ts
@@ -24,7 +24,7 @@ import { getProp } from "../src";
 //     - Unique Web App: a88285b001574cf3bfc91c4da11391cf
 //     - Common Web App: 63c765456d23439e8faf0e4172fc9b23
 
-describe("deepContains:", () => {
+fdescribe("deepContains:", () => {
   const siteItemId: string = "c84347eb5d0a4a7b84c334fe84a5bbfe";
   const siteAppItemId: string = "7da7ea6055d34afd9125a2ccd63be5e1";
   const projectItemId: string = "9c0ecf87bcc04a1d93dec04b54332458";
@@ -53,8 +53,8 @@ describe("deepContains:", () => {
         ctxMgr.context
       );
       expect(chk.isContained).toBeTruthy();
-
-      // console.info(`App in Site Catalog: Time: ${chk.duration} ms`);
+      // tslint:disable-next-line:no-console
+      console.info(`App in Site Catalog: Time: ${chk.duration} ms`);
 
       // hold the catalog and do another check
       siteCatalogInfo.catalog = getProp(
@@ -67,8 +67,8 @@ describe("deepContains:", () => {
         ctxMgr.context
       );
       expect(chk2.isContained).toBeTruthy();
-
-      // console.info(`App in Site Catalog (cached): Time: ${chk2.duration} ms`);
+      // tslint:disable-next-line:no-console
+      console.info(`App in Site Catalog (cached): Time: ${chk2.duration} ms`);
     });
 
     it("finds app in initiative catalog", async () => {
@@ -89,8 +89,8 @@ describe("deepContains:", () => {
       );
 
       expect(chk.isContained).toBeTruthy();
-
-      // console.info(`App in Initiative Catalog: Time: ${chk.duration} ms`);
+      // tslint:disable-next-line:no-console
+      console.info(`App in Initiative Catalog: Time: ${chk.duration} ms`);
     });
 
     it("finds app in project catalog", async () => {
@@ -116,8 +116,8 @@ describe("deepContains:", () => {
       );
 
       expect(chk.isContained).toBeTruthy();
-
-      // console.info(`App in Project Catalog: Time: ${chk.duration} ms`);
+      // tslint:disable-next-line:no-console
+      console.info(`App in Project Catalog: Time: ${chk.duration} ms`);
     });
   });
   describe("pass in catalogs", () => {
@@ -135,8 +135,8 @@ describe("deepContains:", () => {
         ctxMgr.context
       );
       expect(chk.isContained).toBeTruthy();
-
-      // console.info(`App in Site Catalog (passed in): Time: ${chk.duration} ms`);
+      // tslint:disable-next-line:no-console
+      console.info(`App in Site Catalog (passed in): Time: ${chk.duration} ms`);
     });
     it("find app in initiative catalog", async () => {
       const ctxMgr = await factory.getContextManager(orgName, "admin");
@@ -158,8 +158,10 @@ describe("deepContains:", () => {
       );
 
       expect(chk.isContained).toBeTruthy();
-
-      // console.info(`App in Initiative Catalog (passed in): Time: ${chk.duration} ms`);
+      // tslint:disable-next-line:no-console
+      console.info(
+        `App in Initiative Catalog (passed in): Time: ${chk.duration} ms`
+      );
     });
     it("find app in project catalog", async () => {
       const ctxMgr = await factory.getContextManager(orgName, "admin");
@@ -187,8 +189,10 @@ describe("deepContains:", () => {
       );
 
       expect(chk.isContained).toBeTruthy();
-
-      // console.info(`App in Project Catalog (passed in): Time: ${chk.duration} ms`);
+      // tslint:disable-next-line:no-console
+      console.info(
+        `App in Project Catalog (passed in): Time: ${chk.duration} ms`
+      );
     });
   });
 });

--- a/packages/common/e2e/hub-sites-contains.e2e.ts
+++ b/packages/common/e2e/hub-sites-contains.e2e.ts
@@ -1,0 +1,180 @@
+import Artifactory from "./helpers/Artifactory";
+import config from "./helpers/config";
+import { HubSite } from "../src/sites/HubSite";
+import { IDeepCatalogInfo, IHubCatalog } from "../src/search";
+import { ArcGISContextManager, IArcGISContext } from "../src";
+
+// Fixtures - shared with deep-contains.e2e.ts
+//
+// Site: c84347eb5d0a4a7b84c334fe84a5bbfe
+// - Catalog Group: b29562e1236f4743bc08d2444497b008
+//   - Content
+//     - Initiative: 270b4696648e4e4a8767a1dc9753ae34
+//     - Unique Web App: 7da7ea6055d34afd9125a2ccd63be5e1
+//     - Common Web App: 63c765456d23439e8faf0e4172fc9b23
+// Initiative: 270b4696648e4e4a8767a1dc9753ae34
+// - Catalog Group: 1d568e44a1b043529f67122340a33890#overview
+//   - Content:
+//     - Project: 9c0ecf87bcc04a1d93dec04b54332458
+//     - Unique Web App: c4597275ee874820bf578cdee3106e2f
+//     - Common Web App: 63c765456d23439e8faf0e4172fc9b23
+// Project: 9c0ecf87bcc04a1d93dec04b54332458
+// - Catalog Group: 5d92405aaa2b414d8632a469f9983be8
+//   - Content
+//     - Unique Web App: a88285b001574cf3bfc91c4da11391cf
+//     - Common Web App: 63c765456d23439e8faf0e4172fc9b23
+
+fdescribe("HubSite.contains:", () => {
+  const siteItemId: string = "c84347eb5d0a4a7b84c334fe84a5bbfe";
+  const siteAppItemId: string = "7da7ea6055d34afd9125a2ccd63be5e1";
+  const projectItemId: string = "9c0ecf87bcc04a1d93dec04b54332458";
+  const projectAppItemId: string = "a88285b001574cf3bfc91c4da11391cf";
+  const initiativeItemId: string = "270b4696648e4e4a8767a1dc9753ae34";
+  const initiativeAppItemId: string = "c4597275ee874820bf578cdee3106e2f";
+  const commonAppItemId: string = "63c765456d23439e8faf0e4172fc9b23";
+
+  let factory: Artifactory;
+  const orgName = "hubBasic";
+  let siteInstance: HubSite;
+  let context: IArcGISContext;
+  beforeAll(async () => {
+    factory = new Artifactory(config);
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
+    const ctxMgr = await factory.getContextManager(orgName, "admin");
+    context = ctxMgr.context;
+  });
+
+  beforeEach(async () => {
+    // re-create site for each test so we can verify the caching works
+    siteInstance = await HubSite.fetch(siteItemId, context);
+  });
+
+  describe(" passing only id:", () => {
+    it("finds app in site catalog", async () => {
+      const chk = await siteInstance.contains(siteAppItemId);
+      expect(chk.isContained).toBeTruthy();
+      // tslint:disable-next-line:no-console
+      console.info(
+        `HubSite.contains: App in Site Catalog: Time: ${chk.duration} ms`
+      );
+
+      const chk2 = await siteInstance.contains(commonAppItemId);
+      expect(chk2.isContained).toBeTruthy();
+      // tslint:disable-next-line:no-console
+      console.info(
+        `HubSite.contains: App in Site Catalog (cached): Time: ${chk2.duration} ms`
+      );
+      const chk3 = await siteInstance.contains(projectAppItemId);
+      expect(chk3.isContained).toBeFalsy();
+      // tslint:disable-next-line:no-console
+      console.info(
+        `HubSite.contains: App not in Site Catalog (cached): Time: ${chk3.duration} ms`
+      );
+    });
+
+    it("finds app in initiative catalog", async () => {
+      const initiativeCatalogInfo: IDeepCatalogInfo = {
+        id: initiativeItemId,
+        entityType: "item",
+      };
+
+      const chk = await siteInstance.contains(initiativeAppItemId, [
+        initiativeCatalogInfo,
+      ]);
+
+      expect(chk.isContained).toBeTruthy();
+      // tslint:disable-next-line:no-console
+      console.info(
+        `HubSite.contains: App in Initiative Catalog: Time: ${chk.duration} ms`
+      );
+    });
+
+    it("finds app in project catalog", async () => {
+      const initiativeCatalogInfo: IDeepCatalogInfo = {
+        id: initiativeItemId,
+        entityType: "item",
+      };
+      const projectCatalogInfo: IDeepCatalogInfo = {
+        id: projectItemId,
+        entityType: "item",
+      };
+
+      const chk = await siteInstance.contains(
+        projectAppItemId,
+
+        [projectCatalogInfo, initiativeCatalogInfo]
+      );
+
+      expect(chk.isContained).toBeTruthy();
+      // tslint:disable-next-line:no-console
+      console.info(
+        `HubSite.contains: App in Project Catalog: Time: ${chk.duration} ms`
+      );
+    });
+  });
+  describe("pass in catalogs", () => {
+    it("find app in initiative catalog", async () => {
+      const initiativeCatalogInfo: IDeepCatalogInfo = {
+        id: initiativeItemId,
+        entityType: "item",
+        catalog: createCatalog("1d568e44a1b043529f67122340a33890"),
+      };
+
+      const chk = await siteInstance.contains(initiativeAppItemId, [
+        initiativeCatalogInfo,
+      ]);
+
+      expect(chk.isContained).toBeTruthy();
+      // tslint:disable-next-line:no-console
+      console.info(
+        `HubSite.contains: App in Initiative Catalog (passed in): Time: ${chk.duration} ms`
+      );
+    });
+    it("find app in project catalog", async () => {
+      const initiativeCatalogInfo: IDeepCatalogInfo = {
+        id: initiativeItemId,
+        entityType: "item",
+        catalog: createCatalog("1d568e44a1b043529f67122340a33890"),
+      };
+      const projectCatalogInfo: IDeepCatalogInfo = {
+        id: projectItemId,
+        entityType: "item",
+        catalog: createCatalog("5d92405aaa2b414d8632a469f9983be8"),
+      };
+
+      const chk = await siteInstance.contains(
+        initiativeAppItemId,
+
+        [projectCatalogInfo, initiativeCatalogInfo]
+      );
+
+      expect(chk.isContained).toBeTruthy();
+      // tslint:disable-next-line:no-console
+      console.info(
+        `HubSite.contains: App in Project Catalog (passed in): Time: ${chk.duration} ms`
+      );
+    });
+  });
+});
+
+function createCatalog(groupId: string): IHubCatalog {
+  return {
+    schemaVersion: 1,
+    title: "Default Catalog",
+    scopes: {
+      item: {
+        targetEntity: "item",
+        filters: [
+          {
+            predicates: [
+              {
+                group: [groupId],
+              },
+            ],
+          },
+        ],
+      },
+    },
+    collections: [],
+  };
+}

--- a/packages/common/src/core/types/IHubProject.ts
+++ b/packages/common/src/core/types/IHubProject.ts
@@ -1,6 +1,10 @@
 import { IHubTimeline, IHubItemEntity } from "./index";
-import { IWithLayout, IWithPermissions, IWithSlug } from "../traits/index";
-import { IWithCatalog } from "../traits/IWithCatalog";
+import {
+  IWithLayout,
+  IWithPermissions,
+  IWithSlug,
+  IWithCatalog,
+} from "../traits/index";
 
 /**
  * Defines the properties of a Hub Project object

--- a/packages/common/src/core/types/IHubSite.ts
+++ b/packages/common/src/core/types/IHubSite.ts
@@ -1,13 +1,22 @@
 import { IExtent } from "@esri/arcgis-rest-feature-layer";
-import { IWithSlug } from "../traits/IWithSlug";
-import { IWithLayout } from "../traits/IWithLayout";
+import {
+  IWithCatalog,
+  IWithLayout,
+  IWithPermissions,
+  IWithSlug,
+} from "../traits/index";
 import { IHubItemEntity } from "./IHubItemEntity";
 
 /**
  * DRAFT: Under development and more properties will likely be added
  * @internal
  */
-export interface IHubSite extends IHubItemEntity, IWithSlug, IWithLayout {
+export interface IHubSite
+  extends IHubItemEntity,
+    IWithSlug,
+    IWithCatalog,
+    IWithLayout,
+    IWithPermissions {
   /**
    * Array of minimal page objects
    */
@@ -21,13 +30,7 @@ export interface IHubSite extends IHubItemEntity, IWithSlug, IWithLayout {
    * Array of capabilities enabled for the site
    */
   capabilities: string[];
-  /**
-   * Currently not an actual ICatalog
-   */
-  catalog: {
-    groups: string[];
-    [key: string]: any;
-  };
+
   /**
    * Subdomain of the site
    * Will be prepended to `<org-key>.hub.arcgis.com`

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -1,0 +1,198 @@
+import {
+  IHubSite,
+  IWithPermissionBehavior,
+  IWithCatalogBehavior,
+  PermissionManager,
+  IWithStoreBehavior,
+  IWithSharingBehavior,
+  UiSchemaElementOptions,
+} from "../core";
+
+import { Catalog } from "../search/Catalog";
+import { IArcGISContext } from "../ArcGISContext";
+import { HubItemEntity } from "../core/HubItemEntity";
+import {
+  EditorConfigType,
+  IEditorConfig,
+} from "../core/behaviors/IWithEditorBehavior";
+import { DEFAULT_SITE } from "./defaults";
+import { createSite, deleteSite, fetchSite, updateSite } from "./HubSites";
+
+/**
+ * Hub Site Class
+ */
+export class HubSite
+  extends HubItemEntity<IHubSite>
+  implements
+    IWithStoreBehavior<IHubSite>,
+    IWithPermissionBehavior,
+    IWithCatalogBehavior,
+    IWithSharingBehavior
+{
+  private _catalog: Catalog;
+  private _permissionManager: PermissionManager;
+  /**
+   * Private constructor so we don't have `new` all over the place. Allows for
+   * more flexibility in how we create the HubSiteManager over time.
+   * @param context
+   */
+  private constructor(site: IHubSite, context: IArcGISContext) {
+    super(site, context);
+    this._catalog = Catalog.fromJson(site.catalog, this.context);
+    this._permissionManager = PermissionManager.fromJson(
+      site.permissions,
+      this.context
+    );
+  }
+  /**
+   * Catalog instance for this project. Note: Do not hold direct references to this object; always access it from the project.
+   * @returns
+   */
+  get catalog(): Catalog {
+    return this._catalog;
+  }
+
+  /**
+   * PermissionManager instance for this project. Note: Do not hold direct references to this object; always access it from the project.
+   * @returns
+   */
+  get permissions(): PermissionManager {
+    return this._permissionManager;
+  }
+  /**
+   * Create an instance from an IHubSite object
+   * @param json - JSON object to create a HubSite from
+   * @param context - ArcGIS context
+   * @returns
+   */
+  static fromJson(json: Partial<IHubSite>, context: IArcGISContext): HubSite {
+    // merge what we have with the default values
+    const pojo = this.applyDefaults(json, context);
+    return new HubSite(pojo, context);
+  }
+
+  /**
+   *
+   * NOT IMPLEMENTED YET: Create a new HubSite, returning a HubSite instance.
+   * Note: This does not persist the Project into the backing store
+   * @param partialSite
+   * @param context
+   * @returns
+   */
+  static async create(
+    partialSite: Partial<IHubSite>,
+    context: IArcGISContext,
+    save: boolean = false
+  ): Promise<HubSite> {
+    throw new Error("HubSite.create Not implemented");
+  }
+
+  /**
+   * Fetch a Project from the backing store and return a HubSite instance.
+   * @param identifier - Identifier of the project to load
+   * @param context
+   * @returns
+   */
+  static async fetch(
+    identifier: string,
+    context: IArcGISContext
+  ): Promise<HubSite> {
+    // fetch the project by id or slug
+    try {
+      const project = await fetchSite(identifier, context.hubRequestOptions);
+      // create an instance of HubSite from the project
+      return HubSite.fromJson(project, context);
+    } catch (ex) {
+      if (
+        (ex as Error).message ===
+        "CONT_0001: Item does not exist or is inaccessible."
+      ) {
+        throw new Error(`Project not found.`);
+      } else {
+        throw ex;
+      }
+    }
+  }
+
+  private static applyDefaults(
+    partialSite: Partial<IHubSite>,
+    context: IArcGISContext
+  ): IHubSite {
+    // ensure we have the orgUrlKey
+    if (!partialSite.orgUrlKey) {
+      partialSite.orgUrlKey = context.portal.urlKey;
+    }
+    // extend the partial over the defaults
+    const pojo = { ...DEFAULT_SITE, ...partialSite } as IHubSite;
+    return pojo;
+  }
+
+  /**
+   * Apply a new state to the instance
+   * @param changes
+   */
+  update(changes: Partial<IHubSite>): void {
+    if (this.isDestroyed) {
+      throw new Error("HubSite is already destroyed.");
+    }
+    // merge partial onto existing entity
+    this.entity = { ...this.entity, ...changes };
+
+    // update internal instances
+    if (changes.catalog) {
+      this._catalog = Catalog.fromJson(this.entity.catalog, this.context);
+    }
+    if (changes.permissions) {
+      this._permissionManager = PermissionManager.fromJson(
+        this.entity.permissions,
+        this.context
+      );
+    }
+  }
+
+  /**
+   * Save the HubSite to the backing store.
+   * Currently Sites are stored as Items in Portal
+   * @returns
+   */
+  async save(): Promise<void> {
+    if (this.isDestroyed) {
+      throw new Error("HubSite is already destroyed.");
+    }
+    // get the catalog, and permission configs
+    this.entity.catalog = this._catalog.toJson();
+    this.entity.permissions = this._permissionManager.toJson();
+
+    if (this.entity.id) {
+      // update it
+      this.entity = await updateSite(
+        this.entity,
+        this.context.hubRequestOptions
+      );
+    } else {
+      // create it
+      this.entity = await createSite(
+        this.entity,
+        this.context.hubRequestOptions
+      );
+    }
+    // call the after save hook on superclass
+    await super.afterSave();
+
+    return;
+  }
+
+  /**
+   * Delete the HubSite from the store
+   * set a flag to indicate that it is destroyed
+   * @returns
+   */
+  async delete(): Promise<void> {
+    if (this.isDestroyed) {
+      throw new Error("HubSite is already destroyed.");
+    }
+    this.isDestroyed = true;
+    // Delegate to module fn
+    await deleteSite(this.entity.id, this.context.userRequestOptions);
+  }
+}

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -254,14 +254,23 @@ export class HubSite
       }
     });
 
-    // push the site and it's catalog into the hierarchy as the last entry
-    hierarchy.push({
-      id: this.id,
-      entityType: "item",
-      catalog: this._catalog.toJson(),
-    });
+    // Add the site and it's catalog into the hierarchy as the last entry
+    const hierarchyWithSiteCatalog = [
+      ...hierarchy,
+      ...[
+        {
+          id: this.id,
+          entityType: "item",
+          catalog: this._catalog.toJson(),
+        } as IDeepCatalogInfo,
+      ],
+    ];
     // delegate to fn
-    const response = await deepContains(identifier, hierarchy, this.context);
+    const response = await deepContains(
+      identifier,
+      hierarchyWithSiteCatalog,
+      this.context
+    );
     // cache the catalogs
     Object.keys(response.catalogInfo).forEach((key) => {
       // don't cache the site's catalog

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -5,21 +5,18 @@ import {
   PermissionManager,
   IWithStoreBehavior,
   IWithSharingBehavior,
-  UiSchemaElementOptions,
 } from "../core";
 
 import { Catalog } from "../search/Catalog";
 import { IArcGISContext } from "../ArcGISContext";
 import { HubItemEntity } from "../core/HubItemEntity";
-import {
-  EditorConfigType,
-  IEditorConfig,
-} from "../core/behaviors/IWithEditorBehavior";
+
 import { DEFAULT_SITE } from "./defaults";
 import { createSite, deleteSite, fetchSite, updateSite } from "./HubSites";
 
 /**
  * Hub Site Class
+ * NOTE: This is a minimal implementation. Create operations are not supported at this time
  */
 export class HubSite
   extends HubItemEntity<IHubSite>

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -62,7 +62,7 @@ const DEFAULT_SITE: Partial<IHubSite> = {
     "socialSharing",
   ],
   catalog: {
-    groups: [],
+    schemaVersion: 1,
   },
   subdomain: "",
   defaultHostname: "",
@@ -404,6 +404,7 @@ export async function updateSite(
 }
 
 /**
+ * @private
  * Remove a Hub Site
  *
  * This simply removes the Site item, and it's associated domain records.
@@ -414,6 +415,25 @@ export async function updateSite(
  * @returns
  */
 export async function destroySite(
+  id: string,
+  requestOptions: IHubRequestOptions
+): Promise<void> {
+  // tslint:disable-next-line:no-console
+  console.warn(`destroySite is deprecated, use deleteSite instead`);
+  return deleteSite(id, requestOptions);
+}
+
+/**
+ * Remove a Hub Site
+ *
+ * This simply removes the Site item, and it's associated domain records.
+ * This does not remove any Teams/Groups or content associated with the
+ * Site
+ * @param id
+ * @param requestOptions
+ * @returns
+ */
+export async function deleteSite(
   id: string,
   requestOptions: IHubRequestOptions
 ): Promise<void> {

--- a/packages/common/src/sites/defaults.ts
+++ b/packages/common/src/sites/defaults.ts
@@ -1,0 +1,37 @@
+import { IHubSite } from "../core";
+import { IModel } from "../types";
+
+export const HUB_SITE_ITEM_TYPE = "Hub Site Application";
+
+/**
+ * Default values of a IHubSite
+ */
+export const DEFAULT_SITE: Partial<IHubSite> = {
+  name: "No title provided",
+  tags: [],
+  typeKeywords: ["Hub Site", "hubSite"],
+  catalog: { schemaVersion: 0 },
+  permissions: [],
+  schemaVersion: 1,
+};
+
+/**
+ * Default values for a new HubProject Model
+ */
+export const DEFAULT_SITE_MODEL: IModel = {
+  item: {
+    type: HUB_SITE_ITEM_TYPE,
+    title: "No Title Provided",
+    description: "",
+    snippet: "",
+    tags: [],
+    typeKeywords: ["Hub Site", "hubSite"],
+    properties: {
+      slug: "",
+      schemaVersion: 1,
+    },
+  },
+  data: {
+    layout: {},
+  },
+} as unknown as IModel;

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -1,0 +1,385 @@
+import * as PortalModule from "@esri/arcgis-rest-portal";
+import { ArcGISContextManager } from "../../src/ArcGISContextManager";
+import { HubSite } from "../../src/sites/HubSite";
+import { MOCK_AUTH } from "../mocks/mock-auth";
+import * as HubSitesModule from "../../src/sites/HubSites";
+import {
+  Catalog,
+  IDeepCatalogInfo,
+  IHubCatalog,
+  IHubSite,
+  PermissionManager,
+} from "../../src";
+import * as ContainsModule from "../../src/core/_internal/deepContains";
+describe("HubSite Class:", () => {
+  let authdCtxMgr: ArcGISContextManager;
+  let portalCtxMgr: ArcGISContextManager;
+  let unauthdCtxMgr: ArcGISContextManager;
+  beforeEach(async () => {
+    unauthdCtxMgr = await ArcGISContextManager.create();
+    // When we pass in all this information, the context
+    // manager will not try to fetch anything, so no need
+    // to mock those calls
+    authdCtxMgr = await ArcGISContextManager.create({
+      authentication: MOCK_AUTH,
+      currentUser: {
+        username: "casey",
+      } as unknown as PortalModule.IUser,
+      portal: {
+        name: "DC R&D Center",
+        id: "BRXFAKE",
+        urlKey: "fake-org",
+      } as unknown as PortalModule.IPortal,
+      portalUrl: "https://fake-org.maps.arcgis.com",
+    });
+    portalCtxMgr = await ArcGISContextManager.create({
+      authentication: MOCK_AUTH,
+      currentUser: {
+        username: "casey",
+      } as unknown as PortalModule.IUser,
+      portal: {
+        isPortal: true,
+        name: "My Portal Install",
+        id: "BRXFAKE",
+        urlKey: "fake-org",
+      } as unknown as PortalModule.IPortal,
+      portalUrl: "https://myserver.com",
+    });
+  });
+
+  describe("static methods:", () => {
+    it("loads from minimal json", () => {
+      const createSpy = spyOn(HubSitesModule, "createSite");
+      const chk = HubSite.fromJson({ name: "Test Site" }, authdCtxMgr.context);
+
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(chk.toJson().name).toEqual("Test Site");
+      // adds empty permissions and catalog
+      const json = chk.toJson();
+      expect(json.permissions).toEqual([]);
+      expect(json.catalog).toEqual({ schemaVersion: 0 });
+    });
+    it("loads based on identifier", async () => {
+      const fetchSpy = spyOn(HubSitesModule, "fetchSite").and.callFake(
+        (id: string) => {
+          return Promise.resolve({
+            id,
+            name: "Test Site",
+          });
+        }
+      );
+
+      const chk = await HubSite.fetch("3ef", authdCtxMgr.context);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(chk.toJson().id).toBe("3ef");
+      expect(chk.toJson().name).toBe("Test Site");
+    });
+
+    it("handle load missing projects", async () => {
+      const fetchSpy = spyOn(HubSitesModule, "fetchSite").and.callFake(
+        (id: string) => {
+          const err = new Error(
+            "CONT_0001: Item does not exist or is inaccessible."
+          );
+          return Promise.reject(err);
+        }
+      );
+      try {
+        await HubSite.fetch("3ef", authdCtxMgr.context);
+      } catch (ex) {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(ex.message).toBe("Site not found.");
+      }
+    });
+
+    it("handle load errors", async () => {
+      const fetchSpy = spyOn(HubSitesModule, "fetchSite").and.callFake(
+        (id: string) => {
+          const err = new Error("ZOMG!");
+          return Promise.reject(err);
+        }
+      );
+      try {
+        await HubSite.fetch("3ef", authdCtxMgr.context);
+      } catch (ex) {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(ex.message).toBe("ZOMG!");
+      }
+    });
+  });
+
+  it("save calls createSite if object does not have an id", async () => {
+    const createSpy = spyOn(HubSitesModule, "createSite").and.callFake(
+      (p: IHubSite) => {
+        return Promise.resolve(p);
+      }
+    );
+    const chk = await HubSite.fromJson(
+      { name: "Test Site" },
+      authdCtxMgr.context
+    );
+    await chk.save();
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(chk.toJson().name).toEqual("Test Site");
+  });
+
+  it("create saves the instance if passed true", async () => {
+    const createSpy = spyOn(HubSitesModule, "createSite").and.callFake(
+      (p: IHubSite) => {
+        p.id = "3ef";
+        return Promise.resolve(p);
+      }
+    );
+    const chk = await HubSite.create(
+      { name: "Test Site" },
+      authdCtxMgr.context,
+      true
+    );
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(chk.toJson().name).toEqual("Test Site");
+    expect(chk.toJson().type).toEqual("Hub Site Application");
+  });
+  it("create does not save by default", async () => {
+    const createSpy = spyOn(HubSitesModule, "createSite");
+    const chk = await HubSite.create(
+      { name: "Test Site", orgUrlKey: "foo" },
+      portalCtxMgr.context
+    );
+
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(chk.toJson().name).toEqual("Test Site");
+    expect(chk.toJson().type).toEqual("Site Application");
+  });
+
+  it("update applies partial chagnes to internal state", () => {
+    const chk = HubSite.fromJson(
+      { name: "Test Site", catalog: { schemaVersion: 0 } },
+      authdCtxMgr.context
+    );
+    chk.update({
+      name: "Test Site 2",
+      permissions: [
+        { permission: "addEvent", target: "group", targetId: "3ef" },
+      ],
+      catalog: { schemaVersion: 2 },
+    });
+    expect(chk.toJson().name).toEqual("Test Site 2");
+    expect(chk.toJson().catalog).toEqual({ schemaVersion: 2 });
+
+    chk.update({ tags: ["one", "two"] });
+    expect(chk.toJson().tags).toEqual(["one", "two"]);
+  });
+
+  it("save updates if object has id", async () => {
+    const updateSpy = spyOn(HubSitesModule, "updateSite").and.callFake(
+      (p: IHubSite) => {
+        return Promise.resolve(p);
+      }
+    );
+    const chk = HubSite.fromJson(
+      {
+        id: "bc3",
+        name: "Test Site",
+        catalog: { schemaVersion: 0 },
+      },
+      authdCtxMgr.context
+    );
+    await chk.save();
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("delete", async () => {
+    const deleteSpy = spyOn(HubSitesModule, "deleteSite").and.callFake(() => {
+      return Promise.resolve();
+    });
+    const chk = HubSite.fromJson({ name: "Test Site" }, authdCtxMgr.context);
+    await chk.delete();
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
+    // all fns should now throw an error
+    expect(() => {
+      chk.toJson();
+    }).toThrowError("Entity is already destroyed.");
+
+    expect(() => {
+      chk.update({ name: "Test Site 2" } as IHubSite);
+    }).toThrowError("HubSite is already destroyed.");
+
+    // async calls
+    try {
+      await chk.delete();
+    } catch (e) {
+      expect(e.message).toEqual("HubSite is already destroyed.");
+    }
+
+    try {
+      await chk.save();
+    } catch (e) {
+      expect(e.message).toEqual("HubSite is already destroyed.");
+    }
+  });
+
+  it("internal instance accessors", () => {
+    const chk = HubSite.fromJson(
+      { name: "Test Site", catalog: { schemaVersion: 0 } },
+      authdCtxMgr.context
+    );
+
+    expect(chk.catalog instanceof Catalog).toBeTruthy();
+    expect(chk.permissions instanceof PermissionManager).toBeTruthy();
+  });
+
+  it("setting catalog updates catalog instance", () => {
+    const chk = HubSite.fromJson(
+      { name: "Test Site", catalog: { schemaVersion: 0 } },
+      authdCtxMgr.context
+    );
+    chk.update({ catalog: { schemaVersion: 2 } });
+    expect(chk.toJson().catalog).toEqual({ schemaVersion: 2 });
+    expect(chk.catalog.schemaVersion).toEqual(2);
+  });
+  describe(" contains:", () => {
+    it("checks site catalog by default", async () => {
+      const containsSpy = spyOn(ContainsModule, "deepContains").and.callFake(
+        (id: string, h: IDeepCatalogInfo[]) => {
+          return Promise.resolve({
+            identifier: id,
+            isContained: true,
+            catalogInfo: {},
+          });
+        }
+      );
+      const chk = HubSite.fromJson(
+        {
+          id: "3ef",
+          catalog: createCatalog("00a"),
+        },
+        authdCtxMgr.context
+      );
+      const result = await chk.contains("cc0");
+      expect(containsSpy).toHaveBeenCalledTimes(1);
+      const hiearchy = containsSpy.calls.argsFor(0)[1];
+      expect(hiearchy.length).toBe(1);
+      expect(hiearchy[0].catalog).toEqual(
+        createCatalog("00a"),
+        "should pass the site catalog"
+      );
+      expect(result).toEqual({
+        identifier: "cc0",
+        isContained: true,
+        catalogInfo: {},
+      });
+    });
+
+    it("adds site catalog to others", async () => {
+      const containsSpy = spyOn(ContainsModule, "deepContains").and.callFake(
+        (id: string, h: IDeepCatalogInfo[]) => {
+          return Promise.resolve({
+            identifier: id,
+            isContained: true,
+            catalogInfo: {},
+          });
+        }
+      );
+      const chk = HubSite.fromJson(
+        {
+          id: "3ef",
+          catalog: createCatalog("00a"),
+        },
+        authdCtxMgr.context
+      );
+      // pass in a project catalog
+      const result = await chk.contains("cc0", [
+        { id: "4ef", entityType: "item", catalog: createCatalog("00b") },
+      ]);
+      expect(containsSpy).toHaveBeenCalledTimes(1);
+      const hiearchy = containsSpy.calls.argsFor(0)[1];
+      expect(hiearchy.length).toBe(2);
+      expect(hiearchy[0].catalog).toEqual(
+        createCatalog("00b"),
+        "should pass the project catalog"
+      );
+      expect(hiearchy[1].catalog).toEqual(
+        createCatalog("00a"),
+        "should pass the site catalog"
+      );
+      expect(result).toEqual({
+        identifier: "cc0",
+        isContained: true,
+        catalogInfo: {},
+      });
+    });
+
+    it("caches catalogs", async () => {
+      const containsSpy = spyOn(ContainsModule, "deepContains").and.callFake(
+        (id: string, h: IDeepCatalogInfo[]) => {
+          return Promise.resolve({
+            identifier: id,
+            isContained: true,
+            catalogInfo: {
+              "3ef": {
+                catalog: createCatalog("00a"),
+              },
+              "4ef": {
+                catalog: createCatalog("00b"),
+              },
+            },
+          });
+        }
+      );
+      const chk = HubSite.fromJson(
+        {
+          id: "3ef",
+          catalog: createCatalog("00a"),
+        },
+        authdCtxMgr.context
+      );
+      // First call will warm the cache
+      await chk.contains("cc0", [{ id: "4ef", entityType: "item" }]);
+      // second call will use the cache
+      await chk.contains("cc1", [{ id: "4ef", entityType: "item" }]);
+      expect(containsSpy).toHaveBeenCalledTimes(2);
+      // verify first call does not send the 4ef catalog
+      const hiearchy = containsSpy.calls.argsFor(0)[1];
+      expect(hiearchy.length).toBe(2);
+      expect(hiearchy[0].catalog).not.toBeDefined();
+      expect(hiearchy[1].catalog).toEqual(
+        createCatalog("00a"),
+        "should pass the site catalog"
+      );
+      // verify second call does send the 4ef catalog
+      const hiearchy2 = containsSpy.calls.argsFor(1)[1];
+      expect(hiearchy2.length).toBe(2);
+      expect(hiearchy2[0].catalog).toEqual(
+        createCatalog("00b"),
+        "should pass the project catalog"
+      );
+      expect(hiearchy2[1].catalog).toEqual(
+        createCatalog("00a"),
+        "should pass the site catalog"
+      );
+    });
+  });
+});
+
+function createCatalog(groupId: string): IHubCatalog {
+  return {
+    schemaVersion: 1,
+    title: "Default Catalog",
+    scopes: {
+      item: {
+        targetEntity: "item",
+        filters: [
+          {
+            predicates: [
+              {
+                group: [groupId],
+              },
+            ],
+          },
+        ],
+      },
+    },
+    collections: [],
+  };
+}

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -73,7 +73,7 @@ const SITE: commonModule.IHubSite = {
   theme: {},
   subdomain: "site-org",
   capabilities: [],
-  catalog: { groups: [] },
+  catalog: { schemaVersion: 0 },
   pages: [],
   defaultHostname: "site-org.hub.arcgis.com",
   customHostname: "",
@@ -84,6 +84,7 @@ const SITE: commonModule.IHubSite = {
   headerSass: "",
   thumbnailUrl: "",
   schemaVersion: 2,
+  permissions: [],
 };
 
 const SITE_ITEM_ENRICH: portalModule.IItem = {


### PR DESCRIPTION
1. Description:

Implement just enough of HubSite class so we can create an instance in the app, and use the `.contains(...)` method on the content routes. 

Issue: [4869](https://devtopia.esri.com/dc/hub/issues/4869)

1. Instructions for testing:

- run tests and/or `hub-sites-contains.e2e.ts`

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
