### PR TITLE
feat(hub-discussions): consolidate post reactions to a single propert…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63976,7 +63976,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "12.13.0",
+			"version": "12.13.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64001,7 +64001,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "20.0.0",
+			"version": "20.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -415,10 +415,6 @@ export enum PostType {
   Question = "question",
 }
 
-export type PostReactionSummary = {
-  [key in PostReaction]: string[];
-};
-
 /**
  * representation of post from service
  *
@@ -444,12 +440,11 @@ export interface IPost extends IWithAuthor, IWithEditor, IWithTimestamps {
   parent?: IPost | null;
   replies?: IPost[] | IPagedResponse<IPost>;
   replyCount?: number;
-  reactions?: PostReactionSummary;
-  userReactions?: IReaction[];
+  reactions?: IReaction[];
 }
 
 /**
- * base paramaters for creating a post
+ * base parameters for creating a post
  *
  * @export
  * @interface IPostOptions

--- a/packages/discussions/test/reactions.test.ts
+++ b/packages/discussions/test/reactions.test.ts
@@ -7,7 +7,7 @@ describe("reactions", () => {
   const response = new Response("ok", { status: 200 });
   const baseOpts: IDiscussionsRequestOptions = {
     hubApiUrl: "https://hub.arcgis.com/api",
-    authentication: null,
+    authentication: undefined,
   };
 
   beforeEach(() => {


### PR DESCRIPTION
…y - reactions

affects: @esri/hub-discussions

BREAKING CHANGE:
Remove IPost.userReactions. Change IPost.reactions to IReaction[]. Remove type PostReactionSummary

1. Description: Modify the IPost interface with a single reaction property, which is changed to IReaction[]

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
