### PR TITLE
feat(hub-discussions): expand isDiscussable

### DIFF
--- a/packages/discussions/src/utils/posts/index.ts
+++ b/packages/discussions/src/utils/posts/index.ts
@@ -1,6 +1,6 @@
 import { IGroup, IItem } from "@esri/arcgis-rest-portal";
 import { IChannel, IDiscussionParams, IPost } from "../../types";
-import { parseDatasetId, IHubContent } from "@esri/hub-common";
+import { parseDatasetId, IHubContent, IHubItemEntity } from "@esri/hub-common";
 import { IUser } from "@esri/arcgis-rest-auth";
 import { canModifyChannel } from "../channels";
 import { CANNOT_DISCUSS, MENTION_ATTRIBUTE } from "../constants";
@@ -47,13 +47,15 @@ export function parseDiscussionURI(discussion: string): IDiscussionParams {
 }
 
 /**
- * Utility to determine if a given IGroup, IItem or IHubContent
+ * Utility to determine if a given IGroup, IItem, IHubContent, or IHubItemEntity
  * is discussable.
  * @export
- * @param {IGroup|IItem|IHubContent} The subject to evaluate
+ * @param {IGroup|IItem|IHubContent|IHubItemEntity} The subject to evaluate
  * @return {boolean}
  */
-export function isDiscussable(subject: IGroup | IItem | IHubContent) {
+export function isDiscussable(
+  subject: IGroup | IItem | IHubContent | IHubItemEntity
+) {
   return !(subject.typeKeywords ?? []).includes(CANNOT_DISCUSS);
 }
 


### PR DESCRIPTION
affects: @esri/hub-discussions

ISSUES CLOSED: 6883

1. Description: Expands isDiscussable so it can be used to determine IHubEntity discussability.

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
