### PR TITLE
refactor: update to @v3 of checkout and setup-node actions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,9 +8,9 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
 
@@ -21,7 +21,7 @@ jobs:
         run: npm run docs:build
 
       - name: Deploy GH Pages 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -29,8 +29,8 @@ jobs:
         node: [14, 16]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       # Npm 7 is needed for workspaces, and it shipped w/ Node 16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
         node: [16]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 
@@ -58,8 +58,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.13
 

--- a/.github/workflows/stale-notify.yml
+++ b/.github/workflows/stale-notify.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"         
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Notify dedicated teams channel
         uses: skitionek/notify-microsoft-teams@master
         with:


### PR DESCRIPTION
1. Description:

the `@v2` versions of `checkout` and `setup-node` actions are deprecated and throwing warnings. 

This bumps them to `@v3`.

Also loosens the version on `github-pages-deploy-action`, matching what we use in `hub-components`

1. Instructions for testing:
- merge this?

1. Closes Issues: #<number> (if appropriate)
- n/a follow on from debugging some other actions

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
