### PR TITLE
feat: add arcgis-js-api typings to repo & change IHubLocation interfa…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
 				"@esri/arcgis-rest-types": "^3.1.1",
 				"@semantic-release/changelog": "^6.0.1",
 				"@semantic-release/git": "^10.0.1",
-				"@types/arcgis-js-api": "~4.25.0",
+				"@types/arcgis-js-api": "~4.26.0",
 				"@types/es6-promise": "0.0.32",
 				"@types/fetch-mock": "^7.0.0",
 				"@types/isomorphic-fetch": "0.0.34",
@@ -9853,9 +9853,9 @@
 			"dev": true
 		},
 		"node_modules/@types/arcgis-js-api": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.25.0.tgz",
-			"integrity": "sha512-bXm03oiGgT0GSqK3CN59Qr2v7lJlsDrwr6NuvM6oWk9gBN10YF6xB3fGvSuqOpgSMVPj7P3FQQToE5qswv2Veg==",
+			"version": "4.26.0",
+			"resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.26.0.tgz",
+			"integrity": "sha512-rQSgYUy2FqPTFu47h2ibXhh5RdoQ/dgIXNdUcLTwebJ8OeXFvuzF5+hHmzKr2aLfX8w34W08ZIhUwiE4m+vBLQ==",
 			"dev": true
 		},
 		"node_modules/@types/body-parser": {
@@ -71828,9 +71828,9 @@
 			"dev": true
 		},
 		"@types/arcgis-js-api": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.25.0.tgz",
-			"integrity": "sha512-bXm03oiGgT0GSqK3CN59Qr2v7lJlsDrwr6NuvM6oWk9gBN10YF6xB3fGvSuqOpgSMVPj7P3FQQToE5qswv2Veg==",
+			"version": "4.26.0",
+			"resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.26.0.tgz",
+			"integrity": "sha512-rQSgYUy2FqPTFu47h2ibXhh5RdoQ/dgIXNdUcLTwebJ8OeXFvuzF5+hHmzKr2aLfX8w34W08ZIhUwiE4m+vBLQ==",
 			"dev": true
 		},
 		"@types/body-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
 				"@esri/arcgis-rest-types": "^3.1.1",
 				"@semantic-release/changelog": "^6.0.1",
 				"@semantic-release/git": "^10.0.1",
+				"@types/arcgis-js-api": "~4.25.0",
 				"@types/es6-promise": "0.0.32",
 				"@types/fetch-mock": "^7.0.0",
 				"@types/isomorphic-fetch": "0.0.34",
@@ -9849,6 +9850,12 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
 			"integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw==",
+			"dev": true
+		},
+		"node_modules/@types/arcgis-js-api": {
+			"version": "4.25.0",
+			"resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.25.0.tgz",
+			"integrity": "sha512-bXm03oiGgT0GSqK3CN59Qr2v7lJlsDrwr6NuvM6oWk9gBN10YF6xB3fGvSuqOpgSMVPj7P3FQQToE5qswv2Veg==",
 			"dev": true
 		},
 		"node_modules/@types/body-parser": {
@@ -63969,7 +63976,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "12.8.0",
+			"version": "12.10.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -63994,7 +64001,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "19.5.1",
+			"version": "20.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -64093,7 +64100,7 @@
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "12.4.1",
+			"version": "12.5.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -71818,6 +71825,12 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
 			"integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw==",
+			"dev": true
+		},
+		"@types/arcgis-js-api": {
+			"version": "4.25.0",
+			"resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.25.0.tgz",
+			"integrity": "sha512-bXm03oiGgT0GSqK3CN59Qr2v7lJlsDrwr6NuvM6oWk9gBN10YF6xB3fGvSuqOpgSMVPj7P3FQQToE5qswv2Veg==",
 			"dev": true
 		},
 		"@types/body-parser": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@esri/arcgis-rest-types": "^3.1.1",
 		"@semantic-release/changelog": "^6.0.1",
 		"@semantic-release/git": "^10.0.1",
-		"@types/arcgis-js-api": "~4.25.0",
+		"@types/arcgis-js-api": "~4.26.0",
 		"@types/es6-promise": "0.0.32",
 		"@types/fetch-mock": "^7.0.0",
 		"@types/isomorphic-fetch": "0.0.34",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@esri/arcgis-rest-types": "^3.1.1",
 		"@semantic-release/changelog": "^6.0.1",
 		"@semantic-release/git": "^10.0.1",
+		"@types/arcgis-js-api": "~4.25.0",
 		"@types/es6-promise": "0.0.32",
 		"@types/fetch-mock": "^7.0.0",
 		"@types/isomorphic-fetch": "0.0.34",

--- a/packages/common/src/core/types/IHubLocation.ts
+++ b/packages/common/src/core/types/IHubLocation.ts
@@ -18,4 +18,11 @@ export interface IHubLocation {
 
   // An esri geometry: __esri.Geometry
   geometries?: __esri.Geometry[];
+
+  // DEPRECATED: the following will be removed at next breaking version
+  provenance?: "none" | "custom" | "existing";
+  center?: number[];
+  orgSpatialReference?: ISpatialReference;
+  graphic?: any;
+  geoJson?: any;
 }

--- a/packages/common/src/core/types/IHubLocation.ts
+++ b/packages/common/src/core/types/IHubLocation.ts
@@ -1,4 +1,5 @@
 import { ISpatialReference } from "@esri/arcgis-rest-types";
+import { IHubLocationType } from "./types";
 
 /**
  * A location associated with an item and stored as a json resource.
@@ -7,23 +8,14 @@ export interface IHubLocation {
   // Where did the location come from originally?
   // This is used in the location picker component to determine
   // what source was used
-  provenance: "none" | "custom" | "existing";
-
-  // the center of the location
-  center?: number[];
+  type: IHubLocationType;
 
   // the spatial reference of the location usuually WGS84
   spatialReference?: ISpatialReference;
 
-  // the org spatial reference in case we have some custom org once
-  orgSpatialReference?: ISpatialReference;
-
   // the extent of the location
   extent?: number[][];
 
-  // An esri graphics layer: __esri.GraphicsLayer
-  graphic?: any;
-
-  // GeoJSON, for hub api search purposes
-  geoJson?: any;
+  // An esri geometry: __esri.Geometry
+  geometries?: __esri.Geometry[];
 }

--- a/packages/common/src/core/types/types.ts
+++ b/packages/common/src/core/types/types.ts
@@ -17,3 +17,5 @@ export const EntityResourceMap: {
 } = {
   location: "location.json",
 };
+
+export type IHubLocationType = "none" | "custom" | "default" | "org-extent";

--- a/packages/common/src/core/types/types.ts
+++ b/packages/common/src/core/types/types.ts
@@ -18,4 +18,10 @@ export const EntityResourceMap: {
   location: "location.json",
 };
 
-export type IHubLocationType = "none" | "custom" | "default" | "org-extent";
+/**
+ * Where did the location come from originally?
+ * This is used in the location picker component to determine
+ * what source was used. The values are used in IHubLocation.type.
+ * Please note that adding more values will require changes in the location picker
+ */
+export type IHubLocationType = "none" | "custom" | "org" | "item";

--- a/packages/common/test/models/models.test.ts
+++ b/packages/common/test/models/models.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../../src";
 
 const LOCATION: IHubLocation = {
-  provenance: "custom",
+  type: "custom",
 };
 
 describe("model utils:", () => {

--- a/packages/common/test/projects/projects.test.ts
+++ b/packages/common/test/projects/projects.test.ts
@@ -52,7 +52,7 @@ const PROJECT_DATA = {
 };
 
 const PROJECT_LOCATION: IHubLocation = {
-  provenance: "custom",
+  type: "custom",
 };
 
 const PROJECT_MODEL = {
@@ -139,7 +139,7 @@ describe("HubProjects:", () => {
       expect(chk.id).toBe(GUID);
       expect(chk.owner).toBe("vader");
       expect(chk.location).toEqual({
-        provenance: "custom",
+        type: "custom",
       });
 
       expect(getItemSpy.calls.count()).toBe(1);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,7 +53,8 @@
     ],                                        /* List of folders to include type definitions from. */
     "types": [
       "node",
-      "jasmine"
+      "jasmine",
+      "arcgis-js-api"
     ],                           /* Type declaration files to be included in compilation. */
     "allowSyntheticDefaultImports": true  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
 


### PR DESCRIPTION
…ce to match decided footprint

Adds arcgis-js-api typings to repo && changes up IHubLocation interface to match decided structure in confluence.

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
