### PR TITLE
fix: rename relatedItem to featuredContent in project

### DIFF
--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -36,7 +36,7 @@ export const HubProjectSchema: IConfigurationSchema = {
         featuredImage: {
           type: "object",
         },
-        relatedItemIds: {
+        featuredContentIds: {
           type: "array",
           items: {
             type: "string",
@@ -253,15 +253,15 @@ export const HubProjectEditUiSchema: IUiSchema = {
     },
     {
       type: "Section",
-      labelKey: "{{i18nScope}}.relatedItems.label",
+      labelKey: "{{i18nScope}}.featuredContent.label",
       options: {
         helperText: {
-          labelKey: "{{i18nScope}}.relatedItems.helperText",
+          labelKey: "{{i18nScope}}.featuredContent.helperText",
         },
       },
       elements: [
         {
-          scope: "/properties/view/properties/relatedItemIds",
+          scope: "/properties/view/properties/featuredContentIds",
           type: "Control",
           options: {
             control: "hub-field-input-gallery-picker",

--- a/packages/common/src/core/traits/IWithViewSettings.ts
+++ b/packages/common/src/core/traits/IWithViewSettings.ts
@@ -11,5 +11,5 @@ export interface IWithViewSettings {
    */
   featuredImageUrl?: string;
 
-  relatedItemIds: string[];
+  featuredContentIds: string[];
 }


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Rename relatedItem to featuredContent in all project related files

1. Instructions for testing:

1. Closes Issues: 
Partial [5681](https://zentopia.esri.com/workspaces/collaboration-sprint-board-614f9bfc0946c40011ef574e/issues/dc/hub/5681)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
