### PR TITLE
feat(hub-discussions): legacy permission checks mixed channels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22644,9 +22644,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22661,21 +22662,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22689,9 +22693,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22709,9 +22714,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64966,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.0.0",
+			"version": "12.42.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64991,7 +64997,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "24.0.0",
+			"version": "22.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65004,12 +65010,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "^12.4.0 || 13"
+				"@esri/hub-common": "^12.4.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "13.0.0",
+			"version": "12.4.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -65024,12 +65030,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "^12.4.0 || 13"
+				"@esri/hub-common": "^12.4.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "13.0.0",
+			"version": "12.4.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65044,12 +65050,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0 || 13"
+				"@esri/hub-common": "^12.4.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "13.0.0",
+			"version": "12.4.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65063,12 +65069,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^13"
+				"@esri/hub-common": "^12.4.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "13.0.0",
+			"version": "12.4.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65085,34 +65091,34 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0 || 13"
+				"@esri/hub-common": "^12.4.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "13.0.0",
+			"version": "12.6.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
 				"@esri/hub-common": "*",
-				"@esri/hub-initiatives": "^13.0.0",
-				"@esri/hub-teams": "^13.0.0",
+				"@esri/hub-initiatives": "*",
+				"@esri/hub-teams": "*",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^13",
-				"@esri/hub-initiatives": "^13.0.0",
-				"@esri/hub-teams": "^13.0.0"
+				"@esri/hub-common": "^12.4.0",
+				"@esri/hub-initiatives": "^12.4.0",
+				"@esri/hub-teams": "^12.4.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "13.0.0",
+			"version": "12.4.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65127,12 +65133,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0 || 13"
+				"@esri/hub-common": "^12.4.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "13.0.0",
+			"version": "12.4.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65146,7 +65152,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0 || 13"
+				"@esri/hub-common": "^12.4.0"
 			}
 		}
 	},
@@ -68756,8 +68762,8 @@
 			"version": "file:packages/sites",
 			"requires": {
 				"@esri/hub-common": "*",
-				"@esri/hub-initiatives": "^13.0.0",
-				"@esri/hub-teams": "^13.0.0",
+				"@esri/hub-initiatives": "*",
+				"@esri/hub-teams": "*",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -83376,7 +83382,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83391,17 +83398,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83415,7 +83425,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83432,7 +83443,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22644,10 +22644,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22662,24 +22661,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22693,10 +22689,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22714,10 +22709,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64972,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "12.42.0",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64997,7 +64991,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "22.2.0",
+			"version": "24.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65010,12 +65004,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^12.4.0 || 13"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "12.4.1",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -65030,12 +65024,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^12.4.0 || 13"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "12.4.1",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65050,12 +65044,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^12.4.0 || 13"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "12.4.1",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65069,12 +65063,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^13"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "12.4.1",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65091,34 +65085,34 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^12.4.0 || 13"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "12.6.0",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
 				"@esri/hub-common": "*",
-				"@esri/hub-initiatives": "*",
-				"@esri/hub-teams": "*",
+				"@esri/hub-initiatives": "^13.0.0",
+				"@esri/hub-teams": "^13.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0",
-				"@esri/hub-initiatives": "^12.4.0",
-				"@esri/hub-teams": "^12.4.0"
+				"@esri/hub-common": "^13",
+				"@esri/hub-initiatives": "^13.0.0",
+				"@esri/hub-teams": "^13.0.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "12.4.1",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65133,12 +65127,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^12.4.0 || 13"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "12.4.1",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65152,7 +65146,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^12.4.0 || 13"
 			}
 		}
 	},
@@ -68762,8 +68756,8 @@
 			"version": "file:packages/sites",
 			"requires": {
 				"@esri/hub-common": "*",
-				"@esri/hub-initiatives": "*",
-				"@esri/hub-teams": "*",
+				"@esri/hub-initiatives": "^13.0.0",
+				"@esri/hub-teams": "^13.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -83382,8 +83376,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83398,20 +83391,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83425,8 +83415,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83443,8 +83432,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/discussions/src/utils/channel-permission.ts
+++ b/packages/discussions/src/utils/channel-permission.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-types";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
 import {
   AclCategory,
   AclSubCategory,

--- a/packages/discussions/src/utils/channels/can-create-channel.ts
+++ b/packages/discussions/src/utils/channels/can-create-channel.ts
@@ -35,8 +35,12 @@ function isAuthorizedToCreateByLegacyPermissions(
   user: IDiscussionsUser,
   channelParams: ILegacyChannelPermissions
 ): boolean {
-  const { username, groups: userGroups } = user;
-  const { access, groups: channelGroupIds, orgs: channelOrgs } = channelParams;
+  const { username, groups: userGroups = [] } = user;
+  const {
+    access,
+    groups: channelGroupIds = [],
+    orgs: channelOrgs,
+  } = channelParams;
 
   // ensure authenticated
   if (username === null) {
@@ -48,7 +52,10 @@ function isAuthorizedToCreateByLegacyPermissions(
   }
 
   // public or org access
-  return isOrgAdminAndInChannelOrgs(user, channelOrgs);
+  return (
+    canAllowGroupsLegacy(userGroups, channelGroupIds) &&
+    isChannelOrgAdmin(user, channelOrgs)
+  );
 }
 
 function canAllowGroupsLegacy(
@@ -78,7 +85,7 @@ function isGroupDiscussable(userGroup: IGroup) {
   return !typeKeywords.includes(CANNOT_DISCUSS);
 }
 
-function isOrgAdminAndInChannelOrgs(
+function isChannelOrgAdmin(
   user: IDiscussionsUser,
   channelOrgs: string[]
 ): boolean {

--- a/packages/discussions/src/utils/channels/can-create-channel.ts
+++ b/packages/discussions/src/utils/channels/can-create-channel.ts
@@ -1,11 +1,5 @@
 import { IGroup, IUser } from "@esri/arcgis-rest-types";
-import {
-  AclCategory,
-  IChannel,
-  IChannelAclPermissionDefinition,
-  IDiscussionsUser,
-  SharingAccess,
-} from "../../types";
+import { IChannel, IDiscussionsUser, SharingAccess } from "../../types";
 import { ChannelPermission } from "../channel-permission";
 import { CANNOT_DISCUSS } from "../constants";
 import { isOrgAdmin } from "../platform";
@@ -14,13 +8,13 @@ type ILegacyChannelPermissions = Pick<IChannel, "access" | "groups" | "orgs">;
 
 export function canCreateChannel(
   channel: IChannel,
-  user: IDiscussionsUser
+  user: IUser | IDiscussionsUser = {}
 ): boolean {
   const { channelAcl, access, groups, orgs } = channel;
 
   if (channelAcl) {
     const channelPermission = new ChannelPermission(channelAcl);
-    return channelPermission.canCreateChannel(user);
+    return channelPermission.canCreateChannel(user as IDiscussionsUser);
   }
 
   return isAuthorizedToCreateByLegacyPermissions(user, {
@@ -32,7 +26,7 @@ export function canCreateChannel(
 
 // Once ACL usage is enforced, we will remove authorization by legacy permissions
 function isAuthorizedToCreateByLegacyPermissions(
-  user: IDiscussionsUser,
+  user: IUser | IDiscussionsUser,
   channelParams: ILegacyChannelPermissions
 ): boolean {
   const { username, groups: userGroups = [] } = user;
@@ -43,7 +37,7 @@ function isAuthorizedToCreateByLegacyPermissions(
   } = channelParams;
 
   // ensure authenticated
-  if (username === null) {
+  if (!username) {
     return false;
   }
 
@@ -86,7 +80,7 @@ function isGroupDiscussable(userGroup: IGroup) {
 }
 
 function isChannelOrgAdmin(
-  user: IDiscussionsUser,
+  user: IUser | IDiscussionsUser,
   channelOrgs: string[]
 ): boolean {
   return isOrgAdmin(user) && channelOrgs.includes(user.orgId);

--- a/packages/discussions/src/utils/channels/can-post-to-channel.ts
+++ b/packages/discussions/src/utils/channels/can-post-to-channel.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-types";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser, Role, SharingAccess } from "../../types";
 import { ChannelPermission } from "../channel-permission";
 import { CANNOT_DISCUSS } from "../constants";
@@ -20,13 +20,13 @@ type ILegacyChannelPermissions = Pick<
 
 export function canPostToChannel(
   channel: IChannel,
-  user: IDiscussionsUser
+  user: IUser | IDiscussionsUser = {}
 ): boolean {
   const { channelAcl, access, groups, orgs, allowAnonymous } = channel;
 
   if (channelAcl) {
     const channelPermission = new ChannelPermission(channelAcl);
-    return channelPermission.canPostToChannel(user);
+    return channelPermission.canPostToChannel(user as IDiscussionsUser);
   }
 
   // Once channelAcl usage is enforced, we will remove authorization by legacy permissions
@@ -39,7 +39,7 @@ export function canPostToChannel(
 }
 
 function isAuthorizedToPostByLegacyPermissions(
-  user: IDiscussionsUser,
+  user: IUser | IDiscussionsUser,
   channelParams: ILegacyChannelPermissions
 ): boolean {
   const { username, groups: userGroups, orgId: userOrgId } = user;
@@ -50,7 +50,7 @@ function isAuthorizedToPostByLegacyPermissions(
     return true;
   }
 
-  if (username === null) {
+  if (!username) {
     return false;
   }
 

--- a/packages/discussions/src/utils/channels/index.ts
+++ b/packages/discussions/src/utils/channels/index.ts
@@ -44,12 +44,15 @@ export function canReadFromChannel(channel: IChannel, user: IUser): boolean {
   if (channel.access === "private") {
     // ensure user is member of at least one group
     return intersectGroups(["member", "owner", "admin"])(user, channel);
-  } else if (channel.access === "org") {
+  }
+
+  if (channel.access === "org") {
     return (
       intersectGroups(["member", "owner", "admin"])(user, channel) ||
       isChannelOrgMember(channel, user)
     );
   }
+
   // public channel
   return true;
 }
@@ -71,8 +74,12 @@ export function canModifyChannel(channel: IChannel, user: IUser): boolean {
     // ensure user is owner/admin of at least one group
     return intersectGroups(["owner", "admin"])(user, channel);
   }
-  // if org or public channel, must be org admin
-  return isChannelOrgAdmin(channel, user);
+
+  // org or public channel
+  return (
+    intersectGroups(["owner", "admin"])(user, channel) ||
+    isChannelOrgAdmin(channel, user)
+  );
 }
 
 /**

--- a/packages/discussions/src/utils/channels/index.ts
+++ b/packages/discussions/src/utils/channels/index.ts
@@ -10,8 +10,8 @@ function intersectGroups(
   membershipTypes: GroupMembership[]
 ): (arg0: IUser, arg1: IChannel) => boolean {
   return (user: IUser, channel: IChannel): boolean => {
-    const { groups: sharedGroups } = channel;
-    const { groups: userGroups } = user;
+    const { groups: sharedGroups = [] } = channel;
+    const { groups: userGroups = [] } = user;
     const eligibleUserGroups = userGroups.reduce(
       reduceByGroupMembership(membershipTypes),
       []
@@ -45,8 +45,12 @@ export function canReadFromChannel(channel: IChannel, user: IUser): boolean {
     // ensure user is member of at least one group
     return intersectGroups(["member", "owner", "admin"])(user, channel);
   } else if (channel.access === "org") {
-    return isChannelOrgMember(channel, user);
+    return (
+      intersectGroups(["member", "owner", "admin"])(user, channel) ||
+      isChannelOrgMember(channel, user)
+    );
   }
+  // public channel
   return true;
 }
 

--- a/packages/discussions/src/utils/posts/can-modify-post-status.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post-status.ts
@@ -7,20 +7,23 @@ const ADMIN_GROUP_ROLES = Object.freeze(["owner", "admin"]);
 
 export function canModifyPostStatus(
   channel: IChannel,
-  user: IDiscussionsUser
+  user: IUser | IDiscussionsUser = {}
 ): boolean {
   const { channelAcl } = channel;
 
   if (channelAcl) {
     const channelPermission = new ChannelPermission(channelAcl);
-    return channelPermission.canModifyPostStatus(user, channel.creator);
+    return channelPermission.canModifyPostStatus(
+      user as IDiscussionsUser,
+      channel.creator
+    );
   }
 
   return isAuthorizedToModifyStatusByLegacyPermissions(user, channel);
 }
 
 function isAuthorizedToModifyStatusByLegacyPermissions(
-  user: IDiscussionsUser,
+  user: IUser | IDiscussionsUser,
   channel: IChannel
 ): boolean {
   const { username, groups: userGroups = [], orgId: userOrgId } = user;
@@ -72,6 +75,9 @@ function isAuthorizedToModifyStatusByLegacyGroup(
   });
 }
 
-function isChannelOrgAdmin(channelOrgs: string[], user: IUser): boolean {
+function isChannelOrgAdmin(
+  channelOrgs: string[],
+  user: IUser | IDiscussionsUser
+): boolean {
   return isOrgAdmin(user) && channelOrgs.includes(user.orgId);
 }

--- a/packages/discussions/src/utils/posts/can-modify-post-status.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post-status.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-types";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser, SharingAccess } from "../../types";
 import { isOrgAdmin } from "../platform";
 import { ChannelPermission } from "../channel-permission";
@@ -44,14 +44,17 @@ function isAuthorizedToModifyStatusByLegacyPermissions(
   }
 
   // public or org access
-  return channelOrgs.includes(userOrgId) && isOrgAdmin(user);
+  return (
+    isAuthorizedToModifyStatusByLegacyGroup(channelGroups, userGroups) ||
+    isChannelOrgAdmin(channelOrgs, user)
+  );
 }
 
 /**
  * Ensure the user is an owner/admin of one of the channel groups
  */
 function isAuthorizedToModifyStatusByLegacyGroup(
-  channelGroups: string[],
+  channelGroups: string[] = [],
   userGroups: IGroup[] = []
 ) {
   return channelGroups.some((channelGroupId: string) => {
@@ -67,4 +70,8 @@ function isAuthorizedToModifyStatusByLegacyGroup(
       );
     });
   });
+}
+
+function isChannelOrgAdmin(channelOrgs: string[] = [], user: IUser): boolean {
+  return isOrgAdmin(user) && channelOrgs.includes(user.orgId);
 }

--- a/packages/discussions/src/utils/posts/can-modify-post-status.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post-status.ts
@@ -23,11 +23,11 @@ function isAuthorizedToModifyStatusByLegacyPermissions(
   user: IDiscussionsUser,
   channel: IChannel
 ): boolean {
-  const { username, groups: userGroups, orgId: userOrgId } = user;
+  const { username, groups: userGroups = [], orgId: userOrgId } = user;
   const {
     access,
-    groups: channelGroups,
-    orgs: channelOrgs,
+    groups: channelGroups = [],
+    orgs: channelOrgs = [],
     creator: channelCreator,
   } = channel;
 
@@ -54,8 +54,8 @@ function isAuthorizedToModifyStatusByLegacyPermissions(
  * Ensure the user is an owner/admin of one of the channel groups
  */
 function isAuthorizedToModifyStatusByLegacyGroup(
-  channelGroups: string[] = [],
-  userGroups: IGroup[] = []
+  channelGroups: string[],
+  userGroups: IGroup[]
 ) {
   return channelGroups.some((channelGroupId: string) => {
     return userGroups.some((group: IGroup) => {
@@ -72,6 +72,6 @@ function isAuthorizedToModifyStatusByLegacyGroup(
   });
 }
 
-function isChannelOrgAdmin(channelOrgs: string[] = [], user: IUser): boolean {
+function isChannelOrgAdmin(channelOrgs: string[], user: IUser): boolean {
   return isOrgAdmin(user) && channelOrgs.includes(user.orgId);
 }

--- a/packages/discussions/src/utils/posts/can-modify-post.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post.ts
@@ -29,7 +29,7 @@ export function canModifyPost(
 }
 
 function isPostCreator(post: IPost, user: IDiscussionsUser) {
-  return post.creator === user.username;
+  return user.username && post.creator === user.username;
 }
 
 function isAuthorizedToModifyByLegacyPermissions(
@@ -37,16 +37,20 @@ function isAuthorizedToModifyByLegacyPermissions(
   channelParams: ILegacyChannelPermissions
 ) {
   const { groups: userGroups, orgId: userOrgId } = user;
-  const { access, groups: channelGroups, orgs } = channelParams;
+  const { access, groups: channelGroups = [], orgs = [] } = channelParams;
 
   if (access === SharingAccess.PUBLIC) {
     return true;
   }
 
   if (access === SharingAccess.ORG) {
-    return orgs.includes(userOrgId);
+    return (
+      isAuthorizedToModifyPostByLegacyGroup(channelGroups, userGroups) ||
+      orgs.includes(userOrgId)
+    );
   }
 
+  // private
   return isAuthorizedToModifyPostByLegacyGroup(channelGroups, userGroups);
 }
 

--- a/packages/discussions/src/utils/posts/can-modify-post.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post.ts
@@ -36,7 +36,7 @@ function isAuthorizedToModifyByLegacyPermissions(
   user: IDiscussionsUser,
   channelParams: ILegacyChannelPermissions
 ) {
-  const { groups: userGroups, orgId: userOrgId } = user;
+  const { groups: userGroups = [], orgId: userOrgId } = user;
   const { access, groups: channelGroups = [], orgs = [] } = channelParams;
 
   if (access === SharingAccess.PUBLIC) {
@@ -59,8 +59,8 @@ function isAuthorizedToModifyByLegacyPermissions(
  * and the group is not marked as non-discussable
  */
 function isAuthorizedToModifyPostByLegacyGroup(
-  channelGroups: string[] = [],
-  userGroups: IGroup[] = []
+  channelGroups: string[],
+  userGroups: IGroup[]
 ) {
   return channelGroups.some((channelGroupId: string) => {
     return userGroups.some((group: IGroup) => {

--- a/packages/discussions/src/utils/posts/can-modify-post.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post.ts
@@ -29,7 +29,7 @@ export function canModifyPost(
 }
 
 function isPostCreator(post: IPost, user: IDiscussionsUser) {
-  return user.username && post.creator === user.username;
+  return !!user.username && post.creator === user.username;
 }
 
 function isAuthorizedToModifyByLegacyPermissions(

--- a/packages/discussions/src/utils/posts/can-modify-post.ts
+++ b/packages/discussions/src/utils/posts/can-modify-post.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-types";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser, IPost, SharingAccess } from "../../types";
 import { CANNOT_DISCUSS } from "../constants";
 
@@ -12,7 +12,7 @@ type ILegacyChannelPermissions = Pick<
  */
 export function canModifyPost(
   post: IPost,
-  user: IDiscussionsUser,
+  user: IUser | IDiscussionsUser = {},
   channel: IChannel
 ) {
   const { access, groups, orgs, allowAnonymous } = channel;
@@ -28,12 +28,12 @@ export function canModifyPost(
   );
 }
 
-function isPostCreator(post: IPost, user: IDiscussionsUser) {
+function isPostCreator(post: IPost, user: IUser | IDiscussionsUser) {
   return !!user.username && post.creator === user.username;
 }
 
 function isAuthorizedToModifyByLegacyPermissions(
-  user: IDiscussionsUser,
+  user: IUser | IDiscussionsUser,
   channelParams: ILegacyChannelPermissions
 ) {
   const { groups: userGroups = [], orgId: userOrgId } = user;

--- a/packages/discussions/src/utils/posts/index.ts
+++ b/packages/discussions/src/utils/posts/index.ts
@@ -75,7 +75,7 @@ export function canDeletePost(
 }
 
 function isPostCreator(post: IPost, user: IUser) {
-  return user.username && post.creator === user.username;
+  return !!user.username && post.creator === user.username;
 }
 
 const MENTION_ATTRIBUTE_AND_VALUE_PATTERN = new RegExp(

--- a/packages/discussions/src/utils/posts/index.ts
+++ b/packages/discussions/src/utils/posts/index.ts
@@ -75,7 +75,7 @@ export function canDeletePost(
 }
 
 function isPostCreator(post: IPost, user: IUser) {
-  return post.creator === user.username;
+  return user.username && post.creator === user.username;
 }
 
 const MENTION_ATTRIBUTE_AND_VALUE_PATTERN = new RegExp(

--- a/packages/discussions/src/utils/posts/index.ts
+++ b/packages/discussions/src/utils/posts/index.ts
@@ -1,6 +1,11 @@
 import { IGroup, IItem } from "@esri/arcgis-rest-portal";
-import { IChannel, IDiscussionParams, IPost } from "../../types";
 import { parseDatasetId, IHubContent, IHubItemEntity } from "@esri/hub-common";
+import {
+  IChannel,
+  IDiscussionParams,
+  IDiscussionsUser,
+  IPost,
+} from "../../types";
 import { IUser } from "@esri/arcgis-rest-auth";
 import { canModifyChannel } from "../channels";
 import { CANNOT_DISCUSS, MENTION_ATTRIBUTE } from "../constants";
@@ -69,12 +74,12 @@ export function isDiscussable(
 export function canDeletePost(
   post: IPost,
   channel: IChannel,
-  user: IUser
+  user: IUser | IDiscussionsUser = {}
 ): boolean {
   return isPostCreator(post, user) || canModifyChannel(channel, user);
 }
 
-function isPostCreator(post: IPost, user: IUser) {
+function isPostCreator(post: IPost, user: IUser | IDiscussionsUser) {
   return !!user.username && post.creator === user.username;
 }
 

--- a/packages/discussions/test/utils/channels/can-create-channel.test.ts
+++ b/packages/discussions/test/utils/channels/can-create-channel.test.ts
@@ -123,6 +123,16 @@ describe("canCreateChannel", () => {
       expect(canCreateChannel(channel, user)).toEqual(false);
     });
 
+    it("returns false if user undefined", () => {
+      const channel = {
+        access: SharingAccess.PRIVATE,
+        orgs: [orgId1],
+        groups: [groupId1, groupId2],
+      } as IChannel;
+
+      expect(canCreateChannel(channel)).toEqual(false);
+    });
+
     describe("Private access channel", () => {
       it("returns true if user is member of all channel groups", () => {
         const channel = {

--- a/packages/discussions/test/utils/channels/can-create-channel.test.ts
+++ b/packages/discussions/test/utils/channels/can-create-channel.test.ts
@@ -146,6 +146,17 @@ describe("canCreateChannel", () => {
         expect(canCreateChannel(channel, user)).toEqual(false);
       });
 
+      it("returns false if user does not have groups", () => {
+        const channel = {
+          access: SharingAccess.PRIVATE,
+          orgs: [orgId1],
+          groups: [groupId1, groupId2, groupId3], // groupId3 not a user group
+        } as IChannel;
+        const user = buildUser({ groups: undefined });
+
+        expect(canCreateChannel(channel, user)).toEqual(false);
+      });
+
       it("returns false if user is a member of all channel groups but memberType is not authorized", () => {
         const channel = {
           access: SharingAccess.PRIVATE,
@@ -180,6 +191,72 @@ describe("canCreateChannel", () => {
     });
 
     describe("Org access channel", () => {
+      it("returns true if user is member of all channel groups and user is org_admin", () => {
+        const channel = {
+          access: SharingAccess.ORG,
+          orgs: [orgId1],
+          groups: [groupId1, groupId2],
+        } as IChannel;
+        const user = buildUser({ role: "org_admin" });
+
+        expect(canCreateChannel(channel, user)).toEqual(true);
+      });
+
+      it("returns false if user is member of all channel groups but user is not org_admin", () => {
+        const channel = {
+          access: SharingAccess.ORG,
+          orgs: [orgId1],
+          groups: [groupId1, groupId2],
+        } as IChannel;
+        const user = buildUser();
+
+        expect(canCreateChannel(channel, user)).toEqual(false);
+      });
+
+      it("returns false if user is not member of all channel groups and user is org_admin", () => {
+        const channel = {
+          access: SharingAccess.ORG,
+          orgs: [orgId1],
+          groups: [groupId1, groupId2, groupId3], // groupId3 not a user group
+        } as IChannel;
+        const user = buildUser({ role: "org_admin" });
+
+        expect(canCreateChannel(channel, user)).toEqual(false);
+      });
+
+      it("returns false if user is a member of all channel groups but memberType is not authorized and user is org_admin", () => {
+        const channel = {
+          access: SharingAccess.ORG,
+          orgs: [orgId1],
+          groups: [groupId1, groupId2],
+        } as IChannel;
+        const user = buildUser({
+          role: "org_admin",
+          groups: [
+            buildGroup(groupId1, "member"),
+            buildGroup(groupId2, "none"), // memberType none not authorized
+          ],
+        });
+
+        expect(canCreateChannel(channel, user)).toEqual(false);
+      });
+
+      it("returns false if user is a member of all channel groups but group is not discussable and user is org_admin", () => {
+        const channel = {
+          access: SharingAccess.ORG,
+          orgs: [orgId1],
+          groups: [groupId1, groupId2],
+        } as IChannel;
+        const user = buildUser({
+          groups: [
+            buildGroup(groupId1, "member"),
+            buildGroup(groupId2, "admin", [CANNOT_DISCUSS]),
+          ],
+        });
+
+        expect(canCreateChannel(channel, user)).toEqual(false);
+      });
+
       it("returns true if user is org admin included within orgs list", () => {
         const channel = {
           access: SharingAccess.ORG,
@@ -212,6 +289,72 @@ describe("canCreateChannel", () => {
     });
 
     describe("Public Access channel", () => {
+      it("returns true if user is member of all channel groups and user is org_admin", () => {
+        const channel = {
+          access: SharingAccess.PUBLIC,
+          orgs: [orgId1],
+          groups: [groupId1, groupId2],
+        } as IChannel;
+        const user = buildUser({ role: "org_admin" });
+
+        expect(canCreateChannel(channel, user)).toEqual(true);
+      });
+
+      it("returns false if user is member of all channel groups but user is not org_admin", () => {
+        const channel = {
+          access: SharingAccess.PUBLIC,
+          orgs: [orgId1],
+          groups: [groupId1, groupId2],
+        } as IChannel;
+        const user = buildUser();
+
+        expect(canCreateChannel(channel, user)).toEqual(false);
+      });
+
+      it("returns false if user is not member of all channel groups and user is org_admin", () => {
+        const channel = {
+          access: SharingAccess.PUBLIC,
+          orgs: [orgId1],
+          groups: [groupId1, groupId2, groupId3], // groupId3 not a user group
+        } as IChannel;
+        const user = buildUser({ role: "org_admin" });
+
+        expect(canCreateChannel(channel, user)).toEqual(false);
+      });
+
+      it("returns false if user is a member of all channel groups but memberType is not authorized and user is org_admin", () => {
+        const channel = {
+          access: SharingAccess.PUBLIC,
+          orgs: [orgId1],
+          groups: [groupId1, groupId2],
+        } as IChannel;
+        const user = buildUser({
+          role: "org_admin",
+          groups: [
+            buildGroup(groupId1, "member"),
+            buildGroup(groupId2, "none"), // memberType none not authorized
+          ],
+        });
+
+        expect(canCreateChannel(channel, user)).toEqual(false);
+      });
+
+      it("returns false if user is a member of all channel groups but group is not discussable and user is org_admin", () => {
+        const channel = {
+          access: SharingAccess.PUBLIC,
+          orgs: [orgId1],
+          groups: [groupId1, groupId2],
+        } as IChannel;
+        const user = buildUser({
+          groups: [
+            buildGroup(groupId1, "member"),
+            buildGroup(groupId2, "admin", [CANNOT_DISCUSS]),
+          ],
+        });
+
+        expect(canCreateChannel(channel, user)).toEqual(false);
+      });
+
       it("returns true if user is org admin included within orgs list", () => {
         const channel = {
           access: SharingAccess.PUBLIC,

--- a/packages/discussions/test/utils/channels/can-post-to-channel.test.ts
+++ b/packages/discussions/test/utils/channels/can-post-to-channel.test.ts
@@ -76,6 +76,14 @@ describe("canPostToChannel", () => {
   });
 
   describe("with legacy permissions", () => {
+    it("returns true if undefined user attempts to create post in allowAnonymous === true channel", () => {
+      const channel = {
+        allowAnonymous: true,
+      } as IChannel;
+
+      expect(canPostToChannel(channel)).toBe(true);
+    });
+
     it("returns true if anonymous user attempts to create post in allowAnonymous === true channel", () => {
       const user: IDiscussionsUser = { username: null };
       const channel = {

--- a/packages/discussions/test/utils/channels/index.test.ts
+++ b/packages/discussions/test/utils/channels/index.test.ts
@@ -208,6 +208,15 @@ describe("Util: Channel Access", () => {
         });
         expect(canReadFromChannel(channel, user)).toBeFalsy();
       });
+      it("returns false for user that has no groups", () => {
+        const userNoGroups = fakeUser();
+        const channel = fakeChannel({
+          access: SharingAccess.PRIVATE,
+          orgs: [orgId1],
+          groups: ["unknown"],
+        });
+        expect(canReadFromChannel(channel, userNoGroups)).toBeFalsy();
+      });
     });
 
     describe("Org channel", () => {

--- a/packages/discussions/test/utils/channels/index.test.ts
+++ b/packages/discussions/test/utils/channels/index.test.ts
@@ -208,6 +208,14 @@ describe("Util: Channel Access", () => {
         });
         expect(canReadFromChannel(channel, user)).toBeFalsy();
       });
+      it("returns false undefined user", () => {
+        const channel = fakeChannel({
+          access: SharingAccess.PRIVATE,
+          orgs: [orgId1],
+          groups: ["unknown"],
+        });
+        expect(canReadFromChannel(channel)).toBeFalsy();
+      });
       it("returns false for user that has no groups", () => {
         const userNoGroups = fakeUser();
         const channel = fakeChannel({
@@ -273,6 +281,15 @@ describe("Util: Channel Access", () => {
   });
 
   describe("canModifyChannel", () => {
+    it("returns false undefined user", () => {
+      const channel = fakeChannel({
+        access: SharingAccess.PRIVATE,
+        orgs: [orgId1],
+        groups: [groupId1], // member here
+      });
+      expect(canModifyChannel(channel)).toBeFalsy();
+    });
+
     describe("Private channel", () => {
       it("returns true for user that is channel owner but not an admin/owner of channel groups", () => {
         const channelOwner = fakeUser({

--- a/packages/discussions/test/utils/posts/can-modify-post-status.test.ts
+++ b/packages/discussions/test/utils/posts/can-modify-post-status.test.ts
@@ -69,6 +69,12 @@ describe("canModifyPostStatus", () => {
       expect(canModifyPostStatus(channel, userNull)).toBe(false);
     });
 
+    it("returns false if the user is undefined", () => {
+      const channel = { access: SharingAccess.PUBLIC } as IChannel;
+
+      expect(canModifyPostStatus(channel)).toBe(false);
+    });
+
     it("returns true if the user created the channel", () => {
       const user = { username: "john" } as IDiscussionsUser;
       const channel = { creator: "john" } as IChannel;

--- a/packages/discussions/test/utils/posts/can-modify-post-status.test.ts
+++ b/packages/discussions/test/utils/posts/can-modify-post-status.test.ts
@@ -77,7 +77,110 @@ describe("canModifyPostStatus", () => {
     });
 
     describe("public channel", () => {
-      it("returns true if the user is an orgAdmin and the users org is in the channel orgs", () => {
+      it("returns true if the user is an admin of one of the channel groups", () => {
+        const user = {
+          username: "john",
+          groups: [
+            {
+              id: "aaa",
+              userMembership: { memberType: "member" },
+            },
+            {
+              id: "bbb",
+              userMembership: { memberType: "admin" }, // admin
+            },
+          ] as unknown as IGroup[],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PUBLIC,
+          groups: ["aaa", "bbb"],
+          orgs: ["zzz"], // user not in org
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(true);
+      });
+
+      it("returns true if the user is an owner of one of the channel groups", () => {
+        const user = {
+          username: "john",
+          groups: [
+            {
+              id: "aaa",
+              userMembership: { memberType: "member" },
+            },
+            {
+              id: "bbb",
+              userMembership: { memberType: "owner" }, // owner
+            },
+          ] as unknown as IGroup[],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PUBLIC,
+          groups: ["aaa", "bbb"],
+          orgs: ["zzz"], // user not in org
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(true);
+      });
+
+      it("returns false if the user is not an owner or admin of any channel groups, and not in channel orgs", () => {
+        const user = {
+          username: "john",
+          groups: [
+            {
+              id: "aaa",
+              userMembership: { memberType: "member" }, // member
+            },
+            {
+              id: "bbb",
+              userMembership: { memberType: "member" }, // member
+            },
+          ] as unknown as IGroup[],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PUBLIC,
+          groups: ["aaa", "bbb"],
+          orgs: ["zzz"], // user not in org
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(false);
+      });
+
+      it("returns false if the user is a group admin or owner but not in channel groups and not in channel orgs", () => {
+        const user = {
+          username: "john",
+          groups: [
+            {
+              id: "aaa",
+              userMembership: { memberType: "admin" },
+            },
+            {
+              id: "bbb",
+              userMembership: { memberType: "owner" },
+            },
+          ] as unknown as IGroup[],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PUBLIC,
+          groups: ["zzz"], // user groups not included
+          orgs: ["zzz"], // user not in org
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(false);
+      });
+
+      it("returns false if the user is not in any groups and not in any orgs", () => {
+        const user = { username: "john" } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PUBLIC,
+          groups: ["zzz"],
+          orgs: ["zzz"], // user not in org
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(false);
+      });
+
+      it("returns true if the user not in channel groups, is an orgAdmin and the users org is in the channel orgs", () => {
         const user = {
           username: "john",
           orgId: "aaa",
@@ -90,6 +193,21 @@ describe("canModifyPostStatus", () => {
 
         const result = canModifyPostStatus(channel, user);
         expect(result).toBe(true);
+      });
+
+      it("returns false if the user not in channel groups, is an orgAdmin but the users org is not in the channel orgs", () => {
+        const user = {
+          username: "john",
+          orgId: "aaa",
+          role: "org_admin",
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.PUBLIC,
+          orgs: ["zzz"], // user not in this org
+        } as IChannel;
+
+        const result = canModifyPostStatus(channel, user);
+        expect(result).toBe(false);
       });
     });
 
@@ -191,20 +309,113 @@ describe("canModifyPostStatus", () => {
 
         expect(canModifyPostStatus(channel, user)).toBe(false);
       });
+    });
 
-      it("returns false if the user is not in any groups", () => {
-        const user = { username: "john" } as IDiscussionsUser;
+    describe("org channel", () => {
+      it("returns true if the user is an admin of one of the channel groups", () => {
+        const user = {
+          username: "john",
+          groups: [
+            {
+              id: "aaa",
+              userMembership: { memberType: "member" },
+            },
+            {
+              id: "bbb",
+              userMembership: { memberType: "admin" }, // admin
+            },
+          ] as unknown as IGroup[],
+        } as IDiscussionsUser;
         const channel = {
-          access: SharingAccess.PRIVATE,
-          groups: ["zzz"],
+          access: SharingAccess.ORG,
+          groups: ["aaa", "bbb"],
+          orgs: ["zzz"], // user not in org
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(true);
+      });
+
+      it("returns true if the user is an owner of one of the channel groups", () => {
+        const user = {
+          username: "john",
+          groups: [
+            {
+              id: "aaa",
+              userMembership: { memberType: "member" },
+            },
+            {
+              id: "bbb",
+              userMembership: { memberType: "owner" }, // owner
+            },
+          ] as unknown as IGroup[],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.ORG,
+          groups: ["aaa", "bbb"],
+          orgs: ["zzz"], // user not in org
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(true);
+      });
+
+      it("returns false if the user is not an owner or admin of any channel groups, and not in channel orgs", () => {
+        const user = {
+          username: "john",
+          groups: [
+            {
+              id: "aaa",
+              userMembership: { memberType: "member" }, // member
+            },
+            {
+              id: "bbb",
+              userMembership: { memberType: "member" }, // member
+            },
+          ] as unknown as IGroup[],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.ORG,
+          groups: ["aaa", "bbb"],
+          orgs: ["zzz"], // user not in org
         } as IChannel;
 
         expect(canModifyPostStatus(channel, user)).toBe(false);
       });
-    });
 
-    describe("org channel", () => {
-      it("returns true if the user is an orgAdmin and the users org is in the channel orgs", () => {
+      it("returns false if the user is a group admin or owner but not in channel groups and not in channel orgs", () => {
+        const user = {
+          username: "john",
+          groups: [
+            {
+              id: "aaa",
+              userMembership: { memberType: "admin" },
+            },
+            {
+              id: "bbb",
+              userMembership: { memberType: "owner" },
+            },
+          ] as unknown as IGroup[],
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.ORG,
+          groups: ["zzz"], // user groups not included
+          orgs: ["zzz"], // user not in org
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(false);
+      });
+
+      it("returns false if the user is not in any groups and not in any orgs", () => {
+        const user = { username: "john" } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.ORG,
+          groups: ["zzz"],
+          orgs: ["zzz"], // user not in org
+        } as IChannel;
+
+        expect(canModifyPostStatus(channel, user)).toBe(false);
+      });
+
+      it("returns true if the user not in channel groups, is an orgAdmin and the users org is in the channel orgs", () => {
         const user = {
           username: "john",
           orgId: "aaa",
@@ -217,6 +428,21 @@ describe("canModifyPostStatus", () => {
 
         const result = canModifyPostStatus(channel, user);
         expect(result).toBe(true);
+      });
+
+      it("returns false if the user not in channel groups, is an orgAdmin but the users org is not in the channel orgs", () => {
+        const user = {
+          username: "john",
+          orgId: "aaa",
+          role: "org_admin",
+        } as IDiscussionsUser;
+        const channel = {
+          access: SharingAccess.ORG,
+          orgs: ["zzz"], // user not in this org
+        } as IChannel;
+
+        const result = canModifyPostStatus(channel, user);
+        expect(result).toBe(false);
       });
     });
   });

--- a/packages/discussions/test/utils/posts/can-modify-post.test.ts
+++ b/packages/discussions/test/utils/posts/can-modify-post.test.ts
@@ -27,6 +27,15 @@ describe("canModifyPost", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false if the user undefined", () => {
+    const post = { id: "postId" } as IPost; // asAnonymous post
+    const user = undefined as unknown as IDiscussionsUser;
+    const channel = { access: SharingAccess.PUBLIC } as IChannel;
+
+    const result = canModifyPost(post, user, channel);
+    expect(result).toBe(false);
+  });
+
   describe("Legacy Permissions", () => {
     describe("public channel", () => {
       it("returns true if user is creator", () => {

--- a/packages/discussions/test/utils/posts/index.test.ts
+++ b/packages/discussions/test/utils/posts/index.test.ts
@@ -103,7 +103,7 @@ describe("canDeletePost", () => {
     expect(canModifyChannelSpy).not.toHaveBeenCalled();
   });
 
-  it("returns when user can modify channel", () => {
+  it("returns true when user did not create the post and user can modify channel", () => {
     const canModifyChannelSpy = spyOn(
       channelUtils,
       "canModifyChannel"

--- a/packages/discussions/test/utils/posts/index.test.ts
+++ b/packages/discussions/test/utils/posts/index.test.ts
@@ -1,5 +1,10 @@
 import { IGroup, IUser } from "@esri/arcgis-rest-types";
-import { IChannel, IDiscussionParams, IPost } from "../../../src/types";
+import {
+  IChannel,
+  IDiscussionParams,
+  IDiscussionsUser,
+  IPost,
+} from "../../../src/types";
 import {
   isDiscussable,
   parseDiscussionURI,
@@ -129,6 +134,33 @@ describe("canDeletePost", () => {
     expect(result).toBe(false);
     expect(canModifyChannelSpy).toHaveBeenCalledTimes(1);
     expect(canModifyChannelSpy).toHaveBeenCalledWith(channel, user);
+  });
+
+  it("returns false when the user is unauthenticated", () => {
+    const canModifyChannelSpy = spyOn(
+      channelUtils,
+      "canModifyChannel"
+    ).and.returnValue(false);
+    const post = { id: "post1", creator: "user1" } as IPost;
+    const user = { username: null } as IDiscussionsUser;
+    const channel = { id: "channel1" } as IChannel;
+    const result = canDeletePost(post, channel, user);
+    expect(result).toBe(false);
+    expect(canModifyChannelSpy).toHaveBeenCalledTimes(1);
+    expect(canModifyChannelSpy).toHaveBeenCalledWith(channel, user);
+  });
+
+  it("returns false when the user is undefined", () => {
+    const canModifyChannelSpy = spyOn(
+      channelUtils,
+      "canModifyChannel"
+    ).and.returnValue(false);
+    const post = { id: "post1", creator: "user1" } as IPost;
+    const channel = { id: "channel1" } as IChannel;
+    const result = canDeletePost(post, channel);
+    expect(result).toBe(false);
+    expect(canModifyChannelSpy).toHaveBeenCalledTimes(1);
+    expect(canModifyChannelSpy).toHaveBeenCalledWith(channel, {});
   });
 });
 


### PR DESCRIPTION
Issue [6820](https://zentopia.esri.com/workspaces/engagement-workspace-61508ae50946c40014ef574f/issues/dc/hub/6820)

1. Description: Audit the channel and post permission checks for mixed access channels (org and public channels can now also have groups) and handle `undefined` user case for all access util functions

`canPostToChannel`
  - no changes

`canCreateChannel`
  - org and public channels now require the user to be a member of every provided group (and channel org admin)

`canReadFromChannel`
  - org channels now allow reads from channel group members OR channel org members

`canModifyChannel`
  - org channels now allow modification from channel group owner/admins OR channel org admins

`canModifyPost`
  - posts in org channels now require that user created the post AND (user is member of channel groups OR user is channel org member)

`canModifyPostStatus`
  - public or org channels now allow channel group owner/admins OR channel org admins to modify post status (moderate)

`canDeletePost`
  - calls `canModifyChannel`, same changes as above


1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
