### PR TITLE
fix: remove showMap from project schema/uiSchema

### DIFF
--- a/packages/common/src/projects/_internal/ProjectSchema.ts
+++ b/packages/common/src/projects/_internal/ProjectSchema.ts
@@ -56,9 +56,6 @@ export const ProjectSchema: IConfigurationSchema = {
         featuredImage: {
           type: "object",
         },
-        showMap: {
-          type: "boolean",
-        },
         // TODO: extend this schema definition to provide
         // appropriate validation for the timeline editor
         timeline: {

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -97,11 +97,6 @@ export const uiSchema: IUiSchema = {
             control: "hub-field-input-location-picker",
           },
         },
-        {
-          labelKey: "{{i18nScope}}.fields.showMap.label",
-          scope: "/properties/view/properties/showMap",
-          type: "Control",
-        },
       ],
     },
     {


### PR DESCRIPTION
1. Description:

remove the `showMap` property from the project `schema` and edit `uiSchema`. I've left the `showMap` property on the entity itself as I'm unsure if we will leverage it in the future.

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.