### PR TITLE
fix(hub-common): stop cloning authentication object in hubSearch as it breaks downstream functions

### DIFF
--- a/packages/common/src/search/hubSearch.ts
+++ b/packages/common/src/search/hubSearch.ts
@@ -59,8 +59,15 @@ export async function hubSearch(
   // Get the type of the first filterGroup
   const filterType = query.targetEntity;
 
-  const formattedOptions = cloneObject(options);
-  formattedOptions.api = getApi(filterType, options);
+  // NOTE: We want to clone the `options` object to do some expansion operations,
+  // But if we clone `options.requestOptions`, the underlying `UserSession` will
+  // lose some fundamental functions like `getToken`. As a workaround, we just
+  // clone everything else on the `options` object.
+  const { requestOptions, ...remainder } = options;
+  const formattedOptions: IHubSearchOptions = cloneObject(remainder);
+  formattedOptions.requestOptions = requestOptions;
+
+  formattedOptions.api = getApi(filterType, formattedOptions);
 
   const fnHash = {
     arcgis: {

--- a/packages/common/test/search/hubSearch.test.ts
+++ b/packages/common/test/search/hubSearch.test.ts
@@ -155,7 +155,8 @@ describe("hubSearch Module:", () => {
         const [query, options] = portalSearchItemsSpy.calls.argsFor(0);
         expect(query).toEqual(qry);
         expect(options.include).toBeDefined();
-        expect(options.requestOptions).toEqual(opts.requestOptions);
+        // Any cloning of auth can break downstream functions
+        expect(options.requestOptions).toBe(opts.requestOptions);
       });
       it("items + arcgis: portalSearchItems", async () => {
         const qry: IQuery = {
@@ -181,7 +182,8 @@ describe("hubSearch Module:", () => {
         const [query, options] = portalSearchItemsSpy.calls.argsFor(0);
         expect(query).toEqual(qry);
         expect(options.include).toBeDefined();
-        expect(options.requestOptions).toEqual(opts.requestOptions);
+        // Any cloning of auth can break downstream functions
+        expect(options.requestOptions).toBe(opts.requestOptions);
       });
       it("items + arcgis-hub: hubSearchItems", async () => {
         const qry: IQuery = {
@@ -209,7 +211,8 @@ describe("hubSearch Module:", () => {
         const [query, options] = hubSearchItemsSpy.calls.argsFor(0);
         expect(query).toEqual(qry);
         expect(options.include).toBeDefined();
-        expect(options.requestOptions).toEqual(opts.requestOptions);
+        // Any cloning of auth can break downstream functions
+        expect(options.requestOptions).toBe(opts.requestOptions);
         expect(options.api).toEqual({
           type: "arcgis-hub",
           url: "https://my-site.hub.arcgis.com/api/search/v1",
@@ -239,7 +242,8 @@ describe("hubSearch Module:", () => {
         const [query, options] = portalSearchGroupsSpy.calls.argsFor(0);
         expect(query).toEqual(qry);
         expect(options.include).toBeDefined();
-        expect(options.requestOptions).toEqual(opts.requestOptions);
+        // Any cloning of auth can break downstream functions
+        expect(options.requestOptions).toBe(opts.requestOptions);
       });
     });
   });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Fixes a bug introduced in https://github.com/Esri/hub.js/pull/1036. It turns out that when you clone a `UserSession` object, member functions like `getToken` are omitted from the clone.

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
