### PR TITLE
fix(hub-common): take care when i18nScope is undefined case in dotifyString

### DIFF
--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -43,9 +43,7 @@ export interface IGetWellKnownCatalogOptions {
  * @returns i18nScope with a "." at the end if it is defined
  */
 function dotifyString(i18nScope: string): string {
-  if (i18nScope && i18nScope.slice(-1) !== ".") {
-    return `${i18nScope}.`;
-  }
+  return i18nScope && i18nScope.slice(-1) !== "." ? `${i18nScope}.` : "";
 }
 
 /** Get a single catalog based on the name, entity type and optional requests
@@ -209,7 +207,7 @@ function getAllCollectionsMap(i18nScope: string, entityType: EntityType): any {
     } as IHubCollection,
     document: {
       key: "document",
-      label: `{{${i18nScope}collection.document:translate}}`,
+      label: `{{${i18nScope}collection.documents:translate}}`,
       targetEntity: entityType,
       include: [],
       scope: {

--- a/packages/common/test/search/wellKnownCatalog.test.ts
+++ b/packages/common/test/search/wellKnownCatalog.test.ts
@@ -17,7 +17,6 @@ describe("WellKnownCatalog", () => {
         collectionNames: [],
       };
     });
-    it("throws if there is no ");
     it("returns the expected catalog", () => {
       let chk = getWellKnownCatalog(
         "mockI18nScope",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
 - Take care when i18nScope is undefined case in dotifyString
 - Pluralize "documents" in translation path
 - Remove an extra line in test I forgot to remove in my previous PR
 
1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
