### PR TITLE
feat(hub-common): add optional categories prop to IHubItemEntity

### DIFF
--- a/packages/common/src/core/types/IHubItemEntity.ts
+++ b/packages/common/src/core/types/IHubItemEntity.ts
@@ -21,6 +21,11 @@ export interface IHubItemEntity extends IHubEntityBase, IWithPermissions {
   boundary?: IHubGeography;
 
   /**
+   * Parsed item categories (see parseItemCategories)
+   */
+  categories?: string[];
+
+  /**
    * Culture code of the content
    * i.e. `en-us`
    */

--- a/packages/common/src/projects/_internal/ProjectSchema.ts
+++ b/packages/common/src/projects/_internal/ProjectSchema.ts
@@ -30,6 +30,18 @@ export const ProjectSchema: IConfigurationSchema = {
       enum: Object.keys(PROJECT_STATUSES),
     },
     extent: ENTITY_EXTENT_SCHEMA,
+    tags: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+    categories: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
     view: {
       type: "object",
       properties: {
@@ -50,18 +62,6 @@ export const ProjectSchema: IConfigurationSchema = {
         // appropriate validation for the timeline editor
         timeline: {
           type: "object",
-        },
-        tags: {
-          type: "array",
-          items: {
-            type: "string",
-          },
-        },
-        categories: {
-          type: "array",
-          items: {
-            type: "string",
-          },
         },
       },
     },

--- a/packages/common/src/projects/_internal/ProjectSchema.ts
+++ b/packages/common/src/projects/_internal/ProjectSchema.ts
@@ -4,7 +4,7 @@ import {
   ENTITY_NAME_SCHEMA,
 } from "../../core/schemas/shared";
 
-export type ProjectEditorType = (typeof ProjectEditorTypes)[number];
+export type ProjectEditorType = typeof ProjectEditorTypes[number];
 export const ProjectEditorTypes = [
   "hub:project:create",
   "hub:project:edit",
@@ -50,6 +50,18 @@ export const ProjectSchema: IConfigurationSchema = {
         // appropriate validation for the timeline editor
         timeline: {
           type: "object",
+        },
+        tags: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        categories: {
+          type: "array",
+          items: {
+            type: "string",
+          },
         },
       },
     },

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -59,19 +59,23 @@ export const uiSchema: IUiSchema = {
           },
         },
         {
-          labelKey: "{{i18nScope}}.fields.combobox.label",
-          scope: "/properties/view/properties/combobox",
+          labelKey: "{{i18nScope}}.fields.tags.label",
+          scope: "/properties/tags",
           type: "Control",
           options: {
             control: "hub-field-input-combobox",
+            allowCustomValues: true,
+            selectionMode: "multiple",
           },
         },
         {
           labelKey: "{{i18nScope}}.fields.categories.label",
-          scope: "/properties/view/properties/categories",
+          scope: "/properties/categories",
           type: "Control",
           options: {
             control: "hub-field-input-combobox",
+            allowCustomValues: false,
+            selectionMode: "multiple",
           },
         },
       ],

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -58,6 +58,22 @@ export const uiSchema: IUiSchema = {
             },
           },
         },
+        {
+          labelKey: "{{i18nScope}}.fields.combobox.label",
+          scope: "/properties/view/properties/combobox",
+          type: "Control",
+          options: {
+            control: "hub-field-input-combobox",
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.categories.label",
+          scope: "/properties/view/properties/categories",
+          type: "Control",
+          options: {
+            control: "hub-field-input-combobox",
+          },
+        },
       ],
     },
     {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

- Add an optional `categories` prop in `IHubItemEntity`, this is needed for the Categories field on Project and will be useful for future item related features.
- Add "Tags" and "Categories" to ProjectSchema and ProjectUiSchemaEdit so we can add those two comboxbox fields to Project

After testing them in hub-components:

![image](https://user-images.githubusercontent.com/16672774/230466992-b9336ee1-7f14-4ed2-81df-0653bde448d7.png)

![image](https://user-images.githubusercontent.com/16672774/230467063-e87644f8-4785-4760-8521-06197295c835.png)


1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
