### PR TITLE
feat: versions have descriptions

### DIFF
--- a/packages/common/src/versioning/_internal/constants.ts
+++ b/packages/common/src/versioning/_internal/constants.ts
@@ -2,6 +2,7 @@ export const VERSION_RESOURCE_NAME = "version.json";
 export const VERSION_RESOURCE_PROPERTIES = [
   "created",
   "creator",
+  "description",
   "id",
   "name",
   "parent",

--- a/packages/common/src/versioning/createVersion.ts
+++ b/packages/common/src/versioning/createVersion.ts
@@ -30,6 +30,7 @@ export async function createVersion(
   // TODO: in the future, we could make the data a separate resource file and reference it here with jsonref or something: { data: "#resources/data.json" }
   const data = getVersionData(model, includeList);
   const name = options?.name;
+  const description = options?.description;
   const parent = options?.parentId;
   const id = createId();
 
@@ -39,6 +40,7 @@ export async function createVersion(
     created: now,
     creator: getProp(requestOptions, "authentication.username"),
     data,
+    description,
     id,
     name,
     parent,

--- a/packages/common/src/versioning/types/ICreateVersionOptions.ts
+++ b/packages/common/src/versioning/types/ICreateVersionOptions.ts
@@ -3,6 +3,10 @@
  */
 export interface ICreateVersionOptions {
   /**
+   * Optional description of the version
+   */
+  description?: string;
+  /**
    * Optional name of the version
    */
   name?: string;

--- a/packages/common/src/versioning/types/IVersionMetadata.ts
+++ b/packages/common/src/versioning/types/IVersionMetadata.ts
@@ -16,6 +16,10 @@ export interface IVersionMetadata {
    */
   creator: string;
   /**
+   * The description of the version
+   */
+  description?: string;
+  /**
    * The id of the version
    */
   id: string;

--- a/packages/common/test/mocks/versioning/resources.json
+++ b/packages/common/test/mocks/versioning/resources.json
@@ -8,7 +8,7 @@
       "resource": "hubVersion_izao424h6/version.json",
       "created": 1675967213000,
       "size": 24321,
-      "properties": "{\"created\":1675967213542,\"creator\":\"paige_pa\",\"id\":\"izao424h6\",\"updated\":1675967213542}",
+      "properties": "{\"created\":1675967213542,\"creator\":\"paige_pa\",\"description\":\"this is the description\",\"id\":\"izao424h6\",\"updated\":1675967213542}",
       "access": "private"
     },
     {

--- a/packages/common/test/versioning/createVersion.test.ts
+++ b/packages/common/test/versioning/createVersion.test.ts
@@ -40,6 +40,7 @@ describe("createVersion", () => {
     },
     id: "def456",
     name: undefined,
+    description: undefined,
     parent: undefined,
     path: "hubVersion_def456/version.json",
     updated: "9876543210",
@@ -102,12 +103,14 @@ describe("createVersion", () => {
 
   it("should create a version when provided options object", async () => {
     const result = await createVersion(model, requestOpts, {
+      description: "this is the description",
       name: "my special version",
       parentId: "ghi789",
     });
 
     const versionResult: IVersion = {
       ...expectedVersionResult,
+      description: "this is the description",
       name: "my special version",
       parent: "ghi789",
     } as unknown as IVersion;
@@ -118,6 +121,7 @@ describe("createVersion", () => {
         properties: {
           created: "9876543210",
           creator: "casey",
+          description: "this is the description",
           id: "def456",
           name: "my special version",
           parent: "ghi789",

--- a/packages/common/test/versioning/searchVersions.test.ts
+++ b/packages/common/test/versioning/searchVersions.test.ts
@@ -39,5 +39,14 @@ describe("searchVersions", () => {
     expect(getItemResourcesSpy).toHaveBeenCalledTimes(1);
     expect(getItemResourcesSpy).toHaveBeenCalledWith(id, options);
     expect(result.length).toEqual(7);
+
+    expect(result[0].description).toBe("this is the description");
+    expect(result[0].name).toBeUndefined();
+
+    expect(result[1].description).toBeUndefined();
+    expect(result[1].name).toBeUndefined();
+
+    expect(result[2].description).toBeUndefined();
+    expect(result[2].name).toBe("jupe");
   });
 });

--- a/packages/common/test/versioning/versionMetadataFromResource.test.ts
+++ b/packages/common/test/versioning/versionMetadataFromResource.test.ts
@@ -32,6 +32,25 @@ describe("versionMetadataFromResource", () => {
     expect(result).toEqual(expected);
   });
 
+  it("handles expected resource structure with name and description", async () => {
+    const resource = {
+      ...baseResource,
+      properties:
+        '{"created":1675967213542,"creator":"paige_pa","description":"this is the description","id":"abc123","name":"this is the name","updated":1675967213542}',
+    };
+    const result = versionMetadataFromResource(resource);
+    const expected = {
+      ...baseExpected,
+      created: 1675967213542,
+      creator: "paige_pa",
+      description: "this is the description",
+      id: "abc123",
+      name: "this is the name",
+      updated: 1675967213542,
+    };
+    expect(result).toEqual(expected);
+  });
+
   it("handles missing properties key", async () => {
     const result = versionMetadataFromResource(baseResource);
     expect(result).toEqual(baseExpected);


### PR DESCRIPTION
1. Description: entity versions now have descriptions

1. Instructions for testing: run tests

1. Closes Issues: #6340 (if appropriate)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
