### PR TITLE
feat: project.location is stored in item.properties.location

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/hub-common",
-  "version": "12.24.0",
+  "version": "12.23.1",
   "description": "Common TypeScript types and utility functions for @esri/hub.js.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/hub-common",
-  "version": "12.23.1",
+  "version": "12.24.0",
   "description": "Common TypeScript types and utility functions for @esri/hub.js.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",

--- a/packages/common/src/core/_internal/configureBaseResources.ts
+++ b/packages/common/src/core/_internal/configureBaseResources.ts
@@ -6,8 +6,8 @@
  * @return {*}
  */
 export function configureBaseResources(
-  resources: any,
-  entityResourceMap: any
+  resources: Record<string, any>,
+  entityResourceMap: Record<string, string>
 ): Array<{ filename: string; resource: any }> {
   return Object.entries(resources).reduce((acc, resourceProp) => {
     const fileName = entityResourceMap[resourceProp[0]];

--- a/packages/common/src/projects/_internal/ProjectSchema.ts
+++ b/packages/common/src/projects/_internal/ProjectSchema.ts
@@ -1,10 +1,7 @@
 import { PROJECT_STATUSES, IConfigurationSchema } from "../../core";
-import {
-  ENTITY_EXTENT_SCHEMA,
-  ENTITY_NAME_SCHEMA,
-} from "../../core/schemas/shared";
+import { ENTITY_NAME_SCHEMA } from "../../core/schemas/shared";
 
-export type ProjectEditorType = typeof ProjectEditorTypes[number];
+export type ProjectEditorType = (typeof ProjectEditorTypes)[number];
 export const ProjectEditorTypes = [
   "hub:project:create",
   "hub:project:edit",
@@ -29,7 +26,9 @@ export const ProjectSchema: IConfigurationSchema = {
       default: PROJECT_STATUSES.notStarted,
       enum: Object.keys(PROJECT_STATUSES),
     },
-    extent: ENTITY_EXTENT_SCHEMA,
+    location: {
+      type: "object",
+    },
     tags: {
       type: "array",
       items: {

--- a/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
@@ -69,10 +69,10 @@ export const uiSchema: IUiSchema = {
               labelKey: "{{i18nScope}}.sections.location.label",
               elements: [
                 {
-                  scope: "/properties/extent",
+                  scope: "/properties/location",
                   type: "Control",
                   options: {
-                    control: "hub-field-input-boundary-picker",
+                    control: "hub-field-input-location-picker",
                   },
                 },
               ],

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -85,10 +85,10 @@ export const uiSchema: IUiSchema = {
       labelKey: "{{i18nScope}}.sections.location.label",
       elements: [
         {
-          scope: "/properties/extent",
+          scope: "/properties/location",
           type: "Control",
           options: {
-            control: "hub-field-input-boundary-picker",
+            control: "hub-field-input-location-picker",
           },
         },
         {

--- a/packages/common/src/projects/_internal/getPropertyMap.ts
+++ b/packages/common/src/projects/_internal/getPropertyMap.ts
@@ -23,6 +23,10 @@ export function getPropertyMap(): IPropertyMap[] {
     objectKey: "capabilities",
     modelKey: "data.settings.capabilities",
   });
+  map.push({
+    objectKey: "location",
+    modelKey: "item.properties.location",
+  });
 
   return map;
 }

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -5,7 +5,7 @@ import {
   createModel,
   getModel,
   updateModel,
-  upsertModelResources,
+  // upsertModelResources,
 } from "../models";
 import { constructSlug, getUniqueSlug, setSlugKeyword } from "../items/slugs";
 import { IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
@@ -39,7 +39,7 @@ export async function createProject(
   partialProject: Partial<IHubProject>,
   requestOptions: IUserRequestOptions
 ): Promise<IHubProject> {
-  let resources;
+  // let resources;
   // merge incoming with the default
   // this expansion solves the typing somehow
   const project = { ...DEFAULT_PROJECT, ...partialProject };
@@ -57,19 +57,19 @@ export async function createProject(
   // create model from object, using the default model as a starting point
   let model = mapper.objectToModel(project, cloneObject(DEFAULT_PROJECT_MODEL));
   // if we have resources disconnect them from the model for now.
-  if (model.resources) {
-    resources = configureBaseResources(
-      cloneObject(model.resources),
-      EntityResourceMap
-    );
-    delete model.resources;
-  }
+  // if (model.resources) {
+  //   resources = configureBaseResources(
+  //     cloneObject(model.resources),
+  //     EntityResourceMap
+  //   );
+  //   delete model.resources;
+  // }
   // create the item
   model = await createModel(model, requestOptions);
   // if we have resources, create them, then re-attach them to the model
-  if (resources) {
-    model = await upsertModelResources(model, resources, requestOptions);
-  }
+  // if (resources) {
+  //   model = await upsertModelResources(model, resources, requestOptions);
+  // }
   // map the model back into a IHubProject
   let newProject = mapper.modelToObject(model, {});
   newProject = computeProps(model, newProject, requestOptions);
@@ -87,7 +87,7 @@ export async function updateProject(
   project: IHubProject,
   requestOptions: IUserRequestOptions
 ): Promise<IHubProject> {
-  let resources;
+  // let resources;
   // verify that the slug is unique, excluding the current project
   project.slug = await getUniqueSlug(
     { slug: project.slug, existingId: project.id },
@@ -102,23 +102,23 @@ export async function updateProject(
   // but this is where we would apply that sort of logic
   const modelToUpdate = mapper.objectToModel(project, model);
   // if we have resources disconnect them from the model for now.
-  if (modelToUpdate.resources) {
-    resources = configureBaseResources(
-      cloneObject(modelToUpdate.resources),
-      EntityResourceMap
-    );
-    delete modelToUpdate.resources;
-  }
+  // if (modelToUpdate.resources) {
+  //   resources = configureBaseResources(
+  //     cloneObject(modelToUpdate.resources),
+  //     EntityResourceMap
+  //   );
+  //   delete modelToUpdate.resources;
+  // }
   // update the backing item
-  let updatedModel = await updateModel(modelToUpdate, requestOptions);
+  const updatedModel = await updateModel(modelToUpdate, requestOptions);
   // if we have resources, create them, then re-attach them to the model
-  if (resources) {
-    updatedModel = await upsertModelResources(
-      updatedModel,
-      resources,
-      requestOptions
-    );
-  }
+  // if (resources) {
+  //   updatedModel = await upsertModelResources(
+  //     updatedModel,
+  //     resources,
+  //     requestOptions
+  //   );
+  // }
   // now map back into a project and return that
   let updatedProject = mapper.modelToObject(updatedModel, project);
   updatedProject = computeProps(model, updatedProject, requestOptions);

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -33,7 +33,6 @@ export async function createProject(
   partialProject: Partial<IHubProject>,
   requestOptions: IUserRequestOptions
 ): Promise<IHubProject> {
-  // let resources;
   // merge incoming with the default
   // this expansion solves the typing somehow
   const project = { ...DEFAULT_PROJECT, ...partialProject };
@@ -69,7 +68,6 @@ export async function updateProject(
   project: IHubProject,
   requestOptions: IUserRequestOptions
 ): Promise<IHubProject> {
-  // let resources;
   // verify that the slug is unique, excluding the current project
   project.slug = await getUniqueSlug(
     { slug: project.slug, existingId: project.id },

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -1,12 +1,7 @@
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 // Note - we separate these imports so we can cleanly spy on things in tests
-import {
-  createModel,
-  getModel,
-  updateModel,
-  // upsertModelResources,
-} from "../models";
+import { createModel, getModel, updateModel } from "../models";
 import { constructSlug, getUniqueSlug, setSlugKeyword } from "../items/slugs";
 import { IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
@@ -16,7 +11,6 @@ import { computeProps } from "./_internal/computeProps";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 import { ProjectEditorType } from "./_internal/ProjectSchema";
 import { cloneObject } from "../util";
-import { configureBaseResources } from "../core/_internal/configureBaseResources";
 import {
   getEntityEditorSchemas,
   UiSchemaElementOptions,
@@ -56,20 +50,8 @@ export async function createProject(
   const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
   // create model from object, using the default model as a starting point
   let model = mapper.objectToModel(project, cloneObject(DEFAULT_PROJECT_MODEL));
-  // if we have resources disconnect them from the model for now.
-  // if (model.resources) {
-  //   resources = configureBaseResources(
-  //     cloneObject(model.resources),
-  //     EntityResourceMap
-  //   );
-  //   delete model.resources;
-  // }
   // create the item
   model = await createModel(model, requestOptions);
-  // if we have resources, create them, then re-attach them to the model
-  // if (resources) {
-  //   model = await upsertModelResources(model, resources, requestOptions);
-  // }
   // map the model back into a IHubProject
   let newProject = mapper.modelToObject(model, {});
   newProject = computeProps(model, newProject, requestOptions);
@@ -101,24 +83,8 @@ export async function updateProject(
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic
   const modelToUpdate = mapper.objectToModel(project, model);
-  // if we have resources disconnect them from the model for now.
-  // if (modelToUpdate.resources) {
-  //   resources = configureBaseResources(
-  //     cloneObject(modelToUpdate.resources),
-  //     EntityResourceMap
-  //   );
-  //   delete modelToUpdate.resources;
-  // }
   // update the backing item
   const updatedModel = await updateModel(modelToUpdate, requestOptions);
-  // if we have resources, create them, then re-attach them to the model
-  // if (resources) {
-  //   updatedModel = await upsertModelResources(
-  //     updatedModel,
-  //     resources,
-  //     requestOptions
-  //   );
-  // }
   // now map back into a project and return that
   let updatedProject = mapper.modelToObject(updatedModel, project);
   updatedProject = computeProps(model, updatedProject, requestOptions);

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -55,12 +55,6 @@ export async function convertItemToProject(
   requestOptions: IRequestOptions
 ): Promise<IHubProject> {
   const model = await fetchModelFromItem(item, requestOptions);
-  // Fetch resources based on above obj
-  // model.resources = await fetchModelResources(
-  //   item,
-  //   {}, // EntityResourceMap,
-  //   requestOptions
-  // );
   // TODO: In the future we will handle the boundary fetching from resource
   const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
   const prj = mapper.modelToObject(model, {}) as IHubProject;

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -3,7 +3,7 @@ import { getItem, IItem } from "@esri/arcgis-rest-portal";
 
 import { getFamily } from "../content/get-family";
 import { getHubRelativeUrl } from "../content/_internal/internalContentUtils";
-import { EntityResourceMap, IHubProject } from "../core/types";
+import { IHubProject } from "../core/types";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
 import { getItemBySlug } from "../items/slugs";
 import { fetchItemEnrichments } from "../items/_enrichments";
@@ -56,11 +56,11 @@ export async function convertItemToProject(
 ): Promise<IHubProject> {
   const model = await fetchModelFromItem(item, requestOptions);
   // Fetch resources based on above obj
-  model.resources = await fetchModelResources(
-    item,
-    EntityResourceMap,
-    requestOptions
-  );
+  // model.resources = await fetchModelResources(
+  //   item,
+  //   {}, // EntityResourceMap,
+  //   requestOptions
+  // );
   // TODO: In the future we will handle the boundary fetching from resource
   const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
   const prj = mapper.modelToObject(model, {}) as IHubProject;

--- a/packages/common/test/models/models.test.ts
+++ b/packages/common/test/models/models.test.ts
@@ -11,6 +11,8 @@ import {
   IModel,
   updateModel,
   upsertModelResources,
+  fetchModelResources,
+  EntityResourceMap,
 } from "../../src";
 
 const LOCATION: IHubLocation = {
@@ -307,6 +309,58 @@ describe("model utils:", () => {
       expect(chk.resources).toEqual({
         location: LOCATION,
       });
+    });
+  });
+
+  describe("fetchModelResources", () => {
+    it("fetches model resources", async () => {
+      const fetchResourceSpy = spyOn(
+        portalModule,
+        "getItemResource"
+      ).and.returnValue(Promise.resolve(LOCATION));
+
+      const i = {
+        id: "00c",
+        owner: "fakeOwner",
+        title: "My New Thing",
+        type: "Hub Project",
+        created: 1643663750004,
+        modified: 1643663750007,
+        extent: "1, 2, 3, 4" as unknown as number[][],
+      } as unknown as portalModule.IItem;
+
+      const chk = await fetchModelResources(i, EntityResourceMap, {
+        authentication: MOCK_AUTH,
+      });
+
+      expect(fetchResourceSpy.calls.count()).toBe(1);
+      expect(chk).toEqual({
+        location: LOCATION,
+      });
+    });
+
+    it("rejects model resources", async () => {
+      const fetchResourceSpy = spyOn(
+        portalModule,
+        "getItemResource"
+      ).and.returnValue(Promise.reject("nope"));
+
+      const i = {
+        id: "00c",
+        owner: "fakeOwner",
+        title: "My New Thing",
+        type: "Hub Project",
+        created: 1643663750004,
+        modified: 1643663750007,
+        extent: "1, 2, 3, 4" as unknown as number[][],
+      } as unknown as portalModule.IItem;
+
+      const chk = await fetchModelResources(i, EntityResourceMap, {
+        authentication: MOCK_AUTH,
+      });
+
+      expect(fetchResourceSpy.calls.count()).toBe(1);
+      expect(chk).toEqual({});
     });
   });
 });


### PR DESCRIPTION
1. Description: Project.location is stored in item.properties.location. rolls back resources behaviors in projects for the time being.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
