### PR TITLE
fix(hub-common): make sure error gets caught when unshare an item from groups

### DIFF
--- a/packages/common/src/items/unshare-item-from-groups.ts
+++ b/packages/common/src/items/unshare-item-from-groups.ts
@@ -33,7 +33,7 @@ export function unshareItemFromGroups(
       // individual call in another try/catch block to
       // make sure it catches before all promises finish
       try {
-        return unshareItemWithGroup(opt);
+        return await unshareItemWithGroup(opt);
       } catch (err) {
         throw Error(`Error unsharing item: ${itemId} with group: ${groupId}`);
       }

--- a/packages/common/src/items/unshare-item-from-groups.ts
+++ b/packages/common/src/items/unshare-item-from-groups.ts
@@ -28,9 +28,10 @@ export function unshareItemFromGroups(
       if (owner) {
         opt.owner = owner;
       }
-      // Because we are using Promise.all, we need to wrapping
-      // each individual call in another try/catch block to
-      // make sure it catches before all promises finishes
+      // Because we are using Promise.all, we need to
+      // mark the callback fn as async and wrap each
+      // individual call in another try/catch block to
+      // make sure it catches before all promises finish
       try {
         return unshareItemWithGroup(opt);
       } catch (err) {

--- a/packages/common/src/items/unshare-item-from-groups.ts
+++ b/packages/common/src/items/unshare-item-from-groups.ts
@@ -19,7 +19,7 @@ export function unshareItemFromGroups(
   owner?: string
 ): Promise<ISharingResponse[]> {
   return Promise.all(
-    groups.map((groupId) => {
+    groups.map(async (groupId) => {
       const opt = Object.assign(
         {},
         { id: itemId, groupId },
@@ -28,7 +28,14 @@ export function unshareItemFromGroups(
       if (owner) {
         opt.owner = owner;
       }
-      return unshareItemWithGroup(opt);
+      // Because we are using Promise.all, we need to wrapping
+      // each individual call in another try/catch block to
+      // make sure it catches before all promises finishes
+      try {
+        return unshareItemWithGroup(opt);
+      } catch (err) {
+        throw Error(`Error unsharing item: ${itemId} with group: ${groupId}`);
+      }
     })
   );
 }

--- a/packages/common/test/items/unshare-item-from-groups.test.ts
+++ b/packages/common/test/items/unshare-item-from-groups.test.ts
@@ -52,7 +52,7 @@ describe("unshareItemFromGroups", function () {
       () => Promise.reject(new Error("unshare from groups failed"))
     );
     try {
-      await unshareItemFromGroups("item-id", ["grp1", "grp2"], {
+      await unshareItemFromGroups("item-id", ["grp1"], {
         authentication: mockUserSession,
       });
     } catch (err) {

--- a/packages/common/test/items/unshare-item-from-groups.test.ts
+++ b/packages/common/test/items/unshare-item-from-groups.test.ts
@@ -25,7 +25,7 @@ describe("unshareItemFromGroups", function () {
     expect(unshareItemSpy.calls.argsFor(0)[0].groupId).toEqual("grp1");
     expect(unshareItemSpy.calls.argsFor(1)[0].groupId).toEqual("grp2");
     expect(responses.length).toBe(2);
-    expect(responses[0].notUnsharedFrom.length).toBe(0);
+    expect(responses[0].notUnsharedFrom?.length).toBe(0);
   });
   it("delegates to arcgis-rest-js without owner", async function () {
     const unshareItemSpy = spyOn(portal, "unshareItemWithGroup").and.callFake(
@@ -44,6 +44,22 @@ describe("unshareItemFromGroups", function () {
     expect(unshareItemSpy.calls.argsFor(0)[0].groupId).toEqual("grp1");
     expect(unshareItemSpy.calls.argsFor(1)[0].groupId).toEqual("grp2");
     expect(responses.length).toBe(2);
-    expect(responses[0].notUnsharedFrom.length).toBe(0);
+    expect(responses[0].notUnsharedFrom?.length).toBe(0);
+  });
+
+  it("throws when fails to unshare", async () => {
+    const unshareItemSpy = spyOn(portal, "unshareItemWithGroup").and.callFake(
+      () => Promise.reject(new Error("unshare from groups failed"))
+    );
+    try {
+      await unshareItemFromGroups("item-id", ["grp1", "grp2"], {
+        authentication: mockUserSession,
+      });
+    } catch (err) {
+      expect(unshareItemSpy).toHaveBeenCalled();
+      expect(err.message).toBe(
+        "Error unsharing item: item-id with group: grp1"
+      );
+    }
   });
 });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

When unshare an item from groups, because we are using Promise.all, we need to mark the callback fn as async and wrap each individual call in another try/catch block to make sure it catches before all promises finish

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
