### PR TITLE
fix(): serialize geometry parameter for searchPosts call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22644,9 +22644,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22661,21 +22662,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22689,9 +22693,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22709,9 +22714,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64966,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "12.27.1",
+			"version": "12.30.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64991,7 +64997,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "22.0.0",
+			"version": "22.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -83376,7 +83382,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83391,17 +83398,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83415,7 +83425,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83432,7 +83443,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/discussions/src/posts/posts.ts
+++ b/packages/discussions/src/posts/posts.ts
@@ -26,7 +26,6 @@ export function searchPosts(
 ): Promise<IPagedResponse<IPost>> {
   const url = `/posts`;
   options.httpMethod = "GET";
-  // let data: any = options.data;
   // need to serialize geometry since this is a GET request.
   // we should consider requiring this to be a base64 string
   // to safeguard against large geometries that will exceed

--- a/packages/discussions/src/posts/posts.ts
+++ b/packages/discussions/src/posts/posts.ts
@@ -26,17 +26,18 @@ export function searchPosts(
 ): Promise<IPagedResponse<IPost>> {
   const url = `/posts`;
   options.httpMethod = "GET";
-  let data: any = options.data;
+  // let data: any = options.data;
   // need to serialize geometry since this is a GET request.
   // we should consider requiring this to be a base64 string
   // to safeguard against large geometries that will exceed
   // URL character limits
-  if (data?.geometry) {
-    data = {
-      ...data,
-      geometry: JSON.stringify(data.geometry),
-    };
-  }
+  const data = ["geometry", "featureGeometry"].reduce(
+    (acc, property) =>
+      acc?.[property]
+        ? { ...acc, [property]: JSON.stringify(acc[property]) }
+        : acc,
+    options.data as any
+  );
   return request(url, { ...options, data });
 }
 

--- a/packages/discussions/src/posts/posts.ts
+++ b/packages/discussions/src/posts/posts.ts
@@ -26,7 +26,18 @@ export function searchPosts(
 ): Promise<IPagedResponse<IPost>> {
   const url = `/posts`;
   options.httpMethod = "GET";
-  return request(url, options);
+  let data: any = options.data;
+  // need to serialize geometry since this is a GET request.
+  // we should consider requiring this to be a base64 string
+  // to safeguard against large geometries that will exceed
+  // URL character limits
+  if (data?.geometry) {
+    data = {
+      ...data,
+      geometry: JSON.stringify(data.geometry),
+    };
+  }
+  return request(url, { ...options, data });
 }
 
 /**

--- a/packages/discussions/src/posts/posts.ts
+++ b/packages/discussions/src/posts/posts.ts
@@ -1,4 +1,5 @@
 /* tslint:disable unified-signatures */
+import { cloneObject } from "@esri/hub-common";
 import { request } from "../request";
 import {
   ICreatePostParams,
@@ -25,19 +26,20 @@ export function searchPosts(
   options: ISearchPostsParams
 ): Promise<IPagedResponse<IPost>> {
   const url = `/posts`;
-  options.httpMethod = "GET";
-  // need to serialize geometry since this is a GET request.
-  // we should consider requiring this to be a base64 string
-  // to safeguard against large geometries that will exceed
-  // URL character limits
+  const opts = cloneObject(options);
+  opts.httpMethod = "GET";
+  // need to serialize geometry and featureGeometry since this
+  // is a GET request. we should consider requiring this to be
+  // a base64 string to safeguard against large geometries that
+  // will exceed URL character limits
   const data = ["geometry", "featureGeometry"].reduce(
     (acc, property) =>
       acc?.[property]
         ? { ...acc, [property]: JSON.stringify(acc[property]) }
         : acc,
-    options.data as any
+    opts.data as any
   );
-  return request(url, { ...options, data });
+  return request(url, { ...opts, data });
 }
 
 /**

--- a/packages/discussions/test/posts.test.ts
+++ b/packages/discussions/test/posts.test.ts
@@ -106,6 +106,46 @@ describe("posts", () => {
       .catch(() => fail());
   });
 
+  it("queries posts with featureGeometry", (done) => {
+    const geometry: Geometry = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [180, -90],
+          [180, 90],
+          [-180, 90],
+          [-180, -90],
+          [180, -90],
+        ],
+      ],
+    };
+    const query = {
+      access: [SharingAccess.PUBLIC],
+      groups: ["foo"],
+      featureGeometry: geometry,
+    };
+
+    const options = { ...baseOpts, data: query };
+    searchPosts(options)
+      .then(() => {
+        expect(requestSpy.calls.count()).toEqual(1);
+        const [url, opts] = requestSpy.calls.argsFor(0);
+        expect(url).toEqual(`/posts`);
+        expect(opts).toEqual({
+          ...{
+            ...options,
+            data: {
+              ...query,
+              featureGeometry: JSON.stringify(query.featureGeometry),
+            },
+          },
+          httpMethod: "GET",
+        });
+        done();
+      })
+      .catch(() => fail());
+  });
+
   it("creates post on unknown or non-existent channel", (done) => {
     const body = {
       access: SharingAccess.PRIVATE,

--- a/packages/discussions/test/posts.test.ts
+++ b/packages/discussions/test/posts.test.ts
@@ -1,3 +1,4 @@
+import { Geometry } from "geojson";
 import {
   createPost,
   searchPosts,
@@ -33,7 +34,24 @@ describe("posts", () => {
     );
   });
 
-  it("queries posts", (done) => {
+  it("queries posts with no parameters", (done) => {
+    const options = { ...baseOpts };
+    searchPosts(options)
+      .then(() => {
+        expect(requestSpy.calls.count()).toEqual(1);
+        const [url, opts] = requestSpy.calls.argsFor(0);
+        expect(url).toEqual(`/posts`);
+        expect(opts).toEqual({
+          ...options,
+          data: undefined,
+          httpMethod: "GET",
+        });
+        done();
+      })
+      .catch(() => fail());
+  });
+
+  it("queries posts with parameters", (done) => {
     const query = {
       access: [SharingAccess.PUBLIC],
       groups: ["foo"],
@@ -46,6 +64,43 @@ describe("posts", () => {
         const [url, opts] = requestSpy.calls.argsFor(0);
         expect(url).toEqual(`/posts`);
         expect(opts).toEqual({ ...options, httpMethod: "GET" });
+        done();
+      })
+      .catch(() => fail());
+  });
+
+  it("queries posts with geometry", (done) => {
+    const geometry: Geometry = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [180, -90],
+          [180, 90],
+          [-180, 90],
+          [-180, -90],
+          [180, -90],
+        ],
+      ],
+    };
+    const query = {
+      access: [SharingAccess.PUBLIC],
+      groups: ["foo"],
+      geometry,
+    };
+
+    const options = { ...baseOpts, data: query };
+    searchPosts(options)
+      .then(() => {
+        expect(requestSpy.calls.count()).toEqual(1);
+        const [url, opts] = requestSpy.calls.argsFor(0);
+        expect(url).toEqual(`/posts`);
+        expect(opts).toEqual({
+          ...{
+            ...options,
+            data: { ...query, geometry: JSON.stringify(query.geometry) },
+          },
+          httpMethod: "GET",
+        });
         done();
       })
       .catch(() => fail());


### PR DESCRIPTION
1. Description:
- `searchPosts` needs to serialize the `geometry` parameter before issuing the `GET /v1/posts` request since so it gets encoded correctly.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
