### PR TITLE
feat(hub-common): add support for passing an item to getFamily()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62622,14 +62622,14 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "12.4.0"
+				"@esri/hub-common": "^12.4.0"
 			}
 		},
 		"packages/downloads": {
@@ -62645,7 +62645,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -62653,7 +62653,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "12.4.0"
+				"@esri/hub-common": "^12.4.0"
 			}
 		},
 		"packages/events": {
@@ -62669,7 +62669,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -62678,7 +62678,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "12.4.0"
+				"@esri/hub-common": "^12.4.0"
 			}
 		},
 		"packages/initiatives": {
@@ -62692,7 +62692,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -62700,7 +62700,7 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "12.4.0"
+				"@esri/hub-common": "^12.4.0"
 			}
 		},
 		"packages/search": {
@@ -62716,7 +62716,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -62727,7 +62727,7 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "12.4.0"
+				"@esri/hub-common": "^12.4.0"
 			}
 		},
 		"packages/sites": {
@@ -62741,18 +62741,18 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
-				"@esri/hub-initiatives": "12.4.0",
-				"@esri/hub-teams": "12.4.0",
+				"@esri/hub-common": "*",
+				"@esri/hub-initiatives": "*",
+				"@esri/hub-teams": "*",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "12.4.0",
-				"@esri/hub-initiatives": "12.4.0",
-				"@esri/hub-teams": "12.4.0"
+				"@esri/hub-common": "^12.4.0",
+				"@esri/hub-initiatives": "^12.4.0",
+				"@esri/hub-teams": "^12.4.0"
 			}
 		},
 		"packages/surveys": {
@@ -62768,7 +62768,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -62777,7 +62777,7 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "12.4.0"
+				"@esri/hub-common": "^12.4.0"
 			}
 		},
 		"packages/teams": {
@@ -62792,7 +62792,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -62800,7 +62800,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "12.4.0"
+				"@esri/hub-common": "^12.4.0"
 			}
 		}
 	},
@@ -66367,7 +66367,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -66380,7 +66380,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -66394,7 +66394,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -66405,7 +66405,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -66419,7 +66419,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -66432,9 +66432,9 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
-				"@esri/hub-initiatives": "12.4.0",
-				"@esri/hub-teams": "12.4.0",
+				"@esri/hub-common": "*",
+				"@esri/hub-initiatives": "*",
+				"@esri/hub-teams": "*",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -66447,7 +66447,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -66459,7 +66459,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.4.0",
+				"@esri/hub-common": "*",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -62583,7 +62583,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "12.3.2",
+			"version": "12.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -62613,7 +62613,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "19.4.3",
+			"version": "19.5.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62622,19 +62622,19 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "12.3.2"
+				"@esri/hub-common": "12.4.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "12.3.2",
+			"version": "12.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -62645,7 +62645,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -62653,12 +62653,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "12.3.2"
+				"@esri/hub-common": "12.4.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "12.3.2",
+			"version": "12.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62669,7 +62669,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -62678,12 +62678,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "12.3.2"
+				"@esri/hub-common": "12.4.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "12.3.2",
+			"version": "12.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62692,7 +62692,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -62700,12 +62700,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "12.3.2"
+				"@esri/hub-common": "12.4.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "12.3.2",
+			"version": "12.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62716,7 +62716,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -62727,12 +62727,12 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "12.3.2"
+				"@esri/hub-common": "12.4.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "12.3.2",
+			"version": "12.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62741,43 +62741,23 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
-				"@esri/hub-initiatives": "12.3.2",
-				"@esri/hub-teams": "12.3.2",
-				"@esri/hub-types": "^6.10.0",
+				"@esri/hub-common": "12.4.0",
+				"@esri/hub-initiatives": "12.4.0",
+				"@esri/hub-teams": "12.4.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "12.3.2",
-				"@esri/hub-initiatives": "12.3.2",
-				"@esri/hub-teams": "12.3.2"
-			}
-		},
-		"packages/sites/node_modules/@esri/arcgis-rest-types": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.25.0.tgz",
-			"integrity": "sha512-2iMwX8tUVTImpoyKjNVsigc0JCUM8hTlyIu/hF2NnehyetvsefSut8njMObwHy872zfBzZ+kOMyulGGzdHvLxg==",
-			"deprecated": "Development work on ArcGIS REST JS 3.x has ceased. Types in this package have moved to their respective packages in 4.x.x https://developers.arcgis.com/arcgis-rest-js/release-notes/upgrade-v3-v4/.",
-			"dev": true,
-			"peer": true
-		},
-		"packages/sites/node_modules/@esri/hub-types": {
-			"version": "6.10.0",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^1.13.0"
-			},
-			"peerDependencies": {
-				"@esri/arcgis-rest-types": "^2.13.0"
+				"@esri/hub-common": "12.4.0",
+				"@esri/hub-initiatives": "12.4.0",
+				"@esri/hub-teams": "12.4.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "12.3.2",
+			"version": "12.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62788,7 +62768,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -62797,12 +62777,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "12.3.2"
+				"@esri/hub-common": "12.4.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "12.3.2",
+			"version": "12.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -62812,7 +62792,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -62820,7 +62800,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "12.3.2"
+				"@esri/hub-common": "12.4.0"
 			}
 		}
 	},
@@ -66387,7 +66367,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -66400,7 +66380,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -66414,7 +66394,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -66425,7 +66405,7 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -66439,7 +66419,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -66452,28 +66432,11 @@
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
-				"@esri/hub-initiatives": "12.3.2",
-				"@esri/hub-teams": "12.3.2",
-				"@esri/hub-types": "^6.10.0",
+				"@esri/hub-common": "12.4.0",
+				"@esri/hub-initiatives": "12.4.0",
+				"@esri/hub-teams": "12.4.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
-			},
-			"dependencies": {
-				"@esri/arcgis-rest-types": {
-					"version": "2.25.0",
-					"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.25.0.tgz",
-					"integrity": "sha512-2iMwX8tUVTImpoyKjNVsigc0JCUM8hTlyIu/hF2NnehyetvsefSut8njMObwHy872zfBzZ+kOMyulGGzdHvLxg==",
-					"dev": true,
-					"peer": true
-				},
-				"@esri/hub-types": {
-					"version": "6.10.0",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.13.0"
-					}
-				}
 			}
 		},
 		"@esri/hub-surveys": {
@@ -66484,7 +66447,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -66496,7 +66459,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@esri/hub-common": "12.3.2",
+				"@esri/hub-common": "12.4.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/package.json
+++ b/package.json
@@ -140,9 +140,9 @@
 		"tsc:v": "lerna run tsc:v",
 		"y:publish": "lerna run y:publish",
 		"y:push": "lerna run y:push",
-		"release:dry": "multi-semantic-release --dry-run  --deps.release=inherit --ignore-private-packages --debug",
+		"release:dry": "multi-semantic-release --dry-run --deps.bump=satisfy --deps.release=inherit --ignore-private-packages --debug",
     "prerelease": "npm config set workspaces-update false",
-		"release": "multi-semantic-release --deps.release=inherit --ignore-private-packages"
+		"release": "multi-semantic-release --deps.bump=satisfy --deps.release=inherit --ignore-private-packages"
 	},
 	"husky": {
 		"hooks": {

--- a/packages/common/src/content/get-family.ts
+++ b/packages/common/src/content/get-family.ts
@@ -1,3 +1,4 @@
+import { IItem } from "@esri/arcgis-rest-portal";
 import { HubFamily } from "../types";
 import { getCollection, getCollectionTypes } from "../collections";
 
@@ -15,7 +16,8 @@ function collectionToFamily(collection: string): string {
  * @param type item type
  * @returns Hub family
  */
-export function getFamily(type: string) {
+export function getFamily(itemOrType: IItem | string) {
+  const type = (itemOrType as IItem).type || (itemOrType as string);
   let family;
   // override default behavior for the rows that are highlighted in yellow here:
   // https://esriis.sharepoint.com/:x:/r/sites/ArcGISHub/_layouts/15/Doc.aspx?sourcedoc=%7BADA1C9DC-4F6C-4DE4-92C6-693EF9571CFA%7D&file=Hub%20Routes.xlsx&nav=MTBfe0VENEREQzI4LUZFMDctNEI0Ri04NjcyLThCQUE2MTA0MEZGRn1fezIwMTIwMEJFLTA4MEQtNEExRC05QzA4LTE5MTAzOUQwMEE1RH0&action=default&mobileredirect=true&cid=df1c874b-c367-4cea-bc13-7bebfad3f2ac

--- a/packages/common/test/content/get-family.test.ts
+++ b/packages/common/test/content/get-family.test.ts
@@ -1,6 +1,12 @@
-import { getFamilyTypes } from "../../src";
+import { getFamily, getFamilyTypes } from "../../src";
 
 describe("getFamily", () => {
+  describe("getFamily", () => {
+    it("works with an item", () => {
+      const item = { type: "Map Service" };
+      expect(getFamily(item as any)).toEqual("map");
+    });
+  });
   describe("getFamilyTypes", () => {
     it("can get 'content' types", () => {
       const types = getFamilyTypes("content");

--- a/packages/discussions/package.json
+++ b/packages/discussions/package.json
@@ -13,13 +13,13 @@
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.14.0 || 3",
     "@esri/arcgis-rest-request": "^2.14.0 || 3",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/arcgis-rest-types": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "@types/geojson": "^7946.0.7",
     "typescript": "^3.8.1"
   },

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -16,14 +16,14 @@
     "@esri/arcgis-rest-feature-layer": "^3.1.0",
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.0",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-feature-layer": "^3.1.1",
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "typescript": "^3.8.1"
   },
   "files": [

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-portal": "^2.15.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
@@ -24,7 +24,7 @@
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/arcgis-rest-types": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "typescript": "^3.8.1"
   },
   "files": [

--- a/packages/initiatives/package.json
+++ b/packages/initiatives/package.json
@@ -14,13 +14,13 @@
     "@esri/arcgis-rest-auth": "^2.13.0 || 3",
     "@esri/arcgis-rest-portal": "^2.13.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "blob": "0.0.4",
     "typescript": "^3.8.1"
   },

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-portal": "^2.6.1 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
@@ -24,7 +24,7 @@
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/arcgis-rest-types": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "@types/faker": "^5.1.5",
     "faker": "^5.1.0",
     "typescript": "^3.8.1"

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -25,7 +25,6 @@
     "@esri/hub-common": "12.4.0",
     "@esri/hub-initiatives": "12.4.0",
     "@esri/hub-teams": "12.4.0",
-    "@esri/hub-types": "^6.10.0",
     "typescript": "^3.8.1"
   },
   "files": [

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -14,17 +14,17 @@
     "@esri/arcgis-rest-auth": "^2.13.0 || 3",
     "@esri/arcgis-rest-portal": "^2.19.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
-    "@esri/hub-common": "12.4.0",
-    "@esri/hub-initiatives": "12.4.0",
-    "@esri/hub-teams": "12.4.0"
+    "@esri/hub-common": "^12.4.0",
+    "@esri/hub-initiatives": "^12.4.0",
+    "@esri/hub-teams": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
-    "@esri/hub-initiatives": "12.4.0",
-    "@esri/hub-teams": "12.4.0",
+    "@esri/hub-common": "*",
+    "@esri/hub-initiatives": "*",
+    "@esri/hub-teams": "*",
     "typescript": "^3.8.1"
   },
   "files": [

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-portal": "^2.13.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
@@ -24,7 +24,7 @@
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/arcgis-rest-types": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "typescript": "^3.8.1"
   },
   "files": [

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -15,14 +15,14 @@
     "@esri/arcgis-rest-portal": "^2.15.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/arcgis-rest-types": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "typescript": "^3.8.1"
   },
   "files": [


### PR DESCRIPTION
1. Description:


This fixes the peer and dev dependencies between packages by making them ranges, and configures multi-semantic-release to only bump dependent packages if the new version of the dependency does not satisfy the dependent's specified range.

**IMPORTANT**:

This means that we will need to _manually_ update `peerDependencies` in dependent packages when those packages need to use features introduced by a minor release of a dependency. **I'm not aware of a way to automate or enforce that.**

It also adds a commit to support `getFamily(item)`, which is really just a way of forcing a release to verify the dependency and semantic configuration changes are working.

TODO: use item properties like type keywords to refine the family returned, for example to avoid doing stuff like [this](https://github.com/ArcGIS/opendata-ui/pull/10869/files#diff-ecc6e1e20fe4ffcee5a21b8ac9ba3aed134074232476fda8857a059a39e05320R39-R45) I'll leave that as an excercise for @tannerjt and/or @sonofflynn89 for their individual use cases.

1. Instructions for testing:

~~let CI do it's thing~~

1. pull
2. check out master (release only runs on master)
3. `git merge f/get-item-family`
4. `npm run release:dry`

You should see output like this that indicates that only hub-common will be bumped:

<img width="1282" alt="image" src="https://user-images.githubusercontent.com/662944/217336468-f80f70da-0ee5-4c72-a5b0-99ea3ce5390c.png">



1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
