### PR TITLE
fix(hub-common): fix what dotifyString returns when i18nScope is defined and ending with '.'

### DIFF
--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -42,7 +42,7 @@ export interface IGetWellKnownCatalogOptions {
  * @param i18nScope
  * @returns i18nScope with a "." at the end if it is defined
  */
-function dotifyString(i18nScope: string): string {
+export function dotifyString(i18nScope: string): string {
   return i18nScope && i18nScope.slice(-1) !== "." ? `${i18nScope}.` : i18nScope;
 }
 

--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -43,7 +43,7 @@ export interface IGetWellKnownCatalogOptions {
  * @returns i18nScope with a "." at the end if it is defined
  */
 function dotifyString(i18nScope: string): string {
-  return i18nScope && i18nScope.slice(-1) !== "." ? `${i18nScope}.` : "";
+  return i18nScope && i18nScope.slice(-1) !== "." ? `${i18nScope}.` : i18nScope;
 }
 
 /** Get a single catalog based on the name, entity type and optional requests

--- a/packages/common/test/search/wellKnownCatalog.test.ts
+++ b/packages/common/test/search/wellKnownCatalog.test.ts
@@ -1,10 +1,12 @@
 import { EntityType } from "../../src";
+import * as wellKnownCatalog from "../../src/search/wellKnownCatalog";
 import {
   getWellKnownCatalog,
   getWellknownCollection,
   getWellknownCollections,
   IGetWellKnownCatalogOptions,
   WellKnownCollection,
+  dotifyString,
 } from "../../src/search/wellKnownCatalog";
 import { mockUser } from "../test-helpers/fake-user";
 
@@ -140,6 +142,17 @@ describe("WellKnownCatalog", () => {
     it("returns the correct collection requested", () => {
       const chk = getWellknownCollection("mockI18nScope", "item", "appAndMap");
       expect(chk.key).toEqual("appAndMap");
+    });
+  });
+
+  describe("dotifyString", () => {
+    it("returns the correct dotified strings", () => {
+      let chk = dotifyString("stringWithoutDot");
+      expect(chk).toEqual("stringWithoutDot.");
+      chk = dotifyString("stringWithDot.");
+      expect(chk).toEqual("stringWithDot.");
+      chk = dotifyString("");
+      expect(chk).toEqual("");
     });
   });
 });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
In `getWellKnownCatalog`, when the `i18nScope` is defined and ending with '.', we are returning "" now, but for cases like when the `i18nScope` is `catalog.`, we will want to return that instead of "". 

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
