### PR TITLE
feat: add new hub:project:owner permission and update project settings with it

### DIFF
--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -33,7 +33,7 @@ export const ProjectCapabilityPermissions: ICapabilityPermission[] = [
   {
     entity: "project",
     capability: "settings",
-    permissions: ["hub:project:edit"],
+    permissions: ["hub:project:owner"],
   },
 ];
 
@@ -47,6 +47,7 @@ export const ProjectPermissions = [
   "hub:project:delete",
   "hub:project:edit",
   "hub:project:view",
+  "hub:project:owner",
 ] as const;
 
 /**
@@ -76,6 +77,13 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:project:delete",
+    authenticated: true,
+    subsystems: ["projects"],
+    entityOwner: true,
+    licenses: ["hub-premium"],
+  },
+  {
+    permission: "hub:project:owner",
     authenticated: true,
     subsystems: ["projects"],
     entityOwner: true,


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Because we wanted to add a gating to non project owners for project settings panel, we would need to add a new project owner permission so the workspace link definitions can filter it out before rendering the navigation

1. Instructions for testing:

1. Closes Issues: [5790](https://zentopia.esri.com/workspaces/collaboration-sprint-board-614f9bfc0946c40011ef574e/issues/dc/hub/5790)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
