### PR TITLE
fix(): getItemBySlug returns full item via getItem

### DIFF
--- a/packages/common/src/items/slugs.ts
+++ b/packages/common/src/items/slugs.ts
@@ -1,4 +1,4 @@
-import { ISearchOptions, searchItems } from "@esri/arcgis-rest-portal";
+import { getItem, ISearchOptions, searchItems } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IItem } from "@esri/arcgis-rest-types";
 import { slugify } from "../utils";
@@ -52,7 +52,9 @@ export function getItemBySlug(
 ): Promise<IItem> {
   return findItemsBySlug({ slug }, requestOptions).then((results) => {
     if (results.length) {
-      return results[0];
+      // search results only include a subset of properties of the item, so
+      // issue a subsequent call to getItem to get the full item details
+      return getItem(results[0].id, requestOptions);
     } else {
       return null;
     }


### PR DESCRIPTION
1. Description:

Search results return a subset of properties, e.g. `orgId` is returned on results from `getItem` but not `searchItems`. This PR refactors `getItemBySlug` method to issue a subsequent `getItem` request so we get the full AGO item + props.

1. Instructions for testing:

1. Closes Issues: [5906](https://devtopia.esri.com/dc/hub/issues/5906)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
