### PR TITLE
feat(): adds page headContent to draft allow list

### DIFF
--- a/packages/sites/src/drafts/page-draft-include-list.ts
+++ b/packages/sites/src/drafts/page-draft-include-list.ts
@@ -5,5 +5,6 @@
 export const PAGE_DRAFT_INCLUDE_LIST = [
   "item.title",
   "item.snippet",
-  "data.values.layout"
+  "data.values.layout",
+  "data.values.headContent",
 ];


### PR DESCRIPTION
affects: @esri/hub-sites

1. Description:
    - allows `headContent` to be saved in page drafts


1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
