### PR TITLE
fix: use correct prop for clientKey, send correct options

### DIFF
--- a/packages/common/e2e/helpers/Artifactory.ts
+++ b/packages/common/e2e/helpers/Artifactory.ts
@@ -18,10 +18,10 @@ export default class Artifactory {
   public orgs: any[];
   public agoBaseDomain: string;
 
-  constructor(config: any) {
+  constructor(config: any, env?: string) {
     // qaext | prod
     // console.info(`Artifactory configured for qaext`);
-    this.env = "qaext";
+    this.env = env || "qaext";
     // hold the orgs...
     this.orgs = config.envs[this.env].orgs;
     // Copy over a set of other properties...

--- a/packages/common/e2e/helpers/config.ts
+++ b/packages/common/e2e/helpers/config.ts
@@ -104,6 +104,24 @@ const config = {
         },
       },
     },
+    devext: {
+      agoBaseDomain: "mapsdevext.arcgis.com",
+      hubBaseDomain: "hubdev.arcgis.com",
+      orgs: {
+        hubPremium: {
+          orgShort: "dev-pre-hub",
+          orgUrl: "https://dev-pre-hub.mapsdevext.arcgis.com",
+          admin: {
+            username: "e2e_pre_pub_admin",
+            password: PWD,
+          },
+          user: {
+            username: "e2e_pre_pub_publisher",
+            password: PWD,
+          },
+        },
+      },
+    },
   },
 };
 

--- a/packages/common/e2e/metrics.e2e.ts
+++ b/packages/common/e2e/metrics.e2e.ts
@@ -16,7 +16,7 @@ import {
   createScopeGroup,
 } from "./helpers/metric-fixtures-crud";
 
-fdescribe("metrics development harness:", () => {
+describe("metrics development harness:", () => {
   let factory: Artifactory;
   const orgName = "hubPremium";
   beforeAll(() => {

--- a/packages/common/e2e/verify-domains.e2e.ts
+++ b/packages/common/e2e/verify-domains.e2e.ts
@@ -1,0 +1,93 @@
+import Artifactory from "./helpers/Artifactory";
+import config from "./helpers/config";
+import {
+  HubSite,
+  IHubSite,
+  cloneObject,
+  ensureUniqueDomainName,
+  getDomainsForSite,
+  getPortalApiUrl,
+} from "../src";
+import { IRequestOptions, request } from "@esri/arcgis-rest-request";
+
+describe("verify domain updates:", () => {
+  let factory: Artifactory;
+  const orgName = "hubPremium";
+  beforeAll(() => {
+    factory = new Artifactory(config, "devext");
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
+  });
+  it("create site, verify domain, remove site", async () => {
+    const ctxMgr = await factory.getContextManager(orgName, "admin");
+    const tmpl: Partial<IHubSite> = cloneObject(defaultSite);
+    const site = await HubSite.create(tmpl, ctxMgr.context, true);
+
+    try {
+      // verify domain
+      const domains = await getDomainsForSite(
+        site.id,
+        ctxMgr.context.hubRequestOptions
+      );
+      expect(domains.length).toBe(1);
+      const siteJson = site.toJson();
+      expect(domains[0].hostname).toBe(siteJson.defaultHostname);
+
+      // update domain which should update the redirectUris
+      siteJson.subdomain = await ensureUniqueDomainName(
+        "e2e-updated-site",
+        ctxMgr.context.hubRequestOptions
+      );
+      siteJson.defaultHostname = `${siteJson.subdomain}.hubdev.arcgis.com`;
+      site.update(siteJson);
+      await site.save();
+      // verify domain is updated
+      const domains2 = await getDomainsForSite(
+        site.id,
+        ctxMgr.context.hubRequestOptions
+      );
+      expect(domains2.length).toBe(1);
+      expect(domains2[0].hostname).toBe(siteJson.defaultHostname);
+
+      // verify redirectUris on the site item
+      const info = await getAppInfo(
+        siteJson.clientId,
+        ctxMgr.context.hubRequestOptions
+      );
+      expect(info.redirect_uris.length).toBe(1);
+      expect(info.redirect_uris[0]).toBe(
+        `https://${siteJson.defaultHostname}/`
+      );
+    } catch (error) {
+      throw error;
+    } finally {
+      // remove site
+      await site.delete();
+      // verify domain entry is removed
+      const domains3 = await getDomainsForSite(
+        site.id,
+        ctxMgr.context.hubRequestOptions
+      );
+      expect(domains3.length).toBe(0);
+    }
+  });
+});
+
+function getAppInfo(
+  clientId: string,
+  requestOptions: IRequestOptions
+): Promise<any> {
+  const url = `${getPortalApiUrl(requestOptions)}/oauth2/apps/${clientId}`;
+  const options = {
+    authentication: requestOptions.authentication,
+  };
+  return request(url, options);
+}
+
+const defaultSite: Partial<IHubSite> = {
+  name: "e2e site",
+  description: "e2e site description",
+  defaultHostname: "e2e-site-dev-pre-hub.hubdev.arcgis.com",
+  subdomain: "e2e-site-dev-pre-hub",
+  orgUrlKey: "dev-pre-hub",
+  type: "Hub Site Application",
+};

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -210,7 +210,7 @@ export class HubSite
     }
     this.isDestroyed = true;
     // Delegate to module fn
-    await deleteSite(this.entity.id, this.context.userRequestOptions);
+    await deleteSite(this.entity.id, this.context.hubRequestOptions);
   }
 
   /**

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -33,6 +33,7 @@ import { IHubSearchResult } from "../search/types/IHubSearchResult";
 import { mapBy } from "../utils";
 import { getProp, setProp } from "../objects";
 import { getItemThumbnailUrl } from "../resources/get-item-thumbnail-url";
+import { getDomainsForSite, removeDomainByHostname } from "./domains";
 
 export const HUB_SITE_ITEM_TYPE = "Hub Site Application";
 export const ENTERPRISE_SITE_ITEM_TYPE = "Site Application";
@@ -276,7 +277,7 @@ export async function createSite(
 
   // Register domain and at the same time register the site as an application
   const domainResponses = await addSiteDomains(model, requestOptions);
-  model.data.values.clientId = domainResponses[0].client_id;
+  model.data.values.clientId = domainResponses[0].clientKey;
 
   // update the model
   const updatedModel = await updateModel(


### PR DESCRIPTION
Also adds an e2e harness and devext config to verify domain service correctly updates the backing app registration re-direct uris

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
