### PR TITLE
feat(): add servicesDirectoryDisabled property to content server object

### DIFF
--- a/packages/common/src/core/types/IServerEnrichments.ts
+++ b/packages/common/src/core/types/IServerEnrichments.ts
@@ -13,4 +13,7 @@ export interface IServerEnrichments {
   // TODO: should we remove this once fetchContent() no longer fetches it?
   /** The count of records for the layer referenced by this content */
   recordCount?: number | null;
+
+  /** If the server's services directory is disabled. See https://enterprise.arcgis.com/en/server/latest/administer/linux/disabling-the-services-directory.htm */
+  servicesDirectoryDisabled?: boolean;
 }

--- a/packages/common/src/items/_enrichments.ts
+++ b/packages/common/src/items/_enrichments.ts
@@ -17,6 +17,7 @@ import OperationStack from "../OperationStack";
 import { getItemMetadata } from "@esri/arcgis-rest-portal";
 import { getItemOrgId } from "../content/_internal";
 import { fetchOrg } from "../org";
+import { isServicesDirectoryDisabled } from "./is-services-directory-disabled";
 
 /**
  * An object containing the item and fetched enrichments
@@ -190,10 +191,23 @@ const enrichServer = (
     ...requestOptions,
     url,
   };
-  return getService(options)
-    .then((server) => {
+  return Promise.all([
+    getService(options),
+    isServicesDirectoryDisabled(data.item, requestOptions),
+  ])
+    .then(([server, servicesDirectoryDisabled]) => {
       stack.finish(opId);
-      return { data: { ...data, server }, stack, requestOptions };
+      return {
+        data: {
+          ...data,
+          server: {
+            ...server,
+            servicesDirectoryDisabled,
+          },
+        },
+        stack,
+        requestOptions,
+      };
     })
     .catch((error) => handleEnrichmentError(error, input, opId));
 };

--- a/packages/common/src/items/index.ts
+++ b/packages/common/src/items/index.ts
@@ -21,3 +21,4 @@ export * from "./create-item-from-file";
 export * from "./create-item-from-url";
 export * from "./create-item-from-url-or-file";
 export * from "./uploadImageResource";
+export * from "./is-services-directory-disabled";

--- a/packages/common/src/items/is-services-directory-disabled.ts
+++ b/packages/common/src/items/is-services-directory-disabled.ts
@@ -1,0 +1,42 @@
+import { parseServiceUrl } from "@esri/arcgis-rest-feature-layer";
+import { getItem } from "@esri/arcgis-rest-portal";
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { IItem } from "@esri/arcgis-rest-types";
+
+/**
+ * Checks if a server's services directory is disabled. Consider hoisting this to RESTJS
+ * @param idOrItem A feature service ID or item
+ * @param requestOptions Request options
+ * @returns Promise that resolves boolean
+ */
+export const isServicesDirectoryDisabled = async (
+  idOrItem: string | IItem,
+  requestOptions: IRequestOptions
+): Promise<boolean> => {
+  let disabled;
+  try {
+    const item =
+      typeof idOrItem === "string"
+        ? await getItem(idOrItem, requestOptions)
+        : idOrItem;
+    if (item.url) {
+      let url = parseServiceUrl(item.url);
+      if (item.access !== "public" && requestOptions.authentication) {
+        const token = await requestOptions.authentication.getToken(
+          item.url,
+          requestOptions
+        );
+        if (token) {
+          url = `${url}?token=${token}`;
+        }
+      }
+      const { status } = await fetch(url);
+      disabled = status !== 200;
+    } else {
+      disabled = true;
+    }
+  } catch (e) {
+    disabled = true;
+  }
+  return disabled;
+};

--- a/packages/common/test/items/is-services-directory-disabled.test.ts
+++ b/packages/common/test/items/is-services-directory-disabled.test.ts
@@ -1,0 +1,86 @@
+import { isServicesDirectoryDisabled } from "../../src/items/is-services-directory-disabled";
+import { IItem } from "@esri/arcgis-rest-types";
+import * as fetchMock from "fetch-mock";
+import * as restPortal from "@esri/arcgis-rest-portal";
+import {
+  IAuthenticationManager,
+  IRequestOptions,
+} from "@esri/arcgis-rest-request";
+
+describe("isServicesDirectoryDisabled", function () {
+  const url =
+    "https://maps.bouldercounty.org/arcgis/rest/services/PublicSafety/POLICE_STATIONS/MapServer";
+  let item: IItem;
+  let requestOptions: IRequestOptions;
+  let getItemSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    item = {
+      id: "abc",
+      url,
+    } as IItem;
+
+    requestOptions = {} as IRequestOptions;
+
+    getItemSpy = spyOn(restPortal, "getItem").and.returnValue(
+      Promise.resolve(item)
+    );
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it("should resolve true when an error occurs", async () => {
+    getItemSpy.and.returnValue(Promise.reject(new Error("fail")));
+    const result = await isServicesDirectoryDisabled(item.id, requestOptions);
+    expect(getItemSpy).toHaveBeenCalledTimes(1);
+    expect(getItemSpy).toHaveBeenCalledWith(item.id, requestOptions);
+    expect(result).toBe(true);
+  });
+
+  it("should resolve true when the item has no url", async () => {
+    delete item.url;
+    const result = await isServicesDirectoryDisabled(item, requestOptions);
+    expect(getItemSpy).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it("should fetch the item when given an id", async () => {
+    fetchMock.get(url, 200);
+    const result = await isServicesDirectoryDisabled(item.id, requestOptions);
+    expect(getItemSpy).toHaveBeenCalledTimes(1);
+    expect(getItemSpy).toHaveBeenCalledWith(item.id, requestOptions);
+    expect(result).toBe(false);
+  });
+
+  it("should resolve true when the status is not 200", async () => {
+    fetchMock.get(url, 403);
+    const result = await isServicesDirectoryDisabled(item, requestOptions);
+    expect(getItemSpy).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it("should append the token when access is not public and user has a session", async () => {
+    const token = "token123";
+    const getTokenSpy = jasmine.createSpy().and.returnValue(token);
+    requestOptions.authentication = {
+      getToken: getTokenSpy,
+    } as any as IAuthenticationManager;
+    fetchMock.get(`${url}?token=${token}`, 200);
+    const result = await isServicesDirectoryDisabled(item, requestOptions);
+    expect(getItemSpy).not.toHaveBeenCalled();
+    expect(result).toBe(false);
+  });
+
+  it("should not append the token when a token is not returned", async () => {
+    const getTokenSpy = jasmine.createSpy().and.returnValue(null);
+    requestOptions.authentication = {
+      getToken: getTokenSpy,
+    } as any as IAuthenticationManager;
+    fetchMock.get(url, 200);
+    const result = await isServicesDirectoryDisabled(item, requestOptions);
+    expect(getItemSpy).not.toHaveBeenCalled();
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
1. Description:
[2900](https://devtopia.esri.com/dc/hub/issues/2900)

- Adds a `servicesDirectoryDisabled` property to content `server` property

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
