### PR TITLE
feat(hub-common): populate 'geometry' for item IHubSearchResults coming from portal

### DIFF
--- a/packages/common/src/content/HubContent.ts
+++ b/packages/common/src/content/HubContent.ts
@@ -1,5 +1,5 @@
 import { IItem } from "@esri/arcgis-rest-types";
-import { isMaster } from "cluster";
+import { extentToPolygon, bBoxToExtent, isBBox } from "../extent";
 import { fetchItemEnrichments } from "../items/_enrichments";
 import { getProp } from "../objects";
 import { getItemThumbnailUrl } from "../resources";
@@ -46,6 +46,16 @@ export async function enrichContentSearchResult(
       thumbnail: "not-implemented",
     },
   };
+
+  if (isBBox(item.extent)) {
+    const extent = bBoxToExtent(item.extent);
+    const geometryPolygon = extentToPolygon(extent);
+    result.geometry = {
+      geometry: { type: "polygon", ...geometryPolygon },
+      provenance: "item",
+      spatialReference: extent.spatialReference,
+    };
+  }
 
   // default includes
   const DEFAULTS: string[] = [];


### PR DESCRIPTION
affects: @esri/hub-common

**Description**: populates the results of `portalSearchItems` with geometry if an extent is available. The need for this arose as I was creating a map search prototype and figured we didn't want to lose the work. Tests have not yet been added and we will want to validate that I have correctly filled out the property.

For reference, the interface for `result.geometry` ([IHubGeography](https://github.com/Esri/hub.js/blob/master/packages/common/src/types.ts#L208)) was created by @tomwayson 3 years ago and the interface was included in `IHubSearchResult` by @dbouwman almost a year ago. We may want to evaluate if we want any additional changes before we start using the interface.

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
