### PR TITLE
fix(): auth issue in searchPosts

### DIFF
--- a/packages/discussions/src/posts/posts.ts
+++ b/packages/discussions/src/posts/posts.ts
@@ -1,5 +1,4 @@
 /* tslint:disable unified-signatures */
-import { cloneObject } from "@esri/hub-common";
 import { request } from "../request";
 import {
   ICreatePostParams,
@@ -26,20 +25,19 @@ export function searchPosts(
   options: ISearchPostsParams
 ): Promise<IPagedResponse<IPost>> {
   const url = `/posts`;
-  const opts = cloneObject(options);
-  opts.httpMethod = "GET";
+  options.httpMethod = "GET";
   // need to serialize geometry and featureGeometry since this
   // is a GET request. we should consider requiring this to be
   // a base64 string to safeguard against large geometries that
   // will exceed URL character limits
   const data = ["geometry", "featureGeometry"].reduce(
     (acc, property) =>
-      acc?.[property]
+      acc[property]
         ? { ...acc, [property]: JSON.stringify(acc[property]) }
         : acc,
-    opts.data as any
+    { ...(options.data ?? {}) } as any
   );
-  return request(url, { ...opts, data });
+  return request(url, { ...options, data });
 }
 
 /**

--- a/packages/discussions/src/posts/posts.ts
+++ b/packages/discussions/src/posts/posts.ts
@@ -25,7 +25,6 @@ export function searchPosts(
   options: ISearchPostsParams
 ): Promise<IPagedResponse<IPost>> {
   const url = `/posts`;
-  options.httpMethod = "GET";
   // need to serialize geometry and featureGeometry since this
   // is a GET request. we should consider requiring this to be
   // a base64 string to safeguard against large geometries that
@@ -37,7 +36,11 @@ export function searchPosts(
         : acc,
     { ...(options.data ?? {}) } as any
   );
-  return request(url, { ...options, data });
+  return request(url, {
+    ...options,
+    data,
+    httpMethod: "GET",
+  });
 }
 
 /**

--- a/packages/discussions/test/posts.test.ts
+++ b/packages/discussions/test/posts.test.ts
@@ -43,7 +43,7 @@ describe("posts", () => {
         expect(url).toEqual(`/posts`);
         expect(opts).toEqual({
           ...options,
-          data: undefined,
+          data: {},
           httpMethod: "GET",
         });
         done();


### PR DESCRIPTION
1. Description:
[1034](https://github.com/Esri/hub.js/pull/1034) introduced a regression. Using `cloneObject` had an unanticipated side-effect of converting `UserSession` instances to POJOs which caused issues when `searchPosts` was called. This takes a slightly different approach to not mutating the provided `options` argument and fixes the auth issue. I used `yalc` to link this branch into `hub-components` and verified everything now works as expected with these changes.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
