### PR TITLE
feat: add access and groups to project schema

### DIFF
--- a/packages/common/src/core/schemas/shared/subschemas.ts
+++ b/packages/common/src/core/schemas/shared/subschemas.ts
@@ -9,6 +9,26 @@ export const ENTITY_NAME_SCHEMA = {
   maxLength: 250,
 };
 
+export const ENTITY_ACCESS_SCHEMA = {
+  type: "string",
+  enum: ["public", "org", "private"],
+  default: "private",
+};
+
+export const ENTITY_TAGS_SCHEMA = {
+  type: "array",
+  items: {
+    type: "string",
+  },
+};
+
+export const ENTITY_CATEGORIES_SCHEMA = {
+  type: "array",
+  items: {
+    type: "string",
+  },
+};
+
 export const ENTITY_EXTENT_SCHEMA = {
   type: "object",
   properties: {

--- a/packages/common/src/projects/_internal/ProjectSchema.ts
+++ b/packages/common/src/projects/_internal/ProjectSchema.ts
@@ -1,5 +1,10 @@
 import { PROJECT_STATUSES, IConfigurationSchema } from "../../core";
-import { ENTITY_NAME_SCHEMA } from "../../core/schemas/shared";
+import {
+  ENTITY_ACCESS_SCHEMA,
+  ENTITY_CATEGORIES_SCHEMA,
+  ENTITY_NAME_SCHEMA,
+  ENTITY_TAGS_SCHEMA,
+} from "../../core/schemas/shared";
 
 export type ProjectEditorType = (typeof ProjectEditorTypes)[number];
 export const ProjectEditorTypes = [
@@ -21,6 +26,13 @@ export const ProjectSchema: IConfigurationSchema = {
     description: {
       type: "string",
     },
+    access: ENTITY_ACCESS_SCHEMA,
+    groups: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
     status: {
       type: "string",
       default: PROJECT_STATUSES.notStarted,
@@ -29,18 +41,8 @@ export const ProjectSchema: IConfigurationSchema = {
     location: {
       type: "object",
     },
-    tags: {
-      type: "array",
-      items: {
-        type: "string",
-      },
-    },
-    categories: {
-      type: "array",
-      items: {
-        type: "string",
-      },
-    },
+    tags: ENTITY_TAGS_SCHEMA,
+    categories: ENTITY_CATEGORIES_SCHEMA,
     view: {
       type: "object",
       properties: {

--- a/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
@@ -38,14 +38,13 @@ export const uiSchema: IUiSchema = {
                   },
                 },
                 {
-                  labelKey: "{{i18nScope}}.fields.description.label",
-                  scope: "/properties/description",
+                  labelKey: "{{i18nScope}}.fields.status.label",
+                  scope: "/properties/status",
                   type: "Control",
                   options: {
-                    control: "hub-field-input-input",
-                    type: "textarea",
-                    helperText: {
-                      labelKey: "{{i18nScope}}.fields.description.helperText",
+                    control: "hub-field-input-select",
+                    enum: {
+                      i18nScope: "{{i18nScope}}.fields.status.enum",
                     },
                   },
                 },
@@ -81,7 +80,7 @@ export const uiSchema: IUiSchema = {
         },
         {
           type: "Step",
-          labelKey: "{{i18nScope}}.sections.statusAndTimeline.label",
+          labelKey: "{{i18nScope}}.sections.sharing.label",
           rule: {
             effect: UiSchemaRuleEffects.DISABLE,
             condition: {
@@ -91,34 +90,22 @@ export const uiSchema: IUiSchema = {
           },
           elements: [
             {
-              type: "Section",
-              labelKey: "{{i18nScope}}.sections.status.label",
-              elements: [
-                {
-                  labelKey: "{{i18nScope}}.fields.status.label",
-                  scope: "/properties/status",
-                  type: "Control",
-                  options: {
-                    control: "hub-field-input-select",
-                    enum: {
-                      i18nScope: "{{i18nScope}}.fields.status.enum",
-                    },
-                  },
-                },
-              ],
+              scope: "/properties/access",
+              type: "Control",
+              options: {
+                control: "arcgis-hub-access-level-controls",
+                itemType: "{{{{i18nScope}}.fields.access.itemType:translate}}",
+              },
             },
             {
-              type: "Section",
-              labelKey: "{{i18nScope}}.sections.timeline.label",
-              elements: [
-                {
-                  scope: "/properties/view/properties/timeline",
-                  type: "Control",
-                  options: {
-                    control: "arcgis-hub-timeline-editor",
-                  },
-                },
-              ],
+              labelKey: "{{i18nScope}}.fields.groups.label",
+              scope: "/properties/groups",
+              type: "Control",
+              options: {
+                control: "hub-field-input-combobox",
+                allowCustomValues: false,
+                selectionMode: "multiple",
+              },
             },
           ],
         },

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -66,6 +66,8 @@ export const uiSchema: IUiSchema = {
             control: "hub-field-input-combobox",
             allowCustomValues: true,
             selectionMode: "multiple",
+            placeholderIcon: "label",
+            helperText: { labelKey: "{{i18nScope}}.sections.tags.helperText" },
           },
         },
         {
@@ -76,6 +78,10 @@ export const uiSchema: IUiSchema = {
             control: "hub-field-input-combobox",
             allowCustomValues: false,
             selectionMode: "multiple",
+            placeholderIcon: "select-category",
+            helperText: {
+              labelKey: "{{i18nScope}}.sections.categories.helperText",
+            },
           },
         },
       ],
@@ -143,6 +149,27 @@ export const uiSchema: IUiSchema = {
           options: {
             control: "hub-field-input-gallery-picker",
             targetEntity: "item",
+            facets: [
+              {
+                label:
+                  "{{{{i18nScope}}.fields.featuredContent.facets.type:translate}}",
+                key: "type",
+                display: "multi-select",
+                field: "type",
+                options: [],
+                operation: "OR",
+                aggLimit: 100,
+              },
+              {
+                label:
+                  "{{{{i18nScope}}.fields.featuredContent.facets.sharing:translate}}",
+                key: "access",
+                display: "multi-select",
+                field: "access",
+                options: [],
+                operation: "OR",
+              },
+            ],
           },
         },
       ],


### PR DESCRIPTION
1. Description:
- update the project `schema` to include access and groups
- update the project create `uiSchema` to include access and groups
- general project schemas cleanup
   - remove description from "Details" step of project creation and replace with status
   - remove timeline from project creation all-together and replace with access and group sharing
   - move some non-dynamic parts of the `uiSchemas` out of `hub-components` and into the static definitions here

1. Instructions for testing:
N/A

1. Closes Issues: #<number> (if appropriate)
N/A

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.