### PR TITLE
feat(hub-common): remove required property prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64966,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.4.1",
+			"version": "13.7.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/src/discussions/_internal/DiscussionSchema.ts
+++ b/packages/common/src/discussions/_internal/DiscussionSchema.ts
@@ -16,12 +16,13 @@ export const DiscussionEditorTypes = [
  * defines the JSON schema for a Discussion's editable fields
  */
 export const DiscussionSchema: IConfigurationSchema = {
-  required: ["name", "prompt"],
+  required: ["name"],
   type: "object",
   properties: {
     name: ENTITY_NAME_SCHEMA,
     prompt: {
       type: "string",
+      default: "We want to hear from you!",
     },
     summary: {
       type: "string",

--- a/packages/common/src/discussions/defaults.ts
+++ b/packages/common/src/discussions/defaults.ts
@@ -30,5 +30,7 @@ export const DEFAULT_DISCUSSION_MODEL: IModel = {
       schemaVersion: 1,
     },
   },
-  data: {},
+  data: {
+    prompt: "We want to hear from you!",
+  },
 } as unknown as IModel;


### PR DESCRIPTION
affects: @esri/hub-common

remove required property prompt from discussions schema

ISSUES CLOSED: 6876

1. Description: Removes `prompt` as a required property from the Discussions schema.  Adds a default value for `prompt` . 

1. Instructions for testing:

1. Closes Issues: #6876

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
