### PR TITLE
feat: adds headContent to draft allow list

### DIFF
--- a/packages/sites/src/drafts/site-draft-include-list.ts
+++ b/packages/sites/src/drafts/site-draft-include-list.ts
@@ -17,4 +17,5 @@ export const SITE_DRAFT_INCLUDE_LIST = [
   "data.values.map",
   "data.values.capabilities",
   "data.values.contentViews",
+  "data.values.headContent",
 ];


### PR DESCRIPTION
affects: @esri/hub-sites

1. Description:
    - allows `headContent` to be saved in site drafts


1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
