### PR TITLE
feat(hub-common): add isDiscussable mapping

### DIFF
--- a/packages/common/src/core/HubItemEntity.ts
+++ b/packages/common/src/core/HubItemEntity.ts
@@ -37,7 +37,7 @@ import { IWithThumbnailBehavior } from "./behaviors/IWithThumbnailBehavior";
 import { IHubItemEntity, SettableAccessLevel } from "./types";
 import { sharedWith } from "./_internal/sharedWith";
 import { IWithDiscussionsBehavior } from "./behaviors/IWithDiscussionsBehavior";
-import { CANNOT_DISCUSS } from "../discussions";
+import { setDiscussableKeyword } from "../discussions";
 
 const FEATURED_IMAGE_FILENAME = "featuredImage.png";
 
@@ -347,11 +347,10 @@ export abstract class HubItemEntity<T extends IHubItemEntity>
    * @param isDiscussable whether to enable or disable discussions
    */
   updateIsDiscussable(isDiscussable: boolean): void {
-    const typeKeywords = isDiscussable
-      ? this.entity.typeKeywords.filter(
-          (typeKeyword) => typeKeyword !== CANNOT_DISCUSS
-        )
-      : [...this.entity.typeKeywords, CANNOT_DISCUSS];
+    const typeKeywords = setDiscussableKeyword(
+      this.entity.typeKeywords,
+      isDiscussable
+    );
     this.update({ typeKeywords, isDiscussable } as Partial<T>);
   }
 }

--- a/packages/common/src/discussions/_internal/DiscussionSchema.ts
+++ b/packages/common/src/discussions/_internal/DiscussionSchema.ts
@@ -35,6 +35,11 @@ export const DiscussionSchema: IConfigurationSchema = {
     },
     tags: ENTITY_TAGS_SCHEMA,
     categories: ENTITY_CATEGORIES_SCHEMA,
+    isDiscussable: {
+      type: "boolean",
+      enum: [true, false],
+      default: true,
+    },
     view: {
       type: "object",
       properties: {

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -135,5 +135,28 @@ export const uiSchema: IUiSchema = {
         },
       ],
     },
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.settings.label",
+      elements: [
+        {
+          labelKey: "{{i18nScope}}.fields.discussable.label",
+          scope: "/properties/isDiscussable",
+          type: "Control",
+          options: {
+            control: "hub-field-input-radio",
+            labels: [
+              "{{{{i18nScope}}.fields.discussable.enabled.label:translate}}",
+              "{{{{i18nScope}}.fields.discussable.disabled.label:translate}}",
+            ],
+            descriptions: [
+              "{{{{i18nScope}}.fields.discussable.enabled.description:translate}}",
+              "{{{{i18nScope}}.fields.discussable.disabled.description:translate}}",
+            ],
+            icons: ["speech-bubbles", "circle-disallowed"],
+          },
+        },
+      ],
+    },
   ],
 };

--- a/packages/common/src/discussions/_internal/computeProps.ts
+++ b/packages/common/src/discussions/_internal/computeProps.ts
@@ -5,6 +5,7 @@ import { IModel } from "../../types";
 import { DiscussionDefaultCapabilities } from "./DiscussionBusinessRules";
 import { IHubDiscussion } from "../../core";
 import { processEntityCapabilities } from "../../capabilities";
+import { isDiscussable } from "../utils";
 
 /**
  * Given a model and a Discussion, set various computed properties that can't be directly mapped
@@ -36,6 +37,7 @@ export function computeProps(
   discussion.createdDateSource = "item.created";
   discussion.updatedDate = new Date(model.item.modified);
   discussion.updatedDateSource = "item.modified";
+  discussion.isDiscussable = isDiscussable(discussion);
 
   // Handle capabilities
   discussion.capabilities = processEntityCapabilities(

--- a/packages/common/src/discussions/edit.ts
+++ b/packages/common/src/discussions/edit.ts
@@ -3,7 +3,7 @@ import { IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
 import { IHubDiscussion } from "../core/types";
 import { createModel, getModel, updateModel } from "../models";
 import { constructSlug, getUniqueSlug, setSlugKeyword } from "../items/slugs";
-import { cloneObject } from "../index";
+import { cloneObject, setDiscussableKeyword } from "../index";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 import { computeProps } from "./_internal/computeProps";
@@ -41,6 +41,10 @@ export async function createDiscussion(
     discussion.typeKeywords,
     discussion.slug
   );
+  discussion.typeKeywords = setDiscussableKeyword(
+    discussion.typeKeywords,
+    discussion.isDiscussable
+  );
   // Map discussion object onto a default discussion Model
   const mapper = new PropertyMapper<Partial<IHubDiscussion>>(getPropertyMap());
   // create model from object, using the default model as a starting point
@@ -72,6 +76,10 @@ export async function updateDiscussion(
   discussion.slug = await getUniqueSlug(
     { slug: discussion.slug, existingId: discussion.id },
     requestOptions
+  );
+  discussion.typeKeywords = setDiscussableKeyword(
+    discussion.typeKeywords,
+    discussion.isDiscussable
   );
   // get the backing item & data
   const model = await getModel(discussion.id, requestOptions);

--- a/packages/common/src/discussions/utils.ts
+++ b/packages/common/src/discussions/utils.ts
@@ -27,10 +27,11 @@ export function setDiscussableKeyword(
   typeKeywords: string[],
   discussable: boolean
 ): string[] {
-  const updatedTypeKeywords = discussable
-    ? typeKeywords.filter(
-        (typeKeyword: string) => typeKeyword !== CANNOT_DISCUSS
-      )
-    : [...typeKeywords, CANNOT_DISCUSS];
+  const updatedTypeKeywords = typeKeywords.filter(
+    (typeKeyword: string) => typeKeyword !== CANNOT_DISCUSS
+  );
+  if (!discussable) {
+    updatedTypeKeywords.push(CANNOT_DISCUSS);
+  }
   return updatedTypeKeywords;
 }

--- a/packages/common/src/discussions/utils.ts
+++ b/packages/common/src/discussions/utils.ts
@@ -1,16 +1,36 @@
 import { IGroup, IItem } from "@esri/arcgis-rest-types";
 import { IHubContent, IHubItemEntity } from "../core";
 import { CANNOT_DISCUSS } from "./constants";
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { updateItem, updateGroup } from "@esri/arcgis-rest-portal";
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 /**
  * Utility to determine if a given IGroup, IItem, IHubContent, or IHubItemEntity
  * is discussable.
- * @export
- * @param {IGroup|IItem|IHubContent|IHubItemEntity} The subject to evaluate
+ * @param {IGroup|IItem|IHubContent|IHubItemEntity} subject
  * @return {boolean}
  */
 export function isDiscussable(
-  subject: IGroup | IItem | IHubContent | IHubItemEntity
+  subject: Partial<IGroup | IItem | IHubContent | IHubItemEntity>
 ) {
   return !(subject.typeKeywords ?? []).includes(CANNOT_DISCUSS);
+}
+
+/**
+ * Adds or removes CANNOT_DISCUSS type keyword and returns the updated list
+ * @param {IGroup|IHubContent|IHubItemEntity} subject
+ * @param {boolean} discussable
+ * @returns {string[]} updated list of type keywords
+ */
+export function setDiscussableKeyword(
+  typeKeywords: string[],
+  discussable: boolean
+): string[] {
+  const updatedTypeKeywords = discussable
+    ? typeKeywords.filter(
+        (typeKeyword: string) => typeKeyword !== CANNOT_DISCUSS
+      )
+    : [...typeKeywords, CANNOT_DISCUSS];
+  return updatedTypeKeywords;
 }

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -24,6 +24,7 @@ import {
   getFamily,
   IHubRequestOptions,
   getItemHomeUrl,
+  setDiscussableKeyword,
 } from "../index";
 import {
   IItem,
@@ -75,6 +76,10 @@ export async function createInitiative(
     initiative.typeKeywords,
     initiative.slug
   );
+  initiative.typeKeywords = setDiscussableKeyword(
+    initiative.typeKeywords,
+    initiative.isDiscussable
+  );
   // Map initiative object onto a default initiative Model
   const mapper = new PropertyMapper<Partial<IHubInitiative>>(getPropertyMap());
   // create model from object, using the default model as a starting point
@@ -105,6 +110,10 @@ export async function updateInitiative(
   initiative.slug = await getUniqueSlug(
     { slug: initiative.slug, existingId: initiative.id },
     requestOptions
+  );
+  initiative.typeKeywords = setDiscussableKeyword(
+    initiative.typeKeywords,
+    initiative.isDiscussable
   );
   // get the backing item & data
   const model = await getModel(initiative.id, requestOptions);

--- a/packages/common/src/initiatives/_internal/computeProps.ts
+++ b/packages/common/src/initiatives/_internal/computeProps.ts
@@ -5,8 +5,7 @@ import { processEntityCapabilities } from "../../capabilities";
 import { IModel } from "../../types";
 import { InitiativeDefaultCapabilities } from "./InitiativeBusinessRules";
 import { IHubInitiative } from "../../core";
-import { upgradeCatalogSchema } from "../../search/upgradeCatalogSchema";
-import { IHubCatalog } from "../../search/types/IHubCatalog";
+import { isDiscussable } from "../../discussions";
 
 /**
  * Given a model and an Initiative, set various computed properties that can't be directly mapped
@@ -38,6 +37,7 @@ export function computeProps(
   initiative.createdDateSource = "item.created";
   initiative.updatedDate = new Date(model.item.modified);
   initiative.updatedDateSource = "item.modified";
+  initiative.isDiscussable = isDiscussable(initiative);
 
   // Handle capabilities
   initiative.capabilities = processEntityCapabilities(

--- a/packages/common/src/projects/_internal/computeProps.ts
+++ b/packages/common/src/projects/_internal/computeProps.ts
@@ -5,6 +5,7 @@ import { IHubProject } from "../../core";
 import { IModel } from "../../types";
 import { ProjectDefaultCapabilities } from "./ProjectBusinessRules";
 import { processEntityCapabilities } from "../../capabilities";
+import { isDiscussable } from "../../discussions";
 
 /**
  * Given a model and a project, set various computed properties that can't be directly mapped
@@ -32,6 +33,7 @@ export function computeProps(
   project.createdDateSource = "item.created";
   project.updatedDate = new Date(model.item.modified);
   project.updatedDateSource = "item.modified";
+  project.isDiscussable = isDiscussable(project);
 
   // Handle capabilities
   project.capabilities = processEntityCapabilities(

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -20,6 +20,7 @@ import {
   EditorConfigType,
   IEditorConfig,
 } from "../core/behaviors/IWithEditorBehavior";
+import { setDiscussableKeyword } from "../discussions";
 
 /**
  * @private
@@ -47,6 +48,10 @@ export async function createProject(
   // add slug and status to keywords
   project.typeKeywords = setSlugKeyword(project.typeKeywords, project.slug);
   project.typeKeywords = setStatusKeyword(project.typeKeywords, project.status);
+  project.typeKeywords = setDiscussableKeyword(
+    project.typeKeywords,
+    project.isDiscussable
+  );
   // Map project object onto a default project Model
   const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
   // create model from object, using the default model as a starting point
@@ -77,6 +82,10 @@ export async function updateProject(
   );
   // update the status keyword
   project.typeKeywords = setStatusKeyword(project.typeKeywords, project.status);
+  project.typeKeywords = setDiscussableKeyword(
+    project.typeKeywords,
+    project.isDiscussable
+  );
   // get the backing item & data
   const model = await getModel(project.id, requestOptions);
   // create the PropertyMapper

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -35,6 +35,7 @@ import { getProp, setProp } from "../objects";
 import { getItemThumbnailUrl } from "../resources/get-item-thumbnail-url";
 import { upgradeCatalogSchema } from "../search/upgradeCatalogSchema";
 import { catalogMigration } from "./_internal/catalogMigration";
+import { setDiscussableKeyword } from "../discussions";
 
 export const HUB_SITE_ITEM_TYPE = "Hub Site Application";
 export const ENTERPRISE_SITE_ITEM_TYPE = "Site Application";
@@ -263,6 +264,11 @@ export async function createSite(
     setProp("layout.header.component.settings.title", site.name, site);
   }
 
+  site.typeKeywords = setDiscussableKeyword(
+    site.typeKeywords,
+    site.isDiscussable
+  );
+
   // Now convert the IHubSite into an IModel
   const mapper = new PropertyMapper<Partial<IHubSite>>(getPropertyMap());
   let model = mapper.objectToModel(site, cloneObject(DEFAULT_SITE_MODEL));
@@ -303,6 +309,10 @@ export async function updateSite(
   site: IHubSite,
   requestOptions: IHubRequestOptions
 ): Promise<IHubSite> {
+  site.typeKeywords = setDiscussableKeyword(
+    site.typeKeywords,
+    site.isDiscussable
+  );
   // convert IHubSite to model
   const siteModel = convertSiteToModel(site, requestOptions);
   // Fetch backing model from the portal

--- a/packages/common/src/sites/_internal/computeProps.ts
+++ b/packages/common/src/sites/_internal/computeProps.ts
@@ -6,6 +6,7 @@ import { IModel } from "../../types";
 import { SiteDefaultCapabilities } from "./SiteBusinessRules";
 import { processEntityCapabilities } from "../../capabilities";
 import { upgradeCatalogSchema } from "../../search/upgradeCatalogSchema";
+import { isDiscussable } from "../../discussions";
 
 /**
  * Given a model and a site, set various computed properties that can't be directly mapped
@@ -33,6 +34,7 @@ export function computeProps(
   site.createdDateSource = "item.created";
   site.updatedDate = new Date(model.item.modified);
   site.updatedDateSource = "item.modified";
+  site.isDiscussable = isDiscussable(site);
 
   // Handle capabilities
   // NOTE: This does not currently contain the older "capabilities" values!

--- a/packages/common/test/discussions/edit.test.ts
+++ b/packages/common/test/discussions/edit.test.ts
@@ -161,6 +161,7 @@ describe("discussions edit:", () => {
         schemaVersion: 1,
         canEdit: false,
         canDelete: false,
+        typeKeywords: [],
       };
       const chk = await updateDiscussion(prj, { authentication: MOCK_AUTH });
       expect(chk.id).toBe(GUID);

--- a/packages/common/test/discussions/utils.test.ts
+++ b/packages/common/test/discussions/utils.test.ts
@@ -1,0 +1,39 @@
+import {
+  CANNOT_DISCUSS,
+  isDiscussable,
+  setDiscussableKeyword,
+} from "../../src";
+
+describe("discussions utils", () => {
+  describe("isDiscussable", () => {
+    it("returns true if CANNOT_DISCUSS is not present", () => {
+      const subject = {
+        typeKeywords: ["some keyword"],
+      };
+      const result = isDiscussable(subject);
+      expect(result).toBeTruthy();
+    });
+    it("returns false if CANNOT_DISCUSS is present", () => {
+      const subject = {
+        typeKeywords: [CANNOT_DISCUSS],
+      };
+      const result = isDiscussable(subject);
+      expect(result).toBeFalsy();
+    });
+    it("returns true if typeKeywords property does not exist", () => {
+      const subject = {};
+      const result = isDiscussable(subject);
+      expect(result).toBeTruthy();
+    });
+  });
+  describe("setDiscussableKeyword", () => {
+    it("returns array without CANNOT_DISCUSS when isDiscussable is true", () => {
+      const result = setDiscussableKeyword([CANNOT_DISCUSS], true);
+      expect(result).toEqual([]);
+    });
+    it("returns array with CANNOT_DISCUSS when isDiscussable is false", () => {
+      const result = setDiscussableKeyword([], false);
+      expect(result).toEqual([CANNOT_DISCUSS]);
+    });
+  });
+});

--- a/packages/common/test/initiatives/HubInitiatives.test.ts
+++ b/packages/common/test/initiatives/HubInitiatives.test.ts
@@ -301,6 +301,7 @@ describe("HubInitiatives:", () => {
         schemaVersion: 1,
         canEdit: false,
         canDelete: false,
+        typeKeywords: [],
       };
       const chk = await updateInitiative(prj, { authentication: MOCK_AUTH });
       expect(chk.id).toBe(GUID);

--- a/packages/common/test/projects/projects.test.ts
+++ b/packages/common/test/projects/projects.test.ts
@@ -254,6 +254,7 @@ describe("HubProjects:", () => {
         "Hub Project",
         "slug|dcdev|hello-world",
         "status|notStarted",
+        "cannotDiscuss",
       ]);
       // should ensure unique slug
       expect(slugSpy.calls.count()).toBe(1);
@@ -299,6 +300,7 @@ describe("HubProjects:", () => {
         "Hub Project",
         "slug|dcdev|hello-world",
         "status|inProgress",
+        "cannotDiscuss",
       ]);
       // should ensure unique slug
       expect(slugSpy.calls.count()).toBe(1);
@@ -370,6 +372,7 @@ describe("HubProjects:", () => {
         "Hub Project",
         "slug|dcdev-wat-blarg",
         "status|inProgress",
+        "cannotDiscuss",
       ]);
       expect(chk.location).toEqual({
         type: "none",

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -55,6 +55,7 @@ const SITE: commonModule.IHubSite = {
   orgUrlKey: "dcdev",
   owner: "dcdev_dude",
   type: "Hub Site Application",
+  typeKeywords: [],
   createdDate: new Date(1595878748000),
   createdDateSource: "item.created",
   updatedDate: new Date(1595878750000),


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Allows isDiscussable property on entities to be updated.

1. Instructions for testing: Can be tested in the hub-components workspace harness. Note: there is a known bug in the radio buttons where they do not reflect the current value of isDiscussable, this is known and being fixed in a separate PR.

1. Closes Issues: 6883

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
