### PR TITLE
feat(hub-common): add automatic api detection and wellKnownCollections to hubSearch

### DIFF
--- a/packages/common/src/search/_internal/commonHelpers/getApi.ts
+++ b/packages/common/src/search/_internal/commonHelpers/getApi.ts
@@ -1,0 +1,41 @@
+import { EntityType } from "../../types/IHubCatalog";
+import { IHubSearchOptions } from "../../types/IHubSearchOptions";
+import { IApiDefinition } from "../../types/types";
+import { expandApi } from "../../utils";
+import { shouldUseOgcApi } from "./shouldUseOgcApi";
+
+/**
+ * @private
+ * Determines Which API should be hit for the given search parameters.
+ * Hierarchy:
+ * - Target options.api if available
+ * - Target the OGC API current parameters allow
+ * - Target the Portal API based off options.requestOptions.portal
+ * @param targetEntity target entity of the query
+ * @param options search options
+ * @returns an API Definition object describing what should be targeted
+ */
+export function getApi(
+  targetEntity: EntityType,
+  options: IHubSearchOptions
+): IApiDefinition {
+  const {
+    api,
+    site,
+    requestOptions: { portal },
+  } = options;
+
+  let result: IApiDefinition;
+  if (api) {
+    result = expandApi(api);
+  } else if (shouldUseOgcApi(targetEntity, options)) {
+    result = {
+      type: "arcgis-hub",
+      url: `${site}/api/search/v1`,
+    };
+  } else {
+    result = { type: "arcgis", url: portal };
+  }
+
+  return result;
+}

--- a/packages/common/src/search/_internal/commonHelpers/shouldUseOgcApi.ts
+++ b/packages/common/src/search/_internal/commonHelpers/shouldUseOgcApi.ts
@@ -1,0 +1,19 @@
+import { EntityType } from "../../types/IHubCatalog";
+import { IHubSearchOptions } from "../../types/IHubSearchOptions";
+
+/**
+ * @private
+ * Determines whether the OGC API can be targeted with the given search parameters
+ * @param targetEntity target entity of the query
+ * @param options search options
+ */
+export function shouldUseOgcApi(
+  targetEntity: EntityType,
+  options: IHubSearchOptions
+): boolean {
+  const {
+    site,
+    requestOptions: { isPortal },
+  } = options;
+  return targetEntity === "item" && !!site && !isPortal;
+}

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcCollectionUrl.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcCollectionUrl.ts
@@ -15,8 +15,6 @@ import { IApiDefinition } from "../../types/types";
  */
 export function getOgcCollectionUrl(query: IQuery, options: IHubSearchOptions) {
   const apiDefinition = options.api as IApiDefinition;
-  const collectionId = query.wellKnownCollectionId;
-  return collectionId
-    ? `${apiDefinition.url}/collections/${collectionId}`
-    : `${apiDefinition.url}/collections/all`;
+  const collectionId = query.collection || "all";
+  return `${apiDefinition.url}/collections/${collectionId}`;
 }

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcCollectionUrl.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcCollectionUrl.ts
@@ -1,0 +1,11 @@
+import { IQuery } from "../../types/IHubCatalog";
+import { IHubSearchOptions } from "../../types/IHubSearchOptions";
+import { IApiDefinition } from "../../types/types";
+
+export function getOgcCollectionUrl(query: IQuery, options: IHubSearchOptions) {
+  const apiDefinition = options.api as IApiDefinition;
+  const collectionId = query.wellKnownQueryId;
+  return collectionId
+    ? `${apiDefinition.url}/collections/${collectionId}`
+    : `${apiDefinition.url}/collections/all`;
+}

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcCollectionUrl.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcCollectionUrl.ts
@@ -4,7 +4,7 @@ import { IApiDefinition } from "../../types/types";
 
 export function getOgcCollectionUrl(query: IQuery, options: IHubSearchOptions) {
   const apiDefinition = options.api as IApiDefinition;
-  const collectionId = query.wellKnownQueryId;
+  const collectionId = query.wellKnownCollectionId;
   return collectionId
     ? `${apiDefinition.url}/collections/${collectionId}`
     : `${apiDefinition.url}/collections/all`;

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcCollectionUrl.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcCollectionUrl.ts
@@ -2,6 +2,17 @@ import { IQuery } from "../../types/IHubCatalog";
 import { IHubSearchOptions } from "../../types/IHubSearchOptions";
 import { IApiDefinition } from "../../types/types";
 
+/**
+ * @private
+ *
+ * Given a query, returns the correct OGC Collection URL to target.
+ * If a collectionId is indicated, that collection is targeted. Else
+ * the all collection is targeted.
+ *
+ * @param query the query the request is based on
+ * @param options request options, including the base OGC api url
+ * @returns the collection url
+ */
 export function getOgcCollectionUrl(query: IQuery, options: IHubSearchOptions) {
   const apiDefinition = options.api as IApiDefinition;
   const collectionId = query.wellKnownCollectionId;

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/searchOgcAggregations.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/searchOgcAggregations.ts
@@ -2,17 +2,16 @@ import { IQuery } from "../../types/IHubCatalog";
 import { IHubSearchOptions } from "../../types/IHubSearchOptions";
 import { IHubSearchResponse } from "../../types/IHubSearchResponse";
 import { IHubSearchResult } from "../../types/IHubSearchResult";
-import { IApiDefinition } from "../../types/types";
 import { formatOgcAggregationsResponse } from "./formatOgcAggregationsResponse";
 import { getOgcAggregationQueryParams } from "./getOgcAggregationQueryParams";
+import { getOgcCollectionUrl } from "./getOgcCollectionUrl";
 import { ogcApiRequest } from "./ogcApiRequest";
 
 export async function searchOgcAggregations(
   query: IQuery,
   options: IHubSearchOptions
 ): Promise<IHubSearchResponse<IHubSearchResult>> {
-  const apiDefinition = options.api as IApiDefinition;
-  const url = `${apiDefinition.url}/aggregations`;
+  const url = `${getOgcCollectionUrl(query, options)}/aggregations`;
   const queryParams = getOgcAggregationQueryParams(query, options);
 
   const rawResponse = await ogcApiRequest(url, queryParams, options);

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/searchOgcItems.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/searchOgcItems.ts
@@ -2,8 +2,8 @@ import { IQuery } from "../../types/IHubCatalog";
 import { IHubSearchOptions } from "../../types/IHubSearchOptions";
 import { IHubSearchResponse } from "../../types/IHubSearchResponse";
 import { IHubSearchResult } from "../../types/IHubSearchResult";
-import { IApiDefinition } from "../../types/types";
 import { formatOgcItemsResponse } from "./formatOgcItemsResponse";
+import { getOgcCollectionUrl } from "./getOgcCollectionUrl";
 import { getOgcItemQueryParams } from "./getOgcItemQueryParams";
 import { IOgcItemsResponse } from "./interfaces";
 import { ogcApiRequest } from "./ogcApiRequest";
@@ -12,8 +12,7 @@ export async function searchOgcItems(
   query: IQuery,
   options: IHubSearchOptions
 ): Promise<IHubSearchResponse<IHubSearchResult>> {
-  const apiDefinition = options.api as IApiDefinition;
-  const url = `${apiDefinition.url}/items`;
+  const url = `${getOgcCollectionUrl(query, options)}/items`;
   const queryParams = getOgcItemQueryParams(query, options);
 
   const rawResponse: IOgcItemsResponse = await ogcApiRequest(

--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -394,16 +394,12 @@ export const WellKnownItemPredicates: IWellKnownItemPredicates = {
  */
 export function applyWellKnownCollectionFilters(query: IQuery): IQuery {
   const updated = cloneObject(query);
-  if (updated.wellKnownCollectionId) {
-    const {
-      wellKnownCollectionId,
-      targetEntity,
-      filters: queryFilters,
-    } = query;
+  if (updated.collection) {
+    const { collection, targetEntity, filters: queryFilters } = query;
     const wellKnownCollection = getWellknownCollection(
       "",
       targetEntity,
-      wellKnownCollectionId
+      collection
     );
     const wellKnownFilters: IFilter[] =
       getProp(wellKnownCollection, "scope.filters") || [];

--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -389,8 +389,8 @@ export const WellKnownItemPredicates: IWellKnownItemPredicates = {
  *
  * Only exported for testing.
  *
- * @param query
- * @returns
+ * @param query query to add collection filters to
+ * @returns a copy of the query with the additional filters
  */
 export function applyWellKnownCollectionFilters(query: IQuery): IQuery {
   const updated = cloneObject(query);

--- a/packages/common/src/search/hubSearch.ts
+++ b/packages/common/src/search/hubSearch.ts
@@ -7,7 +7,7 @@ import {
   IHubSearchResult,
   IQuery,
 } from "./types";
-import { getApi } from "./utils";
+import { getApi } from "./_internal/commonHelpers/getApi";
 import {
   hubSearchItems,
   portalSearchItems,

--- a/packages/common/src/search/hubSearch.ts
+++ b/packages/common/src/search/hubSearch.ts
@@ -7,7 +7,7 @@ import {
   IHubSearchResult,
   IQuery,
 } from "./types";
-import { expandApi } from "./utils";
+import { getApi } from "./utils";
 import {
   hubSearchItems,
   portalSearchItems,
@@ -50,8 +50,9 @@ export async function hubSearch(
 
   // Get the type of the first filterGroup
   const filterType = query.targetEntity;
-  // get the API
-  const apiType = expandApi(options.api || "arcgis").type;
+
+  const formattedOptions = cloneObject(options);
+  formattedOptions.api = getApi(filterType, options);
 
   const fnHash = {
     arcgis: {
@@ -64,12 +65,12 @@ export async function hubSearch(
     },
   };
 
-  const fn = getProp(fnHash, `${apiType}.${filterType}`);
+  const fn = getProp(fnHash, `${formattedOptions.api.type}.${filterType}`);
   if (!fn) {
     throw new HubError(
       `hubSearch`,
-      `Search via "${filterType}" filter against "${apiType}" api is not implemented. Please ensure "targetEntity" is defined on the query.`
+      `Search via "${filterType}" filter against "${formattedOptions.api.type}" api is not implemented. Please ensure "targetEntity" is defined on the query.`
     );
   }
-  return fn(cloneObject(query), options);
+  return fn(cloneObject(query), formattedOptions);
 }

--- a/packages/common/src/search/hubSearch.ts
+++ b/packages/common/src/search/hubSearch.ts
@@ -32,7 +32,12 @@ export async function hubSearch(
   if (!query) {
     throw new HubError("hubSearch", "Query is required.");
   }
-  if (!query.filters?.length && !query.wellKnownCollectionId) {
+
+  if (!Array.isArray(query.filters)) {
+    throw new HubError("hubSearch", "Query must have a filters array.");
+  }
+
+  if (!query.filters.length && !query.wellKnownCollectionId) {
     throw new HubError(
       "hubSearch",
       "Query must contain at least one Filter or a wellKnownCollectionId."

--- a/packages/common/src/search/hubSearch.ts
+++ b/packages/common/src/search/hubSearch.ts
@@ -32,8 +32,11 @@ export async function hubSearch(
   if (!query) {
     throw new HubError("hubSearch", "Query is required.");
   }
-  if (!query.filters || !query.filters.length) {
-    throw new HubError("hubSearch", "Query must contain at least one Filter.");
+  if ((!query.filters || !query.filters.length) && !query.wellKnownQueryId) {
+    throw new HubError(
+      "hubSearch",
+      "Query must contain at least one Filter or wellKnownQueryId"
+    );
   }
 
   if (!options.requestOptions) {

--- a/packages/common/src/search/hubSearch.ts
+++ b/packages/common/src/search/hubSearch.ts
@@ -32,10 +32,10 @@ export async function hubSearch(
   if (!query) {
     throw new HubError("hubSearch", "Query is required.");
   }
-  if ((!query.filters || !query.filters.length) && !query.wellKnownQueryId) {
+  if (!query.filters?.length && !query.wellKnownCollectionId) {
     throw new HubError(
       "hubSearch",
-      "Query must contain at least one Filter or wellKnownQueryId"
+      "Query must contain at least one Filter or a wellKnownCollectionId."
     );
   }
 

--- a/packages/common/src/search/hubSearch.ts
+++ b/packages/common/src/search/hubSearch.ts
@@ -37,10 +37,10 @@ export async function hubSearch(
     throw new HubError("hubSearch", "Query must have a filters array.");
   }
 
-  if (!query.filters.length && !query.wellKnownCollectionId) {
+  if (!query.filters.length && !query.collection) {
     throw new HubError(
       "hubSearch",
-      "Query must contain at least one Filter or a wellKnownCollectionId."
+      "Query must contain at least one Filter or a collection."
     );
   }
 

--- a/packages/common/src/search/types/IHubCatalog.ts
+++ b/packages/common/src/search/types/IHubCatalog.ts
@@ -1,3 +1,5 @@
+import { WellKnownCollection } from "../wellKnownCatalog";
+
 export interface IHubCatalog {
   /**
    * Title for the Gallery
@@ -65,9 +67,13 @@ export interface IQuery {
    * ensure we query the correct API
    */
   targetEntity: EntityType;
-
-  wellKnownQueryId?: string;
-
+  /**
+   * An id for a well known collection that the query should use.
+   *
+   * Note: The well known collection's filters will be used _in addition_ to
+   * any existing filters within the IQuery.filters array
+   */
+  wellKnownCollectionId?: WellKnownCollection;
   /**
    * Filters that make up the query
    */

--- a/packages/common/src/search/types/IHubCatalog.ts
+++ b/packages/common/src/search/types/IHubCatalog.ts
@@ -65,6 +65,9 @@ export interface IQuery {
    * ensure we query the correct API
    */
   targetEntity: EntityType;
+
+  wellKnownQueryId?: string;
+
   /**
    * Filters that make up the query
    */

--- a/packages/common/src/search/types/IHubCatalog.ts
+++ b/packages/common/src/search/types/IHubCatalog.ts
@@ -70,10 +70,10 @@ export interface IQuery {
   /**
    * An id for a well known collection that the query should use.
    *
-   * Note: The well known collection's filters will be used _in addition_ to
+   * Note: The collection's filters will be used _in addition_ to
    * any existing filters within the IQuery.filters array
    */
-  wellKnownCollectionId?: WellKnownCollection;
+  collection?: WellKnownCollection;
   /**
    * Filters that make up the query
    */

--- a/packages/common/src/search/types/IHubSearchOptions.ts
+++ b/packages/common/src/search/types/IHubSearchOptions.ts
@@ -32,7 +32,7 @@ export interface IHubSearchOptions {
    * Site whose API should be targeted. Ignored in an enterprise context.
    * e.g., https://my-site.hub.arcgis.com
    */
-  siteUrl?: string;
+  site?: string;
 
   /**
    * DEPRECATE in favor of requestOptions

--- a/packages/common/src/search/types/IHubSearchOptions.ts
+++ b/packages/common/src/search/types/IHubSearchOptions.ts
@@ -23,9 +23,17 @@ export interface IHubSearchOptions {
   aggLimit?: number;
 
   /**
+   * TODO: Deprecate in favor of `requestOptions` and `siteUrl`
    * Specify API to call. Defaults to ArcGIS Online Portal API
    */
   api?: NamedApis | IApiDefinition;
+
+  /**
+   * Site whose API should be targeted. Ignored in an enterprise context.
+   * e.g., https://my-site.hub.arcgis.com
+   */
+  siteUrl?: string;
+
   /**
    * DEPRECATE in favor of requestOptions
    */

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -97,7 +97,7 @@ export function getApi(
 ): IApiDefinition {
   const {
     api,
-    siteUrl,
+    site,
     requestOptions: { portal },
   } = options;
 
@@ -107,7 +107,7 @@ export function getApi(
   } else if (shouldUseOgcApi(targetEntity, options)) {
     result = {
       type: "arcgis-hub",
-      url: `${siteUrl}/api/search/v1`,
+      url: `${site}/api/search/v1`,
     };
   } else {
     result = { type: "arcgis", url: portal };
@@ -127,10 +127,10 @@ export function shouldUseOgcApi(
   options: IHubSearchOptions
 ): boolean {
   const {
-    siteUrl,
+    site,
     requestOptions: { isPortal },
   } = options;
-  return targetEntity === "item" && !!siteUrl && !isPortal;
+  return targetEntity === "item" && !!site && !isPortal;
 }
 
 /**

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -107,7 +107,7 @@ export function getApi(
   } else if (shouldUseOgcApi(targetEntity, options)) {
     result = {
       type: "arcgis-hub",
-      url: `${siteUrl}/api/search/v1/collections/all`,
+      url: `${siteUrl}/api/search/v1`,
     };
   } else {
     result = { type: "arcgis", url: portal };

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -1,11 +1,12 @@
 /* Copyright (c) 2018-2021 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+// TODO: deprecate all private functions in this file and more them to ./_internal
+
 import { IUser, UserSession } from "@esri/arcgis-rest-auth";
 import { IGroup, ISearchOptions } from "@esri/arcgis-rest-portal";
 import { ISearchResponse } from "../types";
 import { cloneObject } from "../util";
-import { EntityType, IHubSearchOptions } from "./types";
 import {
   IMatchOptions,
   IDateRange,
@@ -78,59 +79,6 @@ export function expandApi(api: NamedApis | IApiDefinition): IApiDefinition {
     // it's an object, so we trust that it's well formed
     return api as IApiDefinition;
   }
-}
-
-/**
- * @private
- * Determines Which API should be hit for the given search parameters.
- * Hierarchy:
- * - Target options.api if available
- * - Target the OGC API current parameters allow
- * - Target the Portal API based off options.requestOptions.portal
- * @param targetEntity target entity of the query
- * @param options search options
- * @returns an API Definition object describing what should be targeted
- */
-export function getApi(
-  targetEntity: EntityType,
-  options: IHubSearchOptions
-): IApiDefinition {
-  const {
-    api,
-    site,
-    requestOptions: { portal },
-  } = options;
-
-  let result: IApiDefinition;
-  if (api) {
-    result = expandApi(api);
-  } else if (shouldUseOgcApi(targetEntity, options)) {
-    result = {
-      type: "arcgis-hub",
-      url: `${site}/api/search/v1`,
-    };
-  } else {
-    result = { type: "arcgis", url: portal };
-  }
-
-  return result;
-}
-
-/**
- * @private
- * Determines whether the OGC API can be targeted with the given search parameters
- * @param targetEntity target entity of the query
- * @param options search options
- */
-export function shouldUseOgcApi(
-  targetEntity: EntityType,
-  options: IHubSearchOptions
-): boolean {
-  const {
-    site,
-    requestOptions: { isPortal },
-  } = options;
-  return targetEntity === "item" && !!site && !isPortal;
 }
 
 /**
@@ -209,6 +157,7 @@ export function relativeDateToDateRange(
 }
 
 /**
+ * @private
  * Create a `.next()` function for a type
  * @param request
  * @param nextStart

--- a/packages/common/test/search/_internal/getApi.test.ts
+++ b/packages/common/test/search/_internal/getApi.test.ts
@@ -1,0 +1,45 @@
+import { IHubSearchOptions } from "../../../src/search/types/IHubSearchOptions";
+import { NamedApis } from "../../../src/search/types/types";
+import { SEARCH_APIS } from "../../../src/search/utils";
+import { getApi } from "../../../src/search/_internal/commonHelpers/getApi";
+
+describe("getApi", () => {
+  const site = "https://my-site.hub.arcgis-com";
+  const targetEntity = "item";
+  it("returns the expanded options.api if available", () => {
+    const options = {
+      api: "hubQA" as NamedApis,
+      site,
+      requestOptions: {
+        isPortal: false,
+      },
+    } as unknown as IHubSearchOptions;
+    expect(getApi(targetEntity, options)).toBe(SEARCH_APIS.hubQA);
+  });
+  it("otherwise returns reference to OGC API if possible", () => {
+    const options = {
+      site,
+      requestOptions: {
+        isPortal: false,
+      },
+    } as unknown as IHubSearchOptions;
+    expect(getApi(targetEntity, options)).toEqual({
+      type: "arcgis-hub",
+      url: `${site}/api/search/v1`,
+    });
+  });
+  it("otherwise returns a reference to the Portal API from requestOptions", () => {
+    const portal = "https://my-enterprise-server.com/sharing/rest";
+    const options = {
+      site,
+      requestOptions: {
+        isPortal: true,
+        portal,
+      },
+    } as unknown as IHubSearchOptions;
+    expect(getApi(targetEntity, options)).toEqual({
+      type: "arcgis",
+      url: portal,
+    });
+  });
+});

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -42,7 +42,7 @@ import { getOgcCollectionUrl } from "../../../src/search/_internal/hubSearchItem
 describe("hubSearchItems Module |", () => {
   describe("Request Transformation Helpers |", () => {
     describe("getOgcCollectionUrl", () => {
-      it("defaults to the all collection if a wellKnown id is not present", () => {
+      it("defaults to the all collection if a collection id is not present", () => {
         const query: IQuery = {
           targetEntity: "item",
           filters: [],
@@ -56,10 +56,10 @@ describe("hubSearchItems Module |", () => {
         const result = getOgcCollectionUrl(query, options);
         expect(result).toBe("https://my-hub.com/api/search/v1/collections/all");
       });
-      it("points to the provided collection if a wellKnown id is present", () => {
+      it("points to the provided collection if a collection id is present", () => {
         const query: IQuery = {
           targetEntity: "item",
-          wellKnownCollectionId: "dataset",
+          collection: "dataset",
           filters: [],
         };
         const options: IHubSearchOptions = {
@@ -766,7 +766,7 @@ describe("hubSearchItems Module |", () => {
         it("hits the items endpoint for the specified collection", async () => {
           const query: IQuery = {
             targetEntity: "item",
-            wellKnownCollectionId: "dataset",
+            collection: "dataset",
             filters: [
               {
                 predicates: [
@@ -805,7 +805,7 @@ describe("hubSearchItems Module |", () => {
           // TODO: add a query once the aggregations endpoint can handle arbitrary filters
           const query: IQuery = {
             targetEntity: "item",
-            wellKnownCollectionId: "dataset",
+            collection: "dataset",
             filters: [],
           };
           const options: IHubSearchOptions = {

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -37,9 +37,43 @@ import { ogcAggregationsResponse } from "./mocks/ogcAggregationsResponse";
 import * as getNextOgcCallbackModule from "../../../src/search/_internal/hubSearchItemsHelpers/getNextOgcCallback";
 import { hubSearchItems } from "../../../src/search/_internal/hubSearchItems";
 import { ogcApiRequest } from "../../../src/search/_internal/hubSearchItemsHelpers/ogcApiRequest";
+import { getOgcCollectionUrl } from "../../../src/search/_internal/hubSearchItemsHelpers/getOgcCollectionUrl";
 
 describe("hubSearchItems Module |", () => {
   describe("Request Transformation Helpers |", () => {
+    describe("getOgcCollectionUrl", () => {
+      it("defaults to the all collection if a wellKnown id is not present", () => {
+        const query: IQuery = {
+          targetEntity: "item",
+          filters: [],
+        };
+        const options: IHubSearchOptions = {
+          api: {
+            type: "arcgis-hub",
+            url: "https://my-hub.com/api/search/v1",
+          },
+        };
+        const result = getOgcCollectionUrl(query, options);
+        expect(result).toBe("https://my-hub.com/api/search/v1/collections/all");
+      });
+      it("points to the provided collection if a wellKnown id is present", () => {
+        const query: IQuery = {
+          targetEntity: "item",
+          wellKnownCollectionId: "dataset",
+          filters: [],
+        };
+        const options: IHubSearchOptions = {
+          api: {
+            type: "arcgis-hub",
+            url: "https://my-hub.com/api/search/v1",
+          },
+        };
+        const result = getOgcCollectionUrl(query, options);
+        expect(result).toBe(
+          "https://my-hub.com/api/search/v1/collections/dataset"
+        );
+      });
+    });
     describe("formatPredicate |", () => {
       it("handles a date range predicate", () => {
         const predicate = {
@@ -729,9 +763,10 @@ describe("hubSearchItems Module |", () => {
       });
       describe("searchOgcItems |", () => {
         afterEach(fetchMock.restore);
-        it("hits the items endpoint for the specified collection api url", async () => {
+        it("hits the items endpoint for the specified collection", async () => {
           const query: IQuery = {
             targetEntity: "item",
+            wellKnownCollectionId: "dataset",
             filters: [
               {
                 predicates: [
@@ -746,7 +781,7 @@ describe("hubSearchItems Module |", () => {
           const options: IHubSearchOptions = {
             api: {
               type: "arcgis-hub",
-              url: "https://my-test-site.arcgis.com/api/v1/search/collections/all",
+              url: "https://my-test-site.arcgis.com/api/v1/search",
             },
             num: 1,
             targetEntity: "item",
@@ -754,7 +789,7 @@ describe("hubSearchItems Module |", () => {
           };
 
           fetchMock.once(
-            "https://my-test-site.arcgis.com/api/v1/search/collections/all/items?filter=((type='Feature Service'))&limit=1",
+            "https://my-test-site.arcgis.com/api/v1/search/collections/dataset/items?filter=((type='Feature Service'))&limit=1",
             ogcItemsResponse
           );
           const response = await hubSearchItems(query, options);
@@ -768,11 +803,15 @@ describe("hubSearchItems Module |", () => {
         afterEach(fetchMock.restore);
         it("hits the aggregations endpoint for the specified collection api url", async () => {
           // TODO: add a query once the aggregations endpoint can handle arbitrary filters
-          const query: IQuery = null;
+          const query: IQuery = {
+            targetEntity: "item",
+            wellKnownCollectionId: "dataset",
+            filters: [],
+          };
           const options: IHubSearchOptions = {
             api: {
               type: "arcgis-hub",
-              url: "https://my-test-site.arcgis.com/api/v1/search/collections/all",
+              url: "https://my-test-site.arcgis.com/api/v1/search",
             },
             targetEntity: "item",
             aggFields: ["access", "type"],
@@ -782,7 +821,7 @@ describe("hubSearchItems Module |", () => {
           };
 
           fetchMock.once(
-            "https://my-test-site.arcgis.com/api/v1/search/collections/all/aggregations?aggregations=terms(fields=(access,type))",
+            "https://my-test-site.arcgis.com/api/v1/search/collections/dataset/aggregations?aggregations=terms(fields=(access,type))",
             ogcAggregationsResponse
           );
           const response = await hubSearchItems(query, options);

--- a/packages/common/test/search/_internal/portalSearchItems.test.ts
+++ b/packages/common/test/search/_internal/portalSearchItems.test.ts
@@ -1,10 +1,17 @@
 import * as Portal from "@esri/arcgis-rest-portal";
-import { cloneObject, IHubSearchOptions, IQuery } from "../../../src";
+import {
+  cloneObject,
+  getWellknownCollection,
+  IHubSearchOptions,
+  IQuery,
+  WellKnownCollection,
+} from "../../../src";
 
 import * as SimpleResponse from "../../mocks/portal-search/simple-response.json";
 import * as AllTypesResponse from "../../mocks/portal-search/response-with-key-types.json";
 import { MOCK_AUTH } from "../../mocks/mock-auth";
 import {
+  applyWellKnownCollectionFilters,
   applyWellKnownItemPredicates,
   portalSearchItems,
   portalSearchItemsAsItems,
@@ -465,6 +472,47 @@ describe("portalSearchItems Module:", () => {
         expect(chk.filters[0].operation).toBe("OR");
         expect(chk.filters[0].predicates[0].type).toEqual(expected);
         expect(chk.filters[0].predicates[0].owner).not.toBeDefined();
+      });
+    });
+    describe("applyWellKnownCollectionFilters", () => {
+      const baseQuery: IQuery = {
+        targetEntity: "item",
+        filters: [
+          {
+            predicates: [
+              {
+                term: "My Search Terms",
+              },
+            ],
+          },
+        ],
+      };
+      it("performs a no-op when no well-known collection is indicated", () => {
+        const query = cloneObject(baseQuery);
+        const result = applyWellKnownCollectionFilters(query);
+        expect(result).toEqual(query);
+      });
+
+      it("performs a no-op when an invalid well-known collection is indicated", () => {
+        const query = cloneObject(baseQuery);
+        query.wellKnownCollectionId = "fake" as WellKnownCollection;
+        const result = applyWellKnownCollectionFilters(query);
+        expect(result).toEqual(query);
+      });
+
+      it("appends the a well-known collection's filters when available", () => {
+        const query = cloneObject(baseQuery);
+        query.wellKnownCollectionId = "dataset";
+        const result = applyWellKnownCollectionFilters(query);
+
+        const datasetCollection = getWellknownCollection("", "item", "dataset");
+        const expected = cloneObject(query);
+        expected.filters = [
+          ...expected.filters,
+          ...datasetCollection.scope.filters,
+        ];
+
+        expect(result).toEqual(expected);
       });
     });
   });

--- a/packages/common/test/search/_internal/portalSearchItems.test.ts
+++ b/packages/common/test/search/_internal/portalSearchItems.test.ts
@@ -487,22 +487,22 @@ describe("portalSearchItems Module:", () => {
           },
         ],
       };
-      it("performs a no-op when no well-known collection is indicated", () => {
+      it("performs a no-op when no collection collection is indicated", () => {
         const query = cloneObject(baseQuery);
         const result = applyWellKnownCollectionFilters(query);
         expect(result).toEqual(query);
       });
 
-      it("performs a no-op when an invalid well-known collection is indicated", () => {
+      it("performs a no-op when an invalid collection id is indicated", () => {
         const query = cloneObject(baseQuery);
-        query.wellKnownCollectionId = "fake" as WellKnownCollection;
+        query.collection = "fake" as WellKnownCollection;
         const result = applyWellKnownCollectionFilters(query);
         expect(result).toEqual(query);
       });
 
-      it("appends the a well-known collection's filters when available", () => {
+      it("appends the a collection's filters when available", () => {
         const query = cloneObject(baseQuery);
-        query.wellKnownCollectionId = "dataset";
+        query.collection = "dataset";
         const result = applyWellKnownCollectionFilters(query);
 
         const datasetCollection = getWellknownCollection("", "item", "dataset");

--- a/packages/common/test/search/_internal/shouldUseOgcApi.test.ts
+++ b/packages/common/test/search/_internal/shouldUseOgcApi.test.ts
@@ -1,0 +1,48 @@
+import { IHubSearchOptions } from "../../../src/search/types/IHubSearchOptions";
+import { shouldUseOgcApi } from "../../../src/search/_internal/commonHelpers/shouldUseOgcApi";
+
+describe("shouldUseOgcApi", () => {
+  const site = "https://my-site.hub.arcgis-com";
+  it("returns false when targetEntity isn't item", () => {
+    const targetEntity = "group";
+    const options = {
+      site,
+      requestOptions: {
+        isPortal: false,
+      },
+    } as unknown as IHubSearchOptions;
+    expect(shouldUseOgcApi(targetEntity, options)).toBeFalsy();
+  });
+
+  it("returns false when no siteUrl is provided", () => {
+    const targetEntity = "item";
+    const options = {
+      requestOptions: {
+        isPortal: false,
+      },
+    } as unknown as IHubSearchOptions;
+    expect(shouldUseOgcApi(targetEntity, options)).toBeFalsy();
+  });
+
+  it("returns false when in an enterprise environment", () => {
+    const targetEntity = "item";
+    const options = {
+      site,
+      requestOptions: {
+        isPortal: true,
+      },
+    } as unknown as IHubSearchOptions;
+    expect(shouldUseOgcApi(targetEntity, options)).toBeFalsy();
+  });
+
+  it("returns true otherwise", () => {
+    const targetEntity = "item";
+    const options = {
+      site,
+      requestOptions: {
+        isPortal: false,
+      },
+    } as unknown as IHubSearchOptions;
+    expect(shouldUseOgcApi(targetEntity, options)).toBeTruthy();
+  });
+});

--- a/packages/common/test/search/hubSearch.test.ts
+++ b/packages/common/test/search/hubSearch.test.ts
@@ -1,4 +1,4 @@
-import { IHubSearchOptions, IQuery } from "../../src";
+import { IHubSearchOptions, IQuery, SEARCH_APIS } from "../../src";
 import { hubSearch } from "../../src/search/hubSearch";
 
 import * as SearchFunctionModule from "../../src/search/_internal";
@@ -191,10 +191,11 @@ describe("hubSearch Module:", () => {
           ],
         };
         const opts: IHubSearchOptions = {
+          siteUrl: "https://my-site.hub.arcgis.com",
           requestOptions: {
+            isPortal: false,
             portal: "https://qaext.arcgis.com/sharing/rest",
           },
-          api: "hubDEV",
           include: ["server"],
         };
         const chk = await hubSearch(qry, opts);
@@ -206,6 +207,10 @@ describe("hubSearch Module:", () => {
         expect(query).toEqual(qry);
         expect(options.include).toBeDefined();
         expect(options.requestOptions).toEqual(opts.requestOptions);
+        expect(options.api).toEqual({
+          type: "arcgis-hub",
+          url: "https://my-site.hub.arcgis.com/api/search/v1/collections/all",
+        });
       });
       it("groups + arcgis: portalSearchGroups", async () => {
         const qry: IQuery = {

--- a/packages/common/test/search/hubSearch.test.ts
+++ b/packages/common/test/search/hubSearch.test.ts
@@ -194,7 +194,7 @@ describe("hubSearch Module:", () => {
           ],
         };
         const opts: IHubSearchOptions = {
-          siteUrl: "https://my-site.hub.arcgis.com",
+          site: "https://my-site.hub.arcgis.com",
           requestOptions: {
             isPortal: false,
             portal: "https://qaext.arcgis.com/sharing/rest",

--- a/packages/common/test/search/hubSearch.test.ts
+++ b/packages/common/test/search/hubSearch.test.ts
@@ -17,7 +17,7 @@ describe("hubSearch Module:", () => {
           expect(err.message).toBe("Query is required.");
         }
       });
-      it("throws if Query does not have filters or wellKnownCollectionId props", async () => {
+      it("throws if Query does not have filters", async () => {
         try {
           await hubSearch(
             {} as unknown as IQuery,
@@ -25,12 +25,10 @@ describe("hubSearch Module:", () => {
           );
         } catch (err) {
           expect(err.name).toBe("HubError");
-          expect(err.message).toBe(
-            "Query must contain at least one Filter or a wellKnownCollectionId."
-          );
+          expect(err.message).toBe("Query must have a filters array.");
         }
       });
-      it("throws if Query does not have filters with entries", async () => {
+      it("throws if Query has an empty filters array and no wellKnownCollectionId props", async () => {
         try {
           await hubSearch(
             { filters: [] } as unknown as IQuery,

--- a/packages/common/test/search/hubSearch.test.ts
+++ b/packages/common/test/search/hubSearch.test.ts
@@ -1,4 +1,4 @@
-import { IHubSearchOptions, IQuery, SEARCH_APIS } from "../../src";
+import { IHubSearchOptions, IQuery } from "../../src";
 import { hubSearch } from "../../src/search/hubSearch";
 
 import * as SearchFunctionModule from "../../src/search/_internal";
@@ -17,7 +17,7 @@ describe("hubSearch Module:", () => {
           expect(err.message).toBe("Query is required.");
         }
       });
-      it("throws if Query does not have filters prop", async () => {
+      it("throws if Query does not have filters or wellKnownCollectionId props", async () => {
         try {
           await hubSearch(
             {} as unknown as IQuery,
@@ -25,7 +25,9 @@ describe("hubSearch Module:", () => {
           );
         } catch (err) {
           expect(err.name).toBe("HubError");
-          expect(err.message).toBe("Query must contain at least one Filter.");
+          expect(err.message).toBe(
+            "Query must contain at least one Filter or a wellKnownCollectionId."
+          );
         }
       });
       it("throws if Query does not have filters with entries", async () => {
@@ -36,7 +38,9 @@ describe("hubSearch Module:", () => {
           );
         } catch (err) {
           expect(err.name).toBe("HubError");
-          expect(err.message).toBe("Query must contain at least one Filter.");
+          expect(err.message).toBe(
+            "Query must contain at least one Filter or a wellKnownCollectionId."
+          );
         }
       });
       it("throws if options does not have requestOptions", async () => {
@@ -184,6 +188,7 @@ describe("hubSearch Module:", () => {
       it("items + arcgis-hub: hubSearchItems", async () => {
         const qry: IQuery = {
           targetEntity: "item",
+          wellKnownCollectionId: "dataset",
           filters: [
             {
               predicates: [{ term: "water" }],
@@ -209,7 +214,7 @@ describe("hubSearch Module:", () => {
         expect(options.requestOptions).toEqual(opts.requestOptions);
         expect(options.api).toEqual({
           type: "arcgis-hub",
-          url: "https://my-site.hub.arcgis.com/api/search/v1/collections/all",
+          url: "https://my-site.hub.arcgis.com/api/search/v1",
         });
       });
       it("groups + arcgis: portalSearchGroups", async () => {

--- a/packages/common/test/search/hubSearch.test.ts
+++ b/packages/common/test/search/hubSearch.test.ts
@@ -28,7 +28,7 @@ describe("hubSearch Module:", () => {
           expect(err.message).toBe("Query must have a filters array.");
         }
       });
-      it("throws if Query has an empty filters array and no wellKnownCollectionId props", async () => {
+      it("throws if Query has an empty filters array and no collection prop", async () => {
         try {
           await hubSearch(
             { filters: [] } as unknown as IQuery,
@@ -37,7 +37,7 @@ describe("hubSearch Module:", () => {
         } catch (err) {
           expect(err.name).toBe("HubError");
           expect(err.message).toBe(
-            "Query must contain at least one Filter or a wellKnownCollectionId."
+            "Query must contain at least one Filter or a collection."
           );
         }
       });
@@ -186,7 +186,7 @@ describe("hubSearch Module:", () => {
       it("items + arcgis-hub: hubSearchItems", async () => {
         const qry: IQuery = {
           targetEntity: "item",
-          wellKnownCollectionId: "dataset",
+          collection: "dataset",
           filters: [
             {
               predicates: [{ term: "water" }],

--- a/packages/common/test/search/utils.test.ts
+++ b/packages/common/test/search/utils.test.ts
@@ -37,11 +37,11 @@ describe("Search Utils:", () => {
   });
 
   describe("shouldUseOgcApi", () => {
-    const siteUrl = "https://my-site.hub.arcgis-com";
+    const site = "https://my-site.hub.arcgis-com";
     it("returns false when targetEntity isn't item", () => {
       const targetEntity = "group";
       const options = {
-        siteUrl,
+        site,
         requestOptions: {
           isPortal: false,
         },
@@ -62,7 +62,7 @@ describe("Search Utils:", () => {
     it("returns false when in an enterprise environment", () => {
       const targetEntity = "item";
       const options = {
-        siteUrl,
+        site,
         requestOptions: {
           isPortal: true,
         },
@@ -73,7 +73,7 @@ describe("Search Utils:", () => {
     it("returns true otherwise", () => {
       const targetEntity = "item";
       const options = {
-        siteUrl,
+        site,
         requestOptions: {
           isPortal: false,
         },
@@ -83,12 +83,12 @@ describe("Search Utils:", () => {
   });
 
   describe("getApi", () => {
-    const siteUrl = "https://my-site.hub.arcgis-com";
+    const site = "https://my-site.hub.arcgis-com";
     const targetEntity = "item";
     it("returns the expanded options.api if available", () => {
       const options = {
         api: "hubQA" as NamedApis,
-        siteUrl,
+        site,
         requestOptions: {
           isPortal: false,
         },
@@ -97,20 +97,20 @@ describe("Search Utils:", () => {
     });
     it("otherwise returns reference to OGC API if possible", () => {
       const options = {
-        siteUrl,
+        site,
         requestOptions: {
           isPortal: false,
         },
       } as unknown as IHubSearchOptions;
       expect(getApi(targetEntity, options)).toEqual({
         type: "arcgis-hub",
-        url: `${siteUrl}/api/search/v1`,
+        url: `${site}/api/search/v1`,
       });
     });
     it("otherwise returns a reference to the Portal API from requestOptions", () => {
       const portal = "https://my-enterprise-server.com/sharing/rest";
       const options = {
-        siteUrl,
+        site,
         requestOptions: {
           isPortal: true,
           portal,

--- a/packages/common/test/search/utils.test.ts
+++ b/packages/common/test/search/utils.test.ts
@@ -1,21 +1,13 @@
 import { IGroup, ISearchOptions, IUser } from "@esri/arcgis-rest-portal";
 import { ISearchResponse } from "../../src";
+import { IHubSearchResult, IRelativeDate } from "../../src/search";
 import {
-  IHubSearchOptions,
-  IHubSearchResult,
-  IRelativeDate,
-  NamedApis,
-} from "../../src/search";
-import {
-  shouldUseOgcApi,
-  getApi,
   expandApis,
   getUserThumbnailUrl,
   valueToMatchOptions,
   relativeDateToDateRange,
   getGroupThumbnailUrl,
   getNextFunction,
-  SEARCH_APIS,
 } from "../../src/search/utils";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import { mockUserSession } from "../test-helpers/fake-user-session";
@@ -33,93 +25,6 @@ describe("Search Utils:", () => {
       ]);
       expect(chk.length).toBe(1);
       expect(chk[0].type).toBe("arcgis");
-    });
-  });
-
-  describe("shouldUseOgcApi", () => {
-    const site = "https://my-site.hub.arcgis-com";
-    it("returns false when targetEntity isn't item", () => {
-      const targetEntity = "group";
-      const options = {
-        site,
-        requestOptions: {
-          isPortal: false,
-        },
-      } as unknown as IHubSearchOptions;
-      expect(shouldUseOgcApi(targetEntity, options)).toBeFalsy();
-    });
-
-    it("returns false when no siteUrl is provided", () => {
-      const targetEntity = "item";
-      const options = {
-        requestOptions: {
-          isPortal: false,
-        },
-      } as unknown as IHubSearchOptions;
-      expect(shouldUseOgcApi(targetEntity, options)).toBeFalsy();
-    });
-
-    it("returns false when in an enterprise environment", () => {
-      const targetEntity = "item";
-      const options = {
-        site,
-        requestOptions: {
-          isPortal: true,
-        },
-      } as unknown as IHubSearchOptions;
-      expect(shouldUseOgcApi(targetEntity, options)).toBeFalsy();
-    });
-
-    it("returns true otherwise", () => {
-      const targetEntity = "item";
-      const options = {
-        site,
-        requestOptions: {
-          isPortal: false,
-        },
-      } as unknown as IHubSearchOptions;
-      expect(shouldUseOgcApi(targetEntity, options)).toBeTruthy();
-    });
-  });
-
-  describe("getApi", () => {
-    const site = "https://my-site.hub.arcgis-com";
-    const targetEntity = "item";
-    it("returns the expanded options.api if available", () => {
-      const options = {
-        api: "hubQA" as NamedApis,
-        site,
-        requestOptions: {
-          isPortal: false,
-        },
-      } as unknown as IHubSearchOptions;
-      expect(getApi(targetEntity, options)).toBe(SEARCH_APIS.hubQA);
-    });
-    it("otherwise returns reference to OGC API if possible", () => {
-      const options = {
-        site,
-        requestOptions: {
-          isPortal: false,
-        },
-      } as unknown as IHubSearchOptions;
-      expect(getApi(targetEntity, options)).toEqual({
-        type: "arcgis-hub",
-        url: `${site}/api/search/v1`,
-      });
-    });
-    it("otherwise returns a reference to the Portal API from requestOptions", () => {
-      const portal = "https://my-enterprise-server.com/sharing/rest";
-      const options = {
-        site,
-        requestOptions: {
-          isPortal: true,
-          portal,
-        },
-      } as unknown as IHubSearchOptions;
-      expect(getApi(targetEntity, options)).toEqual({
-        type: "arcgis",
-        url: portal,
-      });
     });
   });
 

--- a/packages/common/test/search/utils.test.ts
+++ b/packages/common/test/search/utils.test.ts
@@ -104,7 +104,7 @@ describe("Search Utils:", () => {
       } as unknown as IHubSearchOptions;
       expect(getApi(targetEntity, options)).toEqual({
         type: "arcgis-hub",
-        url: `${siteUrl}/api/search/v1/collections/all`,
+        url: `${siteUrl}/api/search/v1`,
       });
     });
     it("otherwise returns a reference to the Portal API from requestOptions", () => {


### PR DESCRIPTION
Description:
Part of https://devtopia.esri.com/dc/hub/issues/5748

This PR consists of two parts:
- Users of `hubSearch` no longer have to explicitly pass an API object. The target API can derived from the requestOptions and a new `site` option. If a `site` is passed and the OGC API is available, it will be targeted. Otherwise, the portal API will be targeted
- Users of `hubSearch` can now append a `collection` to `Query`. This will automatically append the filters from a well known collection to the existing query filters. If targeting the Portal API, the filters will be populated using `getWellKnownCollection`. If targeting the OGC API, those filters are populated server-side as we target a corresponding collection endpoint.

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
