### PR TITLE
feat(hub-discussions): updates IPost and IPostOptions to support anon…

### DIFF
--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -441,7 +441,10 @@ export enum PostType {
  * @extends {IWithEditor}
  * @extends {IWithTimestamps}
  */
-export interface IPost extends IWithAuthor, IWithEditor, IWithTimestamps {
+export interface IPost
+  extends Partial<IWithAuthor>,
+    Partial<IWithEditor>,
+    IWithTimestamps {
   id: string;
   title: string | null;
   body: string;
@@ -473,6 +476,7 @@ export interface IPostOptions {
   geometry?: Geometry;
   featureGeometry?: Geometry;
   appInfo?: string;
+  asAnonymous?: boolean;
 }
 
 /**


### PR DESCRIPTION
…ymous posts

affects: @esri/hub-discussions

1. Description: Update `IPost` interface to optional include `editor` and `creator`, since anonymous posts will hide these properties.  Adds `asAnonymous` to `IPostOptions` interface to denote that a post should be treated as anonymous.

1. Instructions for testing: n/a - just interface changes

1. Closes Issues: n/a

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
