### PR TITLE
feat(hub-common): modify getFamilyTypes to return "Feature Service" as part of the "Dataset" family

### DIFF
--- a/packages/common/src/content/get-family.ts
+++ b/packages/common/src/content/get-family.ts
@@ -79,7 +79,9 @@ export function getFamilyTypes(family: HubFamily): string[] {
       types = getCollectionTypes(family.toLowerCase()).filter(
         (type) =>
           type !== "Feature Collection Template" &&
-          type !== "Feature Service" &&
+          // Changed as part of https://confluencewikidev.esri.com/x/KYJuDg
+          // Remove when reclassification has been completed
+          // type !== "Feature Service" &&
           type !== "Raster Layer" &&
           type !== "Microsoft Excel"
       );
@@ -89,7 +91,12 @@ export function getFamilyTypes(family: HubFamily): string[] {
       types = getCollectionTypes(family.toLowerCase()).filter(
         (type) => type !== "Image Service"
       );
-      types = types.concat(["Feature Service", "Raster Layer"]);
+      types = types.concat([
+        // Changed as part of https://confluencewikidev.esri.com/x/KYJuDg
+        // Remove when reclassification has been completed
+        // "Feature Service",
+        "Raster Layer",
+      ]);
       break;
     case "document":
       types = getCollectionTypes(family.toLowerCase()).filter(

--- a/packages/common/test/content/get-family.test.ts
+++ b/packages/common/test/content/get-family.test.ts
@@ -25,7 +25,10 @@ describe("getFamily", () => {
       expect(types.length > 0).toBeTruthy();
       expect(types.includes("Image Service")).toBeTruthy();
       expect(types.includes("Feature Collection Template")).toBeFalsy();
-      expect(types.includes("Feature Service")).toBeFalsy();
+      // Changed as part of https://confluencewikidev.esri.com/x/KYJuDg
+      // Remove when reclassification has been completed
+      // expect(types.includes("Feature Service")).toBeFalsy();
+      expect(types.includes("Feature Service")).toBeTruthy();
       expect(types.includes("Raster Layer")).toBeFalsy();
       expect(types.includes("Microsoft Excel")).toBeFalsy();
     });
@@ -35,7 +38,10 @@ describe("getFamily", () => {
       expect(Array.isArray(types)).toBeTruthy();
       expect(types.length > 0).toBeTruthy();
       expect(types.includes("Image Service")).toBeFalsy();
-      expect(types.includes("Feature Service")).toBeTruthy();
+      // Changed as part of https://confluencewikidev.esri.com/x/KYJuDg
+      // Remove when reclassification has been completed
+      // expect(types.includes("Feature Service")).toBeTruthy();
+      expect(types.includes("Feature Service")).toBeFalsy();
       expect(types.includes("Raster Layer")).toBeTruthy();
     });
 

--- a/packages/common/test/search/wellKnownCatalog.test.ts
+++ b/packages/common/test/search/wellKnownCatalog.test.ts
@@ -113,6 +113,8 @@ describe("WellKnownCatalog", () => {
         "CSV",
         "Feature Collection",
         "Feature Layer",
+        // Changed as part of https://confluencewikidev.esri.com/x/KYJuDg
+        "Feature Service",
         "File Geodatabase",
         "GeoJSON",
         "GeoJson",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Issue: [5582](https://devtopia.esri.com/dc/hub/issues/5582)

This was changed as part of https://confluencewikidev.esri.com/x/KYJuDg. `getFamilyTypes` now returns "Feature Service" as part of the "Dataset" family. As a result, `getFamilyTypes` is now temporarily out of sync with `getFamily`.

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
