### PR TITLE
fix: re-export _shareItemsToSiteGroups to avoid update to solution.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64972,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "12.31.1",
+			"version": "13.0.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64997,32 +64997,32 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "22.1.2",
+			"version": "23.0.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^13.0.0-next.1"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "12.4.1",
+			"version": "13.0.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65030,18 +65030,18 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^13.0.0-next.1"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "12.4.1",
+			"version": "13.0.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65050,18 +65050,18 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^13.0.0-next.1"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "12.4.1",
+			"version": "13.0.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -65069,18 +65069,18 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^13.0.0-next.1"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "12.4.1",
+			"version": "13.0.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -65091,40 +65091,40 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^13.0.0-next.1"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "12.6.0",
+			"version": "13.0.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
-				"@esri/hub-initiatives": "*",
-				"@esri/hub-teams": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
+				"@esri/hub-initiatives": "^13.0.0-next.1",
+				"@esri/hub-teams": "^13.0.0-next.1",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0",
-				"@esri/hub-initiatives": "^12.4.0",
-				"@esri/hub-teams": "^12.4.0"
+				"@esri/hub-common": "^13.0.0-next.1",
+				"@esri/hub-initiatives": "^13.0.0-next.1",
+				"@esri/hub-teams": "^13.0.0-next.1"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "12.4.1",
+			"version": "13.0.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65133,18 +65133,18 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^13.0.0-next.1"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "12.4.1",
+			"version": "13.0.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65152,7 +65152,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^13.0.0-next.1"
 			}
 		}
 	},
@@ -68716,7 +68716,7 @@
 		"@esri/hub-discussions": {
 			"version": "file:packages/discussions",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68725,7 +68725,7 @@
 		"@esri/hub-downloads": {
 			"version": "file:packages/downloads",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68734,7 +68734,7 @@
 		"@esri/hub-events": {
 			"version": "file:packages/events",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68742,7 +68742,7 @@
 		"@esri/hub-initiatives": {
 			"version": "file:packages/initiatives",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68751,7 +68751,7 @@
 		"@esri/hub-search": {
 			"version": "file:packages/search",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -68761,9 +68761,9 @@
 		"@esri/hub-sites": {
 			"version": "file:packages/sites",
 			"requires": {
-				"@esri/hub-common": "*",
-				"@esri/hub-initiatives": "*",
-				"@esri/hub-teams": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
+				"@esri/hub-initiatives": "^13.0.0-next.1",
+				"@esri/hub-teams": "^13.0.0-next.1",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68771,7 +68771,7 @@
 		"@esri/hub-surveys": {
 			"version": "file:packages/surveys",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68779,7 +68779,7 @@
 		"@esri/hub-teams": {
 			"version": "file:packages/teams",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^13.0.0-next.1",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/sites/src/share-items-to-site-groups.ts
+++ b/packages/sites/src/share-items-to-site-groups.ts
@@ -46,3 +46,7 @@ export function shareItemsToSiteGroups(
     )
   );
 }
+
+// Temporary to avoid a complex multi-project update
+// @private
+export { shareItemsToSiteGroups as _shareItemsToSiteGroups };


### PR DESCRIPTION
1. Description:

Solution.js relies on `_shareItemToSiteGroups` which we'd removed (dropped the `_`) on the `-next` branch. To avoid having to orchestrate an update of solution.js AND hub.js, we are temporarily re-exporting that function.

1. Instructions for testing:

run tests

1. Closes Issues: n/a

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] n/a updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
