### PR TITLE
feat(hub-common): add collapse to IHubTimeline

### DIFF
--- a/packages/common/src/core/types/IHubTimeline.ts
+++ b/packages/common/src/core/types/IHubTimeline.ts
@@ -6,6 +6,7 @@ export interface IHubTimeline {
   title: string;
   description: string;
   stages: IHubStage[];
+  collapse: boolean;
 }
 
 /**


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Add a new collapse prop to IHubTimeline, so we could sync its value between the timeline and timeline editor. Issue: [4747](https://zentopia.esri.com/workspaces/collaboration-sprint-board-614f9bfc0946c40011ef574e/issues/dc/hub/4747)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
