### PR TITLE
fix: allows for project fields to be cleared out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61188,7 +61188,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "11.20.1",
+			"version": "11.21.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -61218,7 +61218,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "14.16.1",
+			"version": "14.17.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61227,19 +61227,19 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "11.20.1"
+				"@esri/hub-common": "11.21.2"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "11.20.1",
+			"version": "11.21.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -61250,7 +61250,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61258,12 +61258,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "11.20.1"
+				"@esri/hub-common": "11.21.2"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "11.20.1",
+			"version": "11.21.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61274,7 +61274,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61283,12 +61283,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.20.1"
+				"@esri/hub-common": "11.21.2"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "11.20.1",
+			"version": "11.21.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61297,7 +61297,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -61305,12 +61305,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "11.20.1"
+				"@esri/hub-common": "11.21.2"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "11.20.1",
+			"version": "11.21.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61321,7 +61321,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -61332,12 +61332,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.20.1"
+				"@esri/hub-common": "11.21.2"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "11.21.0",
+			"version": "11.22.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61346,9 +61346,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
-				"@esri/hub-initiatives": "11.20.1",
-				"@esri/hub-teams": "11.20.1",
+				"@esri/hub-common": "11.21.2",
+				"@esri/hub-initiatives": "11.21.2",
+				"@esri/hub-teams": "11.21.2",
 				"@esri/hub-types": "^6.10.0",
 				"typescript": "^3.8.1"
 			},
@@ -61356,9 +61356,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "11.20.1",
-				"@esri/hub-initiatives": "11.20.1",
-				"@esri/hub-teams": "11.20.1"
+				"@esri/hub-common": "11.21.2",
+				"@esri/hub-initiatives": "11.21.2",
+				"@esri/hub-teams": "11.21.2"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61380,7 +61380,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "11.20.1",
+			"version": "11.21.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61391,7 +61391,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61400,12 +61400,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.20.1"
+				"@esri/hub-common": "11.21.2"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "11.20.1",
+			"version": "11.21.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61415,7 +61415,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61423,7 +61423,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.20.1"
+				"@esri/hub-common": "11.21.2"
 			}
 		}
 	},
@@ -64829,7 +64829,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64842,7 +64842,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64856,7 +64856,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -64867,7 +64867,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64881,7 +64881,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -64894,9 +64894,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
-				"@esri/hub-initiatives": "11.20.1",
-				"@esri/hub-teams": "11.20.1",
+				"@esri/hub-common": "11.21.2",
+				"@esri/hub-initiatives": "11.21.2",
+				"@esri/hub-teams": "11.21.2",
 				"@esri/hub-types": "^6.10.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64924,7 +64924,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -64936,7 +64936,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.20.1",
+				"@esri/hub-common": "11.21.2",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/common/src/core/_internal/getBasePropertyMap.ts
+++ b/packages/common/src/core/_internal/getBasePropertyMap.ts
@@ -20,8 +20,6 @@ export function getBasePropertyMap(): IPropertyMap[] {
     "typeKeywords",
     "thumbnail",
     "url",
-    // Allows for clearing out fields with an empty string
-    "clearEmptyFields",
   ];
   const dataProps = ["display", "geometry", "location", "view"];
   const map: IPropertyMap[] = [];

--- a/packages/common/src/core/_internal/getBasePropertyMap.ts
+++ b/packages/common/src/core/_internal/getBasePropertyMap.ts
@@ -20,6 +20,8 @@ export function getBasePropertyMap(): IPropertyMap[] {
     "typeKeywords",
     "thumbnail",
     "url",
+    // Allows for clearing out fields with an empty string
+    "clearEmptyFields",
   ];
   const dataProps = ["display", "geometry", "location", "view"];
   const map: IPropertyMap[] = [];

--- a/packages/common/src/models/index.ts
+++ b/packages/common/src/models/index.ts
@@ -134,6 +134,16 @@ export function updateModel(
     // and normally should never be done.
     item.extent = bboxToString(item.extent) as unknown as number[][];
   }
+
+  // If we have a field we are trying to clear (by making it an empty string like description / snippet)
+  // We need to send clearEmptyFields: true to the updateItem call
+  if (shouldClearEmptyFields(item)) {
+    requestOptions.params = {
+      ...requestOptions.params,
+      clearEmptyFields: true,
+    };
+  }
+
   const opts = {
     item,
     ...requestOptions,
@@ -165,4 +175,14 @@ export async function fetchModelFromItem(
     item,
     data,
   } as IModel;
+}
+
+/**
+ * Given an Item, determine if there are any fields to be cleared
+ *
+ * @param {IItem} item
+ * @return {*} boolean
+ */
+function shouldClearEmptyFields(item: IItem) {
+  return ["description", "snippet"].some((field) => item[field] === "");
 }

--- a/packages/common/test/models/models.test.ts
+++ b/packages/common/test/models/models.test.ts
@@ -197,6 +197,7 @@ describe("model utils:", () => {
       expect(opts?.params?.clearEmptyFields).toBeTruthy();
       expect(opts.item.data).toBeDefined();
       expect(opts.item.extent).toBe("1, 2, 3, 4" as unknown as number[][]);
+      expect(opts.item.description).toBe("");
     });
     it("updates a model w/ extent as string", async () => {
       const updateItemSpy = spyOn(portalModule, "updateItem").and.returnValue(

--- a/packages/common/test/models/models.test.ts
+++ b/packages/common/test/models/models.test.ts
@@ -162,6 +162,7 @@ describe("model utils:", () => {
 
       const m = {
         item: {
+          description: "",
           id: "00c",
           title: "My New Thing",
           type: "Hub Project",
@@ -192,6 +193,8 @@ describe("model utils:", () => {
       )[0] as unknown as portalModule.IUpdateItemOptions;
 
       expect(opts.authentication).toBe(MOCK_AUTH);
+      expect(opts.params).toBeDefined();
+      expect(opts?.params?.clearEmptyFields).toBeTruthy();
       expect(opts.item.data).toBeDefined();
       expect(opts.item.extent).toBe("1, 2, 3, 4" as unknown as number[][]);
     });


### PR DESCRIPTION
1. Description: Adds `clearEmptyFields` to `getBasePropertyMap` so that empty fields can be cleared.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
