### PR TITLE
feat(hub-discussions): add channelAcl as a possible channel relation

### DIFF
--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -687,6 +687,7 @@ export enum ChannelSort {
  */
 export enum ChannelRelation {
   SETTINGS = "settings",
+  CHANNEL_ACL = "channelAcl",
 }
 
 /**


### PR DESCRIPTION
affects: @esri/hub-discussions

1. Description: add `channelAcl` to the ChannelRelation enum, which can be used to optionally include `channelAcl` permissions on the channel reponse

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
