### PR TITLE
fix: resolve missing export problems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63976,7 +63976,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "12.18.0",
+			"version": "12.20.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/src/access/can-edit-event.ts
+++ b/packages/common/src/access/can-edit-event.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-types";
+import { IUser } from "@esri/arcgis-rest-portal";
 import { IInitiativeModel } from "../types";
 import { getProp } from "../objects";
 import { findBy } from "../util";

--- a/packages/common/src/access/can-edit-item.ts
+++ b/packages/common/src/access/can-edit-item.ts
@@ -1,4 +1,4 @@
-import { IItem, IUser, IGroup } from "@esri/arcgis-rest-types";
+import { IItem, IUser, IGroup } from "@esri/arcgis-rest-portal";
 import { isUpdateGroup, includes } from "../utils";
 import { getProp } from "../objects";
 import { hasBasePriv } from "./has-base-priv";
@@ -25,7 +25,7 @@ export function canEditItem(item: IItem, user: IUser): boolean {
   } else if (hasPriv) {
     const itemGroups = [
       ...(getProp(item, "groupIds") || []),
-      getProp(item, "properties.collaborationGroupId")
+      getProp(item, "properties.collaborationGroupId"),
     ];
     const isGroupEditable = (group: IGroup): boolean =>
       isUpdateGroup(group) && includes(itemGroups, group.id);

--- a/packages/common/src/access/can-edit-site-content.ts
+++ b/packages/common/src/access/can-edit-site-content.ts
@@ -1,4 +1,4 @@
-import { IItem, IUser } from "@esri/arcgis-rest-types";
+import { IItem, IUser } from "@esri/arcgis-rest-portal";
 import { includes } from "../utils";
 import { getProp } from "../objects";
 import { hasBasePriv } from "./has-base-priv";
@@ -9,7 +9,7 @@ export const REQUIRED_PRIVS = [
   "portal:user:createItem",
   "portal:user:shareToGroup",
   "portal:user:viewOrgGroups",
-  "portal:user:viewOrgItems"
+  "portal:user:viewOrgItems",
 ];
 
 /**
@@ -32,7 +32,9 @@ export function canEditSiteContent(item: IItem, user: IUser): boolean {
     const sameOrg = !!userOrgId && userOrgId === itemOrgId;
     if (sameOrg) {
       const privileges = user.privileges || [];
-      res = REQUIRED_PRIVS.every(privilege => includes(privileges, privilege));
+      res = REQUIRED_PRIVS.every((privilege) =>
+        includes(privileges, privilege)
+      );
     }
   }
   return res;

--- a/packages/common/src/access/can-edit-site.ts
+++ b/packages/common/src/access/can-edit-site.ts
@@ -1,4 +1,4 @@
-import { IItem, IUser } from "@esri/arcgis-rest-types";
+import { IItem, IUser } from "@esri/arcgis-rest-portal";
 import { getProp } from "../objects";
 import { hasBasePriv } from "./has-base-priv";
 import { canEditItem } from "./can-edit-item";

--- a/packages/common/src/access/has-base-priv.ts
+++ b/packages/common/src/access/has-base-priv.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-types";
+import { IUser } from "@esri/arcgis-rest-portal";
 import { includes } from "../utils";
 
 /**

--- a/packages/common/src/categories.ts
+++ b/packages/common/src/categories.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-types";
+import { IItem } from "@esri/arcgis-rest-portal";
 import { collections } from "./collections";
 
 const {

--- a/packages/common/src/content/_fetch.ts
+++ b/packages/common/src/content/_fetch.ts
@@ -12,7 +12,8 @@ import {
 import { isMapOrFeatureServerUrl } from "../urls";
 import { cloneObject } from "../util";
 import { includes } from "../utils";
-import { IHubExtent, normalizeItemType } from "./compose";
+import { IHubExtent } from "./compose";
+import { normalizeItemType } from "./normalizeItemType";
 import { getFamily } from "./get-family";
 import { parseDatasetId } from "./slugs";
 import { DatasetResource } from "./types";
@@ -33,7 +34,7 @@ const shouldFetchData = (item: IItem) => {
  * @returns the default list of enrichments to fetch for content
  * @private
  */
-export const getContentEnrichments = (item: IItem) => {
+export function getContentEnrichments(item: IItem) {
   // we fetch these enrichments for all content types
   const enrichments: ItemOrServerEnrichment[] = [
     "groupIds",
@@ -49,7 +50,7 @@ export const getContentEnrichments = (item: IItem) => {
   return isMapOrFeatureServerUrl(item.url)
     ? enrichments.concat("server", "layers")
     : enrichments;
-};
+}
 
 /**
  * The set of enrichments that we fetch from the Hub API
@@ -141,10 +142,10 @@ const getDatasetEnrichments = (dataset: DatasetResource) => {
  * @returns enrichments from the Hub API (slug, boundary, statistic, etc)
  * @private
  */
-export const fetchHubEnrichmentsBySlug = async (
+export async function fetchHubEnrichmentsBySlug(
   slug: string,
   requestOptions?: IHubRequestOptions
-) => {
+) {
   // NOTE: we don't catch errors here b/c
   // searching by slug is the first step in fetchContent()
   // and if this fails, we don't have an id to fall back on
@@ -153,7 +154,7 @@ export const fetchHubEnrichmentsBySlug = async (
     getHubEnrichmentsOptions(requestOptions, slug)
   );
   return getDatasetEnrichments(response.data[0]);
-};
+}
 
 /**
  * fetch enrichment from the Hub API by id
@@ -162,10 +163,10 @@ export const fetchHubEnrichmentsBySlug = async (
  * @returns enrichments from the Hub API (slug, boundary, statistic, etc)
  * @private
  */
-export const fetchHubEnrichmentsById = async (
+export async function fetchHubEnrichmentsById(
   hubId: string,
   requestOptions?: IHubRequestOptions
-) => {
+) {
   try {
     const response = await hubApiRequest(
       `/datasets/${hubId}`,
@@ -177,4 +178,4 @@ export const fetchHubEnrichmentsById = async (
     // b/c we can still look up the item and enrichments by id
     return { errors: getEnrichmentErrors(e as Error) };
   }
-};
+}

--- a/packages/common/src/content/_internal/getItemOrgId.ts
+++ b/packages/common/src/content/_internal/getItemOrgId.ts
@@ -1,0 +1,5 @@
+import { IItem, IUser } from "@esri/arcgis-rest-portal";
+
+export function getItemOrgId(item: IItem, ownerUser?: IUser) {
+  return item.orgId || ownerUser?.orgId;
+}

--- a/packages/common/src/content/contentUtils.ts
+++ b/packages/common/src/content/contentUtils.ts
@@ -13,11 +13,8 @@ import {
   isPageType,
 } from "./_internal/internalContentUtils";
 import { camelize } from "../util";
-import {
-  normalizeItemType,
-  getContentTypeIcon,
-  composeContent,
-} from "./compose";
+import { getContentTypeIcon, composeContent } from "./compose";
+import { normalizeItemType } from "./normalizeItemType";
 import { getFamily } from "./get-family";
 import { parseDatasetId, removeContextFromSlug } from "./slugs";
 import { DatasetResource } from "./types";
@@ -378,10 +375,10 @@ export function datasetToItem(dataset: DatasetResource): IItem {
  * @param type new type
  * @returns new content
  */
-export const setContentType = (
+export function setContentType(
   content: IHubContent,
   type: string
-): IHubContent => {
+): IHubContent {
   // get family and normalized type based on new type
   const normalizedType = normalizeItemType({ ...content.item, type });
   const family = getFamily(normalizedType);
@@ -402,7 +399,7 @@ export const setContentType = (
   return appendContentUrls(updated, {
     relative: getContentRelativeUrl(updated),
   });
-};
+}
 
 /**
  * Compute the content type label
@@ -410,30 +407,24 @@ export const setContentType = (
  * @param isProxied
  * @returns content type label
  */
-export const getContentTypeLabel = (
-  contentType: string,
-  isProxied: boolean
-) => {
+export function getContentTypeLabel(contentType: string, isProxied: boolean) {
   return isProxied ? "CSV" : camelize(contentType || "");
-};
+}
 
 // URL helpers
-const appendContentUrls = (
+function appendContentUrls(
   content: IHubContent,
   newUrls: Record<string, string>
-): IHubContent => {
+): IHubContent {
   // merge new urls into existing ones and return a new content
   const urls = { ...content.urls, ...newUrls };
   return { ...content, urls };
-};
+}
 
-const getContentRelativeUrl = (
-  content: IHubContent,
-  siteIdentifier?: string
-) => {
+function getContentRelativeUrl(content: IHubContent, siteIdentifier?: string) {
   return getHubRelativeUrl(
     content.type,
     siteIdentifier || content.identifier,
     content.typeKeywords
   );
-};
+}

--- a/packages/common/src/content/fetchHubContent.ts
+++ b/packages/common/src/content/fetchHubContent.ts
@@ -1,0 +1,28 @@
+import { IHubEditableContent } from "../core";
+import { ItemOrServerEnrichment } from "../items/_enrichments";
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { PropertyMapper } from "../core/_internal/PropertyMapper";
+import { getPropertyMap } from "./_internal/getPropertyMap";
+import { IFetchContentOptions, fetchContent } from "./fetch";
+
+export async function fetchHubContent(
+  identifier: string,
+  requestOptions: IRequestOptions
+): Promise<IHubEditableContent> {
+  // TODO: fetch data? org? ownerUser? metadata?
+  // could use getItemEnrichments() and remove server, layers, etc
+  // but we'd have to do that _after_ fetching the item first
+  const enrichments = [] as ItemOrServerEnrichment[];
+  const options = { ...requestOptions, enrichments } as IFetchContentOptions;
+  // for now we call fetchContent(), which returns a superset of IHubEditableContent
+  // in the long run we probably want to replace this w/ fetchItemAndEnrichments()
+  // and then use the property mapper and computeProps() to compose the object
+  const model = await fetchContent(identifier, options);
+  // for now we still need property mapper to get defaults not set by composeContent()
+  const mapper = new PropertyMapper<Partial<IHubEditableContent>>(
+    getPropertyMap()
+  );
+  const content = mapper.modelToObject(model, {}) as IHubEditableContent;
+  // TODO: computeProps if we end up using fetchItemAndEnrichments()
+  return content;
+}

--- a/packages/common/src/content/index.ts
+++ b/packages/common/src/content/index.ts
@@ -9,3 +9,6 @@ export * from "./HubContent";
 export * from "./search";
 export * from "./slugs";
 export * from "./types";
+export * from "./normalizeItemType";
+export * from "./fetchHubContent";
+export * from "./isSiteType";

--- a/packages/common/src/content/isSiteType.ts
+++ b/packages/common/src/content/isSiteType.ts
@@ -1,0 +1,14 @@
+/**
+ * Determines whether, given a type and typekeywords, the input is
+ * a site item type or not
+ * @param type - the type value on the item
+ * @param typeKeywords - the typeKeywords on the item
+ */
+
+export function isSiteType(type: string, typeKeywords: string[] = []) {
+  return (
+    type === "Site Application" ||
+    type === "Hub Site Application" ||
+    (type === "Web Mapping Application" && typeKeywords.includes("hubSite"))
+  );
+}

--- a/packages/common/src/content/normalizeItemType.ts
+++ b/packages/common/src/content/normalizeItemType.ts
@@ -1,0 +1,42 @@
+import { includes } from "../utils";
+import { isSiteType } from "./isSiteType";
+
+/**
+ * ```js
+ * import { normalizeItemType } from "@esri/hub-common";
+ * //
+ * normalizeItemType(item)
+ * > [ 'Hub Site Application' ]
+ * ```
+ * @param item Item object.
+ * @returns type of the input item.
+ *
+ */
+
+export function normalizeItemType(item: any = {}): string {
+  let ret = item.type;
+  const typeKeywords = item.typeKeywords || [];
+  if (isSiteType(item.type, typeKeywords)) {
+    ret = "Hub Site Application";
+  }
+  if (
+    item.type === "Site Page" ||
+    (item.type === "Web Mapping Application" &&
+      includes(typeKeywords, "hubPage"))
+  ) {
+    ret = "Hub Page";
+  }
+  if (
+    item.type === "Hub Initiative" &&
+    includes(typeKeywords, "hubInitiativeTemplate")
+  ) {
+    ret = "Hub Initiative Template";
+  }
+  if (
+    item.type === "Web Mapping Application" &&
+    includes(typeKeywords, "hubSolutionTemplate")
+  ) {
+    ret = "Solution";
+  }
+  return ret;
+}

--- a/packages/common/src/content/search.ts
+++ b/packages/common/src/content/search.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-types";
+import { IItem } from "@esri/arcgis-rest-portal";
 import { isMaster } from "cluster";
 import { fetchItemEnrichments } from "../items/_enrichments";
 import { getProp } from "../objects";

--- a/packages/common/src/core/fetchHubEntity.ts
+++ b/packages/common/src/core/fetchHubEntity.ts
@@ -5,7 +5,7 @@ import { HubEntity } from "./types/HubEntity";
 import { HubEntityType } from "./types/HubEntityType";
 import { IArcGISContext } from "../ArcGISContext";
 import { fetchDiscussion } from "../discussions/fetch";
-import { fetchHubContent } from "../content/fetch";
+import { fetchHubContent } from "../content/fetchHubContent";
 
 /**
  * Fetch a Hub entity by identifier (id or slug)

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-types";
+import { IGroup } from "@esri/arcgis-rest-portal";
 import { fetchGroupEnrichments } from "./_internal/enrichments";
 import { getProp } from "../objects";
 import { getGroupThumbnailUrl, IHubSearchResult } from "../search";

--- a/packages/common/src/items/apply-properties-to-items.ts
+++ b/packages/common/src/items/apply-properties-to-items.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-types";
+import { IItem } from "@esri/arcgis-rest-portal";
 
 /**
  * Apply a hash of properties to an array of items.

--- a/packages/common/src/items/create-item-from-url-or-file.ts
+++ b/packages/common/src/items/create-item-from-url-or-file.ts
@@ -4,8 +4,9 @@ import {
   ISharingResponse,
   setItemAccess,
   shareItemWithGroup,
+  IGroup,
 } from "@esri/arcgis-rest-portal";
-import { IGroup, IItemAdd } from "@esri/arcgis-rest-types";
+import { IItemAdd } from "@esri/arcgis-rest-types";
 import { failSafe, isUpdateGroup } from "../utils";
 import { createItemFromFile } from "./create-item-from-file";
 import { createItemFromUrl } from "./create-item-from-url";

--- a/packages/common/src/items/enrichOrg.ts
+++ b/packages/common/src/items/enrichOrg.ts
@@ -1,0 +1,33 @@
+import { IPipeable } from "../utils";
+import { fetchOrg } from "../org/fetch-org";
+import { getItemOrgId } from "../content/_internal/getItemOrgId";
+import { IItemAndEnrichments, handleEnrichmentError } from "./_enrichments";
+
+// Note, this MUST be run after `enrichOwnerUser` to access the correct orgId during processing.
+// `item.orgId` is only SOMETIMES returned by Portal, so we need the ownerUser's orgId as a backup.
+//
+// If an orgId isn't present on either the item or the ownerUser, this operation will be skipped.
+
+export function enrichOrg(
+  input: IPipeable<IItemAndEnrichments>
+): Promise<IPipeable<IItemAndEnrichments>> {
+  const { data, stack, requestOptions } = input;
+  const opId = stack.start("enrichOrg");
+
+  const orgId = getItemOrgId(data.item, data.ownerUser);
+
+  // Only fetch the org if an explicit orgId is present
+  const orgPromise = orgId
+    ? fetchOrg(orgId, requestOptions)
+    : Promise.resolve(undefined);
+  return orgPromise
+    .then((org) => {
+      stack.finish(opId);
+      return {
+        data: { ...data, org },
+        stack,
+        requestOptions,
+      };
+    })
+    .catch((error) => handleEnrichmentError(error, input, opId));
+}

--- a/packages/common/src/items/is-services-directory-disabled.ts
+++ b/packages/common/src/items/is-services-directory-disabled.ts
@@ -1,7 +1,6 @@
 import { parseServiceUrl } from "@esri/arcgis-rest-feature-layer";
-import { getItem } from "@esri/arcgis-rest-portal";
+import { getItem, IItem } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IItem } from "@esri/arcgis-rest-types";
 
 /**
  * Checks if a server's services directory is disabled. Consider hoisting this to RESTJS
@@ -9,10 +8,10 @@ import { IItem } from "@esri/arcgis-rest-types";
  * @param requestOptions Request options
  * @returns Promise that resolves boolean
  */
-export const isServicesDirectoryDisabled = async (
+export async function isServicesDirectoryDisabled(
   idOrItem: string | IItem,
   requestOptions: IRequestOptions
-): Promise<boolean> => {
+): Promise<boolean> {
   let disabled;
   try {
     const item =
@@ -39,4 +38,4 @@ export const isServicesDirectoryDisabled = async (
     disabled = true;
   }
   return disabled;
-};
+}

--- a/packages/common/src/items/normalize-solution-template-item.ts
+++ b/packages/common/src/items/normalize-solution-template-item.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-types";
+import { IItem } from "@esri/arcgis-rest-portal";
 import { IItemTemplate } from "../types";
 import { cloneObject } from "../util";
 
@@ -28,7 +28,7 @@ export const itemPropsNotInTemplates = [
   "appCategories",
   "industries",
   "languages",
-  "largeThumbnail"
+  "largeThumbnail",
 ];
 
 /**
@@ -39,7 +39,7 @@ export const itemPropsNotInTemplates = [
 export function normalizeSolutionTemplateItem(item: IItem): IItemTemplate {
   const template = cloneObject(item) as IItemTemplate;
 
-  itemPropsNotInTemplates.forEach(prop => {
+  itemPropsNotInTemplates.forEach((prop) => {
     delete template[prop];
   });
 

--- a/packages/common/src/items/slugs.ts
+++ b/packages/common/src/items/slugs.ts
@@ -1,6 +1,10 @@
-import { getItem, ISearchOptions, searchItems } from "@esri/arcgis-rest-portal";
+import {
+  getItem,
+  ISearchOptions,
+  searchItems,
+  IItem,
+} from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IItem } from "@esri/arcgis-rest-types";
 import { slugify } from "../utils";
 
 // TODO: work out how to unify content slug fns

--- a/packages/common/src/models/serializeModel.ts
+++ b/packages/common/src/models/serializeModel.ts
@@ -1,6 +1,6 @@
 import { IModel } from "../types";
 import { cloneObject } from "../util";
-import { IItem } from "@esri/arcgis-rest-types";
+import { IItem } from "@esri/arcgis-rest-portal";
 
 interface ISerializedModel extends IItem {
   text: string;

--- a/packages/common/src/pages/HubPages.ts
+++ b/packages/common/src/pages/HubPages.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-types";
+import { IItem } from "@esri/arcgis-rest-portal";
 import { getFamily } from "../content/get-family";
 import { getHubRelativeUrl } from "../content/_internal/internalContentUtils";
 import { fetchItemEnrichments } from "../items/_enrichments";

--- a/packages/common/src/resources/get-item-assets.ts
+++ b/packages/common/src/resources/get-item-assets.ts
@@ -1,8 +1,8 @@
 import { IHubRequestOptions, ITemplateAsset } from "../types";
-import { IItem } from "@esri/arcgis-rest-types";
+
 import { getPortalApiUrl } from "../urls";
 import { getItemThumbnailUrl } from "./get-item-thumbnail-url";
-import { getItemResources } from "@esri/arcgis-rest-portal";
+import { getItemResources, IItem } from "@esri/arcgis-rest-portal";
 
 /**
  * Given an item, return an array of assets that includes
@@ -23,17 +23,17 @@ export function getItemAssets(
     assets.push({
       name: item.thumbnail,
       url: thumbnailUrl,
-      type: "thumbnail"
+      type: "thumbnail",
     });
   }
   // get all the other resources
   // TODO: see how this works w/ folders
-  return getItemResources(item.id, hubRequestOptions).then(response => {
+  return getItemResources(item.id, hubRequestOptions).then((response) => {
     const resourceAssets = response.resources.map((e: any) => {
       return {
         name: e.resource,
         type: "resource",
-        url: `${itemUrl}/resources/${e.resource}`
+        url: `${itemUrl}/resources/${e.resource}`,
       };
     });
     return assets.concat(resourceAssets);

--- a/packages/common/src/resources/get-item-thumbnail-url.ts
+++ b/packages/common/src/resources/get-item-thumbnail-url.ts
@@ -1,6 +1,6 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IItem } from "@esri/arcgis-rest-types";
-import { IPortal } from "@esri/arcgis-rest-portal";
+
+import { IPortal, IItem } from "@esri/arcgis-rest-portal";
 import { IHubRequestOptions } from "../types";
 import { getItemApiUrl } from "../urls/get-item-api-url";
 

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-types";
+import { IItem } from "@esri/arcgis-rest-portal";
 import { IHubRequestOptions } from "../../../types";
 import { IHubSearchResult } from "../../types/IHubSearchResult";
 import { itemToSearchResult } from "../portalSearchItems";

--- a/packages/common/src/search/_internal/portalSearchGroups.ts
+++ b/packages/common/src/search/_internal/portalSearchGroups.ts
@@ -1,5 +1,4 @@
-import { ISearchOptions, searchGroups } from "@esri/arcgis-rest-portal";
-import { IGroup } from "@esri/arcgis-rest-types";
+import { ISearchOptions, searchGroups, IGroup } from "@esri/arcgis-rest-portal";
 
 import { enrichGroupSearchResult } from "../../groups/HubGroups";
 import HubError from "../../HubError";

--- a/packages/common/src/search/_internal/portalSearchUsers.ts
+++ b/packages/common/src/search/_internal/portalSearchUsers.ts
@@ -2,8 +2,9 @@ import {
   ISearchOptions,
   IUserSearchOptions,
   searchUsers,
+  IUser,
 } from "@esri/arcgis-rest-portal";
-import { IUser } from "@esri/arcgis-rest-types";
+
 import { enrichUserSearchResult } from "../../users";
 import { serializeQueryForPortal } from "../serializeQueryForPortal";
 import HubError from "../../HubError";

--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-types";
+import { IUser } from "@esri/arcgis-rest-portal";
 import { getFamilyTypes } from "../content/get-family";
 import { HubFamily } from "../types";
 import { EntityType, IHubCatalog, IHubCollection } from "./types";

--- a/packages/common/src/surveys/is-fieldworker-view.ts
+++ b/packages/common/src/surveys/is-fieldworker-view.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-types";
+import { IItem } from "@esri/arcgis-rest-portal";
 
 /**
  * Determines if the provided Feature Service item is a

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -2,14 +2,12 @@
  * Apache-2.0 */
 
 import {
-  IItem,
-  IUser,
   IGroup,
   IPolygon,
   ISpatialReference,
   IGeometry,
 } from "@esri/arcgis-rest-types";
-import { IPortal, ISearchResult } from "@esri/arcgis-rest-portal";
+import { IItem, IUser, IPortal, ISearchResult } from "@esri/arcgis-rest-portal";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 

--- a/packages/common/src/users/HubUsers.ts
+++ b/packages/common/src/users/HubUsers.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-types";
+import { IUser } from "@esri/arcgis-rest-portal";
 import { fetchUserEnrichments } from "./_internal/enrichments";
 import { getProp } from "../objects";
 import { getUserThumbnailUrl, IHubSearchResult } from "../search";

--- a/packages/common/src/utils/is-update-group.ts
+++ b/packages/common/src/utils/is-update-group.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IGroup } from "@esri/arcgis-rest-types";
+import { IGroup } from "@esri/arcgis-rest-portal";
 
 /**
  * Determines if a given IGroup is an update group

--- a/packages/common/src/versioning/_internal/getIncludeListFromItemType.ts
+++ b/packages/common/src/versioning/_internal/getIncludeListFromItemType.ts
@@ -1,5 +1,5 @@
 import { IModel } from "../../types";
-import { isSiteType } from "../../content/compose";
+import { isSiteType } from "../../content/isSiteType";
 import { isPageType } from "../../content/_internal/internalContentUtils";
 import { SiteVersionIncludeList } from "../../sites/_internal/SiteBusinessRules";
 import { PageVersionIncludeList } from "../../pages/_internal/PageBusinessRules";

--- a/packages/common/test/content/content.test.ts
+++ b/packages/common/test/content/content.test.ts
@@ -40,6 +40,7 @@ import {
   getHubRelativeUrl,
   extractFirstContact,
   getPublisherInfo,
+  getItemOrgId,
 } from "../../src/content/_internal/internalContentUtils";
 
 import { cloneObject } from "../../src/util";
@@ -56,6 +57,28 @@ describe("getTypes", () => {
       "Hub Site Application",
       "Site Application",
     ]);
+  });
+});
+
+describe("getItemOrgId", () => {
+  it("returns itemId by default", () => {
+    const user = { orgId: "userOrgId" };
+    const item = { id: "itemId", orgId: "itemOrgId" } as unknown as IItem;
+    expect(getItemOrgId(item, user)).toEqual("itemOrgId");
+  });
+  it("returns user.orgId if item.org is undefined", () => {
+    const user = { orgId: "userOrgId" };
+    const item = { id: "itemId" } as unknown as IItem;
+    expect(getItemOrgId(item, user)).toEqual("userOrgId");
+  });
+  it("returns undefined if neither have orgId", () => {
+    const user = { username: "dave" };
+    const item = { id: "itemId" } as unknown as IItem;
+    expect(getItemOrgId(item, user)).toBeUndefined();
+  });
+  it("returns undefined if neither have orgId and user is not passed", () => {
+    const item = { id: "itemId" } as unknown as IItem;
+    expect(getItemOrgId(item)).toBeUndefined();
   });
 });
 

--- a/packages/common/test/content/fetch.test.ts
+++ b/packages/common/test/content/fetch.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../src";
 import * as _enrichmentsModule from "../../src/items/_enrichments";
 import * as _fetchModule from "../../src/content/_fetch";
+
 import * as documentItem from "../mocks/items/document.json";
 import * as multiLayerFeatureServiceItem from "../mocks/items/multi-layer-feature-service.json";
 

--- a/packages/common/test/core/fetchHubEntity.test.ts
+++ b/packages/common/test/core/fetchHubEntity.test.ts
@@ -65,7 +65,7 @@ describe("fetchHubEntity:", () => {
       requestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
     const spy = spyOn(
-      require("../../src/content/fetch"),
+      require("../../src/content/fetchHubContent"),
       "fetchHubContent"
     ).and.returnValue(Promise.resolve({}));
     await fetchHubEntity("content", "123", ctx);


### PR DESCRIPTION
1. Description:

This PR does a few things:
- `/common/src/content/index` was acting as a re-export file and exporting functions. Not sure this was an actual issue, but it was inconsistent with other parts of the codebase.
- ensures consistent import of portal types from `@esri/arcgis-rest-portal` and not `@esri/arcgis-rest-types`
- swap all exports of function expressions (`export const myFn(...) => {...}`) to named functions. This _seems_ to have been the source of some problems where minor refactors would result in massive test failures due to a whole set of functions no longer being available in the run-time environment, despite no changes to the exports.

I can't find a tslint rule, but there is a means to specify only `function declarations` via eslint. 

1. Instructions for testing: run tests

1. Closes Issues: #<number> (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
