### PR TITLE
fix: refactor so conversion of model to ihubsite is separate fn

### DIFF
--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -461,6 +461,19 @@ export async function fetchSite(
   // get the model
   const model = await fetchSiteModel(identifier, requestOptions);
 
+  return convertModelToSite(model, requestOptions);
+}
+
+/**
+ * Convert an IModel for a Hub Site Item into an IHubSite
+ * @param model
+ * @param requestOptions
+ * @returns
+ */
+export function convertModelToSite(
+  model: IModel,
+  requestOptions: IHubRequestOptions
+): IHubSite {
   // convert to site
   const mapper = new PropertyMapper<Partial<IHubSite>>(getSitePropertyMap());
   const site = mapper.modelToObject(model, {}) as IHubSite;


### PR DESCRIPTION
1. Description:

This extracts part of the `HubSites::fetch` fn into a separate fn that will just convert a IModel into an IHubSite. This greatly streamlines usage in OpenData-ui

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
