### PR TITLE
fix(hub-discussions): move allowAnonymous to channel permissions inte…

### DIFF
--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -768,7 +768,6 @@ export interface IChannelAclPermission
  */
 export interface ICreateChannelSettings {
   allowReply?: boolean;
-  allowAnonymous?: boolean;
   softDelete?: boolean;
   defaultPostStatus?: PostStatus;
   allowReaction?: boolean;
@@ -785,6 +784,7 @@ export interface ICreateChannelSettings {
  */
 export interface ICreateChannelPermissions {
   access?: SharingAccess;
+  allowAnonymous?: boolean;
   groups?: string[];
   orgs?: string[];
   /**
@@ -792,6 +792,17 @@ export interface ICreateChannelPermissions {
    * @hidden
    */
   channelAclDefinition?: IChannelAclPermissionDefinition[];
+}
+
+/**
+ * permissions parameters for updating a channel
+ *
+ * @export
+ * @interface IUpdateChannelPermissions
+ */
+export interface IUpdateChannelPermissions {
+  access?: SharingAccess;
+  allowAnonymous?: boolean;
 }
 
 /**
@@ -838,10 +849,12 @@ export interface IChannel extends IWithAuthor, IWithEditor, IWithTimestamps {
  * @export
  * @interface IUpdateChannel
  * @extends {ICreateChannelSettings}
+ * @extends { IUpdateChannelPermissions}
  * @extends {Partial<IWithAuthor>}
  */
 export interface IUpdateChannel
   extends ICreateChannelSettings,
+    IUpdateChannelPermissions,
     Partial<IWithAuthor> {}
 
 /**


### PR DESCRIPTION
…rface and add access to channel

affects: @esri/hub-discussions

1. Description: In order to introduce `access` as a possible channel update parameter - move `allowAnonymous` from create channel settings interface to create channel permissions interface and create a new update channelPermission interface.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ x] used semantic commit messages
  
1. [x ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
