### PR TITLE
fix: updateVersionMetadata sends owner param

### DIFF
--- a/packages/common/src/versioning/updateVersionMetadata.ts
+++ b/packages/common/src/versioning/updateVersionMetadata.ts
@@ -27,6 +27,7 @@ export async function updateVersionMetadata(
     ...requestOptions,
     id,
     name: VERSION_RESOURCE_NAME,
+    owner: properties.creator,
     params: { properties },
     prefix,
   });

--- a/packages/common/test/versioning/updateVersionMetadata.test.ts
+++ b/packages/common/test/versioning/updateVersionMetadata.test.ts
@@ -50,6 +50,7 @@ describe("updateVersionMetadata", () => {
           updated: 456,
         },
       },
+      owner: "jupe",
       prefix: "hubVersion_def456",
     };
 


### PR DESCRIPTION
1. Description: adds owner param to updateItemResource call in updateVersionMetadata

1. Instructions for testing:

1. Closes Issues: [6540](https://devtopia.esri.com/dc/hub/issues/6540)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
