### PR TITLE
fix: updateVersionMetadata takes item owner

### DIFF
--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -353,6 +353,7 @@ export class HubSite
     return updateVersionMetadata(
       this.entity.id,
       version,
+      this.entity.owner,
       this.context.userRequestOptions
     );
   }

--- a/packages/common/src/versioning/updateVersionMetadata.ts
+++ b/packages/common/src/versioning/updateVersionMetadata.ts
@@ -14,12 +14,14 @@ import { updateItemResource } from "@esri/arcgis-rest-portal";
  * Updates the specified version's metadata
  * @param id
  * @param versionMetadata
+ * @param owner
  * @param requestOptions
  * @returns
  */
 export async function updateVersionMetadata(
   id: string,
   versionMetadata: IVersionMetadata,
+  owner: string,
   requestOptions: IHubUserRequestOptions
 ): Promise<IVersionMetadata> {
   const prefix = getPrefix(versionMetadata.id);
@@ -39,7 +41,7 @@ export async function updateVersionMetadata(
     ...requestOptions,
     id,
     name: VERSION_RESOURCE_NAME,
-    owner: properties.creator,
+    owner,
     params: { properties },
     prefix,
     resource: versionBlob,

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -501,6 +501,7 @@ describe("HubSite Class:", () => {
       expect(updateVersionMetadataSpy).toHaveBeenCalledWith(
         model.item.id,
         version,
+        model.item.owner,
         authdCtxMgr.context.userRequestOptions
       );
     });

--- a/packages/common/test/versioning/updateVersionMetadata.test.ts
+++ b/packages/common/test/versioning/updateVersionMetadata.test.ts
@@ -49,7 +49,12 @@ describe("updateVersionMetadata", () => {
       versionBlob
     );
 
-    const result = await updateVersionMetadata(id, version, requestOpts);
+    const result = await updateVersionMetadata(
+      id,
+      version,
+      "casey",
+      requestOpts
+    );
 
     const options = {
       ...requestOpts,
@@ -64,7 +69,7 @@ describe("updateVersionMetadata", () => {
           updated: 456,
         },
       },
-      owner: "jupe",
+      owner: "casey",
       prefix: "hubVersion_def456",
       resource: versionBlob,
     };


### PR DESCRIPTION
1. Description: fixes updateVersionMetadata by adding an owner param

1. Instructions for testing: run the tests

1. Closes Issues: [#6740](https://devtopia.esri.com/dc/hub/issues/6740)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
