### PR TITLE
feat(hub-common): add bbox search to portal-based item searches

### DIFF
--- a/docs/src/guides/advanced/queries-and-filters.md
+++ b/docs/src/guides/advanced/queries-and-filters.md
@@ -184,6 +184,7 @@ Although the `IPredicate` structure allows for any key, value combinations, the 
 | Property           | Entity                  | Allowed Types                         |
 | ------------------ | ----------------------- | ------------------------------------- |
 | `access`           | `item`, `group`, `user` | `string`, `string[]`, `IMatchOptions` |
+| `bbox`             | `item`                  | `string`                              |
 | `categories`       | `item`                  | `string`, `string[]`, `IMatchOptions` |
 | `created`          | `item`, `group`, `user` | `IDateRange<number>` `IRelativeDate`  |
 | `description`      | `item`, `group`         | `string`, `string[]`, `IMatchOptions` |

--- a/packages/common/src/search/_internal/commonHelpers/getTopLevelPredicate.ts
+++ b/packages/common/src/search/_internal/commonHelpers/getTopLevelPredicate.ts
@@ -1,0 +1,68 @@
+import { IFilter, IPredicate } from "../../types/IHubCatalog";
+
+/**
+ * Searches through a list of filters and finds a specific predicate that should be appended at the top level of a search
+ * (i.e., has special requirements for combining with other predicates). Also verifies that the predicate is not combined in any invalid ways.
+ *
+ * Combination Requirements:
+ * - Only ONE filter can have a predicate with the target field
+ * - Only ONE predicate with the target field can exist
+ * - The predicate can only be ANDed to other predicates
+ * - The predicate's field value MUST be a string (not string[] or IMatchOptions)
+ *
+ * Example: Portal's bbox field cannot be conditionally searched. Any value provided will always be applied as a top-level filter.
+ * - Valid: `?bbox=1,2,3,4&filter=type:CSV`
+ * - Invalid: `?filter=type:CSV OR (type:PDF AND bbox=1,2,3,4)
+ *
+ * @param field the field of the desired predicate
+ * @param filters filters to be searched / validated
+ * @returns the predicate (if present and all requirements are met)
+ */
+export function getTopLevelPredicate(
+  field: string,
+  filters: IFilter[]
+): IPredicate {
+  let result = null;
+
+  const matchingFilters: IFilter[] = filters.filter((f) => {
+    return f.predicates.find((p) => !!p[field]);
+  });
+
+  if (matchingFilters.length > 1) {
+    throw new Error(
+      `Only 1 IFilter can have a '${field}' predicate but ${matchingFilters.length} were detected`
+    );
+  }
+
+  if (matchingFilters.length) {
+    const matchingFilter = matchingFilters[0];
+    const matchingPredicates = matchingFilter.predicates.filter(
+      (p) => !!p[field]
+    );
+
+    if (matchingPredicates.length > 1) {
+      throw new Error(
+        `Only 1 '${field}' predicate is allowed but ${matchingPredicates.length} were detected`
+      );
+    }
+
+    if (
+      matchingFilter.operation !== "AND" &&
+      matchingFilter.predicates.length > 1
+    ) {
+      throw new Error(
+        `'${field}' predicates cannot be OR'd to other predicates`
+      );
+    }
+
+    const topLevelPredicate = matchingPredicates[0];
+    if (typeof topLevelPredicate[field] !== "string") {
+      throw new Error(
+        `'${field}' predicate must have a string value, string[] and IMatchOptions are not allowed.`
+      );
+    }
+    result = topLevelPredicate;
+  }
+
+  return result;
+}

--- a/packages/common/src/search/_internal/expandPredicate.ts
+++ b/packages/common/src/search/_internal/expandPredicate.ts
@@ -20,6 +20,7 @@ export function expandPredicate(predicate: IPredicate): IPredicate {
     "searchUserAccess",
     "isopendata",
     "searchUserName",
+    "bbox",
   ];
   const nonMatchOptionsFields = [...dateProps, ...copyProps];
   // Do the conversion

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getQQueryParam.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getQQueryParam.ts
@@ -1,51 +1,12 @@
+import { IQuery } from "../../types/IHubCatalog";
+import { getTopLevelPredicate } from "../commonHelpers/getTopLevelPredicate";
+
 // TODO: the 'q' query param logic is only here because the
 // OGC API currently has a bug where 'q' cannot be included
 // in the 'filter' string. Once that bug is resolved, rip this
-// logic out and let predicates with 'term' to be processed
+// logic out and let predicates with 'term' to be processed normally
 
-import { IFilter, IQuery } from "../../types/IHubCatalog";
-
-// normally
 export function getQQueryParam(query: IQuery) {
-  const qFilters: IFilter[] = query.filters.filter((f) => {
-    return f.predicates.find((p) => !!p.term);
-  });
-
-  const qPredicate = getQPredicate(qFilters);
+  const qPredicate = getTopLevelPredicate("term", query.filters);
   return qPredicate?.term;
-}
-
-export function getQPredicate(filters: IFilter[]) {
-  let result;
-
-  if (filters.length > 1) {
-    throw new Error(
-      `IQuery can only have 1 IFilter with a 'term' predicate but ${filters.length} were detected`
-    );
-  }
-
-  if (filters.length) {
-    const filter = filters[0];
-    const qPredicates = filter.predicates.filter((p) => !!p.term);
-
-    if (qPredicates.length > 1) {
-      throw new Error(
-        `IQuery can only have 1 'term' predicate but ${qPredicates.length} were detected`
-      );
-    }
-
-    if (filter.operation !== "AND" && filter.predicates.length > 1) {
-      throw new Error(`'term' predicates cannot be OR'd to other predicates`);
-    }
-
-    const qPredicate = qPredicates[0];
-    if (typeof qPredicate.term !== "string") {
-      throw new Error(
-        `'term' predicate must have a string value, string[] and IMatchOptions are not allowed.`
-      );
-    }
-    result = qPredicate;
-  }
-
-  return result;
 }

--- a/packages/common/src/search/serializeQueryForPortal.ts
+++ b/packages/common/src/search/serializeQueryForPortal.ts
@@ -6,6 +6,7 @@ import {
   IPredicate,
   IQuery,
 } from "./types";
+import { getTopLevelPredicate } from "./_internal/commonHelpers/getTopLevelPredicate";
 import { expandPredicate } from "./_internal/expandPredicate";
 
 /**
@@ -18,6 +19,11 @@ export function serializeQueryForPortal(query: IQuery): ISearchOptions {
   // remove any empty entries
   const nonEmptyOptions = filterSearchOptions.filter(removeEmptyEntries);
   const result = mergeSearchOptions(nonEmptyOptions, "AND");
+
+  const bboxPredicate = getTopLevelPredicate("bbox", query.filters);
+  if (bboxPredicate) {
+    result.params = { bbox: bboxPredicate.bbox };
+  }
 
   return result;
 }
@@ -92,6 +98,7 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
     "searchUserName",
     "categoriesAsParam",
     "categoryFilter",
+    "bbox",
   ];
   const specialProps = [
     "filterType",

--- a/packages/common/test/search/_internal/getTopLevelPredicate.test.ts
+++ b/packages/common/test/search/_internal/getTopLevelPredicate.test.ts
@@ -1,0 +1,111 @@
+import { IFilter } from "../../../src/search/types/IHubCatalog";
+import { getTopLevelPredicate } from "../../../src/search/_internal/commonHelpers/getTopLevelPredicate";
+
+describe("getTopLevelPredicate |", () => {
+  it("returns null when passed an empty array", () => {
+    const result = getTopLevelPredicate("bbox", []);
+    expect(result).toBeNull();
+  });
+  it("throws an error when more than 1 filter with target field predicates are passed in", () => {
+    const filters: IFilter[] = [
+      { predicates: [{ bbox: "1,2,3,4" }] },
+      { predicates: [{ bbox: "4,5,6,7" }] },
+    ];
+
+    try {
+      getTopLevelPredicate("bbox", filters);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err.message).toEqual(
+        "Only 1 IFilter can have a 'bbox' predicate but 2 were detected"
+      );
+    }
+  });
+
+  it("throws an error when a filter with more than one target field predicate is passed in", () => {
+    const filters: IFilter[] = [
+      {
+        predicates: [{ bbox: "1,2,3,4" }, { bbox: "4,5,6,7" }],
+      },
+    ];
+
+    try {
+      getTopLevelPredicate("bbox", filters);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err.message).toEqual(
+        "Only 1 'bbox' predicate is allowed but 2 were detected"
+      );
+    }
+  });
+
+  it("throws an error when a target field predicate is ORd with another predicate", () => {
+    const filters: IFilter[] = [
+      {
+        operation: "OR",
+        predicates: [{ bbox: "1,2,3,4" }, { type: "typeA" }],
+      },
+    ];
+
+    try {
+      getTopLevelPredicate("bbox", filters);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err.message).toEqual(
+        "'bbox' predicates cannot be OR'd to other predicates"
+      );
+    }
+  });
+
+  it("throws an error when a target field predicate is an array", () => {
+    const filters: IFilter[] = [
+      {
+        predicates: [{ bbox: ["1,2,3,4", "5,6,7,8"] }],
+      },
+    ];
+
+    try {
+      getTopLevelPredicate("bbox", filters);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err.message).toEqual(
+        "'bbox' predicate must have a string value, string[] and IMatchOptions are not allowed."
+      );
+    }
+  });
+
+  it("throws an error when a target field predicate is an IMatchOptions", () => {
+    const filters: IFilter[] = [
+      {
+        predicates: [
+          {
+            bbox: {
+              any: ["1,2,3,4", "5,6,7,8"],
+            },
+          },
+        ],
+      },
+    ];
+
+    try {
+      getTopLevelPredicate("bbox", filters);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err.message).toEqual(
+        "'bbox' predicate must have a string value, string[] and IMatchOptions are not allowed."
+      );
+    }
+  });
+
+  it("returns the predicate when the target field predicate is a string", () => {
+    const expected = { bbox: "1,2,3,4" };
+    const filters: IFilter[] = [
+      {
+        predicates: [expected],
+      },
+    ];
+
+    const result = getTopLevelPredicate("bbox", filters);
+    expect(result).toBe(expected);
+  });
+});

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -20,17 +20,12 @@ import {
 import { getOgcItemQueryParams } from "../../../src/search/_internal/hubSearchItemsHelpers/getOgcItemQueryParams";
 import { getQueryString } from "../../../src/search/_internal/hubSearchItemsHelpers/getQueryString";
 import { getOgcAggregationQueryParams } from "../../../src/search/_internal/hubSearchItemsHelpers/getOgcAggregationQueryParams";
-import {
-  getQPredicate,
-  getQQueryParam,
-} from "../../../src/search/_internal/hubSearchItemsHelpers/getQQueryParam";
+import { getQQueryParam } from "../../../src/search/_internal/hubSearchItemsHelpers/getQQueryParam";
 import { IOgcItem } from "../../../src/search/_internal/hubSearchItemsHelpers/interfaces";
 import * as ogcItemToSearchResultModule from "../../../src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult";
 import { formatOgcItemsResponse } from "../../../src/search/_internal/hubSearchItemsHelpers/formatOgcItemsResponse";
 import { formatOgcAggregationsResponse } from "../../../src/search/_internal/hubSearchItemsHelpers/formatOgcAggregationsResponse";
 import * as searchOgcItemsModule from "../../../src/search/_internal/hubSearchItemsHelpers/searchOgcItems";
-import * as searchOgcAggregationsModule from "../../../src/search/_internal/hubSearchItemsHelpers/searchOgcAggregations";
-
 import * as portalSearchItemsModule from "../../../src/search/_internal/portalSearchItems";
 import { IItem } from "@esri/arcgis-rest-types";
 import * as fetchMock from "fetch-mock";
@@ -439,115 +434,6 @@ describe("hubSearchItems Module |", () => {
         expect(queryString).toEqual(
           "?aggregations=terms(fields=(type,tags,categories))&token=abc"
         );
-      });
-    });
-
-    describe("getQPredicate |", () => {
-      it("returns undefined when passed an empty array", () => {
-        const result = getQPredicate([]);
-        expect(result).toBeUndefined();
-      });
-      it("throws an error when more than 1 filter is passed in", () => {
-        const filters: IFilter[] = [
-          { predicates: [{ term: "term1" }] },
-          { predicates: [{ term: "term2" }] },
-        ];
-
-        try {
-          getQPredicate(filters);
-          expect(true).toBe(false);
-        } catch (err) {
-          expect(err.message).toEqual(
-            "IQuery can only have 1 IFilter with a 'term' predicate but 2 were detected"
-          );
-        }
-      });
-
-      it("throws an error when a filter with more than one term predicate is passed in", () => {
-        const filters: IFilter[] = [
-          {
-            predicates: [{ term: "term1" }, { term: "term2" }],
-          },
-        ];
-
-        try {
-          getQPredicate(filters);
-          expect(true).toBe(false);
-        } catch (err) {
-          expect(err.message).toEqual(
-            "IQuery can only have 1 'term' predicate but 2 were detected"
-          );
-        }
-      });
-
-      it("throws an error when a term predicate ORd with another predicate", () => {
-        const filters: IFilter[] = [
-          {
-            operation: "OR",
-            predicates: [{ term: "term1" }, { type: "typeA" }],
-          },
-        ];
-
-        try {
-          getQPredicate(filters);
-          expect(true).toBe(false);
-        } catch (err) {
-          expect(err.message).toEqual(
-            "'term' predicates cannot be OR'd to other predicates"
-          );
-        }
-      });
-
-      it("throws an error when a term predicate is an array", () => {
-        const filters: IFilter[] = [
-          {
-            predicates: [{ term: ["term1", "term2"] }],
-          },
-        ];
-
-        try {
-          getQPredicate(filters);
-          expect(true).toBe(false);
-        } catch (err) {
-          expect(err.message).toEqual(
-            "'term' predicate must have a string value, string[] and IMatchOptions are not allowed."
-          );
-        }
-      });
-
-      it("throws an error when a term predicate is an IMatchOptions", () => {
-        const filters: IFilter[] = [
-          {
-            predicates: [
-              {
-                term: {
-                  any: ["term1", "term2"],
-                },
-              },
-            ],
-          },
-        ];
-
-        try {
-          getQPredicate(filters);
-          expect(true).toBe(false);
-        } catch (err) {
-          expect(err.message).toEqual(
-            "'term' predicate must have a string value, string[] and IMatchOptions are not allowed."
-          );
-        }
-      });
-
-      it("returns the predicate when term is a string", () => {
-        const expected = { term: "term1" };
-        const filters: IFilter[] = [
-          {
-            predicates: [expected],
-          },
-        ];
-
-        const result = getQPredicate(filters);
-        expect(result).toBe(expected);
       });
     });
 

--- a/packages/common/test/search/_internal/portalSearchItems.test.ts
+++ b/packages/common/test/search/_internal/portalSearchItems.test.ts
@@ -64,6 +64,38 @@ describe("portalSearchItems Module:", () => {
       expect(expectedParams.q).toEqual("(water)");
       expect(expectedParams.countFields).not.toBeDefined();
     });
+    it("simple search with bbox", async () => {
+      const searchItemsSpy = spyOn(Portal, "searchItems").and.callFake(() => {
+        return Promise.resolve(cloneObject(AllTypesResponse));
+      });
+      const qry: IQuery = {
+        targetEntity: "item",
+        filters: [
+          {
+            predicates: [
+              {
+                term: "water",
+                bbox: "1,2,3,4",
+              },
+            ],
+          },
+        ],
+      };
+      const opts: IHubSearchOptions = {
+        requestOptions: {
+          portal: "https://www.arcgis.com/sharing/rest",
+        },
+      };
+
+      await portalSearchItems(qry, opts);
+
+      expect(searchItemsSpy.calls.count()).toBe(1, "should call searchItems");
+      const [expectedParams] = searchItemsSpy.calls.argsFor(0);
+      expect(expectedParams.portal).toEqual(opts.requestOptions?.portal);
+      expect(expectedParams.q).toEqual("(water)");
+      expect(expectedParams.params.bbox).toEqual("1,2,3,4");
+      expect(expectedParams.countFields).not.toBeDefined();
+    });
     it("simple search with auth", async () => {
       const searchItemsSpy = spyOn(Portal, "searchItems").and.callFake(() => {
         return Promise.resolve(cloneObject(SimpleResponse));


### PR DESCRIPTION
1. Description:

Adds `bbox` as a valid parameter for portal-based item searches of `hubSearch`.

There are some special rules for using a `bbox` predicate within an `IQuery`:
- Only ONE filter can have a predicate with the target field
- Only ONE predicate with the target field can exist
- The predicate can only be ANDed to other predicates
- The predicate value must be a string representation of a bbox (i.e. `"1,2,3,4")

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
