### PR TITLE
feat(hub-common): return "license" and "source" as part of results from hubSearchItems

### DIFF
--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
@@ -4,7 +4,7 @@ import { IHubSearchResult } from "../../types/IHubSearchResult";
 import { itemToSearchResult } from "../portalSearchItems";
 import { IOgcItem } from "./interfaces";
 
-export function ogcItemToSearchResult(
+export async function ogcItemToSearchResult(
   ogcItem: IOgcItem,
   includes?: string[],
   requestOptions?: IHubRequestOptions
@@ -13,5 +13,10 @@ export function ogcItemToSearchResult(
   // NOTE: the properties hash may also have some extraneous members such
   // as `license` and `source` if the OgcItem came from the index.
   const pseudoItem = ogcItem.properties as IItem;
-  return itemToSearchResult(pseudoItem, includes, requestOptions);
+  const result = await itemToSearchResult(pseudoItem, includes, requestOptions);
+  // Expose extraneous members like `license` and `source`
+  result.source = ogcItem.properties.source;
+  result.license = ogcItem.properties.license;
+
+  return result;
 }

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -634,6 +634,8 @@ describe("hubSearchItems Module |", () => {
       updatedDate: new Date(1671554653000),
       updatedDateSource: "item.modified",
       family: "map",
+      source: "my-source",
+      license: "CC-BY-4.0",
       links: {
         self: "https://www.arcgis.com/home/item.html?id=f4bcc",
         siteRelative: "/maps/f4bcc",
@@ -646,7 +648,7 @@ describe("hubSearchItems Module |", () => {
   describe("Response Transformation Helpers |", () => {
     describe("ogcItemToSearchResult |", () => {
       const { ogcItemToSearchResult } = ogcItemToSearchResultModule;
-      const item = {
+      const ogcItemProperties: any = {
         id: "9001",
         owner: "goku",
         created: 1006,
@@ -659,10 +661,12 @@ describe("hubSearchItems Module |", () => {
         typeKeywords: [],
         tags: [],
         categories: [],
-      } as unknown as IItem;
+        source: "my-source",
+        license: "CC-BY-4.0",
+      };
 
-      it("delegates to itemToSearchResult", async () => {
-        const mockedResult = {
+      it("delegates to itemToSearchResult, then tacks on enrichment fields", async () => {
+        const mockedItemToSearchResultResponse = {
           id: "9001",
           type: "Feature Service",
           family: "map",
@@ -670,14 +674,16 @@ describe("hubSearchItems Module |", () => {
         const delegateSpy = spyOn(
           portalSearchItemsModule,
           "itemToSearchResult"
-        ).and.returnValue(Promise.resolve(mockedResult));
+        ).and.returnValue(
+          Promise.resolve(cloneObject(mockedItemToSearchResultResponse))
+        );
         const ogcItem: IOgcItem = {
           id: "9001",
           type: "Feature",
           geometry: null, // for simplicity
           time: null, // for simplicity
           links: [], // for simplicity
-          properties: item,
+          properties: cloneObject(ogcItemProperties),
         };
         const includes: string[] = [];
         const requestOptions: IHubRequestOptions = {};
@@ -689,11 +695,15 @@ describe("hubSearchItems Module |", () => {
         );
         expect(delegateSpy).toHaveBeenCalledTimes(1);
         expect(delegateSpy).toHaveBeenCalledWith(
-          item,
+          ogcItemProperties,
           includes,
           requestOptions
         );
-        expect(result).toEqual(mockedResult);
+        expect(result).toEqual({
+          ...mockedItemToSearchResultResponse,
+          source: "my-source",
+          license: "CC-BY-4.0",
+        });
       });
     });
 

--- a/packages/common/test/search/_internal/mocks/ogcItemsResponse.ts
+++ b/packages/common/test/search/_internal/mocks/ogcItemsResponse.ts
@@ -33,6 +33,8 @@ export const ogcItemsResponse: IOgcItemsResponse = {
         snippet: "How else can I push past my limits?",
         thumbnail: "thumbnail/hub_thumbnail_1658341016537.png",
         documentation: null,
+        source: "my-source",
+        license: "CC-BY-4.0",
         extent: {
           type: "Polygon",
           coordinates: [


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Adds `license` and `source` as top level properties of `IHubSearchResult` when using the `hubSearchItems` branch of the `hubSearch` subsystem of functions.

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
