### PR TITLE
fix: update project uiSchemas for translation purposes

### DIFF
--- a/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
@@ -24,6 +24,16 @@ export const uiSchema: IUiSchema = {
                   labelKey: "{{i18nScope}}.fields.name.label",
                   scope: "/properties/name",
                   type: "Control",
+                  options: {
+                    messages: [
+                      {
+                        type: "ERROR",
+                        keyword: "required",
+                        icon: true,
+                        labelKey: "{{i18nScope}}.fields.name.requiredError",
+                      },
+                    ],
+                  },
                 },
                 {
                   labelKey: "{{i18nScope}}.fields.summary.label",

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -16,6 +16,16 @@ export const uiSchema: IUiSchema = {
           labelKey: "{{i18nScope}}.fields.name.label",
           scope: "/properties/name",
           type: "Control",
+          options: {
+            messages: [
+              {
+                type: "ERROR",
+                keyword: "required",
+                icon: true,
+                labelKey: "{{i18nScope}}.fields.name.requiredError",
+              },
+            ],
+          },
         },
         {
           labelKey: "{{i18nScope}}.fields.summary.label",
@@ -67,7 +77,7 @@ export const uiSchema: IUiSchema = {
             allowCustomValues: true,
             selectionMode: "multiple",
             placeholderIcon: "label",
-            helperText: { labelKey: "{{i18nScope}}.sections.tags.helperText" },
+            helperText: { labelKey: "{{i18nScope}}.fields.tags.helperText" },
           },
         },
         {
@@ -80,7 +90,7 @@ export const uiSchema: IUiSchema = {
             selectionMode: "multiple",
             placeholderIcon: "select-category",
             helperText: {
-              labelKey: "{{i18nScope}}.sections.categories.helperText",
+              labelKey: "{{i18nScope}}.fields.categories.helperText",
             },
           },
         },
@@ -89,6 +99,11 @@ export const uiSchema: IUiSchema = {
     {
       type: "Section",
       labelKey: "{{i18nScope}}.sections.location.label",
+      options: {
+        helperText: {
+          labelKey: "{{i18nScope}}.sections.location.helperText",
+        },
+      },
       elements: [
         {
           scope: "/properties/location",


### PR DESCRIPTION
[6714](https://devtopia.esri.com/dc/hub/issues/6714)

### Description:
update project create and edit `uiSchema`s for translation purposes

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.