### PR TITLE
feat(): move isSiteType to index to allow consumables to use

### DIFF
--- a/packages/common/src/content/_internal.ts
+++ b/packages/common/src/content/_internal.ts
@@ -181,21 +181,6 @@ export const getHubRelativeUrl = (
 export const isPageType = (type: string, typeKeywords: string[] = []) =>
   ["Hub Page", "Site Page"].includes(type) || typeKeywords.includes("hubPage");
 
-/**
- * Determines whether, given a type and typekeywords, the input is
- * a site item type or not
- * @param type - the type value on the item
- * @param typeKeywords - the typeKeywords on the item
- */
-
-export function isSiteType(type: string, typeKeywords: string[] = []) {
-  return (
-    type === "Site Application" ||
-    type === "Hub Site Application" ||
-    (type === "Web Mapping Application" && typeKeywords.includes("hubSite"))
-  );
-}
-
 const getSolutionUrl = (
   type: string,
   identifier: string,

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -35,7 +35,6 @@ import {
   getItemOrgId,
 } from "./_internal";
 import { getFamily } from "./get-family";
-import { isSiteType } from ".";
 
 // helper fns - move this to _internal if needed elsewhere
 const getOnlyQueryLayer = (layers: ILayerDefinition[]) => {
@@ -403,6 +402,21 @@ export const getLayerIdFromUrl = (url: string) => {
 export const isFeatureService = (type: string) => {
   return type && type.toLowerCase() === "feature service";
 };
+
+/**
+ * Determines whether, given a type and typekeywords, the input is
+ * a site item type or not
+ * @param type - the type value on the item
+ * @param typeKeywords - the typeKeywords on the item
+ */
+
+export function isSiteType(type: string, typeKeywords: string[] = []) {
+  return (
+    type === "Site Application" ||
+    type === "Hub Site Application" ||
+    (type === "Web Mapping Application" && typeKeywords.includes("hubSite"))
+  );
+}
 
 /**
  * ```js

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -35,7 +35,7 @@ import {
   getItemOrgId,
 } from "./_internal";
 import { getFamily } from "./get-family";
-import { isSiteType } from "./_internal";
+import { isSiteType } from ".";
 
 // helper fns - move this to _internal if needed elsewhere
 const getOnlyQueryLayer = (layers: ILayerDefinition[]) => {

--- a/packages/common/src/content/index.ts
+++ b/packages/common/src/content/index.ts
@@ -421,21 +421,6 @@ export const getContentTypeLabel = (
   return isProxied ? "CSV" : camelize(contentType || "");
 };
 
-/**
- * Determines whether, given a type and typekeywords, the input is
- * a site item type or not
- * @param type - the type value on the item
- * @param typeKeywords - the typeKeywords on the item
- */
-
-export function isSiteType(type: string, typeKeywords: string[] = []) {
-  return (
-    type === "Site Application" ||
-    type === "Hub Site Application" ||
-    (type === "Web Mapping Application" && typeKeywords.includes("hubSite"))
-  );
-}
-
 // URL helpers
 const appendContentUrls = (
   content: IHubContent,

--- a/packages/common/src/content/index.ts
+++ b/packages/common/src/content/index.ts
@@ -421,6 +421,21 @@ export const getContentTypeLabel = (
   return isProxied ? "CSV" : camelize(contentType || "");
 };
 
+/**
+ * Determines whether, given a type and typekeywords, the input is
+ * a site item type or not
+ * @param type - the type value on the item
+ * @param typeKeywords - the typeKeywords on the item
+ */
+
+export function isSiteType(type: string, typeKeywords: string[] = []) {
+  return (
+    type === "Site Application" ||
+    type === "Hub Site Application" ||
+    (type === "Web Mapping Application" && typeKeywords.includes("hubSite"))
+  );
+}
+
 // URL helpers
 const appendContentUrls = (
   content: IHubContent,

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -21,6 +21,7 @@ import {
   setContentType,
   getContentTypeIcon,
   getContentTypeLabel,
+  isSiteType,
 } from "../src/content";
 import {
   isProxiedCSV,
@@ -35,7 +36,6 @@ import {
   getHubRelativeUrl,
   extractFirstContact,
   getPublisherInfo,
-  isSiteType,
 } from "../src/content/_internal";
 import { IModel } from "../src/types";
 import {

--- a/packages/common/test/content.test.ts
+++ b/packages/common/test/content.test.ts
@@ -7,6 +7,7 @@ import {
   getTypes,
   normalizeItemType,
   isFeatureService,
+  isSiteType,
   getLayerIdFromUrl,
   getItemLayerId,
   getItemHubId,
@@ -21,7 +22,6 @@ import {
   setContentType,
   getContentTypeIcon,
   getContentTypeLabel,
-  isSiteType,
 } from "../src/content";
 import {
   isProxiedCSV,


### PR DESCRIPTION
1. Description:
Moves isSiteType from _internal to index to allow for consumables to use it.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)
2. Works on issue [5348](https://zentopia.esri.com/workspaces/polaris-sprint-board-614a18b38a61a3001196c48d/issues/dc/hub/5348). 

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
