### PR TITLE
fix(hub-common): rename collapse to canCollapse in IHubTimeline

### DIFF
--- a/packages/common/src/core/types/IHubTimeline.ts
+++ b/packages/common/src/core/types/IHubTimeline.ts
@@ -6,7 +6,7 @@ export interface IHubTimeline {
   title: string;
   description: string;
   stages: IHubStage[];
-  isCollapsed: boolean;
+  isCollapsible: boolean;
 }
 
 /**

--- a/packages/common/src/core/types/IHubTimeline.ts
+++ b/packages/common/src/core/types/IHubTimeline.ts
@@ -6,7 +6,7 @@ export interface IHubTimeline {
   title: string;
   description: string;
   stages: IHubStage[];
-  collapse: boolean;
+  isCollapsed: boolean;
 }
 
 /**

--- a/packages/common/src/core/types/IHubTimeline.ts
+++ b/packages/common/src/core/types/IHubTimeline.ts
@@ -6,7 +6,7 @@ export interface IHubTimeline {
   title: string;
   description: string;
   stages: IHubStage[];
-  isCollapsible: boolean;
+  canCollapse: boolean;
 }
 
 /**


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
rename collapse to isCollapsible in IHubTimeline

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
