### PR TITLE
fix(hub-sites): fix peerDependencies should not be fixed to a specifi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,9 +140,9 @@
 		"tsc:v": "lerna run tsc:v",
 		"y:publish": "lerna run y:publish",
 		"y:push": "lerna run y:push",
-		"release:dry": "multi-semantic-release --dry-run  --deps.release=inherit --ignore-private-packages --debug",
+		"release:dry": "multi-semantic-release --dry-run --deps.prefix=^ --deps.bump=satisfy --deps.release=inherit --ignore-private-packages --debug",
     "prerelease": "npm config set workspaces-update false",
-		"release": "multi-semantic-release --deps.release=inherit --ignore-private-packages"
+		"release": "multi-semantic-release --deps.prefix=^ --deps.bump=satisfy --deps.release=inherit --ignore-private-packages"
 	},
 	"husky": {
 		"hooks": {

--- a/packages/discussions/package.json
+++ b/packages/discussions/package.json
@@ -13,13 +13,13 @@
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.14.0 || 3",
     "@esri/arcgis-rest-request": "^2.14.0 || 3",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/arcgis-rest-types": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "@types/geojson": "^7946.0.7",
     "typescript": "^3.8.1"
   },

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -16,14 +16,14 @@
     "@esri/arcgis-rest-feature-layer": "^3.1.0",
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.0",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-feature-layer": "^3.1.1",
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "typescript": "^3.8.1"
   },
   "files": [

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-portal": "^2.15.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
@@ -24,7 +24,7 @@
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/arcgis-rest-types": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "typescript": "^3.8.1"
   },
   "files": [

--- a/packages/initiatives/package.json
+++ b/packages/initiatives/package.json
@@ -14,13 +14,13 @@
     "@esri/arcgis-rest-auth": "^2.13.0 || 3",
     "@esri/arcgis-rest-portal": "^2.13.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "blob": "0.0.4",
     "typescript": "^3.8.1"
   },

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-portal": "^2.6.1 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
@@ -24,7 +24,7 @@
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/arcgis-rest-types": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "@types/faker": "^5.1.5",
     "faker": "^5.1.0",
     "typescript": "^3.8.1"

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -14,18 +14,17 @@
     "@esri/arcgis-rest-auth": "^2.13.0 || 3",
     "@esri/arcgis-rest-portal": "^2.19.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
-    "@esri/hub-common": "12.4.0",
-    "@esri/hub-initiatives": "12.4.0",
-    "@esri/hub-teams": "12.4.0"
+    "@esri/hub-common": "^12.4.0",
+    "@esri/hub-initiatives": "^12.4.0",
+    "@esri/hub-teams": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
-    "@esri/hub-initiatives": "12.4.0",
-    "@esri/hub-teams": "12.4.0",
-    "@esri/hub-types": "^6.10.0",
+    "@esri/hub-common": "*",
+    "@esri/hub-initiatives": "*",
+    "@esri/hub-teams": "*",
     "typescript": "^3.8.1"
   },
   "files": [

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-portal": "^2.13.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
@@ -24,7 +24,7 @@
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/arcgis-rest-types": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "typescript": "^3.8.1"
   },
   "files": [

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -15,14 +15,14 @@
     "@esri/arcgis-rest-portal": "^2.15.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "12.4.0"
+    "@esri/hub-common": "^12.4.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/arcgis-rest-types": "^3.1.1",
-    "@esri/hub-common": "12.4.0",
+    "@esri/hub-common": "*",
     "typescript": "^3.8.1"
   },
   "files": [


### PR DESCRIPTION
…c version

affects: @esri/hub-discussions, @esri/hub-downloads, @esri/hub-events, @esri/hub-initiatives, @esri/hub-search, @esri/hub-sites, @esri/hub-surveys, @esri/hub-teams

1. Description:

like #972 but w/o introducing the feature that was just there to prove that the changes to semantic config worked.

1. Instructions for testing:

1. pull
2. check out master (release only runs on master)
3. git merge f/fix-dependency-ranges
4. npm run release:dry

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
