### PR TITLE
feat: add slug uri conversion functions and use in getItemBySlug

### DIFF
--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -238,10 +238,13 @@ export async function enrichInitiativeSearchResult(
   // TODO: Link handling should be an enrichment
   result.links.thumbnail = getItemThumbnailUrl(item, requestOptions);
   result.links.self = getItemHomeUrl(result.id, requestOptions);
-  let slugOrId = item.id;
-  if (item.properties?.slug) {
-    slugOrId = keywordSlugToUriSlug(item.properties.slug);
-  }
+  const slugOrId = item.id;
+  // Until the new initiatives route is in place we need to
+  // route using the id. Once the route is in place we can
+  // un-comment this
+  // if (item.properties?.slug) {
+  //   slugOrId = keywordSlugToUriSlug(item.properties.slug);
+  // }
 
   result.links.siteRelative = getHubRelativeUrl(
     result.type,

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -11,9 +11,9 @@ import {
   constructSlug,
   getItemBySlug,
   getUniqueSlug,
-  keywordSlugToUriSlug,
   setSlugKeyword,
 } from "../items/slugs";
+
 import {
   isGuid,
   cloneObject,
@@ -238,17 +238,15 @@ export async function enrichInitiativeSearchResult(
   // TODO: Link handling should be an enrichment
   result.links.thumbnail = getItemThumbnailUrl(item, requestOptions);
   result.links.self = getItemHomeUrl(result.id, requestOptions);
-  const slugOrId = item.id;
+  const identifier = item.id;
   // Until the new initiatives route is in place we need to
   // route using the id. Once the route is in place we can
   // un-comment this
-  // if (item.properties?.slug) {
-  //   slugOrId = keywordSlugToUriSlug(item.properties.slug);
-  // }
+  // const identifier = getItemIdentifier(item);
 
   result.links.siteRelative = getHubRelativeUrl(
     result.type,
-    slugOrId,
+    identifier,
     item.typeKeywords
   );
 

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -11,6 +11,7 @@ import {
   constructSlug,
   getItemBySlug,
   getUniqueSlug,
+  keywordSlugToUriSlug,
   setSlugKeyword,
 } from "../items/slugs";
 import {
@@ -237,9 +238,14 @@ export async function enrichInitiativeSearchResult(
   // TODO: Link handling should be an enrichment
   result.links.thumbnail = getItemThumbnailUrl(item, requestOptions);
   result.links.self = getItemHomeUrl(result.id, requestOptions);
+  let slugOrId = item.id;
+  if (item.properties?.slug) {
+    slugOrId = keywordSlugToUriSlug(item.properties.slug);
+  }
+
   result.links.siteRelative = getHubRelativeUrl(
     result.type,
-    result.id,
+    slugOrId,
     item.typeKeywords
   );
 

--- a/packages/common/src/items/_internal/slugConverters.ts
+++ b/packages/common/src/items/_internal/slugConverters.ts
@@ -1,0 +1,27 @@
+// TODO: work out how to unify content slug fns
+// https: github.com/Esri/hub.js/blob/master/packages/common/src/content/index.ts#L301-L348
+/**
+ * Uri slugs have `::` as a separator, but we need to use `|` in the typeKeywords. This function
+ * converts a uri slug to a typeKeyword slug.
+ * @param slug
+ * @returns
+ */
+
+export function uriSlugToKeywordSlug(slug: string): string {
+  if (slug.indexOf("::") > -1) {
+    slug = slug.replace("::", "|");
+  }
+  return slug;
+}
+/**
+ * Convert a typeKeyword slug to a uri slug. This is the reverse of uriSlugToKeywordSlug
+ * @param slug
+ * @returns
+ */
+
+export function keywordSlugToUriSlug(slug: string): string {
+  if (slug.indexOf("|") > -1) {
+    slug = slug.replace("|", "::");
+  }
+  return slug;
+}

--- a/packages/common/src/items/getItemIdentifier.ts
+++ b/packages/common/src/items/getItemIdentifier.ts
@@ -1,0 +1,12 @@
+import { IItem } from "@esri/arcgis-rest-portal";
+import { keywordSlugToUriSlug } from "./_internal/slugConverters";
+
+/**
+ * Consistent means to get an item's identifier - either the slug or the id
+ * @param item
+ * @returns
+ */
+export function getItemIdentifier(item: IItem): string {
+  const slug = item.properties?.slug;
+  return slug ? keywordSlugToUriSlug(slug) : item.id;
+}

--- a/packages/common/src/items/index.ts
+++ b/packages/common/src/items/index.ts
@@ -22,6 +22,7 @@ export * from "./create-item-from-url";
 export * from "./create-item-from-url-or-file";
 export * from "./uploadImageResource";
 export * from "./is-services-directory-disabled";
+export * from "./getItemIdentifier";
 // No longer exported as the only App Hub needed this for was a Site
 // and that registration is now done in the domain service with a
 // signed HMAC request.

--- a/packages/common/src/items/slugs.ts
+++ b/packages/common/src/items/slugs.ts
@@ -2,34 +2,7 @@ import { getItem, ISearchOptions, searchItems } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IItem } from "@esri/arcgis-rest-types";
 import { slugify } from "../utils";
-
-// TODO: work out how to unify content slug fns
-// https: github.com/Esri/hub.js/blob/master/packages/common/src/content/index.ts#L301-L348
-
-/**
- * Uri slugs have `::` as a separator, but we need to use `|` in the typeKeywords. This function
- * converts a uri slug to a typeKeyword slug.
- * @param slug
- * @returns
- */
-export function uriSlugToKeywordSlug(slug: string): string {
-  if (slug.indexOf("::") > -1) {
-    slug = slug.replace("::", "|");
-  }
-  return slug;
-}
-
-/**
- * Convert a typeKeyword slug to a uri slug. This is the reverse of uriSlugToKeywordSlug
- * @param slug
- * @returns
- */
-export function keywordSlugToUriSlug(slug: string): string {
-  if (slug.indexOf("|") > -1) {
-    slug = slug.replace("|", "::");
-  }
-  return slug;
-}
+import { uriSlugToKeywordSlug } from "./_internal/slugConverters";
 
 /**
  * Create a slug, namespaced to an org

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -5,7 +5,8 @@ import { getFamily } from "../content/get-family";
 import { getHubRelativeUrl } from "../content/_internal/internalContentUtils";
 import { IHubProject } from "../core/types";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
-import { getItemBySlug, keywordSlugToUriSlug } from "../items/slugs";
+import { getItemBySlug } from "../items/slugs";
+
 import { fetchItemEnrichments } from "../items/_enrichments";
 import { fetchModelFromItem, fetchModelResources } from "../models";
 import { IHubSearchResult } from "../search";
@@ -18,6 +19,7 @@ import { unique } from "../util";
 import { getProp } from "../objects/get-prop";
 import { getItemThumbnailUrl } from "../resources/get-item-thumbnail-url";
 import { getItemHomeUrl } from "../urls/get-item-home-url";
+import { getItemIdentifier } from "../items";
 
 /**
  * @private
@@ -120,13 +122,10 @@ export async function enrichProjectSearchResult(
   // TODO: Link handling should be an enrichment
   result.links.thumbnail = getItemThumbnailUrl(item, requestOptions);
   result.links.self = getItemHomeUrl(result.id, requestOptions);
-  let slugOrId = item.id;
-  if (item.properties?.slug) {
-    slugOrId = keywordSlugToUriSlug(item.properties.slug);
-  }
+  const identifier = getItemIdentifier(item);
   result.links.siteRelative = getHubRelativeUrl(
     result.type,
-    slugOrId,
+    identifier,
     item.typeKeywords
   );
 

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -5,7 +5,7 @@ import { getFamily } from "../content/get-family";
 import { getHubRelativeUrl } from "../content/_internal/internalContentUtils";
 import { IHubProject } from "../core/types";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
-import { getItemBySlug } from "../items/slugs";
+import { getItemBySlug, keywordSlugToUriSlug } from "../items/slugs";
 import { fetchItemEnrichments } from "../items/_enrichments";
 import { fetchModelFromItem, fetchModelResources } from "../models";
 import { IHubSearchResult } from "../search";
@@ -122,7 +122,7 @@ export async function enrichProjectSearchResult(
   result.links.self = getItemHomeUrl(result.id, requestOptions);
   let slugOrId = item.id;
   if (item.properties?.slug) {
-    slugOrId = item.properties.slug.replace("|", "::");
+    slugOrId = keywordSlugToUriSlug(item.properties.slug);
   }
   result.links.siteRelative = getHubRelativeUrl(
     result.type,

--- a/packages/common/test/initiatives/HubInitiatives.test.ts
+++ b/packages/common/test/initiatives/HubInitiatives.test.ts
@@ -377,6 +377,12 @@ describe("HubInitiatives:", () => {
       const chk = await enrichInitiativeSearchResult(itm, [], hubRo);
       expect(chk.summary).toEqual(itm.snippet);
     });
+    it("uses converts and uses slug if defined", async () => {
+      const itm = cloneObject(INITIATIVE_ITEM_ENRICH);
+      itm.properties = { slug: "myorg|my-slug" };
+      const chk = await enrichInitiativeSearchResult(itm, [], hubRo);
+      expect(chk.links?.siteRelative).toEqual("/content/myorg::my-slug");
+    });
     it("fetches enrichments", async () => {
       const chk = await enrichInitiativeSearchResult(
         cloneObject(INITIATIVE_ITEM_ENRICH),

--- a/packages/common/test/initiatives/HubInitiatives.test.ts
+++ b/packages/common/test/initiatives/HubInitiatives.test.ts
@@ -377,12 +377,6 @@ describe("HubInitiatives:", () => {
       const chk = await enrichInitiativeSearchResult(itm, [], hubRo);
       expect(chk.summary).toEqual(itm.snippet);
     });
-    it("uses converts and uses slug if defined", async () => {
-      const itm = cloneObject(INITIATIVE_ITEM_ENRICH);
-      itm.properties = { slug: "myorg|my-slug" };
-      const chk = await enrichInitiativeSearchResult(itm, [], hubRo);
-      expect(chk.links?.siteRelative).toEqual("/content/myorg::my-slug");
-    });
     it("fetches enrichments", async () => {
       const chk = await enrichInitiativeSearchResult(
         cloneObject(INITIATIVE_ITEM_ENRICH),

--- a/packages/common/test/items/_internal/slugConverters.test.ts
+++ b/packages/common/test/items/_internal/slugConverters.test.ts
@@ -1,0 +1,17 @@
+import {
+  keywordSlugToUriSlug,
+  uriSlugToKeywordSlug,
+} from "../../../src/items/_internal/slugConverters";
+
+describe("slug conversions:", () => {
+  it("converts kwd slug to uri slugs", () => {
+    expect(keywordSlugToUriSlug("slug|foo-bar")).toBe("slug::foo-bar");
+    expect(keywordSlugToUriSlug("slug::foo-bar")).toBe("slug::foo-bar");
+    expect(keywordSlugToUriSlug("foo-bar")).toBe("foo-bar");
+  });
+
+  it("converts uri slug to kwd slugs", () => {
+    expect(uriSlugToKeywordSlug("foo-bar")).toBe("foo-bar");
+    expect(uriSlugToKeywordSlug("slug::foo-bar")).toBe("slug|foo-bar");
+  });
+});

--- a/packages/common/test/items/getItemIdentifier.test.ts
+++ b/packages/common/test/items/getItemIdentifier.test.ts
@@ -1,0 +1,20 @@
+import { IItem } from "@esri/arcgis-rest-portal";
+import { getItemIdentifier } from "../../src";
+
+describe("getItemIdentifier:", () => {
+  it("returns id by default", () => {
+    const item = {
+      id: "3ef",
+    } as unknown as IItem;
+    expect(getItemIdentifier(item)).toBe("3ef");
+  });
+  it("returns slug if defined", () => {
+    const item = {
+      id: "3ef",
+      properties: {
+        slug: "myorg|the-slug",
+      },
+    } as unknown as IItem;
+    expect(getItemIdentifier(item)).toBe("myorg::the-slug");
+  });
+});

--- a/packages/common/test/items/slugs.test.ts
+++ b/packages/common/test/items/slugs.test.ts
@@ -2,24 +2,8 @@ import * as portalModule from "@esri/arcgis-rest-portal";
 import * as slugModule from "../../src/items/slugs";
 import { MOCK_AUTH } from "../groups/add-users-workflow/fixtures";
 import { ISearchOptions } from "@esri/arcgis-rest-portal";
-import {
-  keywordSlugToUriSlug,
-  uriSlugToKeywordSlug,
-} from "../../src/items/slugs";
 
 describe("slug utils: ", () => {
-  describe("uri slugs:", () => {
-    it("converts kwd slug to uri slugs", () => {
-      expect(keywordSlugToUriSlug("slug|foo-bar")).toBe("slug::foo-bar");
-      expect(keywordSlugToUriSlug("slug::foo-bar")).toBe("slug::foo-bar");
-      expect(keywordSlugToUriSlug("foo-bar")).toBe("foo-bar");
-    });
-
-    it("converts uri slug to kwd slugs", () => {
-      expect(uriSlugToKeywordSlug("foo-bar")).toBe("foo-bar");
-      expect(uriSlugToKeywordSlug("slug::foo-bar")).toBe("slug|foo-bar");
-    });
-  });
   describe("createSlug:", () => {
     it("combined org and dasherized title", () => {
       expect(slugModule.constructSlug("Hello World", "DCdev")).toBe(


### PR DESCRIPTION
1. Description:

- add helper functions that convert to / from uri slugs (`myorg::the-slug`) to (`myorg|the-slug`) and back
- use functions in entity functions that convert items to search results
- use function in `getItemBySlug` (lowest level function for fetching) so the uri slugs can be passed waaaay down, ensuring all upstream fns can handle the uri slugs cleanly.

1. Instructions for testing: run tests

1. Closes Issues: #6932

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
