### PR TITLE
feat(): add data enrichment to feature layers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22644,10 +22644,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22662,24 +22661,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22693,10 +22689,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22714,10 +22709,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64972,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "12.30.1",
+			"version": "12.35.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64997,7 +64991,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "22.1.0",
+			"version": "22.1.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -83382,8 +83376,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83398,20 +83391,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83425,8 +83415,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83443,8 +83432,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/content/_fetch.ts
+++ b/packages/common/src/content/_fetch.ts
@@ -22,8 +22,8 @@ import { DatasetResource } from "./types";
 const shouldFetchData = (item: IItem) => {
   const type = normalizeItemType(item);
   const family = getFamily(type);
-  const dataFamilies = ["template", "solution"];
-  const dataTypes = ["Web Map", "Web Scene"];
+  const dataFamilies = ["template", "solution", "map"];
+  const dataTypes = ["Web Map", "Web Scene", "Feature Layer"];
   return includes(dataFamilies, family) || includes(dataTypes, type);
 };
 

--- a/packages/common/test/content/_fetch.test.ts
+++ b/packages/common/test/content/_fetch.test.ts
@@ -44,6 +44,7 @@ describe("_fetch", () => {
         "metadata",
         "ownerUser",
         "org",
+        "data",
         "server",
         "layers",
       ]);

--- a/packages/common/test/content/fetch.test.ts
+++ b/packages/common/test/content/fetch.test.ts
@@ -196,7 +196,15 @@ describe("fetchContent", () => {
         expect(fetchItemEnrichmentsSpy).toHaveBeenCalledTimes(1);
         expect(fetchItemEnrichmentsSpy).toHaveBeenCalledWith(
           multiLayerFeatureServiceItem,
-          ["groupIds", "metadata", "ownerUser", "org", "server", "layers"],
+          [
+            "groupIds",
+            "metadata",
+            "ownerUser",
+            "org",
+            "data",
+            "server",
+            "layers",
+          ],
           options
         );
         expect(fetchLayerHubEnrichmentsSpy).toHaveBeenCalledTimes(1);
@@ -299,6 +307,7 @@ describe("fetchContent", () => {
           "metadata",
           "ownerUser",
           "org",
+          "data",
           "server",
           "layers",
         ]);
@@ -405,6 +414,7 @@ describe("fetchContent", () => {
           "metadata",
           "ownerUser",
           "org",
+          "data",
           "server",
           "layers",
         ]);
@@ -626,7 +636,15 @@ describe("fetchContent", () => {
           expect(fetchItemEnrichmentsSpy).toHaveBeenCalledTimes(1);
           expect(fetchItemEnrichmentsSpy).toHaveBeenCalledWith(
             multiLayerFeatureServiceItem,
-            ["groupIds", "metadata", "ownerUser", "org", "server", "layers"],
+            [
+              "groupIds",
+              "metadata",
+              "ownerUser",
+              "org",
+              "data",
+              "server",
+              "layers",
+            ],
             options
           );
           expect(queryFeaturesSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
1. Description: Expands shouldFetchData to allow Feature Layers access to data enrichment.

1. Instructions for testing:

1. Closes Issues: #3569

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
