### PR TITLE
fix: add default to project schema for location

### DIFF
--- a/packages/common/src/projects/_internal/ProjectSchema.ts
+++ b/packages/common/src/projects/_internal/ProjectSchema.ts
@@ -40,6 +40,7 @@ export const ProjectSchema: IConfigurationSchema = {
     },
     location: {
       type: "object",
+      default: { type: "none" },
     },
     tags: ENTITY_TAGS_SCHEMA,
     categories: ENTITY_CATEGORIES_SCHEMA,


### PR DESCRIPTION
[7034](https://devtopia.esri.com/dc/hub/issues/7034)

### Description:
Add a default value, `{ type: "none" }`, to the location property on the project schema

---
1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
2. [x] used semantic commit messages
3. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
4. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
