### PR TITLE
feat: add Site Edit Schema

### DIFF
--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -392,7 +392,7 @@ export class ArcGISContext implements IArcGISContext {
     } else {
       if (this.isAuthenticated) {
         const hubHostname = this._hubUrl.replace("https://", "");
-        return `https://${this._portalSelf.urlKey}-hub.${hubHostname}`;
+        return `https://${this._portalSelf.urlKey}.${hubHostname}`;
       } else {
         return this._hubUrl;
       }

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -89,6 +89,11 @@ export interface IArcGISContext {
    */
   hubUrl: string;
   /**
+   * Returns the current user's hub-home url. If not authenticated,
+   * returns the Hub Url. If portal, returns undefined
+   */
+  hubHomeUrl: string;
+  /**
    * Returns boolean indicating if the backing system
    * is ArcGIS Enterprise (formerly ArcGIS Portal) or not
    */
@@ -241,6 +246,8 @@ export class ArcGISContext implements IArcGISContext {
 
   private _hubUrl: string;
 
+  private _hubHomeUrl: string;
+
   private _portalSelf: IPortal;
 
   private _currentUser: IUser;
@@ -372,6 +379,23 @@ export class ArcGISContext implements IArcGISContext {
       }
     } else {
       return this._portalUrl;
+    }
+  }
+
+  /**
+   * Returns the current user's hub-home url. If not authenticated,
+   * returns the Hub Url. If portal, returns undefined
+   */
+  public get hubHomeUrl(): string {
+    if (this.isPortal) {
+      return undefined;
+    } else {
+      if (this.isAuthenticated) {
+        const hubHostname = this._hubUrl.replace("https://", "");
+        return `https://${this._portalSelf.urlKey}-hub.${hubHostname}`;
+      } else {
+        return this._hubUrl;
+      }
     }
   }
 

--- a/packages/common/src/core/schemas/getEntityEditorSchemas.ts
+++ b/packages/common/src/core/schemas/getEntityEditorSchemas.ts
@@ -12,6 +12,7 @@ import {
   InitiativeEditorTypes,
   InitiativeEditorType,
 } from "../../initiatives/_internal/InitiativeSchema";
+import { SiteEditorType } from "../../sites/_internal/SiteSchema";
 
 /**
  * defines the possible editor type values - these correspond
@@ -68,6 +69,14 @@ export const getEntityEditorSchemas = async (
         "hub:initiative:edit": () =>
           import("../../initiatives/_internal/InitiativeUiSchemaEdit"),
       }[type as InitiativeEditorType]());
+      break;
+    case "site":
+      const { SiteSchema } = await import("../../sites/_internal/SiteSchema");
+      schema = cloneObject(SiteSchema);
+
+      ({ uiSchema } = await {
+        "hub:site:edit": () => import("../../sites/_internal/SiteUiSchemaEdit"),
+      }[type as SiteEditorType]());
       break;
   }
 

--- a/packages/common/src/core/schemas/getEntityEditorSchemas.ts
+++ b/packages/common/src/core/schemas/getEntityEditorSchemas.ts
@@ -12,7 +12,10 @@ import {
   InitiativeEditorTypes,
   InitiativeEditorType,
 } from "../../initiatives/_internal/InitiativeSchema";
-import { SiteEditorType } from "../../sites/_internal/SiteSchema";
+import {
+  SiteEditorType,
+  SiteEditorTypes,
+} from "../../sites/_internal/SiteSchema";
 
 /**
  * defines the possible editor type values - these correspond
@@ -22,6 +25,7 @@ export type EditorType = (typeof validEditorTypes)[number];
 export const validEditorTypes = [
   ...ProjectEditorTypes,
   ...InitiativeEditorTypes,
+  ...SiteEditorTypes,
 ] as const;
 
 /**

--- a/packages/common/src/core/types/IHubItemEntity.ts
+++ b/packages/common/src/core/types/IHubItemEntity.ts
@@ -102,6 +102,9 @@ export interface IHubItemEntity extends IHubEntityBase, IWithPermissions {
    */
   canDelete: boolean;
 
+  /**
+   * The location of the Entity
+   */
   location?: IHubLocation;
 
   /**

--- a/packages/common/src/core/types/IHubSite.ts
+++ b/packages/common/src/core/types/IHubSite.ts
@@ -70,8 +70,10 @@ export interface IHubSite
    * Header CSS
    */
   headerSass: string;
+
   /**
-   * Classic capabilities
+   * Legacy capabilities
+   * @internal
    */
-  classicCapabilities: string[];
+  legacyCapabilities: string[];
 }

--- a/packages/common/src/initiatives/_internal/InitiativeSchema.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeSchema.ts
@@ -1,5 +1,10 @@
 import { IConfigurationSchema } from "../../core";
-import { ENTITY_NAME_SCHEMA } from "../../core/schemas/shared";
+import {
+  ENTITY_ACCESS_SCHEMA,
+  ENTITY_CATEGORIES_SCHEMA,
+  ENTITY_NAME_SCHEMA,
+  ENTITY_TAGS_SCHEMA,
+} from "../../core/schemas/shared";
 
 export type InitiativeEditorType = (typeof InitiativeEditorTypes)[number];
 export const InitiativeEditorTypes = ["hub:initiative:edit"] as const;
@@ -12,5 +17,24 @@ export const InitiativeSchema: IConfigurationSchema = {
   type: "object",
   properties: {
     name: ENTITY_NAME_SCHEMA,
+    summary: {
+      type: "string",
+    },
+    description: {
+      type: "string",
+    },
+    access: ENTITY_ACCESS_SCHEMA,
+    groups: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+
+    location: {
+      type: "object",
+    },
+    tags: ENTITY_TAGS_SCHEMA,
+    categories: ENTITY_CATEGORIES_SCHEMA,
   },
 } as unknown as IConfigurationSchema;

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -14,6 +14,85 @@ export const uiSchema: IUiSchema = {
           labelKey: "{{i18nScope}}.fields.name.label",
           scope: "/properties/name",
           type: "Control",
+          options: {
+            messages: [
+              {
+                type: "ERROR",
+                keyword: "required",
+                icon: true,
+                labelKey: "{{i18nScope}}.fields.name.requiredError",
+              },
+            ],
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.summary.label",
+          scope: "/properties/summary",
+          type: "Control",
+          options: {
+            control: "hub-field-input-input",
+            type: "textarea",
+            helperText: {
+              labelKey: "{{i18nScope}}.fields.summary.helperText",
+            },
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.description.label",
+          scope: "/properties/description",
+          type: "Control",
+          options: {
+            control: "hub-field-input-input",
+            type: "textarea",
+            helperText: {
+              labelKey: "{{i18nScope}}.fields.description.helperText",
+            },
+          },
+        },
+
+        {
+          labelKey: "{{i18nScope}}.fields.tags.label",
+          scope: "/properties/tags",
+          type: "Control",
+          options: {
+            control: "hub-field-input-combobox",
+            allowCustomValues: true,
+            selectionMode: "multiple",
+            placeholderIcon: "label",
+            helperText: { labelKey: "{{i18nScope}}.fields.tags.helperText" },
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.categories.label",
+          scope: "/properties/categories",
+          type: "Control",
+          options: {
+            control: "hub-field-input-combobox",
+            allowCustomValues: false,
+            selectionMode: "multiple",
+            placeholderIcon: "select-category",
+            helperText: {
+              labelKey: "{{i18nScope}}.fields.categories.helperText",
+            },
+          },
+        },
+      ],
+    },
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.location.label",
+      options: {
+        helperText: {
+          labelKey: "{{i18nScope}}.sections.location.helperText",
+        },
+      },
+      elements: [
+        {
+          scope: "/properties/location",
+          type: "Control",
+          options: {
+            control: "hub-field-input-location-picker",
+          },
         },
       ],
     },

--- a/packages/common/src/initiatives/_internal/getPropertyMap.ts
+++ b/packages/common/src/initiatives/_internal/getPropertyMap.ts
@@ -23,5 +23,10 @@ export function getPropertyMap(): IPropertyMap[] {
   map.push({ objectKey: "timeline", modelKey: "data.timeline" });
   map.push({ objectKey: "metrics", modelKey: "item.properties.metrics" });
 
+  map.push({
+    objectKey: "location",
+    modelKey: "item.properties.location",
+  });
+
   return map;
 }

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -120,9 +120,13 @@ export async function enrichProjectSearchResult(
   // TODO: Link handling should be an enrichment
   result.links.thumbnail = getItemThumbnailUrl(item, requestOptions);
   result.links.self = getItemHomeUrl(result.id, requestOptions);
+  let slugOrId = item.id;
+  if (item.properties?.slug) {
+    slugOrId = item.properties.slug.replace("|", "::");
+  }
   result.links.siteRelative = getHubRelativeUrl(
     result.type,
-    result.id,
+    slugOrId,
     item.typeKeywords
   );
 

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -66,6 +66,7 @@ export class HubSite
     super(site, context);
     this._catalog = Catalog.fromJson(site.catalog, this.context);
   }
+
   /**
    * Catalog instance for this site. Note: Do not hold direct references to this object; always access it from the site.
    * @returns

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -46,7 +46,7 @@ const DEFAULT_SITE: Partial<IHubSite> = {
   name: "No title provided",
   tags: [],
   typeKeywords: ["Hub Site", "hubSite", "DELETEMESITE"],
-  classicCapabilities: [
+  legacyCapabilities: [
     "api_explorer",
     "pages",
     "my_data",

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -301,38 +301,28 @@ export async function updateSite(
   site: IHubSite,
   requestOptions: IHubRequestOptions
 ): Promise<IHubSite> {
-  // Most of this work is done with an IModel, so first thing it to
   // convert IHubSite to model
-  const mapper = new PropertyMapper<IHubSite>(getPropertyMap());
-  // applying the site onto the default model ensures that a minimum
-  // set of properties exist, regardless what may have been done to
-  // the site pojo
-  const updatedModel = mapper.objectToModel(
-    site,
-    cloneObject(DEFAULT_SITE_MODEL)
-  );
+  const siteModel = convertSiteToModel(site, requestOptions);
   // Fetch backing model from the portal
   const currentModel = await getModel(site.id, requestOptions);
   // handle any domain changes
-  await handleDomainChanges(updatedModel, currentModel, requestOptions);
+  await handleDomainChanges(siteModel, currentModel, requestOptions);
 
-  if (updatedModel.item.properties.slug !== currentModel.item.properties.slug) {
+  if (siteModel.item.properties.slug !== currentModel.item.properties.slug) {
     // ensure slug to keywords
-    updatedModel.item.typeKeywords = setSlugKeyword(
-      updatedModel.item.typeKeywords,
-      updatedModel.item.properties.slug
+    siteModel.item.typeKeywords = setSlugKeyword(
+      siteModel.item.typeKeywords,
+      siteModel.item.properties.slug
     );
   }
 
-  // merge the updated site onto the current model
-  const modelToStore = mapper.objectToModel(site, currentModel);
-  // update the model
+  // send updates to the Portal API and get back the updated site model
   const updatedSiteModel = await updateModel(
-    modelToStore,
+    siteModel,
     requestOptions as unknown as IUserItemOptions
   );
-  // fetch updated model
-  const updatedSite = mapper.modelToObject(updatedSiteModel, site);
+  // convert that back into a IHubSite and return it
+  const updatedSite = convertModelToSite(updatedSiteModel, requestOptions);
   return updatedSite;
 }
 
@@ -398,6 +388,7 @@ export async function fetchSite(
 }
 
 /**
+ * @internal
  * Convert an IModel for a Hub Site Item into an IHubSite
  * @param model
  * @param requestOptions
@@ -420,6 +411,25 @@ export function convertModelToSite(
   const site = mapper.modelToObject(migrated, {}) as IHubSite;
   // compute additional properties
   return computeProps(model, site, requestOptions);
+}
+
+/**
+ * @internal
+ * Convert an IHubSite into an IModel
+ * @param site
+ * @param requestOptions
+ * @returns
+ */
+export function convertSiteToModel(
+  site: IHubSite,
+  requestOptions: IRequestOptions
+): IModel {
+  // create the mapper
+  const mapper = new PropertyMapper<IHubSite>(getPropertyMap());
+  // applying the site onto the default model ensures that a minimum
+  // set of properties exist, regardless what may have been done to
+  // the IHubSite pojo
+  return mapper.objectToModel(site, cloneObject(DEFAULT_SITE_MODEL));
 }
 
 /**

--- a/packages/common/src/sites/_internal/SiteSchema.ts
+++ b/packages/common/src/sites/_internal/SiteSchema.ts
@@ -30,35 +30,10 @@ export const SiteSchema: IConfigurationSchema = {
         type: "string",
       },
     },
-    // status: {
-    //   type: "string",
-    //   default: PROJECT_STATUSES.notStarted,
-    //   enum: Object.keys(PROJECT_STATUSES),
-    // },
     location: {
       type: "object",
     },
     tags: ENTITY_TAGS_SCHEMA,
     categories: ENTITY_CATEGORIES_SCHEMA,
-    view: {
-      type: "object",
-      properties: {
-        featuredContentIds: {
-          type: "array",
-          maxItems: 4,
-          items: {
-            type: "string",
-          },
-        },
-        featuredImage: {
-          type: "object",
-        },
-        // TODO: extend this schema definition to provide
-        // appropriate validation for the timeline editor
-        timeline: {
-          type: "object",
-        },
-      },
-    },
   },
 } as unknown as IConfigurationSchema;

--- a/packages/common/src/sites/_internal/SiteSchema.ts
+++ b/packages/common/src/sites/_internal/SiteSchema.ts
@@ -1,0 +1,64 @@
+import { IConfigurationSchema } from "../../core";
+import {
+  ENTITY_ACCESS_SCHEMA,
+  ENTITY_CATEGORIES_SCHEMA,
+  ENTITY_NAME_SCHEMA,
+  ENTITY_TAGS_SCHEMA,
+} from "../../core/schemas/shared";
+
+export type SiteEditorType = (typeof SiteEditorTypes)[number];
+export const SiteEditorTypes = ["hub:site:edit"] as const;
+
+/**
+ * defines the JSON schema for a Hub Site's editable fields
+ */
+export const SiteSchema: IConfigurationSchema = {
+  required: ["name"],
+  type: "object",
+  properties: {
+    name: ENTITY_NAME_SCHEMA,
+    summary: {
+      type: "string",
+    },
+    description: {
+      type: "string",
+    },
+    access: ENTITY_ACCESS_SCHEMA,
+    groups: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+    // status: {
+    //   type: "string",
+    //   default: PROJECT_STATUSES.notStarted,
+    //   enum: Object.keys(PROJECT_STATUSES),
+    // },
+    location: {
+      type: "object",
+    },
+    tags: ENTITY_TAGS_SCHEMA,
+    categories: ENTITY_CATEGORIES_SCHEMA,
+    view: {
+      type: "object",
+      properties: {
+        featuredContentIds: {
+          type: "array",
+          maxItems: 4,
+          items: {
+            type: "string",
+          },
+        },
+        featuredImage: {
+          type: "object",
+        },
+        // TODO: extend this schema definition to provide
+        // appropriate validation for the timeline editor
+        timeline: {
+          type: "object",
+        },
+      },
+    },
+  },
+} as unknown as IConfigurationSchema;

--- a/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
@@ -1,0 +1,125 @@
+import { IUiSchema, UiSchemaRuleEffects } from "../../core";
+
+/**
+ * minimal create uiSchema for Hub Projects - this defines
+ * how the schema properties should be rendered in the
+ * project creation experience
+ */
+export const uiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      type: "Section",
+      options: { section: "stepper", scale: "l" },
+      elements: [
+        {
+          type: "Step",
+          labelKey: "{{i18nScope}}.sections.details.label",
+          elements: [
+            {
+              type: "Section",
+              labelKey: "{{i18nScope}}.sections.basicInfo.label",
+              elements: [
+                {
+                  labelKey: "{{i18nScope}}.fields.name.label",
+                  scope: "/properties/name",
+                  type: "Control",
+                  options: {
+                    messages: [
+                      {
+                        type: "ERROR",
+                        keyword: "required",
+                        icon: true,
+                        labelKey: "{{i18nScope}}.fields.name.requiredError",
+                      },
+                    ],
+                  },
+                },
+                {
+                  labelKey: "{{i18nScope}}.fields.summary.label",
+                  scope: "/properties/summary",
+                  type: "Control",
+                  options: {
+                    control: "hub-field-input-input",
+                    type: "textarea",
+                    helperText: {
+                      labelKey: "{{i18nScope}}.fields.summary.helperText",
+                    },
+                  },
+                },
+                {
+                  labelKey: "{{i18nScope}}.fields.status.label",
+                  scope: "/properties/status",
+                  type: "Control",
+                  options: {
+                    control: "hub-field-input-select",
+                    enum: {
+                      i18nScope: "{{i18nScope}}.fields.status.enum",
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "Step",
+          labelKey: "{{i18nScope}}.sections.location.label",
+          rule: {
+            effect: UiSchemaRuleEffects.DISABLE,
+            condition: {
+              scope: "/properties/name",
+              schema: { const: "" },
+            },
+          },
+          elements: [
+            {
+              type: "Section",
+              labelKey: "{{i18nScope}}.sections.location.label",
+              elements: [
+                {
+                  scope: "/properties/location",
+                  type: "Control",
+                  options: {
+                    control: "hub-field-input-location-picker",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "Step",
+          labelKey: "{{i18nScope}}.sections.sharing.label",
+          rule: {
+            effect: UiSchemaRuleEffects.DISABLE,
+            condition: {
+              scope: "/properties/name",
+              schema: { const: "" },
+            },
+          },
+          elements: [
+            {
+              scope: "/properties/access",
+              type: "Control",
+              options: {
+                control: "arcgis-hub-access-level-controls",
+                itemType: "{{{{i18nScope}}.fields.access.itemType:translate}}",
+              },
+            },
+            {
+              labelKey: "{{i18nScope}}.fields.groups.label",
+              scope: "/properties/groups",
+              type: "Control",
+              options: {
+                control: "hub-field-input-combobox",
+                allowCustomValues: false,
+                selectionMode: "multiple",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -51,23 +51,7 @@ export const uiSchema: IUiSchema = {
             },
           },
         },
-        // {
-        //   labelKey: "{{i18nScope}}.fields.featuredImage.label",
-        //   scope: "/properties/view/properties/featuredImage",
-        //   type: "Control",
-        //   options: {
-        //     control: "hub-field-input-image-picker",
-        //     maxWidth: 727,
-        //     maxHeight: 484,
-        //     aspectRatio: 1.5,
-        //     helperText: {
-        //       labelKey: "{{i18nScope}}.fields.featuredImage.helperText",
-        //     },
-        //     sizeDescription: {
-        //       labelKey: "{{i18nScope}}.fields.featuredImage.sizeDescription",
-        //     },
-        //   },
-        // },
+
         {
           labelKey: "{{i18nScope}}.fields.tags.label",
           scope: "/properties/tags",
@@ -110,76 +94,6 @@ export const uiSchema: IUiSchema = {
           type: "Control",
           options: {
             control: "hub-field-input-location-picker",
-          },
-        },
-      ],
-    },
-    // {
-    //   type: "Section",
-    //   labelKey: "{{i18nScope}}.sections.status.label",
-    //   elements: [
-    //     {
-    //       scope: "/properties/status",
-    //       type: "Control",
-    //       labelKey: "{{i18nScope}}.fields.status.label",
-    //       options: {
-    //         control: "hub-field-input-select",
-    //         enum: {
-    //           i18nScope: "{{i18nScope}}.fields.status.enum",
-    //         },
-    //       },
-    //     },
-    //   ],
-    // },
-    // {
-    //   type: "Section",
-    //   labelKey: "{{i18nScope}}.sections.timeline.label",
-    //   elements: [
-    //     {
-    //       scope: "/properties/view/properties/timeline",
-    //       type: "Control",
-    //       options: {
-    //         control: "arcgis-hub-timeline-editor",
-    //       },
-    //     },
-    //   ],
-    // },
-    {
-      type: "Section",
-      labelKey: "{{i18nScope}}.sections.featuredContent.label",
-      options: {
-        helperText: {
-          labelKey: "{{i18nScope}}.sections.featuredContent.helperText",
-        },
-      },
-      elements: [
-        {
-          scope: "/properties/view/properties/featuredContentIds",
-          type: "Control",
-          options: {
-            control: "hub-field-input-gallery-picker",
-            targetEntity: "item",
-            facets: [
-              {
-                label:
-                  "{{{{i18nScope}}.fields.featuredContent.facets.type:translate}}",
-                key: "type",
-                display: "multi-select",
-                field: "type",
-                options: [],
-                operation: "OR",
-                aggLimit: 100,
-              },
-              {
-                label:
-                  "{{{{i18nScope}}.fields.featuredContent.facets.sharing:translate}}",
-                key: "access",
-                display: "multi-select",
-                field: "access",
-                options: [],
-                operation: "OR",
-              },
-            ],
           },
         },
       ],

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -1,0 +1,188 @@
+import { IUiSchema } from "../../core";
+
+/**
+ * complete edit uiSchema for Hub Projects - this defines
+ * how the schema properties should be rendered in the
+ * project editing experience
+ */
+export const uiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.basicInfo.label",
+      elements: [
+        {
+          labelKey: "{{i18nScope}}.fields.name.label",
+          scope: "/properties/name",
+          type: "Control",
+          options: {
+            messages: [
+              {
+                type: "ERROR",
+                keyword: "required",
+                icon: true,
+                labelKey: "{{i18nScope}}.fields.name.requiredError",
+              },
+            ],
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.summary.label",
+          scope: "/properties/summary",
+          type: "Control",
+          options: {
+            control: "hub-field-input-input",
+            type: "textarea",
+            helperText: {
+              labelKey: "{{i18nScope}}.fields.summary.helperText",
+            },
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.description.label",
+          scope: "/properties/description",
+          type: "Control",
+          options: {
+            control: "hub-field-input-input",
+            type: "textarea",
+            helperText: {
+              labelKey: "{{i18nScope}}.fields.description.helperText",
+            },
+          },
+        },
+        // {
+        //   labelKey: "{{i18nScope}}.fields.featuredImage.label",
+        //   scope: "/properties/view/properties/featuredImage",
+        //   type: "Control",
+        //   options: {
+        //     control: "hub-field-input-image-picker",
+        //     maxWidth: 727,
+        //     maxHeight: 484,
+        //     aspectRatio: 1.5,
+        //     helperText: {
+        //       labelKey: "{{i18nScope}}.fields.featuredImage.helperText",
+        //     },
+        //     sizeDescription: {
+        //       labelKey: "{{i18nScope}}.fields.featuredImage.sizeDescription",
+        //     },
+        //   },
+        // },
+        {
+          labelKey: "{{i18nScope}}.fields.tags.label",
+          scope: "/properties/tags",
+          type: "Control",
+          options: {
+            control: "hub-field-input-combobox",
+            allowCustomValues: true,
+            selectionMode: "multiple",
+            placeholderIcon: "label",
+            helperText: { labelKey: "{{i18nScope}}.fields.tags.helperText" },
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.categories.label",
+          scope: "/properties/categories",
+          type: "Control",
+          options: {
+            control: "hub-field-input-combobox",
+            allowCustomValues: false,
+            selectionMode: "multiple",
+            placeholderIcon: "select-category",
+            helperText: {
+              labelKey: "{{i18nScope}}.fields.categories.helperText",
+            },
+          },
+        },
+      ],
+    },
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.location.label",
+      options: {
+        helperText: {
+          labelKey: "{{i18nScope}}.sections.location.helperText",
+        },
+      },
+      elements: [
+        {
+          scope: "/properties/location",
+          type: "Control",
+          options: {
+            control: "hub-field-input-location-picker",
+          },
+        },
+      ],
+    },
+    // {
+    //   type: "Section",
+    //   labelKey: "{{i18nScope}}.sections.status.label",
+    //   elements: [
+    //     {
+    //       scope: "/properties/status",
+    //       type: "Control",
+    //       labelKey: "{{i18nScope}}.fields.status.label",
+    //       options: {
+    //         control: "hub-field-input-select",
+    //         enum: {
+    //           i18nScope: "{{i18nScope}}.fields.status.enum",
+    //         },
+    //       },
+    //     },
+    //   ],
+    // },
+    // {
+    //   type: "Section",
+    //   labelKey: "{{i18nScope}}.sections.timeline.label",
+    //   elements: [
+    //     {
+    //       scope: "/properties/view/properties/timeline",
+    //       type: "Control",
+    //       options: {
+    //         control: "arcgis-hub-timeline-editor",
+    //       },
+    //     },
+    //   ],
+    // },
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.featuredContent.label",
+      options: {
+        helperText: {
+          labelKey: "{{i18nScope}}.sections.featuredContent.helperText",
+        },
+      },
+      elements: [
+        {
+          scope: "/properties/view/properties/featuredContentIds",
+          type: "Control",
+          options: {
+            control: "hub-field-input-gallery-picker",
+            targetEntity: "item",
+            facets: [
+              {
+                label:
+                  "{{{{i18nScope}}.fields.featuredContent.facets.type:translate}}",
+                key: "type",
+                display: "multi-select",
+                field: "type",
+                options: [],
+                operation: "OR",
+                aggLimit: 100,
+              },
+              {
+                label:
+                  "{{{{i18nScope}}.fields.featuredContent.facets.sharing:translate}}",
+                key: "access",
+                display: "multi-select",
+                field: "access",
+                options: [],
+                operation: "OR",
+              },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/packages/common/src/sites/_internal/getPropertyMap.ts
+++ b/packages/common/src/sites/_internal/getPropertyMap.ts
@@ -42,7 +42,7 @@ export function getPropertyMap(): IPropertyMap[] {
     modelKey: "item.properties.slug",
   });
   map.push({
-    objectKey: "classicCapabilities",
+    objectKey: "legacyCapabilities",
     modelKey: "data.values.capabilities",
   });
   map.push({
@@ -57,6 +57,11 @@ export function getPropertyMap(): IPropertyMap[] {
     objectKey: "name",
     modelKey: "item.title",
   });
+  map.push({
+    objectKey: "location",
+    modelKey: "item.properties.location",
+  });
+
   // Catalog mappings
   // Since v1.x sites use data.catalog, which is really just `{groiups: []}`
   // we can't overtly migrate data.catalog, but we can map the properties

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -171,7 +171,7 @@ describe("ArcGISContext:", () => {
 
       expect(mgr.context.sharingApiUrl).toBe(MOCK_AUTH.portal);
       expect(mgr.context.hubUrl).toBe("https://hub.arcgis.com");
-      expect(mgr.context.hubHomeUrl).toBe("https://myorg-hub.hub.arcgis.com");
+      expect(mgr.context.hubHomeUrl).toBe("https://myorg.hub.arcgis.com");
       expect(mgr.context.session).toBe(MOCK_AUTH);
       expect(mgr.context.isAuthenticated).toBe(true);
       // RequestOptions
@@ -193,7 +193,7 @@ describe("ArcGISContext:", () => {
         "https://hub.arcgis.com"
       );
 
-      expect(mgr.context.hubHomeUrl).toBe("https://myorg-hub.hub.arcgis.com");
+      expect(mgr.context.hubHomeUrl).toBe("https://myorg.hub.arcgis.com");
 
       // Hub Urls
       const base = mgr.context.hubUrl;

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -93,6 +93,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.portalUrl).toBe("https://www.arcgis.com");
       expect(mgr.context.isPortal).toBe(false);
       expect(mgr.context.hubUrl).toBe("https://hub.arcgis.com");
+      expect(mgr.context.hubHomeUrl).toBe("https://hub.arcgis.com");
       expect(mgr.context.requestOptions).toEqual({
         portal: mgr.context.sharingApiUrl,
       });
@@ -167,8 +168,10 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.portalUrl).toBe(
         MOCK_AUTH.portal.replace(`/sharing/rest`, "")
       );
+
       expect(mgr.context.sharingApiUrl).toBe(MOCK_AUTH.portal);
       expect(mgr.context.hubUrl).toBe("https://hub.arcgis.com");
+      expect(mgr.context.hubHomeUrl).toBe("https://myorg-hub.hub.arcgis.com");
       expect(mgr.context.session).toBe(MOCK_AUTH);
       expect(mgr.context.isAuthenticated).toBe(true);
       // RequestOptions
@@ -189,6 +192,8 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.hubRequestOptions.hubApiUrl).toBe(
         "https://hub.arcgis.com"
       );
+
+      expect(mgr.context.hubHomeUrl).toBe("https://myorg-hub.hub.arcgis.com");
 
       // Hub Urls
       const base = mgr.context.hubUrl;
@@ -316,6 +321,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.isPortal).toBe(true);
 
       expect(mgr.context.hubUrl).toBeUndefined();
+      expect(mgr.context.hubHomeUrl).toBeUndefined();
       expect(mgr.context.discussionsServiceUrl).toBeUndefined();
       expect(mgr.context.hubSearchServiceUrl).toBeUndefined();
       expect(mgr.context.domainServiceUrl).toBeUndefined();

--- a/packages/common/test/core/schemas/getEntityEditorSchema.test.ts
+++ b/packages/common/test/core/schemas/getEntityEditorSchema.test.ts
@@ -1,23 +1,26 @@
 import { getEntityEditorSchemas } from "../../../src/core/schemas/getEntityEditorSchemas";
 import { ProjectEditorTypes } from "../../../src/projects/_internal/ProjectSchema";
 import { InitiativeEditorTypes } from "../../../src/initiatives/_internal/InitiativeSchema";
+import { SiteEditorTypes } from "../../../src/sites/_internal/SiteSchema";
 import * as applyOptionsModule from "../../../src/core/schemas/internal/applyUiSchemaElementOptions";
 import * as filterSchemaModule from "../../../src/core/schemas/internal/filterSchemaToUiSchema";
 import * as itemsModule from "../../../src/items";
 
 describe("getEntityEditorSchemas", () => {
   it("returns a schema & uiSchema for a given entity and editor type", () => {
-    [...ProjectEditorTypes, ...InitiativeEditorTypes].forEach(
-      async (type, idx) => {
-        const { schema, uiSchema } = await getEntityEditorSchemas(
-          "some.scope",
-          type
-        );
+    [
+      ...ProjectEditorTypes,
+      ...InitiativeEditorTypes,
+      ...SiteEditorTypes,
+    ].forEach(async (type, idx) => {
+      const { schema, uiSchema } = await getEntityEditorSchemas(
+        "some.scope",
+        type
+      );
 
-        expect(schema).toBeDefined();
-        expect(uiSchema).toBeDefined();
-      }
-    );
+      expect(schema).toBeDefined();
+      expect(uiSchema).toBeDefined();
+    });
   });
   it("filters, and applies dynamic options to the schemas before returning", async () => {
     const filterSchemaToUiSchemaSpy = spyOn(

--- a/packages/common/test/projects/projects.test.ts
+++ b/packages/common/test/projects/projects.test.ts
@@ -12,8 +12,6 @@ import {
   updateProject,
   IHubRequestOptions,
   enrichProjectSearchResult,
-  UiSchemaElementOptions,
-  deepFind,
   PROJECT_STATUSES,
   IHubLocation,
 } from "../../src";
@@ -22,7 +20,6 @@ import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as modelUtils from "../../src/models";
 import * as slugUtils from "../../src/items/slugs";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { filterSchemaToUiSchema } from "../../src/core/schemas/internal";
 
 const PROJECT_LOCATION: IHubLocation = {
   type: "custom",
@@ -449,6 +446,12 @@ describe("HubProjects:", () => {
       itm.snippet = "This should be used";
       const chk = await enrichProjectSearchResult(itm, [], hubRo);
       expect(chk.summary).toEqual(itm.snippet);
+    });
+    it("uses slug in site-relative link if defined", async () => {
+      const itm = cloneObject(PROJECT_ITEM_ENRICH);
+      itm.properties = { slug: "myorg|my-slug" };
+      const chk = await enrichProjectSearchResult(itm, [], hubRo);
+      expect(chk.links?.siteRelative).toEqual("/projects/myorg::my-slug");
     });
     it("fetches enrichments", async () => {
       const chk = await enrichProjectSearchResult(

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -70,7 +70,7 @@ const SITE: commonModule.IHubSite = {
   layout: { sections: [{}] },
   theme: {},
   subdomain: "site-org",
-  classicCapabilities: [],
+  legacyCapabilities: [],
   catalog: { schemaVersion: 0 },
   pages: [],
   defaultHostname: "site-org.hub.arcgis.com",

--- a/packages/common/test/sites/fixtures/expected-model.jsonc
+++ b/packages/common/test/sites/fixtures/expected-model.jsonc
@@ -1,0 +1,1038 @@
+// Structure we need out of mappings
+{
+  "data": {
+    "catalog": {
+      "groups": [
+        "f2266019e642414ab8bf931a1f856b15"
+      ]
+    },
+    "feeds": {},
+    "values": {
+      "capabilities": [
+        "api_explorer",
+        "pages",
+        "my_data",
+        "social_logins",
+        "json_chart_card",
+        "document_iframes",
+        "items_view",
+        "app_page",
+        "underlinedLinks",
+        "globalNav",
+        "socialSharing"
+      ],
+      "clientId": "7YjUTPIE2K5z6Ku1",
+      "contentViews": {
+        "sidePanelOpen": {
+          "app": true,
+          "dataset": true,
+          "document": true,
+          "feedback": true,
+          "map": true
+        }
+      },
+      "defaultExtent": {
+        "spatialReference": {
+          "wkid": 102100
+        },
+        "xmax": -6199999.999999268,
+        "xmin": -14999999.999998225,
+        "ymax": 6499999.999998959,
+        "ymin": 2699999.9999996596
+      },
+      "defaultHostname": "workspace-qa-pre-a-hub.hubqa.arcgis.com",
+      "faviconUrl": "",
+      "footerSass": "\n  .footer-background {\n    padding-top: 20px;\n    padding-bottom: 20px;\n    background-color: #fcfcfc;\n  }\n\n  .logo, .nav {\n    margin-bottom: 10px;\n  }\n\n  .nav-pills {\n      display: flex;\n      flex-wrap: wrap;\n      justify-content: center;\n  }\n",
+      "headContent": "",
+      "headerSass": ".first-tier {\n  height: 80px;\n  margin-bottom: 0px;\n  background-color: #005e95;\n}\n\n.first-tier .nav > li > a {\n  margin-top: 5px;\n  padding: 3px 6px;\n  color: #fff;\n}\n\n.first-tier .nav > li > a:focus,\n.first-tier .nav>li>a:hover {\n  background-color: #136fbf;\n  color: #fff;\n}\n\n.first-tier .site-logo img {\n  vertical-align: middle;\n}\n\n.first-tier h1 {\n  display: inline;\n  font-size: 25px;\n}\n\n.second-tier {\n  margin-bottom: 0px;\n  background-color: #05466c;\n}\n\n.site-header .navbar-header img {\n  vertical-align: middle;\n  height: 50px;\n  padding: 5px;\n}\n\n@media (max-width: 768px) {\n  .first-tier {\n    height: 100px;\n  }\n}\n\n@media (max-width: 498px) {\n  .navbar-brand {\n    padding: 0px;\n  }\n}\n\n.navbar-inverse .navbar-toggle {\n  border-color: #ffffff;\n}\n\n.navbar-inverse .navbar-toggle:hover {\n  background-color: transparent;\n}\n\n.navbar-inverse .navbar-toggle .icon-bar {\n  background-color: #ffffff;\n}\n\n",
+      "layout": {
+        "footer": {
+          "component": {
+            "name": "site-footer",
+            "settings": {
+              "footerType": "custom",
+              "markdown": "<div class=\"footer-background\">\n  <div class=\"container-fluid\">\n    <div class=\"col-xs-12\">\n      <img src=\"https://via.placeholder.com/50\" alt=\"\" class=\"center-block logo\">\n    </div>\n    <div class=\"col-xs-6 center-block\">\n      <ul class=\"nav nav-pills\">\n\n        <li><a href=\"\">URL</a></li>\n\n        <li><a href=\"\">URL</a></li>\n\n        <li><a href=\"\">URL</a></li>\n\n        <li><a href=\"\">URL</a></li>\n\n      </ul>\n    </div>\n    <div class=\"col-xs-6 center-block\">\n      <ul class=\"nav nav-pills\" style=\"float:right;\">\n        <li><a href=\"#\">Terms of Service</a></li>\n        <li><a href=\"#\">Privacy Policy</a></li>\n      </ul>\n    </div>\n    <div class=\"col-xs-12\">\n      <div class=\"text-white\" style=\"padding-top: 3rem; text-align: center;\">\n        <p>&copy; Custom Initiative Template. All photos used on this site are from <a href=\"https://unsplash.com/\" style=\"text-decoration: underline;\">Unsplash</a>.</p>\n      </div>\n    </div>\n  </div>\n</div>",
+              "schemaVersion": 1
+            }
+          },
+          "showEditor": false
+        },
+        "header": {
+          "component": {
+            "name": "site-header",
+            "settings": {
+              "fullWidth": false,
+              "headerType": "default",
+              "iframeHeight": "150px",
+              "iframeUrl": "",
+              "links": [],
+              "logo": {
+                "display": {}
+              },
+              "logoUrl": "",
+              "markdown": "<nav class=\"navbar navbar-default navbar-static-top first-tier\">\n  <div class=\"container\">\n    <ul class=\"nav nav-pills pull-right\" role=\"navigation\">\n      <li><a href=\"#\">Terms of Use</a></li>\n      <li><a href=\"#\">Twitter</a></li>\n      <li><a href=\"#\">Blog</a></li>\n    </ul>\n    <div class=\"navbar-brand\">\n      <div class=\"site-logo\">\n        <img src=\"https://via.placeholder.com/50\" alt=\"\">\n        <h1>My Organization</h1>\n      </div>\n    </div>\n  </div>\n</nav>\n<nav class=\"navbar navbar-inverse navbar-static-top second-tier\" role=\"navigation\">\n  <div class=\"navbar-header\">\n    <button type=\"button\" class=\"navbar-toggle collapsed\" data-toggle=\"collapse\" data-target=\"#bs-example-navbar-collapse-1\" aria-expanded=\"false\">\n      <span class=\"sr-only\">Toggle navigation</span>\n      <span class=\"icon-bar\"></span>\n      <span class=\"icon-bar\"></span>\n      <span class=\"icon-bar\"></span>\n    </button>\n  </div>\n  <div class=\"collapse navbar-collapse\" id=\"bs-example-navbar-collapse-1\">\n    <div class=\"container\">\n      <div class=\"navbar\">\n        <ul class=\"nav navbar-nav\">\n          <li class=\"active\"><a href=\"#\">Home</a></li>\n          <li><a href=\"#about\">About</a></li>\n          <li><a href=\"#contact\">Contact</a></li>\n          <li><a href=\"#contact\">Contact</a></li>\n          <li><a href=\"#contact\">Contact</a></li>\n          <li><a href=\"#contact\">Contact</a></li>\n          <li><a href=\"#contact\">Contact</a></li>\n        </ul>\n      </div>\n    </div>\n  </div>\n</nav>\n",
+              "menuLinks": [],
+              "schemaVersion": 3,
+              "shortTitle": "",
+              "showLogo": true,
+              "showTitle": true,
+              "socialLinks": {
+                "facebook": {},
+                "instagram": {},
+                "twitter": {},
+                "youtube": {}
+              },
+              "title": "workspace"
+            }
+          },
+          "showEditor": false
+        },
+        "sections": [
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "\n<br>\n<br>\n<br>\n<br>\n<br><div style=\"text-align: center;\" class=\"banner-heading\"><b>workspace</b></div><p style=\"text-align: center;\"><br></p><p style=\"text-align: center;\"><br></p><p style=\"text-align: center;\">Verify Workspaces for All the Things</p>\n\n\n<br>\n<br>\n<br>\n<br>\n<br>",
+                        "schemaVersion": 2.1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#000000",
+                "cropSrc": "pexels-pixabay-162553.jpg",
+                "display": {},
+                "fileSrc": "pexels-pixabay-162553.jpg",
+                "image": "https://s3.amazonaws.com/geohub-assets/templates/public-engagement/city-architecture.jpg",
+                "isFile": true,
+                "isUrl": false,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "valid",
+                "transparency": 30
+              },
+              "color": "#ffffff",
+              "rowLayout": "box"
+            },
+            "visibility": {
+              "access": "default",
+              "groups": []
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<h5 style=\"text-align: center;\">Create your own initiative by combining existing applications with a custom site. Use this initiative to form teams around a problem and invite your community to participate.</h5><h5 style=\"text-align: center;\"><br></h5><h5 style=\"text-align: center;\">\n</h5><p style=\"text-align: center;\"></p>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#3276ae",
+                "display": {},
+                "image": "",
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              },
+              "color": "#ffffff"
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mt-8 mb-8\" style=\"text-align: center;\">\n    <h1>Our Progress So Far</h1>\n    <p>Leverage this section to share progress or other stats with the public. Make it transparent and exciting to see the results of the hard work or why an initiative needs support. This is also a great space to inspire your audience to potentially get involved.</p>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "summary-statistic-card",
+                      "settings": {
+                        "currencyCode": "USD",
+                        "decimalPlaces": 2,
+                        "formatNumberGroupings": true,
+                        "leadingText": "",
+                        "showAsCurrency": false,
+                        "statFieldName": "",
+                        "statFieldType": "",
+                        "statType": "",
+                        "statValueAlign": "left",
+                        "statValueColor": null,
+                        "timeout": 10,
+                        "title": "Statistic Title",
+                        "titleAlign": "left",
+                        "trailingText": "...",
+                        "trailingTextAlign": "left",
+                        "url": ""
+                      }
+                    },
+                    "width": 4
+                  },
+                  {
+                    "component": {
+                      "name": "summary-statistic-card",
+                      "settings": {
+                        "currencyCode": "USD",
+                        "decimalPlaces": 2,
+                        "formatNumberGroupings": true,
+                        "leadingText": "",
+                        "showAsCurrency": false,
+                        "statFieldName": "",
+                        "statFieldType": "",
+                        "statType": "",
+                        "statValueAlign": "left",
+                        "statValueColor": null,
+                        "timeout": 10,
+                        "title": "Statistic Title",
+                        "titleAlign": "left",
+                        "trailingText": "...",
+                        "trailingTextAlign": "left",
+                        "url": ""
+                      }
+                    },
+                    "width": 4
+                  },
+                  {
+                    "component": {
+                      "name": "summary-statistic-card",
+                      "settings": {
+                        "currencyCode": "USD",
+                        "decimalPlaces": 2,
+                        "formatNumberGroupings": true,
+                        "leadingText": "",
+                        "showAsCurrency": false,
+                        "statFieldName": "",
+                        "statFieldType": "",
+                        "statType": "",
+                        "statValueAlign": "left",
+                        "statValueColor": null,
+                        "timeout": 10,
+                        "title": "Statistic Title",
+                        "titleAlign": "left",
+                        "trailingText": "...",
+                        "trailingTextAlign": "left",
+                        "url": ""
+                      }
+                    },
+                    "width": 4
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mb-4\"></div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "transparent",
+                "display": {},
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              }
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mt-8 mb-4\" style=\"text-align: center;\">\n<h1>Get Involved with the Community Today!</h1>\n<p>Utilize this section to provide steps on how to get involved, show different phases of your initiative or simply highlight areas of concern.</p>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<ul class=\"pledge-wrapper pledge-wrapper-center pledge-numbers-white\">\n\n  <li>\n    <div class=\"pledge-content\">\n      <h3 class=\"pledge-title\">Help improve the air quality</h3>\n      <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n    </div>\n  </li>\n\n  <li>\n    <div class=\"pledge-content\">\n      <h3 class=\"pledge-title\">Report Data</h3>\n      <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n    </div>\n  </li>\n\n  <li>\n    <div class=\"pledge-content\">\n      <h3 class=\"pledge-title\">Become Involved</h3>\n      <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n    </div>\n  </li>\n\n  <li>\n    <div class=\"pledge-content\">\n      <h3 class=\"pledge-title\">Contribute</h3>\n      <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n    </div>\n  </li>\n  \n</ul>\n\n\n<style>\n/* Pledge Wrapper - Default */\n.pledge-wrapper,\n.pledge-wrapper-center,\n.pledge-wrapper-simple {\n  list-style: none;\n  margin: 0;\n  padding: 0;\n  display: flex;\n  flex-flow: row wrap; }\n\n.pledge-wrapper li,\n.pledge-wrapper-center li,\n.pledge-wrapper-simple li {\n  counter-increment: pledge-counter;\n  position: relative;\n  flex-basis: 25%;\n  width: 25%;\n  margin-top: 40px;\n  padding-top: 40px; }\n\n@media screen and (max-width: 800px) {\n  .pledge-wrapper li,\n  .pledge-wrapper-center li,\n  .pledge-wrapper-simple li {\n    flex-basis: 50%;\n    width: 50%; }\n  .pledge-wrapper li::before,\n  .pledge-wrapper-center li::before,\n  .pledge-wrapper-simple li::before {\n    transform: translate(0, -50%) !important; } }\n\n@media screen and (max-width: 600px) {\n  .pledge-wrapper li,\n  .pledge-wrapper-center li,\n  .pledge-wrapper-simple li {\n    flex-basis: 100%;\n    width: 100%; } }\n\n.pledge-wrapper li::before,\n.pledge-wrapper-center li::before,\n.pledge-wrapper-simple li::before {\n  box-sizing: border-box;\n  content: counter(pledge-counter);\n  display: inline-block;\n  font-family: 'Avenir', sans-serif;\n  font-size: 3rem;\n  font-weight: 600;\n  line-height: 1;\n  text-align: center;\n  background-color: #4C93E0;\n  border-radius: 50%;\n  color: #fff;\n  padding: 1rem;\n  height: 48px;\n  width: 48px;\n  position: absolute;\n  top: 0;\n  left: 0;\n  transform: translate(-50%, -50%);\n  z-index: 4; }\n\n.pledge-wrapper li::after,\n.pledge-wrapper-center li::after {\n  content: '';\n  display: block;\n  background-color: #4C93E0;\n  border-radius: 0;\n  height: 10px;\n  width: 100%;\n  position: absolute;\n  top: 0;\n  transform: translateY(-50%);\n  z-index: 2; }\n\n.pledge-wrapper li:first-of-type::after,\n.pledge-wrapper-center li:first-of-type::after {\n  border-radius: 10px 0 0 10px; }\n\n.pledge-wrapper li:last-of-type::after,\n.pledge-wrapper-center li:last-of-type::after {\n  border-radius: 0 10px 10px 0; }\n\n.pledge-wrapper .pledge-content,\n.pledge-wrapper-center .pledge-content {\n  box-sizing: border-box;\n  margin-top: -1.5rem;\n  padding: 0 2rem; }\n\n.pledge-wrapper .pledge-content .pledge-title,\n.pledge-wrapper-center .pledge-content .pledge-title,\n.pledge-wrapper-simple .pledge-content .pledge-title {\n  font-family: 'Avenir', sans-serif;\n  font-size: 2rem;\n  font-weight: 500; }\n\n/* Pledge Wrapper - Centered */\n.pledge-wrapper-center li::before {\n  font-size: 2rem;\n  left: 50%;\n  height: 56px;\n  width: 56px; }\n\n@media screen and (max-width: 800px) {\n  .pledge-wrapper-center li::before {\n    transform: translate(-50%, -50%) !important; } }\n\n.pledge-wrapper-center li::after {\n  border-radius: 0; }\n\n.pledge-wrapper-center .pledge-content {\n  text-align: center; }\n\n/* Pledge Wrapper - List */\n.pledge-wrapper-list {\n  list-style: none;\n  margin: 0;\n  padding: 0; }\n\n.pledge-wrapper-list li {\n  counter-increment: pledge-counter;\n  position: relative;\n  margin-left: 60px;\n  padding: 1rem 0; }\n\n.pledge-wrapper-list li::before {\n  box-sizing: border-box;\n  content: counter(pledge-counter);\n  display: inline-block;\n  font-family: 'Avenir', sans-serif;\n  font-size: 6rem;\n  font-weight: 600;\n  line-height: 1;\n  text-align: center;\n  color: #4C93E0;\n  position: absolute;\n  top: 50%;\n  left: -35px;\n  transform: translate(-50%, -50%);\n  z-index: 4; }\n\n/* Pledge Wrapper - Simple */\n.pledge-wrapper-simple li::before {\n  background-color: transparent;\n  border-radius: 0;\n  color: #4C93E0;\n  font-size: 6rem; }\n\n/* Pledge Wrapper - White Numbers (Modifier) */\n.pledge-numbers-white li::before {\n  background-color: #fff;\n  border: 1px solid #4C93E0;\n  color: #4C93E0; }\n\n.flex-row {\n  display: flex;\n  align-items: center; }\n\n@media screen and (max-width: 767px) {\n  .flex-row {\n    flex-direction: column; } }\n</style>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mt-3 mb-10\" style=\"text-align: center;\">\n  <a href=\"#\" class=\"btn btn-lg btn-primary\">Contribute</a>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#f5f5f5",
+                "display": {},
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              },
+              "color": "#4e4e4e"
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mt-8 mb-6\" style=\"text-align: center;\">\n  <h1>Our Focus</h1>\n<p>Leverage these sections to tell your initiative story. Provide key information regarding your initiatives with an opportunity to go to a specific page or app to learn more.  </p>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "image-card",
+                      "settings": {
+                        "alt": "",
+                        "caption": "",
+                        "captionAlign": "center",
+                        "cropSrc": "",
+                        "display": {
+                          "position": {
+                            "x": "center",
+                            "y": "center"
+                          },
+                          "reflow": false
+                        },
+                        "fileSrc": "",
+                        "hyperlink": "",
+                        "hyperlinkTabOption": "new",
+                        "isFile": false,
+                        "isUrl": true,
+                        "src": "https://s3.amazonaws.com/geohub-assets/templates/public-engagement/planting-trees.jpg",
+                        "state": "valid"
+                      }
+                    },
+                    "width": 6
+                  },
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"display-flex flex-middle\" style=\"min-height: 360px\">\n  <div>\n    <h2>Section Heading</h2>\n    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>\n    \n    <p><a href=\"#\" class=\"btn btn-primary\">Call To Action</a></p>\n  </div>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 6
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"display-flex flex-middle\" style=\"min-height: 360px\">\n  <div>\n    <h2>Section Heading</h2>\n    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>\n    \n    <p><a href=\"#\" class=\"btn btn-primary\">Call To Action</a></p>\n  </div>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 6
+                  },
+                  {
+                    "component": {
+                      "name": "image-card",
+                      "settings": {
+                        "alt": "",
+                        "caption": "",
+                        "captionAlign": "center",
+                        "cropSrc": "",
+                        "display": {
+                          "position": {
+                            "x": "center",
+                            "y": "center"
+                          },
+                          "reflow": false
+                        },
+                        "fileSrc": "",
+                        "hyperlink": "",
+                        "hyperlinkTabOption": "new",
+                        "isFile": false,
+                        "isUrl": true,
+                        "src": "https://s3.amazonaws.com/geohub-assets/templates/public-engagement/growing-tomatoes.jpg",
+                        "state": "valid"
+                      }
+                    },
+                    "width": 6
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "image-card",
+                      "settings": {
+                        "alt": "",
+                        "caption": "",
+                        "captionAlign": "center",
+                        "cropSrc": "",
+                        "display": {
+                          "position": {
+                            "x": "center",
+                            "y": "center"
+                          },
+                          "reflow": false
+                        },
+                        "fileSrc": "",
+                        "hyperlink": "",
+                        "hyperlinkTabOption": "new",
+                        "isFile": false,
+                        "isUrl": true,
+                        "src": "https://s3.amazonaws.com/geohub-assets/templates/public-engagement/wind-turbines.jpg",
+                        "state": "valid"
+                      }
+                    },
+                    "width": 6
+                  },
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"display-flex flex-middle\" style=\"min-height: 360px\">\n  <div>\n    <h2>Section Heading</h2>\n    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>\n    \n    <p><a href=\"#\" class=\"btn btn-primary\">Call To Action</a></p>\n  </div>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 6
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"display-flex flex-middle\" style=\"min-height: 360px\">\n  <div>\n    <h2>Section Heading</h2>\n    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>\n    \n    <p><a href=\"#\" class=\"btn btn-primary\">Call To Action</a></p>\n  </div>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 6
+                  },
+                  {
+                    "component": {
+                      "name": "image-card",
+                      "settings": {
+                        "alt": "",
+                        "caption": "",
+                        "captionAlign": "center",
+                        "cropSrc": "",
+                        "display": {
+                          "position": {
+                            "x": "center",
+                            "y": "center"
+                          },
+                          "reflow": false
+                        },
+                        "fileSrc": "",
+                        "hyperlink": "",
+                        "hyperlinkTabOption": "new",
+                        "isFile": false,
+                        "isUrl": true,
+                        "src": "https://s3.amazonaws.com/geohub-assets/templates/public-engagement/bike-rentals.jpg",
+                        "state": "valid"
+                      }
+                    },
+                    "width": 6
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "transparent",
+                "display": {},
+                "image": "",
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              },
+              "color": "#444444"
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mt-4 mb-2\" style=\"text-align: center;\">\n  <h1>Don't just tell the story, show the story</h1>\n<p> Utilize an Esri Map on this page to show the changes or the primary areas of focus. </p>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "webmap-card",
+                      "settings": {
+                        "enableMapLegend": false,
+                        "height": "400",
+                        "mobileEnableMapLegend": false,
+                        "mobileHeight": 500,
+                        "mobileItem": null,
+                        "mobileShowTitle": true,
+                        "mobileTitle": "New Map",
+                        "mobileTitleAlign": "left",
+                        "mobileWebmap": null,
+                        "mobileWebscene": null,
+                        "showTitle": true,
+                        "title": "",
+                        "titleAlign": "left",
+                        "webmap": "",
+                        "webscene": null
+                      }
+                    },
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#ededed",
+                "display": {},
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              },
+              "color": "#444444"
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div  class=\"mt-10 mb-8\" style=\"text-align: center;\">\n<h1>See Our City in Action</h1>\n<p>Use this section to save your community visitors research time and connect them with reports, apps, and links to other sites, that will give them deeper insights on the initiative regarding your city.</p>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "hub-gallery-card",
+                      "settings": {
+                        "contentResponse": true,
+                        "displayOption": [
+                          "application"
+                        ],
+                        "imageType": "Thumbnails",
+                        "includedOption": "application",
+                        "orgId": "Xj56SBi2udA78cC9",
+                        "query": {
+                          "num": "4",
+                          "tags": []
+                        },
+                        "selectedGroups": [
+                          {
+                            "id": "6751456a44104631b1006fd0d9a2573c",
+                            "title": "workspace"
+                          }
+                        ],
+                        "siteId": "",
+                        "viewText": "Explore"
+                      }
+                    },
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#ffffff",
+                "display": {},
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              },
+              "color": "#444444"
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "event-list-card",
+                      "settings": {
+                        "backgroundColor": "#ffffff",
+                        "cardVersion": 2,
+                        "defaultView": "calendar",
+                        "display": {
+                          "colorPalette": "custom",
+                          "cornerStyle": "square",
+                          "dropShadow": "none"
+                        },
+                        "displayMode": "calendar",
+                        "eventListTitleAlign": "left",
+                        "height": 500,
+                        "initiativeIds": [
+                          "409e55090f704fd99de0b04eaea082b8"
+                        ],
+                        "listEnabled": true,
+                        "showTitle": true,
+                        "subtitle": "Location",
+                        "textColor": "#000000",
+                        "title": "List of upcoming events"
+                      }
+                    },
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#367aaa",
+                "display": {},
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              }
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"section-follow mt-10\">\n  <h1 class=\"section-follow-title\">Sign Up and Follow this initiative</h1>\n  <hr />\n  <div class=\"section-follow-content\">\n    <p>Drive people to Sign Up for a community account and follow this initiative to receive updates from you. You can use the list to send email communication and invitations to host events.</p>\n  </div>\n</div>\n\n\n<style>\n  .section-follow {\n    margin-left: auto;\n    margin-right: auto;\n    padding-top: 2rem;\n    text-align: center;\n    width: 60%;\n  }\n\n  .section-follow .section-follow-title {\n    margin: 0 0 1.5rem;\n  }\n\n  .section-follow hr {\n    background-color: #3677ac;\n    border: 0;\n    height: 2px;\n    width: 100px;\n  }\n\n  .section-follow .section-follow-content {\n    font-size: 16px;\n    margin-bottom: 2rem;\n  }\n</style>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "follow-initiative-card",
+                      "settings": {
+                        "buttonAlign": "center",
+                        "buttonStyle": "solid",
+                        "buttonText": "Follow Our Initiative",
+                        "callToActionAlign": "center",
+                        "callToActionText": "",
+                        "initiativeId": "409e55090f704fd99de0b04eaea082b8",
+                        "unfollowButtonText": "Stop Following"
+                      }
+                    },
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mb-10\">&nbsp;</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#333333",
+                "darken": true,
+                "display": {},
+                "image": "https://s3.amazonaws.com/geohub-assets/templates/public-engagement/greenspace-community-center.jpg",
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "valid",
+                "transparency": 0
+              },
+              "color": "#ffffff"
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div>&nbsp;</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 3
+                  },
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mt-6 mb-6\" style=\"text-align: center;\">\n  <h1>Contact</h1>\n  <p>Make your site a two-way communication platform with your community. Use this to let them know that you welcome their feedback and that you want to hear from them.</p>\n  <p><a href=\"#\" class=\"btn btn-lg btn-primary\">Call To Action</a></p>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 6
+                  },
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div>&nbsp;</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 3
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#555555",
+                "darken": true,
+                "display": {},
+                "image": "",
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              },
+              "color": "#ffffff"
+            }
+          }
+        ]
+      },
+      "map": {
+        "basemaps": {
+          "primary": {
+            "baseMapLayers": [
+              {
+                "id": "VectorTile_4246",
+                "layerType": "VectorTileLayer",
+                "opacity": 1,
+                "styleUrl": "https://cdn.arcgis.com/sharing/rest/content/items/aa30dd52509a4fea939ccbfc3c3e14de/resources/styles/root.json",
+                "title": "Colored Pencil",
+                "type": "VectorTileLayer",
+                "visibility": true
+              }
+            ],
+            "id": "a17e26cc129844668c8af39e26144006",
+            "operationalLayers": [],
+            "title": "Colored Pencil Map"
+          }
+        }
+      },
+      "pages": [],
+      "public": false,
+      "subdomain": "workspace",
+      "telemetry": {
+        "consentNotice": {
+          "consentText": "",
+          "isTheme": true,
+          "policyURL": ""
+        },
+        "customAnalytics": {
+          "ga": {
+            "customerTracker": {
+              "enabled": false
+            }
+          }
+        }
+      },
+      "theme": {
+        "body": {
+          "background": "#ffffff",
+          "link": "#004da8",
+          "text": "#242424"
+        },
+        "button": {
+          "background": "#55ff00",
+          "text": "#004da8"
+        },
+        "fonts": {
+          "base": {
+            "family": "Avenir Next",
+            "url": ""
+          },
+          "heading": {
+            "family": "Avenir Next",
+            "url": ""
+          }
+        },
+        "globalNav": {
+          "background": "#004da8",
+          "text": "#55ff00"
+        },
+        "header": {
+          "background": "#004da8",
+          "text": "#55ff00"
+        },
+        "logo": {
+          "small": "https://qa-pre-a-hub.mapsqa.arcgis.com/sharing/rest/content/items/ae2026ab67c04ad9ad0d109ce2ff8a07/data"
+        }
+      },
+      "title": "workspace",
+      "uiVersion": "2.4",
+      "updatedAt": "2023-05-16T20:31:30.473Z",
+      "updatedBy": "paige_pa"
+    }
+  },
+  "item": {
+    "access": "shared",
+    "accessInformation": null,
+    "advancedSettings": null,
+    "appCategories": [],
+    "avgRating": 0,
+    "banner": null,
+    "categories": [],
+    "commentsEnabled": true,
+    "contentOrigin": "self",
+    "created": 1684268891000,
+    "culture": "en-us",
+    "description": "Create your own initiative by combining existing applications with a custom site. Use this initiative to form teams around a problem and invite your community to participate.",
+    "documentation": null,
+    "extent": [
+      [
+        -134.74729261791228,
+        23.560962423767485
+      ],
+      [
+        -55.695547615403754,
+        50.309217030283726
+      ]
+    ],
+    "groupDesignations": null,
+    "guid": null,
+    "id": "cb30e780b44146c49841ed7343394d58",
+    "industries": [],
+    "isOrgItem": true,
+    "itemControl": "admin",
+    "languages": [],
+    "largeThumbnail": null,
+    "lastViewed": 1684504800000,
+    "licenseInfo": null,
+    "listed": false,
+    "modified": 1684269091000,
+    "name": null,
+    "numComments": 0,
+    "numRatings": 0,
+    "numViews": 141,
+    "owner": "paige_pa",
+    "ownerFolder": "9fce746a44f84204964179e6f9bb7b97",
+    "properties": {
+      "children": [],
+      "collaborationGroupId": "6751456a44104631b1006fd0d9a2573c",
+      "contentGroupId": "f2266019e642414ab8bf931a1f856b15",
+      "createdFrom": "premiumDefaultSite Solution Template (embedded)",
+      "followersGroupId": "0e81c6bbd49040ccba0ef98827ee7f92",
+      "parentId": "embedded-premium-default-site",
+      "parentInitiativeId": "409e55090f704fd99de0b04eaea082b8",
+      "schemaVersion": 1.6
+    },
+    "protected": true,
+    "proxyFilter": null,
+    "scoreCompleteness": 28,
+    "screenshots": [],
+    "size": 1291745,
+    "snippet": "Create your own initiative by combining existing applications with a custom site. Use this initiative to form teams around a problem and invite your community to participate.",
+    "spatialReference": null,
+    "subInfo": 0,
+    "tags": [
+      "Hub Site"
+    ],
+    "thumbnail": null,
+    "title": "workspace",
+    "type": "Hub Site Application",
+    "typeKeywords": [
+      "Hub",
+      "hubSite",
+      "hubSolution",
+      "JavaScript",
+      "Map",
+      "Mapping Site",
+      "Online Map",
+      "OpenData",
+      "Ready To Use",
+      "selfConfigured",
+      "source-embedded-premium-default-site",
+      "Web Map",
+      "Registered App"
+    ],
+    "url": "https://workspace-qa-pre-a-hub.hubqa.arcgis.com"
+  }
+}

--- a/packages/common/test/sites/fixtures/mapped-model.jsonc
+++ b/packages/common/test/sites/fixtures/mapped-model.jsonc
@@ -1,0 +1,1039 @@
+// Structure we are getting out of the mapping
+{
+  "data": {
+    "capabilities": {
+      "details": true,
+      "overview": true,
+      "settings": true
+    },
+    "catalog": {
+      "groups": [
+        "f2266019e642414ab8bf931a1f856b15"
+      ]
+    },
+    "catalogv2": {
+      "collections": [],
+      "schemaVersion": 1,
+      "scopes": {
+        "item": {
+          "filters": [
+            {
+              "predicates": [
+                {
+                  "group": [
+                    "f2266019e642414ab8bf931a1f856b15"
+                  ]
+                }
+              ]
+            }
+          ],
+          "targetEntity": "item"
+        }
+      },
+      "title": "Default Catalog"
+    },
+    "feeds": {},
+    "permissions": [
+      {
+        "collaborationId": "f2266019e642414ab8bf931a1f856b15",
+        "collaborationType": "group",
+        "permission": "hub:project:create"
+      },
+      {
+        "collaborationId": "paige_pa",
+        "collaborationType": "user",
+        "permission": "hub:site:delete"
+      }
+    ],
+    "settings": {
+      "capabilities": {
+        "details": true,
+        "overview": true,
+        "settings": true
+      }
+    },
+    "values": {
+      "capabilities": [
+        "api_explorer",
+        "pages",
+        "my_data",
+        "social_logins",
+        "json_chart_card",
+        "document_iframes",
+        "items_view",
+        "app_page",
+        "underlinedLinks",
+        "globalNav",
+        "socialSharing"
+      ],
+      "clientId": "7YjUTPIE2K5z6Ku1",
+      "contentViews": {
+        "sidePanelOpen": {
+          "app": true,
+          "dataset": true,
+          "document": true,
+          "feedback": true,
+          "map": true
+        }
+      },
+      "customHostname": "",
+      "defaultExtent": {
+        "spatialReference": {
+          "wkid": 102100
+        },
+        "xmax": -6199999.999999268,
+        "xmin": -14999999.999998225,
+        "ymax": 6499999.999998959,
+        "ymin": 2699999.9999996596
+      },
+      "defaultHostname": "workspace-qa-pre-a-hub.hubqa.arcgis.com",
+      "faviconUrl": "",
+      "headContent": "",
+      "headerSass": ".first-tier {\n  height: 80px;\n  margin-bottom: 0px;\n  background-color: #005e95;\n}\n\n.first-tier .nav > li > a {\n  margin-top: 5px;\n  padding: 3px 6px;\n  color: #fff;\n}\n\n.first-tier .nav > li > a:focus,\n.first-tier .nav>li>a:hover {\n  background-color: #136fbf;\n  color: #fff;\n}\n\n.first-tier .site-logo img {\n  vertical-align: middle;\n}\n\n.first-tier h1 {\n  display: inline;\n  font-size: 25px;\n}\n\n.second-tier {\n  margin-bottom: 0px;\n  background-color: #05466c;\n}\n\n.site-header .navbar-header img {\n  vertical-align: middle;\n  height: 50px;\n  padding: 5px;\n}\n\n@media (max-width: 768px) {\n  .first-tier {\n    height: 100px;\n  }\n}\n\n@media (max-width: 498px) {\n  .navbar-brand {\n    padding: 0px;\n  }\n}\n\n.navbar-inverse .navbar-toggle {\n  border-color: #ffffff;\n}\n\n.navbar-inverse .navbar-toggle:hover {\n  background-color: transparent;\n}\n\n.navbar-inverse .navbar-toggle .icon-bar {\n  background-color: #ffffff;\n}\n\n",
+      "layout": {
+        "footer": {
+          "component": {
+            "name": "site-footer",
+            "settings": {
+              "footerType": "custom",
+              "markdown": "<div class=\"footer-background\">\n  <div class=\"container-fluid\">\n    <div class=\"col-xs-12\">\n      <img src=\"https://via.placeholder.com/50\" alt=\"\" class=\"center-block logo\">\n    </div>\n    <div class=\"col-xs-6 center-block\">\n      <ul class=\"nav nav-pills\">\n\n        <li><a href=\"\">URL</a></li>\n\n        <li><a href=\"\">URL</a></li>\n\n        <li><a href=\"\">URL</a></li>\n\n        <li><a href=\"\">URL</a></li>\n\n      </ul>\n    </div>\n    <div class=\"col-xs-6 center-block\">\n      <ul class=\"nav nav-pills\" style=\"float:right;\">\n        <li><a href=\"#\">Terms of Service</a></li>\n        <li><a href=\"#\">Privacy Policy</a></li>\n      </ul>\n    </div>\n    <div class=\"col-xs-12\">\n      <div class=\"text-white\" style=\"padding-top: 3rem; text-align: center;\">\n        <p>&copy; Custom Initiative Template. All photos used on this site are from <a href=\"https://unsplash.com/\" style=\"text-decoration: underline;\">Unsplash</a>.</p>\n      </div>\n    </div>\n  </div>\n</div>",
+              "schemaVersion": 1
+            }
+          },
+          "showEditor": false
+        },
+        "header": {
+          "component": {
+            "name": "site-header",
+            "settings": {
+              "fullWidth": false,
+              "headerType": "default",
+              "iframeHeight": "150px",
+              "iframeUrl": "",
+              "links": [],
+              "logo": {
+                "display": {}
+              },
+              "logoUrl": "",
+              "markdown": "<nav class=\"navbar navbar-default navbar-static-top first-tier\">\n  <div class=\"container\">\n    <ul class=\"nav nav-pills pull-right\" role=\"navigation\">\n      <li><a href=\"#\">Terms of Use</a></li>\n      <li><a href=\"#\">Twitter</a></li>\n      <li><a href=\"#\">Blog</a></li>\n    </ul>\n    <div class=\"navbar-brand\">\n      <div class=\"site-logo\">\n        <img src=\"https://via.placeholder.com/50\" alt=\"\">\n        <h1>My Organization</h1>\n      </div>\n    </div>\n  </div>\n</nav>\n<nav class=\"navbar navbar-inverse navbar-static-top second-tier\" role=\"navigation\">\n  <div class=\"navbar-header\">\n    <button type=\"button\" class=\"navbar-toggle collapsed\" data-toggle=\"collapse\" data-target=\"#bs-example-navbar-collapse-1\" aria-expanded=\"false\">\n      <span class=\"sr-only\">Toggle navigation</span>\n      <span class=\"icon-bar\"></span>\n      <span class=\"icon-bar\"></span>\n      <span class=\"icon-bar\"></span>\n    </button>\n  </div>\n  <div class=\"collapse navbar-collapse\" id=\"bs-example-navbar-collapse-1\">\n    <div class=\"container\">\n      <div class=\"navbar\">\n        <ul class=\"nav navbar-nav\">\n          <li class=\"active\"><a href=\"#\">Home</a></li>\n          <li><a href=\"#about\">About</a></li>\n          <li><a href=\"#contact\">Contact</a></li>\n          <li><a href=\"#contact\">Contact</a></li>\n          <li><a href=\"#contact\">Contact</a></li>\n          <li><a href=\"#contact\">Contact</a></li>\n          <li><a href=\"#contact\">Contact</a></li>\n        </ul>\n      </div>\n    </div>\n  </div>\n</nav>\n",
+              "menuLinks": [],
+              "schemaVersion": 3,
+              "shortTitle": "",
+              "showLogo": true,
+              "showTitle": true,
+              "socialLinks": {
+                "facebook": {},
+                "instagram": {},
+                "twitter": {},
+                "youtube": {}
+              },
+              "title": "workspace"
+            }
+          },
+          "showEditor": false
+        },
+        "sections": [
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "\n<br>\n<br>\n<br>\n<br>\n<br><div style=\"text-align: center;\" class=\"banner-heading\"><b>workspace</b></div><p style=\"text-align: center;\"><br></p><p style=\"text-align: center;\"><br></p><p style=\"text-align: center;\">Verify Workspaces for All the Things</p>\n\n\n<br>\n<br>\n<br>\n<br>\n<br>",
+                        "schemaVersion": 2.1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#000000",
+                "cropSrc": "pexels-pixabay-162553.jpg",
+                "display": {},
+                "fileSrc": "pexels-pixabay-162553.jpg",
+                "image": "https://s3.amazonaws.com/geohub-assets/templates/public-engagement/city-architecture.jpg",
+                "isFile": true,
+                "isUrl": false,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "valid",
+                "transparency": 30
+              },
+              "color": "#ffffff",
+              "rowLayout": "box"
+            },
+            "visibility": {
+              "access": "default",
+              "groups": []
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<h5 style=\"text-align: center;\">Create your own initiative by combining existing applications with a custom site. Use this initiative to form teams around a problem and invite your community to participate.</h5><h5 style=\"text-align: center;\"><br></h5><h5 style=\"text-align: center;\">\n</h5><p style=\"text-align: center;\"></p>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#3276ae",
+                "display": {},
+                "image": "",
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              },
+              "color": "#ffffff"
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mt-8 mb-8\" style=\"text-align: center;\">\n    <h1>Our Progress So Far</h1>\n    <p>Leverage this section to share progress or other stats with the public. Make it transparent and exciting to see the results of the hard work or why an initiative needs support. This is also a great space to inspire your audience to potentially get involved.</p>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "summary-statistic-card",
+                      "settings": {
+                        "currencyCode": "USD",
+                        "decimalPlaces": 2,
+                        "formatNumberGroupings": true,
+                        "leadingText": "",
+                        "showAsCurrency": false,
+                        "statFieldName": "",
+                        "statFieldType": "",
+                        "statType": "",
+                        "statValueAlign": "left",
+                        "statValueColor": null,
+                        "timeout": 10,
+                        "title": "Statistic Title",
+                        "titleAlign": "left",
+                        "trailingText": "...",
+                        "trailingTextAlign": "left",
+                        "url": ""
+                      }
+                    },
+                    "width": 4
+                  },
+                  {
+                    "component": {
+                      "name": "summary-statistic-card",
+                      "settings": {
+                        "currencyCode": "USD",
+                        "decimalPlaces": 2,
+                        "formatNumberGroupings": true,
+                        "leadingText": "",
+                        "showAsCurrency": false,
+                        "statFieldName": "",
+                        "statFieldType": "",
+                        "statType": "",
+                        "statValueAlign": "left",
+                        "statValueColor": null,
+                        "timeout": 10,
+                        "title": "Statistic Title",
+                        "titleAlign": "left",
+                        "trailingText": "...",
+                        "trailingTextAlign": "left",
+                        "url": ""
+                      }
+                    },
+                    "width": 4
+                  },
+                  {
+                    "component": {
+                      "name": "summary-statistic-card",
+                      "settings": {
+                        "currencyCode": "USD",
+                        "decimalPlaces": 2,
+                        "formatNumberGroupings": true,
+                        "leadingText": "",
+                        "showAsCurrency": false,
+                        "statFieldName": "",
+                        "statFieldType": "",
+                        "statType": "",
+                        "statValueAlign": "left",
+                        "statValueColor": null,
+                        "timeout": 10,
+                        "title": "Statistic Title",
+                        "titleAlign": "left",
+                        "trailingText": "...",
+                        "trailingTextAlign": "left",
+                        "url": ""
+                      }
+                    },
+                    "width": 4
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mb-4\"></div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "transparent",
+                "display": {},
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              }
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mt-8 mb-4\" style=\"text-align: center;\">\n<h1>Get Involved with the Community Today!</h1>\n<p>Utilize this section to provide steps on how to get involved, show different phases of your initiative or simply highlight areas of concern.</p>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<ul class=\"pledge-wrapper pledge-wrapper-center pledge-numbers-white\">\n\n  <li>\n    <div class=\"pledge-content\">\n      <h3 class=\"pledge-title\">Help improve the air quality</h3>\n      <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n    </div>\n  </li>\n\n  <li>\n    <div class=\"pledge-content\">\n      <h3 class=\"pledge-title\">Report Data</h3>\n      <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n    </div>\n  </li>\n\n  <li>\n    <div class=\"pledge-content\">\n      <h3 class=\"pledge-title\">Become Involved</h3>\n      <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n    </div>\n  </li>\n\n  <li>\n    <div class=\"pledge-content\">\n      <h3 class=\"pledge-title\">Contribute</h3>\n      <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n    </div>\n  </li>\n  \n</ul>\n\n\n<style>\n/* Pledge Wrapper - Default */\n.pledge-wrapper,\n.pledge-wrapper-center,\n.pledge-wrapper-simple {\n  list-style: none;\n  margin: 0;\n  padding: 0;\n  display: flex;\n  flex-flow: row wrap; }\n\n.pledge-wrapper li,\n.pledge-wrapper-center li,\n.pledge-wrapper-simple li {\n  counter-increment: pledge-counter;\n  position: relative;\n  flex-basis: 25%;\n  width: 25%;\n  margin-top: 40px;\n  padding-top: 40px; }\n\n@media screen and (max-width: 800px) {\n  .pledge-wrapper li,\n  .pledge-wrapper-center li,\n  .pledge-wrapper-simple li {\n    flex-basis: 50%;\n    width: 50%; }\n  .pledge-wrapper li::before,\n  .pledge-wrapper-center li::before,\n  .pledge-wrapper-simple li::before {\n    transform: translate(0, -50%) !important; } }\n\n@media screen and (max-width: 600px) {\n  .pledge-wrapper li,\n  .pledge-wrapper-center li,\n  .pledge-wrapper-simple li {\n    flex-basis: 100%;\n    width: 100%; } }\n\n.pledge-wrapper li::before,\n.pledge-wrapper-center li::before,\n.pledge-wrapper-simple li::before {\n  box-sizing: border-box;\n  content: counter(pledge-counter);\n  display: inline-block;\n  font-family: 'Avenir', sans-serif;\n  font-size: 3rem;\n  font-weight: 600;\n  line-height: 1;\n  text-align: center;\n  background-color: #4C93E0;\n  border-radius: 50%;\n  color: #fff;\n  padding: 1rem;\n  height: 48px;\n  width: 48px;\n  position: absolute;\n  top: 0;\n  left: 0;\n  transform: translate(-50%, -50%);\n  z-index: 4; }\n\n.pledge-wrapper li::after,\n.pledge-wrapper-center li::after {\n  content: '';\n  display: block;\n  background-color: #4C93E0;\n  border-radius: 0;\n  height: 10px;\n  width: 100%;\n  position: absolute;\n  top: 0;\n  transform: translateY(-50%);\n  z-index: 2; }\n\n.pledge-wrapper li:first-of-type::after,\n.pledge-wrapper-center li:first-of-type::after {\n  border-radius: 10px 0 0 10px; }\n\n.pledge-wrapper li:last-of-type::after,\n.pledge-wrapper-center li:last-of-type::after {\n  border-radius: 0 10px 10px 0; }\n\n.pledge-wrapper .pledge-content,\n.pledge-wrapper-center .pledge-content {\n  box-sizing: border-box;\n  margin-top: -1.5rem;\n  padding: 0 2rem; }\n\n.pledge-wrapper .pledge-content .pledge-title,\n.pledge-wrapper-center .pledge-content .pledge-title,\n.pledge-wrapper-simple .pledge-content .pledge-title {\n  font-family: 'Avenir', sans-serif;\n  font-size: 2rem;\n  font-weight: 500; }\n\n/* Pledge Wrapper - Centered */\n.pledge-wrapper-center li::before {\n  font-size: 2rem;\n  left: 50%;\n  height: 56px;\n  width: 56px; }\n\n@media screen and (max-width: 800px) {\n  .pledge-wrapper-center li::before {\n    transform: translate(-50%, -50%) !important; } }\n\n.pledge-wrapper-center li::after {\n  border-radius: 0; }\n\n.pledge-wrapper-center .pledge-content {\n  text-align: center; }\n\n/* Pledge Wrapper - List */\n.pledge-wrapper-list {\n  list-style: none;\n  margin: 0;\n  padding: 0; }\n\n.pledge-wrapper-list li {\n  counter-increment: pledge-counter;\n  position: relative;\n  margin-left: 60px;\n  padding: 1rem 0; }\n\n.pledge-wrapper-list li::before {\n  box-sizing: border-box;\n  content: counter(pledge-counter);\n  display: inline-block;\n  font-family: 'Avenir', sans-serif;\n  font-size: 6rem;\n  font-weight: 600;\n  line-height: 1;\n  text-align: center;\n  color: #4C93E0;\n  position: absolute;\n  top: 50%;\n  left: -35px;\n  transform: translate(-50%, -50%);\n  z-index: 4; }\n\n/* Pledge Wrapper - Simple */\n.pledge-wrapper-simple li::before {\n  background-color: transparent;\n  border-radius: 0;\n  color: #4C93E0;\n  font-size: 6rem; }\n\n/* Pledge Wrapper - White Numbers (Modifier) */\n.pledge-numbers-white li::before {\n  background-color: #fff;\n  border: 1px solid #4C93E0;\n  color: #4C93E0; }\n\n.flex-row {\n  display: flex;\n  align-items: center; }\n\n@media screen and (max-width: 767px) {\n  .flex-row {\n    flex-direction: column; } }\n</style>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mt-3 mb-10\" style=\"text-align: center;\">\n  <a href=\"#\" class=\"btn btn-lg btn-primary\">Contribute</a>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#f5f5f5",
+                "display": {},
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              },
+              "color": "#4e4e4e"
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mt-8 mb-6\" style=\"text-align: center;\">\n  <h1>Our Focus</h1>\n<p>Leverage these sections to tell your initiative story. Provide key information regarding your initiatives with an opportunity to go to a specific page or app to learn more.  </p>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "image-card",
+                      "settings": {
+                        "alt": "",
+                        "caption": "",
+                        "captionAlign": "center",
+                        "cropSrc": "",
+                        "display": {
+                          "position": {
+                            "x": "center",
+                            "y": "center"
+                          },
+                          "reflow": false
+                        },
+                        "fileSrc": "",
+                        "hyperlink": "",
+                        "hyperlinkTabOption": "new",
+                        "isFile": false,
+                        "isUrl": true,
+                        "src": "https://s3.amazonaws.com/geohub-assets/templates/public-engagement/planting-trees.jpg",
+                        "state": "valid"
+                      }
+                    },
+                    "width": 6
+                  },
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"display-flex flex-middle\" style=\"min-height: 360px\">\n  <div>\n    <h2>Section Heading</h2>\n    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>\n    \n    <p><a href=\"#\" class=\"btn btn-primary\">Call To Action</a></p>\n  </div>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 6
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"display-flex flex-middle\" style=\"min-height: 360px\">\n  <div>\n    <h2>Section Heading</h2>\n    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>\n    \n    <p><a href=\"#\" class=\"btn btn-primary\">Call To Action</a></p>\n  </div>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 6
+                  },
+                  {
+                    "component": {
+                      "name": "image-card",
+                      "settings": {
+                        "alt": "",
+                        "caption": "",
+                        "captionAlign": "center",
+                        "cropSrc": "",
+                        "display": {
+                          "position": {
+                            "x": "center",
+                            "y": "center"
+                          },
+                          "reflow": false
+                        },
+                        "fileSrc": "",
+                        "hyperlink": "",
+                        "hyperlinkTabOption": "new",
+                        "isFile": false,
+                        "isUrl": true,
+                        "src": "https://s3.amazonaws.com/geohub-assets/templates/public-engagement/growing-tomatoes.jpg",
+                        "state": "valid"
+                      }
+                    },
+                    "width": 6
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "image-card",
+                      "settings": {
+                        "alt": "",
+                        "caption": "",
+                        "captionAlign": "center",
+                        "cropSrc": "",
+                        "display": {
+                          "position": {
+                            "x": "center",
+                            "y": "center"
+                          },
+                          "reflow": false
+                        },
+                        "fileSrc": "",
+                        "hyperlink": "",
+                        "hyperlinkTabOption": "new",
+                        "isFile": false,
+                        "isUrl": true,
+                        "src": "https://s3.amazonaws.com/geohub-assets/templates/public-engagement/wind-turbines.jpg",
+                        "state": "valid"
+                      }
+                    },
+                    "width": 6
+                  },
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"display-flex flex-middle\" style=\"min-height: 360px\">\n  <div>\n    <h2>Section Heading</h2>\n    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>\n    \n    <p><a href=\"#\" class=\"btn btn-primary\">Call To Action</a></p>\n  </div>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 6
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"display-flex flex-middle\" style=\"min-height: 360px\">\n  <div>\n    <h2>Section Heading</h2>\n    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>\n    \n    <p><a href=\"#\" class=\"btn btn-primary\">Call To Action</a></p>\n  </div>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 6
+                  },
+                  {
+                    "component": {
+                      "name": "image-card",
+                      "settings": {
+                        "alt": "",
+                        "caption": "",
+                        "captionAlign": "center",
+                        "cropSrc": "",
+                        "display": {
+                          "position": {
+                            "x": "center",
+                            "y": "center"
+                          },
+                          "reflow": false
+                        },
+                        "fileSrc": "",
+                        "hyperlink": "",
+                        "hyperlinkTabOption": "new",
+                        "isFile": false,
+                        "isUrl": true,
+                        "src": "https://s3.amazonaws.com/geohub-assets/templates/public-engagement/bike-rentals.jpg",
+                        "state": "valid"
+                      }
+                    },
+                    "width": 6
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "transparent",
+                "display": {},
+                "image": "",
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              },
+              "color": "#444444"
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mt-4 mb-2\" style=\"text-align: center;\">\n  <h1>Don't just tell the story, show the story</h1>\n<p> Utilize an Esri Map on this page to show the changes or the primary areas of focus. </p>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "webmap-card",
+                      "settings": {
+                        "enableMapLegend": false,
+                        "height": "400",
+                        "mobileEnableMapLegend": false,
+                        "mobileHeight": 500,
+                        "mobileItem": null,
+                        "mobileShowTitle": true,
+                        "mobileTitle": "New Map",
+                        "mobileTitleAlign": "left",
+                        "mobileWebmap": null,
+                        "mobileWebscene": null,
+                        "showTitle": true,
+                        "title": "",
+                        "titleAlign": "left",
+                        "webmap": "",
+                        "webscene": null
+                      }
+                    },
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#ededed",
+                "display": {},
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              },
+              "color": "#444444"
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div  class=\"mt-10 mb-8\" style=\"text-align: center;\">\n<h1>See Our City in Action</h1>\n<p>Use this section to save your community visitors research time and connect them with reports, apps, and links to other sites, that will give them deeper insights on the initiative regarding your city.</p>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "hub-gallery-card",
+                      "settings": {
+                        "contentResponse": true,
+                        "displayOption": [
+                          "application"
+                        ],
+                        "imageType": "Thumbnails",
+                        "includedOption": "application",
+                        "orgId": "Xj56SBi2udA78cC9",
+                        "query": {
+                          "num": "4",
+                          "tags": []
+                        },
+                        "selectedGroups": [
+                          {
+                            "id": "6751456a44104631b1006fd0d9a2573c",
+                            "title": "workspace"
+                          }
+                        ],
+                        "siteId": "",
+                        "viewText": "Explore"
+                      }
+                    },
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#ffffff",
+                "display": {},
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              },
+              "color": "#444444"
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "event-list-card",
+                      "settings": {
+                        "backgroundColor": "#ffffff",
+                        "cardVersion": 2,
+                        "defaultView": "calendar",
+                        "display": {
+                          "colorPalette": "custom",
+                          "cornerStyle": "square",
+                          "dropShadow": "none"
+                        },
+                        "displayMode": "calendar",
+                        "eventListTitleAlign": "left",
+                        "height": 500,
+                        "initiativeIds": [
+                          "409e55090f704fd99de0b04eaea082b8"
+                        ],
+                        "listEnabled": true,
+                        "showTitle": true,
+                        "subtitle": "Location",
+                        "textColor": "#000000",
+                        "title": "List of upcoming events"
+                      }
+                    },
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#367aaa",
+                "display": {},
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              }
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"section-follow mt-10\">\n  <h1 class=\"section-follow-title\">Sign Up and Follow this initiative</h1>\n  <hr />\n  <div class=\"section-follow-content\">\n    <p>Drive people to Sign Up for a community account and follow this initiative to receive updates from you. You can use the list to send email communication and invitations to host events.</p>\n  </div>\n</div>\n\n\n<style>\n  .section-follow {\n    margin-left: auto;\n    margin-right: auto;\n    padding-top: 2rem;\n    text-align: center;\n    width: 60%;\n  }\n\n  .section-follow .section-follow-title {\n    margin: 0 0 1.5rem;\n  }\n\n  .section-follow hr {\n    background-color: #3677ac;\n    border: 0;\n    height: 2px;\n    width: 100px;\n  }\n\n  .section-follow .section-follow-content {\n    font-size: 16px;\n    margin-bottom: 2rem;\n  }\n</style>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "follow-initiative-card",
+                      "settings": {
+                        "buttonAlign": "center",
+                        "buttonStyle": "solid",
+                        "buttonText": "Follow Our Initiative",
+                        "callToActionAlign": "center",
+                        "callToActionText": "",
+                        "initiativeId": "409e55090f704fd99de0b04eaea082b8",
+                        "unfollowButtonText": "Stop Following"
+                      }
+                    },
+                    "width": 12
+                  }
+                ]
+              },
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mb-10\">&nbsp;</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 12
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#333333",
+                "darken": true,
+                "display": {},
+                "image": "https://s3.amazonaws.com/geohub-assets/templates/public-engagement/greenspace-community-center.jpg",
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "valid",
+                "transparency": 0
+              },
+              "color": "#ffffff"
+            }
+          },
+          {
+            "containment": "fixed",
+            "isFooter": false,
+            "rows": [
+              {
+                "cards": [
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div>&nbsp;</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 3
+                  },
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div class=\"mt-6 mb-6\" style=\"text-align: center;\">\n  <h1>Contact</h1>\n  <p>Make your site a two-way communication platform with your community. Use this to let them know that you welcome their feedback and that you want to hear from them.</p>\n  <p><a href=\"#\" class=\"btn btn-lg btn-primary\">Call To Action</a></p>\n</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 6
+                  },
+                  {
+                    "component": {
+                      "name": "markdown-card",
+                      "settings": {
+                        "markdown": "<div>&nbsp;</div>",
+                        "schemaVersion": 1
+                      }
+                    },
+                    "showEditor": false,
+                    "width": 3
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "background": {
+                "color": "#555555",
+                "darken": true,
+                "display": {},
+                "image": "",
+                "isFile": false,
+                "isUrl": true,
+                "position": {
+                  "x": "center",
+                  "y": "center"
+                },
+                "state": "",
+                "transparency": 0
+              },
+              "color": "#ffffff"
+            }
+          }
+        ]
+      },
+      "map": {
+        "basemaps": {
+          "primary": {
+            "baseMapLayers": [
+              {
+                "id": "VectorTile_4246",
+                "layerType": "VectorTileLayer",
+                "opacity": 1,
+                "styleUrl": "https://cdn.arcgis.com/sharing/rest/content/items/aa30dd52509a4fea939ccbfc3c3e14de/resources/styles/root.json",
+                "title": "Colored Pencil",
+                "type": "VectorTileLayer",
+                "visibility": true
+              }
+            ],
+            "id": "a17e26cc129844668c8af39e26144006",
+            "operationalLayers": [],
+            "title": "Colored Pencil Map"
+          }
+        }
+      },
+      "pages": [],
+      "subdomain": "workspace",
+      "telemetry": {
+        "consentNotice": {
+          "consentText": "",
+          "isTheme": true,
+          "policyURL": ""
+        },
+        "customAnalytics": {
+          "ga": {
+            "customerTracker": {
+              "enabled": false
+            }
+          }
+        }
+      },
+      "theme": {
+        "body": {
+          "background": "#ffffff",
+          "link": "#004da8",
+          "text": "#242424"
+        },
+        "button": {
+          "background": "#55ff00",
+          "text": "#004da8"
+        },
+        "fonts": {
+          "base": {
+            "family": "Avenir Next",
+            "url": ""
+          },
+          "heading": {
+            "family": "Avenir Next",
+            "url": ""
+          }
+        },
+        "globalNav": {
+          "background": "#004da8",
+          "text": "#55ff00"
+        },
+        "header": {
+          "background": "#004da8",
+          "text": "#55ff00"
+        },
+        "logo": {
+          "small": "https://qa-pre-a-hub.mapsqa.arcgis.com/sharing/rest/content/items/ae2026ab67c04ad9ad0d109ce2ff8a07/data"
+        }
+      },
+      "title": "",
+      "uiVersion": "2.4"
+    }
+  },
+  "item": {
+    "access": "shared",
+    "categories": [],
+    "created": 1684268891000,
+    "culture": "en-us",
+    "description": "Create your own initiative by combining existing applications with a custom site. Use this initiative to form teams around a problem and invite your community to participate.",
+    "id": "cb30e780b44146c49841ed7343394d58",
+    "itemControl": "admin",
+    "modified": 1684269091000,
+    "owner": "paige_pa",
+    "properties": {
+      "clientId": "",
+      "customHostname": "",
+      "defaultHostname": "",
+      "orgUrlKey": "qa-pre-a-hub",
+      "schemaVersion": 1.7,
+      "slug": "",
+      "subdomain": ""
+    },
+    "snippet": "Create your own initiative by combining existing applications with a custom site. Use this initiative to form teams around a problem and invite your community to participate.",
+    "tags": [
+      "Hub Site"
+    ],
+    "title": "workspace yo",
+    "type": "Hub Site Application",
+    "typeKeywords": [
+      "Hub",
+      "hubSite",
+      "hubSolution",
+      "JavaScript",
+      "Map",
+      "Mapping Site",
+      "Online Map",
+      "OpenData",
+      "Ready To Use",
+      "selfConfigured",
+      "source-embedded-premium-default-site",
+      "Web Map",
+      "Registered App"
+    ],
+    "url": "https://workspace-qa-pre-a-hub.hubqa.arcgis.com"
+  }
+}


### PR DESCRIPTION
1. Description:
- adds just enough Site Schema to enable loading a Site into the Configuration Editor. The schema is incomplete, and the config editor can not actually save the site because mapping from `IHubSite` -> `IModel` does not include all the necessary information required to actually update a Site item. Additional work is necessary.
- Also adds more props to the Initiative editor schema - title, desc, snippet, location etc

1. Instructions for testing: run-tests

1. Related to Issues: #[6789](https://devtopia.esri.com/dc/hub/issues/6789)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
