### PR TITLE
fix: address issue creating sites on portal

### DIFF
--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -273,14 +273,13 @@ export async function createSite(
   );
 
   // Register as an app
-  // const registration = await registerSiteAsApplication(model, requestOptions);
-  // model.data.values.clientId = registration.client_id;
   // NOTE: Site registration needs to happen via the hub api domain api calls
   // See https://devtopia.esri.com/dc/hub/issues/6390 for info
 
   // Register domain and at the same time register the site as an application
+  // for portal, this will return a single entry with just the clientKey
   const domainResponses = await addSiteDomains(model, requestOptions);
-  model.data.values.clientId = domainResponses[0].client_id;
+  model.data.values.clientId = domainResponses[0].clientKey;
 
   // update the model
   const updatedModel = await updateModel(

--- a/packages/common/src/sites/domains/addSiteDomains.ts
+++ b/packages/common/src/sites/domains/addSiteDomains.ts
@@ -5,6 +5,8 @@ import { addDomain } from "./add-domain";
 /**
  * Given a Site Model, register the domains with the Domain Service.
  *
+ * For Portal, this will return a sparse entry that contains just the portal clientKey
+ *
  * This should only be used when creating a site. To update domains related
  * to a site, use the `addDomain` and `removeDomain` functions directly
  *
@@ -16,7 +18,8 @@ export function addSiteDomains(
   hubRequestOptions: IHubRequestOptions
 ): Promise<any[]> {
   if (hubRequestOptions.isPortal) {
-    // For enterprise we don't register the domain, and we don't
+    // For enterprise we don't register the domain, but we do return a sparse entry
+    // that contains just the portal clientKey so that the caller can use it.
     return Promise.resolve([{ clientKey: "arcgisonline" }]);
   } else {
     const props = ["defaultHostname", "customHostname"];

--- a/packages/common/src/sites/domains/addSiteDomains.ts
+++ b/packages/common/src/sites/domains/addSiteDomains.ts
@@ -16,7 +16,8 @@ export function addSiteDomains(
   hubRequestOptions: IHubRequestOptions
 ): Promise<any[]> {
   if (hubRequestOptions.isPortal) {
-    return Promise.resolve([]);
+    // For enterprise we don't register the domain, and we don't
+    return Promise.resolve([{ clientKey: "arcgisonline" }]);
   } else {
     const props = ["defaultHostname", "customHostname"];
     return Promise.all(

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -348,114 +348,125 @@ describe("HubSites:", () => {
         const newModel = commonModule.cloneObject(m);
         return Promise.resolve(newModel);
       });
-
-      addDomainsSpy = spyOn(
-        require("../../src/sites/domains/addSiteDomains"),
-        "addSiteDomains"
-      ).and.returnValue(Promise.resolve([{ clientKey: "FAKE_CLIENT_KEY" }]));
     });
-    it("works with a sparse IHubSite", async () => {
-      const sparseSite: Partial<commonModule.IHubSite> = {
-        name: "my site",
-        orgUrlKey: "dcdev",
-      };
+    describe("online: ", () => {
+      beforeEach(() => {
+        addDomainsSpy = spyOn(
+          require("../../src/sites/domains/addSiteDomains"),
+          "addSiteDomains"
+        ).and.returnValue(Promise.resolve([{ clientKey: "FAKE_CLIENT_KEY" }]));
+      });
+      it("works with a sparse IHubSite", async () => {
+        const sparseSite: Partial<commonModule.IHubSite> = {
+          name: "my site",
+          orgUrlKey: "dcdev",
+        };
 
-      const chk = await commonModule.createSite(sparseSite, MOCK_HUB_REQOPTS);
+        const chk = await commonModule.createSite(sparseSite, MOCK_HUB_REQOPTS);
 
-      expect(uniqueDomainSpy.calls.count()).toBe(1);
-      expect(createModelSpy.calls.count()).toBe(1);
-      expect(updateModelSpy.calls.count()).toBe(1);
+        expect(uniqueDomainSpy.calls.count()).toBe(1);
+        expect(createModelSpy.calls.count()).toBe(1);
+        expect(updateModelSpy.calls.count()).toBe(1);
 
-      expect(addDomainsSpy.calls.count()).toBe(1);
+        expect(addDomainsSpy.calls.count()).toBe(1);
 
-      const modelToCreate = createModelSpy.calls.argsFor(0)[0];
-      expect(modelToCreate.item.title).toBe("my site");
-      expect(modelToCreate.item.type).toBe("Hub Site Application");
-      expect(modelToCreate.item.properties.slug).toBe("dcdev|my-site");
-      expect(modelToCreate.item.properties.orgUrlKey).toBe("org");
+        const modelToCreate = createModelSpy.calls.argsFor(0)[0];
+        expect(modelToCreate.item.title).toBe("my site");
+        expect(modelToCreate.item.type).toBe("Hub Site Application");
+        expect(modelToCreate.item.properties.slug).toBe("dcdev|my-site");
+        expect(modelToCreate.item.properties.orgUrlKey).toBe("org");
+        const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
+        expect(modelToUpdate.data.values.clientId).toBe("FAKE_CLIENT_KEY");
 
-      expect(chk.name).toBe("my site");
-      expect(chk.url).toBe("https://my-site-org.hubqa.arcgis.com");
-    });
-    it("works with a full IHubSite", async () => {
-      const site: Partial<commonModule.IHubSite> = {
-        name: "Special Site",
-        slug: "CuStOm-Slug",
-        subdomain: "custom-subdomain",
-        customHostname: "site.myorg.com",
-        theme: {
-          fake: "theme",
-        },
-        defaultExtent: {
-          xmax: 10,
-          ymax: 10,
-          xmin: 5,
-          ymin: 5,
-          spatialReference: {
-            wkid: 4326,
+        expect(chk.name).toBe("my site");
+        expect(chk.url).toBe("https://my-site-org.hubqa.arcgis.com");
+      });
+      it("works with a full IHubSite", async () => {
+        const site: Partial<commonModule.IHubSite> = {
+          name: "Special Site",
+          slug: "CuStOm-Slug",
+          subdomain: "custom-subdomain",
+          customHostname: "site.myorg.com",
+          theme: {
+            fake: "theme",
           },
-        },
-        culture: "fr-ca",
-        map: {
-          basemaps: {
-            primary: {
-              fake: "basemap",
+          defaultExtent: {
+            xmax: 10,
+            ymax: 10,
+            xmin: 5,
+            ymin: 5,
+            spatialReference: {
+              wkid: 4326,
             },
           },
-        },
-        orgUrlKey: "dcdev",
-        layout: {
-          sections: [{}],
-          header: {
-            component: {
-              settings: {
-                title: "Title that is already set",
+          culture: "fr-ca",
+          map: {
+            basemaps: {
+              primary: {
+                fake: "basemap",
               },
             },
           },
-        },
-      };
+          orgUrlKey: "dcdev",
+          layout: {
+            sections: [{}],
+            header: {
+              component: {
+                settings: {
+                  title: "Title that is already set",
+                },
+              },
+            },
+          },
+        };
 
-      const chk = await commonModule.createSite(site, MOCK_HUB_REQOPTS);
+        const chk = await commonModule.createSite(site, MOCK_HUB_REQOPTS);
 
-      expect(uniqueDomainSpy.calls.count()).toBe(1);
-      expect(createModelSpy.calls.count()).toBe(1);
-      expect(updateModelSpy.calls.count()).toBe(1);
+        expect(uniqueDomainSpy.calls.count()).toBe(1);
+        expect(createModelSpy.calls.count()).toBe(1);
+        expect(updateModelSpy.calls.count()).toBe(1);
 
-      expect(addDomainsSpy.calls.count()).toBe(1);
+        expect(addDomainsSpy.calls.count()).toBe(1);
 
-      expect(chk.name).toBe("Special Site");
-      expect(chk.url).toBe("https://site.myorg.com");
-      expect(chk.culture).toBe("fr-ca");
-      expect(chk.theme).toEqual({ fake: "theme" });
-      expect(chk.defaultExtent.xmax).toBe(10);
-      expect(chk.map.basemaps.primary).toEqual({ fake: "basemap" });
+        const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
+        expect(modelToUpdate.data.values.clientId).toBe("FAKE_CLIENT_KEY");
+        expect(chk.name).toBe("Special Site");
+        expect(chk.url).toBe("https://site.myorg.com");
+        expect(chk.culture).toBe("fr-ca");
+        expect(chk.theme).toEqual({ fake: "theme" });
+        expect(chk.defaultExtent.xmax).toBe(10);
+        expect(chk.map.basemaps.primary).toEqual({ fake: "basemap" });
+      });
     });
-    it("works in portal", async () => {
-      const sparseSite: Partial<commonModule.IHubSite> = {
-        name: "my site",
-        orgUrlKey: "dcdev",
-      };
+    describe("portal:", () => {
+      it("works in portal", async () => {
+        const sparseSite: Partial<commonModule.IHubSite> = {
+          name: "my site",
+          orgUrlKey: "dcdev",
+        };
 
-      const chk = await commonModule.createSite(
-        sparseSite,
-        MOCK_ENTERPRISE_REQOPTS
-      );
+        const chk = await commonModule.createSite(
+          sparseSite,
+          MOCK_ENTERPRISE_REQOPTS
+        );
 
-      expect(uniqueDomainSpy.calls.count()).toBe(1);
-      expect(createModelSpy.calls.count()).toBe(1);
-      expect(updateModelSpy.calls.count()).toBe(1);
+        expect(uniqueDomainSpy.calls.count()).toBe(1);
+        expect(createModelSpy.calls.count()).toBe(1);
+        expect(updateModelSpy.calls.count()).toBe(1);
 
-      expect(addDomainsSpy.calls.count()).toBe(1);
-
-      const modelToCreate = createModelSpy.calls.argsFor(0)[0];
-      expect(modelToCreate.item.title).toBe("my site");
-      expect(modelToCreate.item.type).toBe("Site Application");
-      expect(modelToCreate.item.properties.slug).toBe("dcdev|my-site");
-      expect(modelToCreate.item.properties.orgUrlKey).toBe("org");
-      expect(chk.url).toBe("https://my-server.com/portal/apps/sites/#/my-site");
-      expect(chk.typeKeywords).toContain(`hubsubdomain|${chk.subdomain}`);
-      expect(chk.subdomain).toBe(`my-site`);
+        const modelToCreate = createModelSpy.calls.argsFor(0)[0];
+        expect(modelToCreate.item.title).toBe("my site");
+        expect(modelToCreate.item.type).toBe("Site Application");
+        expect(modelToCreate.item.properties.slug).toBe("dcdev|my-site");
+        expect(modelToCreate.item.properties.orgUrlKey).toBe("org");
+        const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
+        expect(modelToUpdate.data.values.clientId).toBe("arcgisonline");
+        expect(chk.url).toBe(
+          "https://my-server.com/portal/apps/sites/#/my-site"
+        );
+        expect(chk.typeKeywords).toContain(`hubsubdomain|${chk.subdomain}`);
+        expect(chk.subdomain).toBe(`my-site`);
+      });
     });
   });
   describe("enrichments:", () => {

--- a/packages/common/test/sites/domains/addSiteDomains.test.ts
+++ b/packages/common/test/sites/domains/addSiteDomains.test.ts
@@ -75,7 +75,12 @@ describe("addSiteDomains", () => {
       },
     } as unknown as IHubRequestOptions;
 
-    await addSiteDomains(model, ro);
+    const result = await addSiteDomains(model, ro);
+
+    expect(result[0].clientKey).toBe(
+      "arcgisonline",
+      "returns portal client key"
+    );
 
     expect(addSpy.calls.count()).toBe(0);
   });

--- a/packages/sites/src/create-site.ts
+++ b/packages/sites/src/create-site.ts
@@ -17,7 +17,6 @@ import {
 } from "@esri/arcgis-rest-portal";
 
 import { updateInitiativeSiteId } from "@esri/hub-initiatives";
-import { domain } from "process";
 
 /**
  * Create a New Site

--- a/packages/sites/src/create-site.ts
+++ b/packages/sites/src/create-site.ts
@@ -17,6 +17,7 @@ import {
 } from "@esri/arcgis-rest-portal";
 
 import { updateInitiativeSiteId } from "@esri/hub-initiatives";
+import { domain } from "process";
 
 /**
  * Create a New Site
@@ -64,9 +65,8 @@ export function createSite(
     })
     .then((domainResponses) => {
       // client id will be the same for all domain resonses so we can just grab the first one
-      // no guard clause because the only way we don't get a response is if addSiteDomains throws
-      // which would not hit this code
       model.data.values.clientId = domainResponses[0].clientKey;
+
       // If we have a dcat section, hoist it out as it may contain complex adlib
       // templates that are needed at run-time
       // If we have data.values.dcatConfig, yank it off b/c that may have adlib template stuff in it


### PR DESCRIPTION
1. Description:
Solutions team was testing on ArcGIS Enterprise, and noted an issue connected to recent changes to that were ArcGIS Online specific, but caused a regression for portal.

This changes how `addSiteDomains(..)` works in Portal, so that it returns a single "domain record" that includes the portal `clientKey`. This ensures that in all cased, at least one entry is returned from `addSiteDomains`

1. Instructions for testing - run tests

1. Closes Issues: For expediency, no bug was logged

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
