### PR TITLE
feat: project edit schema supports featured image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61188,7 +61188,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "11.21.3",
+			"version": "11.22.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -61218,7 +61218,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "14.19.0",
+			"version": "15.1.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61227,19 +61227,19 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "11.21.3"
+				"@esri/hub-common": "11.22.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "11.21.3",
+			"version": "11.22.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -61250,7 +61250,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61258,12 +61258,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "11.21.3"
+				"@esri/hub-common": "11.22.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "11.21.3",
+			"version": "11.22.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61274,7 +61274,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61283,12 +61283,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.21.3"
+				"@esri/hub-common": "11.22.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "11.21.3",
+			"version": "11.22.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61297,7 +61297,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -61305,12 +61305,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "11.21.3"
+				"@esri/hub-common": "11.22.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "11.21.3",
+			"version": "11.22.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61321,7 +61321,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -61332,12 +61332,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.21.3"
+				"@esri/hub-common": "11.22.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "11.23.0",
+			"version": "11.24.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61346,9 +61346,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
-				"@esri/hub-initiatives": "11.21.3",
-				"@esri/hub-teams": "11.21.3",
+				"@esri/hub-common": "11.22.0",
+				"@esri/hub-initiatives": "11.22.0",
+				"@esri/hub-teams": "11.22.0",
 				"@esri/hub-types": "^6.10.0",
 				"typescript": "^3.8.1"
 			},
@@ -61356,9 +61356,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "11.21.3",
-				"@esri/hub-initiatives": "11.21.3",
-				"@esri/hub-teams": "11.21.3"
+				"@esri/hub-common": "11.22.0",
+				"@esri/hub-initiatives": "11.22.0",
+				"@esri/hub-teams": "11.22.0"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61380,7 +61380,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "11.21.3",
+			"version": "11.22.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61391,7 +61391,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61400,12 +61400,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.21.3"
+				"@esri/hub-common": "11.22.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "11.21.3",
+			"version": "11.22.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61415,7 +61415,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61423,7 +61423,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.21.3"
+				"@esri/hub-common": "11.22.0"
 			}
 		}
 	},
@@ -64829,7 +64829,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64842,7 +64842,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64856,7 +64856,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -64867,7 +64867,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64881,7 +64881,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -64894,9 +64894,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
-				"@esri/hub-initiatives": "11.21.3",
-				"@esri/hub-teams": "11.21.3",
+				"@esri/hub-common": "11.22.0",
+				"@esri/hub-initiatives": "11.22.0",
+				"@esri/hub-teams": "11.22.0",
 				"@esri/hub-types": "^6.10.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -64924,7 +64924,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -64936,7 +64936,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.21.3",
+				"@esri/hub-common": "11.22.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/common/src/core/HubItemEntity.ts
+++ b/packages/common/src/core/HubItemEntity.ts
@@ -264,7 +264,7 @@ export abstract class HubItemEntity<T extends IHubItemEntity>
    */
   async setFeaturedImage(file: any): Promise<void> {
     // If we have a featured image then clear it out.
-    if (this.entity.featuredImageUrl) {
+    if (this.entity.view?.featuredImageUrl) {
       await this.clearFeaturedImage();
     }
     // add the new featured image
@@ -276,7 +276,10 @@ export abstract class HubItemEntity<T extends IHubItemEntity>
       this.context.userRequestOptions
     );
     // If successful, update the entity
-    this.entity.featuredImageUrl = featuredImageUrl;
+    this.entity.view = {
+      ...this.entity.view,
+      featuredImageUrl,
+    };
     // save the entity
     await this.save();
   }
@@ -300,7 +303,7 @@ export abstract class HubItemEntity<T extends IHubItemEntity>
         );
       }
       // If successful, clear the featured image url
-      this.entity.featuredImageUrl = null;
+      this.entity.view.featuredImageUrl = null;
       // save the entity
       await this.save();
     } catch (err) {

--- a/packages/common/src/core/_internal/getBasePropertyMap.ts
+++ b/packages/common/src/core/_internal/getBasePropertyMap.ts
@@ -54,5 +54,9 @@ export function getBasePropertyMap(): IPropertyMap[] {
     objectKey: "boundary",
     modelKey: "item.properties.boundary",
   });
+  map.push({
+    objectKey: "featuredImageUrl",
+    modelKey: "item.properties.featuredImageUrl",
+  });
   return map;
 }

--- a/packages/common/src/core/_internal/getBasePropertyMap.ts
+++ b/packages/common/src/core/_internal/getBasePropertyMap.ts
@@ -54,9 +54,5 @@ export function getBasePropertyMap(): IPropertyMap[] {
     objectKey: "boundary",
     modelKey: "item.properties.boundary",
   });
-  map.push({
-    objectKey: "featuredImageUrl",
-    modelKey: "item.properties.featuredImageUrl",
-  });
   return map;
 }

--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -30,6 +30,9 @@ export const HubProjectSchema: IConfigurationSchema = {
     timeline: {
       type: "object",
     },
+    featuredImage: {
+      type: "object",
+    },
   },
 } as unknown as IConfigurationSchema;
 
@@ -172,6 +175,17 @@ export const HubProjectEditUiSchema: IUiSchema = {
             helperText: {
               labelKey: "{{i18nScope}}.description.helperText",
             },
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.featuredImage.label",
+          scope: "/properties/featuredImage",
+          type: "Control",
+          options: {
+            control: "hub-field-input-image-picker",
+            sizeDescription: "{{i18nScope}}.featuredImage.sizeDescription",
+            maxWidth: 727,
+            aspectRatio: 1.5,
           },
         },
       ],

--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -21,17 +21,22 @@ export const HubProjectSchema: IConfigurationSchema = {
       default: PROJECT_STATUSES.notStarted,
       enum: Object.keys(PROJECT_STATUSES),
     },
-    showMap: {
-      type: "boolean",
-    },
     extent: {
       type: "object",
     },
     timeline: {
       type: "object",
     },
-    featuredImage: {
+    view: {
       type: "object",
+      properties: {
+        showMap: {
+          type: "boolean",
+        },
+        featuredImage: {
+          type: "object",
+        },
+      },
     },
   },
 } as unknown as IConfigurationSchema;
@@ -179,7 +184,7 @@ export const HubProjectEditUiSchema: IUiSchema = {
         },
         {
           labelKey: "{{i18nScope}}.featuredImage.label",
-          scope: "/properties/featuredImage",
+          scope: "/properties/view/properties/featuredImage",
           type: "Control",
           options: {
             control: "hub-field-input-image-picker",
@@ -202,7 +207,7 @@ export const HubProjectEditUiSchema: IUiSchema = {
         },
         {
           labelKey: "{{i18nScope}}.showMap.label",
-          scope: "/properties/showMap",
+          scope: "/properties/view/properties/showMap",
           type: "Control",
         },
       ],

--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -183,7 +183,6 @@ export const HubProjectEditUiSchema: IUiSchema = {
           type: "Control",
           options: {
             control: "hub-field-input-image-picker",
-            sizeDescription: "{{i18nScope}}.featuredImage.sizeDescription",
             maxWidth: 727,
             aspectRatio: 1.5,
           },

--- a/packages/common/src/core/traits/IWithViewSettings.ts
+++ b/packages/common/src/core/traits/IWithViewSettings.ts
@@ -1,9 +1,13 @@
 /**
  * Hub Project view: defines the display properties of a project
  */
-export interface IHubViewSettings {
+export interface IWithViewSettings {
   /**
    * Should the map be shown or not
    */
   showMap?: boolean;
+  /**
+   * Url of the items featured image
+   */
+  featuredImageUrl?: string;
 }

--- a/packages/common/src/core/traits/index.ts
+++ b/packages/common/src/core/traits/index.ts
@@ -3,3 +3,4 @@ export * from "./IWithLayout";
 export * from "./IWithSlug";
 export * from "./IWithPermissions";
 export * from "./IWithCatalog";
+export * from "./IWithViewSettings";

--- a/packages/common/src/core/types/IHubItemEntity.ts
+++ b/packages/common/src/core/types/IHubItemEntity.ts
@@ -1,6 +1,7 @@
 import { IHubEntityBase } from "./IHubEntityBase";
 import { IHubGeography } from "../../types";
 import { AccessLevel } from "./types";
+import { IWithViewSettings } from "../traits";
 
 /**
  * Properties exposed by Entities that are backed by Items
@@ -71,7 +72,7 @@ export interface IHubItemEntity extends IHubEntityBase {
   typeKeywords?: string[];
 
   /**
-   * Url of the items featured image
+   * Project display properties
    */
-  featuredImageUrl?: string;
+  view?: IWithViewSettings;
 }

--- a/packages/common/src/core/types/IHubProject.ts
+++ b/packages/common/src/core/types/IHubProject.ts
@@ -1,4 +1,4 @@
-import { IHubTimeline, IHubItemEntity, IHubViewSettings } from "./index";
+import { IHubTimeline, IHubItemEntity } from "./index";
 import {
   IWithLayout,
   IWithPermissions,
@@ -23,10 +23,6 @@ export interface IHubProject
    * Project Status
    */
   status: PROJECT_STATUSES;
-  /**
-   * Project display properties
-   */
-  view?: IHubViewSettings;
 }
 
 export enum PROJECT_STATUSES {

--- a/packages/common/src/core/types/index.ts
+++ b/packages/common/src/core/types/index.ts
@@ -17,4 +17,4 @@ export * from "./IItemEnrichments";
 export * from "./IServerEnrichments";
 export * from "./types";
 export * from "./IHubPermission";
-export * from "./IHubViewSettings";
+export * from "../traits/IWithViewSettings";

--- a/packages/common/test/core/HubItemEntity.test.ts
+++ b/packages/common/test/core/HubItemEntity.test.ts
@@ -510,14 +510,16 @@ describe("HubItemEntity Class: ", () => {
         {
           id: "00c",
           owner: "deke",
-          featuredImageUrl: "https://fake.com/featured.png",
+          view: {
+            featuredImageUrl: "https://fake.com/featured.png",
+          },
         },
         authdCtxMgr.context
       );
       await instance.clearFeaturedImage();
       expect(clearImageSpy).toHaveBeenCalledTimes(1);
       const chk = instance.toJson();
-      expect(chk.featuredImageUrl).toBeNull();
+      expect(chk.view.featuredImageUrl).toBeNull();
     });
 
     it("should throw hub error if clear featured image fails", async () => {
@@ -530,7 +532,9 @@ describe("HubItemEntity Class: ", () => {
         {
           id: "00c",
           owner: "deke",
-          featuredImageUrl: "https://fake.com/featured.png",
+          view: {
+            featuredImageUrl: "https://fake.com/featured.png",
+          },
         },
         authdCtxMgr.context
       );
@@ -542,7 +546,7 @@ describe("HubItemEntity Class: ", () => {
       }
       expect(clearImageSpy).toHaveBeenCalledTimes(1);
       const chk = instance.toJson();
-      expect(chk.featuredImageUrl).toBe("https://fake.com/featured.png");
+      expect(chk.view.featuredImageUrl).toBe("https://fake.com/featured.png");
     });
 
     it("throws hub error if removeItemResource rejects with error", async () => {
@@ -555,7 +559,9 @@ describe("HubItemEntity Class: ", () => {
         {
           id: "00c",
           owner: "deke",
-          featuredImageUrl: "https://fake.com/featured.png",
+          view: {
+            featuredImageUrl: "https://fake.com/featured.png",
+          },
         },
         authdCtxMgr.context
       );
@@ -567,7 +573,7 @@ describe("HubItemEntity Class: ", () => {
       }
       expect(clearImageSpy).toHaveBeenCalledTimes(1);
       const chk = instance.toJson();
-      expect(chk.featuredImageUrl).toBe("https://fake.com/featured.png");
+      expect(chk.view.featuredImageUrl).toBe("https://fake.com/featured.png");
     });
 
     it("throws hub error if remove rejects", async () => {
@@ -580,7 +586,9 @@ describe("HubItemEntity Class: ", () => {
         {
           id: "00c",
           owner: "deke",
-          featuredImageUrl: "https://fake.com/featured.png",
+          view: {
+            featuredImageUrl: "https://fake.com/featured.png",
+          },
         },
         authdCtxMgr.context
       );
@@ -592,7 +600,7 @@ describe("HubItemEntity Class: ", () => {
       }
       expect(clearImageSpy).toHaveBeenCalledTimes(1);
       const chk = instance.toJson();
-      expect(chk.featuredImageUrl).toBe("https://fake.com/featured.png");
+      expect(chk.view.featuredImageUrl).toBe("https://fake.com/featured.png");
     });
 
     it("should set featured image", async () => {
@@ -615,7 +623,7 @@ describe("HubItemEntity Class: ", () => {
       await instance.setFeaturedImage("fake-file");
       expect(setImageSpy).toHaveBeenCalledTimes(1);
       const chk = instance.toJson();
-      expect(chk.featuredImageUrl).toBe(
+      expect(chk.view.featuredImageUrl).toBe(
         "https://www.arcgis.com/sharing/rest/content/items/3ef/resources/featuredImage.png"
       );
     });
@@ -639,7 +647,9 @@ describe("HubItemEntity Class: ", () => {
         {
           id: "00c",
           owner: "deke",
-          featuredImageUrl: "https://fake.com/featured.png",
+          view: {
+            featuredImageUrl: "https://fake.com/featured.png",
+          },
         },
         authdCtxMgr.context
       );
@@ -647,7 +657,7 @@ describe("HubItemEntity Class: ", () => {
       expect(clearImageSpy).toHaveBeenCalledTimes(1);
       expect(setImageSpy).toHaveBeenCalledTimes(1);
       const chk = instance.toJson();
-      expect(chk.featuredImageUrl).toBe(
+      expect(chk.view.featuredImageUrl).toBe(
         "https://www.arcgis.com/sharing/rest/content/items/3ef/resources/featuredImage.png"
       );
     });


### PR DESCRIPTION
1. Description: expands project edit schema with featuredImage support. Adds featuredImageUrl to getBasePropertyMap bc I forgot about it.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
