### PR TITLE
fix(hub-discussions): change restrictedBefore type to string

### DIFF
--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -810,7 +810,7 @@ export interface IChannelAclPermissionDefinition {
   subCategory?: AclSubCategory;
   key?: string;
   role: Role;
-  restrictedBefore?: Date;
+  restrictedBefore?: string;
 }
 
 /**
@@ -837,7 +837,7 @@ export interface IChannelAclPermission
     IWithEditor,
     IWithTimestamps {
   id: string;
-  restrictedBefore: Date;
+  restrictedBefore: string;
 }
 
 /**


### PR DESCRIPTION
affects: @esri/hub-discussions

1. Description: change type for `restrictedBefore` from Date to string

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
