### PR TITLE
refactor: site permission migration and alpha org

### DIFF
--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -161,6 +161,12 @@ export interface IArcGISContext {
    * System status
    */
   systemStatus: HubSystemStatus;
+
+  /**
+   * Is this user in a Hub Alpha org?
+   * Derived from properties.alphaOrgs
+   */
+  isAlphaOrg: boolean;
 }
 
 /**
@@ -284,6 +290,20 @@ export class ArcGISContext implements IArcGISContext {
    */
   public get isAuthenticated(): boolean {
     return !!this._authentication;
+  }
+
+  /**
+   * Is the users org in the alpha orgs list?
+   * Alpha orgs are passed in via properties.alphaOrgs
+   */
+  public get isAlphaOrg(): boolean {
+    let result = false;
+    const orgs = this._properties?.alphaOrgs || [];
+    const orgId = this._portalSelf?.id;
+    if (orgs.length && orgId) {
+      result = orgs.includes(orgId);
+    }
+    return result;
   }
 
   /**

--- a/packages/common/src/permissions/_internal/checkAlphaGating.ts
+++ b/packages/common/src/permissions/_internal/checkAlphaGating.ts
@@ -1,0 +1,36 @@
+import { IArcGISContext } from "../../ArcGISContext";
+import { HubEntity } from "../../core";
+import { IPermissionPolicy, PolicyResponse, IPolicyCheck } from "../types";
+import { getPolicyResponseCode } from "./getPolicyResponseCode";
+
+/**
+ * Validate entityOwner policy
+ * @param policy
+ * @param context
+ * @param entity
+ * @returns
+ */
+export function checkAlphaGating(
+  policy: IPermissionPolicy,
+  context: IArcGISContext,
+  entity?: HubEntity
+): IPolicyCheck[] {
+  const checks = [] as IPolicyCheck[];
+  // Only return a check if the policy is defined
+  if (policy.alpha) {
+    const result: PolicyResponse = context.isAlphaOrg
+      ? "granted"
+      : "not-alpha-org";
+
+    // create the check
+    const check: IPolicyCheck = {
+      name: `user in alpha org`,
+      value: context.hubLicense,
+      code: getPolicyResponseCode(result),
+      response: result,
+    };
+    checks.push(check);
+  }
+
+  return checks;
+}

--- a/packages/common/src/permissions/_internal/getPolicyResponseCode.ts
+++ b/packages/common/src/permissions/_internal/getPolicyResponseCode.ts
@@ -6,23 +6,28 @@ interface IPolicyLookup {
 }
 
 // TODO: Determine how to keep this in sycn with the PolicyResponse type
+// Crappy tool https://jsbin.com/gojelov/edit?js,console,output
 const policyResponseCodes: IPolicyLookup[] = [
-  { response: "granted", code: "PC001" },
-  { response: "org-member", code: "PC002" },
-  { response: "not-org-member", code: "PC003" },
-  { response: "group-member", code: "PC004" },
-  { response: "not-group-member", code: "PC005" },
-  { response: "is-user", code: "PC006" },
-  { response: "not-owner", code: "PC007" },
-  { response: "not-licensed", code: "PC008" },
-  { response: "not-available", code: "PC009" },
-  { response: "not-granted", code: "PC010" },
-  { response: "no-edit-access", code: "PC011" },
-  { response: "invalid-permission", code: "PC012" },
-  { response: "privilege-required", code: "PC013" },
-  { response: "system-offline", code: "PC014" },
-  { response: "system-maintenance", code: "PC015" },
-  { response: "not-licensed-available", code: "PC016" },
+  { response: "granted", code: "PC100" },
+  { response: "org-member", code: "PC101" },
+  { response: "not-org-member", code: "PC102" },
+  { response: "group-member", code: "PC103" },
+  { response: "not-group-member", code: "PC104" },
+  { response: "not-group-admin", code: "PC105" },
+  { response: "is-user", code: "PC106" },
+  { response: "not-owner", code: "PC107" },
+  { response: "not-licensed", code: "PC108" },
+  { response: "not-licensed-available", code: "PC109" },
+  { response: "not-available", code: "PC110" },
+  { response: "not-granted", code: "PC111" },
+  { response: "no-edit-access", code: "PC112" },
+  { response: "invalid-permission", code: "PC113" },
+  { response: "privilege-required", code: "PC114" },
+  { response: "system-offline", code: "PC115" },
+  { response: "system-maintenance", code: "PC116" },
+  { response: "entity-required", code: "PC117" },
+  { response: "not-authenticated", code: "PC118" },
+  { response: "not-alpha-org", code: "PC119" },
 ];
 
 /**

--- a/packages/common/src/permissions/types/IPermissionPolicy.ts
+++ b/packages/common/src/permissions/types/IPermissionPolicy.ts
@@ -47,4 +47,8 @@ export interface IPermissionPolicy {
    * Does the user need to be the owner of the entity to be granted this permission?
    */
   entityOwner?: boolean;
+  /**
+   * Is this gated to alpha orgs?
+   */
+  alpha?: boolean;
 }

--- a/packages/common/src/permissions/types/PolicyResponse.ts
+++ b/packages/common/src/permissions/types/PolicyResponse.ts
@@ -21,4 +21,5 @@ export type PolicyResponse =
   | "system-offline" // subsystem is offline
   | "system-maintenance" // subsystem is in maintenance mode
   | "entity-required" // entity is required but not passed
-  | "not-authenticated"; // user is not authenticated
+  | "not-authenticated" // user is not authenticated
+  | "not-alpha-org"; // user is not in an alpha org

--- a/packages/common/src/projects/defaults.ts
+++ b/packages/common/src/projects/defaults.ts
@@ -40,5 +40,6 @@ export const DEFAULT_PROJECT_MODEL: IModel = {
     view: {
       showMap: true,
     },
+    permissions: [],
   },
 } as unknown as IModel;

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -509,15 +509,6 @@ export async function convertItemToSite(
 ): Promise<IHubSite> {
   const model = await fetchModelFromItem(item, requestOptions);
   return convertModelToSite(model, requestOptions);
-  // const mapper = new PropertyMapper<Partial<IHubSite>>(getSitePropertyMap());
-  // let token: string;
-  // if (requestOptions.authentication) {
-  //   const session: UserSession = requestOptions.authentication as UserSession;
-  //   token = session.token;
-  // }
-  // const site = mapper.modelToObject(model, {}) as IHubSite;
-  // site.thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
-  // return site;
 }
 
 /**

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -37,6 +37,7 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { fetchItemEnrichments } from "../items/_enrichments";
 import { parseInclude } from "../search/_internal/parseInclude";
 import { getHubRelativeUrl } from "../content/_internal";
+import { applyPermissionMigration } from "./_internal/applyPermissionMigration";
 
 export const HUB_SITE_ITEM_TYPE = "Hub Site Application";
 export const ENTERPRISE_SITE_ITEM_TYPE = "Site Application";
@@ -212,7 +213,7 @@ function getSitePropertyMap(): IPropertyMap[] {
   itemProps.forEach((entry) => {
     map.push({ objectKey: entry, modelKey: `item.${entry}` });
   });
-  const dataProps = ["catalog", "feeds"];
+  const dataProps = ["catalog", "feeds", "permissions"];
   dataProps.forEach((entry) => {
     map.push({ objectKey: entry, modelKey: `data.${entry}` });
   });
@@ -460,7 +461,7 @@ export async function fetchSite(
 ): Promise<IHubSite> {
   // get the model
   const model = await fetchSiteModel(identifier, requestOptions);
-
+  // convert to IHubSite
   return convertModelToSite(model, requestOptions);
 }
 
@@ -472,18 +473,26 @@ export async function fetchSite(
  */
 export function convertModelToSite(
   model: IModel,
-  requestOptions: IHubRequestOptions
+  requestOptions: IRequestOptions
 ): IHubSite {
+  // Add permissions based on Groups
+  // This may get moved to a formal schema migration in the future but for now
+  // we can do it here as there is no ux for managing permissions yet.
+  const modelWithPermissions = applyPermissionMigration(model);
   // convert to site
   const mapper = new PropertyMapper<Partial<IHubSite>>(getSitePropertyMap());
-  const site = mapper.modelToObject(model, {}) as IHubSite;
+  const site = mapper.modelToObject(modelWithPermissions, {}) as IHubSite;
   let token: string;
   if (requestOptions.authentication) {
     const us: UserSession = requestOptions.authentication as UserSession;
     token = us.token;
   }
 
-  site.thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
+  site.thumbnailUrl = getItemThumbnailUrl(
+    modelWithPermissions.item,
+    requestOptions,
+    token
+  );
   return site;
 }
 
@@ -499,15 +508,16 @@ export async function convertItemToSite(
   requestOptions: IRequestOptions
 ): Promise<IHubSite> {
   const model = await fetchModelFromItem(item, requestOptions);
-  const mapper = new PropertyMapper<Partial<IHubSite>>(getSitePropertyMap());
-  let token: string;
-  if (requestOptions.authentication) {
-    const session: UserSession = requestOptions.authentication as UserSession;
-    token = session.token;
-  }
-  const site = mapper.modelToObject(model, {}) as IHubSite;
-  site.thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
-  return site;
+  return convertModelToSite(model, requestOptions);
+  // const mapper = new PropertyMapper<Partial<IHubSite>>(getSitePropertyMap());
+  // let token: string;
+  // if (requestOptions.authentication) {
+  //   const session: UserSession = requestOptions.authentication as UserSession;
+  //   token = session.token;
+  // }
+  // const site = mapper.modelToObject(model, {}) as IHubSite;
+  // site.thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
+  // return site;
 }
 
 /**

--- a/packages/common/src/sites/_internal/applyPermissionMigration.ts
+++ b/packages/common/src/sites/_internal/applyPermissionMigration.ts
@@ -1,0 +1,64 @@
+import {
+  cloneObject,
+  CollaborationType,
+  getProp,
+  IEntityPermissionPolicy,
+  IModel,
+  Permission,
+} from "../../index";
+
+/**
+ * Informal migration that creates default permission policies based on the
+ * Content and Collaboration Groups
+ * @param model
+ */
+export function applyPermissionMigration(model: IModel) {
+  // TODO: Once we formalize the permission mapping we need to
+  // bump the current schema version, and add it here so this gets
+  // applied once and then never again.
+  // const PERMISSION_SCHEMA_VERSION = 1.6
+  // if (
+  //   getProp(model, "item.properties.schemaVersion") >= PERMISSION_SCHEMA_VERSION
+  // )
+  //   return model;
+
+  const clone = cloneObject(model);
+  clone.data.permissions = clone.data.permissions || [];
+  const permissionMigrations = [
+    // Per discussion with @jaydev on 2022-12-01 we are going to
+    // allow content team members to create projects in the context
+    // of a site
+    {
+      prop: "item.properties.contentGroupId",
+      type: "group" as CollaborationType,
+      permissions: ["hub:project:create"] as Permission[],
+    },
+    {
+      prop: "item.owner",
+      type: "user" as CollaborationType,
+      permissions: ["hub:site:delete"] as Permission[],
+    },
+  ];
+
+  permissionMigrations.forEach((defn) => {
+    const value = getProp(clone, defn.prop);
+    if (value) {
+      defn.permissions.forEach((permission: Permission) => {
+        const present = clone.data.permissions.find(
+          (p: IEntityPermissionPolicy) =>
+            p.permission === permission && p.collaborationId === value
+        );
+        if (!present) {
+          clone.data.permissions.push({
+            permission,
+            collaborationType: defn.type,
+            collaborationId: value,
+          });
+        }
+      });
+    }
+  });
+  // TODO: Uncomment when we formalize the schema version this applies to
+  // clone.item.properties.schemaVersion = PERMISSION_SCHEMA_VERSION;
+  return clone;
+}

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -103,6 +103,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.eventsConfig).toBeUndefined();
       expect(mgr.context.helperServices).toBeUndefined();
       expect(mgr.context.hubEnabled).toBeFalsy();
+      expect(mgr.context.isAlphaOrg).toBeFalsy();
       // Hub Urls
       const base = mgr.context.hubUrl;
       expect(mgr.context.discussionsServiceUrl).toBe(
@@ -235,6 +236,9 @@ describe("ArcGISContext:", () => {
         portal: onlinePortalSelfResponse,
         currentUser: onlineUserResponse,
         systemStatus: { discussions: "offline" } as HubSystemStatus,
+        properties: {
+          alphaOrgs: ["FAKEID", "FOTHERID"],
+        },
       });
       expect(selfSpy.calls.count()).toBe(0);
       expect(userSpy.calls.count()).toBe(0);
@@ -244,6 +248,8 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.systemStatus).toEqual({
         discussions: "offline",
       } as HubSystemStatus);
+      expect(mgr.context.properties.alphaOrgs).toEqual(["FAKEID", "FOTHERID"]);
+      expect(mgr.context.isAlphaOrg).toBeTruthy();
     });
     it("verify props update setting session after", async () => {
       spyOn(portalModule, "getSelf").and.callFake(() => {

--- a/packages/common/test/permissions/_internal/checkAlphaGating.test.ts
+++ b/packages/common/test/permissions/_internal/checkAlphaGating.test.ts
@@ -1,0 +1,40 @@
+import { IArcGISContext, IPermissionPolicy } from "../../../src";
+import { checkAlphaGating } from "../../../src/permissions/_internal/checkAlphaGating";
+
+describe("checkAlphaGating:", () => {
+  it("no check if alpha not specified in policy", () => {
+    const ctx = {
+      isAlphaOrg: true,
+    } as unknown as IArcGISContext;
+    const policy = {
+      licenses: ["hub-premium"],
+    } as unknown as IPermissionPolicy;
+
+    const chks = checkAlphaGating(policy, ctx);
+    expect(chks.length).toBe(0);
+  });
+  it("returns not-alpha-org if not alpha org", () => {
+    const ctx = {
+      isAlphaOrg: false,
+    } as unknown as IArcGISContext;
+    const policy = {
+      alpha: true,
+    } as unknown as IPermissionPolicy;
+
+    const chks = checkAlphaGating(policy, ctx);
+    expect(chks.length).toBe(1);
+    expect(chks[0].response).toBe("not-alpha-org");
+  });
+  it("returns granted if alpha org", () => {
+    const ctx = {
+      isAlphaOrg: true,
+    } as unknown as IArcGISContext;
+    const policy = {
+      alpha: true,
+    } as unknown as IPermissionPolicy;
+
+    const chks = checkAlphaGating(policy, ctx);
+    expect(chks.length).toBe(1);
+    expect(chks[0].response).toBe("granted");
+  });
+});

--- a/packages/common/test/permissions/_internal/getPolicyResponseCode.test.ts
+++ b/packages/common/test/permissions/_internal/getPolicyResponseCode.test.ts
@@ -1,0 +1,13 @@
+import { PolicyResponse } from "../../../src";
+import { getPolicyResponseCode } from "../../../src/permissions/_internal/getPolicyResponseCode";
+
+describe("getPolicyResponseCode:", () => {
+  it("returns PC000 if no entry", () => {
+    const chk = getPolicyResponseCode("foo" as PolicyResponse);
+    expect(chk).toBe("PC000");
+  });
+  it("returns code ", () => {
+    const chk = getPolicyResponseCode("granted");
+    expect(chk).toBe("PC100");
+  });
+});

--- a/packages/common/test/sites/_internal/applyPermissionMigration.test.ts
+++ b/packages/common/test/sites/_internal/applyPermissionMigration.test.ts
@@ -1,0 +1,74 @@
+import { IEntityPermissionPolicy, IModel } from "../../../src";
+import { applyPermissionMigration } from "../../../src/sites/_internal/applyPermissionMigration";
+
+describe("applyPermissionMigration:", () => {
+  it("returns clone", () => {
+    const siteModel = {
+      item: { properties: { schemaVersion: 1.4 } },
+      data: { values: {} },
+    } as unknown as IModel;
+    const result = applyPermissionMigration(siteModel);
+    expect(result).not.toBe(siteModel, "The site object should be a clone.");
+  });
+  it("ensures permissions array exists", () => {
+    const siteModel = {
+      item: { properties: { schemaVersion: 1.4 } },
+      data: { values: {} },
+    } as unknown as IModel;
+    const result = applyPermissionMigration(siteModel);
+    expect(result.data?.permissions).toBeDefined();
+    expect(Array.isArray(result.data?.permissions)).toBeTruthy();
+  });
+  it("created default policies", () => {
+    const siteModel = {
+      item: {
+        owner: "jsmith",
+        properties: {
+          schemaVersion: 1.5,
+          contentGroupId: "00c",
+        },
+      },
+      data: { values: {} },
+    } as unknown as IModel;
+    const result = applyPermissionMigration(siteModel);
+    const groupPolicy = result.data?.permissions?.find(
+      (p: any) => p.collaborationType === "group"
+    ) as IEntityPermissionPolicy;
+    expect(groupPolicy.collaborationId).toEqual("00c");
+    expect(groupPolicy.permission).toEqual("hub:project:create");
+
+    const ownerPolicy = result.data?.permissions?.find(
+      (p: any) => p.collaborationType === "user"
+    ) as IEntityPermissionPolicy;
+    expect(ownerPolicy.collaborationId).toBe("jsmith");
+  });
+  it("respects existing policies", () => {
+    const siteModel = {
+      item: {
+        owner: "jsmith",
+        properties: {
+          schemaVersion: 1.5,
+          contentGroupId: "00c",
+        },
+      },
+      data: {
+        permissions: [
+          {
+            permission: "hub:project:create",
+            collaborationType: "group",
+            collaborationId: "00f",
+          },
+          {
+            permission: "hub:project:create",
+            collaborationType: "group",
+            collaborationId: "00c",
+          },
+        ],
+        values: {},
+      },
+    } as unknown as IModel;
+    const result = applyPermissionMigration(siteModel);
+    // should have 3 policies
+    expect(result.data?.permissions?.length).toBe(3);
+  });
+});


### PR DESCRIPTION
1. Description:

- add a proto-migration that derives site's permissions hash for `hub:project:create` based on the contentGroupId stored on the site. Currently, this is always applied when an `IModel` is transformed into an `IHubSite`. Once we have a UX for permission management, we will run this one can bump the schema version when complete.
- adds support for `alpha` in the `IPerissionPolicy` structure, allowing us to gate access to alpha orgs, and creating a pattern for other flagging

1. Instructions for testing: Run tests

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
