### PR TITLE
feat(hub-common): add getWellknownGroupCatalog function to get well known group catalogs

### DIFF
--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -239,7 +239,7 @@ function getWellknownGroupCatalog(
       catalog = buildCatalog(
         i18nScope,
         catalogName,
-        [{ group: options.user.orgId }],
+        [{ capabilities: [""] }],
         [],
         "group"
       );

--- a/packages/common/test/search/wellKnownCatalog.test.ts
+++ b/packages/common/test/search/wellKnownCatalog.test.ts
@@ -1,5 +1,4 @@
 import { EntityType } from "../../src";
-import * as wellKnownCatalog from "../../src/search/wellKnownCatalog";
 import {
   getWellKnownCatalog,
   getWellknownCollection,
@@ -19,7 +18,7 @@ describe("WellKnownCatalog", () => {
         collectionNames: [],
       };
     });
-    it("returns the expected catalog", () => {
+    it("returns the expected catalog for items", () => {
       let chk = getWellKnownCatalog(
         "mockI18nScope",
         "myContent",
@@ -48,6 +47,53 @@ describe("WellKnownCatalog", () => {
         "document",
         "feedback",
         "site",
+      ]);
+    });
+    it("returns the expected catalog for groups", () => {
+      let chk = getWellKnownCatalog(
+        "mockI18nScope",
+        "editGroups",
+        "group",
+        options
+      );
+      expect(chk.scopes).toBeDefined();
+      expect(chk.scopes?.group?.filters).toEqual([
+        { predicates: [{ capabilities: ["updateitemcontrol"] }] },
+      ]);
+      expect(chk.collections).toEqual([
+        {
+          targetEntity: "group",
+          key: "editGroups",
+          label: "editGroups",
+          scope: {
+            targetEntity: "group",
+            filters: [
+              {
+                predicates: [{ q: "*" }],
+              },
+            ],
+          },
+        },
+      ]);
+      chk = getWellKnownCatalog("mockI18nScope", "allGroups", "group", options);
+      expect(chk.scopes).toBeDefined();
+      expect(chk.scopes?.group?.filters).toEqual([
+        { predicates: [{ group: "theClub" }] },
+      ]);
+      expect(chk.collections).toEqual([
+        {
+          targetEntity: "group",
+          key: "allGroups",
+          label: "allGroups",
+          scope: {
+            targetEntity: "group",
+            filters: [
+              {
+                predicates: [{ q: "*" }],
+              },
+            ],
+          },
+        },
       ]);
     });
     it("throws if not passing a user for a catalog that requires it", () => {

--- a/packages/common/test/search/wellKnownCatalog.test.ts
+++ b/packages/common/test/search/wellKnownCatalog.test.ts
@@ -78,7 +78,7 @@ describe("WellKnownCatalog", () => {
       chk = getWellKnownCatalog("mockI18nScope", "allGroups", "group", options);
       expect(chk.scopes).toBeDefined();
       expect(chk.scopes?.group?.filters).toEqual([
-        { predicates: [{ group: "theClub" }] },
+        { predicates: [{ group: "theClubId" }] },
       ]);
       expect(chk.collections).toEqual([
         {

--- a/packages/common/test/search/wellKnownCatalog.test.ts
+++ b/packages/common/test/search/wellKnownCatalog.test.ts
@@ -78,7 +78,7 @@ describe("WellKnownCatalog", () => {
       chk = getWellKnownCatalog("mockI18nScope", "allGroups", "group", options);
       expect(chk.scopes).toBeDefined();
       expect(chk.scopes?.group?.filters).toEqual([
-        { predicates: [{ group: "theClubId" }] },
+        { predicates: [{ capabilities: [""] }] },
       ]);
       expect(chk.collections).toEqual([
         {

--- a/packages/common/test/test-helpers/fake-user.ts
+++ b/packages/common/test/test-helpers/fake-user.ts
@@ -10,4 +10,5 @@ export const mockUser = {
   role: "org_admin",
   created: 1609559200000,
   modified: 1612167600000,
+  orgId: "theClub",
 } as IUser;

--- a/packages/common/test/test-helpers/fake-user.ts
+++ b/packages/common/test/test-helpers/fake-user.ts
@@ -10,5 +10,5 @@ export const mockUser = {
   role: "org_admin",
   created: 1609559200000,
   modified: 1612167600000,
-  orgId: "theClub",
+  orgId: "theClubId",
 } as IUser;

--- a/packages/common/test/test-helpers/fake-user.ts
+++ b/packages/common/test/test-helpers/fake-user.ts
@@ -10,5 +10,4 @@ export const mockUser = {
   role: "org_admin",
   created: 1609559200000,
   modified: 1612167600000,
-  orgId: "theClubId",
 } as IUser;


### PR DESCRIPTION
…

affects: @esri/hub-common

1. Description:

- add getWellknownGroupCatalog function to get eidt-groups and all-groups catalogs
- a few pameter name changes that should effect current use cases

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
