### PR TITLE
feat(): adds discussion create ui schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64972,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "12.42.0",
+			"version": "13.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64997,7 +64997,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "22.2.0",
+			"version": "24.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65010,12 +65010,12 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^12.4.0 || 13"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "12.4.1",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -65030,12 +65030,12 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^12.4.0 || 13"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "12.4.1",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65050,12 +65050,12 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^12.4.0 || 13"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "12.4.1",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65069,12 +65069,12 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^13"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "12.4.1",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65091,34 +65091,34 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^12.4.0 || 13"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "12.6.0",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
 				"@esri/hub-common": "*",
-				"@esri/hub-initiatives": "*",
-				"@esri/hub-teams": "*",
+				"@esri/hub-initiatives": "^13.0.0",
+				"@esri/hub-teams": "^13.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0",
-				"@esri/hub-initiatives": "^12.4.0",
-				"@esri/hub-teams": "^12.4.0"
+				"@esri/hub-common": "^13",
+				"@esri/hub-initiatives": "^13.0.0",
+				"@esri/hub-teams": "^13.0.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "12.4.1",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65133,12 +65133,12 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^12.4.0 || 13"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "12.4.1",
+			"version": "13.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65152,7 +65152,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0"
+				"@esri/hub-common": "^12.4.0 || 13"
 			}
 		}
 	},
@@ -68762,8 +68762,8 @@
 			"version": "file:packages/sites",
 			"requires": {
 				"@esri/hub-common": "*",
-				"@esri/hub-initiatives": "*",
-				"@esri/hub-teams": "*",
+				"@esri/hub-initiatives": "^13.0.0",
+				"@esri/hub-teams": "^13.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/common/src/core/schemas/getEntityEditorSchemas.ts
+++ b/packages/common/src/core/schemas/getEntityEditorSchemas.ts
@@ -16,6 +16,10 @@ import {
   SiteEditorType,
   SiteEditorTypes,
 } from "../../sites/_internal/SiteSchema";
+import {
+  DiscussionEditorType,
+  DiscussionEditorTypes,
+} from "../../discussions/_internal/DiscussionSchema";
 
 /**
  * defines the possible editor type values - these correspond
@@ -26,6 +30,7 @@ export const validEditorTypes = [
   ...ProjectEditorTypes,
   ...InitiativeEditorTypes,
   ...SiteEditorTypes,
+  ...DiscussionEditorTypes,
 ] as const;
 
 /**
@@ -81,6 +86,17 @@ export const getEntityEditorSchemas = async (
       ({ uiSchema } = await {
         "hub:site:edit": () => import("../../sites/_internal/SiteUiSchemaEdit"),
       }[type as SiteEditorType]());
+      break;
+    case "discussion":
+      const { DiscussionSchema } = await import(
+        "../../discussions/_internal/DiscussionSchema"
+      );
+      schema = cloneObject(DiscussionSchema);
+
+      ({ uiSchema } = await {
+        "hub:discussion:edit": () =>
+          import("../../discussions/_internal/DiscussionUiSchemaEdit"),
+      }[type as DiscussionEditorType]());
       break;
   }
 

--- a/packages/common/src/core/schemas/getEntityEditorSchemas.ts
+++ b/packages/common/src/core/schemas/getEntityEditorSchemas.ts
@@ -96,6 +96,8 @@ export const getEntityEditorSchemas = async (
       ({ uiSchema } = await {
         "hub:discussion:edit": () =>
           import("../../discussions/_internal/DiscussionUiSchemaEdit"),
+        "hub:discussion:create": () =>
+          import("../../discussions/_internal/DiscussionUiSchemaCreate"),
       }[type as DiscussionEditorType]());
       break;
   }

--- a/packages/common/src/core/types/HubEntity.ts
+++ b/packages/common/src/core/types/HubEntity.ts
@@ -2,5 +2,11 @@ import { IHubInitiative } from "./IHubInitiative";
 import { IHubPage } from "./IHubPage";
 import { IHubProject } from "./IHubProject";
 import { IHubSite } from "./IHubSite";
+import { IHubDiscussion } from "./IHubDiscussion";
 
-export type HubEntity = IHubSite | IHubProject | IHubInitiative | IHubPage;
+export type HubEntity =
+  | IHubSite
+  | IHubProject
+  | IHubDiscussion
+  | IHubInitiative
+  | IHubPage;

--- a/packages/common/src/discussions/_internal/DiscussionSchema.ts
+++ b/packages/common/src/discussions/_internal/DiscussionSchema.ts
@@ -23,13 +23,6 @@ export const DiscussionSchema: IConfigurationSchema = {
     description: {
       type: "string",
     },
-    access: ENTITY_ACCESS_SCHEMA,
-    groups: {
-      type: "array",
-      items: {
-        type: "string",
-      },
-    },
     location: {
       type: "object",
     },

--- a/packages/common/src/discussions/_internal/DiscussionSchema.ts
+++ b/packages/common/src/discussions/_internal/DiscussionSchema.ts
@@ -1,0 +1,50 @@
+import { IConfigurationSchema } from "../../core";
+import {
+  ENTITY_ACCESS_SCHEMA,
+  ENTITY_CATEGORIES_SCHEMA,
+  ENTITY_NAME_SCHEMA,
+  ENTITY_TAGS_SCHEMA,
+} from "../../core/schemas/shared";
+
+export type DiscussionEditorType = (typeof DiscussionEditorTypes)[number];
+export const DiscussionEditorTypes = ["hub:discussion:edit"] as const;
+
+/**
+ * defines the JSON schema for a Discussion's editable fields
+ */
+export const DiscussionSchema: IConfigurationSchema = {
+  required: ["name"],
+  type: "object",
+  properties: {
+    name: ENTITY_NAME_SCHEMA,
+    summary: {
+      type: "string",
+    },
+    description: {
+      type: "string",
+    },
+    access: ENTITY_ACCESS_SCHEMA,
+    groups: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+    location: {
+      type: "object",
+    },
+    tags: ENTITY_TAGS_SCHEMA,
+    categories: ENTITY_CATEGORIES_SCHEMA,
+    view: {
+      type: "object",
+      properties: {
+        featuredImage: {
+          type: "object",
+        },
+        featuredImageAltText: {
+          type: "string",
+        },
+      },
+    },
+  },
+} as unknown as IConfigurationSchema;

--- a/packages/common/src/discussions/_internal/DiscussionSchema.ts
+++ b/packages/common/src/discussions/_internal/DiscussionSchema.ts
@@ -7,7 +7,10 @@ import {
 } from "../../core/schemas/shared";
 
 export type DiscussionEditorType = (typeof DiscussionEditorTypes)[number];
-export const DiscussionEditorTypes = ["hub:discussion:edit"] as const;
+export const DiscussionEditorTypes = [
+  "hub:discussion:edit",
+  "hub:discussion:create",
+] as const;
 
 /**
  * defines the JSON schema for a Discussion's editable fields

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaCreate.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaCreate.ts
@@ -1,0 +1,27 @@
+import { IUiSchema, UiSchemaRuleEffects } from "../../core";
+
+/**
+ * create uiSchema for Hub Discussions - this
+ * defines how the schema properties should be
+ * rendered in the Discussions creation experience
+ */
+export const uiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      labelKey: "{{i18nScope}}.fields.name.label",
+      scope: "/properties/name",
+      type: "Control",
+      options: {
+        messages: [
+          {
+            type: "ERROR",
+            keyword: "required",
+            icon: true,
+            labelKey: "{{i18nScope}}.fields.name.requiredError",
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -1,0 +1,116 @@
+import { IUiSchema } from "../../core";
+
+/**
+ * complete edit uiSchema for Hub discussions - this defines
+ * how the schema properties should be rendered in the
+ * discussion editing experience
+ */
+export const uiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.basicInfo.label",
+      elements: [
+        {
+          labelKey: "{{i18nScope}}.fields.name.label",
+          scope: "/properties/name",
+          type: "Control",
+          options: {
+            messages: [
+              {
+                type: "ERROR",
+                keyword: "required",
+                icon: true,
+                labelKey: "{{i18nScope}}.fields.name.requiredError",
+              },
+            ],
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.summary.label",
+          scope: "/properties/summary",
+          type: "Control",
+          options: {
+            control: "hub-field-input-input",
+            type: "textarea",
+            helperText: {
+              labelKey: "{{i18nScope}}.fields.summary.helperText",
+            },
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.description.label",
+          scope: "/properties/description",
+          type: "Control",
+          options: {
+            control: "hub-field-input-input",
+            type: "textarea",
+            helperText: {
+              labelKey: "{{i18nScope}}.fields.description.helperText",
+            },
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.featuredImage.label",
+          scope: "/properties/view/properties/featuredImage",
+          type: "Control",
+          options: {
+            control: "hub-field-input-image-picker",
+            maxWidth: 727,
+            maxHeight: 484,
+            aspectRatio: 1.5,
+            sizeDescription: {
+              labelKey: "{{i18nScope}}.fields.featuredImage.sizeDescription",
+            },
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.featuredImage.altText.label",
+          scope: "/properties/view/properties/featuredImageAltText",
+          type: "Control",
+          options: {
+            helperText: {
+              labelKey: "{{i18nScope}}.fields.featuredImage.altText.helperText",
+            },
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.tags.label",
+          scope: "/properties/tags",
+          type: "Control",
+          options: {
+            control: "hub-field-input-combobox",
+            allowCustomValues: true,
+            selectionMode: "multiple",
+            placeholderIcon: "label",
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.categories.label",
+          scope: "/properties/categories",
+          type: "Control",
+          options: {
+            control: "hub-field-input-combobox",
+            allowCustomValues: false,
+            selectionMode: "multiple",
+            placeholderIcon: "select-category",
+          },
+        },
+      ],
+    },
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.location.label",
+      elements: [
+        {
+          scope: "/properties/location",
+          type: "Control",
+          options: {
+            control: "hub-field-input-location-picker",
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/packages/common/test/core/schemas/getEntityEditorSchema.test.ts
+++ b/packages/common/test/core/schemas/getEntityEditorSchema.test.ts
@@ -2,6 +2,7 @@ import { getEntityEditorSchemas } from "../../../src/core/schemas/getEntityEdito
 import { ProjectEditorTypes } from "../../../src/projects/_internal/ProjectSchema";
 import { InitiativeEditorTypes } from "../../../src/initiatives/_internal/InitiativeSchema";
 import { SiteEditorTypes } from "../../../src/sites/_internal/SiteSchema";
+import { DiscussionEditorTypes } from "../../../src/discussions/_internal/DiscussionSchema";
 import * as applyOptionsModule from "../../../src/core/schemas/internal/applyUiSchemaElementOptions";
 import * as filterSchemaModule from "../../../src/core/schemas/internal/filterSchemaToUiSchema";
 import * as itemsModule from "../../../src/items";
@@ -12,6 +13,7 @@ describe("getEntityEditorSchemas", () => {
       ...ProjectEditorTypes,
       ...InitiativeEditorTypes,
       ...SiteEditorTypes,
+      ...DiscussionEditorTypes,
     ].forEach(async (type, idx) => {
       const { schema, uiSchema } = await getEntityEditorSchemas(
         "some.scope",


### PR DESCRIPTION
1. Description: Adds `create` uiSchema for Discussions for 'new' discussion board workflow. (includes `cherry-picked` commits from [1080](https://github.com/Esri/hub.js/pull/1080).

1. Instructions for testing:

1. Closes Issues: Part of #6876

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
