### PR TITLE
feat: project and initiative associations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64972,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "12.30.1",
+			"version": "12.33.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64997,7 +64997,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "22.1.0",
+			"version": "22.1.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/e2e/metrics.e2e.ts
+++ b/packages/common/e2e/metrics.e2e.ts
@@ -78,6 +78,52 @@ fdescribe("metrics development harness:", () => {
     ],
   };
 
+  fdescribe("association validation", () => {
+    describe("initiative associations", () => {
+      it("initiative should get all projects", async () => {
+        const ctxMgr = await factory.getContextManager(orgName, "admin");
+        const context = ctxMgr.context;
+        const initiative = await HubInitiative.fetch(ITEMS.initiative, context);
+        const projects = await initiative.fetchAssociatedProjects();
+        expect(projects).toBeDefined();
+        expect(projects.length).toBe(ITEMS.projects.length);
+        // ensure each project is in the list
+        for (const project of projects) {
+          expect(ITEMS.projects).toContain(project.id);
+        }
+        const approved = await initiative.fetchApprovedProjects();
+        expect(approved).toBeDefined();
+        expect(approved.length).toBe(ITEMS.projects.length);
+        // ensure each project is in the list
+        for (const project of approved) {
+          expect(ITEMS.projects).toContain(project.id);
+        }
+      });
+    });
+
+    describe("project associations:", () => {
+      it("can list its associations", async () => {
+        const ctxMgr = await factory.getContextManager(orgName, "admin");
+        const context = ctxMgr.context;
+        const project = await HubProject.fetch(ITEMS.projects[0], context);
+        const associations = await project.fetchAssociatedInitiatives();
+        expect(associations).toBeDefined();
+        expect(associations.length).toBe(1);
+        expect(associations[0].id).toBe(ITEMS.initiative);
+      });
+      fit("can list approved Initiatives", async () => {
+        const ctxMgr = await factory.getContextManager(orgName, "admin");
+        const context = ctxMgr.context;
+        const project = await HubProject.fetch(ITEMS.projects[0], context);
+        const associations = await project.fetchApprovedInitiatives();
+
+        expect(associations).toBeDefined();
+        expect(associations.length).toBe(1);
+        expect(associations[0].id).toBe(ITEMS.initiative);
+      });
+    });
+  });
+
   describe("resolve project metrics:", () => {
     it("resolve static via function:", async () => {
       const ctxMgr = await factory.getContextManager(orgName, "admin");

--- a/packages/common/src/core/types/types.ts
+++ b/packages/common/src/core/types/types.ts
@@ -25,3 +25,21 @@ export const EntityResourceMap: {
  * Please note that adding more values will require changes in the location picker
  */
 export type IHubLocationType = "none" | "custom" | "org" | "item";
+
+/**
+ * Simple definition of an Association
+ * This will be persisted in the item's typekeywords
+ * as `type|id`
+ */
+export interface IAssociationInfo {
+  // Type of the association. Currently only initiative is supported
+  type: AssociationType;
+  // Id of the associated item
+  id: string;
+}
+
+/**
+ * Association type. Currently only initiative is supported
+ * but as we add more types, we can add them here
+ */
+export type AssociationType = "initiative";

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -238,7 +238,7 @@ export class HubInitiative
   }
 
   /**
-   * Fetch the Projects that are associated with this Initiative
+   * Fetch the Projects that are associated with this Initiative.
    * Executes a query for Hub Projects that have typekeywords of "initiative|<initiative-id>"
    * System will only return Projects the current user has access to, regardless of the access level of the Initiative
    * @returns
@@ -251,7 +251,7 @@ export class HubInitiative
   }
 
   /**
-   * Fetch the Projects that are associated with this Initiative
+   * Fetch the Projects that are associated with this Initiative.
    * Executes a query for Hub Projects that have typekeywords of "initiative|<initiative-id>" and are included in the
    * Projects collection in the Initiative's Catalog
    * System will only return Projects the current user has access to, regardless of the access level of the Initiative
@@ -264,6 +264,14 @@ export class HubInitiative
     return fetchApprovedProjects(this.entity, this.context.requestOptions);
   }
 
+  /**
+   * Check if a Project is an Approved part of this Initiative.
+   * To be "approved", the project must have the Initiative's id
+   * in its typeKeywords and be included in the Initiative's Projects collection
+   * in the Initiative's Catalog
+   * @param id
+   * @returns
+   */
   async isProjectApproved(id: string): Promise<boolean> {
     if (this.isDestroyed) {
       throw new Error("HubInitiative is already destroyed.");

--- a/packages/common/src/items/associations.ts
+++ b/packages/common/src/items/associations.ts
@@ -1,0 +1,194 @@
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { IItem, ISearchOptions, searchItems } from "@esri/arcgis-rest-portal";
+import {
+  AssociationType,
+  IAssociationInfo,
+  IEntityInfo,
+  IHubInitiative,
+  IHubItemEntity,
+  IHubProject,
+} from "../core";
+import { fetchAllPages } from "./fetch-all-pages";
+import { IHubCollection, IQuery } from "../search/types/IHubCatalog";
+import { combineQueries } from "../search/_internal/combineQueries";
+import { serializeQueryForPortal } from "../search";
+
+/**
+ * Add an association to an entity
+ * @param info
+ * @param entity
+ */
+export function addAssociation(
+  info: IAssociationInfo,
+  entity: IHubItemEntity
+): void {
+  if (!entity.typeKeywords) {
+    entity.typeKeywords = [];
+  }
+  const association = `${info.type}|${info.id}`;
+  if (!entity.typeKeywords.includes(association)) {
+    entity.typeKeywords.push(association);
+  }
+}
+
+/**
+ * Remove an association from an entity
+ * @param info
+ * @param entity
+ * @returns
+ */
+export function removeAssociation(
+  info: IAssociationInfo,
+  entity: IHubItemEntity
+): void {
+  if (!entity.typeKeywords) {
+    return;
+  }
+  const association = `${info.type}|${info.id}`;
+  const index = entity.typeKeywords.indexOf(association);
+  if (index > -1) {
+    entity.typeKeywords.splice(index, 1);
+  }
+}
+
+/**
+ * Return a list of all associations on an entity
+ * Currently only "initiative" associations are supported
+ * @param entity
+ * @returns
+ */
+export function listAssociations(
+  entity: IHubItemEntity,
+  type: AssociationType
+): IAssociationInfo[] {
+  if (!entity.typeKeywords) {
+    return [];
+  }
+  return entity.typeKeywords
+    .filter((tk) => tk.indexOf(`${type}|`) > -1)
+    .map((tk) => {
+      const [t, id] = tk.split("|");
+      return { type: t, id } as IAssociationInfo;
+    });
+}
+
+/**
+ * Fetch the Initiatives that a Project has been associated
+ * Extracts id's from the `initiative|<initiative-id>` typekeywords
+ * and issues a search for those items. System will only return items
+ * the current user has access to, regardless of the access level of the Project
+ * @param entity
+ * @param type
+ * @param requestOptions
+ * @returns
+ */
+export function fetchAssociatedInitiatives(
+  project: IHubProject,
+  requestOptions: IRequestOptions
+): Promise<IEntityInfo[]> {
+  const type: AssociationType = "initiative";
+  const associations = listAssociations(project, type);
+  if (associations.length === 0) {
+    return Promise.resolve([]);
+  }
+  // construct query usign the ids from the associations
+  const query = associations.map((a) => `id:${a.id}`).join(" OR ");
+  return searchItemsAsEntityInfo(query, requestOptions);
+}
+
+/**
+ * Fetch the Projects that are associated with an Initiative
+ * Executes a query for Hub Projects that have typekeywords of "initiative|<initiative-id>"
+ * System will only return Projects the current user has access to, regardless of the access level of the Initiative
+ * @param initiative
+ * @param requestOptions
+ * @returns
+ */
+export function fetchAssociatedProjects(
+  initiative: IHubInitiative,
+  requestOptions: IRequestOptions
+): Promise<IEntityInfo[]> {
+  const query = serializeQueryForPortal(getAssociatedProjectsQuery(initiative));
+  return searchItemsAsEntityInfo(query.q as string, requestOptions);
+}
+
+/**
+ * Fetch the Projects that are approved for an Initiative. This is a subset of the associated projects, limited
+ * to those that have the initiative typekeyword and are included in the Initiative's Projects collection
+ * @param initiative
+ * @param requestOptions
+ * @param query: Optional `IQuery` to further filter the results
+ * @returns
+ */
+export function fetchApprovedProjects(
+  initiative: IHubInitiative,
+  requestOptions: IRequestOptions,
+  query?: IQuery
+): Promise<IEntityInfo[]> {
+  let projectQuery = getApprovedProjectsQuery(initiative);
+  if (query) {
+    projectQuery = combineQueries([projectQuery, query]);
+  }
+  const opts = serializeQueryForPortal(projectQuery);
+  return searchItemsAsEntityInfo(opts.q as string, requestOptions);
+}
+
+/**
+ * Associated Projects are those that have the Initiative id in the typekeywords
+ * @param initiative
+ * @returns
+ */
+export function getAssociatedProjectsQuery(initiative: IHubInitiative): IQuery {
+  return {
+    targetEntity: "item",
+    filters: [
+      {
+        operation: "AND",
+        predicates: [
+          {
+            type: "Hub Project",
+            typekeywords: `initiative|${initiative.id}`,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/**
+ * Approved projects are those with the Initiative id in the typekeywords
+ * and is included in the Projects collection in the Initiative's catalog.
+ * @param initiative
+ * @returns
+ */
+export function getApprovedProjectsQuery(initiative: IHubInitiative): IQuery {
+  let query = getAssociatedProjectsQuery(initiative);
+  const projectsCollection =
+    initiative.catalog.collections.find((c) => c.key === "projects") ||
+    ({} as IHubCollection);
+  const projectsScope = projectsCollection.scope;
+  if (projectsScope) {
+    query = combineQueries([query, projectsScope]);
+  }
+  return query;
+}
+
+function searchItemsAsEntityInfo(q: string, requestOptions: IRequestOptions) {
+  const opts: ISearchOptions = {
+    q,
+    num: 100,
+    ...requestOptions,
+  };
+  // in some extreme cases, we may need to fetch more than 100 items
+  return fetchAllPages(searchItems, opts, -1, 100).then((response) => {
+    // return the results
+    const typedResponse = response as IItem[];
+    return typedResponse.map((r) => {
+      return {
+        id: r.id,
+        name: r.title,
+        type: r.type,
+      } as IEntityInfo;
+    });
+  });
+}

--- a/packages/common/test/items/associations.test.ts
+++ b/packages/common/test/items/associations.test.ts
@@ -1,0 +1,330 @@
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { IHubInitiative, IHubItemEntity } from "../../src";
+import {
+  addAssociation,
+  fetchApprovedProjects,
+  fetchAssociatedInitiatives,
+  fetchAssociatedProjects,
+  getAssociatedProjectsQuery,
+  listAssociations,
+  removeAssociation,
+} from "../../src/items/associations";
+import * as portal from "@esri/arcgis-rest-portal";
+import { IHubProject } from "../../dist/types/core/types/IHubProject";
+import { IQuery } from "../../dist/types/search/types/IHubCatalog";
+
+describe("item associations:", () => {
+  describe("addAssociation:", () => {
+    it("adds the typekeyword", () => {
+      const entity = {
+        typeKeywords: [],
+      } as unknown as IHubItemEntity;
+      addAssociation({ type: "initiative", id: "123" }, entity);
+      expect(entity.typeKeywords).toEqual(["initiative|123"]);
+    });
+
+    it("works if keyword already present", () => {
+      const entity = {
+        typeKeywords: ["initiative|123"],
+      } as unknown as IHubItemEntity;
+      addAssociation({ type: "initiative", id: "123" }, entity);
+      expect(entity.typeKeywords).toEqual(["initiative|123"]);
+    });
+
+    it("adds the typekeywords if not present", () => {
+      const entity = {} as unknown as IHubItemEntity;
+      addAssociation({ type: "initiative", id: "123" }, entity);
+      expect(entity.typeKeywords).toEqual(["initiative|123"]);
+    });
+  });
+
+  describe("removeAssociation:", () => {
+    it("removes the keyword if present", () => {
+      const entity = {
+        typeKeywords: ["other", "initiative|123"],
+      } as unknown as IHubItemEntity;
+      removeAssociation({ type: "initiative", id: "123" }, entity);
+      expect(entity.typeKeywords).toEqual(["other"]);
+    });
+
+    it("works if keyword not present", () => {
+      const entity = {
+        typeKeywords: ["other"],
+      } as unknown as IHubItemEntity;
+      removeAssociation({ type: "initiative", id: "123" }, entity);
+      expect(entity.typeKeywords).toEqual(["other"]);
+    });
+
+    it("works if keywords not present", () => {
+      const entity = {} as unknown as IHubItemEntity;
+      removeAssociation({ type: "initiative", id: "123" }, entity);
+      expect(entity.typeKeywords).not.toBeDefined();
+    });
+  });
+
+  describe("listAssociations:", () => {
+    it("returns empty array if no keywords prop", () => {
+      const entity = {} as unknown as IHubItemEntity;
+      const list = listAssociations(entity, "initiative");
+      expect(list).toBeDefined();
+      expect(list.length).toBe(0);
+    });
+
+    it("returns empty array if none found", () => {
+      const entity = {
+        typeKeywords: ["other"],
+      } as unknown as IHubItemEntity;
+      const list = listAssociations(entity, "initiative");
+      expect(list).toBeDefined();
+      expect(list.length).toBe(0);
+    });
+
+    it("returns all entries", () => {
+      const entity = {
+        typeKeywords: ["other", "initiative|00c", "initiative|00d"],
+      } as unknown as IHubItemEntity;
+      const list = listAssociations(entity, "initiative");
+      expect(list).toBeDefined();
+      expect(list.length).toBe(2);
+      expect(list[0].id).toBe("00c");
+      expect(list[1].id).toBe("00d");
+    });
+  });
+
+  describe("get queries", () => {
+    it("returns associated projects query object", () => {
+      const init = {
+        id: "00c",
+      } as unknown as IHubInitiative;
+      const chk = getAssociatedProjectsQuery(init);
+      expect(chk).toBeDefined();
+      const pred = chk.filters[0].predicates[0];
+      expect(pred).toBeDefined();
+      expect(pred.type).toBe("Hub Project");
+      expect(pred.typekeywords).toBe(`initiative|00c`);
+    });
+  });
+
+  describe("fetch functions: ", () => {
+    let searchItemsSpy: jasmine.Spy;
+
+    it("fetches associated projects", async () => {
+      searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
+        Promise.resolve({
+          results: [
+            {
+              id: "00c",
+              title: "Project 1",
+              type: "Hub Project",
+              typeKeywords: ["initiative|001"],
+            },
+            {
+              id: "00b",
+              title: "Project 2",
+              type: "Hub Project",
+              typeKeywords: ["initiative|001"],
+            },
+            {
+              id: "00e",
+              title: "Project 3",
+              type: "Hub Project",
+              typeKeywords: ["initiative|001"],
+            },
+          ],
+        })
+      );
+
+      const init = { id: "001" } as unknown as IHubInitiative;
+      const chk = await fetchAssociatedProjects(
+        init,
+        {} as unknown as IRequestOptions
+      );
+      expect(chk).toBeDefined();
+      expect(chk.length).toBe(3);
+      expect(chk[0].id).toBe("00c");
+      expect(chk[1].id).toBe("00b");
+      expect(chk[2].id).toBe("00e");
+    });
+
+    it("fetches associated initiatives", async () => {
+      searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
+        Promise.resolve({
+          results: [
+            {
+              id: "c01",
+              title: "Initiative 1",
+              type: "Hub Initiative",
+              typeKeywords: [],
+            },
+            {
+              id: "c02",
+              title: "Initiative 2",
+              type: "Hub Initiative",
+              typeKeywords: [],
+            },
+          ],
+        })
+      );
+      const project = {
+        typeKeywords: ["initiative|c01", "initiative|c02"],
+      } as unknown as IHubProject;
+      const chk = await fetchAssociatedInitiatives(
+        project,
+        {} as unknown as IRequestOptions
+      );
+      expect(chk).toBeDefined();
+      expect(chk.length).toBe(2);
+      expect(chk[0].id).toBe("c01");
+      expect(chk[1].id).toBe("c02");
+    });
+
+    it("early return if no initiatives associated", async () => {
+      const project = {
+        typeKeywords: [],
+      } as unknown as IHubProject;
+      const chk = await fetchAssociatedInitiatives(
+        project,
+        {} as unknown as IRequestOptions
+      );
+      expect(chk).toBeDefined();
+      expect(chk.length).toBe(0);
+    });
+
+    it("fetches approved projects", async () => {
+      searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
+        Promise.resolve({
+          results: [
+            {
+              id: "00b",
+              title: "Project 2",
+              type: "Hub Project",
+              typeKeywords: ["initiative|001"],
+            },
+          ],
+        })
+      );
+
+      const init = {
+        id: "001",
+        catalog: {
+          collections: [
+            {
+              key: "projects",
+              scope: {
+                targetEntity: "item",
+                filters: [
+                  {
+                    operation: "AND",
+                    predicates: [
+                      {
+                        type: "Hub Project",
+                        group: ["ff2", "001"],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      } as unknown as IHubInitiative;
+
+      const chk = await fetchApprovedProjects(
+        init,
+        {} as unknown as IRequestOptions
+      );
+      expect(chk).toBeDefined();
+      expect(chk.length).toBe(1);
+      const args = searchItemsSpy.calls.argsFor(0);
+
+      const q = args[0].q;
+      expect(q).toEqual(
+        '(type:"Hub Project" AND typekeywords:"initiative|001") AND (type:"Hub Project" AND (group:"ff2" OR group:"001"))'
+      );
+    });
+
+    it("fetches approved projects: no project collection", async () => {
+      searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
+        Promise.resolve({
+          results: [
+            {
+              id: "00b",
+              title: "Project 2",
+              type: "Hub Project",
+              typeKeywords: ["initiative|001"],
+            },
+          ],
+        })
+      );
+
+      const init = {
+        id: "001",
+        catalog: {
+          collections: [],
+        },
+      } as unknown as IHubInitiative;
+
+      const chk = await fetchApprovedProjects(
+        init,
+        {} as unknown as IRequestOptions
+      );
+      expect(chk).toBeDefined();
+      expect(chk.length).toBe(1);
+      const args = searchItemsSpy.calls.argsFor(0);
+
+      const q = args[0].q;
+      expect(q).toEqual(
+        '(type:"Hub Project" AND typekeywords:"initiative|001")'
+      );
+    });
+    it("fetches approved projects: with query", async () => {
+      searchItemsSpy = spyOn(portal, "searchItems").and.returnValue(
+        Promise.resolve({
+          results: [
+            {
+              id: "00b",
+              title: "Project 2",
+              type: "Hub Project",
+              typeKeywords: ["initiative|001"],
+            },
+          ],
+        })
+      );
+
+      const init = {
+        id: "001",
+        catalog: {
+          collections: [],
+        },
+      } as unknown as IHubInitiative;
+
+      const qry: IQuery = {
+        targetEntity: "item",
+        filters: [
+          {
+            operation: "AND",
+            predicates: [
+              {
+                owner: "dbouwman",
+              },
+            ],
+          },
+        ],
+      };
+
+      const chk = await fetchApprovedProjects(
+        init,
+        {} as unknown as IRequestOptions,
+        qry
+      );
+      expect(chk).toBeDefined();
+      expect(chk.length).toBe(1);
+      const args = searchItemsSpy.calls.argsFor(0);
+
+      const q = args[0].q;
+      expect(q).toEqual(
+        '(type:"Hub Project" AND typekeywords:"initiative|001") AND (owner:"dbouwman")'
+      );
+    });
+  });
+});


### PR DESCRIPTION
1. Description:
- add association related functions and connect into the HubInitiative and HubProject classes.
- also added info on Associating projects to Initiatives on https://confluencewikidev.esri.com/display/Hub/Projects+v1


1. Instructions for testing: - run tests

1. Closes Issues: #6220

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] n/a updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
