### PR TITLE
feat: remove calls to register or update app

### DIFF
--- a/packages/common/src/items/index.ts
+++ b/packages/common/src/items/index.ts
@@ -22,3 +22,7 @@ export * from "./create-item-from-url";
 export * from "./create-item-from-url-or-file";
 export * from "./uploadImageResource";
 export * from "./is-services-directory-disabled";
+// No longer exported as the only App Hub needed this for was a Site
+// and that registration is now done in the domain service with a
+// signed HMAC request.
+// export * from "./registerBrowserApp";

--- a/packages/common/src/items/registerBrowserApp.ts
+++ b/packages/common/src/items/registerBrowserApp.ts
@@ -2,6 +2,8 @@ import { IRequestOptions, request } from "@esri/arcgis-rest-request";
 import { getPortalApiUrl } from "../urls";
 
 /**
+ * @private
+ * @internal
  * Register an Item as an application, enabling oAuth flows at custom
  * domains. Only item types with "Application" in the name are valid
  * with this API call.

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -273,11 +273,14 @@ export async function createSite(
   );
 
   // Register as an app
-  const registration = await registerSiteAsApplication(model, requestOptions);
-  model.data.values.clientId = registration.client_id;
+  // const registration = await registerSiteAsApplication(model, requestOptions);
+  // model.data.values.clientId = registration.client_id;
+  // NOTE: Site registration needs to happen via the hub api domain api calls
+  // See https://devtopia.esri.com/dc/hub/issues/6390 for info
 
-  // Register domains
-  await addSiteDomains(model, requestOptions);
+  // Register domain and at the same time register the site as an application
+  const domainResponses = await addSiteDomains(model, requestOptions);
+  model.data.values.clientId = domainResponses[0].client_id;
 
   // update the model
   const updatedModel = await updateModel(
@@ -324,26 +327,6 @@ export async function updateSite(
   // convert that back into a IHubSite and return it
   const updatedSite = convertModelToSite(updatedSiteModel, requestOptions);
   return updatedSite;
-}
-
-/**
- * @private
- * Remove a Hub Site
- *
- * This simply removes the Site item, and it's associated domain records.
- * This does not remove any Teams/Groups or content associated with the
- * Site
- * @param id
- * @param requestOptions
- * @returns
- */
-export async function destroySite(
-  id: string,
-  requestOptions: IHubRequestOptions
-): Promise<void> {
-  // tslint:disable-next-line:no-console
-  console.warn(`destroySite is deprecated, use deleteSite instead`);
-  return deleteSite(id, requestOptions);
 }
 
 /**

--- a/packages/common/src/sites/index.ts
+++ b/packages/common/src/sites/index.ts
@@ -7,7 +7,9 @@ export * from "./fetchSiteModel";
 export * from "./get-site-by-id";
 export * from "./HubSite";
 export * from "./HubSites";
-export * from "./registerSiteAsApplication";
 export * from "./site-schema-version";
 export * from "./themes";
 export * from "./upgrade-site-schema";
+// No longer exported b/c site app registration is now handled
+// by the domain service due to requirement to send signed HMAC request
+// export * from "./registerSiteAsApplication";

--- a/packages/common/src/sites/registerSiteAsApplication.ts
+++ b/packages/common/src/sites/registerSiteAsApplication.ts
@@ -3,6 +3,10 @@ import { getProp } from "../objects";
 import { IHubRequestOptions, IModel } from "../types";
 import { _getHttpAndHttpsUris } from "../urls";
 /**
+ * @private
+ * @internal
+ * As of May 2023, Hub Site Application registration must be done via HMAC signed request
+ * which is handled by the Hub Domain Service. This file is left here for reference.
  * Register the Site item as an application so we can oauth against it
  * @param {string} siteId Item Id of the site
  * @param {Array} uris Arrayf valid uris for the site

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -299,7 +299,7 @@ export interface IUpdatePageOptions extends IHubUserRequestOptions {
 }
 
 export interface IDomainEntry {
-  clientKey: string;
+  clientKey?: string;
   createdAt?: string;
   hostname: string;
   id: string;

--- a/packages/common/test/items/registerBrowserApp.test.ts
+++ b/packages/common/test/items/registerBrowserApp.test.ts
@@ -1,4 +1,4 @@
-import { registerBrowserApp } from "../../src";
+import { registerBrowserApp } from "../../src/items/registerBrowserApp";
 import * as requestModule from "@esri/arcgis-rest-request";
 
 describe("registerBrowserApp", () => {

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -232,7 +232,7 @@ describe("HubSites:", () => {
     });
   });
 
-  describe("destroySite:", () => {
+  describe("deleteSite:", () => {
     it("removes item and domains in AGO", async () => {
       const removeSpy = spyOn(portalModule, "removeItem").and.returnValue(
         Promise.resolve({ success: true })
@@ -243,7 +243,7 @@ describe("HubSites:", () => {
         "removeDomainsBySiteId"
       ).and.returnValue(Promise.resolve());
 
-      const result = await commonModule.destroySite("3ef", {
+      const result = await commonModule.deleteSite("3ef", {
         authentication: MOCK_AUTH,
       });
       expect(result).toBeUndefined();
@@ -258,7 +258,7 @@ describe("HubSites:", () => {
         Promise.resolve({ success: true })
       );
 
-      const result = await commonModule.destroySite(
+      const result = await commonModule.deleteSite(
         "3ef",
         MOCK_ENTERPRISE_REQOPTS
       );
@@ -324,7 +324,7 @@ describe("HubSites:", () => {
     let uniqueDomainSpy: jasmine.Spy;
     let createModelSpy: jasmine.Spy;
     let updateModelSpy: jasmine.Spy;
-    let registerAppSpy: jasmine.Spy;
+
     let addDomainsSpy: jasmine.Spy;
     beforeEach(() => {
       uniqueDomainSpy = spyOn(
@@ -348,15 +348,11 @@ describe("HubSites:", () => {
         const newModel = commonModule.cloneObject(m);
         return Promise.resolve(newModel);
       });
-      registerAppSpy = spyOn(
-        require("../../src/sites/registerSiteAsApplication"),
-        "registerSiteAsApplication"
-      ).and.returnValue(Promise.resolve({ client_id: "FAKE_CLIENT_ID" }));
 
       addDomainsSpy = spyOn(
         require("../../src/sites/domains/addSiteDomains"),
         "addSiteDomains"
-      ).and.returnValue(Promise.resolve());
+      ).and.returnValue(Promise.resolve([{ clientKey: "FAKE_CLIENT_KEY" }]));
     });
     it("works with a sparse IHubSite", async () => {
       const sparseSite: Partial<commonModule.IHubSite> = {
@@ -369,7 +365,7 @@ describe("HubSites:", () => {
       expect(uniqueDomainSpy.calls.count()).toBe(1);
       expect(createModelSpy.calls.count()).toBe(1);
       expect(updateModelSpy.calls.count()).toBe(1);
-      expect(registerAppSpy.calls.count()).toBe(1);
+
       expect(addDomainsSpy.calls.count()).toBe(1);
 
       const modelToCreate = createModelSpy.calls.argsFor(0)[0];
@@ -425,7 +421,7 @@ describe("HubSites:", () => {
       expect(uniqueDomainSpy.calls.count()).toBe(1);
       expect(createModelSpy.calls.count()).toBe(1);
       expect(updateModelSpy.calls.count()).toBe(1);
-      expect(registerAppSpy.calls.count()).toBe(1);
+
       expect(addDomainsSpy.calls.count()).toBe(1);
 
       expect(chk.name).toBe("Special Site");
@@ -449,7 +445,7 @@ describe("HubSites:", () => {
       expect(uniqueDomainSpy.calls.count()).toBe(1);
       expect(createModelSpy.calls.count()).toBe(1);
       expect(updateModelSpy.calls.count()).toBe(1);
-      expect(registerAppSpy.calls.count()).toBe(1);
+
       expect(addDomainsSpy.calls.count()).toBe(1);
 
       const modelToCreate = createModelSpy.calls.argsFor(0)[0];

--- a/packages/common/test/sites/registerBrowserApp.test.ts
+++ b/packages/common/test/sites/registerBrowserApp.test.ts
@@ -1,4 +1,4 @@
-import { registerBrowserApp } from "../../src";
+import { registerBrowserApp } from "../../src/items/registerBrowserApp";
 import * as requestModule from "@esri/arcgis-rest-request";
 
 describe("registerBrowserApp", () => {

--- a/packages/common/test/sites/registerSiteAsApplication.test.ts
+++ b/packages/common/test/sites/registerSiteAsApplication.test.ts
@@ -1,4 +1,5 @@
 import * as commonModule from "../../src";
+import { registerSiteAsApplication } from "../../src/sites/registerSiteAsApplication";
 import * as regiserBrowserAppModule from "../../src/items/registerBrowserApp";
 
 describe("registerSiteAsApplication", () => {
@@ -19,7 +20,7 @@ describe("registerSiteAsApplication", () => {
       },
     } as unknown as commonModule.IModel;
 
-    await commonModule.registerSiteAsApplication(
+    await registerSiteAsApplication(
       model,
       {} as commonModule.IHubRequestOptions
     );
@@ -58,7 +59,7 @@ describe("registerSiteAsApplication", () => {
       },
     } as unknown as commonModule.IModel;
 
-    await commonModule.registerSiteAsApplication(
+    await registerSiteAsApplication(
       model,
       {} as commonModule.IHubRequestOptions
     );
@@ -97,7 +98,7 @@ describe("registerSiteAsApplication", () => {
       },
     } as unknown as commonModule.IModel;
 
-    await commonModule.registerSiteAsApplication(model, {
+    await registerSiteAsApplication(model, {
       isPortal: true,
     } as commonModule.IHubRequestOptions);
 

--- a/packages/discussions/package.json
+++ b/packages/discussions/package.json
@@ -13,7 +13,7 @@
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.14.0 || 3",
     "@esri/arcgis-rest-request": "^2.14.0 || 3",
-    "@esri/hub-common": "^12.4.0"
+    "@esri/hub-common": "^12.4.0 || 13"
   },
   "devDependencies": {
     "@esri/hub-common": "*",

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-feature-layer": "^3.1.0",
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.0",
-    "@esri/hub-common": "^12.4.0"
+    "@esri/hub-common": "^12.4.0 || 13"
   },
   "devDependencies": {
     "@esri/hub-common": "*",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-portal": "^2.15.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "^12.4.0"
+    "@esri/hub-common": "^12.4.0 || 13"
   },
   "devDependencies": {
     "@esri/hub-common": "*",

--- a/packages/initiatives/package.json
+++ b/packages/initiatives/package.json
@@ -14,7 +14,7 @@
     "@esri/arcgis-rest-auth": "^2.13.0 || 3",
     "@esri/arcgis-rest-portal": "^2.13.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
-    "@esri/hub-common": "^12.4.0"
+    "@esri/hub-common": "^13"
   },
   "devDependencies": {
     "@esri/hub-common": "*",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-portal": "^2.6.1 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "^12.4.0"
+    "@esri/hub-common": "^12.4.0 || 13"
   },
   "devDependencies": {
     "@esri/hub-common": "*",

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -14,7 +14,7 @@
     "@esri/arcgis-rest-auth": "^2.13.0 || 3",
     "@esri/arcgis-rest-portal": "^2.19.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
-    "@esri/hub-common": "^12.4.0",
+    "@esri/hub-common": "^13",
     "@esri/hub-initiatives": "^12.4.0",
     "@esri/hub-teams": "^12.4.0"
   },

--- a/packages/sites/src/create-site.ts
+++ b/packages/sites/src/create-site.ts
@@ -7,7 +7,6 @@ import {
   uploadResourcesFromUrl,
   getProp,
   addSiteDomains,
-  registerSiteAsApplication,
 } from "@esri/hub-common";
 import { ensureRequiredSiteProperties } from "./ensure-required-site-properties";
 import {
@@ -60,13 +59,14 @@ export function createSite(
       });
     })
     .then((protectResponse) => {
-      // do app registration
-
-      return registerSiteAsApplication(model, hubRequestOptions);
+      // get the clientId out of the addSiteDomains call
+      return addSiteDomains(model, hubRequestOptions);
     })
-    .then((appRegistrationResponse) => {
-      // store the clientId
-      model.data.values.clientId = appRegistrationResponse.client_id;
+    .then((domainResponses) => {
+      // client id will be the same for all domain resonses so we can just grab the first one
+      // no guard clause because the only way we don't get a response is if addSiteDomains throws
+      // which would not hit this code
+      model.data.values.clientId = domainResponses[0].clientKey;
       // If we have a dcat section, hoist it out as it may contain complex adlib
       // templates that are needed at run-time
       // If we have data.values.dcatConfig, yank it off b/c that may have adlib template stuff in it
@@ -85,11 +85,6 @@ export function createSite(
       });
     })
     .then((updateResponse) => {
-      // Handle domains
-
-      return addSiteDomains(model, hubRequestOptions);
-    })
-    .then((domainResponses) => {
       // upload resources from url
 
       return uploadResourcesFromUrl(

--- a/packages/sites/src/update-site-application-uris.ts
+++ b/packages/sites/src/update-site-application-uris.ts
@@ -23,21 +23,11 @@ export function updateSiteApplicationUris(
   hubRequestOptions: IHubRequestOptions
 ) {
   if (hubRequestOptions.isPortal) return Promise.resolve({});
-  // get http and https versions of all uris
-  const redirectUris = uris.reduce((acc, uri) => {
-    return acc.concat(_getHttpAndHttpsUris(uri));
-  }, []);
-  // update the redirect uris for the application
-  return updateAppRedirectUris(
-    site.data.values.clientId,
-    redirectUris,
-    hubRequestOptions
-  )
-    .then(() => {
-      // now we update the domains, removing any that are no longer used
-      return getDomainsForSite(site.item.id, hubRequestOptions);
-    })
-    .then((domainInfos: IDomainEntry[]) => {
+
+  // Domain service handles updating the app redirect uris for sites
+  // First, get the domain records associated with the site
+  return getDomainsForSite(site.item.id, hubRequestOptions).then(
+    (domainInfos: IDomainEntry[]) => {
       // get all domains that are no longer associated with the site
       const domainsToRemove = domainInfos.filter(
         (domain) => !includes(uris, domain.hostname)
@@ -69,5 +59,6 @@ export function updateSiteApplicationUris(
         )
       );
       return Promise.all(domainPromises);
-    });
+    }
+  );
 }

--- a/packages/sites/test/create-site.test.ts
+++ b/packages/sites/test/create-site.test.ts
@@ -6,27 +6,8 @@ import * as initiativesModule from "@esri/hub-initiatives";
 import { IModel } from "@esri/hub-common";
 
 describe("create site :: ", function () {
-  const APP_REGISTRATION_RESPONSE: any = {
-    itemId: "3ef",
-    client_id: "031AYEM9fd1X1ac9",
-    client_secret: "f44501a0ab744463af5ce338429833db",
-    appType: "browser",
-    redirect_uris: [
-      "http://my-site.com",
-      "https://my-site.com",
-      "https://name-org.hub.arcgis.com",
-      "http://name-org.hub.arcgis.com",
-    ],
-    registered: 1580932896000,
-    modified: 1580932896000,
-    apnsProdCert: null,
-    apnsSandboxCert: null,
-    gcmApiKey: null,
-  };
-
   let createSpy: jasmine.Spy;
   let protectSpy: jasmine.Spy;
-  let registerSpy: jasmine.Spy;
   let updateSpy: jasmine.Spy;
   let domainsSpy: jasmine.Spy;
   let uploadResourcesSpy: jasmine.Spy;
@@ -38,15 +19,16 @@ describe("create site :: ", function () {
     protectSpy = spyOn(portalModule, "protectItem").and.returnValue(
       Promise.resolve({ success: true, id: "3ef" })
     );
-    registerSpy = spyOn(
-      commonModule,
-      "registerSiteAsApplication"
-    ).and.returnValue(Promise.resolve(APP_REGISTRATION_RESPONSE));
+
     updateSpy = spyOn(portalModule, "updateItem").and.returnValue(
       Promise.resolve({ success: true, id: "3ef" })
     );
     domainsSpy = spyOn(commonModule, "addSiteDomains").and.returnValue(
-      Promise.resolve({})
+      Promise.resolve([
+        {
+          clientKey: "FAKECLIENTKEY",
+        },
+      ])
     );
     uploadResourcesSpy = spyOn(
       commonModule,
@@ -79,15 +61,15 @@ describe("create site :: ", function () {
     const result = await createSite(site, {}, ro);
 
     expect(result.item.id).toBe("3ef", "should attach id into returned model");
-    expect(result.data.values.clientId).toBe(
-      "031AYEM9fd1X1ac9",
+    expect(result.data?.values.clientId).toBe(
+      "FAKECLIENTKEY",
       "should attach client Id into returned model"
     );
     expect(result.item.typeKeywords).toContain(
       "hubSite",
       "should add missing typeKeywords array and add hubSite"
     );
-    expect(result.data.values.verifySecondPass).toBe(
+    expect(result.data?.values.verifySecondPass).toBe(
       "this should be 3ef interpolated",
       "should do second pass appid interpolation"
     );
@@ -95,14 +77,7 @@ describe("create site :: ", function () {
     // no collab group, so no sharing call
     expect(shareSpy).not.toHaveBeenCalled();
     expectAllCalled(
-      [
-        createSpy,
-        protectSpy,
-        registerSpy,
-        updateSpy,
-        domainsSpy,
-        uploadResourcesSpy,
-      ],
+      [createSpy, protectSpy, updateSpy, domainsSpy, uploadResourcesSpy],
       expect
     );
   });
@@ -143,14 +118,7 @@ describe("create site :: ", function () {
     expect(call[0]).toBe("bc7", "should send the initiative id");
     expect(call[1]).toBe("3ef", "should send the site id");
     expectAllCalled(
-      [
-        createSpy,
-        protectSpy,
-        registerSpy,
-        updateSpy,
-        domainsSpy,
-        uploadResourcesSpy,
-      ],
+      [createSpy, protectSpy, updateSpy, domainsSpy, uploadResourcesSpy],
       expect
     );
   });
@@ -176,15 +144,15 @@ describe("create site :: ", function () {
     const result = await createSite(site, {}, ro);
 
     expect(result.item.id).toBe("3ef", "should attach id into returned model");
-    expect(result.data.values.clientId).toBe(
-      "031AYEM9fd1X1ac9",
+    expect(result.data?.values.clientId).toBe(
+      "FAKECLIENTKEY",
       "should attach client Id into returned model"
     );
     expect(result.item.typeKeywords).toContain(
       "hubSite",
       "should add missing typeKeywords array and add hubSite"
     );
-    expect(result.data.values.verifySecondPass).toBe(
+    expect(result.data?.values.verifySecondPass).toBe(
       "this should be 3ef interpolated",
       "should do second pass appid interpolation"
     );
@@ -193,14 +161,7 @@ describe("create site :: ", function () {
     expect(shareSpy).toHaveBeenCalled();
     expect(shareSpy.calls.argsFor(0)[0].groupId).toBe("foo-bar-baz");
     expectAllCalled(
-      [
-        createSpy,
-        protectSpy,
-        registerSpy,
-        updateSpy,
-        domainsSpy,
-        uploadResourcesSpy,
-      ],
+      [createSpy, protectSpy, updateSpy, domainsSpy, uploadResourcesSpy],
       expect
     );
   });
@@ -228,7 +189,7 @@ describe("create site :: ", function () {
 
     const result = await createSite(site, {}, ro);
 
-    expect(result.data.values.dcatConfig.foo).toBe(
+    expect(result.data?.values.dcatConfig.foo).toBe(
       "{{some.undefined.thing}}",
       "dcatConfig not interpolated"
     );
@@ -258,14 +219,7 @@ describe("create site :: ", function () {
 
     expect(createSpy).toHaveBeenCalled();
     expectAll(
-      [
-        protectSpy,
-        registerSpy,
-        updateSpy,
-        domainsSpy,
-        uploadResourcesSpy,
-        shareSpy,
-      ],
+      [protectSpy, updateSpy, domainsSpy, uploadResourcesSpy, shareSpy],
       "toHaveBeenCalled",
       false,
       expect

--- a/packages/sites/test/update-app-redirect-uris.test.ts
+++ b/packages/sites/test/update-app-redirect-uris.test.ts
@@ -1,4 +1,4 @@
-import { updateAppRedirectUris } from "../src";
+import { updateAppRedirectUris } from "../src/update-app-redirect-uris";
 import * as requestModule from "@esri/arcgis-rest-request";
 import { IHubRequestOptions } from "@esri/hub-common";
 
@@ -12,8 +12,8 @@ describe("updateAppRedirectUris", () => {
 
     const ro = {
       authentication: {
-        token: "token"
-      }
+        token: "token",
+      },
     } as IHubRequestOptions;
 
     const clientId = "abc-clientid";
@@ -31,8 +31,8 @@ describe("updateAppRedirectUris", () => {
         authentication: ro.authentication,
         params: {
           client_id: clientId,
-          redirect_uris: JSON.stringify(redirectUris)
-        }
+          redirect_uris: JSON.stringify(redirectUris),
+        },
       },
       "request called with correct config"
     );

--- a/packages/sites/test/update-site-application-uris.test.ts
+++ b/packages/sites/test/update-site-application-uris.test.ts
@@ -24,16 +24,10 @@ describe("updateSiteApplicationUris", () => {
     },
   } as unknown as IHubRequestOptions;
 
-  let updateRedirectSpy: jasmine.Spy;
   let removeSpy: jasmine.Spy;
   let addSpy: jasmine.Spy;
   let getDomainsSpy: jasmine.Spy;
   beforeEach(() => {
-    updateRedirectSpy = spyOn(
-      updateRedirectModule,
-      "updateAppRedirectUris"
-    ).and.returnValue(Promise.resolve());
-
     getDomainsSpy = spyOn(commonModule, "getDomainsForSite").and.returnValue(
       Promise.resolve([
         { id: "foo-id", hostname: "foo", sslOnly: false },
@@ -55,7 +49,6 @@ describe("updateSiteApplicationUris", () => {
 
     await updateSiteApplicationUris(site, uris, ro);
 
-    expect(updateRedirectSpy).toHaveBeenCalled();
     expect(getDomainsSpy).toHaveBeenCalled();
 
     expect(removeSpy.calls.count()).toBe(1, "one domain removed");
@@ -71,13 +64,13 @@ describe("updateSiteApplicationUris", () => {
     );
     expect(addSpy.calls.argsFor(0)[0]).toEqual(
       {
-        orgKey: ro.portalSelf.urlKey,
-        orgId: ro.portalSelf.id,
-        orgTitle: ro.portalSelf.name,
+        orgKey: ro.portalSelf?.urlKey,
+        orgId: ro.portalSelf?.id,
+        orgTitle: ro.portalSelf?.name,
         hostname: "bar",
         siteId: site.item.id,
         siteTitle: site.item.title,
-        clientKey: site.data.values.clientId,
+        clientKey: site.data?.values.clientId,
         sslOnly: false,
       },
       "correct parameters for addDomain"
@@ -103,7 +96,6 @@ describe("updateSiteApplicationUris", () => {
       isPortal: true,
     } as IHubRequestOptions);
 
-    expect(updateRedirectSpy).not.toHaveBeenCalled();
     expect(getDomainsSpy).not.toHaveBeenCalled();
     expect(removeSpy).not.toHaveBeenCalled();
     expect(addSpy).not.toHaveBeenCalled();

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-portal": "^2.13.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "^12.4.0"
+    "@esri/hub-common": "^12.4.0 || 13"
   },
   "devDependencies": {
     "@esri/hub-common": "*",

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -15,7 +15,7 @@
     "@esri/arcgis-rest-portal": "^2.15.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "^12.4.0"
+    "@esri/hub-common": "^12.4.0 || 13"
   },
   "devDependencies": {
     "@esri/hub-common": "*",


### PR DESCRIPTION
1. Description:

Remove calls to /registerApp or /updateApp for Hub Sites, and rely on Hub Domain service to do that work. This code was previously validated on the `next` branch and deployed to DEVEXT. However, that branch also included a lot of other changes related to deprecating additional functions, which created a very messy rebase which we could not resolve in a timely manner.

affects: @esri/hub-common, @esri/hub-sites

BREAKING CHANGE:
Client code no longer makes calls to
register site as application or to update application redirect uris. This is all expected to be handled server-side by the Hub Domain service.

BREAKING CHANGE:
remove deprecated destroySite()

1. Instructions for testing: - run tests

1. Closes Issues: #6390

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
