### PR TITLE
fix: problem with updateVersionMetadata implementation

### DIFF
--- a/packages/common/src/versioning/createVersion.ts
+++ b/packages/common/src/versioning/createVersion.ts
@@ -58,7 +58,6 @@ export async function createVersion(
     owner: getProp(model, "item.owner"),
     params: { properties },
     prefix,
-    private: true,
     resource: versionBlob,
   });
 

--- a/packages/common/src/versioning/updateVersion.ts
+++ b/packages/common/src/versioning/updateVersion.ts
@@ -71,7 +71,6 @@ export async function updateVersion(
     owner: getProp(model, "item.owner"),
     params: { properties },
     prefix,
-    private: true,
     resource: versionBlob,
   });
 

--- a/packages/common/src/versioning/updateVersionMetadata.ts
+++ b/packages/common/src/versioning/updateVersionMetadata.ts
@@ -1,27 +1,39 @@
 import { IHubUserRequestOptions } from "../types";
 import { mergeObjects } from "../objects/merge-objects";
+import { objectToJsonBlob } from "../resources/object-to-json-blob";
 import { IVersionMetadata } from "./types";
 import { getPrefix } from "./_internal/getPrefix";
 import {
   VERSION_RESOURCE_NAME,
   VERSION_RESOURCE_PROPERTIES,
 } from "./_internal/constants";
+import { getVersion } from "./getVersion";
 import { updateItemResource } from "@esri/arcgis-rest-portal";
 
 /**
  * Updates the specified version's metadata
  * @param id
- * @param version
+ * @param versionMetadata
  * @param requestOptions
  * @returns
  */
 export async function updateVersionMetadata(
   id: string,
-  version: IVersionMetadata,
+  versionMetadata: IVersionMetadata,
   requestOptions: IHubUserRequestOptions
 ): Promise<IVersionMetadata> {
-  const prefix = getPrefix(version.id);
-  const properties = mergeObjects(version, {}, VERSION_RESOURCE_PROPERTIES);
+  const prefix = getPrefix(versionMetadata.id);
+  const properties = mergeObjects(
+    versionMetadata,
+    {},
+    VERSION_RESOURCE_PROPERTIES
+  );
+
+  // fetch the whole version so we can update it
+  const version = await getVersion(id, versionMetadata.id, requestOptions);
+  // apply the metadata to the version
+  mergeObjects(versionMetadata, version, VERSION_RESOURCE_PROPERTIES);
+  const versionBlob = objectToJsonBlob(version);
 
   await updateItemResource({
     ...requestOptions,
@@ -30,7 +42,8 @@ export async function updateVersionMetadata(
     owner: properties.creator,
     params: { properties },
     prefix,
+    resource: versionBlob,
   });
 
-  return version;
+  return versionMetadata;
 }

--- a/packages/common/test/versioning/createVersion.test.ts
+++ b/packages/common/test/versioning/createVersion.test.ts
@@ -75,7 +75,6 @@ describe("createVersion", () => {
         },
       },
       prefix: "hubVersion_def456",
-      private: true,
       resource: versionBlob,
     };
 

--- a/packages/common/test/versioning/updateVersion.test.ts
+++ b/packages/common/test/versioning/updateVersion.test.ts
@@ -58,7 +58,6 @@ describe("updateVersion", () => {
         },
       },
       prefix: "hubVersion_def456",
-      private: true,
       resource: versionBlob,
     };
 

--- a/packages/common/test/versioning/updateVersion.test.ts
+++ b/packages/common/test/versioning/updateVersion.test.ts
@@ -75,7 +75,7 @@ describe("updateVersion", () => {
       name: undefined,
       parent: undefined,
       path: "hubVersion_def456/version.json",
-      updated: "9876543210",
+      updated: "1675954801031",
       size: 123,
     } as unknown as IVersion;
 
@@ -116,13 +116,13 @@ describe("updateVersion", () => {
 
   it("should throw when attempting to update a stale version", async () => {
     try {
+      version.updated = 1;
       await updateVersion(model, version, requestOpts);
       fail("should reject");
     } catch (err) {
       expect(err.message).toBe(
         "Version def456 is stale. Use force to overwrite."
       );
-      expect(err.updated).toBe(1675954801031);
     }
   });
 });

--- a/packages/common/test/versioning/updateVersionMetadata.test.ts
+++ b/packages/common/test/versioning/updateVersionMetadata.test.ts
@@ -2,6 +2,9 @@ import * as portalModule from "@esri/arcgis-rest-portal";
 import { updateVersionMetadata } from "../../src/versioning/updateVersionMetadata";
 import { IHubUserRequestOptions } from "../../src/types";
 import { MOCK_AUTH } from "../mocks/mock-auth";
+import * as ResourceResponse from "../mocks/versioning/resource.json";
+import * as objectToJsonBlobModule from "../../src/resources/object-to-json-blob";
+
 import { IVersionMetadata } from "../../src";
 
 describe("updateVersionMetadata", () => {
@@ -30,10 +33,21 @@ describe("updateVersionMetadata", () => {
     };
     const id = "abc123";
 
+    const getItemResourceSpy = spyOn(
+      portalModule,
+      "getItemResource"
+    ).and.returnValue(Promise.resolve(ResourceResponse));
+
     const updateItemResourceSpy = spyOn(
       portalModule,
       "updateItemResource"
     ).and.returnValue(Promise.resolve(version));
+
+    const versionBlob = { size: 123 };
+
+    spyOn(objectToJsonBlobModule, "objectToJsonBlob").and.returnValue(
+      versionBlob
+    );
 
     const result = await updateVersionMetadata(id, version, requestOpts);
 
@@ -52,8 +66,10 @@ describe("updateVersionMetadata", () => {
       },
       owner: "jupe",
       prefix: "hubVersion_def456",
+      resource: versionBlob,
     };
 
+    expect(getItemResourceSpy).toHaveBeenCalledTimes(1);
     expect(updateItemResourceSpy).toHaveBeenCalledTimes(1);
     expect(updateItemResourceSpy).toHaveBeenCalledWith(options);
     expect(result).toEqual(version);


### PR DESCRIPTION
1. Description: Fixes an issue i discovered with the updateVersionMetadata implementation.

1. Instructions for testing: Run tests?

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
