### PR TITLE
fix(hub-common): update project property mappings and schemas

### DIFF
--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -59,42 +59,48 @@ export const HubProjectCreateUiSchema: IUiSchema = {
       elements: [
         {
           type: "Step",
-          labelKey: "{{i18nScope}}.describeProject.label",
+          labelKey: "{{i18nScope}}.section.details.label",
           elements: [
             {
-              labelKey: "{{i18nScope}}.name.label",
-              scope: "/properties/name",
-              type: "Control",
-            },
-            {
-              labelKey: "{{i18nScope}}.summary.label",
-              scope: "/properties/summary",
-              type: "Control",
-              options: {
-                control: "hub-field-input-input",
-                type: "textarea",
-                helperText: {
-                  labelKey: "{{i18nScope}}.summary.helperText",
+              type: "Section",
+              labelKey: "{{i18nScope}}.basicInfo.label",
+              elements: [
+                {
+                  labelKey: "{{i18nScope}}.fields.name.label",
+                  scope: "/properties/name",
+                  type: "Control",
                 },
-              },
-            },
-            {
-              labelKey: "{{i18nScope}}.description.label",
-              scope: "/properties/description",
-              type: "Control",
-              options: {
-                control: "hub-field-input-input",
-                type: "textarea",
-                helperText: {
-                  labelKey: "{{i18nScope}}.description.helperText",
+                {
+                  labelKey: "{{i18nScope}}.fields.summary.label",
+                  scope: "/properties/summary",
+                  type: "Control",
+                  options: {
+                    control: "hub-field-input-input",
+                    type: "textarea",
+                    helperText: {
+                      labelKey: "{{i18nScope}}.summary.helperText",
+                    },
+                  },
                 },
-              },
+                {
+                  labelKey: "{{i18nScope}}.fields.description.label",
+                  scope: "/properties/description",
+                  type: "Control",
+                  options: {
+                    control: "hub-field-input-input",
+                    type: "textarea",
+                    helperText: {
+                      labelKey: "{{i18nScope}}.description.helperText",
+                    },
+                  },
+                },
+              ],
             },
           ],
         },
         {
           type: "Step",
-          labelKey: "{{i18nScope}}.setLocation.label",
+          labelKey: "{{i18nScope}}.sections.location.label",
           rule: {
             effect: UiSchemaRuleEffects.DISABLE,
             condition: {
@@ -104,17 +110,23 @@ export const HubProjectCreateUiSchema: IUiSchema = {
           },
           elements: [
             {
-              scope: "/properties/extent",
-              type: "Control",
-              options: {
-                control: "hub-field-input-boundary-picker",
-              },
+              type: "Section",
+              labelKey: "{{i18nScope}}.sections.location.label",
+              elements: [
+                {
+                  scope: "/properties/extent",
+                  type: "Control",
+                  options: {
+                    control: "hub-field-input-boundary-picker",
+                  },
+                },
+              ],
             },
           ],
         },
         {
           type: "Step",
-          labelKey: "{{i18nScope}}.statusAndTimeline.label",
+          labelKey: "{{i18nScope}}.sections.statusAndTimeline.label",
           rule: {
             effect: UiSchemaRuleEffects.DISABLE,
             condition: {
@@ -124,23 +136,34 @@ export const HubProjectCreateUiSchema: IUiSchema = {
           },
           elements: [
             {
-              labelKey: "{{i18nScope}}.status.label",
-              scope: "/properties/status",
-              type: "Control",
-              options: {
-                control: "hub-field-input-select",
-                enum: {
-                  i18nScope: "{{i18nScope}}.status.enum",
+              type: "Section",
+              labelKey: "{{i18nScope}}.sections.status.label",
+              elements: [
+                {
+                  labelKey: "{{i18nScope}}.fields.status.label",
+                  scope: "/properties/status",
+                  type: "Control",
+                  options: {
+                    control: "hub-field-input-select",
+                    enum: {
+                      i18nScope: "{{i18nScope}}.fields.status.enum",
+                    },
+                  },
                 },
-              },
+              ],
             },
             {
-              labelKey: "{{i18nScope}}.timeline.label",
-              scope: "/properties/view/properties/timeline",
-              type: "Control",
-              options: {
-                control: "arcgis-hub-timeline-editor",
-              },
+              type: "Section",
+              labelKey: "{{i18nScope}}.sections.timeline.label",
+              elements: [
+                {
+                  scope: "/properties/view/properties/timeline",
+                  type: "Control",
+                  options: {
+                    control: "arcgis-hub-timeline-editor",
+                  },
+                },
+              ],
             },
           ],
         },

--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -59,11 +59,11 @@ export const HubProjectCreateUiSchema: IUiSchema = {
       elements: [
         {
           type: "Step",
-          labelKey: "{{i18nScope}}.section.details.label",
+          labelKey: "{{i18nScope}}.sections.details.label",
           elements: [
             {
               type: "Section",
-              labelKey: "{{i18nScope}}.basicInfo.label",
+              labelKey: "{{i18nScope}}.sections.basicInfo.label",
               elements: [
                 {
                   labelKey: "{{i18nScope}}.fields.name.label",
@@ -78,7 +78,7 @@ export const HubProjectCreateUiSchema: IUiSchema = {
                     control: "hub-field-input-input",
                     type: "textarea",
                     helperText: {
-                      labelKey: "{{i18nScope}}.summary.helperText",
+                      labelKey: "{{i18nScope}}.fields.summary.helperText",
                     },
                   },
                 },
@@ -90,7 +90,7 @@ export const HubProjectCreateUiSchema: IUiSchema = {
                     control: "hub-field-input-input",
                     type: "textarea",
                     helperText: {
-                      labelKey: "{{i18nScope}}.description.helperText",
+                      labelKey: "{{i18nScope}}.fields.description.helperText",
                     },
                   },
                 },
@@ -180,39 +180,39 @@ export const HubProjectEditUiSchema: IUiSchema = {
   elements: [
     {
       type: "Section",
-      labelKey: "{{i18nScope}}.basicInfo.label",
+      labelKey: "{{i18nScope}}.sections.basicInfo.label",
       elements: [
         {
-          labelKey: "{{i18nScope}}.name.label",
+          labelKey: "{{i18nScope}}.fields.name.label",
           scope: "/properties/name",
           type: "Control",
         },
         {
-          labelKey: "{{i18nScope}}.summary.label",
+          labelKey: "{{i18nScope}}.fields.summary.label",
           scope: "/properties/summary",
           type: "Control",
           options: {
             control: "hub-field-input-input",
             type: "textarea",
             helperText: {
-              labelKey: "{{i18nScope}}.summary.helperText",
+              labelKey: "{{i18nScope}}.fields.summary.helperText",
             },
           },
         },
         {
-          labelKey: "{{i18nScope}}.description.label",
+          labelKey: "{{i18nScope}}.fields.description.label",
           scope: "/properties/description",
           type: "Control",
           options: {
             control: "hub-field-input-input",
             type: "textarea",
             helperText: {
-              labelKey: "{{i18nScope}}.description.helperText",
+              labelKey: "{{i18nScope}}.fields.description.helperText",
             },
           },
         },
         {
-          labelKey: "{{i18nScope}}.featuredImage.label",
+          labelKey: "{{i18nScope}}.fields.featuredImage.label",
           scope: "/properties/view/properties/featuredImage",
           type: "Control",
           options: {
@@ -221,7 +221,7 @@ export const HubProjectEditUiSchema: IUiSchema = {
             maxHeight: 484,
             aspectRatio: 1.5,
             helperText: {
-              labelKey: "{{i18nScope}}.featuredImage.helperText",
+              labelKey: "{{i18nScope}}.fields.featuredImage.helperText",
             },
           },
         },
@@ -229,7 +229,7 @@ export const HubProjectEditUiSchema: IUiSchema = {
     },
     {
       type: "Section",
-      labelKey: "{{i18nScope}}.location.label",
+      labelKey: "{{i18nScope}}.sections.location.label",
       elements: [
         {
           scope: "/properties/extent",
@@ -239,7 +239,7 @@ export const HubProjectEditUiSchema: IUiSchema = {
           },
         },
         {
-          labelKey: "{{i18nScope}}.showMap.label",
+          labelKey: "{{i18nScope}}.fields.showMap.label",
           scope: "/properties/view/properties/showMap",
           type: "Control",
         },
@@ -247,15 +247,16 @@ export const HubProjectEditUiSchema: IUiSchema = {
     },
     {
       type: "Section",
-      labelKey: "{{i18nScope}}.status.label",
+      labelKey: "{{i18nScope}}.sections.status.label",
       elements: [
         {
           scope: "/properties/status",
           type: "Control",
+          labelKey: "{{i18nScope}}.fields.status.label",
           options: {
             control: "hub-field-input-select",
             enum: {
-              i18nScope: "{{i18nScope}}.status.enum",
+              i18nScope: "{{i18nScope}}.fields.status.enum",
             },
           },
         },
@@ -263,7 +264,7 @@ export const HubProjectEditUiSchema: IUiSchema = {
     },
     {
       type: "Section",
-      labelKey: "{{i18nScope}}.timeline.label",
+      labelKey: "{{i18nScope}}.sections.timeline.label",
       elements: [
         {
           scope: "/properties/view/properties/timeline",
@@ -276,10 +277,10 @@ export const HubProjectEditUiSchema: IUiSchema = {
     },
     {
       type: "Section",
-      labelKey: "{{i18nScope}}.featuredContent.label",
+      labelKey: "{{i18nScope}}.sections.featuredContent.label",
       options: {
         helperText: {
-          labelKey: "{{i18nScope}}.featuredContent.helperText",
+          labelKey: "{{i18nScope}}.sections.featuredContent.helperText",
         },
       },
       elements: [

--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -24,23 +24,23 @@ export const HubProjectSchema: IConfigurationSchema = {
     extent: {
       type: "object",
     },
-    timeline: {
-      type: "object",
-    },
     view: {
       type: "object",
       properties: {
-        showMap: {
-          type: "boolean",
-        },
-        featuredImage: {
-          type: "object",
-        },
         featuredContentIds: {
           type: "array",
           items: {
             type: "string",
           },
+        },
+        featuredImage: {
+          type: "object",
+        },
+        showMap: {
+          type: "boolean",
+        },
+        timeline: {
+          type: "object",
         },
       },
     },
@@ -136,7 +136,7 @@ export const HubProjectCreateUiSchema: IUiSchema = {
             },
             {
               labelKey: "{{i18nScope}}.timeline.label",
-              scope: "/properties/timeline",
+              scope: "/properties/view/properties/timeline",
               type: "Control",
               options: {
                 control: "arcgis-hub-timeline-editor",
@@ -243,7 +243,7 @@ export const HubProjectEditUiSchema: IUiSchema = {
       labelKey: "{{i18nScope}}.timeline.label",
       elements: [
         {
-          scope: "/properties/timeline",
+          scope: "/properties/view/properties/timeline",
           type: "Control",
           options: {
             control: "arcgis-hub-timeline-editor",

--- a/packages/common/src/core/schemas/hubproject.ts
+++ b/packages/common/src/core/schemas/hubproject.ts
@@ -223,6 +223,9 @@ export const HubProjectEditUiSchema: IUiSchema = {
             helperText: {
               labelKey: "{{i18nScope}}.fields.featuredImage.helperText",
             },
+            sizeDescription: {
+              labelKey: "{{i18nScope}}.fields.featuredImage.sizeDescription",
+            },
           },
         },
       ],

--- a/packages/common/src/core/traits/IWithViewSettings.ts
+++ b/packages/common/src/core/traits/IWithViewSettings.ts
@@ -1,15 +1,28 @@
+import { IHubTimeline } from "../types";
+
 /**
- * Hub Project view: defines the display properties of a project
+ * Properties to be exclusively displayed on an entity's
+ * pre-defined view
  */
 export interface IWithViewSettings {
   /**
-   * Should the map be shown or not
+   * array of contacts associated with an entity. Contact interface TBD
+   */
+  contacts?: any[];
+  /**
+   * array of entity's featured content ids to be rendered in a gallery
+   */
+  featuredContentIds?: string[];
+  /**
+   * entity's featured image url
+   */
+  featuredImageUrl?: string;
+  /**
+   * whether the entity should render it's location on a map
    */
   showMap?: boolean;
   /**
-   * Url of the items featured image
+   * timeline associated with an entity
    */
-  featuredImageUrl?: string;
-
-  featuredContentIds: string[];
+  timeline?: IHubTimeline;
 }

--- a/packages/common/src/projects/_internal/getPropertyMap.ts
+++ b/packages/common/src/projects/_internal/getPropertyMap.ts
@@ -11,7 +11,11 @@ import { getBasePropertyMap } from "../../core/_internal/getBasePropertyMap";
 export function getPropertyMap(): IPropertyMap[] {
   const map = getBasePropertyMap();
 
-  // Type specific mappings
+  /**
+   * project-specific mappings. Note: we do not need to explicitly map
+   * properties from the project item's data.view into the entity's view
+   * because that mapping is already defined in the base property map
+   */
   map.push({ objectKey: "status", modelKey: "data.status" });
   map.push({ objectKey: "catalog", modelKey: "data.catalog" });
   map.push({ objectKey: "permissions", modelKey: "data.permissions" });
@@ -19,8 +23,6 @@ export function getPropertyMap(): IPropertyMap[] {
     objectKey: "capabilities",
     modelKey: "data.settings.capabilities",
   });
-  map.push({ objectKey: "contacts", modelKey: "data.contacts" });
-  map.push({ objectKey: "timeline", modelKey: "data.timeline" });
 
   return map;
 }

--- a/packages/common/src/projects/defaults.ts
+++ b/packages/common/src/projects/defaults.ts
@@ -7,13 +7,18 @@ export const HUB_PROJECT_ITEM_TYPE = "Hub Project";
  * Default values of a IHubProject
  */
 export const DEFAULT_PROJECT: Partial<IHubProject> = {
-  name: "No title provided",
-  tags: [],
-  typeKeywords: ["Hub Project"],
-  status: PROJECT_STATUSES.notStarted,
   catalog: { schemaVersion: 0 },
+  name: "No title provided",
   permissions: [],
   schemaVersion: 1,
+  status: PROJECT_STATUSES.notStarted,
+  tags: [],
+  typeKeywords: [HUB_PROJECT_ITEM_TYPE],
+  view: {
+    contacts: [],
+    featuredContentIds: [],
+    showMap: true,
+  },
 };
 
 /**
@@ -26,7 +31,7 @@ export const DEFAULT_PROJECT_MODEL: IModel = {
     description: "",
     snippet: "",
     tags: [],
-    typeKeywords: ["Hub Project"],
+    typeKeywords: [HUB_PROJECT_ITEM_TYPE],
     properties: {
       slug: "",
       schemaVersion: 1,
@@ -34,12 +39,12 @@ export const DEFAULT_PROJECT_MODEL: IModel = {
   },
   data: {
     display: "about",
-    timeline: {},
+    permissions: [],
     status: PROJECT_STATUSES.notStarted,
-    contacts: [],
     view: {
+      contacts: [],
+      featuredContentIds: [],
       showMap: true,
     },
-    permissions: [],
   },
 } as unknown as IModel;

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -145,10 +145,10 @@ export async function getHubProjectEditorConfig(
     schema = filterSchemaToUiSchema(schema, uiSchema);
   }
 
-  // interpolate the i18n scope into the uiSchema
-  uiSchema = interpolate(uiSchema, { i18nScope });
   // apply the options
   uiSchema = applyUiSchemaElementOptions(uiSchema, options);
+  // interpolate the i18n scope into the uiSchema
+  uiSchema = interpolate(uiSchema, { i18nScope });
 
   return Promise.resolve({ schema, uiSchema });
 }


### PR DESCRIPTION
1. Description:

- [5633](https://devtopia.esri.com/dc/hub/issues/5633): Store UX/UI related properties (properties directly consumed by the Project view) on `item.data.view` and `project.view` rather than directly on `item.data` and at the top-level of the project entity
   - update the project entity and model defaults
   - update the model <> entity mappings
   - update relevant properties in the project `schema`/`uiSchema`
- [5730](https://devtopia.esri.com/dc/hub/issues/5730): While I was already in here, I decided to refine the styling/structure of the project create/edit forms by updating the relevant `schema`/`uiSchema` properties

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)