### PR TITLE
feat: add resolveReferences function

### DIFF
--- a/packages/common/src/objects/index.ts
+++ b/packages/common/src/objects/index.ts
@@ -10,3 +10,4 @@ export * from "./deep-string-replace";
 export * from "./merge-objects";
 export * from "./set-prop";
 export * from "./deepFind";
+export * from "./resolveReferences";

--- a/packages/common/src/objects/resolveReferences.ts
+++ b/packages/common/src/objects/resolveReferences.ts
@@ -1,0 +1,63 @@
+import { _isDate, _isFunction, _isObject, _isRegExp } from ".";
+import { cloneObject } from "../util";
+import { _deepMapValues } from "./_deep-map-values";
+import { getProp } from "./get-prop";
+
+/**
+ * Resolve all $use references in an object graph.
+ * The $use syntax is relative to an entire object so
+ * the developer must ensure they resolve the references
+ * on the same graph they were defined on.
+ * Put another way, you can't resolve references on a subset
+ * of an object graph.
+ * @param obj
+ * @param ctx
+ * @returns
+ */
+export function resolveReferences(
+  obj: Record<string, any>,
+  ctx?: Record<string, any>
+): Record<string, any> {
+  const keys = Object.keys(obj);
+  ctx = ctx || cloneObject(obj);
+  const newObject = keys.reduce(function (
+    acc: Record<string, any>,
+    currentKey
+  ) {
+    // if the value is an array, map over it
+    if (Array.isArray(obj[currentKey])) {
+      acc[currentKey] = obj[currentKey].map((entry: any) => {
+        return resolveReferences(entry, ctx);
+      });
+    }
+    // if the value is an object, resolve it's references
+    else if (
+      obj[currentKey] &&
+      _isObject(obj[currentKey]) &&
+      !_isDate(obj[currentKey]) &&
+      !_isRegExp(obj[currentKey]) &&
+      !_isFunction(obj[currentKey])
+    ) {
+      // if the value is an object it may be a reference
+      if (obj[currentKey] && obj[currentKey].$use) {
+        // use getProp to resolve the reference
+        const useRef = getProp(ctx, obj[currentKey].$use);
+        if (_isObject(useRef)) {
+          // references could contain references, so resolve them
+          acc[currentKey] = resolveReferences(useRef, ctx);
+        } else {
+          acc[currentKey] = useRef;
+        }
+      } else {
+        acc[currentKey] = resolveReferences(obj[currentKey], ctx);
+      }
+    } else {
+      // assign value
+      acc[currentKey] = obj[currentKey];
+    }
+
+    return acc;
+  },
+  {});
+  return newObject;
+}

--- a/packages/common/test/objects/resolveReferences.test.ts
+++ b/packages/common/test/objects/resolveReferences.test.ts
@@ -1,0 +1,89 @@
+import { resolveReferences } from "../../src";
+
+describe("resolveReferences:", () => {
+  it("returns object without changes if no $use", () => {
+    const obj = {
+      a: 1,
+      b: {
+        c: 2,
+      },
+    };
+    const result = resolveReferences(obj);
+    expect(result).toEqual(obj);
+  });
+  it("resolves simple values", () => {
+    const obj = {
+      a: {
+        $use: "b",
+      },
+      b: 1,
+    };
+    const result = resolveReferences(obj);
+    expect(result).toEqual({ a: 1, b: 1 });
+  });
+  it("resolves values in arrays", () => {
+    const obj = {
+      a: [
+        {
+          val: { $use: "b" },
+        },
+      ],
+      b: 1,
+    };
+    const result = resolveReferences(obj);
+    expect(result).toEqual({ a: [{ val: 1 }], b: 1 });
+  });
+  it("resolves values from arrays", () => {
+    const obj = {
+      a: [
+        {
+          val: 2,
+        },
+      ],
+      b: { $use: "a[0].val" },
+    };
+    const result = resolveReferences(obj);
+    expect(result).toEqual({ a: [{ val: 2 }], b: 2 });
+  });
+  it("resolves values from arrays", () => {
+    const obj = {
+      a: [
+        {
+          id: "cat",
+          val: 2,
+        },
+      ],
+      b: { $use: "a[findBy(id,cat)].val" },
+    };
+    const result = resolveReferences(obj);
+    expect(result).toEqual({ a: [{ id: "cat", val: 2 }], b: 2 });
+  });
+  it("returns complex resolved values", () => {
+    const obj = {
+      defs: [
+        { id: "a", value: 1 },
+        { id: "b", value: 2 },
+      ],
+      sources: [
+        { id: "s1", def: { $use: "defs[findBy(id,a)]" } },
+        { id: "s2", def: { $use: "defs[findBy(id,b)]" } },
+      ],
+      layout: [
+        {
+          cards: [{ chart: { source: { $use: "sources[findBy(id,s2)]" } } }],
+        },
+        {
+          cards: [{ chart: { source: { $use: "sources[findBy(id,s1)]" } } }],
+        },
+      ],
+    };
+    const result = resolveReferences(obj);
+    // admittedly this is hard to follow, but it's testing very convoluted
+    // references... hopefully we rarely have to do this in real objects
+    expect(result.defs).toEqual(obj.defs);
+    expect(result.sources[0].def).toEqual(obj.defs[0]);
+    expect(result.sources[1].def).toEqual(obj.defs[1]);
+    const card = result.layout[0].cards[0];
+    expect(card.chart.source).toEqual({ id: "s2", def: { id: "b", value: 2 } });
+  });
+});


### PR DESCRIPTION
1. Description:

Adds `resolveReferences(obj):obj` which recursively walks the graph, and resolves any `{ $use: "path.to.other" }` `IReferences`. This will be used in the Metrics subsystem.

1. Instructions for testing: run tests


1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
