### PR TITLE
fix(hub-discussions): prevent post edit when user group is non-discus…

### DIFF
--- a/packages/discussions/src/index.ts
+++ b/packages/discussions/src/index.ts
@@ -6,8 +6,8 @@ export * from "./channels";
 export * from "./reactions";
 export * from "./types";
 
-export * from "./utils/posts";
 export * from "./utils/channels/";
+export * from "./utils/posts/";
 export * from "./utils/reactions";
 export * from "./utils/platform";
 export * from "./utils/constants";

--- a/packages/discussions/src/utils/posts/can-modify-post.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post.ts
@@ -22,6 +22,7 @@ export function canModifyPost(
   const { access, groups, orgs, allowAnonymous } = channel;
 
   if (!channel) {
+    // backwards compatibility
     return isPostCreator(post, user);
   }
 

--- a/packages/discussions/src/utils/posts/can-modify-post.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post.ts
@@ -52,15 +52,11 @@ function isAuthorizedToModifyByLegacyPermissions(
     return true;
   }
 
-  if (access === SharingAccess.PRIVATE) {
-    return isAuthorizedToModifyPostByLegacyGroup(channelGroups, userGroups);
-  }
-
   if (access === SharingAccess.ORG) {
     return orgs.includes(userOrgId);
   }
 
-  return false;
+  return isAuthorizedToModifyPostByLegacyGroup(channelGroups, userGroups);
 }
 
 /**

--- a/packages/discussions/src/utils/posts/can-modify-post.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post.ts
@@ -21,11 +21,6 @@ export function canModifyPost(
 ) {
   const { access, groups, orgs, allowAnonymous } = channel;
 
-  if (!channel) {
-    // backwards compatibility
-    return isPostCreator(post, user);
-  }
-
   return (
     isPostCreator(post, user) &&
     isAuthorizedToModifyByLegacyPermissions(user, {

--- a/packages/discussions/src/utils/posts/can-modify-post.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post.ts
@@ -1,0 +1,85 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import { IChannel, IDiscussionsUser, IPost, SharingAccess } from "../../types";
+import { CANNOT_DISCUSS } from "../constants";
+
+type ILegacyChannelPermissions = Pick<
+  IChannel,
+  "groups" | "orgs" | "access" | "allowAnonymous"
+>;
+
+/**
+ * Determine if a user can modify an existing post
+ * @param post
+ * @param user
+ * @param channel
+ * @returns boolean
+ */
+export function canModifyPost(
+  post: IPost,
+  user: IDiscussionsUser,
+  channel: IChannel
+) {
+  const { access, groups, orgs, allowAnonymous } = channel;
+
+  if (!channel) {
+    return isPostCreator(post, user);
+  }
+
+  return (
+    isPostCreator(post, user) &&
+    isAuthorizedToModifyByLegacyPermissions(user, {
+      access,
+      groups,
+      orgs,
+      allowAnonymous,
+    })
+  );
+}
+
+function isPostCreator(post: IPost, user: IDiscussionsUser) {
+  return post.creator === user.username;
+}
+
+function isAuthorizedToModifyByLegacyPermissions(
+  user: IDiscussionsUser,
+  channelParams: ILegacyChannelPermissions
+) {
+  const { groups: userGroups, orgId: userOrgId } = user;
+  const { access, groups: channelGroups, orgs } = channelParams;
+
+  if (access === SharingAccess.PUBLIC) {
+    return true;
+  }
+
+  if (access === SharingAccess.PRIVATE) {
+    return isAuthorizedToModifyPostByLegacyGroup(channelGroups, userGroups);
+  }
+
+  if (access === SharingAccess.ORG) {
+    return orgs.includes(userOrgId);
+  }
+
+  return false;
+}
+
+/**
+ * Ensure the user is a member of one of the channel groups
+ * and the group is not marked as non-discussable
+ * @param channelGroups
+ * @param userGroups
+ * @returns
+ */
+function isAuthorizedToModifyPostByLegacyGroup(
+  channelGroups: string[] = [],
+  userGroups: IGroup[] = []
+) {
+  return channelGroups.some((channelGroupId: string) => {
+    return userGroups.some((group: IGroup) => {
+      const { id: userGroupId, typeKeywords = [] } = group;
+
+      return (
+        channelGroupId === userGroupId && !typeKeywords.includes(CANNOT_DISCUSS)
+      );
+    });
+  });
+}

--- a/packages/discussions/src/utils/posts/index.ts
+++ b/packages/discussions/src/utils/posts/index.ts
@@ -4,9 +4,8 @@ import { parseDatasetId, IHubContent } from "@esri/hub-common";
 import { IUser } from "@esri/arcgis-rest-auth";
 import { canModifyChannel } from "../channels";
 import { CANNOT_DISCUSS, MENTION_ATTRIBUTE } from "../constants";
-import { canModifyPost } from "../posts/can-modify-post";
 
-export { canModifyPost };
+export { canModifyPost } from "../posts/can-modify-post";
 
 /**
  * Utility that parses a discussion URI string into its component parts

--- a/packages/discussions/src/utils/posts/index.ts
+++ b/packages/discussions/src/utils/posts/index.ts
@@ -1,9 +1,12 @@
 import { IGroup, IItem } from "@esri/arcgis-rest-portal";
-import { IChannel, IDiscussionParams, IPost } from "../types";
+import { IChannel, IDiscussionParams, IPost } from "../../types";
 import { parseDatasetId, IHubContent } from "@esri/hub-common";
 import { IUser } from "@esri/arcgis-rest-auth";
-import { canModifyChannel } from "./channels";
-import { CANNOT_DISCUSS, MENTION_ATTRIBUTE } from "./constants";
+import { canModifyChannel } from "../channels";
+import { CANNOT_DISCUSS, MENTION_ATTRIBUTE } from "../constants";
+import { canModifyPost } from "../posts/can-modify-post";
+
+export { canModifyPost };
 
 /**
  * Utility that parses a discussion URI string into its component parts
@@ -55,17 +58,6 @@ export function isDiscussable(subject: IGroup | IItem | IHubContent) {
 }
 
 /**
- * Determines if the given user has sufficient privileges to modify a post's editable attributes
- * @param post An IPost object
- * @param channel An IChannel object
- * @param user An IUser object
- * @returns true if the user can modify the post
- */
-export function canModifyPost(post: IPost, user: IUser): boolean {
-  return post.creator === user.username;
-}
-
-/**
  * Determines if the given user has sufficient privileges to modify a post's status
  * @param post An IPost object
  * @param channel An IChannel object
@@ -88,7 +80,11 @@ export function canDeletePost(
   channel: IChannel,
   user: IUser
 ): boolean {
-  return canModifyPost(post, user) || canModifyChannel(channel, user);
+  return isPostCreator(post, user) || canModifyChannel(channel, user);
+}
+
+function isPostCreator(post: IPost, user: IUser) {
+  return post.creator === user.username;
 }
 
 const MENTION_ATTRIBUTE_AND_VALUE_PATTERN = new RegExp(

--- a/packages/discussions/test/utils/posts/can-modify-post.test.ts
+++ b/packages/discussions/test/utils/posts/can-modify-post.test.ts
@@ -77,6 +77,19 @@ describe("canModifyPost", () => {
         const result = canModifyPost(post, user, channel);
         expect(result).toBe(false);
       });
+
+      it("returns false if channel and user groups are empty", () => {
+        const post = { id: "postId", creator: "john" } as IPost;
+        const user = {
+          username: "john",
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PRIVATE,
+        } as IChannel;
+
+        const result = canModifyPost(post, user, channel);
+        expect(result).toBe(false);
+      });
     });
 
     describe("org channel", () => {

--- a/packages/discussions/test/utils/posts/can-modify-post.test.ts
+++ b/packages/discussions/test/utils/posts/can-modify-post.test.ts
@@ -1,0 +1,114 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import {
+  IChannel,
+  IDiscussionsUser,
+  IPost,
+  SharingAccess,
+} from "../../../src/types";
+import { CANNOT_DISCUSS } from "../../../src/utils/constants";
+import { canModifyPost } from "../../../src/utils/posts";
+
+describe("canModifyPost", () => {
+  it("returns false if the user did not create the post", () => {
+    const post = { id: "postId", creator: "john" } as IPost;
+    const user = { username: "notJohn" } as IDiscussionsUser;
+    const channel = { access: SharingAccess.PUBLIC } as IChannel;
+
+    const result = canModifyPost(post, user, channel);
+    expect(result).toBe(false);
+  });
+
+  describe("Legacy Permissions", () => {
+    describe("public channel", () => {
+      it("returns true if user is creator", () => {
+        const post = { id: "postId", creator: "john" } as IPost;
+        const user = { username: "john" } as IDiscussionsUser;
+        const channel = { access: SharingAccess.PUBLIC } as IChannel;
+
+        const result = canModifyPost(post, user, channel);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe("private channel", () => {
+      it("returns true if user is creator and is a member of one of the channel groups", () => {
+        const post = { id: "postId", creator: "john" } as IPost;
+        const user = {
+          username: "john",
+          groups: [{ id: "bbb" }],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PRIVATE,
+          groups: ["bbb"],
+        } as IChannel;
+
+        const result = canModifyPost(post, user, channel);
+        expect(result).toBe(true);
+      });
+
+      it("returns false if user is creator, is a member of one of the channel groups, but group is non-discussable", () => {
+        const post = { id: "postId", creator: "john" } as IPost;
+        const user = {
+          username: "john",
+          groups: [
+            { id: "bbb", typeKeywords: [CANNOT_DISCUSS] },
+          ] as any as IGroup[],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PRIVATE,
+          groups: ["bbb"],
+        } as IChannel;
+
+        const result = canModifyPost(post, user, channel);
+        expect(result).toBe(false);
+      });
+
+      it("returns false if user is creator and is not a member of one of the channel groups", () => {
+        const post = { id: "postId", creator: "john" } as IPost;
+        const user = {
+          username: "john",
+          groups: [{ id: "bbb" }],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PRIVATE,
+          groups: ["zzz"],
+        } as IChannel; // user's group not included
+
+        const result = canModifyPost(post, user, channel);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe("org channel", () => {
+      it("returns true if user is creator and is a member of one of the channel orgs", () => {
+        const post = { id: "postId", creator: "john" } as IPost;
+        const user = {
+          username: "john",
+          orgId: "ccc",
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.ORG,
+          orgs: ["ccc"],
+        } as IChannel;
+
+        const result = canModifyPost(post, user, channel);
+        expect(result).toBe(true);
+      });
+
+      it("returns false if user is creator and is not a member of one of the channel orgs", () => {
+        const post = { id: "postId", creator: "john" } as IPost;
+        const user = {
+          username: "john",
+          orgId: "ccc",
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.ORG,
+          orgs: ["zzz"],
+        } as IChannel; // user's org not included
+
+        const result = canModifyPost(post, user, channel);
+        expect(result).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/discussions/test/utils/posts/index.test.ts
+++ b/packages/discussions/test/utils/posts/index.test.ts
@@ -1,6 +1,6 @@
 import { IItem } from "@esri/arcgis-rest-portal";
 import { IGroup, IUser } from "@esri/arcgis-rest-types";
-import { IChannel, IDiscussionParams, IPost } from "../../src/types";
+import { IChannel, IDiscussionParams, IPost } from "../../../src/types";
 import { IHubContent } from "@esri/hub-common";
 import {
   isDiscussable,
@@ -9,11 +9,14 @@ import {
   canModifyPostStatus,
   canDeletePost,
   parseMentionedUsers,
-} from "../../src/utils/posts";
-import { MENTION_ATTRIBUTE, CANNOT_DISCUSS } from "../../src/utils/constants";
-import * as viewGroup from "../../../common/test/mocks/groups/view-group.json";
-import * as formItem from "../../../common/test/mocks/items/form-item-draft.json";
-import * as channelUtils from "../../src/utils/channels";
+} from "../../../src/utils/posts";
+import {
+  MENTION_ATTRIBUTE,
+  CANNOT_DISCUSS,
+} from "../../../src/utils/constants";
+import * as viewGroup from "@esri/hub-common/test/mocks/groups/view-group.json";
+import * as formItem from "@esri/hub-common/test/mocks/items/form-item-draft.json";
+import * as channelUtils from "../../../src/utils/channels";
 
 describe("parseDiscussionURI", () => {
   it("returns DiscussionParams for valid discussion uri", () => {
@@ -88,22 +91,6 @@ describe("isDiscussable", () => {
       typeKeywords: [CANNOT_DISCUSS],
     } as any as IGroup;
     expect(isDiscussable(group)).toBeFalsy();
-  });
-});
-
-describe("canModifyPost", () => {
-  it("returns true when the user created the post", () => {
-    const post = { id: "post1", creator: "user1" } as IPost;
-    const user = { username: "user1" } as IUser;
-    const result = canModifyPost(post, user);
-    expect(result).toBe(true);
-  });
-
-  it("returns false when user did not create the post", () => {
-    const post = { id: "post1", creator: "user1" } as IPost;
-    const user = { username: "user2" } as IUser;
-    const result = canModifyPost(post, user);
-    expect(result).toBe(false);
   });
 });
 


### PR DESCRIPTION
…sable

affects: @esri/hub-discussions

1. Description: add check to function `canModifyPost` that prevents update if user is authorized by channel group, but the group is marked `cannotDiscuss`
  - add parameter `channel`, and only check channel groups if included (for backwards compatibility)
  - move post utils from `utils/posts` => `/utils/posts/index` and separate out function `canModifyPost`
  - adjust test location in the same manner, and separate out test for `canModifyPost`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
