### PR TITLE
feat(hub-discussions): add optional guidelineUrl to IChannel and ICre…

### DIFF
--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -767,13 +767,14 @@ export interface IChannelAclPermission
  * @interface ICreateChannelSettings
  */
 export interface ICreateChannelSettings {
-  allowReply?: boolean;
-  softDelete?: boolean;
-  defaultPostStatus?: PostStatus;
-  allowReaction?: boolean;
-  name?: string;
   allowedReactions?: PostReaction[];
+  allowReaction?: boolean;
+  allowReply?: boolean;
   blockWords?: string[];
+  defaultPostStatus?: PostStatus;
+  guidelineUrl?: string;
+  name?: string;
+  softDelete?: boolean;
 }
 
 /**
@@ -827,20 +828,21 @@ export interface ICreateChannel
  * @extends {IWithTimestamps}
  */
 export interface IChannel extends IWithAuthor, IWithEditor, IWithTimestamps {
-  id: string;
-  posts?: IPost[];
-  allowReply: boolean;
-  allowAnonymous: boolean;
-  softDelete: boolean;
-  defaultPostStatus: PostStatus;
-  allowReaction: boolean;
-  allowedReactions: PostReaction[] | null;
-  blockWords: string[] | null;
-  name: string | null;
   access: SharingAccess;
-  orgs: string[];
-  groups: string[];
+  allowAnonymous: boolean;
+  allowedReactions: PostReaction[] | null;
+  allowReaction: boolean;
+  allowReply: boolean;
+  blockWords: string[] | null;
   channelAcl?: IChannelAclPermission[];
+  defaultPostStatus: PostStatus;
+  groups: string[];
+  guidelineUrl: string | null;
+  id: string;
+  name: string | null;
+  orgs: string[];
+  posts?: IPost[];
+  softDelete: boolean;
 }
 
 /**


### PR DESCRIPTION
…ateChannelSettings

affects: @esri/hub-discussions

1. Description: Add new channel column `guidelineUrl` to IChannel and optional on create and update channel

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
