### PR TITLE
feat(hub-discussions): update canModifyPostStatus to use channelAcl i…

### DIFF
--- a/packages/discussions/src/utils/channel-permission.ts
+++ b/packages/discussions/src/utils/channel-permission.ts
@@ -96,7 +96,7 @@ export class ChannelPermission {
     return this.ALLOWED_ROLES_FOR_POSTING.includes(role);
   }
 
-  private isAuthorizedToModerate(role?: Role) {
+  private isAuthorizedToModerate(role: Role) {
     return this.ALLOWED_ROLES_FOR_MODERATION.includes(role);
   }
 

--- a/packages/discussions/src/utils/posts/can-modify-post-status.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post-status.ts
@@ -3,7 +3,7 @@ import { IChannel, IDiscussionsUser, SharingAccess } from "../../types";
 import { isOrgAdmin } from "../platform";
 import { ChannelPermission } from "../channel-permission";
 
-const ALLOWED_GROUP_ROLES = Object.freeze(["owner", "admin"]);
+const ADMIN_GROUP_ROLES = Object.freeze(["owner", "admin"]);
 
 export function canModifyPostStatus(
   channel: IChannel,
@@ -51,7 +51,7 @@ function isAuthorizedToModifyStatusByLegacyPermissions(
  * Ensure the user is an owner/admin of one of the channel groups
  */
 function isAuthorizedToModifyStatusByLegacyGroup(
-  channelGroups: string[] = [],
+  channelGroups: string[],
   userGroups: IGroup[] = []
 ) {
   return channelGroups.some((channelGroupId: string) => {
@@ -63,7 +63,7 @@ function isAuthorizedToModifyStatusByLegacyGroup(
 
       return (
         channelGroupId === userGroupId &&
-        ALLOWED_GROUP_ROLES.includes(userMemberType)
+        ADMIN_GROUP_ROLES.includes(userMemberType)
       );
     });
   });

--- a/packages/discussions/src/utils/posts/can-modify-post-status.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post-status.ts
@@ -1,0 +1,70 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import { IChannel, IDiscussionsUser, SharingAccess } from "../../types";
+import { isOrgAdmin } from "../platform";
+import { ChannelPermission } from "../channel-permission";
+
+const ALLOWED_GROUP_ROLES = Object.freeze(["owner", "admin"]);
+
+export function canModifyPostStatus(
+  channel: IChannel,
+  user: IDiscussionsUser
+): boolean {
+  const { channelAcl } = channel;
+
+  if (channelAcl) {
+    const channelPermission = new ChannelPermission(channelAcl);
+    return channelPermission.canModifyPostStatus(user, channel.creator);
+  }
+
+  return isAuthorizedToModifyStatusByLegacyPermissions(user, channel);
+}
+
+function isAuthorizedToModifyStatusByLegacyPermissions(
+  user: IDiscussionsUser,
+  channel: IChannel
+): boolean {
+  const { username, groups: userGroups, orgId: userOrgId } = user;
+  const {
+    access,
+    groups: channelGroups,
+    orgs: channelOrgs,
+    creator: channelCreator,
+  } = channel;
+
+  if (!username) {
+    return false;
+  }
+
+  if (channelCreator === username) {
+    return true;
+  }
+
+  if (access === SharingAccess.PRIVATE) {
+    return isAuthorizedToModifyStatusByLegacyGroup(channelGroups, userGroups);
+  }
+
+  // public or org access
+  return channelOrgs.includes(userOrgId) && isOrgAdmin(user);
+}
+
+/**
+ * Ensure the user is an owner/admin of one of the channel groups
+ */
+function isAuthorizedToModifyStatusByLegacyGroup(
+  channelGroups: string[] = [],
+  userGroups: IGroup[] = []
+) {
+  return channelGroups.some((channelGroupId: string) => {
+    return userGroups.some((group: IGroup) => {
+      const {
+        id: userGroupId,
+        userMembership: { memberType: userMemberType },
+      } = group;
+
+      return (
+        channelGroupId === userGroupId &&
+        ALLOWED_GROUP_ROLES.includes(userMemberType)
+      );
+    });
+  });
+}

--- a/packages/discussions/src/utils/posts/index.ts
+++ b/packages/discussions/src/utils/posts/index.ts
@@ -5,7 +5,8 @@ import { IUser } from "@esri/arcgis-rest-auth";
 import { canModifyChannel } from "../channels";
 import { CANNOT_DISCUSS, MENTION_ATTRIBUTE } from "../constants";
 
-export { canModifyPost } from "../posts/can-modify-post";
+export { canModifyPost } from "./can-modify-post";
+export { canModifyPostStatus } from "./can-modify-post-status";
 
 /**
  * Utility that parses a discussion URI string into its component parts
@@ -54,17 +55,6 @@ export function parseDiscussionURI(discussion: string): IDiscussionParams {
  */
 export function isDiscussable(subject: IGroup | IItem | IHubContent) {
   return !(subject.typeKeywords ?? []).includes(CANNOT_DISCUSS);
-}
-
-/**
- * Determines if the given user has sufficient privileges to modify a post's status
- * @param post An IPost object
- * @param channel An IChannel object
- * @param user An IUser object
- * @returns true if the user can modify the post
- */
-export function canModifyPostStatus(channel: IChannel, user: IUser): boolean {
-  return canModifyChannel(channel, user);
 }
 
 /**

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -847,14 +847,14 @@ describe("ChannelPermission class", () => {
       });
 
       it("returns true if the user created the channel", async () => {
-        const user = buildUser({ username: null });
+        const user = buildUser();
         const channelCreator = user.username;
         const channelAcl = [] as IChannelAclPermission[];
 
         const channelPermission = new ChannelPermission(channelAcl);
 
         expect(channelPermission.canModifyChannel(user, channelCreator)).toBe(
-          false
+          true
         );
       });
     });

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -499,6 +499,59 @@ describe("ChannelPermission class", () => {
     });
   });
 
+  describe("canModifyPostStatus", () => {
+    let canModifyChannelSpy: jasmine.Spy;
+
+    beforeAll(() => {
+      canModifyChannelSpy = spyOn(
+        ChannelPermission.prototype,
+        "canModifyChannel"
+      );
+    });
+
+    beforeEach(() => {
+      canModifyChannelSpy.calls.reset();
+    });
+
+    it("should return true if canModifyChannel returns true", () => {
+      canModifyChannelSpy.and.callFake(() => true);
+
+      const user = buildUser();
+      const channelCreator = user.username;
+      const channelAcl = [] as IChannelAclPermission[];
+
+      const channelPermission = new ChannelPermission(channelAcl);
+
+      expect(channelPermission.canModifyPostStatus(user, channelCreator)).toBe(
+        true
+      );
+
+      expect(canModifyChannelSpy.calls.count()).toBe(1);
+      const [arg1, arg2] = canModifyChannelSpy.calls.allArgs()[0]; // args for 1st call
+      expect(arg1).toBe(user);
+      expect(arg2).toBe(channelCreator);
+    });
+
+    it("should return false if canModifyChannel returns false", () => {
+      canModifyChannelSpy.and.callFake(() => false);
+
+      const user = buildUser();
+      const channelCreator = user.username;
+      const channelAcl = [] as IChannelAclPermission[];
+
+      const channelPermission = new ChannelPermission(channelAcl);
+
+      expect(channelPermission.canModifyPostStatus(user, channelCreator)).toBe(
+        false
+      );
+
+      expect(canModifyChannelSpy.calls.count()).toBe(1);
+      const [arg1, arg2] = canModifyChannelSpy.calls.allArgs()[0]; // args for 1st call
+      expect(arg1).toBe(user);
+      expect(arg2).toBe(channelCreator);
+    });
+  });
+
   describe("canCreateChannel", () => {
     describe("all permissions cases", () => {
       it("returns false if user not authenticated", () => {

--- a/packages/discussions/test/utils/posts/can-modify-post-status.test.ts
+++ b/packages/discussions/test/utils/posts/can-modify-post-status.test.ts
@@ -1,0 +1,223 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import {
+  AclCategory,
+  IChannel,
+  IDiscussionsUser,
+  Role,
+  SharingAccess,
+} from "../../../src/types";
+import { canModifyPostStatus } from "../../../src/utils/posts";
+import { ChannelPermission } from "../../../src/utils/channel-permission";
+
+describe("canModifyPostStatus", () => {
+  describe("With channelAcl Permissions", () => {
+    let canModifyPostStatusSpy: jasmine.Spy;
+
+    beforeAll(() => {
+      canModifyPostStatusSpy = spyOn(
+        ChannelPermission.prototype,
+        "canModifyPostStatus"
+      );
+    });
+
+    beforeEach(() => {
+      canModifyPostStatusSpy.calls.reset();
+    });
+
+    it("return true if channelPermission.canModifyPostStatus is true", () => {
+      canModifyPostStatusSpy.and.callFake(() => true);
+
+      const user = {} as IDiscussionsUser;
+      const channel = {
+        channelAcl: [{ category: AclCategory.ANONYMOUS_USER, role: Role.READ }],
+        creator: "john",
+      } as IChannel;
+
+      expect(canModifyPostStatus(channel, user)).toBe(true);
+
+      expect(canModifyPostStatusSpy.calls.count()).toBe(1);
+      const [arg1, arg2] = canModifyPostStatusSpy.calls.allArgs()[0]; // args for 1st call
+      expect(arg1).toBe(user);
+      expect(arg2).toBe(channel.creator);
+    });
+
+    it("return false if channelPermission.canModifyPostStatus is false", () => {
+      canModifyPostStatusSpy.and.callFake(() => false);
+
+      const user = {} as IDiscussionsUser;
+      const channel = {
+        channelAcl: [{ category: AclCategory.ANONYMOUS_USER, role: Role.READ }],
+        creator: "john",
+      } as IChannel;
+
+      expect(canModifyPostStatus(channel, user)).toBe(false);
+
+      expect(canModifyPostStatusSpy.calls.count()).toBe(1);
+      const [arg1, arg2] = canModifyPostStatusSpy.calls.allArgs()[0]; // args for 1st call
+      expect(arg1).toBe(user);
+      expect(arg2).toBe(channel.creator);
+    });
+  });
+
+  describe("With Legacy Permissions", () => {
+    it("returns false if the user is not authenticated", () => {
+      const user = {} as IDiscussionsUser;
+      const userNull = { username: null } as IDiscussionsUser;
+      const channel = { access: SharingAccess.PUBLIC } as IChannel;
+
+      expect(canModifyPostStatus(channel, user)).toBe(false);
+      expect(canModifyPostStatus(channel, userNull)).toBe(false);
+    });
+
+    it("returns true if the user created the channel", () => {
+      const user = { username: "john" } as IDiscussionsUser;
+      const channel = { creator: "john" } as IChannel;
+
+      expect(canModifyPostStatus(channel, user)).toBe(true);
+    });
+
+    describe("public channel", () => {
+      it("returns true if the user is an orgAdmin and the users org is in the channel orgs", () => {
+        const user = {
+          username: "john",
+          orgId: "aaa",
+          role: "org_admin",
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PUBLIC,
+          orgs: ["aaa"],
+        } as IChannel;
+
+        const result = canModifyPostStatus(channel, user);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe("private channel", () => {
+      it("returns true if the user is an admin of one of the channel groups", () => {
+        const user = {
+          username: "john",
+          groups: [
+            {
+              id: "aaa",
+              userMembership: { memberType: "member" },
+            },
+            {
+              id: "bbb",
+              userMembership: { memberType: "admin" }, // admin
+            },
+          ] as unknown as IGroup[],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PRIVATE,
+          groups: ["aaa", "bbb"],
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(true);
+      });
+
+      it("returns true if the user is an owner of one of the channel groups", () => {
+        const user = {
+          username: "john",
+          groups: [
+            {
+              id: "aaa",
+              userMembership: { memberType: "member" },
+            },
+            {
+              id: "bbb",
+              userMembership: { memberType: "owner" }, // owner
+            },
+          ] as unknown as IGroup[],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PRIVATE,
+          groups: ["aaa", "bbb"],
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(true);
+      });
+
+      it("returns false if the user is not an owner or admin of any channel groups", () => {
+        const user = {
+          username: "john",
+          groups: [
+            {
+              id: "aaa",
+              userMembership: { memberType: "member" }, // member
+            },
+            {
+              id: "bbb",
+              userMembership: { memberType: "member" }, // member
+            },
+          ] as unknown as IGroup[],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PRIVATE,
+          groups: ["aaa", "bbb"],
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(false);
+      });
+
+      it("returns false if the user is a group admin or owner but not in channel groups", () => {
+        const user = {
+          username: "john",
+          groups: [
+            {
+              id: "aaa",
+              userMembership: { memberType: "admin" },
+            },
+            {
+              id: "bbb",
+              userMembership: { memberType: "owner" },
+            },
+          ] as unknown as IGroup[],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PRIVATE,
+          groups: ["zzz"], // user groups not included
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(false);
+      });
+
+      it("returns false if the user is not in any groups", () => {
+        const user = { username: "john" } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PRIVATE,
+          groups: ["zzz"],
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(false);
+      });
+
+      it("returns false if the user is not in any groups", () => {
+        const user = { username: "john" } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PRIVATE,
+          groups: ["zzz"],
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(false);
+      });
+    });
+
+    describe("org channel", () => {
+      it("returns true if the user is an orgAdmin and the users org is in the channel orgs", () => {
+        const user = {
+          username: "john",
+          orgId: "aaa",
+          role: "org_admin",
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.ORG,
+          orgs: ["aaa"],
+        } as IChannel;
+
+        const result = canModifyPostStatus(channel, user);
+        expect(result).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/discussions/test/utils/posts/index.test.ts
+++ b/packages/discussions/test/utils/posts/index.test.ts
@@ -92,34 +92,6 @@ describe("isDiscussable", () => {
   });
 });
 
-describe("canModifyPostStatus", () => {
-  it("returns true when user can modify channel", () => {
-    const canModifyChannelSpy = spyOn(
-      channelUtils,
-      "canModifyChannel"
-    ).and.returnValue(true);
-    const user = { username: "user2" } as IUser;
-    const channel = { id: "channel1" } as IChannel;
-    const result = canModifyPostStatus(channel, user);
-    expect(result).toBe(true);
-    expect(canModifyChannelSpy).toHaveBeenCalledTimes(1);
-    expect(canModifyChannelSpy).toHaveBeenCalledWith(channel, user);
-  });
-
-  it("returns false when user cannot modify channel", () => {
-    const canModifyChannelSpy = spyOn(
-      channelUtils,
-      "canModifyChannel"
-    ).and.returnValue(false);
-    const user = { username: "user2" } as IUser;
-    const channel = { id: "channel1" } as IChannel;
-    const result = canModifyPostStatus(channel, user);
-    expect(result).toBe(false);
-    expect(canModifyChannelSpy).toHaveBeenCalledTimes(1);
-    expect(canModifyChannelSpy).toHaveBeenCalledWith(channel, user);
-  });
-});
-
 describe("canDeletePost", () => {
   it("returns true when the user created the post", () => {
     const canModifyChannelSpy = spyOn(channelUtils, "canModifyChannel");


### PR DESCRIPTION
…f available

affects: @esri/hub-discussions

1. Description: Update `canModifyPostStatus` to use channelAcl if available, otherwise use legacy channel permissions

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
