### PR TITLE
feat(hub-common): enable isviewonly to be able to added to the q for portal

### DIFF
--- a/packages/common/src/search/_internal/expandPredicate.ts
+++ b/packages/common/src/search/_internal/expandPredicate.ts
@@ -21,6 +21,7 @@ export function expandPredicate(predicate: IPredicate): IPredicate {
     "isopendata",
     "searchUserName",
     "bbox",
+    "isviewonly",
   ];
   const nonMatchOptionsFields = [...dateProps, ...copyProps];
   // Do the conversion

--- a/packages/common/src/search/serializeQueryForPortal.ts
+++ b/packages/common/src/search/serializeQueryForPortal.ts
@@ -92,7 +92,7 @@ function serializeFilter(filter: IFilter): ISearchOptions {
  */
 function serializePredicate(predicate: IPredicate): ISearchOptions {
   const dateProps = ["created", "modified"];
-  const boolProps = ["isopendata"];
+  const boolProps = ["isopendata", "isviewonly"];
   const passThroughProps = [
     "searchUserAccess",
     "searchUserName",
@@ -145,6 +145,7 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
     "typekeywords",
     "userlicensetype",
     "username",
+    "isviewonly",
   ];
 
   // TODO: Look at using reduce vs .map and remove the `.filter`


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

We need to use `isviewonly` to determine whether a group member is able to share items with certain groups. This PR is to enable `isviewonly` to be added to the `q` param in the `serializePredicate` fn. 

1. Instructions for testing:

1. Closes Issues: #<6463>

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
