### PR TITLE
fix: update stepper scale to l

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4928,12 +4928,11 @@
 			}
 		},
 		"node_modules/@esri/arcgis-rest-auth": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.5.1.tgz",
-			"integrity": "sha512-k7HWMW3aY+LY8aPfxyj/mcXPKoL6bIzI0BUQHfrXjF+KIr1S1urSzxTMkYJsrUS8H2wuy+eUVzkGNRd3VKyMBg==",
-			"deprecated": "Development work on ArcGIS REST JS 3.x has ceased. This packages funtionality has moved to @esri/arcgis-rest-request at 4.x.x https://developers.arcgis.com/arcgis-rest-js/release-notes/upgrade-v3-v4/.",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.6.0.tgz",
+			"integrity": "sha512-rr7Lv9HAmwTI8UnDGQer5mt1S4LlgTKyD9loQ6WqXn/wdo2y29pUVTWafcOejftnidfZxkkKOhZ/eh7YCKGmZg==",
 			"dependencies": {
-				"@esri/arcgis-rest-types": "^3.5.1",
+				"@esri/arcgis-rest-types": "^3.6.0",
 				"tslib": "^1.13.0"
 			},
 			"peerDependencies": {
@@ -4941,12 +4940,11 @@
 			}
 		},
 		"node_modules/@esri/arcgis-rest-feature-layer": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.5.1.tgz",
-			"integrity": "sha512-bQ8WnwMjiVhxH2tiKq3wX0j+UaHcObeCLEJVW91bGsgQpQMwwL2KwjYyS8XyQ9wkZuRzcCVzOfCdAO0ZE/VUDQ==",
-			"deprecated": "Development work on ArcGIS REST JS 3.x has ceased. This packages funtionality has moved to @esri/arcgis-rest-feature-service at 4.x.x https://developers.arcgis.com/arcgis-rest-js/release-notes/upgrade-v3-v4/.",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.6.0.tgz",
+			"integrity": "sha512-a5BywhJpqzpJIszrXZNDcKdRt9fqGXc/Y60TqS/mVVg0tJIu5Q4VpQQzK4cMkP3D3tFmj7VB2xLBWAzpH7aYVA==",
 			"dependencies": {
-				"@esri/arcgis-rest-types": "^3.5.1",
+				"@esri/arcgis-rest-types": "^3.6.0",
 				"tslib": "^1.13.0"
 			},
 			"peerDependencies": {
@@ -4955,11 +4953,11 @@
 			}
 		},
 		"node_modules/@esri/arcgis-rest-portal": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.5.1.tgz",
-			"integrity": "sha512-jd+xC7+n+XEFI0Z50iUWtBze5wcR0Pzuyk3pRi1ARHwR8WlyRpx7rM585doK7TLTMRoZ3SBuPh2DrZuef+latA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.6.0.tgz",
+			"integrity": "sha512-TPLcbQn+PfKqGlkCvlDYs2AQs7KdTKnM17AhGytnQkqYamNlhkZMAlgC4qq5/H7URTIqlQx52fx/OOfTfO0ABw==",
 			"dependencies": {
-				"@esri/arcgis-rest-types": "^3.5.1",
+				"@esri/arcgis-rest-types": "^3.6.0",
 				"tslib": "^1.13.0"
 			},
 			"peerDependencies": {
@@ -4968,18 +4966,17 @@
 			}
 		},
 		"node_modules/@esri/arcgis-rest-request": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.5.1.tgz",
-			"integrity": "sha512-JmYlIpss0X/yDcyvKAhHEBmbIVoSEdiiIvjv02EVNXnLd42VYgRdfNFdDS5HEc5oXxb01K7pQTLrlyTVeB5mng==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.6.0.tgz",
+			"integrity": "sha512-JDFx1ZjheFUfW/YXWQ0DwxgIwPdQFBtIl5+Bvee4cyCmhxpO1/b82tv7nOLRMnMYBkC2aKRCgpAwkecaJZDpdw==",
 			"dependencies": {
 				"tslib": "^1.10.0"
 			}
 		},
 		"node_modules/@esri/arcgis-rest-types": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.5.1.tgz",
-			"integrity": "sha512-FeX09YZsreTP/n1IQxxlFFyqOenCrn7sF8k/IX+l1hchSCMR0xWX6jYzy459qxUlFV/QWLTC1SsIJT7GWD8zTA==",
-			"deprecated": "Development work on ArcGIS REST JS 3.x has ceased. Types in this package have moved to their respective packages in 4.x.x https://developers.arcgis.com/arcgis-rest-js/release-notes/upgrade-v3-v4/."
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.6.0.tgz",
+			"integrity": "sha512-t6QWdVNmqB9OloYAvVWYNjvqlnrXs/m0nCRNwPGt3ZiAPXn5CpkpSn2UD6LPqGp6vPxKG81lbFQvwCw9az4qIg=="
 		},
 		"node_modules/@esri/hub-common": {
 			"resolved": "packages/common",
@@ -61724,7 +61721,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "11.23.5",
+			"version": "12.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -61754,7 +61751,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "18.2.1",
+			"version": "19.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61763,19 +61760,19 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "11.23.5"
+				"@esri/hub-common": "12.2.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "11.23.5",
+			"version": "12.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -61786,7 +61783,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61794,12 +61791,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "11.23.5"
+				"@esri/hub-common": "12.2.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "11.23.5",
+			"version": "12.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61810,7 +61807,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61819,12 +61816,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.23.5"
+				"@esri/hub-common": "12.2.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "11.23.5",
+			"version": "12.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61833,7 +61830,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -61841,12 +61838,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "11.23.5"
+				"@esri/hub-common": "12.2.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "11.23.5",
+			"version": "12.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61857,7 +61854,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -61868,12 +61865,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.23.5"
+				"@esri/hub-common": "12.2.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "11.26.4",
+			"version": "12.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61882,9 +61879,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
-				"@esri/hub-initiatives": "11.23.5",
-				"@esri/hub-teams": "11.23.5",
+				"@esri/hub-common": "12.2.0",
+				"@esri/hub-initiatives": "12.2.0",
+				"@esri/hub-teams": "12.2.0",
 				"@esri/hub-types": "^6.10.0",
 				"typescript": "^3.8.1"
 			},
@@ -61892,9 +61889,9 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "11.23.5",
-				"@esri/hub-initiatives": "11.23.5",
-				"@esri/hub-teams": "11.23.5"
+				"@esri/hub-common": "12.2.0",
+				"@esri/hub-initiatives": "12.2.0",
+				"@esri/hub-teams": "12.2.0"
 			}
 		},
 		"packages/sites/node_modules/@esri/arcgis-rest-types": {
@@ -61920,7 +61917,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "11.23.5",
+			"version": "12.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61931,7 +61928,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61940,12 +61937,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.23.5"
+				"@esri/hub-common": "12.2.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "11.23.5",
+			"version": "12.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -61955,7 +61952,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -61963,7 +61960,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "11.23.5"
+				"@esri/hub-common": "12.2.0"
 			}
 		}
 	},
@@ -65466,44 +65463,44 @@
 			}
 		},
 		"@esri/arcgis-rest-auth": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.5.1.tgz",
-			"integrity": "sha512-k7HWMW3aY+LY8aPfxyj/mcXPKoL6bIzI0BUQHfrXjF+KIr1S1urSzxTMkYJsrUS8H2wuy+eUVzkGNRd3VKyMBg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.6.0.tgz",
+			"integrity": "sha512-rr7Lv9HAmwTI8UnDGQer5mt1S4LlgTKyD9loQ6WqXn/wdo2y29pUVTWafcOejftnidfZxkkKOhZ/eh7YCKGmZg==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^3.5.1",
+				"@esri/arcgis-rest-types": "^3.6.0",
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/arcgis-rest-feature-layer": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.5.1.tgz",
-			"integrity": "sha512-bQ8WnwMjiVhxH2tiKq3wX0j+UaHcObeCLEJVW91bGsgQpQMwwL2KwjYyS8XyQ9wkZuRzcCVzOfCdAO0ZE/VUDQ==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.6.0.tgz",
+			"integrity": "sha512-a5BywhJpqzpJIszrXZNDcKdRt9fqGXc/Y60TqS/mVVg0tJIu5Q4VpQQzK4cMkP3D3tFmj7VB2xLBWAzpH7aYVA==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^3.5.1",
+				"@esri/arcgis-rest-types": "^3.6.0",
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/arcgis-rest-portal": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.5.1.tgz",
-			"integrity": "sha512-jd+xC7+n+XEFI0Z50iUWtBze5wcR0Pzuyk3pRi1ARHwR8WlyRpx7rM585doK7TLTMRoZ3SBuPh2DrZuef+latA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.6.0.tgz",
+			"integrity": "sha512-TPLcbQn+PfKqGlkCvlDYs2AQs7KdTKnM17AhGytnQkqYamNlhkZMAlgC4qq5/H7URTIqlQx52fx/OOfTfO0ABw==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^3.5.1",
+				"@esri/arcgis-rest-types": "^3.6.0",
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.5.1.tgz",
-			"integrity": "sha512-JmYlIpss0X/yDcyvKAhHEBmbIVoSEdiiIvjv02EVNXnLd42VYgRdfNFdDS5HEc5oXxb01K7pQTLrlyTVeB5mng==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.6.0.tgz",
+			"integrity": "sha512-JDFx1ZjheFUfW/YXWQ0DwxgIwPdQFBtIl5+Bvee4cyCmhxpO1/b82tv7nOLRMnMYBkC2aKRCgpAwkecaJZDpdw==",
 			"requires": {
 				"tslib": "^1.10.0"
 			}
 		},
 		"@esri/arcgis-rest-types": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.5.1.tgz",
-			"integrity": "sha512-FeX09YZsreTP/n1IQxxlFFyqOenCrn7sF8k/IX+l1hchSCMR0xWX6jYzy459qxUlFV/QWLTC1SsIJT7GWD8zTA=="
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.6.0.tgz",
+			"integrity": "sha512-t6QWdVNmqB9OloYAvVWYNjvqlnrXs/m0nCRNwPGt3ZiAPXn5CpkpSn2UD6LPqGp6vPxKG81lbFQvwCw9az4qIg=="
 		},
 		"@esri/hub-common": {
 			"version": "file:packages/common",
@@ -65530,7 +65527,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -65543,7 +65540,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -65557,7 +65554,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -65568,7 +65565,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -65582,7 +65579,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -65595,9 +65592,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
-				"@esri/hub-initiatives": "11.23.5",
-				"@esri/hub-teams": "11.23.5",
+				"@esri/hub-common": "12.2.0",
+				"@esri/hub-initiatives": "12.2.0",
+				"@esri/hub-teams": "12.2.0",
 				"@esri/hub-types": "^6.10.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -65629,7 +65626,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -65641,7 +65638,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "11.23.5",
+				"@esri/hub-common": "12.2.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -49,7 +49,7 @@ export const HubProjectCreateUiSchema: IUiSchema = {
   elements: [
     {
       type: "Section",
-      options: { section: "stepper", scale: "s" },
+      options: { section: "stepper", scale: "l" },
       elements: [
         {
           type: "Step",


### PR DESCRIPTION
Simply bumps the stepper header size.

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
