### PR TITLE
feat(hub-discussions): add channelAcl support to canPostToChannel

### DIFF
--- a/packages/discussions/src/utils/channel-permission.ts
+++ b/packages/discussions/src/utils/channel-permission.ts
@@ -1,0 +1,262 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import {
+  AclCategory,
+  AclSubCategory,
+  IChannelAclPermission,
+  IChannelAclPermissionDefinition,
+  IDiscussionsUser,
+  Role,
+} from "../types";
+import { CANNOT_DISCUSS } from "./constants";
+import { isOrgAdmin } from "./platform";
+
+type PermissionsByAclCategoryMap = {
+  [key in AclCategory]?: IChannelAclPermission[];
+};
+
+export class ChannelPermission {
+  private readonly ALLOWED_GROUP_MEMBER_TYPES = ["owner", "admin", "member"];
+  private readonly ALLOWED_ROLES_FOR_POSTING = [
+    Role.WRITE,
+    Role.READWRITE,
+    Role.MANAGE,
+    Role.MODERATE,
+    Role.OWNER,
+  ];
+
+  private isChannelAclEmpty: boolean;
+  private permissionsByCategory: PermissionsByAclCategoryMap;
+
+  constructor(channelAcl: IChannelAclPermission[]) {
+    this.isChannelAclEmpty = channelAcl.length === 0;
+    this.permissionsByCategory = {};
+
+    channelAcl.forEach((permission) => {
+      const { category } = permission;
+      this.permissionsByCategory[category]?.push(permission) ||
+        (this.permissionsByCategory[category] = [permission]);
+    });
+  }
+
+  canPostToChannel(user: IDiscussionsUser) {
+    if (this.aclAllowsAnyUserToPost()) {
+      return true;
+    }
+
+    if (!this.isUserLoggedIn(user)) {
+      return false;
+    }
+
+    return (
+      this.aclAllowsAnyAuthenticatedUserToPost() ||
+      this.aclAllowsThisUserToPost(user) ||
+      this.aclAllowsThisUserToPostByGroups(user) ||
+      this.aclAllowsThisUserToPostByOrg(user)
+    );
+  }
+
+  canCreateChannel(user: IDiscussionsUser) {
+    if (!this.isUserLoggedIn(user) || this.isChannelAclEmpty) {
+      return false;
+    }
+
+    return (
+      this.userCanAddAnonymousToAcl(user) &&
+      this.userCanAddUnauthenticatedToAcl(user) &&
+      this.userCanAddAllGroupsToAcl(user) &&
+      this.userCanAddAllOrgsToAcl(user) &&
+      this.userCanAddUsersToAcl(user)
+    );
+  }
+
+  private aclAllowsAnyUserToPost() {
+    return this.isAuthorizedToPost(
+      this.permissionsByCategory[AclCategory.ANONYMOUS_USER]?.[0].role
+    );
+  }
+
+  private isAuthorizedToPost(role?: Role) {
+    return this.ALLOWED_ROLES_FOR_POSTING.includes(role);
+  }
+
+  private isUserLoggedIn(user: IDiscussionsUser) {
+    return user.username !== null;
+  }
+
+  private mapUserGroupsById(groups: IGroup[]) {
+    return groups.reduce((accum, userGroup) => {
+      accum[userGroup.id] = userGroup;
+      return accum;
+    }, {} as Record<string, IGroup>);
+  }
+
+  private isMemberTypeAuthorized(userGroup: IGroup) {
+    const {
+      userMembership: { memberType },
+    } = userGroup;
+    return this.ALLOWED_GROUP_MEMBER_TYPES.includes(memberType);
+  }
+
+  private isGroupDiscussable(userGroup: IGroup) {
+    const { typeKeywords = [] } = userGroup;
+    return !typeKeywords.includes(CANNOT_DISCUSS);
+  }
+
+  private aclAllowsAnyAuthenticatedUserToPost() {
+    return this.isAuthorizedToPost(
+      this.permissionsByCategory[AclCategory.AUTHENTICATED_USER]?.[0].role
+    );
+  }
+
+  private aclAllowsThisUserToPost(user: IDiscussionsUser) {
+    const userPermissions = this.permissionsByCategory[AclCategory.USER] ?? [];
+    const username = user.username;
+
+    return userPermissions.some((permission) => {
+      const { role, key } = permission;
+
+      return key === username && this.isAuthorizedToPost(role);
+    });
+  }
+
+  private aclAllowsThisUserToPostByGroups(user: IDiscussionsUser) {
+    const groupPermissions =
+      this.permissionsByCategory[AclCategory.GROUP] ?? [];
+    const userGroupsById = this.mapUserGroupsById(user.groups);
+
+    return groupPermissions.some((permission) => {
+      const userGroup = userGroupsById[permission.key];
+
+      return (
+        userGroup &&
+        this.isMemberTypeAuthorized(userGroup) &&
+        this.isGroupDiscussable(userGroup) &&
+        (this.canAnyGroupMemberPost(permission) ||
+          this.isGroupAdminAndCanAdminsPost(userGroup, permission))
+      );
+    });
+  }
+
+  private canAnyGroupMemberPost(permission: IChannelAclPermission) {
+    const { subCategory, role } = permission;
+    return (
+      subCategory === AclSubCategory.MEMBER && this.isAuthorizedToPost(role)
+    );
+  }
+
+  private isGroupAdminAndCanAdminsPost(
+    userGroup: IGroup,
+    permission: IChannelAclPermission
+  ) {
+    const { subCategory, role } = permission;
+    const {
+      userMembership: { memberType },
+    } = userGroup;
+
+    const isGroupAdmin = memberType === "admin" || memberType === "owner";
+
+    return (
+      isGroupAdmin &&
+      subCategory === AclSubCategory.ADMIN &&
+      this.isAuthorizedToPost(role)
+    );
+  }
+
+  private aclAllowsThisUserToPostByOrg(user: IDiscussionsUser) {
+    const orgPermissions = this.permissionsByCategory[AclCategory.ORG] ?? [];
+    const { orgId: userOrgId } = user;
+
+    return orgPermissions.some((permission) => {
+      const { key } = permission;
+
+      return (
+        key === userOrgId &&
+        (this.canAnyOrgMemberPost(permission) ||
+          this.isOrgAdminAndAdminsCanPost(permission, user))
+      );
+    });
+  }
+
+  private canAnyOrgMemberPost(permission: IChannelAclPermission) {
+    const { subCategory, role } = permission;
+    return (
+      subCategory === AclSubCategory.MEMBER && this.isAuthorizedToPost(role)
+    );
+  }
+
+  private isOrgAdminAndAdminsCanPost(
+    permission: IChannelAclPermission,
+    user: IDiscussionsUser
+  ) {
+    const { subCategory, role } = permission;
+
+    return (
+      isOrgAdmin(user) &&
+      subCategory === AclSubCategory.ADMIN &&
+      this.isAuthorizedToPost(role)
+    );
+  }
+
+  private userCanAddAnonymousToAcl(user: IDiscussionsUser) {
+    if (!this.permissionsByCategory[AclCategory.ANONYMOUS_USER]) {
+      return true;
+    }
+    return isOrgAdmin(user);
+  }
+
+  private userCanAddUnauthenticatedToAcl(user: IDiscussionsUser) {
+    if (!this.permissionsByCategory[AclCategory.AUTHENTICATED_USER]) {
+      return true;
+    }
+    return isOrgAdmin(user);
+  }
+
+  private userCanAddAllGroupsToAcl(user: IDiscussionsUser) {
+    const groupPermissions = this.permissionsByCategory[AclCategory.GROUP];
+    const userGroupsById = this.mapUserGroupsById(user.groups);
+
+    if (!groupPermissions) {
+      return true;
+    }
+
+    return groupPermissions.every((permission) => {
+      const userGroup = userGroupsById[permission.key];
+
+      return (
+        userGroup &&
+        this.isMemberTypeAuthorized(userGroup) &&
+        this.isGroupDiscussable(userGroup)
+      );
+    });
+  }
+
+  private userCanAddAllOrgsToAcl(user: IDiscussionsUser) {
+    const orgPermissions = this.permissionsByCategory[AclCategory.ORG];
+
+    if (!orgPermissions) {
+      return true;
+    }
+
+    return (
+      isOrgAdmin(user) &&
+      this.isEveryPermissionForUserOrg(user.orgId, orgPermissions)
+    );
+  }
+
+  private isEveryPermissionForUserOrg(
+    userOrgId: string,
+    orgPermissions: IChannelAclPermissionDefinition[]
+  ) {
+    return orgPermissions.every((permission) => {
+      const { key: orgId } = permission;
+      return userOrgId === orgId;
+    });
+  }
+
+  // for now user permissions are disabled on channel create
+  // since users are not notified and cannot opt out
+  private userCanAddUsersToAcl(user: IDiscussionsUser) {
+    const userPermissions = this.permissionsByCategory[AclCategory.USER];
+    return !userPermissions;
+  }
+}

--- a/packages/discussions/src/utils/channel-permission.ts
+++ b/packages/discussions/src/utils/channel-permission.ts
@@ -16,13 +16,9 @@ type PermissionsByAclCategoryMap = {
 
 export class ChannelPermission {
   private readonly ALLOWED_GROUP_MEMBER_TYPES = ["owner", "admin", "member"];
-  private readonly ALLOWED_ROLES_FOR_POSTING = [
-    Role.WRITE,
-    Role.READWRITE,
-    Role.MANAGE,
-    Role.MODERATE,
-    Role.OWNER,
-  ];
+  private readonly ALLOWED_ROLES_FOR_POSTING = Object.values(Role).filter(
+    (role) => role !== Role.READ
+  );
 
   private isChannelAclEmpty: boolean;
   private permissionsByCategory: PermissionsByAclCategoryMap;
@@ -43,7 +39,7 @@ export class ChannelPermission {
       return true;
     }
 
-    if (!this.isUserLoggedIn(user)) {
+    if (this.isUserUnAuthenticated(user)) {
       return false;
     }
 
@@ -56,7 +52,7 @@ export class ChannelPermission {
   }
 
   canCreateChannel(user: IDiscussionsUser) {
-    if (!this.isUserLoggedIn(user) || this.isChannelAclEmpty) {
+    if (this.isUserUnAuthenticated(user) || this.isChannelAclEmpty) {
       return false;
     }
 
@@ -79,8 +75,8 @@ export class ChannelPermission {
     return this.ALLOWED_ROLES_FOR_POSTING.includes(role);
   }
 
-  private isUserLoggedIn(user: IDiscussionsUser) {
-    return user.username !== null;
+  private isUserUnAuthenticated(user: IDiscussionsUser) {
+    return user.username === null || user.username === undefined;
   }
 
   private mapUserGroupsById(groups: IGroup[]) {

--- a/packages/discussions/src/utils/channels/can-create-channel.ts
+++ b/packages/discussions/src/utils/channels/can-create-channel.ts
@@ -7,15 +7,11 @@ import {
   SharingAccess,
 } from "../../types";
 import { CANNOT_DISCUSS } from "../constants";
-import { isOrgAdmin } from "../platform";
+import { isOrgAdmin, mapPermissionDefinitionsByCategory } from "../platform";
 
 const ALLOWED_GROUP_ROLES = Object.freeze(["owner", "admin", "member"]);
 
 type ILegacyChannelPermissions = Pick<IChannel, "access" | "groups" | "orgs">;
-
-type PermissionsDefinitionsByAclCategoryMap = {
-  [key in AclCategory]?: IChannelAclPermissionDefinition[];
-};
 
 export function canCreateChannel(
   channel: IChannel,
@@ -44,7 +40,7 @@ function isAuthorizedToCreateByChannelAcl(
     return false;
   }
 
-  const permissions = mapByCategory(channelAcl);
+  const permissions = mapPermissionDefinitionsByCategory(channelAcl);
 
   return (
     canAllowAnonymous(user, permissions[AclCategory.ANONYMOUS_USER]) &&
@@ -53,15 +49,6 @@ function isAuthorizedToCreateByChannelAcl(
     canAllowOrgs(user, permissions[AclCategory.ORG]) &&
     canAllowUsers(user, permissions[AclCategory.USER])
   );
-}
-
-function mapByCategory(channelAcl: IChannelAclPermissionDefinition[]) {
-  return channelAcl.reduce((accum, permission) => {
-    const { category } = permission;
-
-    accum[category]?.push(permission) || (accum[category] = [permission]);
-    return accum;
-  }, {} as PermissionsDefinitionsByAclCategoryMap);
 }
 
 function canAllowAnonymous(

--- a/packages/discussions/src/utils/platform.ts
+++ b/packages/discussions/src/utils/platform.ts
@@ -1,16 +1,4 @@
 import { GroupMembership, IGroup, IUser } from "@esri/arcgis-rest-portal";
-import {
-  AclCategory,
-  IChannelAclPermission,
-  IChannelAclPermissionDefinition,
-} from "../types";
-
-type PermissionsByAclCategoryMap = {
-  [key in AclCategory]?: IChannelAclPermission[];
-};
-type PermissionDefinitionsByAclCategoryMap = {
-  [key in AclCategory]?: IChannelAclPermissionDefinition[];
-};
 
 /**
  * Utility that returns reducer function that filters a user's groups
@@ -44,31 +32,4 @@ export function reduceByGroupMembership(
 // https://github.com/Esri/arcgis-rest-js/blob/7ab072184f89dcb35367518101ee4abeb5a9d112/packages/arcgis-rest-portal/src/sharing/helpers.ts#L45
 export function isOrgAdmin(user: IUser): boolean {
   return user.role === "org_admin" && !user.roleId;
-}
-
-export function mapPermissionsByCategory(channelAcl: IChannelAclPermission[]) {
-  return channelAcl.reduce((accum: PermissionsByAclCategoryMap, permission) => {
-    const { category } = permission;
-
-    accum[category]?.push(permission) || (accum[category] = [permission]);
-    return accum;
-  }, {} as PermissionsByAclCategoryMap);
-}
-
-export function mapPermissionDefinitionsByCategory(
-  channelAcl: IChannelAclPermissionDefinition[]
-) {
-  return channelAcl.reduce((accum, permission) => {
-    const { category } = permission;
-
-    accum[category]?.push(permission) || (accum[category] = [permission]);
-    return accum;
-  }, {} as PermissionDefinitionsByAclCategoryMap);
-}
-
-export function mapUserGroupsById(groups: IGroup[]) {
-  return groups.reduce((accum, userGroup) => {
-    accum[userGroup.id] = userGroup;
-    return accum;
-  }, {} as Record<string, IGroup>);
 }

--- a/packages/discussions/src/utils/platform.ts
+++ b/packages/discussions/src/utils/platform.ts
@@ -1,4 +1,16 @@
 import { GroupMembership, IGroup, IUser } from "@esri/arcgis-rest-portal";
+import {
+  AclCategory,
+  IChannelAclPermission,
+  IChannelAclPermissionDefinition,
+} from "../types";
+
+type PermissionsByAclCategoryMap = {
+  [key in AclCategory]?: IChannelAclPermission[];
+};
+type PermissionDefinitionsByAclCategoryMap = {
+  [key in AclCategory]?: IChannelAclPermissionDefinition[];
+};
 
 /**
  * Utility that returns reducer function that filters a user's groups
@@ -32,4 +44,31 @@ export function reduceByGroupMembership(
 // https://github.com/Esri/arcgis-rest-js/blob/7ab072184f89dcb35367518101ee4abeb5a9d112/packages/arcgis-rest-portal/src/sharing/helpers.ts#L45
 export function isOrgAdmin(user: IUser): boolean {
   return user.role === "org_admin" && !user.roleId;
+}
+
+export function mapPermissionsByCategory(channelAcl: IChannelAclPermission[]) {
+  return channelAcl.reduce((accum: PermissionsByAclCategoryMap, permission) => {
+    const { category } = permission;
+
+    accum[category]?.push(permission) || (accum[category] = [permission]);
+    return accum;
+  }, {} as PermissionsByAclCategoryMap);
+}
+
+export function mapPermissionDefinitionsByCategory(
+  channelAcl: IChannelAclPermissionDefinition[]
+) {
+  return channelAcl.reduce((accum, permission) => {
+    const { category } = permission;
+
+    accum[category]?.push(permission) || (accum[category] = [permission]);
+    return accum;
+  }, {} as PermissionDefinitionsByAclCategoryMap);
+}
+
+export function mapUserGroupsById(groups: IGroup[]) {
+  return groups.reduce((accum, userGroup) => {
+    accum[userGroup.id] = userGroup;
+    return accum;
+  }, {} as Record<string, IGroup>);
 }

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -1,0 +1,774 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import {
+  AclCategory,
+  AclSubCategory,
+  IChannelAclPermission,
+  IDiscussionsUser,
+  Role,
+} from "../../src/types";
+import { ChannelPermission } from "../../src/utils/channel-permission";
+import { CANNOT_DISCUSS } from "../../src/utils/constants";
+
+const ALLOWED_GROUP_ROLES = Object.freeze(["owner", "admin", "member"]);
+const ALLOWED_ROLES_FOR_POSTING = Object.freeze([
+  Role.WRITE,
+  Role.READWRITE,
+  Role.MANAGE,
+  Role.MODERATE,
+  Role.OWNER,
+]);
+
+const orgId1 = "3ef";
+const groupId1 = "aaa";
+const groupId2 = "bbb";
+const groupId3 = "ccc";
+
+function buildUser(overrides = {}) {
+  const defaultUser = {
+    username: "john",
+    orgId: orgId1,
+    role: "org_user",
+    groups: [buildGroup(groupId1, "member"), buildGroup(groupId2, "admin")],
+  };
+
+  return { ...defaultUser, ...overrides } as IDiscussionsUser;
+}
+
+function buildGroup(id: string, memberType: string, typeKeywords?: string[]) {
+  return {
+    id,
+    userMembership: { memberType },
+    typeKeywords,
+  } as any as IGroup;
+}
+
+function buildCompleteAcl() {
+  return [
+    { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
+    { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
+    {
+      category: AclCategory.GROUP,
+      subCategory: AclSubCategory.ADMIN,
+      key: groupId1,
+      role: Role.OWNER,
+    },
+    {
+      category: AclCategory.GROUP,
+      subCategory: AclSubCategory.MEMBER,
+      key: groupId2,
+      role: Role.READ,
+    },
+    {
+      category: AclCategory.ORG,
+      subCategory: AclSubCategory.ADMIN,
+      key: orgId1,
+      role: Role.OWNER,
+    },
+    {
+      category: AclCategory.ORG,
+      subCategory: AclSubCategory.MEMBER,
+      key: orgId1,
+      role: Role.READ,
+    },
+    // this permission currently disabled on channel create
+    // { category: AclCategory.USER, key: 'bob', role: Role.READ },
+  ];
+}
+
+describe("ChannelPermission class", () => {
+  describe("canPostToChannel", () => {
+    describe("all cases", () => {
+      it("returns false if user logged in and channel permissions are empty", async () => {
+        const user = buildUser();
+        const channelAcl = [] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(false);
+      });
+
+      it("returns false if user not logged in and channel permissions are empty", async () => {
+        const user = buildUser({ username: null });
+        const channelAcl = [] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(false);
+      });
+    });
+
+    describe("any anonymous user channel permissions", () => {
+      it(`returns true if anonymous permission defined and role is allowed`, () => {
+        const user = buildUser({ username: null });
+
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channelAcl = [
+            { category: AclCategory.ANONYMOUS_USER, role: allowedRole },
+          ] as IChannelAclPermission[];
+
+          const channelPermission = new ChannelPermission(channelAcl);
+
+          expect(channelPermission.canPostToChannel(user)).toBe(true);
+        });
+      });
+
+      it("returns false if anonymous permission defined but role is read", () => {
+        const user = buildUser({ username: null });
+        const channelAcl = [
+          { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(false);
+      });
+    });
+
+    describe("any authenticated user channel permissions", () => {
+      it(`returns true if authenticated permission defined, user logged in, and role is allowed`, async () => {
+        const user = buildUser();
+
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channelAcl = [
+            { category: AclCategory.AUTHENTICATED_USER, role: allowedRole },
+          ] as IChannelAclPermission[];
+
+          const channelPermission = new ChannelPermission(channelAcl);
+
+          expect(channelPermission.canPostToChannel(user)).toBe(true);
+        });
+      });
+
+      it("returns false if authenticated permission defined, user logged in, and role is read", async () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(false);
+      });
+
+      it("returns false if authenticated permission defined and user is not logged in", async () => {
+        const user = buildUser({ username: null });
+        const channelAcl = [
+          { category: AclCategory.AUTHENTICATED_USER, role: Role.READWRITE },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(false);
+      });
+    });
+
+    describe("specific authenticated user channel permissions", () => {
+      it("returns true if user is in permissions list and role is allowed", () => {
+        const user = buildUser();
+
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channelAcl = [
+            {
+              category: AclCategory.USER,
+              key: user.username,
+              role: allowedRole,
+            },
+          ] as IChannelAclPermission[];
+
+          const channelPermission = new ChannelPermission(channelAcl);
+
+          expect(channelPermission.canPostToChannel(user)).toBe(true);
+        });
+      });
+
+      it("returns false if user is in permissions list but role is read", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(false);
+      });
+    });
+
+    describe("group channel permissions", () => {
+      it("returns true if user is group member in group permission list and role is allowed", async () => {
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channelAcl = [
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.MEMBER,
+              key: groupId1,
+              role: allowedRole, // members write
+            },
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.ADMIN,
+              key: groupId1,
+              role: Role.READ,
+            },
+          ] as IChannelAclPermission[];
+
+          ALLOWED_GROUP_ROLES.forEach((memberType) => {
+            const user = buildUser({
+              orgId: orgId1,
+              groups: [buildGroup(groupId1, memberType)], // member in groupId1
+            });
+
+            const channelPermission = new ChannelPermission(channelAcl);
+
+            expect(channelPermission.canPostToChannel(user)).toBe(true);
+          });
+        });
+      });
+
+      it("returns false if user is group member in group permission list and role is NOT allowed", async () => {
+        const user = buildUser(); // member in groupId1
+        const channelAcl = [
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.MEMBER,
+            key: groupId1,
+            role: Role.READ, // members read
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: groupId1,
+            role: Role.READ,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(false);
+      });
+
+      it("returns false if user is group member in group permission list, role is allowed, but userMemberType is none", async () => {
+        const user = buildUser({
+          groups: [buildGroup(groupId1, "none")], // none in groupId1
+        });
+        const channelAcl = [
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.MEMBER,
+            key: groupId1,
+            role: Role.READWRITE, // members read
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: groupId1,
+            role: Role.READWRITE, // admins read
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(false);
+      });
+
+      it("returns true if user is group owner/admin in group permission list and role is allowed", async () => {
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channelAcl = [
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.MEMBER,
+              key: groupId1,
+              role: Role.READ,
+            },
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.ADMIN,
+              key: groupId1,
+              role: allowedRole, // admins write
+            },
+          ] as IChannelAclPermission[];
+
+          ["owner", "admin"].forEach((memberType) => {
+            const user = buildUser({
+              orgId: orgId1,
+              groups: [buildGroup(groupId1, memberType)], // admin in groupId1
+            });
+
+            const channelPermission = new ChannelPermission(channelAcl);
+
+            expect(channelPermission.canPostToChannel(user)).toBe(true);
+          });
+        });
+      });
+
+      it("returns false if user is group owner/admin in group permission list and role is NOT allowed", async () => {
+        const user = buildUser(); // admin in groupId2
+        const channelAcl = [
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.MEMBER,
+            key: groupId2,
+            role: Role.READ,
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: groupId2,
+            role: Role.READ, // admins read
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(false);
+      });
+
+      it("returns true if user is group member of at least one group in permissions list that is discussable", async () => {
+        const user = buildUser({
+          orgId: orgId1,
+          groups: [
+            buildGroup(groupId1, "member"), // member in groupId1
+            buildGroup(groupId2, "member", [CANNOT_DISCUSS]), // member in groupId2
+          ],
+        });
+        const channelAcl = [
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.MEMBER,
+            key: groupId1,
+            role: Role.READWRITE, // members write
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: groupId1,
+            role: Role.READ,
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.MEMBER,
+            key: groupId2,
+            role: Role.READWRITE, // members write, group CANNOT_DISCUSS
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: groupId2,
+            role: Role.READ,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(true);
+      });
+
+      it("returns false if user is group member in permissions list but the group is not discussable", async () => {
+        const user = buildUser({
+          orgId: orgId1,
+          groups: [
+            buildGroup(groupId1, "member", [CANNOT_DISCUSS]), // member in groupId1
+          ],
+        });
+        const channelAcl = [
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.MEMBER,
+            key: groupId1,
+            role: Role.READWRITE, // members write
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: groupId1,
+            role: Role.READ,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(false);
+      });
+
+      it("returns false if user is group admin but group is not in permissions list", async () => {
+        const user = buildUser({
+          orgId: orgId1,
+          groups: [
+            buildGroup("unknownGroupId", "admin"), // member in unknownGroupId
+          ],
+        });
+        const channelAcl = [
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.MEMBER,
+            key: groupId1,
+            role: Role.READWRITE, // members write
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: groupId1,
+            role: Role.READWRITE, // admin write
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(false);
+      });
+    });
+
+    describe("org channel permissions", () => {
+      it("returns true if user is org member in permissions list and role is allowed", async () => {
+        const user = buildUser();
+
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channelAcl = [
+            {
+              category: AclCategory.ORG,
+              subCategory: AclSubCategory.MEMBER,
+              key: user.orgId,
+              role: allowedRole, // members write
+            },
+            {
+              category: AclCategory.ORG,
+              subCategory: AclSubCategory.ADMIN,
+              key: user.orgId,
+              role: Role.READ, // admin read
+            },
+          ] as IChannelAclPermission[];
+
+          const channelPermission = new ChannelPermission(channelAcl);
+
+          expect(channelPermission.canPostToChannel(user)).toBe(true);
+        });
+      });
+
+      it("returns true if user is org_admin in permissions list and role is allowed", async () => {
+        const user = buildUser({ role: "org_admin" });
+
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channelAcl = [
+            {
+              category: AclCategory.ORG,
+              subCategory: AclSubCategory.MEMBER,
+              key: user.orgId,
+              role: Role.READ, // members read
+            },
+            {
+              category: AclCategory.ORG,
+              subCategory: AclSubCategory.ADMIN,
+              key: user.orgId,
+              role: Role.READWRITE, // admin write
+            },
+          ] as IChannelAclPermission[];
+
+          const channelPermission = new ChannelPermission(channelAcl);
+
+          expect(channelPermission.canPostToChannel(user)).toBe(true);
+        });
+      });
+
+      it("returns false if user is not in the org", async () => {
+        const user = buildUser({ orgId: "unknownOrgId" });
+        const channelAcl = [
+          {
+            category: AclCategory.ORG,
+            subCategory: AclSubCategory.MEMBER,
+            key: orgId1,
+            role: Role.READ, // members read
+          },
+          {
+            category: AclCategory.ORG,
+            subCategory: AclSubCategory.ADMIN,
+            key: orgId1,
+            role: Role.READWRITE, // admin write
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(false);
+      });
+    });
+  });
+
+  describe("canCreateChannel", () => {
+    describe("all permissions cases", () => {
+      it("returns false if user not authenticated", () => {
+        const user = buildUser({ username: null });
+        const channelAcl = [
+          { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(false);
+      });
+
+      it("returns false if permissions list is empty", () => {
+        const user = buildUser();
+        const channelAcl = [] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(false);
+      });
+
+      it("returns true with a full valid channelAcl if user is the org_admin, in all groups, and org permissions only relate to users org", () => {
+        const user = buildUser({ role: "org_admin" });
+        const channelAcl = buildCompleteAcl() as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(true);
+      });
+    });
+
+    describe("Anonymous User Permissions", () => {
+      it("returns true if user is org_admin", () => {
+        const user = buildUser({ role: "org_admin" });
+        const channelAcl = [
+          { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(true);
+      });
+
+      it("returns false if user is not org_admin", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(false);
+      });
+    });
+
+    describe("Authenticated User Permissions", () => {
+      it("returns true if user is org_admin", () => {
+        const user = buildUser({ role: "org_admin" });
+        const channelAcl = [
+          { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(true);
+      });
+
+      it("returns false if user is not org_admin", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(false);
+      });
+    });
+
+    describe("Group Permissions", () => {
+      it("returns true if user is a member of all groups and memberType is member, admin, or owner", async () => {
+        const user = buildUser({
+          groups: [
+            buildGroup(groupId1, "member"),
+            buildGroup(groupId2, "admin"),
+            buildGroup(groupId3, "owner"),
+          ],
+        });
+        const channelAcl = [
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: groupId1,
+            role: Role.OWNER,
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.MEMBER,
+            key: groupId2,
+            role: Role.READ,
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.MEMBER,
+            key: groupId3,
+            role: Role.READ,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(true);
+      });
+
+      it("returns false is user is a member of all groups and memberType is none", async () => {
+        const user = buildUser({
+          groups: [buildGroup(groupId1, "admin"), buildGroup(groupId2, "none")],
+        });
+        const channelAcl = [
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: groupId1,
+            role: Role.OWNER,
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.MEMBER,
+            key: groupId2,
+            role: Role.READ,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(false);
+      });
+
+      it("returns false is user is a member of all groups but group is not discussable", async () => {
+        const user = buildUser({
+          groups: [
+            buildGroup(groupId1, "admin"),
+            buildGroup(groupId2, "member", [CANNOT_DISCUSS]),
+          ],
+        });
+        const channelAcl = [
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: groupId1,
+            role: Role.OWNER,
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.MEMBER,
+            key: groupId2,
+            role: Role.READ,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(false);
+      });
+
+      it("returns false if user is not a member of every group", async () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: groupId1,
+            role: Role.READWRITE,
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: groupId2,
+            role: Role.READWRITE,
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: groupId3, // user not member here
+            role: Role.READWRITE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(false);
+      });
+    });
+
+    describe("Org Permissions", () => {
+      it("returns true if user is org_admin and every permission is for the users orgId", () => {
+        const user = buildUser({ role: "org_admin" });
+        const channelAcl = [
+          {
+            category: AclCategory.ORG,
+            subCategory: AclSubCategory.ADMIN,
+            key: orgId1,
+            role: Role.OWNER,
+          },
+          {
+            category: AclCategory.ORG,
+            subCategory: AclSubCategory.MEMBER,
+            key: orgId1,
+            role: Role.READ,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(true);
+      });
+
+      it("returns false if user is org_admin and every permission is not for the users orgId", () => {
+        const user = buildUser({ role: "org_admin" });
+        const channelAcl = [
+          {
+            category: AclCategory.ORG,
+            subCategory: AclSubCategory.ADMIN,
+            key: orgId1,
+            role: Role.OWNER,
+          },
+          {
+            category: AclCategory.ORG,
+            subCategory: AclSubCategory.MEMBER,
+            key: "unknown",
+            role: Role.READ,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(false);
+      });
+
+      it("returns false if user is not org_admin", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.ORG,
+            subCategory: AclSubCategory.ADMIN,
+            key: orgId1,
+            role: Role.OWNER,
+          },
+          {
+            category: AclCategory.ORG,
+            subCategory: AclSubCategory.MEMBER,
+            key: orgId1,
+            role: Role.READ,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(false);
+      });
+    });
+
+    describe("User Permissions", () => {
+      it("returns false if user permissions are included", () => {
+        const user = buildUser({ role: "org_admin" });
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: "johnUsername",
+            role: Role.READ,
+          },
+        ] as IChannelAclPermission[];
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(false);
+      });
+    });
+  });
+});

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -77,7 +77,7 @@ function buildCompleteAcl() {
 
 describe("ChannelPermission class", () => {
   describe("canPostToChannel", () => {
-    describe("all cases", () => {
+    describe("all permission cases", () => {
       it("returns false if user logged in and channel permissions are empty", async () => {
         const user = buildUser();
         const channelAcl = [] as IChannelAclPermission[];
@@ -97,7 +97,7 @@ describe("ChannelPermission class", () => {
       });
     });
 
-    describe("any anonymous user channel permissions", () => {
+    describe("Anonymous User Permissions", () => {
       it(`returns true if anonymous permission defined and role is allowed`, () => {
         const user = buildUser({ username: null });
 
@@ -124,7 +124,7 @@ describe("ChannelPermission class", () => {
       });
     });
 
-    describe("any authenticated user channel permissions", () => {
+    describe("Authenticated User Permissions", () => {
       it(`returns true if authenticated permission defined, user logged in, and role is allowed`, async () => {
         const user = buildUser();
 
@@ -162,38 +162,7 @@ describe("ChannelPermission class", () => {
       });
     });
 
-    describe("specific authenticated user channel permissions", () => {
-      it("returns true if user is in permissions list and role is allowed", () => {
-        const user = buildUser();
-
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channelAcl = [
-            {
-              category: AclCategory.USER,
-              key: user.username,
-              role: allowedRole,
-            },
-          ] as IChannelAclPermission[];
-
-          const channelPermission = new ChannelPermission(channelAcl);
-
-          expect(channelPermission.canPostToChannel(user)).toBe(true);
-        });
-      });
-
-      it("returns false if user is in permissions list but role is read", () => {
-        const user = buildUser();
-        const channelAcl = [
-          { category: AclCategory.USER, key: user.username, role: Role.READ },
-        ] as IChannelAclPermission[];
-
-        const channelPermission = new ChannelPermission(channelAcl);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(false);
-      });
-    });
-
-    describe("group channel permissions", () => {
+    describe("Group Permissions", () => {
       it("returns true if user is group member in group permission list and role is allowed", async () => {
         ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
           const channelAcl = [
@@ -417,7 +386,7 @@ describe("ChannelPermission class", () => {
       });
     });
 
-    describe("org channel permissions", () => {
+    describe("Org Permissions", () => {
       it("returns true if user is org member in permissions list and role is allowed", async () => {
         const user = buildUser();
 
@@ -483,6 +452,37 @@ describe("ChannelPermission class", () => {
             key: orgId1,
             role: Role.READWRITE, // admin write
           },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl);
+
+        expect(channelPermission.canPostToChannel(user)).toBe(false);
+      });
+    });
+
+    describe("User Permissions", () => {
+      it("returns true if user is in permissions list and role is allowed", () => {
+        const user = buildUser();
+
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channelAcl = [
+            {
+              category: AclCategory.USER,
+              key: user.username,
+              role: allowedRole,
+            },
+          ] as IChannelAclPermission[];
+
+          const channelPermission = new ChannelPermission(channelAcl);
+
+          expect(channelPermission.canPostToChannel(user)).toBe(true);
+        });
+      });
+
+      it("returns false if user is in permissions list but role is read", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ },
         ] as IChannelAclPermission[];
 
         const channelPermission = new ChannelPermission(channelAcl);

--- a/packages/discussions/test/utils/channels/can-create-channel.test.ts
+++ b/packages/discussions/test/utils/channels/can-create-channel.test.ts
@@ -7,6 +7,7 @@ import {
   Role,
   SharingAccess,
 } from "../../../src/types";
+import { ChannelPermission } from "../../../src/utils/channel-permission";
 import { canCreateChannel } from "../../../src/utils/channels";
 import { CANNOT_DISCUSS } from "../../../src/utils/constants";
 
@@ -68,279 +69,48 @@ function buildCompleteAcl() {
 }
 
 describe("canCreateChannel", () => {
-  describe("With ChannelAcl Permissions", () => {
-    it("returns false if user not authenticated", () => {
+  describe("with channelAcl", () => {
+    let canCreateChannelSpy: jasmine.Spy;
+
+    beforeAll(() => {
+      canCreateChannelSpy = spyOn(
+        ChannelPermission.prototype,
+        "canCreateChannel"
+      );
+    });
+
+    beforeEach(() => {
+      canCreateChannelSpy.calls.reset();
+    });
+
+    it("return true if channelPermission.canCreateChannel is true", () => {
+      canCreateChannelSpy.and.callFake(() => true);
+
+      const user = buildUser();
       const channel = {
         channelAcl: [{ category: AclCategory.ANONYMOUS_USER, role: Role.READ }],
       } as IChannel;
-      const user = buildUser({ username: null });
 
-      expect(canCreateChannel(channel, user)).toEqual(false);
+      expect(canCreateChannel(channel, user)).toBe(true);
+
+      expect(canCreateChannelSpy.calls.count()).toBe(1);
+      const [arg] = canCreateChannelSpy.calls.allArgs()[0]; // arg for 1st call
+      expect(arg).toBe(user);
     });
 
-    it("returns false if permissions list is empty", () => {
-      const channel = { channelAcl: [] } as unknown as IChannel;
+    it("return false if channelPermission.canCreateChannel is false", () => {
+      canCreateChannelSpy.and.callFake(() => false);
+
       const user = buildUser();
+      const channel = {
+        channelAcl: [{ category: AclCategory.ANONYMOUS_USER, role: Role.READ }],
+      } as IChannel;
 
-      expect(canCreateChannel(channel, user)).toEqual(false);
-    });
+      expect(canCreateChannel(channel, user)).toBe(false);
 
-    it("returns true with a full valid channelAcl if user is the org_admin, in all groups, and org permissions only relate to users org", () => {
-      const channel = { channelAcl: buildCompleteAcl() } as IChannel;
-      const user = buildUser({ role: "org_admin" });
-
-      expect(canCreateChannel(channel, user)).toEqual(true);
-    });
-
-    describe("Anonymous User Permissions", () => {
-      it("returns true if user is org_admin", () => {
-        const channel = {
-          channelAcl: [
-            { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
-          ],
-        } as IChannel;
-        const user = buildUser({ role: "org_admin" });
-
-        expect(canCreateChannel(channel, user)).toEqual(true);
-      });
-
-      it("returns false if user is not org_admin", () => {
-        const channel = {
-          channelAcl: [
-            { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
-          ],
-        } as IChannel;
-        const user = buildUser();
-
-        expect(canCreateChannel(channel, user)).toEqual(false);
-      });
-    });
-
-    describe("Authenticated User Permissions", () => {
-      it("returns true if user is org_admin", () => {
-        const channel = {
-          channelAcl: [
-            { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
-          ],
-        } as IChannel;
-        const user = buildUser({ role: "org_admin" });
-
-        expect(canCreateChannel(channel, user)).toEqual(true);
-      });
-
-      it("returns false if user is not org_admin", () => {
-        const channel = {
-          channelAcl: [
-            { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
-          ],
-        } as IChannel;
-        const user = buildUser();
-
-        expect(canCreateChannel(channel, user)).toEqual(false);
-      });
-    });
-
-    describe("Group Permissions", () => {
-      it("returns true if user is a member of all groups and memberType is member, admin, or owner", async () => {
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId1,
-              role: Role.OWNER,
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.MEMBER,
-              key: groupId2,
-              role: Role.READ,
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.MEMBER,
-              key: groupId3,
-              role: Role.READ,
-            },
-          ],
-        } as IChannel;
-        const user = buildUser({
-          groups: [
-            buildGroup(groupId1, "member"),
-            buildGroup(groupId2, "admin"),
-            buildGroup(groupId3, "owner"),
-          ],
-        });
-
-        expect(canCreateChannel(channel, user)).toEqual(true);
-      });
-
-      it("returns false is user is a member of all groups and memberType is none", async () => {
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId1,
-              role: Role.OWNER,
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.MEMBER,
-              key: groupId2,
-              role: Role.READ,
-            },
-          ],
-        } as IChannel;
-        const user = buildUser({
-          groups: [buildGroup(groupId1, "admin"), buildGroup(groupId2, "none")],
-        });
-
-        expect(canCreateChannel(channel, user)).toEqual(false);
-      });
-
-      it("returns false is user is a member of all groups but group is not discussable", async () => {
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId1,
-              role: Role.OWNER,
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.MEMBER,
-              key: groupId2,
-              role: Role.READ,
-            },
-          ],
-        } as IChannel;
-        const user = buildUser({
-          groups: [
-            buildGroup(groupId1, "admin"),
-            buildGroup(groupId2, "member", [CANNOT_DISCUSS]),
-          ],
-        });
-
-        expect(canCreateChannel(channel, user)).toEqual(false);
-      });
-
-      it("returns false if user is not a member of every group", async () => {
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId1,
-              role: Role.READWRITE,
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId2,
-              role: Role.READWRITE,
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId3, // user not member here
-              role: Role.READWRITE,
-            },
-          ],
-        } as IChannel;
-        const user = buildUser();
-
-        expect(canCreateChannel(channel, user)).toEqual(false);
-      });
-    });
-
-    describe("Org Permissions", () => {
-      it("returns true if user is org_admin and every permission is for the users orgId", () => {
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.ORG,
-              subCategory: AclSubCategory.ADMIN,
-              key: orgId1,
-              role: Role.OWNER,
-            },
-            {
-              category: AclCategory.ORG,
-              subCategory: AclSubCategory.MEMBER,
-              key: orgId1,
-              role: Role.READ,
-            },
-          ],
-        } as IChannel;
-        const user = buildUser({ role: "org_admin" });
-
-        expect(canCreateChannel(channel, user)).toEqual(true);
-      });
-
-      it("returns false if user is org_admin and every permission is not for the users orgId", () => {
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.ORG,
-              subCategory: AclSubCategory.ADMIN,
-              key: orgId1,
-              role: Role.OWNER,
-            },
-            {
-              category: AclCategory.ORG,
-              subCategory: AclSubCategory.MEMBER,
-              key: "unknown",
-              role: Role.READ,
-            },
-          ],
-        } as IChannel;
-        const user = buildUser({ role: "org_admin" });
-
-        expect(canCreateChannel(channel, user)).toEqual(false);
-      });
-
-      it("returns false if user is not org_admin", () => {
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.ORG,
-              subCategory: AclSubCategory.ADMIN,
-              key: orgId1,
-              role: Role.OWNER,
-            },
-            {
-              category: AclCategory.ORG,
-              subCategory: AclSubCategory.MEMBER,
-              key: orgId1,
-              role: Role.READ,
-            },
-          ],
-        } as IChannel;
-        const user = buildUser();
-
-        expect(canCreateChannel(channel, user)).toEqual(false);
-      });
-    });
-
-    describe("User Permissions", () => {
-      it("returns false if user permissions are included", () => {
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.USER,
-              key: "johnUsername",
-              role: Role.READ,
-            },
-          ],
-        } as IChannel;
-        const user = buildUser({ role: "org_admin" });
-
-        expect(canCreateChannel(channel, user)).toEqual(false);
-      });
+      expect(canCreateChannelSpy.calls.count()).toBe(1);
     });
   });
-
   describe("With Legacy Permissions", () => {
     it("returns false if user not authenticated", () => {
       const channel = {

--- a/packages/discussions/test/utils/channels/can-post-to-channel.test.ts
+++ b/packages/discussions/test/utils/channels/can-post-to-channel.test.ts
@@ -1,5 +1,46 @@
-import { IChannel, IDiscussionsUser } from "../../../src/types";
+import { IGroup } from "@esri/arcgis-rest-types";
+import {
+  AclCategory,
+  AclSubCategory,
+  IChannel,
+  IDiscussionsUser,
+  Role,
+} from "../../../src/types";
 import { canPostToChannel } from "../../../src/utils/channels/can-post-to-channel";
+import { CANNOT_DISCUSS } from "../../../src/utils/constants";
+
+const ALLOWED_GROUP_ROLES = Object.freeze(["owner", "admin", "member"]);
+
+const ALLOWED_ROLES_FOR_POSTING = Object.freeze([
+  Role.WRITE,
+  Role.READWRITE,
+  Role.MANAGE,
+  Role.MODERATE,
+  Role.OWNER,
+]);
+
+const orgId1 = "3ef";
+const groupId1 = "aaa";
+const groupId2 = "bbb";
+
+function buildUser(overrides = {}) {
+  const defaultUser = {
+    username: "john",
+    orgId: orgId1,
+    role: "org_user",
+    groups: [buildGroup(groupId1, "member"), buildGroup(groupId2, "admin")],
+  };
+
+  return { ...defaultUser, ...overrides } as IDiscussionsUser;
+}
+
+function buildGroup(id: string, memberType: string, typeKeywords?: string[]) {
+  return {
+    id,
+    userMembership: { memberType },
+    typeKeywords,
+  } as any as IGroup;
+}
 
 describe("canPostToChannel", () => {
   describe("with ACL", () => {
@@ -415,6 +456,420 @@ describe("canPostToChannel", () => {
           orgId: "abc",
           role: "org_member",
         } as any;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+    });
+  });
+
+  describe("with channelAcl", () => {
+    it("returns false if user logged in and channel permissions are empty", async () => {
+      const user = buildUser();
+      const channel = {
+        channelAcl: [],
+      } as any as IChannel;
+
+      expect(canPostToChannel(channel, user)).toBe(false);
+    });
+
+    it("returns false if user not logged in and channel permissions are empty", async () => {
+      const user = buildUser({ username: null });
+      const channel = {
+        channelAcl: [],
+      } as any as IChannel;
+
+      expect(canPostToChannel(channel, user)).toBe(false);
+    });
+
+    describe("any anonymous user channel permissions", () => {
+      it(`returns true if anonymous permission defined and role is allowed`, () => {
+        const user = buildUser({ username: null });
+
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channel = {
+            channelAcl: [
+              { category: AclCategory.ANONYMOUS_USER, role: allowedRole },
+            ],
+          } as IChannel;
+
+          expect(canPostToChannel(channel, user)).toBe(true);
+        });
+      });
+
+      it("returns false if anonymous permission defined but role is read", () => {
+        const user = buildUser({ username: null });
+        const channel = {
+          channelAcl: [
+            { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
+          ],
+        } as IChannel;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+    });
+
+    describe("any authenticated user channel permissions", () => {
+      it(`returns true if authenticated permission defined, user logged in, and role is allowed`, async () => {
+        const user = buildUser();
+
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channel = {
+            channelAcl: [
+              { category: AclCategory.AUTHENTICATED_USER, role: allowedRole },
+            ],
+          } as IChannel;
+
+          expect(canPostToChannel(channel, user)).toBe(true);
+        });
+      });
+
+      it("returns false if authenticated permission defined, user logged in, and role is read", async () => {
+        const user = buildUser();
+        const channel = {
+          channelAcl: [
+            { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
+          ],
+        } as IChannel;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+
+      it("returns false if authenticated permission defined and user is not logged in", async () => {
+        const user = buildUser({ username: null });
+        const channel = {
+          channelAcl: [
+            { category: AclCategory.AUTHENTICATED_USER, role: Role.READWRITE },
+          ],
+        } as IChannel;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+    });
+
+    describe("specific authenticated user channel permissions", () => {
+      it("returns true if user is in permissions list and role is allowed", () => {
+        const user = buildUser();
+
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channel = {
+            channelAcl: [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              },
+            ],
+          } as IChannel;
+
+          expect(canPostToChannel(channel, user)).toBe(true);
+        });
+      });
+
+      it("returns false if user is in permissions list but role is read", () => {
+        const user = buildUser();
+        const channel = {
+          channelAcl: [
+            { category: AclCategory.USER, key: user.username, role: Role.READ },
+          ],
+        } as IChannel;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+    });
+
+    describe("group channel permissions", () => {
+      it("returns true if user is group member in group permission list and role is allowed", async () => {
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channel = {
+            channelAcl: [
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.MEMBER,
+                key: groupId1,
+                role: allowedRole, // members write
+              },
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: groupId1,
+                role: Role.READ,
+              },
+            ],
+          } as IChannel;
+
+          ALLOWED_GROUP_ROLES.forEach((memberType) => {
+            const user = buildUser({
+              orgId: orgId1,
+              groups: [buildGroup(groupId1, memberType)], // member in groupId1
+            });
+
+            expect(canPostToChannel(channel, user)).toBe(true);
+          });
+        });
+      });
+
+      it("returns false if user is group member in group permission list and role is NOT allowed", async () => {
+        const user = buildUser(); // member in groupId1
+        const channel = {
+          channelAcl: [
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.MEMBER,
+              key: groupId1,
+              role: Role.READ, // members read
+            },
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.ADMIN,
+              key: groupId1,
+              role: Role.READ,
+            },
+          ],
+        } as IChannel;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+
+      it("returns false if user is group member in group permission list, role is allowed, but userMemberType is none", async () => {
+        const user = buildUser({
+          groups: [buildGroup(groupId1, "none")], // none in groupId1
+        });
+        const channel = {
+          channelAcl: [
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.MEMBER,
+              key: groupId1,
+              role: Role.READWRITE, // members read
+            },
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.ADMIN,
+              key: groupId1,
+              role: Role.READWRITE, // admins read
+            },
+          ],
+        } as IChannel;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+
+      it("returns true if user is group owner/admin in group permission list and role is allowed", async () => {
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channel = {
+            channelAcl: [
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.MEMBER,
+                key: groupId1,
+                role: Role.READ,
+              },
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: groupId1,
+                role: allowedRole, // admins write
+              },
+            ],
+          } as IChannel;
+
+          ["owner", "admin"].forEach((memberType) => {
+            const user = buildUser({
+              orgId: orgId1,
+              groups: [buildGroup(groupId1, memberType)], // admin in groupId1
+            });
+
+            expect(canPostToChannel(channel, user)).toBe(true);
+          });
+        });
+      });
+
+      it("returns false if user is group owner/admin in group permission list and role is NOT allowed", async () => {
+        const user = buildUser(); // admin in groupId2
+        const channel = {
+          channelAcl: [
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.MEMBER,
+              key: groupId2,
+              role: Role.READ,
+            },
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.ADMIN,
+              key: groupId2,
+              role: Role.READ, // admins read
+            },
+          ],
+        } as IChannel;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+
+      it("returns true if user is group member of at least one group in permissions list that is discussable", async () => {
+        const user = buildUser({
+          orgId: orgId1,
+          groups: [
+            buildGroup(groupId1, "member"), // member in groupId1
+            buildGroup(groupId2, "member", [CANNOT_DISCUSS]), // member in groupId2
+          ],
+        });
+        const channel = {
+          channelAcl: [
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.MEMBER,
+              key: groupId1,
+              role: Role.READWRITE, // members write
+            },
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.ADMIN,
+              key: groupId1,
+              role: Role.READ,
+            },
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.MEMBER,
+              key: groupId2,
+              role: Role.READWRITE, // members write, group CANNOT_DISCUSS
+            },
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.ADMIN,
+              key: groupId2,
+              role: Role.READ,
+            },
+          ],
+        } as IChannel;
+
+        expect(canPostToChannel(channel, user)).toBe(true);
+      });
+
+      it("returns false if user is group member in permissions list but the group is not discussable", async () => {
+        const user = buildUser({
+          orgId: orgId1,
+          groups: [
+            buildGroup(groupId1, "member", [CANNOT_DISCUSS]), // member in groupId1
+          ],
+        });
+        const channel = {
+          channelAcl: [
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.MEMBER,
+              key: groupId1,
+              role: Role.READWRITE, // members write
+            },
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.ADMIN,
+              key: groupId1,
+              role: Role.READ,
+            },
+          ],
+        } as IChannel;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+
+      it("returns false if user is group admin but group is not in permissions list", async () => {
+        const user = buildUser({
+          orgId: orgId1,
+          groups: [
+            buildGroup("unknownGroupId", "admin"), // member in unknownGroupId
+          ],
+        });
+        const channel = {
+          channelAcl: [
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.MEMBER,
+              key: groupId1,
+              role: Role.READWRITE, // members write
+            },
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.ADMIN,
+              key: groupId1,
+              role: Role.READWRITE, // admin write
+            },
+          ],
+        } as IChannel;
+
+        expect(canPostToChannel(channel, user)).toBe(false);
+      });
+    });
+
+    describe("org channel permissions", () => {
+      it("returns true if user is org member in permissions list and role is allowed", async () => {
+        const user = buildUser();
+
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channel = {
+            channelAcl: [
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.MEMBER,
+                key: user.orgId,
+                role: allowedRole, // members write
+              },
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: user.orgId,
+                role: Role.READ, // admin read
+              },
+            ],
+          } as IChannel;
+
+          expect(canPostToChannel(channel, user)).toBe(true);
+        });
+      });
+
+      it("returns true if user is org_admin in permissions list and role is allowed", async () => {
+        const user = buildUser({ role: "org_admin" });
+
+        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
+          const channel = {
+            channelAcl: [
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.MEMBER,
+                key: user.orgId,
+                role: Role.READ, // members read
+              },
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: user.orgId,
+                role: Role.READWRITE, // admin write
+              },
+            ],
+          } as IChannel;
+
+          expect(canPostToChannel(channel, user)).toBe(true);
+        });
+      });
+
+      it("returns false if user is not in the org", async () => {
+        const user = buildUser({ orgId: "unknownOrgId" });
+        const channel = {
+          channelAcl: [
+            {
+              category: AclCategory.ORG,
+              subCategory: AclSubCategory.MEMBER,
+              key: orgId1,
+              role: Role.READ, // members read
+            },
+            {
+              category: AclCategory.ORG,
+              subCategory: AclSubCategory.ADMIN,
+              key: orgId1,
+              role: Role.READWRITE, // admin write
+            },
+          ],
+        } as IChannel;
 
         expect(canPostToChannel(channel, user)).toBe(false);
       });

--- a/packages/discussions/test/utils/channels/can-post-to-channel.test.ts
+++ b/packages/discussions/test/utils/channels/can-post-to-channel.test.ts
@@ -1,23 +1,12 @@
 import { IGroup } from "@esri/arcgis-rest-types";
 import {
   AclCategory,
-  AclSubCategory,
   IChannel,
   IDiscussionsUser,
   Role,
 } from "../../../src/types";
+import { ChannelPermission } from "../../../src/utils/channel-permission";
 import { canPostToChannel } from "../../../src/utils/channels/can-post-to-channel";
-import { CANNOT_DISCUSS } from "../../../src/utils/constants";
-
-const ALLOWED_GROUP_ROLES = Object.freeze(["owner", "admin", "member"]);
-
-const ALLOWED_ROLES_FOR_POSTING = Object.freeze([
-  Role.WRITE,
-  Role.READWRITE,
-  Role.MANAGE,
-  Role.MODERATE,
-  Role.OWNER,
-]);
 
 const orgId1 = "3ef";
 const groupId1 = "aaa";
@@ -463,416 +452,45 @@ describe("canPostToChannel", () => {
   });
 
   describe("with channelAcl", () => {
-    it("returns false if user logged in and channel permissions are empty", async () => {
+    let canPostToChannelSpy: jasmine.Spy;
+
+    beforeAll(() => {
+      canPostToChannelSpy = spyOn(
+        ChannelPermission.prototype,
+        "canPostToChannel"
+      );
+    });
+
+    beforeEach(() => {
+      canPostToChannelSpy.calls.reset();
+    });
+
+    it("return true if channelPermission.canPostToChannel is true", () => {
+      canPostToChannelSpy.and.callFake(() => true);
+
       const user = buildUser();
       const channel = {
-        channelAcl: [],
-      } as any as IChannel;
+        channelAcl: [{ category: AclCategory.ANONYMOUS_USER, role: Role.READ }],
+      } as IChannel;
 
-      expect(canPostToChannel(channel, user)).toBe(false);
+      expect(canPostToChannel(channel, user)).toBe(true);
+
+      expect(canPostToChannelSpy.calls.count()).toBe(1);
+      const [arg] = canPostToChannelSpy.calls.allArgs()[0]; // arg for 1st call
+      expect(arg).toBe(user);
     });
 
-    it("returns false if user not logged in and channel permissions are empty", async () => {
-      const user = buildUser({ username: null });
+    it("return false if channelPermission.canPostToChannel is false", () => {
+      canPostToChannelSpy.and.callFake(() => false);
+
+      const user = buildUser();
       const channel = {
-        channelAcl: [],
-      } as any as IChannel;
+        channelAcl: [{ category: AclCategory.ANONYMOUS_USER, role: Role.READ }],
+      } as IChannel;
 
       expect(canPostToChannel(channel, user)).toBe(false);
-    });
 
-    describe("any anonymous user channel permissions", () => {
-      it(`returns true if anonymous permission defined and role is allowed`, () => {
-        const user = buildUser({ username: null });
-
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channel = {
-            channelAcl: [
-              { category: AclCategory.ANONYMOUS_USER, role: allowedRole },
-            ],
-          } as IChannel;
-
-          expect(canPostToChannel(channel, user)).toBe(true);
-        });
-      });
-
-      it("returns false if anonymous permission defined but role is read", () => {
-        const user = buildUser({ username: null });
-        const channel = {
-          channelAcl: [
-            { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
-          ],
-        } as IChannel;
-
-        expect(canPostToChannel(channel, user)).toBe(false);
-      });
-    });
-
-    describe("any authenticated user channel permissions", () => {
-      it(`returns true if authenticated permission defined, user logged in, and role is allowed`, async () => {
-        const user = buildUser();
-
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channel = {
-            channelAcl: [
-              { category: AclCategory.AUTHENTICATED_USER, role: allowedRole },
-            ],
-          } as IChannel;
-
-          expect(canPostToChannel(channel, user)).toBe(true);
-        });
-      });
-
-      it("returns false if authenticated permission defined, user logged in, and role is read", async () => {
-        const user = buildUser();
-        const channel = {
-          channelAcl: [
-            { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
-          ],
-        } as IChannel;
-
-        expect(canPostToChannel(channel, user)).toBe(false);
-      });
-
-      it("returns false if authenticated permission defined and user is not logged in", async () => {
-        const user = buildUser({ username: null });
-        const channel = {
-          channelAcl: [
-            { category: AclCategory.AUTHENTICATED_USER, role: Role.READWRITE },
-          ],
-        } as IChannel;
-
-        expect(canPostToChannel(channel, user)).toBe(false);
-      });
-    });
-
-    describe("specific authenticated user channel permissions", () => {
-      it("returns true if user is in permissions list and role is allowed", () => {
-        const user = buildUser();
-
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channel = {
-            channelAcl: [
-              {
-                category: AclCategory.USER,
-                key: user.username,
-                role: allowedRole,
-              },
-            ],
-          } as IChannel;
-
-          expect(canPostToChannel(channel, user)).toBe(true);
-        });
-      });
-
-      it("returns false if user is in permissions list but role is read", () => {
-        const user = buildUser();
-        const channel = {
-          channelAcl: [
-            { category: AclCategory.USER, key: user.username, role: Role.READ },
-          ],
-        } as IChannel;
-
-        expect(canPostToChannel(channel, user)).toBe(false);
-      });
-    });
-
-    describe("group channel permissions", () => {
-      it("returns true if user is group member in group permission list and role is allowed", async () => {
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channel = {
-            channelAcl: [
-              {
-                category: AclCategory.GROUP,
-                subCategory: AclSubCategory.MEMBER,
-                key: groupId1,
-                role: allowedRole, // members write
-              },
-              {
-                category: AclCategory.GROUP,
-                subCategory: AclSubCategory.ADMIN,
-                key: groupId1,
-                role: Role.READ,
-              },
-            ],
-          } as IChannel;
-
-          ALLOWED_GROUP_ROLES.forEach((memberType) => {
-            const user = buildUser({
-              orgId: orgId1,
-              groups: [buildGroup(groupId1, memberType)], // member in groupId1
-            });
-
-            expect(canPostToChannel(channel, user)).toBe(true);
-          });
-        });
-      });
-
-      it("returns false if user is group member in group permission list and role is NOT allowed", async () => {
-        const user = buildUser(); // member in groupId1
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.MEMBER,
-              key: groupId1,
-              role: Role.READ, // members read
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId1,
-              role: Role.READ,
-            },
-          ],
-        } as IChannel;
-
-        expect(canPostToChannel(channel, user)).toBe(false);
-      });
-
-      it("returns false if user is group member in group permission list, role is allowed, but userMemberType is none", async () => {
-        const user = buildUser({
-          groups: [buildGroup(groupId1, "none")], // none in groupId1
-        });
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.MEMBER,
-              key: groupId1,
-              role: Role.READWRITE, // members read
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId1,
-              role: Role.READWRITE, // admins read
-            },
-          ],
-        } as IChannel;
-
-        expect(canPostToChannel(channel, user)).toBe(false);
-      });
-
-      it("returns true if user is group owner/admin in group permission list and role is allowed", async () => {
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channel = {
-            channelAcl: [
-              {
-                category: AclCategory.GROUP,
-                subCategory: AclSubCategory.MEMBER,
-                key: groupId1,
-                role: Role.READ,
-              },
-              {
-                category: AclCategory.GROUP,
-                subCategory: AclSubCategory.ADMIN,
-                key: groupId1,
-                role: allowedRole, // admins write
-              },
-            ],
-          } as IChannel;
-
-          ["owner", "admin"].forEach((memberType) => {
-            const user = buildUser({
-              orgId: orgId1,
-              groups: [buildGroup(groupId1, memberType)], // admin in groupId1
-            });
-
-            expect(canPostToChannel(channel, user)).toBe(true);
-          });
-        });
-      });
-
-      it("returns false if user is group owner/admin in group permission list and role is NOT allowed", async () => {
-        const user = buildUser(); // admin in groupId2
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.MEMBER,
-              key: groupId2,
-              role: Role.READ,
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId2,
-              role: Role.READ, // admins read
-            },
-          ],
-        } as IChannel;
-
-        expect(canPostToChannel(channel, user)).toBe(false);
-      });
-
-      it("returns true if user is group member of at least one group in permissions list that is discussable", async () => {
-        const user = buildUser({
-          orgId: orgId1,
-          groups: [
-            buildGroup(groupId1, "member"), // member in groupId1
-            buildGroup(groupId2, "member", [CANNOT_DISCUSS]), // member in groupId2
-          ],
-        });
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.MEMBER,
-              key: groupId1,
-              role: Role.READWRITE, // members write
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId1,
-              role: Role.READ,
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.MEMBER,
-              key: groupId2,
-              role: Role.READWRITE, // members write, group CANNOT_DISCUSS
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId2,
-              role: Role.READ,
-            },
-          ],
-        } as IChannel;
-
-        expect(canPostToChannel(channel, user)).toBe(true);
-      });
-
-      it("returns false if user is group member in permissions list but the group is not discussable", async () => {
-        const user = buildUser({
-          orgId: orgId1,
-          groups: [
-            buildGroup(groupId1, "member", [CANNOT_DISCUSS]), // member in groupId1
-          ],
-        });
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.MEMBER,
-              key: groupId1,
-              role: Role.READWRITE, // members write
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId1,
-              role: Role.READ,
-            },
-          ],
-        } as IChannel;
-
-        expect(canPostToChannel(channel, user)).toBe(false);
-      });
-
-      it("returns false if user is group admin but group is not in permissions list", async () => {
-        const user = buildUser({
-          orgId: orgId1,
-          groups: [
-            buildGroup("unknownGroupId", "admin"), // member in unknownGroupId
-          ],
-        });
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.MEMBER,
-              key: groupId1,
-              role: Role.READWRITE, // members write
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId1,
-              role: Role.READWRITE, // admin write
-            },
-          ],
-        } as IChannel;
-
-        expect(canPostToChannel(channel, user)).toBe(false);
-      });
-    });
-
-    describe("org channel permissions", () => {
-      it("returns true if user is org member in permissions list and role is allowed", async () => {
-        const user = buildUser();
-
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channel = {
-            channelAcl: [
-              {
-                category: AclCategory.ORG,
-                subCategory: AclSubCategory.MEMBER,
-                key: user.orgId,
-                role: allowedRole, // members write
-              },
-              {
-                category: AclCategory.ORG,
-                subCategory: AclSubCategory.ADMIN,
-                key: user.orgId,
-                role: Role.READ, // admin read
-              },
-            ],
-          } as IChannel;
-
-          expect(canPostToChannel(channel, user)).toBe(true);
-        });
-      });
-
-      it("returns true if user is org_admin in permissions list and role is allowed", async () => {
-        const user = buildUser({ role: "org_admin" });
-
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channel = {
-            channelAcl: [
-              {
-                category: AclCategory.ORG,
-                subCategory: AclSubCategory.MEMBER,
-                key: user.orgId,
-                role: Role.READ, // members read
-              },
-              {
-                category: AclCategory.ORG,
-                subCategory: AclSubCategory.ADMIN,
-                key: user.orgId,
-                role: Role.READWRITE, // admin write
-              },
-            ],
-          } as IChannel;
-
-          expect(canPostToChannel(channel, user)).toBe(true);
-        });
-      });
-
-      it("returns false if user is not in the org", async () => {
-        const user = buildUser({ orgId: "unknownOrgId" });
-        const channel = {
-          channelAcl: [
-            {
-              category: AclCategory.ORG,
-              subCategory: AclSubCategory.MEMBER,
-              key: orgId1,
-              role: Role.READ, // members read
-            },
-            {
-              category: AclCategory.ORG,
-              subCategory: AclSubCategory.ADMIN,
-              key: orgId1,
-              role: Role.READWRITE, // admin write
-            },
-          ],
-        } as IChannel;
-
-        expect(canPostToChannel(channel, user)).toBe(false);
-      });
+      expect(canPostToChannelSpy.calls.count()).toBe(1);
     });
   });
 


### PR DESCRIPTION
affects: @esri/hub-discussions

1. Description: check permissions for canPostToChannel by `channel.channelAcl` if it's available

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
