### PR TITLE
fix(hub-common): bumps adlib to fix leading 0 removal issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10705,9 +10705,9 @@
 			}
 		},
 		"node_modules/adlib": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
-			"integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.8.tgz",
+			"integrity": "sha512-CbQ+mcm45pdDN0aAiGYP6FZWDor+BM4DbqJsrUptM79a2+FbiP8QdF0xHABbgCkioApKqg8lI33Gl6X8GFelfA==",
 			"dependencies": {
 				"esm": "^3.2.25"
 			}
@@ -61188,11 +61188,11 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "11.16.0",
+			"version": "11.18.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
-				"adlib": "^3.0.7",
+				"adlib": "^3.0.8",
 				"ajv": "^6.12.6",
 				"fast-xml-parser": "^3.21.0",
 				"json-schema-typed": "^7.0.3",
@@ -61218,7 +61218,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "14.12.0",
+			"version": "14.14.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61227,19 +61227,19 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "11.16.0"
+				"@esri/hub-common": "11.18.2"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "11.16.0",
+			"version": "11.18.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -61250,7 +61250,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61258,12 +61258,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "11.16.0"
+				"@esri/hub-common": "11.18.2"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "11.16.0",
+			"version": "11.18.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61274,7 +61274,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61283,12 +61283,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.16.0"
+				"@esri/hub-common": "11.18.2"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "11.16.0",
+			"version": "11.18.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61297,7 +61297,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -61305,12 +61305,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "11.16.0"
+				"@esri/hub-common": "11.18.2"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "11.16.0",
+			"version": "11.18.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61321,7 +61321,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -61332,12 +61332,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.16.0"
+				"@esri/hub-common": "11.18.2"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "11.16.0",
+			"version": "11.18.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61346,9 +61346,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
-				"@esri/hub-initiatives": "11.16.0",
-				"@esri/hub-teams": "11.16.0",
+				"@esri/hub-common": "11.18.2",
+				"@esri/hub-initiatives": "11.18.2",
+				"@esri/hub-teams": "11.18.2",
 				"@esri/hub-types": "^6.10.0",
 				"typescript": "^3.8.1"
 			},
@@ -61356,9 +61356,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "11.16.0",
-				"@esri/hub-initiatives": "11.16.0",
-				"@esri/hub-teams": "11.16.0"
+				"@esri/hub-common": "11.18.2",
+				"@esri/hub-initiatives": "11.18.2",
+				"@esri/hub-teams": "11.18.2"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61380,7 +61380,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "11.16.0",
+			"version": "11.18.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61391,7 +61391,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61400,12 +61400,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.16.0"
+				"@esri/hub-common": "11.18.2"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "11.16.0",
+			"version": "11.18.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61415,7 +61415,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61423,7 +61423,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.16.0"
+				"@esri/hub-common": "11.18.2"
 			}
 		}
 	},
@@ -64814,7 +64814,7 @@
 				"@esri/arcgis-rest-types": "^3.1.1",
 				"@types/adlib": "^3.0.1",
 				"abab": "^2.0.5",
-				"adlib": "^3.0.7",
+				"adlib": "^3.0.8",
 				"ajv": "^6.12.6",
 				"fast-xml-parser": "^3.21.0",
 				"json-schema-typed": "^7.0.3",
@@ -64829,7 +64829,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64842,7 +64842,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64856,7 +64856,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -64867,7 +64867,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64881,7 +64881,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -64894,9 +64894,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
-				"@esri/hub-initiatives": "11.16.0",
-				"@esri/hub-teams": "11.16.0",
+				"@esri/hub-common": "11.18.2",
+				"@esri/hub-initiatives": "11.18.2",
+				"@esri/hub-teams": "11.18.2",
 				"@esri/hub-types": "^6.10.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64924,7 +64924,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -64936,7 +64936,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.16.0",
+				"@esri/hub-common": "11.18.2",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -69937,9 +69937,9 @@
 			"dev": true
 		},
 		"adlib": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
-			"integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.8.tgz",
+			"integrity": "sha512-CbQ+mcm45pdDN0aAiGYP6FZWDor+BM4DbqJsrUptM79a2+FbiP8QdF0xHABbgCkioApKqg8lI33Gl6X8GFelfA==",
 			"requires": {
 				"esm": "^3.2.25"
 			}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "abab": "^2.0.5",
-    "adlib": "^3.0.7",
+    "adlib": "^3.0.8",
     "ajv": "^6.12.6",
     "fast-xml-parser": "^3.21.0",
     "jsonapi-typescript": "^0.1.3",


### PR DESCRIPTION
Description:
- bumps adlib in hub-common to fix issue where leading 0s are removed

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
