### PR TITLE
feat(hub-common): support bbox serialization when querying the OGC API via hubSearch

### DIFF
--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getBboxQueryParam.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getBboxQueryParam.ts
@@ -1,0 +1,16 @@
+import { IQuery } from "../../types/IHubCatalog";
+import { getTopLevelPredicate } from "../commonHelpers/getTopLevelPredicate";
+
+/**
+ * @private
+ * Extracts the bbox value that the search should be filtered by.
+ * Also validates that the bbox predicate is not combined in some
+ * invalid way with other predicates.
+ *
+ * @param query query to extract the bbox predicate from
+ * @returns the bbox value to filter by
+ */
+export function getBboxQueryParam(query: IQuery): string {
+  const bboxPredicate = getTopLevelPredicate("bbox", query.filters);
+  return bboxPredicate?.bbox;
+}

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getFilterQueryParam.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getFilterQueryParam.ts
@@ -6,6 +6,7 @@ export function getFilterQueryParam(query: IQuery) {
     query.filters
       .map(formatFilterBlock)
       // TODO: this a bandaid fix, remove once q can be passed into the filter query string
+      // TODO: we also need this as a workaround for bbox. I wonder if there's a better way...
       .filter((f) => f !== "()")
       .join(" AND ")
   );
@@ -16,6 +17,7 @@ export function formatFilterBlock(filter: IFilter) {
   const formatted = filter.predicates
     .map(formatPredicate)
     // TODO: this a bandaid fix, remove once q can be passed into the filter query string
+    // TODO: we also need this as a workaround for bbox. I wonder if there's a better way...
     .filter((p) => p !== "()")
     .join(` ${operation} `);
   return `(${formatted})`;
@@ -23,8 +25,9 @@ export function formatFilterBlock(filter: IFilter) {
 
 export function formatPredicate(predicate: IPredicate) {
   const formatted = Object.entries(predicate)
-    // Remove predicates that use `term` (handled in `getQQueryParam`) and undefined entries
-    .filter(([field, value]) => field !== "term" && !!value)
+    // Remove predicates that use `term` (handled in `getQQueryParam`),
+    // `bbox` (handled in `getBboxQueryParam) or have undefined entries
+    .filter(([field, value]) => field !== "term" && field !== "bbox" && !!value)
     // Create sections for each field
     .reduce((acc, [field, value]) => {
       let section;

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcItemQueryParams.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcItemQueryParams.ts
@@ -1,6 +1,7 @@
 import { getProp } from "../../../objects/get-prop";
 import { IQuery } from "../../types/IHubCatalog";
 import { IHubSearchOptions } from "../../types/IHubSearchOptions";
+import { getBboxQueryParam } from "./getBboxQueryParam";
 import { getFilterQueryParam } from "./getFilterQueryParam";
 import { getQQueryParam } from "./getQQueryParam";
 import { getSortByQueryParam } from "./getSortByQueryParam";
@@ -12,6 +13,7 @@ export interface IOgcItemQueryParams {
   startindex?: number;
   q?: string;
   sortBy?: string;
+  bbox?: string;
 }
 
 /**
@@ -34,6 +36,7 @@ export function getOgcItemQueryParams(
   const startindex = options.start;
   const q = getQQueryParam(query);
   const sortBy = getSortByQueryParam(options);
+  const bbox = getBboxQueryParam(query);
 
   return {
     filter,
@@ -42,5 +45,6 @@ export function getOgcItemQueryParams(
     startindex,
     q,
     sortBy,
+    bbox,
   };
 }

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -370,6 +370,7 @@ describe("hubSearchItems Module |", () => {
           startindex: undefined,
           q: undefined,
           sortBy: undefined,
+          bbox: undefined,
         } as IOgcItemQueryParams;
         expect(result).toEqual(expected);
       });
@@ -391,6 +392,7 @@ describe("hubSearchItems Module |", () => {
           startindex: undefined,
           q: undefined,
           sortBy: undefined,
+          bbox: undefined,
         } as IOgcItemQueryParams;
         expect(result).toEqual(expected);
       });
@@ -413,6 +415,7 @@ describe("hubSearchItems Module |", () => {
           startindex: undefined,
           q: undefined,
           sortBy: undefined,
+          bbox: undefined,
         } as IOgcItemQueryParams;
         expect(result).toEqual(expected);
       });
@@ -436,6 +439,7 @@ describe("hubSearchItems Module |", () => {
           startindex: 10,
           q: undefined,
           sortBy: undefined,
+          bbox: undefined,
         } as IOgcItemQueryParams;
         expect(result).toEqual(expected);
       });
@@ -462,6 +466,7 @@ describe("hubSearchItems Module |", () => {
           startindex: 10,
           q: "term1",
           sortBy: undefined,
+          bbox: undefined,
         } as IOgcItemQueryParams;
         expect(result).toEqual(expected);
       });
@@ -480,7 +485,10 @@ describe("hubSearchItems Module |", () => {
         };
 
         const termQuery: IQuery = cloneObject(query);
-        termQuery.filters.push({ predicates: [{ term: "term1" }] });
+        termQuery.filters.push({
+          operation: "AND",
+          predicates: [{ term: "term1" }, { bbox: "1,2,3,4" }],
+        });
 
         const result = getOgcItemQueryParams(termQuery, options);
         const expected = {
@@ -490,6 +498,7 @@ describe("hubSearchItems Module |", () => {
           startindex: 10,
           q: "term1",
           sortBy: "properties.title",
+          bbox: "1,2,3,4",
         } as IOgcItemQueryParams;
         expect(result).toEqual(expected);
       });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Part of https://devtopia.esri.com/dc/hub/issues/6733
Introduces the same bbox serialization logic for the OGC API that currently exists for portal (hubSearch subsystem)

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
