### PR TITLE
fix: remove license checks on view and edit project permission policies

### DIFF
--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -66,14 +66,12 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:project:view",
     subsystems: ["projects"],
     authenticated: false,
-    licenses: ["hub-premium"],
   },
   {
     permission: "hub:project:edit",
     authenticated: true,
     subsystems: ["projects"],
     entityEdit: true,
-    licenses: ["hub-premium"],
   },
   {
     permission: "hub:project:delete",


### PR DESCRIPTION
[6958](https://devtopia.esri.com/dc/hub/issues/6958)

### Description
remove the `licenses` check from the `hub:project:view` and `hub:project:edit` permission policies to align with our expectations of who can view and edit projects

- [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
- [x] used semantic commit messages
- [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
- [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.