### PR TITLE
feat: updateVersionMetadata

### DIFF
--- a/docs/src/guides/functional/versioning.md
+++ b/docs/src/guides/functional/versioning.md
@@ -37,6 +37,10 @@ The [`createVersion`](/hub.js/api/common/HubSite#createVersion) method can be us
 
 The [`updateVersion`](/hub.js/api/common/HubSite#updateVersion) method can be used to update a version of an entity based on the current state of the entity. It takes an [`IVersion`](/hub.js/api/common/IVersion) and returns an [`IVersion`](/hub.js/api/common/IVersion).
 
+#### Updating the metadata of an entity version
+
+The [`updateVersionMetadata`](/hub.js/api/common/HubSite#updateVersionMetadata) method can be used to update the metadata (primarily name and description) of an entity version. It takes an [`IVersionMetadata`](/hub.js/api/common/IVersionMetadata) and returns an [`IVersionMetadata`](/hub.js/api/common/IVersionMetadata).
+
 #### Deleting a version of an entity
 
 The [`deleteVersion`](/hub.js/api/common/HubSite#deleteVersion) method can be used to delete a version of an entity. It takes a version id.
@@ -62,6 +66,10 @@ The [`createVersion`](/hub.js/api/common/createVersion) function can be used to 
 #### Updating a version of an entity
 
 The [`updateVersion`](/hub.js/api/common/updateVersion) function can be used to update a version of an entity based on the current state of the entity. It takes an [`IModel`](/hub.js/api/common/IModel), an [`IVersion`](/hub.js/api/common/IVersion), and an [`IHubUserRequestOptions`](/hub.js/api/common/IHubUserRequestOptions) and returns an [`IVersion`](/hub.js/api/common/IVersion).
+
+#### Updating the metadata of an entity version
+
+The [`updateVersionMetadata`](/hub.js/api/common/updateVersionMetadata) function can be used to update the metadata (primarily name and description) of an entity version. It takes an item id, an [`IVersionMetadata`](/hub.js/api/common/IVersionMetadata), and an [`IHubUserRequestOptions`](/hub.js/api/common/IHubUserRequestOptions) and returns an [`IVersionMetadata`](/hub.js/api/common/IVersionMetadata).
 
 #### Deleting a version of an entity
 

--- a/packages/common/src/core/behaviors/IWithVersioningBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithVersioningBehavior.ts
@@ -36,6 +36,13 @@ export interface IWithVersioningBehavior {
   updateVersion(version: IVersion): Promise<IVersion>;
 
   /**
+   * Updates the specified entity version's metadata
+   * @param version
+   * @returns
+   */
+  updateVersionMetadata(version: IVersionMetadata): Promise<IVersionMetadata>;
+
+  /**
    * Deletes the specified version of the entity
    * @returns
    */

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -33,6 +33,7 @@ import {
   IVersionMetadata,
   searchVersions,
   updateVersion,
+  updateVersionMetadata,
 } from "../versioning";
 
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
@@ -339,6 +340,21 @@ export class HubSite
     const mapper = new PropertyMapper<IHubSite>(getPropertyMap());
     const model = mapper.objectToModel(this.entity, {} as IModel);
     return updateVersion(model, version, this.context.userRequestOptions);
+  }
+
+  /**
+   * Updates the specified version's metadata
+   * @param version
+   * @returns
+   */
+  async updateVersionMetadata(
+    version: IVersionMetadata
+  ): Promise<IVersionMetadata> {
+    return updateVersionMetadata(
+      this.entity.id,
+      version,
+      this.context.userRequestOptions
+    );
   }
 
   /**

--- a/packages/common/src/versioning/index.ts
+++ b/packages/common/src/versioning/index.ts
@@ -4,4 +4,5 @@ export * from "./getVersion";
 export * from "./types";
 export * from "./searchVersions";
 export * from "./updateVersion";
+export * from "./updateVersionMetadata";
 export * from "./utils";

--- a/packages/common/src/versioning/updateVersionMetadata.ts
+++ b/packages/common/src/versioning/updateVersionMetadata.ts
@@ -1,0 +1,35 @@
+import { IHubUserRequestOptions } from "../types";
+import { mergeObjects } from "../objects/merge-objects";
+import { IVersionMetadata } from "./types";
+import { getPrefix } from "./_internal/getPrefix";
+import {
+  VERSION_RESOURCE_NAME,
+  VERSION_RESOURCE_PROPERTIES,
+} from "./_internal/constants";
+import { updateItemResource } from "@esri/arcgis-rest-portal";
+
+/**
+ * Updates the specified version's metadata
+ * @param id
+ * @param version
+ * @param requestOptions
+ * @returns
+ */
+export async function updateVersionMetadata(
+  id: string,
+  version: IVersionMetadata,
+  requestOptions: IHubUserRequestOptions
+): Promise<IVersionMetadata> {
+  const prefix = getPrefix(version.id);
+  const properties = mergeObjects(version, {}, VERSION_RESOURCE_PROPERTIES);
+
+  await updateItemResource({
+    ...requestOptions,
+    id,
+    name: VERSION_RESOURCE_NAME,
+    params: { properties },
+    prefix,
+  });
+
+  return version;
+}

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -4,7 +4,13 @@ import { HubSite } from "../../src/sites/HubSite";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as HubSitesModule from "../../src/sites/HubSites";
 import * as HubVersioningModule from "../../src/versioning";
-import { IDeepCatalogInfo, IHubCatalog, IHubSite, IVersion } from "../../src";
+import {
+  IDeepCatalogInfo,
+  IHubCatalog,
+  IHubSite,
+  IVersion,
+  IVersionMetadata,
+} from "../../src";
 import { Catalog } from "../../src/search";
 import * as ContainsModule from "../../src/core/_internal/deepContains";
 describe("HubSite Class:", () => {
@@ -471,6 +477,34 @@ describe("HubSite Class:", () => {
         authdCtxMgr.context.userRequestOptions
       );
     });
+
+    it("updates version metadata", async () => {
+      const updateVersionMetadataSpy = spyOn(
+        HubVersioningModule,
+        "updateVersionMetadata"
+      ).and.callFake(() => {
+        return Promise.resolve({});
+      });
+
+      const version: IVersionMetadata = {
+        created: 123456,
+        creator: "paige_pa",
+        id: "abc123",
+        name: "my special version",
+        path: "",
+        updated: 123456,
+      };
+
+      await chk.updateVersionMetadata(version);
+
+      expect(updateVersionMetadataSpy).toHaveBeenCalledTimes(1);
+      expect(updateVersionMetadataSpy).toHaveBeenCalledWith(
+        model.item.id,
+        version,
+        authdCtxMgr.context.userRequestOptions
+      );
+    });
+
     it("deletes a version", async () => {
       const deleteVersionSpy = spyOn(
         HubVersioningModule,

--- a/packages/common/test/versioning/updateVersionMetadata.test.ts
+++ b/packages/common/test/versioning/updateVersionMetadata.test.ts
@@ -1,0 +1,60 @@
+import * as portalModule from "@esri/arcgis-rest-portal";
+import { updateVersionMetadata } from "../../src/versioning/updateVersionMetadata";
+import { IHubUserRequestOptions } from "../../src/types";
+import { MOCK_AUTH } from "../mocks/mock-auth";
+import { IVersionMetadata } from "../../src";
+
+describe("updateVersionMetadata", () => {
+  let portal: string;
+  let hubApiUrl: string;
+  let requestOpts: IHubUserRequestOptions;
+  beforeEach(() => {
+    portal = MOCK_AUTH.portal;
+    hubApiUrl = "https://hubfake.arcgis.com";
+    requestOpts = {
+      portal,
+      isPortal: false,
+      hubApiUrl,
+      authentication: MOCK_AUTH,
+    };
+  });
+
+  it("should update the version metadata", async () => {
+    const version: IVersionMetadata = {
+      id: "def456",
+      created: 123,
+      creator: "jupe",
+      name: "my special version",
+      path: "",
+      updated: 456,
+    };
+    const id = "abc123";
+
+    const updateItemResourceSpy = spyOn(
+      portalModule,
+      "updateItemResource"
+    ).and.returnValue(Promise.resolve(version));
+
+    const result = await updateVersionMetadata(id, version, requestOpts);
+
+    const options = {
+      ...requestOpts,
+      id,
+      name: "version.json",
+      params: {
+        properties: {
+          created: 123,
+          creator: "jupe",
+          id: "def456",
+          name: "my special version",
+          updated: 456,
+        },
+      },
+      prefix: "hubVersion_def456",
+    };
+
+    expect(updateItemResourceSpy).toHaveBeenCalledTimes(1);
+    expect(updateItemResourceSpy).toHaveBeenCalledWith(options);
+    expect(result).toEqual(version);
+  });
+});


### PR DESCRIPTION
1. Description: adds updateVersionMetadata function and class method for updating only the version's metadata (primarily name and description). This is because you might want to do that at a time when all you have is an `IVersionMetadata`.

1. Instructions for testing: Run the tests?

1. Closes Issues: [5447](https://devtopia.esri.com/dc/hub/issues/5447a)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
