### PR TITLE
docs(hub-common): add docs and type annotations to hubSearchItems helper functions

### DIFF
--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/formatOgcAggregationsResponse.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/formatOgcAggregationsResponse.ts
@@ -3,6 +3,13 @@ import { IHubSearchResponse } from "../../types/IHubSearchResponse";
 import { IHubSearchResult } from "../../types/IHubSearchResult";
 import { IOgcAggregationsResponse } from "./interfaces";
 
+/**
+ * Transforms an aggregations response from the OGC API into a
+ * valid format IHubSearch response
+ *
+ * @param response aggregations response from the OGC API
+ * @returns a valid IHubSearch response
+ */
 export function formatOgcAggregationsResponse(
   response: IOgcAggregationsResponse
 ): IHubSearchResponse<IHubSearchResult> {

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/formatOgcItemsResponse.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/formatOgcItemsResponse.ts
@@ -6,6 +6,13 @@ import { getNextOgcCallback } from "./getNextOgcCallback";
 import { IOgcItemsResponse } from "./interfaces";
 import { ogcItemToSearchResult } from "./ogcItemToSearchResult";
 
+/**
+ * Transforms a search response from the OGC API into a
+ * valid format IHubSearch response
+ *
+ * @param response search response from the OGC API
+ * @returns a valid IHubSearch response
+ */
 export async function formatOgcItemsResponse(
   response: IOgcItemsResponse,
   originalQuery: IQuery,

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getNextOgcCallback.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getNextOgcCallback.ts
@@ -5,6 +5,15 @@ import { IHubSearchResult } from "../../types/IHubSearchResult";
 import { IOgcItemsResponse } from "./interfaces";
 import { searchOgcItems } from "./searchOgcItems";
 
+/**
+ * Returns a callback function with pre-bound arguments for fetching the next page of results.
+ * If there is no next page, the callback will resolve to null
+ *
+ * @param response The response to generate the callback for
+ * @param originalQuery  the query that will be modified / bound to the next callback
+ * @param originalOptions the options that will be modified / bound to the next callback
+ * @returns the callback with pre-bound arguments
+ */
 export function getNextOgcCallback(
   response: IOgcItemsResponse,
   originalQuery: IQuery,

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcAggregationQueryParams.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcAggregationQueryParams.ts
@@ -2,6 +2,14 @@ import { getProp } from "../../../objects/get-prop";
 import { IQuery } from "../../types/IHubCatalog";
 import { IHubSearchOptions } from "../../types/IHubSearchOptions";
 
+/**
+ * Creates a hash of query parameters that should be appended onto an
+ * aggregations request for the OGC API.
+ *
+ * @param _query
+ * @param options options object to serialize values from
+ * @returns
+ */
 export function getOgcAggregationQueryParams(
   _query: IQuery,
   options: IHubSearchOptions

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcItemQueryParams.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcItemQueryParams.ts
@@ -4,6 +4,14 @@ import { IHubSearchOptions } from "../../types/IHubSearchOptions";
 import { getFilterQueryParam } from "./getFilterQueryParam";
 import { getQQueryParam } from "./getQQueryParam";
 
+/**
+ * Creates a hash of query parameters that should be appended onto a
+ * search request for the OGC API.
+ *
+ * @param query Query to be serialized
+ * @param options  options to serialize values from
+ * @returns A hash of query parameters that should be included with the request
+ */
 export function getOgcItemQueryParams(
   query: IQuery,
   options: IHubSearchOptions

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getQQueryParam.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getQQueryParam.ts
@@ -5,8 +5,18 @@
 
 import { IFilter, IQuery } from "../../types/IHubCatalog";
 
-// normally
-export function getQQueryParam(query: IQuery) {
+/**
+ * Extracts the value of the term predicate from a query. Also validates that limitations
+ * of the term predicate are not violated, namely:
+ *
+ * - There can only be one term predicate
+ * - The predicate cannot be OR'd with other predicates
+ * - The predicate must contain a simple string value, not an array or IMatchOptions
+ *
+ * @param query query to extract the term predicate from
+ * @returns the serialized q value
+ */
+export function getQQueryParam(query: IQuery): string {
   const qFilters: IFilter[] = query.filters.filter((f) => {
     return f.predicates.find((p) => !!p.term);
   });

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getQueryString.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getQueryString.ts
@@ -1,3 +1,9 @@
+/**
+ * Converts an object with simple key value pairs into a query string
+ *
+ * @param queryParams hash to transform into a query string
+ * @returns query string
+ */
 export function getQueryString(queryParams: Record<string, any>) {
   const result = Object.entries(queryParams)
     .filter(([_key, value]) => !!value)

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcApiRequest.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcApiRequest.ts
@@ -2,6 +2,14 @@ import { RemoteServerError } from "../../../request";
 import { IHubSearchOptions } from "../../types/IHubSearchOptions";
 import { getQueryString } from "./getQueryString";
 
+/**
+ * Wrapper for making a request to a site's OGC API
+ *
+ * @param url fully qualified OGC API endpoint to hit
+ * @param queryParams query params to be appended
+ * @param options options to be included with the request
+ * @returns
+ */
 export async function ogcApiRequest(
   url: string,
   queryParams: Record<string, any>,

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
@@ -4,6 +4,14 @@ import { IHubSearchResult } from "../../types/IHubSearchResult";
 import { itemToSearchResult } from "../portalSearchItems";
 import { IOgcItem } from "./interfaces";
 
+/**
+ * Converts an OGC Item into an IHubSearchResult
+ *
+ * @param ogcItem ogcItem to be transformed
+ * @param includes additional fields to fetch on an item-by-item basis
+ * @param requestOptions request options for fetching any additional includes
+ * @returns the converted result
+ */
 export function ogcItemToSearchResult(
   ogcItem: IOgcItem,
   includes?: string[],

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/searchOgcAggregations.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/searchOgcAggregations.ts
@@ -7,6 +7,13 @@ import { formatOgcAggregationsResponse } from "./formatOgcAggregationsResponse";
 import { getOgcAggregationQueryParams } from "./getOgcAggregationQueryParams";
 import { ogcApiRequest } from "./ogcApiRequest";
 
+/**
+ * Grabs aggregations for a specific collection in the OGC API
+ *
+ * @param query query to serialize (not currently supported)
+ * @param options options for the search
+ * @returns
+ */
 export async function searchOgcAggregations(
   query: IQuery,
   options: IHubSearchOptions

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/searchOgcItems.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/searchOgcItems.ts
@@ -8,6 +8,13 @@ import { getOgcItemQueryParams } from "./getOgcItemQueryParams";
 import { IOgcItemsResponse } from "./interfaces";
 import { ogcApiRequest } from "./ogcApiRequest";
 
+/**
+ * Searchs for items within a specific collection in the OGC API
+ *
+ * @param query query to serialize
+ * @param options options for the search
+ * @returns
+ */
 export async function searchOgcItems(
   query: IQuery,
   options: IHubSearchOptions


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Adds docs that were missing in the initial PR

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
