### PR TITLE
fix(): remove access lines from org and world options in getWellKnownItemCatalog

### DIFF
--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -153,7 +153,7 @@ function getWellknownItemCatalog(
       catalog = buildCatalog(
         i18nScope,
         name,
-        [{ orgid: options.user.orgId, access: "org" }],
+        [{ orgid: options.user.orgId }],
         collections
       );
       break;
@@ -161,7 +161,7 @@ function getWellknownItemCatalog(
       catalog = buildCatalog(
         i18nScope,
         name,
-        [{ access: "public" }],
+        [{ type: { not: ["code attachment"] } }],
         collections
       );
       break;

--- a/packages/common/test/search/wellKnownCatalog.test.ts
+++ b/packages/common/test/search/wellKnownCatalog.test.ts
@@ -64,7 +64,7 @@ describe("WellKnownCatalog", () => {
     it("does not throw if not passing a user for a catalog that does not require it", () => {
       const chk = getWellKnownCatalog("mockI18nScope", "world", "item");
       expect(chk.scopes?.item?.filters).toEqual([
-        { predicates: [{ access: "public" }] },
+        { predicates: [{ type: { not: ["code attachment"] } }] },
       ]);
     });
     it("throws if passed an invalid entity type", () => {


### PR DESCRIPTION
1. Description:
Changes the predicates for the getWellKnownItemCatalog function for the org and world options, removing the access scoping.

1. Instructions for testing:

1. Closes Issues: [#6520](https://zentopia.esri.com/workspaces/polaris-sprint-board-614a18b38a61a3001196c48d/issues/dc/hub/6520)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
