### PR TITLE
fix: refactor fetchModelResources to failSafe

### DIFF
--- a/packages/common/test/models/models.test.ts
+++ b/packages/common/test/models/models.test.ts
@@ -277,11 +277,6 @@ describe("model utils:", () => {
         "upsertResource"
       ).and.returnValue(Promise.resolve("https://fake.com/123"));
 
-      const getItemResourceSpy = spyOn(
-        portalModule,
-        "getItemResource"
-      ).and.returnValue(Promise.resolve(LOCATION));
-
       const m = {
         item: {
           id: "00c",
@@ -309,7 +304,6 @@ describe("model utils:", () => {
       });
 
       expect(upsertResourceSpy.calls.count()).toBe(1);
-      expect(getItemResourceSpy.calls.count()).toBe(1);
       expect(chk.resources).toEqual({
         location: LOCATION,
       });

--- a/packages/common/test/projects/projects.test.ts
+++ b/packages/common/test/projects/projects.test.ts
@@ -220,6 +220,34 @@ describe("HubProjects:", () => {
       // This next stuff is O_o but req'd by typescript
       expect(chk).toEqual(null as unknown as IHubProject);
     });
+
+    it("gets project even if resource is rejected", async () => {
+      const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
+        Promise.resolve(PROJECT_ITEM)
+      );
+      const getItemDataSpy = spyOn(portalModule, "getItemData").and.returnValue(
+        Promise.resolve(PROJECT_DATA)
+      );
+
+      const getItemResourceSpy = spyOn(
+        portalModule,
+        "getItemResource"
+      ).and.returnValue(Promise.reject());
+
+      const chk = await fetchProject(GUID, {
+        authentication: MOCK_AUTH,
+      });
+      expect(chk.id).toBe(GUID);
+      expect(chk.owner).toBe("vader");
+      expect(chk.location).toBe(undefined);
+
+      expect(getItemSpy.calls.count()).toBe(1);
+      expect(getItemSpy.calls.argsFor(0)[0]).toBe(GUID);
+      expect(getItemDataSpy.calls.count()).toBe(1);
+      expect(getItemDataSpy.calls.argsFor(0)[0]).toBe(GUID);
+      expect(getItemResourceSpy.calls.count()).toBe(1);
+      expect(getItemResourceSpy.calls.argsFor(0)[0]).toBe(GUID);
+    });
   });
 
   describe("destroyProject:", () => {


### PR DESCRIPTION
1. Description: Resolves issue where if resource didn't exist during project fetch it would hard fail. Also no longer refetches resource during creation/edit and instead opts with the resources passed into the func.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
