### PR TITLE
fix(hub-discussions): remove channelAclDefinition as a channel and po…

### DIFF
--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -742,7 +742,7 @@ export interface IChannelAclPermission
 }
 
 /**
- * parameters/options for creating a channel
+ * settings parameters for creating a channel
  *
  * @export
  * @interface ICreateChannelSettings
@@ -759,7 +759,7 @@ export interface ICreateChannelSettings {
 }
 
 /**
- * parameters/options for creating a channel
+ * permissions parameters for creating a channel
  *
  * @export
  * @interface ICreateChannelPermissions
@@ -768,11 +768,15 @@ export interface ICreateChannelPermissions {
   access?: SharingAccess;
   groups?: string[];
   orgs?: string[];
+  /**
+   * Not available until the V2 Api is released
+   * @hidden
+   */
   channelAclDefinition?: IChannelAclPermissionDefinition[];
 }
 
 /**
- * parameters/options for creating a channel
+ * permissions and settings options for creating a channel
  *
  * @export
  * @interface ICreateChannel

--- a/packages/discussions/src/utils/posts/can-modify-post.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post.ts
@@ -9,10 +9,6 @@ type ILegacyChannelPermissions = Pick<
 
 /**
  * Determine if a user can modify an existing post
- * @param post
- * @param user
- * @param channel
- * @returns boolean
  */
 export function canModifyPost(
   post: IPost,
@@ -57,9 +53,6 @@ function isAuthorizedToModifyByLegacyPermissions(
 /**
  * Ensure the user is a member of one of the channel groups
  * and the group is not marked as non-discussable
- * @param channelGroups
- * @param userGroups
- * @returns
  */
 function isAuthorizedToModifyPostByLegacyGroup(
   channelGroups: string[] = [],


### PR DESCRIPTION
…st create option

affects: @esri/hub-discussions

Channel creation using the channelAclDefinition property will not be supported until V2 of the discussions API is released

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
