### PR TITLE
feat: add status as a typekeyword on projects

### DIFF
--- a/packages/common/src/projects/_internal/setStatusKeyword.ts
+++ b/packages/common/src/projects/_internal/setStatusKeyword.ts
@@ -1,0 +1,21 @@
+import { PROJECT_STATUSES } from "../../core";
+
+/**
+ * adds/updates the project status typekeyword and returns
+ * a new array of typekeywords
+ * @param typeKeywords project's current typekeywords
+ * @param status project status
+ */
+export function setStatusKeyword(
+  typeKeywords: string[],
+  status: PROJECT_STATUSES
+): string[] {
+  // filter out the existing status typekeyword
+  const filteredTypekeywords = typeKeywords.filter((typekeyword: string) => {
+    return !typekeyword.startsWith("status|");
+  });
+
+  // add the new/updated status typekeyword
+  filteredTypekeywords.push(`status|${status}`);
+  return filteredTypekeywords;
+}

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -10,6 +10,7 @@ import { DEFAULT_PROJECT, DEFAULT_PROJECT_MODEL } from "./defaults";
 import { computeProps } from "./_internal/computeProps";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 import { ProjectEditorType } from "./_internal/ProjectSchema";
+import { setStatusKeyword } from "./_internal/setStatusKeyword";
 import { cloneObject } from "../util";
 import {
   getEntityEditorSchemas,
@@ -45,7 +46,7 @@ export async function createProject(
   project.slug = await getUniqueSlug({ slug: project.slug }, requestOptions);
   // add slug and status to keywords
   project.typeKeywords = setSlugKeyword(project.typeKeywords, project.slug);
-  project.typeKeywords = [...project.typeKeywords, `status|${project.status}`];
+  project.typeKeywords = setStatusKeyword(project.typeKeywords, project.status);
   // Map project object onto a default project Model
   const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
   // create model from object, using the default model as a starting point
@@ -74,6 +75,8 @@ export async function updateProject(
     { slug: project.slug, existingId: project.id },
     requestOptions
   );
+  // update the status keyword
+  project.typeKeywords = setStatusKeyword(project.typeKeywords, project.status);
   // get the backing item & data
   const model = await getModel(project.id, requestOptions);
   // create the PropertyMapper

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -43,8 +43,9 @@ export async function createProject(
   }
   // Ensure slug is  unique
   project.slug = await getUniqueSlug({ slug: project.slug }, requestOptions);
-  // add slug to keywords
+  // add slug and status to keywords
   project.typeKeywords = setSlugKeyword(project.typeKeywords, project.slug);
+  project.typeKeywords = [...project.typeKeywords, `status|${project.status}`];
   // Map project object onto a default project Model
   const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
   // create model from object, using the default model as a starting point

--- a/packages/common/test/projects/_internal/setStatusKeyword.test.ts
+++ b/packages/common/test/projects/_internal/setStatusKeyword.test.ts
@@ -1,0 +1,18 @@
+import { setStatusKeyword } from "../../../src/projects/_internal/setStatusKeyword";
+import { PROJECT_STATUSES } from "../../../src";
+
+describe("setStatusKeyword:", () => {
+  it("updates existing status keyword", () => {
+    const chk = setStatusKeyword(
+      ["status|oldStatus"],
+      PROJECT_STATUSES.inProgress
+    );
+    expect(chk.length).toBe(1);
+    expect(chk[0]).toBe("status|inProgress");
+  });
+  it("adds status entry to keywords", () => {
+    const chk = setStatusKeyword(["otherKeyword"], PROJECT_STATUSES.notStarted);
+    expect(chk.length).toBe(2);
+    expect(chk[1]).toBe("status|notStarted");
+  });
+});

--- a/packages/common/test/projects/projects.test.ts
+++ b/packages/common/test/projects/projects.test.ts
@@ -253,6 +253,11 @@ describe("HubProjects:", () => {
 
       expect(chk.id).toBe(GUID);
       expect(chk.name).toBe("Hello World");
+      expect(chk.typeKeywords).toEqual([
+        "Hub Project",
+        "slug|dcdev|hello-world",
+        "status|notStarted",
+      ]);
       // should ensure unique slug
       expect(slugSpy.calls.count()).toBe(1);
       expect(slugSpy.calls.argsFor(0)[0]).toEqual(
@@ -286,12 +291,18 @@ describe("HubProjects:", () => {
           description: "my desc",
           orgUrlKey: "dcdev",
           location: PROJECT_LOCATION,
+          status: PROJECT_STATUSES.inProgress,
         },
         { authentication: MOCK_AUTH }
       );
       expect(chk.id).toBe(GUID);
       expect(chk.name).toBe("Hello World");
       expect(chk.description).toBe("my desc");
+      expect(chk.typeKeywords).toEqual([
+        "Hub Project",
+        "slug|dcdev|hello-world",
+        "status|inProgress",
+      ]);
       // should ensure unique slug
       expect(slugSpy.calls.count()).toBe(1);
       expect(slugSpy.calls.argsFor(0)[0]).toEqual(

--- a/packages/common/test/projects/projects.test.ts
+++ b/packages/common/test/projects/projects.test.ts
@@ -359,11 +359,21 @@ describe("HubProjects:", () => {
         location: {
           type: "none",
         },
+        typeKeywords: [
+          "Hub Project",
+          "slug|dcdev-wat-blarg",
+          "status|notStarted",
+        ],
       };
       const chk = await updateProject(prj, { authentication: MOCK_AUTH });
       expect(chk.id).toBe(GUID);
       expect(chk.name).toBe("Hello World");
       expect(chk.description).toBe("Some longer description");
+      expect(chk.typeKeywords).toEqual([
+        "Hub Project",
+        "slug|dcdev-wat-blarg",
+        "status|inProgress",
+      ]);
       expect(chk.location).toEqual({
         type: "none",
       });


### PR DESCRIPTION
[6560](https://devtopia.esri.com/dc/hub/issues/6560)

### Description:
- add project's status as a typekeyword (`status|<project.status>`) on project creation
- update typekeyword when project status is updated

---
1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.