### PR TITLE
fix(hub-common): adjust event list card migration to work with alternative site models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22210,10 +22210,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22228,24 +22227,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22259,10 +22255,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22280,10 +22275,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -63976,7 +63970,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "12.18.0",
+			"version": "12.23.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64001,7 +63995,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "21.0.0",
+			"version": "21.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -64100,7 +64094,7 @@
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "12.5.0",
+			"version": "12.6.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -82093,8 +82087,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -82109,20 +82102,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -82136,8 +82126,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -82154,8 +82143,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/sites/_internal/_migrate-event-list-card-configs.ts
+++ b/packages/common/src/sites/_internal/_migrate-event-list-card-configs.ts
@@ -18,9 +18,9 @@ export function _migrateEventListCardConfigs<T extends IModel | IDraft>(
   const clone = cloneObject(model);
   clone.data.values.layout.sections.map((section: any) => ({
     ...section,
-    rows: section.rows.map((row: any) => ({
+    rows: (section.rows || []).map((row: any) => ({
       ...row,
-      cards: row.cards.map((card: any) => {
+      cards: (row.cards || []).map((card: any) => {
         if (card.component.name === "event-list-card") {
           card.component.settings.displayMode = card.component.settings
             .calendarEnabled

--- a/packages/common/test/sites/_internal/_migrate-event-list-card-configs.test.ts
+++ b/packages/common/test/sites/_internal/_migrate-event-list-card-configs.test.ts
@@ -68,6 +68,37 @@ const siteModel = {
   },
 } as unknown as IModel;
 
+const modelWithBadLayout = {
+  item: {
+    properties: {
+      schemaVersion: 1.5,
+    },
+  },
+  data: {
+    values: {
+      layout: {
+        sections: [
+          {
+            rows: [
+              {
+                cards: [],
+              },
+              {
+                otherProp:
+                  "This is an invalid row, lacking a .cards prop - it should be ignored",
+              },
+            ],
+          },
+          {
+            otherProp:
+              "this is an invalid section lacking a .rows prop - it should just be ignored",
+          },
+        ],
+      },
+    },
+  },
+} as unknown as IModel;
+
 describe("_ensure-event-list-card", () => {
   describe("Site model", function () {
     let model: IModel;
@@ -102,6 +133,12 @@ describe("_ensure-event-list-card", () => {
       setProp("item.properties.schemaVersion", 1.6, model);
       const expected: IModel = cloneObject(model);
       const results = _migrateEventListCardConfigs<IModel>(model);
+      expect(results).toEqual(expected);
+    });
+    it("does not apply changes if invalid model", function () {
+      const expected: IModel = cloneObject(modelWithBadLayout);
+      setProp("item.properties.schemaVersion", 1.6, expected);
+      const results = _migrateEventListCardConfigs<IModel>(modelWithBadLayout);
       expect(results).toEqual(expected);
     });
   });


### PR DESCRIPTION
1. Description: Fixes a bug where hub.py sites were failing to load.

1. Instructions for testing:

1. Closes Issues: #6404

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
