### PR TITLE
fix: project edit schema image picker config has a maxHeight

### DIFF
--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -189,6 +189,7 @@ export const HubProjectEditUiSchema: IUiSchema = {
           options: {
             control: "hub-field-input-image-picker",
             maxWidth: 727,
+            maxHeight: 484,
             aspectRatio: 1.5,
             helperText: {
               labelKey: "{{i18nScope}}.featuredImage.helperText",


### PR DESCRIPTION
1. Description: adds a maxHeight to the edit project schema for the image picker. The component in question distorts images if you do not provide both a maxWidth and a maxHeight

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
