### PR TITLE
feat: remove calls to register or update app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64972,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "12.30.1",
+			"version": "12.31.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64997,7 +64997,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "22.1.0",
+			"version": "22.1.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/src/core/behaviors/IWithEditorBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithEditorBehavior.ts
@@ -5,13 +5,6 @@ import {
   EditorType,
 } from "../schemas";
 
-/**
- * DEPRECATED: the following will be removed at next breaking version
- * we will be shifting towards the EditorType defined in the schemas
- * directory
- */
-export type EditorConfigType = "create" | "edit";
-
 export interface IEditorConfig {
   schema: IConfigurationSchema;
   uiSchema: IUiSchema;

--- a/packages/common/src/core/types/IHubLocation.ts
+++ b/packages/common/src/core/types/IHubLocation.ts
@@ -18,11 +18,4 @@ export interface IHubLocation {
 
   // An esri geometry: __esri.Geometry
   geometries?: __esri.Geometry[];
-
-  // DEPRECATED: the following will be removed at next breaking version
-  provenance?: "none" | "custom" | "existing";
-  center?: number[];
-  orgSpatialReference?: ISpatialReference;
-  graphic?: any;
-  geoJson?: any;
 }

--- a/packages/common/src/items/index.ts
+++ b/packages/common/src/items/index.ts
@@ -16,9 +16,13 @@ export * from "./get-structured-license";
 export * from "./slugs";
 export * from "./normalize-solution-template-item";
 export * from "./setItemThumbnail";
-export * from "./registerBrowserApp";
+
 export * from "./create-item-from-file";
 export * from "./create-item-from-url";
 export * from "./create-item-from-url-or-file";
 export * from "./uploadImageResource";
 export * from "./is-services-directory-disabled";
+// No longer exported as the only App Hub needed this for was a Site
+// and that registration is now done in the domain service with a
+// signed HMAC request.
+// export * from "./registerBrowserApp";

--- a/packages/common/src/items/registerBrowserApp.ts
+++ b/packages/common/src/items/registerBrowserApp.ts
@@ -2,6 +2,8 @@ import { IRequestOptions, request } from "@esri/arcgis-rest-request";
 import { getPortalApiUrl } from "../urls";
 
 /**
+ * @private
+ * @internal
  * Register an Item as an application, enabling oAuth flows at custom
  * domains. Only item types with "Application" in the name are valid
  * with this API call.

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -5,20 +5,11 @@ import { createModel, getModel, updateModel } from "../models";
 import { constructSlug, getUniqueSlug, setSlugKeyword } from "../items/slugs";
 import { IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
-import { EntityResourceMap, IHubProject } from "../core/types";
+import { IHubProject } from "../core/types";
 import { DEFAULT_PROJECT, DEFAULT_PROJECT_MODEL } from "./defaults";
 import { computeProps } from "./_internal/computeProps";
 import { getPropertyMap } from "./_internal/getPropertyMap";
-import { ProjectEditorType } from "./_internal/ProjectSchema";
 import { cloneObject } from "../util";
-import {
-  getEntityEditorSchemas,
-  UiSchemaElementOptions,
-} from "../core/schemas";
-import {
-  EditorConfigType,
-  IEditorConfig,
-} from "../core/behaviors/IWithEditorBehavior";
 
 /**
  * @private
@@ -104,25 +95,4 @@ export async function deleteProject(
   const ro = { ...requestOptions, ...{ id } } as IUserItemOptions;
   await removeItem(ro);
   return;
-}
-
-/**
- * DEPRECATED: the following will be removed at next breaking version
- * use the getEntityEditorSchemas function instead (which this function
- * has already been refactored to consume)
- *
- * Get the editor config for for the HubProject entity.
- * @param i18nScope translation scope to be interpolated into the uiSchema
- * @param type editor type - corresonds to the returned uiSchema
- * @param options optional hash of dynamic uiSchema element options
- */
-/* istanbul ignore next deprecated */
-export async function getHubProjectEditorConfig(
-  i18nScope: string,
-  type: EditorConfigType,
-  options: UiSchemaElementOptions[] = []
-): Promise<IEditorConfig> {
-  const editorType = `hub:project:${type}` as ProjectEditorType;
-
-  return getEntityEditorSchemas(i18nScope, editorType, options);
 }

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -336,26 +336,6 @@ export async function updateSite(
 }
 
 /**
- * @private
- * Remove a Hub Site
- *
- * This simply removes the Site item, and it's associated domain records.
- * This does not remove any Teams/Groups or content associated with the
- * Site
- * @param id
- * @param requestOptions
- * @returns
- */
-export async function destroySite(
-  id: string,
-  requestOptions: IHubRequestOptions
-): Promise<void> {
-  // tslint:disable-next-line:no-console
-  console.warn(`destroySite is deprecated, use deleteSite instead`);
-  return deleteSite(id, requestOptions);
-}
-
-/**
  * Remove a Hub Site
  *
  * This simply removes the Site item, and it's associated domain records.

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -271,11 +271,12 @@ export async function createSite(
   );
 
   // Register as an app
-  const registration = await registerSiteAsApplication(model, requestOptions);
-  model.data.values.clientId = registration.client_id;
+  // NOTE: Site registration needs to happen via the hub api domain api calls
+  // See https://devtopia.esri.com/dc/hub/issues/6390 for info
 
-  // Register domains
-  await addSiteDomains(model, requestOptions);
+  // Register domain and at the same time register the site as an application
+  const domainResponses = await addSiteDomains(model, requestOptions);
+  model.data.values.clientId = domainResponses[0].client_id;
 
   // update the model
   const updatedModel = await updateModel(

--- a/packages/common/src/sites/index.ts
+++ b/packages/common/src/sites/index.ts
@@ -7,7 +7,10 @@ export * from "./fetchSiteModel";
 export * from "./get-site-by-id";
 export * from "./HubSite";
 export * from "./HubSites";
-export * from "./registerSiteAsApplication";
 export * from "./site-schema-version";
 export * from "./themes";
 export * from "./upgrade-site-schema";
+
+// No longer exported b/c site app registration is now handled
+// by the domain service due to requirement to send signed HMAC request
+// export * from "./registerSiteAsApplication";

--- a/packages/common/src/sites/registerSiteAsApplication.ts
+++ b/packages/common/src/sites/registerSiteAsApplication.ts
@@ -2,7 +2,10 @@ import { registerBrowserApp } from "../items/registerBrowserApp";
 import { getProp } from "../objects";
 import { IHubRequestOptions, IModel } from "../types";
 import { _getHttpAndHttpsUris } from "../urls";
+
 /**
+ * @private
+ * @internal
  * Register the Site item as an application so we can oauth against it
  * @param {string} siteId Item Id of the site
  * @param {Array} uris Arrayf valid uris for the site

--- a/packages/common/test/items/registerBrowserApp.test.ts
+++ b/packages/common/test/items/registerBrowserApp.test.ts
@@ -1,4 +1,4 @@
-import { registerBrowserApp } from "../../src";
+import { registerBrowserApp } from "../../src/items/registerBrowserApp";
 import * as requestModule from "@esri/arcgis-rest-request";
 
 describe("registerBrowserApp", () => {

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -308,7 +308,7 @@ describe("HubSites:", () => {
     let uniqueDomainSpy: jasmine.Spy;
     let createModelSpy: jasmine.Spy;
     let updateModelSpy: jasmine.Spy;
-    let registerAppSpy: jasmine.Spy;
+
     let addDomainsSpy: jasmine.Spy;
     beforeEach(() => {
       uniqueDomainSpy = spyOn(
@@ -332,15 +332,11 @@ describe("HubSites:", () => {
         const newModel = commonModule.cloneObject(m);
         return Promise.resolve(newModel);
       });
-      registerAppSpy = spyOn(
-        require("../../src/sites/registerSiteAsApplication"),
-        "registerSiteAsApplication"
-      ).and.returnValue(Promise.resolve({ client_id: "FAKE_CLIENT_ID" }));
 
       addDomainsSpy = spyOn(
         require("../../src/sites/domains/addSiteDomains"),
         "addSiteDomains"
-      ).and.returnValue(Promise.resolve());
+      ).and.returnValue(Promise.resolve([{ clientKey: "FAKE_CLIENT_KEY" }]));
     });
     it("works with a sparse IHubSite", async () => {
       const sparseSite: Partial<commonModule.IHubSite> = {
@@ -353,7 +349,7 @@ describe("HubSites:", () => {
       expect(uniqueDomainSpy.calls.count()).toBe(1);
       expect(createModelSpy.calls.count()).toBe(1);
       expect(updateModelSpy.calls.count()).toBe(1);
-      expect(registerAppSpy.calls.count()).toBe(1);
+
       expect(addDomainsSpy.calls.count()).toBe(1);
 
       const modelToCreate = createModelSpy.calls.argsFor(0)[0];
@@ -409,7 +405,7 @@ describe("HubSites:", () => {
       expect(uniqueDomainSpy.calls.count()).toBe(1);
       expect(createModelSpy.calls.count()).toBe(1);
       expect(updateModelSpy.calls.count()).toBe(1);
-      expect(registerAppSpy.calls.count()).toBe(1);
+
       expect(addDomainsSpy.calls.count()).toBe(1);
 
       expect(chk.name).toBe("Special Site");
@@ -433,7 +429,7 @@ describe("HubSites:", () => {
       expect(uniqueDomainSpy.calls.count()).toBe(1);
       expect(createModelSpy.calls.count()).toBe(1);
       expect(updateModelSpy.calls.count()).toBe(1);
-      expect(registerAppSpy.calls.count()).toBe(1);
+
       expect(addDomainsSpy.calls.count()).toBe(1);
 
       const modelToCreate = createModelSpy.calls.argsFor(0)[0];

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -216,7 +216,7 @@ describe("HubSites:", () => {
     });
   });
 
-  describe("destroySite:", () => {
+  describe("deleteSite:", () => {
     it("removes item and domains in AGO", async () => {
       const removeSpy = spyOn(portalModule, "removeItem").and.returnValue(
         Promise.resolve({ success: true })
@@ -227,7 +227,7 @@ describe("HubSites:", () => {
         "removeDomainsBySiteId"
       ).and.returnValue(Promise.resolve());
 
-      const result = await commonModule.destroySite("3ef", {
+      const result = await commonModule.deleteSite("3ef", {
         authentication: MOCK_AUTH,
       });
       expect(result).toBeUndefined();
@@ -242,7 +242,7 @@ describe("HubSites:", () => {
         Promise.resolve({ success: true })
       );
 
-      const result = await commonModule.destroySite(
+      const result = await commonModule.deleteSite(
         "3ef",
         MOCK_ENTERPRISE_REQOPTS
       );

--- a/packages/common/test/sites/registerBrowserApp.test.ts
+++ b/packages/common/test/sites/registerBrowserApp.test.ts
@@ -1,4 +1,4 @@
-import { registerBrowserApp } from "../../src";
+import { registerBrowserApp } from "../../src/items/registerBrowserApp";
 import * as requestModule from "@esri/arcgis-rest-request";
 
 describe("registerBrowserApp", () => {

--- a/packages/common/test/sites/registerSiteAsApplication.test.ts
+++ b/packages/common/test/sites/registerSiteAsApplication.test.ts
@@ -1,4 +1,5 @@
 import * as commonModule from "../../src";
+import { registerSiteAsApplication } from "../../src/sites/registerSiteAsApplication";
 import * as regiserBrowserAppModule from "../../src/items/registerBrowserApp";
 
 describe("registerSiteAsApplication", () => {
@@ -19,7 +20,7 @@ describe("registerSiteAsApplication", () => {
       },
     } as unknown as commonModule.IModel;
 
-    await commonModule.registerSiteAsApplication(
+    await registerSiteAsApplication(
       model,
       {} as commonModule.IHubRequestOptions
     );
@@ -58,7 +59,7 @@ describe("registerSiteAsApplication", () => {
       },
     } as unknown as commonModule.IModel;
 
-    await commonModule.registerSiteAsApplication(
+    await registerSiteAsApplication(
       model,
       {} as commonModule.IHubRequestOptions
     );
@@ -97,7 +98,7 @@ describe("registerSiteAsApplication", () => {
       },
     } as unknown as commonModule.IModel;
 
-    await commonModule.registerSiteAsApplication(model, {
+    await registerSiteAsApplication(model, {
       isPortal: true,
     } as commonModule.IHubRequestOptions);
 

--- a/packages/discussions/package.json
+++ b/packages/discussions/package.json
@@ -13,7 +13,7 @@
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.14.0 || 3",
     "@esri/arcgis-rest-request": "^2.14.0 || 3",
-    "@esri/hub-common": "^12.4.0"
+    "@esri/hub-common": "^12.4.0 || 13"
   },
   "devDependencies": {
     "@esri/hub-common": "*",

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-feature-layer": "^3.1.0",
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.0",
-    "@esri/hub-common": "^12.4.0"
+    "@esri/hub-common": "^12.4.0 || 13"
   },
   "devDependencies": {
     "@esri/hub-common": "*",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-portal": "^2.15.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "^12.4.0"
+    "@esri/hub-common": "^12.4.0 || 13"
   },
   "devDependencies": {
     "@esri/hub-common": "*",

--- a/packages/initiatives/package.json
+++ b/packages/initiatives/package.json
@@ -14,7 +14,7 @@
     "@esri/arcgis-rest-auth": "^2.13.0 || 3",
     "@esri/arcgis-rest-portal": "^2.13.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
-    "@esri/hub-common": "^12.4.0"
+    "@esri/hub-common": "^12.4.0 || 13"
   },
   "devDependencies": {
     "@esri/hub-common": "*",

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -14,7 +14,7 @@
     "@esri/arcgis-rest-auth": "^2.13.0 || 3",
     "@esri/arcgis-rest-portal": "^2.19.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
-    "@esri/hub-common": "^12.4.0",
+    "@esri/hub-common": "^13.0.0",
     "@esri/hub-initiatives": "^12.4.0",
     "@esri/hub-teams": "^12.4.0"
   },

--- a/packages/sites/src/create-site.ts
+++ b/packages/sites/src/create-site.ts
@@ -7,7 +7,6 @@ import {
   uploadResourcesFromUrl,
   getProp,
   addSiteDomains,
-  registerSiteAsApplication,
 } from "@esri/hub-common";
 import { ensureRequiredSiteProperties } from "./ensure-required-site-properties";
 import {
@@ -61,12 +60,17 @@ export function createSite(
     })
     .then((protectResponse) => {
       // do app registration
-
-      return registerSiteAsApplication(model, hubRequestOptions);
+      // TODO: Remove this call, and get the clientId out of the addSiteDomains call
+      // return registerSiteAsApplication(model, hubRequestOptions);
+      // Handle domains
+      return addSiteDomains(model, hubRequestOptions);
     })
-    .then((appRegistrationResponse) => {
-      // store the clientId
-      model.data.values.clientId = appRegistrationResponse.client_id;
+    .then((domainResponses) => {
+      // client id will be the same for all domain resonses so we can just grab the first one
+      // no guard clause because the only way we don't get a response is if addSiteDomains throws
+      // which would not hit this code
+      model.data.values.clientId = domainResponses[0].clientKey;
+
       // If we have a dcat section, hoist it out as it may contain complex adlib
       // templates that are needed at run-time
       // If we have data.values.dcatConfig, yank it off b/c that may have adlib template stuff in it
@@ -85,11 +89,6 @@ export function createSite(
       });
     })
     .then((updateResponse) => {
-      // Handle domains
-
-      return addSiteDomains(model, hubRequestOptions);
-    })
-    .then((domainResponses) => {
       // upload resources from url
 
       return uploadResourcesFromUrl(

--- a/packages/sites/src/index.ts
+++ b/packages/sites/src/index.ts
@@ -1,49 +1,48 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-export * from "./domains";
-export * from "./drafts";
-export * from "./layout";
-export * from "./pages";
-
-export * from "./get-domain";
-export * from "./_remove-site-groups";
-export * from "./_remove-parent-initiative";
-export * from "./_remove-site-from-index";
-export * from "./_remove-site-domains";
-export * from "./_get-portal-domain-type-keyword";
-export * from "./_ensure-optional-groups-templating";
-export * from "./_ensure-type-and-tags";
-export * from "./get-site-item-type";
-export * from "./_ensure-portal-domain-keyword";
-export * from "./get-site-edit-url";
-export * from "./update-site-application-uris";
-export * from "./update-app-redirect-uris";
-export * from "./unlink-site-and-page";
-export * from "./link-site-and-page";
-export * from "./unlink-pages-from-site";
-export * from "./get-site-dependencies";
-export * from "./ensure-optional-groups-templating";
-export * from "./remove-site";
-export * from "./ensure-required-site-properties";
-export * from "./update-site";
-export * from "./create-site";
-export * from "./get-portal-site-url";
-export * from "./get-portal-site-hostname";
 export * from "./_create-site-initiative";
-export * from "./_update-team-tags";
-export * from "./create-site-model-from-template";
-export * from "./convert-site-to-template";
-export * from "./_get-site-data-by-id";
+export * from "./_ensure-optional-groups-templating";
+export * from "./_ensure-portal-domain-keyword";
+export * from "./_ensure-type-and-tags";
+export * from "./_get-portal-domain-type-keyword";
 export * from "./_get-second-pass-sharing-options";
-export * from "./share-items-to-site-groups";
+export * from "./_get-site-data-by-id";
+export * from "./_remove-parent-initiative";
+export * from "./_remove-site-domains";
+export * from "./_remove-site-from-index";
+export * from "./_remove-site-groups";
 export * from "./_second-pass-adlib-pages";
 export * from "./_update-pages";
-export * from "./site-second-pass";
+export * from "./_update-team-tags";
+export * from "./convert-site-to-template";
+export * from "./create-site-model-from-template";
+export * from "./create-site";
+export * from "./domains";
+export * from "./drafts";
+export * from "./ensure-optional-groups-templating";
+export * from "./ensure-required-site-properties";
 export * from "./get-data-for-site-item";
-export * from "./is-site";
+export * from "./get-domain";
 export * from "./get-members";
+export * from "./get-portal-site-hostname";
+export * from "./get-portal-site-url";
+export * from "./get-site-dependencies";
+export * from "./get-site-edit-url";
+export * from "./get-site-item-type";
 export * from "./interpolate-site";
+export * from "./is-site";
+export * from "./layout";
+export * from "./link-site-and-page";
+export * from "./pages";
+export * from "./remove-site";
+export * from "./share-items-to-site-groups";
+export * from "./site-second-pass";
+export * from "./unlink-pages-from-site";
+export * from "./unlink-site-and-page";
+// export * from "./update-app-redirect-uris";
+export * from "./update-site-application-uris";
+export * from "./update-site";
 
 // Re-exports to avoid breaking changes
 export {

--- a/packages/sites/src/update-site-application-uris.ts
+++ b/packages/sites/src/update-site-application-uris.ts
@@ -23,21 +23,15 @@ export function updateSiteApplicationUris(
   hubRequestOptions: IHubRequestOptions
 ) {
   if (hubRequestOptions.isPortal) return Promise.resolve({});
-  // get http and https versions of all uris
-  const redirectUris = uris.reduce((acc, uri) => {
-    return acc.concat(_getHttpAndHttpsUris(uri));
-  }, []);
-  // update the redirect uris for the application
-  return updateAppRedirectUris(
-    site.data.values.clientId,
-    redirectUris,
-    hubRequestOptions
-  )
-    .then(() => {
-      // now we update the domains, removing any that are no longer used
-      return getDomainsForSite(site.item.id, hubRequestOptions);
-    })
-    .then((domainInfos: IDomainEntry[]) => {
+  // // get http and https versions of all uris
+  // const redirectUris = uris.reduce((acc, uri) => {
+  //   return acc.concat(_getHttpAndHttpsUris(uri));
+  // }, []);
+
+  // Domain service handles updating the app redirect uris for sites
+  // First, get the domain records associated with the site
+  return getDomainsForSite(site.item.id, hubRequestOptions).then(
+    (domainInfos: IDomainEntry[]) => {
       // get all domains that are no longer associated with the site
       const domainsToRemove = domainInfos.filter(
         (domain) => !includes(uris, domain.hostname)
@@ -69,5 +63,6 @@ export function updateSiteApplicationUris(
         )
       );
       return Promise.all(domainPromises);
-    });
+    }
+  );
 }

--- a/packages/sites/test/create-site.test.ts
+++ b/packages/sites/test/create-site.test.ts
@@ -6,27 +6,9 @@ import * as initiativesModule from "@esri/hub-initiatives";
 import { IModel } from "@esri/hub-common";
 
 describe("create site :: ", function () {
-  const APP_REGISTRATION_RESPONSE: any = {
-    itemId: "3ef",
-    client_id: "031AYEM9fd1X1ac9",
-    client_secret: "f44501a0ab744463af5ce338429833db",
-    appType: "browser",
-    redirect_uris: [
-      "http://my-site.com",
-      "https://my-site.com",
-      "https://name-org.hub.arcgis.com",
-      "http://name-org.hub.arcgis.com",
-    ],
-    registered: 1580932896000,
-    modified: 1580932896000,
-    apnsProdCert: null,
-    apnsSandboxCert: null,
-    gcmApiKey: null,
-  };
-
   let createSpy: jasmine.Spy;
   let protectSpy: jasmine.Spy;
-  let registerSpy: jasmine.Spy;
+  // let registerSpy: jasmine.Spy;
   let updateSpy: jasmine.Spy;
   let domainsSpy: jasmine.Spy;
   let uploadResourcesSpy: jasmine.Spy;
@@ -38,15 +20,16 @@ describe("create site :: ", function () {
     protectSpy = spyOn(portalModule, "protectItem").and.returnValue(
       Promise.resolve({ success: true, id: "3ef" })
     );
-    registerSpy = spyOn(
-      commonModule,
-      "registerSiteAsApplication"
-    ).and.returnValue(Promise.resolve(APP_REGISTRATION_RESPONSE));
+
     updateSpy = spyOn(portalModule, "updateItem").and.returnValue(
       Promise.resolve({ success: true, id: "3ef" })
     );
     domainsSpy = spyOn(commonModule, "addSiteDomains").and.returnValue(
-      Promise.resolve({})
+      Promise.resolve([
+        {
+          clientKey: "FAKECLIENTKEY",
+        },
+      ])
     );
     uploadResourcesSpy = spyOn(
       commonModule,
@@ -79,15 +62,15 @@ describe("create site :: ", function () {
     const result = await createSite(site, {}, ro);
 
     expect(result.item.id).toBe("3ef", "should attach id into returned model");
-    expect(result.data.values.clientId).toBe(
-      "031AYEM9fd1X1ac9",
+    expect(result.data?.values.clientId).toBe(
+      "FAKECLIENTKEY",
       "should attach client Id into returned model"
     );
     expect(result.item.typeKeywords).toContain(
       "hubSite",
       "should add missing typeKeywords array and add hubSite"
     );
-    expect(result.data.values.verifySecondPass).toBe(
+    expect(result.data?.values.verifySecondPass).toBe(
       "this should be 3ef interpolated",
       "should do second pass appid interpolation"
     );
@@ -95,14 +78,7 @@ describe("create site :: ", function () {
     // no collab group, so no sharing call
     expect(shareSpy).not.toHaveBeenCalled();
     expectAllCalled(
-      [
-        createSpy,
-        protectSpy,
-        registerSpy,
-        updateSpy,
-        domainsSpy,
-        uploadResourcesSpy,
-      ],
+      [createSpy, protectSpy, updateSpy, domainsSpy, uploadResourcesSpy],
       expect
     );
   });
@@ -143,14 +119,7 @@ describe("create site :: ", function () {
     expect(call[0]).toBe("bc7", "should send the initiative id");
     expect(call[1]).toBe("3ef", "should send the site id");
     expectAllCalled(
-      [
-        createSpy,
-        protectSpy,
-        registerSpy,
-        updateSpy,
-        domainsSpy,
-        uploadResourcesSpy,
-      ],
+      [createSpy, protectSpy, updateSpy, domainsSpy, uploadResourcesSpy],
       expect
     );
   });
@@ -176,15 +145,15 @@ describe("create site :: ", function () {
     const result = await createSite(site, {}, ro);
 
     expect(result.item.id).toBe("3ef", "should attach id into returned model");
-    expect(result.data.values.clientId).toBe(
-      "031AYEM9fd1X1ac9",
+    expect(result.data?.values.clientId).toBe(
+      "FAKECLIENTKEY",
       "should attach client Id into returned model"
     );
     expect(result.item.typeKeywords).toContain(
       "hubSite",
       "should add missing typeKeywords array and add hubSite"
     );
-    expect(result.data.values.verifySecondPass).toBe(
+    expect(result.data?.values.verifySecondPass).toBe(
       "this should be 3ef interpolated",
       "should do second pass appid interpolation"
     );
@@ -193,14 +162,7 @@ describe("create site :: ", function () {
     expect(shareSpy).toHaveBeenCalled();
     expect(shareSpy.calls.argsFor(0)[0].groupId).toBe("foo-bar-baz");
     expectAllCalled(
-      [
-        createSpy,
-        protectSpy,
-        registerSpy,
-        updateSpy,
-        domainsSpy,
-        uploadResourcesSpy,
-      ],
+      [createSpy, protectSpy, updateSpy, domainsSpy, uploadResourcesSpy],
       expect
     );
   });
@@ -228,7 +190,7 @@ describe("create site :: ", function () {
 
     const result = await createSite(site, {}, ro);
 
-    expect(result.data.values.dcatConfig.foo).toBe(
+    expect(result.data?.values.dcatConfig.foo).toBe(
       "{{some.undefined.thing}}",
       "dcatConfig not interpolated"
     );
@@ -258,14 +220,7 @@ describe("create site :: ", function () {
 
     expect(createSpy).toHaveBeenCalled();
     expectAll(
-      [
-        protectSpy,
-        registerSpy,
-        updateSpy,
-        domainsSpy,
-        uploadResourcesSpy,
-        shareSpy,
-      ],
+      [protectSpy, updateSpy, domainsSpy, uploadResourcesSpy, shareSpy],
       "toHaveBeenCalled",
       false,
       expect

--- a/packages/sites/test/update-app-redirect-uris.test.ts
+++ b/packages/sites/test/update-app-redirect-uris.test.ts
@@ -1,4 +1,4 @@
-import { updateAppRedirectUris } from "../src";
+import { updateAppRedirectUris } from "../src/update-app-redirect-uris";
 import * as requestModule from "@esri/arcgis-rest-request";
 import { IHubRequestOptions } from "@esri/hub-common";
 
@@ -12,8 +12,8 @@ describe("updateAppRedirectUris", () => {
 
     const ro = {
       authentication: {
-        token: "token"
-      }
+        token: "token",
+      },
     } as IHubRequestOptions;
 
     const clientId = "abc-clientid";
@@ -31,8 +31,8 @@ describe("updateAppRedirectUris", () => {
         authentication: ro.authentication,
         params: {
           client_id: clientId,
-          redirect_uris: JSON.stringify(redirectUris)
-        }
+          redirect_uris: JSON.stringify(redirectUris),
+        },
       },
       "request called with correct config"
     );

--- a/packages/sites/test/update-site-application-uris.test.ts
+++ b/packages/sites/test/update-site-application-uris.test.ts
@@ -24,16 +24,10 @@ describe("updateSiteApplicationUris", () => {
     },
   } as unknown as IHubRequestOptions;
 
-  let updateRedirectSpy: jasmine.Spy;
   let removeSpy: jasmine.Spy;
   let addSpy: jasmine.Spy;
   let getDomainsSpy: jasmine.Spy;
   beforeEach(() => {
-    updateRedirectSpy = spyOn(
-      updateRedirectModule,
-      "updateAppRedirectUris"
-    ).and.returnValue(Promise.resolve());
-
     getDomainsSpy = spyOn(commonModule, "getDomainsForSite").and.returnValue(
       Promise.resolve([
         { id: "foo-id", hostname: "foo", sslOnly: false },
@@ -55,7 +49,6 @@ describe("updateSiteApplicationUris", () => {
 
     await updateSiteApplicationUris(site, uris, ro);
 
-    expect(updateRedirectSpy).toHaveBeenCalled();
     expect(getDomainsSpy).toHaveBeenCalled();
 
     expect(removeSpy.calls.count()).toBe(1, "one domain removed");
@@ -71,13 +64,13 @@ describe("updateSiteApplicationUris", () => {
     );
     expect(addSpy.calls.argsFor(0)[0]).toEqual(
       {
-        orgKey: ro.portalSelf.urlKey,
-        orgId: ro.portalSelf.id,
-        orgTitle: ro.portalSelf.name,
+        orgKey: ro.portalSelf?.urlKey,
+        orgId: ro.portalSelf?.id,
+        orgTitle: ro.portalSelf?.name,
         hostname: "bar",
         siteId: site.item.id,
         siteTitle: site.item.title,
-        clientKey: site.data.values.clientId,
+        clientKey: site.data?.values.clientId,
         sslOnly: false,
       },
       "correct parameters for addDomain"
@@ -103,7 +96,6 @@ describe("updateSiteApplicationUris", () => {
       isPortal: true,
     } as IHubRequestOptions);
 
-    expect(updateRedirectSpy).not.toHaveBeenCalled();
     expect(getDomainsSpy).not.toHaveBeenCalled();
     expect(removeSpy).not.toHaveBeenCalled();
     expect(addSpy).not.toHaveBeenCalled();

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-portal": "^2.13.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "^12.4.0"
+    "@esri/hub-common": "^12.4.0 || 13"
   },
   "devDependencies": {
     "@esri/hub-common": "*",

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -15,7 +15,7 @@
     "@esri/arcgis-rest-portal": "^2.15.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "^12.4.0"
+    "@esri/hub-common": "^12.4.0 || 13"
   },
   "devDependencies": {
     "@esri/hub-common": "*",


### PR DESCRIPTION
BREAKING CHANGE: Client code no longer makes calls to register site as application or to update application redirect uris. This is all expected to be handled server-side by the Hub Domain service.

1. Description:

- remove calls to register app in create site, and calls that would update app redirect uris. 
- Leaves low-level functions in place, but removes exports, and does not call them anymore.

1. Instructions for testing: run tests

1. Closes Issues: #[6604](https://devtopia.esri.com/dc/hub/issues/6604)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.

## PEERDEPS WILL BE BUMPED IN A FOLLOW ON PR
 
