### PR TITLE
feat: deepSet and setProp support replace for objects

### DIFF
--- a/packages/common/src/core/_internal/PropertyMapper.ts
+++ b/packages/common/src/core/_internal/PropertyMapper.ts
@@ -136,7 +136,7 @@ function mapProps<S, T>(
     // if it's not null or undefined
     if (sourceVal !== null && sourceVal !== undefined) {
       // set it
-      deepSet(clone, targetPath, sourceVal);
+      deepSet(clone, targetPath, sourceVal, true);
     }
   });
 

--- a/packages/common/src/objects/deep-set.ts
+++ b/packages/common/src/objects/deep-set.ts
@@ -5,7 +5,7 @@ import { cloneObject } from "../util";
  * @param {Object} target Object we want to set the property on
  * @param {String} path Dotted path to the property we want to set
  * @param {Any} value Value we want to assign to the property
- * @param {Boolean} replace If true, replace the value at the path with the new value instead of set
+ * @param {Boolean} replace If true, replace the value at the path with the new value instead of merging
  */
 export function deepSet(
   target: Record<string, any>,

--- a/packages/common/src/objects/deep-set.ts
+++ b/packages/common/src/objects/deep-set.ts
@@ -5,11 +5,13 @@ import { cloneObject } from "../util";
  * @param {Object} target Object we want to set the property on
  * @param {String} path Dotted path to the property we want to set
  * @param {Any} value Value we want to assign to the property
+ * @param {Boolean} replace If true, replace the value at the path with the new value instead of set
  */
 export function deepSet(
   target: Record<string, any>,
   path: string,
-  value: any = {}
+  value: any = {},
+  replace = false
 ) {
   const parts = path.split(".");
   let worker = target;
@@ -24,7 +26,13 @@ export function deepSet(
       }
     } else if (idx === lastIdx) {
       if (typeof worker[p] === "object" && !Array.isArray(worker[p])) {
-        worker[p] = Object.assign(worker[p], cloneObject(value));
+        if (replace) {
+          // We do this to replace the value wholesale, rather than merge the two
+          // This is for times where value is an object
+          worker[p] = cloneObject(value);
+        } else {
+          worker[p] = Object.assign(worker[p], cloneObject(value));
+        }
       } else {
         worker[p] = value;
       }

--- a/packages/common/src/objects/set-prop.ts
+++ b/packages/common/src/objects/set-prop.ts
@@ -6,7 +6,7 @@ import { deepSet } from "./deep-set";
  * @param path - the path to the property we want to set
  * @param val - the value we want to set it to
  * @param obj - the target object
- * @param replace - if true, replace the value at the path with the new value instead of set
+ * @param replace - if true, replace the value at the path with the new value instead of merging
  */
 export function setProp(
   path: string | string[],

--- a/packages/common/src/objects/set-prop.ts
+++ b/packages/common/src/objects/set-prop.ts
@@ -6,10 +6,16 @@ import { deepSet } from "./deep-set";
  * @param path - the path to the property we want to set
  * @param val - the value we want to set it to
  * @param obj - the target object
+ * @param replace - if true, replace the value at the path with the new value instead of set
  */
-export function setProp(path: string | string[], val: any, obj: any) {
+export function setProp(
+  path: string | string[],
+  val: any,
+  obj: any,
+  replace = false
+) {
   if (Array.isArray(path)) {
     path = path.join(".");
   }
-  deepSet(obj, path, val);
+  deepSet(obj, path, val, replace);
 }

--- a/packages/common/test/objects/set-prop.test.ts
+++ b/packages/common/test/objects/set-prop.test.ts
@@ -24,4 +24,10 @@ describe("setProp", () => {
     setProp("foo.bar", true, obj);
     expect(obj).toEqual({ foo: { bar: true } });
   });
+
+  it("handles replace option", () => {
+    const obj = { foo: { bar: "org", extent: [], geometries: {} } } as any;
+    setProp("foo", { bar: "none" }, obj, true);
+    expect(obj).toEqual({ foo: { bar: "none" } });
+  });
 });

--- a/packages/common/test/projects/projects.test.ts
+++ b/packages/common/test/projects/projects.test.ts
@@ -26,6 +26,27 @@ import { filterSchemaToUiSchema } from "../../src/core/schemas/internal";
 
 const PROJECT_LOCATION: IHubLocation = {
   type: "custom",
+  extent: [
+    [-77.32808191324128, 38.74173655216708],
+    [-76.8191059305754, 39.08220981728297],
+  ],
+  spatialReference: {
+    wkid: 4326,
+  },
+  geometries: [
+    {
+      type: "polygon",
+      spatialReference: {
+        wkid: 4326,
+      },
+      rings: [
+        [
+          [-77.32808191324128, 38.74173655216708],
+          [-76.8191059305754, 39.08220981728297],
+        ],
+      ],
+    } as unknown as __esri.Geometry,
+  ],
 };
 
 const GUID = "9b77674e43cf4bbd9ecad5189b3f1fdc";
@@ -131,9 +152,7 @@ describe("HubProjects:", () => {
       });
       expect(chk.id).toBe(GUID);
       expect(chk.owner).toBe("vader");
-      expect(chk.location).toEqual({
-        type: "custom",
-      });
+      expect(chk.location).toEqual(PROJECT_LOCATION);
 
       expect(getItemSpy.calls.count()).toBe(1);
       expect(getItemSpy.calls.argsFor(0)[0]).toBe(GUID);
@@ -326,11 +345,17 @@ describe("HubProjects:", () => {
         schemaVersion: 1,
         canEdit: false,
         canDelete: false,
+        location: {
+          type: "none",
+        },
       };
       const chk = await updateProject(prj, { authentication: MOCK_AUTH });
       expect(chk.id).toBe(GUID);
       expect(chk.name).toBe("Hello World");
       expect(chk.description).toBe("Some longer description");
+      expect(chk.location).toEqual({
+        type: "none",
+      });
       // should ensure unique slug
       expect(slugSpy.calls.count()).toBe(1);
       expect(slugSpy.calls.argsFor(0)[0]).toEqual(

--- a/packages/common/test/utils/deep-set.test.ts
+++ b/packages/common/test/utils/deep-set.test.ts
@@ -1,24 +1,30 @@
 import { deepSet } from "../../src";
 
-describe("deepSet", function() {
-  it("sets deep properties", function() {
+describe("deepSet", function () {
+  it("sets deep properties", function () {
     const foo: Record<string, any> = {
       horses: {
         types: {
-          spalding: true
-        }
+          spalding: true,
+        },
       },
       apple: null,
       whale: "dolphin",
       cars: {
-        toyota: "camry"
-      }
+        toyota: "camry",
+      },
+      location: {
+        type: "org",
+        extent: [[], []],
+        geometry: {},
+      },
     };
     deepSet(foo, "horses.types.spalding", false);
     deepSet(foo, "bar.baz", "beep");
     deepSet(foo, "apple.orange", "banana");
     deepSet(foo, "whale", "shark");
     deepSet(foo, "cars", { honda: "accord" });
+    deepSet(foo, "location", { type: "none" }, true);
 
     expect(foo.horses.types.spalding).toBeFalsy("sets deep path when exists");
     expect(foo.bar.baz).toBe("beep", "constructs path if doesnt exist");
@@ -27,9 +33,10 @@ describe("deepSet", function() {
     expect(foo.cars).toEqual(
       {
         toyota: "camry",
-        honda: "accord"
+        honda: "accord",
       },
       "merges objects"
     );
+    expect(foo.location).toEqual({ type: "none" }, "replaces objects");
   });
 });


### PR DESCRIPTION
1. Description: deepSet previously did a merge of old/new, rather than a replace. That's fine for non-object values, but cases where we might want to go from a fleshed out object to it's 'null' equivalent need a replace path.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
