### PR TITLE
feat: throw error when attempting to update a stale version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63970,7 +63970,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "12.11.0",
+			"version": "12.12.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/src/versioning/updateVersion.ts
+++ b/packages/common/src/versioning/updateVersion.ts
@@ -14,6 +14,11 @@ import { getIncludeListFromItemType } from "./_internal/getIncludeListFromItemTy
 import { updateItemResource } from "@esri/arcgis-rest-portal";
 import { checkForStaleVersion } from "./utils";
 
+/**
+ * Custom error to be thrown when attempting to save a stale version
+ * @class StaleVersionError
+ * @extends {Error}
+ */
 class StaleVersionError extends Error {
   constructor(id: string, public updated: number) {
     super(`Version ${id} is stale. Use force to overwrite.`);
@@ -23,9 +28,11 @@ class StaleVersionError extends Error {
 
 /**
  * Updates the specified version with with the state of the supplied model
+ * throws an exception if the version is stale and force is not true
  * @param model
  * @param version
  * @param requestOptions
+ * @param force
  * @returns
  */
 export async function updateVersion(

--- a/packages/common/src/versioning/utils.ts
+++ b/packages/common/src/versioning/utils.ts
@@ -28,6 +28,13 @@ interface IStaleVersionResponse {
   updated: number;
 }
 
+/**
+ * Checks if the upstream version is newer than the passed in version
+ * @param itemId
+ * @param version
+ * @param requestOptions
+ * @returns
+ */
 export async function checkForStaleVersion(
   itemId: string,
   version: IVersion,

--- a/packages/common/src/versioning/utils.ts
+++ b/packages/common/src/versioning/utils.ts
@@ -1,7 +1,8 @@
 import { cloneObject } from "../util";
 import { mergeObjects } from "../objects/merge-objects";
-import { IModel } from "../types";
+import { IHubUserRequestOptions, IModel } from "../types";
 import { IVersion } from "./types/IVersion";
+import { getVersion } from "./getVersion";
 import { getIncludeListFromItemType } from "./_internal/getIncludeListFromItemType";
 
 /**
@@ -20,4 +21,22 @@ export function applyVersion(
     includeList = getIncludeListFromItemType(model);
   }
   return mergeObjects(version.data, cloneObject(model), includeList);
+}
+
+interface IStaleVersionResponse {
+  isStale: boolean;
+  updated: number;
+}
+
+export async function checkForStaleVersion(
+  itemId: string,
+  version: IVersion,
+  requestOptions: IHubUserRequestOptions
+): Promise<IStaleVersionResponse> {
+  const upstream = await getVersion(itemId, version.id, requestOptions);
+  const isStale = upstream.updated > version.updated;
+  return {
+    isStale,
+    updated: upstream.updated,
+  };
 }

--- a/packages/common/test/versioning/updateVersion.test.ts
+++ b/packages/common/test/versioning/updateVersion.test.ts
@@ -14,6 +14,7 @@ describe("updateVersion", () => {
   let portal: string;
   let hubApiUrl: string;
   let requestOpts: IHubUserRequestOptions;
+  let version: IVersion;
   let updateItemResourceSpy: jasmine.Spy;
 
   const model = {
@@ -30,24 +31,6 @@ describe("updateVersion", () => {
   } as unknown as IModel;
 
   const versionBlob = { size: 123 };
-
-  const version: IVersion = {
-    created: "9876543210",
-    creator: "casey",
-    data: {
-      data: {
-        values: {
-          layout: "layout",
-        },
-      },
-    },
-    id: "def456",
-    name: undefined,
-    parent: undefined,
-    path: "hubVersion_def456/version.json",
-    updated: "9876543210",
-    size: 123,
-  } as unknown as IVersion;
 
   let options: IItemResourceOptions;
 
@@ -79,6 +62,24 @@ describe("updateVersion", () => {
       resource: versionBlob,
     };
 
+    version = {
+      created: "9876543210",
+      creator: "casey",
+      data: {
+        data: {
+          values: {
+            layout: "layout",
+          },
+        },
+      },
+      id: "def456",
+      name: undefined,
+      parent: undefined,
+      path: "hubVersion_def456/version.json",
+      updated: "9876543210",
+      size: 123,
+    } as unknown as IVersion;
+
     updateItemResourceSpy = spyOn(
       portalModule,
       "updateItemResource"
@@ -100,11 +101,18 @@ describe("updateVersion", () => {
   });
 
   it("should update a version when force=true", async () => {
-    const result = await updateVersion(model, version, requestOpts, true);
+    await updateVersion(model, version, requestOpts, true);
 
     expect(updateItemResourceSpy).toHaveBeenCalledTimes(1);
     expect(updateItemResourceSpy).toHaveBeenCalledWith(options);
-    expect(result).toEqual(version);
+  });
+
+  it("should update a version that is not stale when force=false", async () => {
+    version.updated = 1675954801031;
+    await updateVersion(model, version, requestOpts, false);
+
+    expect(updateItemResourceSpy).toHaveBeenCalledTimes(1);
+    expect(updateItemResourceSpy).toHaveBeenCalledWith(options);
   });
 
   it("should throw when attempting to update a stale version", async () => {

--- a/packages/common/test/versioning/updateVersion.test.ts
+++ b/packages/common/test/versioning/updateVersion.test.ts
@@ -7,11 +7,50 @@ import { VERSION_RESOURCE_NAME } from "../../src/versioning/_internal/constants"
 import * as objectToJsonBlobModule from "../../src/resources/object-to-json-blob";
 import * as utilModule from "../../src/util";
 import { IVersion } from "../../src";
+import { IItemResourceOptions } from "@esri/arcgis-rest-portal";
+import * as ResourceResponse from "../mocks/versioning/resource.json";
 
-describe("createVersion", () => {
+describe("updateVersion", () => {
   let portal: string;
   let hubApiUrl: string;
   let requestOpts: IHubUserRequestOptions;
+  let updateItemResourceSpy: jasmine.Spy;
+
+  const model = {
+    item: {
+      id: "abc123",
+      owner: "paige_pa",
+      type: "Hub Site Application",
+    },
+    data: {
+      values: {
+        layout: "layout",
+      },
+    },
+  } as unknown as IModel;
+
+  const versionBlob = { size: 123 };
+
+  const version: IVersion = {
+    created: "9876543210",
+    creator: "casey",
+    data: {
+      data: {
+        values: {
+          layout: "layout",
+        },
+      },
+    },
+    id: "def456",
+    name: undefined,
+    parent: undefined,
+    path: "hubVersion_def456/version.json",
+    updated: "9876543210",
+    size: 123,
+  } as unknown as IVersion;
+
+  let options: IItemResourceOptions;
+
   beforeEach(() => {
     portal = MOCK_AUTH.portal;
     hubApiUrl = "https://hubfake.arcgis.com";
@@ -21,55 +60,8 @@ describe("createVersion", () => {
       hubApiUrl,
       authentication: MOCK_AUTH,
     };
-  });
 
-  it("should create a version", async () => {
-    const model = {
-      item: {
-        id: "abc123",
-        owner: "paige_pa",
-        type: "Hub Site Application",
-      },
-      data: {
-        values: {
-          layout: "layout",
-        },
-      },
-    } as unknown as IModel;
-
-    const versionBlob = { size: 123 };
-
-    const version: IVersion = {
-      created: "9876543210",
-      creator: "casey",
-      data: {
-        data: {
-          values: {
-            layout: "layout",
-          },
-        },
-      },
-      id: "def456",
-      name: undefined,
-      parent: undefined,
-      path: "hubVersion_def456/version.json",
-      updated: "9876543210",
-      size: 123,
-    } as unknown as IVersion;
-
-    const updateItemResourceSpy = spyOn(
-      portalModule,
-      "updateItemResource"
-    ).and.returnValue(Promise.resolve());
-    spyOn(objectToJsonBlobModule, "objectToJsonBlob").and.returnValue(
-      versionBlob
-    );
-    spyOn(utilModule, "createId").and.returnValue("def456");
-    spyOn(Date, "now").and.returnValue("9876543210");
-
-    const result = await updateVersion(model, version, requestOpts);
-
-    const options = {
+    options = {
       ...requestOpts,
       id: "abc123",
       name: VERSION_RESOURCE_NAME,
@@ -87,8 +79,43 @@ describe("createVersion", () => {
       resource: versionBlob,
     };
 
+    updateItemResourceSpy = spyOn(
+      portalModule,
+      "updateItemResource"
+    ).and.returnValue(Promise.resolve());
+
+    spyOn(portalModule, "getItemResource").and.returnValue(
+      Promise.resolve(ResourceResponse)
+    );
+
+    spyOn(objectToJsonBlobModule, "objectToJsonBlob").and.returnValue(
+      versionBlob
+    );
+    spyOn(utilModule, "createId").and.returnValue("def456");
+    spyOn(Date, "now").and.returnValue("9876543210");
+  });
+
+  afterEach(() => {
+    updateItemResourceSpy.calls.reset();
+  });
+
+  it("should update a version when force=true", async () => {
+    const result = await updateVersion(model, version, requestOpts, true);
+
     expect(updateItemResourceSpy).toHaveBeenCalledTimes(1);
     expect(updateItemResourceSpy).toHaveBeenCalledWith(options);
-    // expect(result).toEqual(versionResult);
+    expect(result).toEqual(version);
+  });
+
+  it("should throw when attempting to update a stale version", async () => {
+    try {
+      await updateVersion(model, version, requestOpts);
+      fail("should reject");
+    } catch (err) {
+      expect(err.message).toBe(
+        "Version def456 is stale. Use force to overwrite."
+      );
+      expect(err.updated).toBe(1675954801031);
+    }
   });
 });


### PR DESCRIPTION
1. Description: Proposed approach for checking for stale versions on update.

1. Instructions for testing: Looking for input on the general approach and naming.

1. Closes Issues: #<number> (if appropriate)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
