### PR TITLE
fix: limit project summary (purpose) to 2048 chars

### DIFF
--- a/packages/common/src/core/schemas/shared/subschemas.ts
+++ b/packages/common/src/core/schemas/shared/subschemas.ts
@@ -9,6 +9,11 @@ export const ENTITY_NAME_SCHEMA = {
   maxLength: 250,
 };
 
+export const ENTITY_SUMMARY_SCHEMA = {
+  type: "string",
+  maxLength: 2048,
+};
+
 export const ENTITY_ACCESS_SCHEMA = {
   type: "string",
   enum: ["public", "org", "private"],

--- a/packages/common/src/projects/_internal/ProjectSchema.ts
+++ b/packages/common/src/projects/_internal/ProjectSchema.ts
@@ -3,6 +3,7 @@ import {
   ENTITY_ACCESS_SCHEMA,
   ENTITY_CATEGORIES_SCHEMA,
   ENTITY_NAME_SCHEMA,
+  ENTITY_SUMMARY_SCHEMA,
   ENTITY_TAGS_SCHEMA,
   ENTITY_TIMELINE_SCHEMA,
 } from "../../core/schemas/shared";
@@ -21,9 +22,7 @@ export const ProjectSchema: IConfigurationSchema = {
   type: "object",
   properties: {
     name: ENTITY_NAME_SCHEMA,
-    summary: {
-      type: "string",
-    },
+    summary: ENTITY_SUMMARY_SCHEMA,
     description: {
       type: "string",
     },


### PR DESCRIPTION
[7066](https://devtopia.esri.com/dc/hub/issues/7066)

### Description
- limit project summary (purpose) to 2048 characters
- abstract this field schema as a reusable entity subschema

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.