### PR TITLE
feat(hub-discussions): create methods for notifications opt out

### DIFF
--- a/packages/discussions/src/channels.ts
+++ b/packages/discussions/src/channels.ts
@@ -8,13 +8,13 @@ import {
   IChannel,
   IPagedResponse,
   IRemoveChannelResponse,
-  IFetchOptOutOptions,
-  ICreateOptOutOptions,
-  IRemoveOptOutOptions,
-  IRemoveActivityOptions,
-  IDeleteChannelNotificationOptOutResponse,
-  IDeleteChannelActivityResponse,
-  IChannelNotificationOptOutResponse,
+  IFetchChannelNotificationOptOutOptions,
+  ICreateChannelNotificationOptOutOptions,
+  IRemoveChannelNotificationOptOutOptions,
+  IRemoveChannelActivityOptions,
+  IRemoveChannelNotificationOptOutResult,
+  IRemoveChannelActivityResult,
+  IChannelNotificationOptOut,
 } from "./types";
 
 /**
@@ -91,12 +91,12 @@ export function removeChannel(
  * get channel opt out status
  *
  * @export
- * @param {IFetchOptOutOptions} options
+ * @param {IFetchChannelNotificationOptOutOptions} options
  * @return {*}
  */
-export function fetchOptOut(
-  options: IFetchOptOutOptions
-): Promise<IChannelNotificationOptOutResponse> {
+export function fetchChannelNotifcationOptOut(
+  options: IFetchChannelNotificationOptOutOptions
+): Promise<IChannelNotificationOptOut> {
   options.httpMethod = "GET";
   return request(
     `/channels/${options.channelId}/notifications/opt-out`,
@@ -108,12 +108,12 @@ export function fetchOptOut(
  * opt out of channel notifs
  *
  * @export
- * @param {ICreateOptOutOptions} options
+ * @param {ICreateChannelNotificationOptOutOptions} options
  * @return {*}
  */
-export function createOptOut(
-  options: ICreateOptOutOptions
-): Promise<IChannelNotificationOptOutResponse> {
+export function createChannelNotificationOptOut(
+  options: ICreateChannelNotificationOptOutOptions
+): Promise<IChannelNotificationOptOut> {
   options.httpMethod = "POST";
   return request(
     `/channels/${options.channelId}/notifications/opt-out`,
@@ -125,12 +125,12 @@ export function createOptOut(
  * opt in to channel notifs
  *
  * @export
- * @param {IRemoveOptOutOptions} options
+ * @param {IRemoveChannelNotificationOptOutOptions} options
  * @return {*}
  */
-export function removeOptOut(
-  options: IRemoveOptOutOptions
-): Promise<IDeleteChannelNotificationOptOutResponse> {
+export function removeChannelNotificationOptOut(
+  options: IRemoveChannelNotificationOptOutOptions
+): Promise<IRemoveChannelNotificationOptOutResult> {
   options.httpMethod = "DELETE";
   return request(
     `/channels/${options.channelId}/notifications/opt-out`,
@@ -142,12 +142,12 @@ export function removeOptOut(
  * remove all posts in a channel
  *
  * @export
- * @param {IRemoveActivityOptions} options
+ * @param {IRemoveChannelActivityOptions} options
  * @return {*}
  */
-export function removeActivity(
-  options: IRemoveActivityOptions
-): Promise<IDeleteChannelActivityResponse> {
+export function removeChannelActivity(
+  options: IRemoveChannelActivityOptions
+): Promise<IRemoveChannelActivityResult> {
   options.httpMethod = "DELETE";
   return request(`/channels/${options.channelId}/activity`, options);
 }

--- a/packages/discussions/src/channels.ts
+++ b/packages/discussions/src/channels.ts
@@ -7,7 +7,14 @@ import {
   IRemoveChannelOptions,
   IChannel,
   IPagedResponse,
-  IRemoveChannelResponse
+  IRemoveChannelResponse,
+  IFetchOptOutOptions,
+  ICreateOptOutOptions,
+  IRemoveOptOutOptions,
+  IRemoveActivityOptions,
+  IDeleteChannelNotificationOptOutResponse,
+  IDeleteChannelActivityResponse,
+  IChannelNotificationOptOutResponse,
 } from "./types";
 
 /**
@@ -78,4 +85,69 @@ export function removeChannel(
 ): Promise<IRemoveChannelResponse> {
   options.httpMethod = "DELETE";
   return request(`/channels/${options.channelId}`, options);
+}
+
+/**
+ * get channel opt out status
+ *
+ * @export
+ * @param {IFetchOptOutOptions} options
+ * @return {*}
+ */
+export function fetchOptOut(
+  options: IFetchOptOutOptions
+): Promise<IChannelNotificationOptOutResponse> {
+  options.httpMethod = "GET";
+  return request(
+    `/channels/${options.channelId}/notifications/opt-out`,
+    options
+  );
+}
+
+/**
+ * opt out of channel notifs
+ *
+ * @export
+ * @param {ICreateOptOutOptions} options
+ * @return {*}
+ */
+export function createOptOut(
+  options: ICreateOptOutOptions
+): Promise<IChannelNotificationOptOutResponse> {
+  options.httpMethod = "POST";
+  return request(
+    `/channels/${options.channelId}/notifications/opt-out`,
+    options
+  );
+}
+
+/**
+ * opt in to channel notifs
+ *
+ * @export
+ * @param {IRemoveOptOutOptions} options
+ * @return {*}
+ */
+export function removeOptOut(
+  options: IRemoveOptOutOptions
+): Promise<IDeleteChannelNotificationOptOutResponse> {
+  options.httpMethod = "DELETE";
+  return request(
+    `/channels/${options.channelId}/notifications/opt-out`,
+    options
+  );
+}
+
+/**
+ * remove all posts in a channel
+ *
+ * @export
+ * @param {IRemoveActivityOptions} options
+ * @return {*}
+ */
+export function removeActivity(
+  options: IRemoveActivityOptions
+): Promise<IDeleteChannelActivityResponse> {
+  options.httpMethod = "DELETE";
+  return request(`/channels/${options.channelId}/activity`, options);
 }

--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -351,6 +351,41 @@ export interface IRemoveChannelResponse {
 }
 
 /**
+ * delete notifications opt out response properties
+ *
+ * @export
+ * @interface IDeleteChannelNotificationOptOutResponse
+ */
+export interface IDeleteChannelNotificationOptOutResponse {
+  success: boolean;
+  channelId: string;
+  username: string;
+}
+
+/**
+ * delete channel activity response properties
+ *
+ * @export
+ * @interface IDeleteChannelActivityResponse
+ */
+export interface IDeleteChannelActivityResponse {
+  success: boolean;
+  channelId: string;
+  username: string;
+}
+
+/**
+ * opt out response properties
+ *
+ * @export
+ * @interface IChannelNotificationOptOutResponse
+ */
+export interface IChannelNotificationOptOutResponse {
+  channelId: string;
+  username: string;
+}
+
+/**
  * delete reaction response properties
  *
  * @export
@@ -815,6 +850,50 @@ export interface IUpdateChannelOptions extends IHubRequestOptions {
  * @extends {IHubRequestOptions}
  */
 export interface IRemoveChannelOptions extends IHubRequestOptions {
+  channelId: string;
+}
+
+/**
+ * request options for fetching opt out status
+ *
+ * @export
+ * @interface IFetchOptOutOptions
+ * @extends {IHubRequestOptions}
+ */
+export interface IFetchOptOutOptions extends IHubRequestOptions {
+  channelId: string;
+}
+
+/**
+ * request options for opting out
+ *
+ * @export
+ * @interface ICreateOptOutOptions
+ * @extends {IHubRequestOptions}
+ */
+export interface ICreateOptOutOptions extends IHubRequestOptions {
+  channelId: string;
+}
+
+/**
+ * request options for opting back in
+ *
+ * @export
+ * @interface IRemoveOptOutOptions
+ * @extends {IHubRequestOptions}
+ */
+export interface IRemoveOptOutOptions extends IHubRequestOptions {
+  channelId: string;
+}
+
+/**
+ * request options for deleting channel activity
+ *
+ * @export
+ * @interface IRemoveActivityOptions
+ * @extends {IHubRequestOptions}
+ */
+export interface IRemoveActivityOptions extends IHubRequestOptions {
   channelId: string;
 }
 

--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -354,9 +354,9 @@ export interface IRemoveChannelResponse {
  * delete notifications opt out response properties
  *
  * @export
- * @interface IDeleteChannelNotificationOptOutResponse
+ * @interface IRemoveChannelNotificationOptOutResult
  */
-export interface IDeleteChannelNotificationOptOutResponse {
+export interface IRemoveChannelNotificationOptOutResult {
   success: boolean;
   channelId: string;
   username: string;
@@ -366,9 +366,9 @@ export interface IDeleteChannelNotificationOptOutResponse {
  * delete channel activity response properties
  *
  * @export
- * @interface IDeleteChannelActivityResponse
+ * @interface IRemoveChannelActivityResult
  */
-export interface IDeleteChannelActivityResponse {
+export interface IRemoveChannelActivityResult {
   success: boolean;
   channelId: string;
   username: string;
@@ -378,9 +378,9 @@ export interface IDeleteChannelActivityResponse {
  * opt out response properties
  *
  * @export
- * @interface IChannelNotificationOptOutResponse
+ * @interface IChannelNotificationOptOut
  */
-export interface IChannelNotificationOptOutResponse {
+export interface IChannelNotificationOptOut {
   channelId: string;
   username: string;
 }
@@ -857,10 +857,11 @@ export interface IRemoveChannelOptions extends IHubRequestOptions {
  * request options for fetching opt out status
  *
  * @export
- * @interface IFetchOptOutOptions
+ * @interface IFetchChannelNotificationOptOutOptions
  * @extends {IHubRequestOptions}
  */
-export interface IFetchOptOutOptions extends IHubRequestOptions {
+export interface IFetchChannelNotificationOptOutOptions
+  extends IHubRequestOptions {
   channelId: string;
 }
 
@@ -868,10 +869,11 @@ export interface IFetchOptOutOptions extends IHubRequestOptions {
  * request options for opting out
  *
  * @export
- * @interface ICreateOptOutOptions
+ * @interface ICreateChannelNotificationOptOutOptions
  * @extends {IHubRequestOptions}
  */
-export interface ICreateOptOutOptions extends IHubRequestOptions {
+export interface ICreateChannelNotificationOptOutOptions
+  extends IHubRequestOptions {
   channelId: string;
 }
 
@@ -879,10 +881,11 @@ export interface ICreateOptOutOptions extends IHubRequestOptions {
  * request options for opting back in
  *
  * @export
- * @interface IRemoveOptOutOptions
+ * @interface IRemoveChannelNotificationOptOutOptions
  * @extends {IHubRequestOptions}
  */
-export interface IRemoveOptOutOptions extends IHubRequestOptions {
+export interface IRemoveChannelNotificationOptOutOptions
+  extends IHubRequestOptions {
   channelId: string;
 }
 
@@ -890,10 +893,10 @@ export interface IRemoveOptOutOptions extends IHubRequestOptions {
  * request options for deleting channel activity
  *
  * @export
- * @interface IRemoveActivityOptions
+ * @interface IRemoveChannelActivityOptions
  * @extends {IHubRequestOptions}
  */
-export interface IRemoveActivityOptions extends IHubRequestOptions {
+export interface IRemoveChannelActivityOptions extends IHubRequestOptions {
   channelId: string;
 }
 

--- a/packages/discussions/test/channels.test.ts
+++ b/packages/discussions/test/channels.test.ts
@@ -4,10 +4,10 @@ import {
   fetchChannel,
   updateChannel,
   removeChannel,
-  fetchOptOut,
-  createOptOut,
-  removeOptOut,
-  removeActivity,
+  fetchChannelNotifcationOptOut,
+  createChannelNotificationOptOut,
+  removeChannelNotificationOptOut,
+  removeChannelActivity,
 } from "../src/channels";
 import * as req from "../src/request";
 import {
@@ -131,7 +131,7 @@ describe("channels", () => {
 
     const options = { ...baseOpts, channelId };
 
-    fetchOptOut(options)
+    fetchChannelNotifcationOptOut(options)
       .then(() => {
         expect(requestSpy.calls.count()).toEqual(1);
         const [url, opts] = requestSpy.calls.argsFor(0);
@@ -147,7 +147,7 @@ describe("channels", () => {
 
     const options = { ...baseOpts, channelId };
 
-    createOptOut(options)
+    createChannelNotificationOptOut(options)
       .then(() => {
         expect(requestSpy.calls.count()).toEqual(1);
         const [url, opts] = requestSpy.calls.argsFor(0);
@@ -163,7 +163,7 @@ describe("channels", () => {
 
     const options = { ...baseOpts, channelId };
 
-    removeOptOut(options)
+    removeChannelNotificationOptOut(options)
       .then(() => {
         expect(requestSpy.calls.count()).toEqual(1);
         const [url, opts] = requestSpy.calls.argsFor(0);
@@ -179,7 +179,7 @@ describe("channels", () => {
 
     const options = { ...baseOpts, channelId };
 
-    removeActivity(options)
+    removeChannelActivity(options)
       .then(() => {
         expect(requestSpy.calls.count()).toEqual(1);
         const [url, opts] = requestSpy.calls.argsFor(0);

--- a/packages/discussions/test/channels.test.ts
+++ b/packages/discussions/test/channels.test.ts
@@ -3,7 +3,11 @@ import {
   searchChannels,
   fetchChannel,
   updateChannel,
-  removeChannel
+  removeChannel,
+  fetchOptOut,
+  createOptOut,
+  removeOptOut,
+  removeActivity,
 } from "../src/channels";
 import * as req from "../src/request";
 import {
@@ -11,7 +15,7 @@ import {
   IHubRequestOptions,
   PostReaction,
   PostStatus,
-  SharingAccess
+  SharingAccess,
 } from "../src/types";
 
 describe("channels", () => {
@@ -19,7 +23,7 @@ describe("channels", () => {
   const response = new Response("ok", { status: 200 });
   const baseOpts: IHubRequestOptions = {
     hubApiUrl: "https://hub.arcgis.com/api",
-    authentication: null
+    authentication: null,
   };
 
   beforeEach(() => {
@@ -28,10 +32,10 @@ describe("channels", () => {
     );
   });
 
-  it("queries channels", done => {
+  it("queries channels", (done) => {
     const query = {
       access: [SharingAccess.PUBLIC],
-      groups: ["foo"]
+      groups: ["foo"],
     };
 
     const options = { ...baseOpts, params: query };
@@ -46,7 +50,7 @@ describe("channels", () => {
       .catch(() => fail());
   });
 
-  it("creates channel", done => {
+  it("creates channel", (done) => {
     const body = {
       access: SharingAccess.PUBLIC,
       groups: ["foo"],
@@ -55,7 +59,7 @@ describe("channels", () => {
       softDelete: true,
       defaultPostStatus: PostStatus.APPROVED,
       allowReaction: true,
-      allowedReactions: [PostReaction.HEART]
+      allowedReactions: [PostReaction.HEART],
     };
 
     const options = { ...baseOpts, params: body };
@@ -71,7 +75,7 @@ describe("channels", () => {
       .catch(() => fail());
   });
 
-  it("gets channel", done => {
+  it("gets channel", (done) => {
     const channelId = "channelId";
 
     const options = { ...baseOpts, channelId };
@@ -87,10 +91,10 @@ describe("channels", () => {
       .catch(() => fail());
   });
 
-  it("updates channel", done => {
+  it("updates channel", (done) => {
     const channelId = "channelId";
     const body = {
-      allowReaction: false
+      allowReaction: false,
     };
 
     const options = { ...baseOpts, channelId, params: body };
@@ -106,7 +110,7 @@ describe("channels", () => {
       .catch(() => fail());
   });
 
-  it("deletes channel", done => {
+  it("deletes channel", (done) => {
     const channelId = "channelId";
 
     const options = { ...baseOpts, channelId };
@@ -116,6 +120,70 @@ describe("channels", () => {
         expect(requestSpy.calls.count()).toEqual(1);
         const [url, opts] = requestSpy.calls.argsFor(0);
         expect(url).toEqual(`/channels/${channelId}`);
+        expect(opts).toEqual({ ...options, httpMethod: "DELETE" });
+        done();
+      })
+      .catch(() => fail());
+  });
+
+  it("gets channel opt out status", (done) => {
+    const channelId = "channelId";
+
+    const options = { ...baseOpts, channelId };
+
+    fetchOptOut(options)
+      .then(() => {
+        expect(requestSpy.calls.count()).toEqual(1);
+        const [url, opts] = requestSpy.calls.argsFor(0);
+        expect(url).toEqual(`/channels/${channelId}/notifications/opt-out`);
+        expect(opts).toEqual({ ...options, httpMethod: "GET" });
+        done();
+      })
+      .catch(() => fail());
+  });
+
+  it("creates channel opt out", (done) => {
+    const channelId = "channelId";
+
+    const options = { ...baseOpts, channelId };
+
+    createOptOut(options)
+      .then(() => {
+        expect(requestSpy.calls.count()).toEqual(1);
+        const [url, opts] = requestSpy.calls.argsFor(0);
+        expect(url).toEqual(`/channels/${channelId}/notifications/opt-out`);
+        expect(opts).toEqual({ ...options, httpMethod: "POST" });
+        done();
+      })
+      .catch(() => fail());
+  });
+
+  it("deletes channel opt out", (done) => {
+    const channelId = "channelId";
+
+    const options = { ...baseOpts, channelId };
+
+    removeOptOut(options)
+      .then(() => {
+        expect(requestSpy.calls.count()).toEqual(1);
+        const [url, opts] = requestSpy.calls.argsFor(0);
+        expect(url).toEqual(`/channels/${channelId}/notifications/opt-out`);
+        expect(opts).toEqual({ ...options, httpMethod: "DELETE" });
+        done();
+      })
+      .catch(() => fail());
+  });
+
+  it("deletes channel activity", (done) => {
+    const channelId = "channelId";
+
+    const options = { ...baseOpts, channelId };
+
+    removeActivity(options)
+      .then(() => {
+        expect(requestSpy.calls.count()).toEqual(1);
+        const [url, opts] = requestSpy.calls.argsFor(0);
+        expect(url).toEqual(`/channels/${channelId}/activity`);
         expect(opts).toEqual({ ...options, httpMethod: "DELETE" });
         done();
       })


### PR DESCRIPTION
affects: @esri/hub-discussions

Description: Adds methods for channel opt out and activity routes.

- [x] used semantic commit messages
- [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
