### PR TITLE
fix: rename stage description to stageDescription

### DIFF
--- a/packages/common/src/core/types/IHubTimeline.ts
+++ b/packages/common/src/core/types/IHubTimeline.ts
@@ -29,7 +29,7 @@ export interface IHubStage {
   /**
    * Stage Description
    */
-  description: string;
+  stageDescription: string;
   /**
    * Stage Link
    */


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Rename stage description to stageDescription so it doesn't cause an error when adding a timeline to project (having the same same as project's description)

1. Instructions for testing:

1. Closes Issues: #<5083> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
