### PR TITLE
fix(hub-common): have capitalize() handle the empty string, change titlelize() to stop stripping white space

### DIFF
--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -403,9 +403,11 @@ export const isNil = (value: unknown) => value == null;
  * @returns Word
  */
 export const capitalize = (word: string) => {
-  // upper case first letter and return as element in array for backwards compatibility
   const chars = Array.from(word);
-  chars[0] = chars[0].toUpperCase();
+  // account for the empty string
+  if (chars.length) {
+    chars[0] = chars[0].toUpperCase();
+  }
   return chars.join("");
 };
 

--- a/packages/common/src/utils/titleize.ts
+++ b/packages/common/src/utils/titleize.ts
@@ -7,7 +7,6 @@ import { capitalize } from "../util";
  */
 export function titleize(value: string) {
   return value
-    .replace(/\s\s+/g, " ")
     .split(" ")
     .map((k) => capitalize(k))
     .join(" ");

--- a/packages/common/test/utils/titleize.test.ts
+++ b/packages/common/test/utils/titleize.test.ts
@@ -4,7 +4,7 @@ describe("titleize", function () {
   it("capitalizes every word in a sentence", function () {
     expect(titleize("hello")).toBe("Hello");
     expect(titleize("hello world")).toBe("Hello World");
-    expect(titleize("hello    world")).toBe("Hello World");
+    expect(titleize("hello    world")).toBe("Hello    World");
     expect(titleize("helloworld")).toBe("Helloworld");
     expect(titleize("hello-world")).toBe("Hello-world");
   });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Fixes https://devtopia.esri.com/dc/hub/issues/6999

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
