### PR TITLE
feat(hub-common): change how we pass api info to hubSearch

### DIFF
--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcCollectionUrl.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcCollectionUrl.ts
@@ -1,0 +1,11 @@
+import { IQuery } from "../../types/IHubCatalog";
+import { IHubSearchOptions } from "../../types/IHubSearchOptions";
+import { IApiDefinition } from "../../types/types";
+
+export function getOgcCollectionUrl(query: IQuery, options: IHubSearchOptions) {
+  const apiDefinition = options.api as IApiDefinition;
+  const collectionId = query.wellKnownQueryId;
+  return collectionId
+    ? `${apiDefinition.url}/collections/${collectionId}`
+    : `${apiDefinition.url}/collections/all`;
+}

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/searchOgcAggregations.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/searchOgcAggregations.ts
@@ -2,17 +2,16 @@ import { IQuery } from "../../types/IHubCatalog";
 import { IHubSearchOptions } from "../../types/IHubSearchOptions";
 import { IHubSearchResponse } from "../../types/IHubSearchResponse";
 import { IHubSearchResult } from "../../types/IHubSearchResult";
-import { IApiDefinition } from "../../types/types";
 import { formatOgcAggregationsResponse } from "./formatOgcAggregationsResponse";
 import { getOgcAggregationQueryParams } from "./getOgcAggregationQueryParams";
+import { getOgcCollectionUrl } from "./getOgcCollectionUrl";
 import { ogcApiRequest } from "./ogcApiRequest";
 
 export async function searchOgcAggregations(
   query: IQuery,
   options: IHubSearchOptions
 ): Promise<IHubSearchResponse<IHubSearchResult>> {
-  const apiDefinition = options.api as IApiDefinition;
-  const url = `${apiDefinition.url}/aggregations`;
+  const url = `${getOgcCollectionUrl(query, options)}/aggregations`;
   const queryParams = getOgcAggregationQueryParams(query, options);
 
   const rawResponse = await ogcApiRequest(url, queryParams, options);

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/searchOgcItems.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/searchOgcItems.ts
@@ -2,8 +2,8 @@ import { IQuery } from "../../types/IHubCatalog";
 import { IHubSearchOptions } from "../../types/IHubSearchOptions";
 import { IHubSearchResponse } from "../../types/IHubSearchResponse";
 import { IHubSearchResult } from "../../types/IHubSearchResult";
-import { IApiDefinition } from "../../types/types";
 import { formatOgcItemsResponse } from "./formatOgcItemsResponse";
+import { getOgcCollectionUrl } from "./getOgcCollectionUrl";
 import { getOgcItemQueryParams } from "./getOgcItemQueryParams";
 import { IOgcItemsResponse } from "./interfaces";
 import { ogcApiRequest } from "./ogcApiRequest";
@@ -12,8 +12,7 @@ export async function searchOgcItems(
   query: IQuery,
   options: IHubSearchOptions
 ): Promise<IHubSearchResponse<IHubSearchResult>> {
-  const apiDefinition = options.api as IApiDefinition;
-  const url = `${apiDefinition.url}/items`;
+  const url = `${getOgcCollectionUrl(query, options)}/items`;
   const queryParams = getOgcItemQueryParams(query, options);
 
   const rawResponse: IOgcItemsResponse = await ogcApiRequest(

--- a/packages/common/src/search/hubSearch.ts
+++ b/packages/common/src/search/hubSearch.ts
@@ -7,7 +7,7 @@ import {
   IHubSearchResult,
   IQuery,
 } from "./types";
-import { expandApi } from "./utils";
+import { getApi } from "./utils";
 import {
   hubSearchItems,
   portalSearchItems,
@@ -50,8 +50,9 @@ export async function hubSearch(
 
   // Get the type of the first filterGroup
   const filterType = query.targetEntity;
-  // get the API
-  const apiType = expandApi(options.api || "arcgis").type;
+
+  const formattedOptions = cloneObject(options);
+  formattedOptions.api = getApi(filterType, options);
 
   const fnHash = {
     arcgis: {
@@ -64,12 +65,12 @@ export async function hubSearch(
     },
   };
 
-  const fn = getProp(fnHash, `${apiType}.${filterType}`);
+  const fn = getProp(fnHash, `${formattedOptions.api.type}.${filterType}`);
   if (!fn) {
     throw new HubError(
       `hubSearch`,
-      `Search via "${filterType}" filter against "${apiType}" api is not implemented. Please ensure "targetEntity" is defined on the query.`
+      `Search via "${filterType}" filter against "${formattedOptions.api.type}" api is not implemented. Please ensure "targetEntity" is defined on the query.`
     );
   }
-  return fn(cloneObject(query), options);
+  return fn(cloneObject(query), formattedOptions);
 }

--- a/packages/common/src/search/hubSearch.ts
+++ b/packages/common/src/search/hubSearch.ts
@@ -32,8 +32,11 @@ export async function hubSearch(
   if (!query) {
     throw new HubError("hubSearch", "Query is required.");
   }
-  if (!query.filters || !query.filters.length) {
-    throw new HubError("hubSearch", "Query must contain at least one Filter.");
+  if ((!query.filters || !query.filters.length) && !query.wellKnownQueryId) {
+    throw new HubError(
+      "hubSearch",
+      "Query must contain at least one Filter or wellKnownQueryId"
+    );
   }
 
   if (!options.requestOptions) {

--- a/packages/common/src/search/types/IHubCatalog.ts
+++ b/packages/common/src/search/types/IHubCatalog.ts
@@ -65,6 +65,9 @@ export interface IQuery {
    * ensure we query the correct API
    */
   targetEntity: EntityType;
+
+  wellKnownQueryId?: string;
+
   /**
    * Filters that make up the query
    */

--- a/packages/common/src/search/types/IHubSearchOptions.ts
+++ b/packages/common/src/search/types/IHubSearchOptions.ts
@@ -23,9 +23,17 @@ export interface IHubSearchOptions {
   aggLimit?: number;
 
   /**
+   * TODO: Deprecate in favor of `requestOptions` and `siteUrl`
    * Specify API to call. Defaults to ArcGIS Online Portal API
    */
   api?: NamedApis | IApiDefinition;
+
+  /**
+   * Site whose API should be targeted. Ignored in an enterprise context.
+   * e.g., https://my-site.hub.arcgis.com
+   */
+  siteUrl?: string;
+
   /**
    * DEPRECATE in favor of requestOptions
    */

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -107,7 +107,7 @@ export function getApi(
   } else if (shouldUseOgcApi(targetEntity, options)) {
     result = {
       type: "arcgis-hub",
-      url: `${siteUrl}/api/search/v1/collections/all`,
+      url: `${siteUrl}/api/search/v1`,
     };
   } else {
     result = { type: "arcgis", url: portal };

--- a/packages/common/test/search/hubSearch.test.ts
+++ b/packages/common/test/search/hubSearch.test.ts
@@ -1,4 +1,4 @@
-import { IHubSearchOptions, IQuery } from "../../src";
+import { IHubSearchOptions, IQuery, SEARCH_APIS } from "../../src";
 import { hubSearch } from "../../src/search/hubSearch";
 
 import * as SearchFunctionModule from "../../src/search/_internal";
@@ -191,10 +191,11 @@ describe("hubSearch Module:", () => {
           ],
         };
         const opts: IHubSearchOptions = {
+          siteUrl: "https://my-site.hub.arcgis.com",
           requestOptions: {
+            isPortal: false,
             portal: "https://qaext.arcgis.com/sharing/rest",
           },
-          api: "hubDEV",
           include: ["server"],
         };
         const chk = await hubSearch(qry, opts);
@@ -206,6 +207,10 @@ describe("hubSearch Module:", () => {
         expect(query).toEqual(qry);
         expect(options.include).toBeDefined();
         expect(options.requestOptions).toEqual(opts.requestOptions);
+        expect(options.api).toEqual({
+          type: "arcgis-hub",
+          url: "https://my-site.hub.arcgis.com/api/search/v1/collections/all",
+        });
       });
       it("groups + arcgis: portalSearchGroups", async () => {
         const qry: IQuery = {

--- a/packages/common/test/search/utils.test.ts
+++ b/packages/common/test/search/utils.test.ts
@@ -104,7 +104,7 @@ describe("Search Utils:", () => {
       } as unknown as IHubSearchOptions;
       expect(getApi(targetEntity, options)).toEqual({
         type: "arcgis-hub",
-        url: `${siteUrl}/api/search/v1/collections/all`,
+        url: `${siteUrl}/api/search/v1`,
       });
     });
     it("otherwise returns a reference to the Portal API from requestOptions", () => {


### PR DESCRIPTION
affects: @esri/hub-common

deprecates options.api in favor of deriving info from siteUrl and requestOptions.portal

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
