### PR TITLE
feat(hub-common): handle viewGroups in getWellknownGroupCatalog

### DIFF
--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -13,6 +13,7 @@ export type WellKnownCatalog =
   | "organization"
   | "world"
   | "editGroups"
+  | "viewGroups"
   | "allGroups";
 
 /**
@@ -205,6 +206,23 @@ function getWellknownGroupCatalog(
 ): IHubCatalog {
   i18nScope = dotifyString(i18nScope);
   let catalog;
+  // because collections are needed in arcgis-hub-catalog and
+  // "searchGroups" allows 'q: "*"', we use this as the collection
+  const collections = [
+    {
+      targetEntity: "group" as EntityType,
+      key: catalogName,
+      label: catalogName,
+      scope: {
+        targetEntity: "group" as EntityType,
+        filters: [
+          {
+            predicates: [{ q: "*" }],
+          },
+        ],
+      },
+    },
+  ];
 
   switch (catalogName) {
     case "editGroups":
@@ -213,26 +231,19 @@ function getWellknownGroupCatalog(
         i18nScope,
         catalogName,
         [{ capabilities: ["updateitemcontrol"] }],
-        [],
+        collections,
         "group"
       );
-      // because collections are needed in arcgis-hub-catalog and
-      // "searchGroups" allows 'q: "*"', we use this as the collection
-      catalog.collections = [
-        {
-          targetEntity: "group",
-          key: catalogName,
-          label: catalogName,
-          scope: {
-            targetEntity: "group",
-            filters: [
-              {
-                predicates: [{ q: "*" }],
-              },
-            ],
-          },
-        },
-      ];
+      break;
+    case "viewGroups":
+      validateUserExistence(catalogName, options);
+      catalog = buildCatalog(
+        i18nScope,
+        catalogName,
+        [{ capabilities: { not: ["updateitemcontrol"] } }],
+        collections,
+        "group"
+      );
       break;
     case "allGroups":
       validateUserExistence(catalogName, options);
@@ -240,24 +251,9 @@ function getWellknownGroupCatalog(
         i18nScope,
         catalogName,
         [{ capabilities: [""] }],
-        [],
+        collections,
         "group"
       );
-      catalog.collections = [
-        {
-          targetEntity: "group",
-          key: catalogName,
-          label: catalogName,
-          scope: {
-            targetEntity: "group",
-            filters: [
-              {
-                predicates: [{ q: "*" }],
-              },
-            ],
-          },
-        },
-      ];
       break;
   }
   return catalog;

--- a/packages/common/test/search/wellKnownCatalog.test.ts
+++ b/packages/common/test/search/wellKnownCatalog.test.ts
@@ -75,6 +75,31 @@ describe("WellKnownCatalog", () => {
           },
         },
       ]);
+      chk = getWellKnownCatalog(
+        "mockI18nScope",
+        "viewGroups",
+        "group",
+        options
+      );
+      expect(chk.scopes).toBeDefined();
+      expect(chk.scopes?.group?.filters).toEqual([
+        { predicates: [{ capabilities: { not: ["updateitemcontrol"] } }] },
+      ]);
+      expect(chk.collections).toEqual([
+        {
+          targetEntity: "group",
+          key: "viewGroups",
+          label: "viewGroups",
+          scope: {
+            targetEntity: "group",
+            filters: [
+              {
+                predicates: [{ q: "*" }],
+              },
+            ],
+          },
+        },
+      ]);
       chk = getWellKnownCatalog("mockI18nScope", "allGroups", "group", options);
       expect(chk.scopes).toBeDefined();
       expect(chk.scopes?.group?.filters).toEqual([


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Add viewGroups handling in getWellknownGroupCatalog so we can obtain its catalogs

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
