### PR TITLE
fix: update resolveMetric to return IResolvedMetric

### DIFF
--- a/packages/common/e2e/metrics.e2e.ts
+++ b/packages/common/e2e/metrics.e2e.ts
@@ -87,7 +87,7 @@ fdescribe("metrics development harness:", () => {
       const metrics = getEntityMetrics(project.toJson());
       const resolved = await resolveMetric(metrics[0], context);
       expect(resolved).toBeDefined();
-      const resolvedMetric = resolved[0];
+      const resolvedMetric = resolved.features[0];
       expect(resolvedMetric.attributes.id).toEqual(ITEMS.projects[0]);
       expect(resolvedMetric.attributes.contractor).toBeDefined();
       expect(resolvedMetric.attributes.type).toEqual("Hub Project");
@@ -100,7 +100,7 @@ fdescribe("metrics development harness:", () => {
       const metrics = getEntityMetrics(project.toJson());
       const resolved = await resolveMetric(metrics[1], context);
       expect(resolved).toBeDefined();
-      const resolvedMetric = resolved[0];
+      const resolvedMetric = resolved.features[0];
       expect(resolvedMetric.attributes.id).toEqual(ITEMS.projects[0]);
       expect(resolvedMetric.attributes.countyFunding).toBeDefined();
       expect(resolvedMetric.attributes.type).toEqual("Hub Project");
@@ -111,8 +111,10 @@ fdescribe("metrics development harness:", () => {
       const project = await HubProject.fetch(ITEMS.projects[0], context);
       const cityFundingMetric = await project.resolveMetric("cityFunding");
       expect(cityFundingMetric).toBeDefined();
-      expect(cityFundingMetric.length).toBe(1);
-      expect(cityFundingMetric[0].attributes.cityFunding).toBeGreaterThan(0);
+      expect(cityFundingMetric.features.length).toBe(1);
+      expect(
+        cityFundingMetric.features[0].attributes.cityFunding
+      ).toBeGreaterThan(0);
     });
     it("resolve dynamic via class method", async () => {
       const ctxMgr = await factory.getContextManager(orgName, "admin");
@@ -122,8 +124,8 @@ fdescribe("metrics development harness:", () => {
         "surveysCompleted_bbb90f365e064f48964ef9cadf53274e"
       );
       expect(metric).toBeDefined();
-      expect(metric.length).toBe(1);
-      expect(metric[0].attributes.surveysCompleted).toBeGreaterThan(0);
+      expect(metric.features.length).toBe(1);
+      expect(metric.features[0].attributes.surveysCompleted).toBeGreaterThan(0);
     });
   });
   describe("resolve initiative metrics:", () => {
@@ -138,7 +140,7 @@ fdescribe("metrics development harness:", () => {
       const budgetMetric = findBy(metrics, "id", "budget");
       const resolved = await resolveMetric(budgetMetric, context);
       expect(resolved).toBeDefined();
-      const resolvedMetric = resolved[0];
+      const resolvedMetric = resolved.features[0];
       expect(resolvedMetric.attributes.id).toEqual(ITEMS.initiative);
       expect(resolvedMetric.attributes.type).toEqual("Hub Initiative");
       expect(resolvedMetric.attributes.budget).toEqual(203000);
@@ -155,17 +157,21 @@ fdescribe("metrics development harness:", () => {
 
       const resolved = await resolveMetric(countyFunding, context);
       expect(resolved).toBeDefined();
-      expect(resolved.length).toEqual(12);
+      expect(resolved.features.length).toEqual(12);
 
-      resolved.forEach((metric) => {
+      resolved.features.forEach((metric) => {
         expect(metric.attributes.type).toEqual("Hub Project");
         expect(metric.attributes.countyFunding).toBeDefined();
       });
-      const sum = aggregateMetrics(resolved, "countyFunding", "sum");
-      const count = aggregateMetrics(resolved, "countyFunding", "count");
-      const min = aggregateMetrics(resolved, "countyFunding", "min");
-      const max = aggregateMetrics(resolved, "countyFunding", "max");
-      const avg = aggregateMetrics(resolved, "countyFunding", "avg");
+      const sum = aggregateMetrics(resolved.features, "countyFunding", "sum");
+      const count = aggregateMetrics(
+        resolved.features,
+        "countyFunding",
+        "count"
+      );
+      const min = aggregateMetrics(resolved.features, "countyFunding", "min");
+      const max = aggregateMetrics(resolved.features, "countyFunding", "max");
+      const avg = aggregateMetrics(resolved.features, "countyFunding", "avg");
 
       expect(avg).toBeCloseTo(106502.9, 1);
       expect(min).toEqual(15905);
@@ -186,9 +192,9 @@ fdescribe("metrics development harness:", () => {
       const resolved = await resolveMetric(contractor, context);
 
       expect(resolved).toBeDefined();
-      expect(resolved.length).toEqual(12);
+      expect(resolved.features.length).toEqual(12);
 
-      resolved.forEach((metric) => {
+      resolved.features.forEach((metric) => {
         expect(metric.attributes.type).toEqual("Hub Project");
         expect(metric.attributes.contractor).toBeDefined();
         expect(
@@ -197,9 +203,13 @@ fdescribe("metrics development harness:", () => {
           )
         ).toBeTruthy();
       });
-      const count = aggregateMetrics(resolved, "contractor", "count");
+      const count = aggregateMetrics(resolved.features, "contractor", "count");
       expect(count).toEqual(12);
-      const cbv = aggregateMetrics(resolved, "contractor", "countByValue");
+      const cbv = aggregateMetrics(
+        resolved.features,
+        "contractor",
+        "countByValue"
+      );
       expect(cbv).toEqual({
         KPMG: 4,
         HDR: 4,
@@ -221,20 +231,20 @@ fdescribe("metrics development harness:", () => {
       // const timing = Date.now() - start;
       // console.info(`12 projects querying feature service timing: ${timing}ms`);
       expect(resolved).toBeDefined();
-      expect(resolved.length).toEqual(12);
+      expect(resolved.features.length).toEqual(12);
 
-      resolved.forEach((metric) => {
+      resolved.features.forEach((metric) => {
         expect(metric.attributes.type).toEqual("Hub Project");
         expect(metric.attributes.surveysCompleted).toEqual(20);
       });
 
       const field = "surveysCompleted";
       // aggregate the values
-      const sum = aggregateMetrics(resolved, field, "sum");
-      const count = aggregateMetrics(resolved, field, "count");
-      const min = aggregateMetrics(resolved, field, "min");
-      const max = aggregateMetrics(resolved, field, "max");
-      const avg = aggregateMetrics(resolved, field, "avg");
+      const sum = aggregateMetrics(resolved.features, field, "sum");
+      const count = aggregateMetrics(resolved.features, field, "count");
+      const min = aggregateMetrics(resolved.features, field, "min");
+      const max = aggregateMetrics(resolved.features, field, "max");
+      const avg = aggregateMetrics(resolved.features, field, "avg");
       expect(avg).toEqual(20);
       expect(min).toEqual(20);
       expect(max).toEqual(20);

--- a/packages/common/src/core/behaviors/IWithMetricsBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithMetricsBehavior.ts
@@ -1,4 +1,4 @@
-import { IMetricFeature } from "../types/Metrics";
+import { IResolvedMetric } from "../types/Metrics";
 
 /**
  * Adds metrics functions to an entity
@@ -7,5 +7,5 @@ export interface IWithMetricsBehavior {
   /**
    * Resolve a single metric
    */
-  resolveMetric(metricId: string): Promise<IMetricFeature[]>;
+  resolveMetric(metricId: string): Promise<IResolvedMetric>;
 }

--- a/packages/common/src/core/types/Metrics.ts
+++ b/packages/common/src/core/types/Metrics.ts
@@ -169,3 +169,11 @@ export interface IMetricFeature {
   attributes: IMetricAttributes;
   geometry?: __esri.Geometry;
 }
+
+/**
+ * Result of resolving a metric
+ */
+export interface IResolvedMetric {
+  features: IMetricFeature[];
+  generatedAt: number;
+}

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -7,7 +7,7 @@ import {
   IWithSharingBehavior,
   UiSchemaElementOptions,
   IEditorConfig,
-  IMetricFeature,
+  IResolvedMetric,
 } from "../core";
 import { getEntityEditorSchemas } from "../core/schemas/getEntityEditorSchemas";
 import {
@@ -221,7 +221,7 @@ export class HubInitiative
    * @param metricId
    * @returns
    */
-  resolveMetric(metricId: string): Promise<IMetricFeature[]> {
+  resolveMetric(metricId: string): Promise<IResolvedMetric> {
     const metrics = getEntityMetrics(this.entity);
     const metric = metrics.find((m) => m.id === metricId);
     // TODO: Add caching

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -6,7 +6,7 @@ import {
   IWithStoreBehavior,
   IWithSharingBehavior,
   UiSchemaElementOptions,
-  IMetricFeature,
+  IResolvedMetric,
 } from "../core";
 import { getEntityEditorSchemas } from "../core/schemas/getEntityEditorSchemas";
 import { Catalog } from "../search";
@@ -215,7 +215,7 @@ export class HubProject
    * @param metricId
    * @returns
    */
-  resolveMetric(metricId: string): Promise<IMetricFeature[]> {
+  resolveMetric(metricId: string): Promise<IResolvedMetric> {
     const metrics = getEntityMetrics(this.entity);
     const metric = metrics.find((m) => m.id === metricId);
     // TODO: add caching

--- a/packages/common/test/initiatives/HubInitiative.test.ts
+++ b/packages/common/test/initiatives/HubInitiative.test.ts
@@ -2,6 +2,7 @@ import * as PortalModule from "@esri/arcgis-rest-portal";
 import {
   IHubInitiative,
   IMetricFeature,
+  IResolvedMetric,
   UiSchemaElementOptions,
 } from "../../src";
 import { Catalog } from "../../src/search";
@@ -293,7 +294,10 @@ describe("HubInitiative Class:", () => {
     it("delegates to resolveMetric", async () => {
       const spy = spyOn(ResolveMetricModule, "resolveMetric").and.callFake(
         () => {
-          return Promise.resolve([] as IMetricFeature[]);
+          return Promise.resolve({
+            features: [],
+            generatedAt: 1683060547818,
+          } as IResolvedMetric);
         }
       );
       const chk = HubInitiative.fromJson(
@@ -320,7 +324,7 @@ describe("HubInitiative Class:", () => {
 
       const result = await chk.resolveMetric("initiativeBudget_00c");
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(result).toEqual([]);
+      expect(result).toEqual({ features: [], generatedAt: 1683060547818 });
     });
   });
 });

--- a/packages/common/test/metrics/resolveMetric.test.ts
+++ b/packages/common/test/metrics/resolveMetric.test.ts
@@ -69,7 +69,7 @@ describe("resolveMetric:", () => {
     };
     it("returns array with single value", async () => {
       const chk = await resolveMetric(metric, ctx);
-      expect(chk).toEqual([
+      expect(chk.features).toEqual([
         {
           attributes: {
             id: "00c",
@@ -79,6 +79,7 @@ describe("resolveMetric:", () => {
           },
         },
       ]);
+      expect(chk.generatedAt).toBeDefined();
     });
   });
 
@@ -125,8 +126,8 @@ describe("resolveMetric:", () => {
       expect(opts.outStatistics).toEqual([statsDef]);
       expect(opts.authentication).toEqual(MOCK_AUTH);
       // inspect the result
-      expect(chk.length).toEqual(1);
-      expect(chk[0].attributes).toEqual({
+      expect(chk.features.length).toEqual(1);
+      expect(chk.features[0].attributes).toEqual({
         id: "00c",
         name: "Some Project Name",
         type: "Hub Project",
@@ -223,7 +224,7 @@ describe("resolveMetric:", () => {
             },
           ],
         });
-        expect(chk[0].attributes).toEqual({
+        expect(chk.features[0].attributes).toEqual({
           id: "cc0",
           name: "Search Result 1",
           type: "Hub Project",

--- a/packages/common/test/projects/HubProject.test.ts
+++ b/packages/common/test/projects/HubProject.test.ts
@@ -1,5 +1,10 @@
 import * as PortalModule from "@esri/arcgis-rest-portal";
-import { IHubProject, IMetricFeature, UiSchemaElementOptions } from "../../src";
+import {
+  IHubProject,
+  IMetricFeature,
+  IResolvedMetric,
+  UiSchemaElementOptions,
+} from "../../src";
 import { Catalog } from "../../src/search";
 import { ArcGISContextManager } from "../../src/ArcGISContextManager";
 import { HubProject } from "../../src/projects/HubProject";
@@ -273,7 +278,10 @@ describe("HubProject Class:", () => {
     it("delegates to resolveMetric", async () => {
       const spy = spyOn(ResolveMetricModule, "resolveMetric").and.callFake(
         () => {
-          return Promise.resolve([] as IMetricFeature[]);
+          return Promise.resolve({
+            features: [],
+            generatedAt: 1683060547818,
+          } as IResolvedMetric);
         }
       );
       const chk = HubProject.fromJson(
@@ -300,7 +308,7 @@ describe("HubProject Class:", () => {
 
       const result = await chk.resolveMetric("projectBudget_00c");
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(result).toEqual([]);
+      expect(result).toEqual({ features: [], generatedAt: 1683060547818 });
     });
   });
 });


### PR DESCRIPTION
1. Description:

To be more aligned with the rest of the platform, and allow for additional debugging information to be returned (not included yet), this PR changes the return type of `resolveMetric` to `IResolvedMetric`. 

While technically a **Breaking Change,** the only devs working with this are aware of this incoming change, and we already have a `-next` branch in flight, which is super messy to deal with when a breaking change is shipped on `master` while that exists. TLDR; we're not being perfect semver citizens, "for reasons"

1. Instructions for testing: - run tests

1. Closes Issues: #6638

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
