### PR TITLE
fix: cloneObject supports blobs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21577,10 +21577,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -21595,24 +21594,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -21626,10 +21622,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -21647,10 +21642,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -61224,7 +61218,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "16.0.0",
+			"version": "16.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61343,7 +61337,7 @@
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "11.25.1",
+			"version": "11.26.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -78914,8 +78908,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -78930,20 +78923,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -78957,8 +78947,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -78975,8 +78964,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -25,6 +25,8 @@ export function cloneObject<T>(obj: T): T {
         if (value != null && typeof value === "object") {
           if (value instanceof Date) {
             clone[i] = new Date(value.getTime());
+          } else if (typeof Blob !== "undefined" && value instanceof Blob) {
+            clone[i] = new Blob([value], { type: value.type });
           } else {
             clone[i] = cloneObject(value);
           }

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -19,7 +19,6 @@ export function cloneObject<T>(obj: T): T {
     clone = obj.map(cloneObject);
   } else if (typeof obj === "object") {
     for (const i in obj) {
-      /* istanbul ignore next no need to deal w/ other side of hasOwnProperty() */
       if (obj.hasOwnProperty(i)) {
         const value = obj[i];
         if (value != null && typeof value === "object") {

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -81,6 +81,30 @@ describe("util functions", () => {
     });
   });
 
+  if (typeof Blob !== "undefined") {
+    it("can clone a Blob", () => {
+      const obj = {
+        color: "red",
+        length: 12,
+        field: {
+          name: "origin",
+          type: "string",
+          csvFile: new Blob(["foo"], { type: "csv" }),
+        },
+      } as any;
+      const c = cloneObject(obj);
+      expect(c).not.toBe(obj);
+      expect(c.field).not.toBe(obj.field);
+
+      ["color", "length"].map((prop) => {
+        expect(c[prop]).toEqual(obj[prop]);
+      });
+      ["name", "type", "csvFile"].map((prop) => {
+        expect(c.field[prop]).toEqual(obj.field[prop]);
+      });
+    });
+  }
+
   it("can clone a deep object with an array", () => {
     const obj = {
       color: "red",


### PR DESCRIPTION
1. Description: cloneObject thusfar has not supported Blob's. This adds that support.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
