### PR TITLE
fix(hub-discussions): add optional properties to IUpdatePost

### DIFF
--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -574,6 +574,10 @@ export interface IUpdatePostStatus {
 export interface IUpdatePost {
   title?: string;
   body?: string;
+  discussion?: string | null;
+  geometry?: Geometry | null;
+  featureGeometry?: Geometry | null;
+  appInfo?: string | null;
 }
 
 /**


### PR DESCRIPTION
affects: @esri/hub-discussions

1. Description: Add optional properties to interface IUpdatePost

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
