### PR TITLE
feat: hubSearch supports groupMember entity type

### DIFF
--- a/packages/common/e2e/helpers/Artifactory.ts
+++ b/packages/common/e2e/helpers/Artifactory.ts
@@ -82,6 +82,14 @@ export default class Artifactory {
     };
     return ArcGISContextManager.create(opts);
   }
+
+  async getAnonContextManager(orgType: string): Promise<ArcGISContextManager> {
+    const org = this.getOrg(orgType);
+    const opts: IArcGISContextManagerOptions = {
+      portalUrl: org.orgUrl as unknown as string,
+    };
+    return ArcGISContextManager.create(opts);
+  }
   /**
    * Get the org-short
    */

--- a/packages/common/e2e/hub-user-search.e2e.ts
+++ b/packages/common/e2e/hub-user-search.e2e.ts
@@ -1,0 +1,102 @@
+import Artifactory from "./helpers/Artifactory";
+import config from "./helpers/config";
+import { IQuery, hubSearch } from "../src/search";
+
+fdescribe("Hub User search", () => {
+  let factory: Artifactory;
+  beforeAll(() => {
+    factory = new Artifactory(config);
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
+  });
+
+  describe("Search for Portal Users", () => {
+    it("can issue portal user search", async () => {
+      const ctxMgr = await factory.getContextManager("hubPremium", "admin");
+      const ctx = ctxMgr.context;
+      const qry: IQuery = {
+        targetEntity: "user",
+        filters: [
+          {
+            predicates: [
+              {
+                term: "dave",
+              },
+            ],
+          },
+        ],
+      };
+
+      const response = await hubSearch(qry, {
+        requestOptions: ctx.hubRequestOptions,
+      });
+      expect(response.results).toBeDefined();
+      expect(response.results.length).toBe(1);
+      expect(response.results[0].owner).toBe("dave_pub_qa_pre");
+    });
+  });
+
+  describe("Search for Group Users", () => {
+    it("can search for users in group by member type", async () => {
+      const ctxMgr = await factory.getContextManager("hubPremium", "admin");
+      const ctx = ctxMgr.context;
+      const qry: IQuery = {
+        targetEntity: "groupMember",
+        filters: [
+          {
+            predicates: [
+              {
+                memberType: "admin",
+                email: "d@b.com",
+              },
+              {
+                name: "e2e",
+              },
+            ],
+          },
+        ],
+        properties: {
+          groupId: "c08c260d3fbc4da384061b48652972e5",
+        },
+      };
+
+      const response = await hubSearch(qry, {
+        requestOptions: ctx.hubRequestOptions,
+      });
+      expect(response.results).toBeDefined();
+      expect(response.results.length).toBe(2);
+      response.results.map((r) => {
+        expect(r.owner).toContain("e2e");
+        expect(r.memberType).toEqual("admin");
+      });
+    });
+    it("can search for users in group by member type without auth", async () => {
+      const ctxMgr = await factory.getAnonContextManager("hubPremium");
+      const ctx = ctxMgr.context;
+      const qry: IQuery = {
+        targetEntity: "groupMember",
+        filters: [
+          {
+            predicates: [
+              {
+                memberType: "admin",
+                email: "d@b.com",
+              },
+              {
+                name: "e2e",
+              },
+            ],
+          },
+        ],
+        properties: {
+          groupId: "e59cab1c38e14a79a4ee36389632106c",
+        },
+      };
+
+      const response = await hubSearch(qry, {
+        requestOptions: ctx.hubRequestOptions,
+      });
+      expect(response.results).toBeDefined();
+      expect(response.results.length).toBe(2);
+    });
+  });
+});

--- a/packages/common/e2e/hub-user-search.e2e.ts
+++ b/packages/common/e2e/hub-user-search.e2e.ts
@@ -2,7 +2,7 @@ import Artifactory from "./helpers/Artifactory";
 import config from "./helpers/config";
 import { IQuery, hubSearch } from "../src/search";
 
-fdescribe("Hub User search", () => {
+describe("Hub User search", () => {
   let factory: Artifactory;
   beforeAll(() => {
     factory = new Artifactory(config);

--- a/packages/common/src/core/types/MaybeTranslate.ts
+++ b/packages/common/src/core/types/MaybeTranslate.ts
@@ -1,0 +1,12 @@
+/**
+ * Type that could be a string or an object with key property to be used for translation
+ */
+export type MaybeTranslate = string | { key: string };
+
+/**
+ * Type that can be used to wrap a type to
+ * add MaybeTranslate to all string properties
+ */
+export type Translatable<T> = {
+  [P in keyof T]: T[P] extends string ? T[P] | MaybeTranslate : T[P];
+};

--- a/packages/common/src/core/types/MaybeTranslate.ts
+++ b/packages/common/src/core/types/MaybeTranslate.ts
@@ -1,10 +1,10 @@
 /**
- * Type that could be a string or an object with key property to be used for translation
+ * Not used yet. Type that could be a string or an object with key property to be used for translation
  */
 export type MaybeTranslate = string | { key: string };
 
 /**
- * Type that can be used to wrap a type to
+ * Not used yet. Type that can be used to wrap a type to
  * add MaybeTranslate to all string properties
  */
 export type Translatable<T> = {

--- a/packages/common/src/core/types/index.ts
+++ b/packages/common/src/core/types/index.ts
@@ -23,3 +23,4 @@ export * from "./types";
 export * from "./DynamicValues";
 export * from "./IReference";
 export * from "./Metrics";
+export * from "./MaybeTranslate";

--- a/packages/common/src/objects/index.ts
+++ b/packages/common/src/objects/index.ts
@@ -11,3 +11,4 @@ export * from "./merge-objects";
 export * from "./set-prop";
 export * from "./deepFind";
 export * from "./resolveReferences";
+export * from "./pickProps";

--- a/packages/common/src/objects/pickProps.ts
+++ b/packages/common/src/objects/pickProps.ts
@@ -1,0 +1,9 @@
+import { mergeObjects } from "./merge-objects";
+
+/**
+ * Pick a set of properties from an object onto a new object
+ * Undefined properties are not copied
+ */
+export function pickProps(obj: any, props: string[]): any {
+  return mergeObjects(obj, {}, props);
+}

--- a/packages/common/src/search/_internal/expandPredicate.ts
+++ b/packages/common/src/search/_internal/expandPredicate.ts
@@ -13,15 +13,17 @@ export function expandPredicate(predicate: IPredicate): IPredicate {
   const result: IPredicate = {};
   const dateProps = ["created", "modified", "lastlogin"];
   const copyProps = [
-    "filterType",
+    "bbox",
     "categoriesAsParam",
     "categoryFilter",
-    "term",
-    "searchUserAccess",
+    "filterType",
     "isopendata",
-    "searchUserName",
-    "bbox",
     "isviewonly",
+    "memberType",
+    "name",
+    "searchUserAccess",
+    "searchUserName",
+    "term",
   ];
   const nonMatchOptionsFields = [...dateProps, ...copyProps];
   // Do the conversion

--- a/packages/common/src/search/_internal/portalSearchGroupMembers.ts
+++ b/packages/common/src/search/_internal/portalSearchGroupMembers.ts
@@ -129,13 +129,18 @@ async function searchGroupMembers(
   };
 }
 
-export interface IGroupMember {
+/**
+ * @private
+ * Rest.js does not have a type for the response from searchGroupUsers
+ * so we create one here vs just using `any`
+ */
+interface IGroupMember {
   username: string;
-  fullName: string;
-  memberType: string;
-  joined: number;
-  orgId: string;
-  thumbnail: string;
+  fullName?: string;
+  memberType?: string;
+  joined?: number;
+  orgId?: string;
+  thumbnail?: string;
 }
 
 /**
@@ -177,9 +182,9 @@ async function memberToSearchResult(
     portal: requestOptions.portal,
   });
   // Map props from the fetched user, onto the user
-  // this is done because the api returns a sparse user under some conditions
-  // and we'd rather have the default user with i18n keys present than a structure
-  // with empty strings and missing keys
+  // this is done because the api returns a sparse IGroupMember under some conditions
+  // and we'd rather have the default user with keys present than a structure
+  // with missing keys
   Object.keys(user).forEach((key) => {
     if (fetchedUser.hasOwnProperty(key) && fetchedUser[key] !== "") {
       setProp(key, fetchedUser[key], user);

--- a/packages/common/src/search/_internal/portalSearchGroupMembers.ts
+++ b/packages/common/src/search/_internal/portalSearchGroupMembers.ts
@@ -52,7 +52,7 @@ export async function portalSearchGroupMembers(
     const validPredicateKeys = ["name", "memberType"];
     filter.predicates = filter.predicates
       // remove any keys that aren't supported
-      .filter((p) => {
+      .map((p) => {
         return pickProps(p, validPredicateKeys);
       })
       // remove any empty predicates

--- a/packages/common/src/search/_internal/portalSearchGroupMembers.ts
+++ b/packages/common/src/search/_internal/portalSearchGroupMembers.ts
@@ -1,0 +1,190 @@
+import { serializeQueryForPortal } from "../serializeQueryForPortal";
+import {
+  IHubSearchOptions,
+  IHubSearchResponse,
+  IHubSearchResult,
+  IQuery,
+} from "../types";
+import {
+  ISearchGroupUsersOptions,
+  IUser,
+  getUser,
+  searchGroupUsers,
+} from "@esri/arcgis-rest-portal";
+import { expandPredicate } from "./expandPredicate";
+import { getNextFunction } from "../utils";
+import HubError from "../../HubError";
+import { IHubRequestOptions } from "../../types";
+import { enrichUserSearchResult } from "../../users";
+import { failSafe } from "../../utils";
+import { pickProps, setProp } from "../../objects";
+
+/**
+ * Search for members of a group.
+ * The group is specified via `IQuery.properties.groupId`
+ *
+ * The backing API is very limited in what
+ * it returns so this method executes the search and then tries to fetch
+ * the user object directly. This is a bit slower but provides a more
+ * information. Even in this case, private users may not be returned, and
+ * so we have a default user that is returned in those cases.
+ *
+ * @param query
+ * @param options
+ * @returns
+ */
+export async function portalSearchGroupMembers(
+  query: IQuery,
+  options: IHubSearchOptions
+): Promise<IHubSearchResponse<IHubSearchResult>> {
+  if (!query.properties?.groupId) {
+    throw new HubError(
+      "portalSearchGroupMembers",
+      "Group Id required. Please pass as query.properties.groupId"
+    );
+  }
+
+  const groupId = query.properties.groupId;
+
+  // Expand the individual predicates in each filter
+  query.filters = query.filters.map((filter) => {
+    // only `name` and `memberType` are supported
+    const validPredicateKeys = ["name", "memberType"];
+    filter.predicates = filter.predicates
+      // remove any keys that aren't supported
+      .filter((p) => {
+        return pickProps(p, validPredicateKeys);
+      })
+      // remove any empty predicates
+      .filter((p) => {
+        return Object.entries(p).length > 0;
+      })
+      // expand the remaining predicates
+      .map(expandPredicate);
+    return filter;
+  });
+
+  // Serialize the all the groups for portal
+  const so = serializeQueryForPortal(query);
+  // Array of properties we want to copy from IHubSearchOptions to the ISearchOptions
+  const props: Array<keyof IHubSearchOptions> = [
+    "num",
+    "sortField",
+    "sortOrder",
+    "include",
+    "start",
+  ];
+  // copy the props over
+  props.forEach((prop) => {
+    if (options.hasOwnProperty(prop)) {
+      so[prop as keyof ISearchGroupUsersOptions] = options[prop];
+    }
+  });
+
+  so.groupId = groupId;
+  so.requestOptions = options.requestOptions;
+
+  // Execute search
+  return searchGroupMembers(so as ISearchGroupUsersOptions);
+}
+
+/**
+ * @private
+ * Portal Search Implementation for Group Members
+ * @param options
+ */
+async function searchGroupMembers(
+  searchOptions: ISearchGroupUsersOptions
+): Promise<IHubSearchResponse<IHubSearchResult>> {
+  // searchGroupUsers needs requestOptions spread into it's options
+  const opts = {
+    ...searchOptions,
+    ...searchOptions.requestOptions,
+  } as ISearchGroupUsersOptions;
+  const resp = await searchGroupUsers(searchOptions.groupId, opts);
+
+  // create mappable fn that will close
+  // over the includes and requestOptions
+  const fn = (member: IGroupMember) => {
+    return memberToSearchResult(
+      member,
+      searchOptions.include,
+      searchOptions.requestOptions
+    );
+  };
+
+  // map over results
+  const results = await Promise.all(resp.users.map(fn));
+
+  return {
+    total: resp.total,
+    results,
+    hasNext: resp.nextStart > -1,
+    next: getNextFunction<IHubSearchResult>(
+      searchOptions,
+      resp.nextStart,
+      resp.total,
+      searchGroupMembers
+    ),
+  };
+}
+
+export interface IGroupMember {
+  username: string;
+  fullName: string;
+  memberType: string;
+  joined: number;
+  orgId: string;
+  thumbnail: string;
+}
+
+/**
+ * Convert an Group Member to a IHubSearchResult
+ * Fetches the backing user and uses that to populate the  user object
+ * If no user is found, the object is very sparse
+ * @param item
+ * @param include
+ * @param requestOptions
+ * @returns
+ */
+async function memberToSearchResult(
+  member: IGroupMember,
+  include: string[] = [],
+  requestOptions?: IHubRequestOptions
+): Promise<IHubSearchResult> {
+  // cross org requests may fail for non-public users
+  // so we have a default user that has minimal information
+  const user: IUser & Record<string, any> = {
+    username: member.username,
+    memberType: member.memberType || "member",
+    access: "private",
+    fullName: null,
+    firstName: null,
+    lastName: null,
+    description: null,
+    orgId: null,
+    groups: [],
+    tags: [],
+    thumbnail: null,
+    created: null,
+    modified: null,
+  };
+
+  const fsGetUser = failSafe(getUser, user);
+  const fetchedUser = await fsGetUser({
+    username: member.username,
+    authentication: requestOptions.authentication,
+    portal: requestOptions.portal,
+  });
+  // Map props from the fetched user, onto the user
+  // this is done because the api returns a sparse user under some conditions
+  // and we'd rather have the default user with i18n keys present than a structure
+  // with empty strings and missing keys
+  Object.keys(user).forEach((key) => {
+    if (fetchedUser.hasOwnProperty(key) && fetchedUser[key] !== "") {
+      setProp(key, fetchedUser[key], user);
+    }
+  });
+
+  return enrichUserSearchResult(user, include, requestOptions);
+}

--- a/packages/common/src/search/_internal/portalSearchUsers.ts
+++ b/packages/common/src/search/_internal/portalSearchUsers.ts
@@ -129,7 +129,7 @@ async function userToSearchResult(
   include: string[] = [],
   requestOptions?: IHubRequestOptions
 ): Promise<IHubSearchResult> {
-  // Delegate to HubGroups module
+  // Delegate to HubUsers module
   // This layer of indirection is not necessary but
   // aligns with how the items search works and
   // allows for future specialization

--- a/packages/common/src/search/hubSearch.ts
+++ b/packages/common/src/search/hubSearch.ts
@@ -14,6 +14,7 @@ import {
   portalSearchGroups,
   portalSearchUsers,
 } from "./_internal";
+import { portalSearchGroupMembers } from "./_internal/portalSearchGroupMembers";
 
 /**
  * Main entrypoint for searching via Hub
@@ -74,6 +75,7 @@ export async function hubSearch(
       item: portalSearchItems,
       group: portalSearchGroups,
       user: portalSearchUsers,
+      groupMember: portalSearchGroupMembers,
     },
     "arcgis-hub": {
       item: hubSearchItems,

--- a/packages/common/src/search/serializeQueryForPortal.ts
+++ b/packages/common/src/search/serializeQueryForPortal.ts
@@ -93,9 +93,13 @@ function serializeFilter(filter: IFilter): ISearchOptions {
 function serializePredicate(predicate: IPredicate): ISearchOptions {
   const dateProps = ["created", "modified"];
   const boolProps = ["isopendata", "isviewonly"];
+  // In order to not get "expanded", these also need to be listed
+  // in the `expandPredicate` function
   const passThroughProps = [
     "searchUserAccess",
     "searchUserName",
+    "memberType",
+    "name",
     "categoriesAsParam",
     "categoryFilter",
     "bbox",

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -4,7 +4,11 @@
 // TODO: deprecate all private functions in this file and more them to ./_internal
 
 import { IUser, UserSession } from "@esri/arcgis-rest-auth";
-import { IGroup, ISearchOptions } from "@esri/arcgis-rest-portal";
+import {
+  IGroup,
+  ISearchGroupUsersOptions,
+  ISearchOptions,
+} from "@esri/arcgis-rest-portal";
 import { ISearchResponse } from "../types";
 import { cloneObject } from "../util";
 import {
@@ -172,7 +176,7 @@ export function relativeDateToDateRange(
  * @returns
  */
 export function getNextFunction<T>(
-  request: ISearchOptions,
+  request: ISearchOptions | ISearchGroupUsersOptions,
   nextStart: number,
   total: number,
   fn: (r: any) => Promise<ISearchResponse<T>>

--- a/packages/common/src/users/HubUsers.ts
+++ b/packages/common/src/users/HubUsers.ts
@@ -37,9 +37,13 @@ export async function enrichUserSearchResult(
     links: {
       self: "not-implemented",
       siteRelative: "not-implemented",
-      thumbnail: "not-implemented",
+      thumbnail: null,
     },
   };
+  // Group Memberships need this prop
+  if (getProp(user, "memberType")) {
+    result.memberType = getProp(user, "memberType");
+  }
 
   // Informal Enrichments - basically adding type-specific props
   // derived directly from the entity
@@ -67,14 +71,17 @@ export async function enrichUserSearchResult(
     result[spec.prop] = getProp(enriched, spec.path);
   });
 
-  const token = requestOptions.authentication.token;
+  const token = requestOptions.authentication?.token;
 
-  // Handle links
-  result.links.thumbnail = getUserThumbnailUrl(
-    requestOptions.portal,
-    user,
-    token
-  );
+  // only construct thumbnail url if we have a thumbnail value
+  // ui layer can decide how to handle a null thumbnail
+  if (user.thumbnail) {
+    result.links.thumbnail = getUserThumbnailUrl(
+      requestOptions.portal,
+      user,
+      token
+    );
+  }
   result.links.self = getUserHomeUrl(result.id, requestOptions);
   result.links.siteRelative = `/people/${result.id}`;
 

--- a/packages/common/src/users/HubUsers.ts
+++ b/packages/common/src/users/HubUsers.ts
@@ -17,7 +17,7 @@ import { AccessLevel } from "../core";
  * @returns
  */
 export async function enrichUserSearchResult(
-  user: IUser,
+  user: IUser & Record<string, any>,
   include: string[],
   requestOptions: IHubRequestOptions
 ): Promise<IHubSearchResult> {
@@ -41,8 +41,8 @@ export async function enrichUserSearchResult(
     },
   };
   // Group Memberships need this prop
-  if (getProp(user, "memberType")) {
-    result.memberType = getProp(user, "memberType");
+  if (user.memberType) {
+    result.memberType = user.memberType;
   }
 
   // Informal Enrichments - basically adding type-specific props

--- a/packages/common/test/objects/pickProps.test.ts
+++ b/packages/common/test/objects/pickProps.test.ts
@@ -1,0 +1,15 @@
+import { pickProps } from "../../src";
+
+describe("pickProps:", () => {
+  it("returns object if passed no props", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = pickProps(obj, []);
+    expect(result).toEqual(obj);
+  });
+  it("drops props not in list", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const props = ["a", "c"];
+    const result = pickProps(obj, props);
+    expect(result).toEqual({ a: 1, c: 3 });
+  });
+});

--- a/packages/common/test/search/_internal/portalSearchGroupMembers.test.ts
+++ b/packages/common/test/search/_internal/portalSearchGroupMembers.test.ts
@@ -103,6 +103,7 @@ describe("portalSearchGroupMembers:", () => {
       )[1] as Portal.ISearchGroupUsersOptions;
       expect(callOpts.memberType).toBe("admin");
       expect(callOpts.name).toBe("steve");
+      expect(callOpts.remove).not.toBeDefined();
       expect(response.results.length).toBe(2);
       const user1 = response.results[0];
       expect(user1.owner).toBe("e2e_pre_hub_c_member");

--- a/packages/common/test/search/_internal/portalSearchGroupMembers.test.ts
+++ b/packages/common/test/search/_internal/portalSearchGroupMembers.test.ts
@@ -1,0 +1,335 @@
+import { IHubSearchOptions, IQuery, cloneObject } from "../../../src";
+import { portalSearchGroupMembers } from "../../../src/search/_internal/portalSearchGroupMembers";
+import * as Portal from "@esri/arcgis-rest-portal";
+import { MOCK_AUTH } from "../../mocks/mock-auth";
+import * as users from "../../../src/users";
+
+describe("portalSearchGroupMembers:", () => {
+  describe("throws if not passed IQuery.properties.group:", () => {
+    let qry: IQuery;
+    beforeEach(() => {
+      qry = {
+        targetEntity: "groupMember",
+        filters: [
+          {
+            predicates: [
+              {
+                name: "steve",
+              },
+            ],
+          },
+        ],
+      };
+    });
+    it("no properties passed", async () => {
+      const opts: IHubSearchOptions = {};
+      try {
+        await portalSearchGroupMembers(qry, opts);
+      } catch (err) {
+        expect(err.message).toEqual(
+          "Group Id required. Please pass as query.properties.groupId"
+        );
+      }
+    });
+    it("passing query.properties", async () => {
+      const opts: IHubSearchOptions = {};
+      qry.properties = {};
+      try {
+        await portalSearchGroupMembers(qry, opts);
+      } catch (err) {
+        expect(err.message).toEqual(
+          "Group Id required. Please pass as query.properties.groupId"
+        );
+      }
+    });
+  });
+  describe("executes search:", () => {
+    let qry: IQuery;
+    beforeEach(() => {
+      qry = {
+        targetEntity: "groupMember",
+        filters: [
+          {
+            predicates: [
+              {
+                name: "steve",
+                remove: "property",
+              },
+              {
+                memberType: "admin",
+              },
+            ],
+          },
+        ],
+        properties: {
+          groupId: "3ef",
+        },
+      };
+    });
+    it("simple search", async () => {
+      const searchSpy = spyOn(Portal, "searchGroupUsers").and.callFake(() => {
+        return Promise.resolve(cloneObject(GroupMembersResponse));
+      });
+      const userSpy = spyOn(Portal, "getUser").and.callFake((options: any) => {
+        const resp = cloneObject(SparseUser);
+        resp.username = options.username;
+        return Promise.resolve(resp);
+      });
+      // NOTE: enrichUserSearchResult is tested elsewhere so we don't assert on the results here
+      const enrichUserSearchResultSpy = spyOn(
+        users,
+        "enrichUserSearchResult"
+      ).and.callThrough();
+      const opts: IHubSearchOptions = {
+        num: 2,
+        requestOptions: {
+          portal: "https://www.arcgis.com/sharing/rest",
+          authentication: MOCK_AUTH,
+        },
+      };
+      const response = await portalSearchGroupMembers(qry, opts);
+      // validate spy calls
+      expect(searchSpy.calls.count()).toBe(1, "should call searchGroupUsers");
+      expect(userSpy.calls.count()).toBe(2, "should get each user");
+      expect(enrichUserSearchResultSpy.calls.count()).toBe(
+        2,
+        "should enrich each user"
+      );
+      // validate call args
+      const groupId = searchSpy.calls.argsFor(0)[0];
+      expect(groupId).toBe("3ef");
+      const callOpts = searchSpy.calls.argsFor(
+        0
+      )[1] as Portal.ISearchGroupUsersOptions;
+      expect(callOpts.memberType).toBe("admin");
+      expect(callOpts.name).toBe("steve");
+      expect(response.results.length).toBe(2);
+      const user1 = response.results[0];
+      expect(user1.owner).toBe("e2e_pre_hub_c_member");
+      expect(user1.orgId).not.toBeDefined();
+      expect(user1.orgName).not.toBeDefined();
+      expect(user1.memberType).toBe("admin");
+      expect(user1.family).toBe("people");
+    });
+    it("search without auth", async () => {
+      const searchSpy = spyOn(Portal, "searchGroupUsers").and.callFake(() => {
+        return Promise.resolve(cloneObject(SparseGroupMembersResponse));
+      });
+      const userSpy = spyOn(Portal, "getUser").and.callFake((options: any) => {
+        const resp = cloneObject(SparseUser);
+        resp.username = options.username;
+        return Promise.resolve(resp);
+      });
+      // NOTE: enrichUserSearchResult is tested elsewhere so we don't assert on the results here
+      const enrichUserSearchResultSpy = spyOn(
+        users,
+        "enrichUserSearchResult"
+      ).and.callThrough();
+      const opts: IHubSearchOptions = {
+        num: 2,
+        requestOptions: {
+          portal: "https://www.arcgis.com/sharing/rest",
+        },
+      };
+      const response = await portalSearchGroupMembers(qry, opts);
+      // validate spy calls
+      expect(searchSpy.calls.count()).toBe(1, "should call searchGroupUsers");
+      expect(userSpy.calls.count()).toBe(2, "should get each user");
+      expect(enrichUserSearchResultSpy.calls.count()).toBe(
+        2,
+        "should enrich each user"
+      );
+      // validate call args
+      const groupId = searchSpy.calls.argsFor(0)[0];
+      expect(groupId).toBe("3ef");
+      const callOpts = searchSpy.calls.argsFor(
+        0
+      )[1] as Portal.ISearchGroupUsersOptions;
+      expect(callOpts.memberType).toBe("admin");
+      expect(callOpts.name).toBe("steve");
+      expect(response.results.length).toBe(2);
+      const user1 = response.results[0];
+
+      expect(user1.owner).toBe("e2e_pre_hub_c_member");
+      expect(user1.orgId).not.toBeDefined();
+      expect(user1.orgName).not.toBeDefined();
+      expect(user1.memberType).toBe("admin");
+      expect(user1.family).toBe("people");
+    });
+  });
+});
+
+const SparseUser: Portal.IUser = {
+  username: "e2e_pre_hub_c_member",
+  udn: null,
+  id: "726f96ef603b4551a1fb76fa99f68364",
+  fullName: "ArcGIS HubE2E",
+  firstName: "ArcGIS",
+  lastName: "HubE2E",
+  description: null,
+  tags: ["org:Q05waIVQNYv92Kgz", "hubRole:participant"],
+  culture: "",
+  cultureFormat: "",
+  region: "US",
+  units: "english",
+  thumbnail: null,
+  access: "public",
+  created: 1569441945000,
+  modified: 1569442018000,
+  provider: "arcgis",
+} as unknown as Portal.IUser;
+
+const GroupMembersResponse = {
+  total: 2,
+  start: 1,
+  num: 25,
+  nextStart: -1,
+  owner: {
+    username: "e2e_pre_pub_admin",
+    fullName: "e2e_pre_pub_admin qa-pre-hub",
+  },
+  users: [
+    {
+      username: "e2e_pre_hub_c_member",
+      fullName: "ArcGIS HubE2E",
+      memberType: "admin",
+      thumbnail: "bozo.jpg",
+      joined: 1575308050000,
+      orgId: "Q05waIVQNYv92Kgz",
+    },
+    {
+      username: "e2e_pre_pub_admin",
+      fullName: "e2e_pre_pub_admin qa-pre-hub",
+      memberType: "admin",
+      thumbnail: "user.jpg",
+      joined: 1575308011000,
+      orgId: "T5cZDlfUaBpDnk6P",
+    },
+  ],
+};
+
+const SparseGroupMembersResponse = {
+  total: 2,
+  start: 1,
+  num: 25,
+  nextStart: -1,
+  owner: {
+    username: "e2e_pre_pub_admin",
+  },
+  users: [
+    {
+      username: "e2e_pre_hub_c_member",
+      fullName: "ArcGIS HubE2E",
+      memberType: "admin",
+      thumbnail: "user.jpg",
+      joined: 1575308050000,
+    },
+    {
+      username: "e2e_pre_pub_admin",
+      joined: 1575308011000,
+    },
+  ],
+};
+const MinimalUser: Portal.IUser = {
+  username: "e2e_pre_pub_admin",
+  udn: null,
+  id: "e9604305b2bf44b1bac01bc78e08d768",
+  fullName: "",
+  firstName: "",
+  lastName: "",
+  created: 1563455713000,
+  modified: 1676495017000,
+  provider: "arcgis",
+} as unknown as Portal.IUser;
+
+const FullUser: Portal.IUser = {
+  username: "e2e_pre_pub_admin",
+  udn: null,
+  id: "e9604305b2bf44b1bac01bc78e08d768",
+  fullName: "e2e_pre_pub_admin qa-pre-hub",
+  categories: [],
+  emailStatus: "verified",
+  emailStatusDate: 1685553302000,
+  firstName: "e2e_pre_pub_admin",
+  lastName: "qa-pre-hub",
+  preferredView: null,
+  description: null,
+  email: "dbouwman@esri.com",
+  userType: "arcgisonly",
+  idpUsername: null,
+  favGroupId: "21b609dac1784585a27ab55a99c09b37",
+  lastLogin: 1687895393000,
+  mfaEnabled: false,
+  storageUsage: 10192336326,
+  storageQuota: 2199023255552,
+  orgId: "T5cZDlfUaBpDnk6P",
+  role: "org_admin",
+  privileges: [
+    "premium:user:networkanalysis:servicearea",
+    "premium:user:networkanalysis:vehiclerouting",
+    "premium:user:places",
+    "premium:user:spatialanalysis",
+  ],
+  level: "2",
+  userLicenseTypeId: "creatorUT",
+  disabled: false,
+  tags: [],
+  culture: "",
+  cultureFormat: "",
+  region: "US",
+  units: null,
+  thumbnail: null,
+  access: "private",
+  created: 1563455713000,
+  modified: 1676495017000,
+  provider: "arcgis",
+  groups: [
+    {
+      id: "00d83db970ee4937b23d5bbf60c92b51",
+      title: "collaborative-events-toggle-1628047171191 Core Team",
+      isInvitationOnly: false,
+      owner: "qa_pre_hub_admin",
+      description:
+        "Adding members to the core team adds them to this group. These team members are also added to the initiative's content and followers groups so they can edit and manage initiative items in the content group as well as view and send email updates to followers. This group is an update group which means that your team members can update its content. Other members of your ArcGIS Online organization can see this group, but only your team can see what it includes and make changes.<br /><br />If you have additional questions about the core team group, please see Esri documentation or contact support.<br /><br /><strong>DO NOT DELETE THIS GROUP.</strong>",
+      snippet:
+        "Members of this group can create, edit, and manage the site, pages, and other content related to collaborative-events-toggle-harness-1.",
+      tags: [
+        "Hub Group",
+        "Hub Initiative Group",
+        "Hub Site Group",
+        "Hub Core Team Group",
+        "Hub Team Group",
+      ],
+      typeKeywords: [],
+      phone: null,
+      sortField: "modified",
+      sortOrder: "desc",
+      isViewOnly: false,
+      featuredItemsId: null,
+      thumbnail: null,
+      created: 1612556050000,
+      modified: 1628047181000,
+      access: "org",
+      capabilities: ["updateitemcontrol"],
+      isFav: false,
+      isReadOnly: false,
+      protected: true,
+      autoJoin: false,
+      notificationsEnabled: false,
+      provider: null,
+      providerGroupName: null,
+      leavingDisallowed: false,
+      hiddenMembers: false,
+      membershipAccess: "collaboration",
+      displaySettings: {
+        itemTypes: "",
+      },
+      properties: null,
+      userMembership: {
+        username: "e2e_pre_pub_admin",
+        memberType: "admin",
+        applications: 0,
+      },
+    },
+  ],
+} as unknown as Portal.IUser;

--- a/packages/common/test/users/HubUsers.test.ts
+++ b/packages/common/test/users/HubUsers.test.ts
@@ -7,7 +7,7 @@ import {
 import * as FetchEnrichments from "../../src/users/_internal/enrichments";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 
-const TEST_USER: IUser = {
+const TEST_USER: IUser & Record<string, any> = {
   username: "juliana_p",
   fullName: "Juliana Mascasa",
 
@@ -40,7 +40,7 @@ const TEST_USER: IUser = {
   modified: 1654549320000,
   provider: "arcgis",
   groups: [],
-};
+} as unknown as IUser;
 
 describe("HubUsers Module:", () => {
   describe("enrichments:", () => {
@@ -84,6 +84,7 @@ describe("HubUsers Module:", () => {
       expect(chk.updatedDate).toEqual(new Date(USR.modified));
       expect(chk.updatedDateSource).toEqual("user.modified");
       expect(chk.family).toEqual("people");
+
       expect(chk.links.self).toEqual(
         `https://some-server.com/gis/home/user.html?user=${USR.username}`
       );
@@ -91,6 +92,12 @@ describe("HubUsers Module:", () => {
       expect(chk.links.thumbnail).toEqual(
         `${hubRo.portal}/community/users/${USR.username}/info/${USR.thumbnail}?token=fake-token`
       );
+    });
+    it("handles memberType", async () => {
+      const USR = cloneObject(TEST_USER);
+      USR.memberType = "admin";
+      const chk = await enrichUserSearchResult(USR, [], hubRo);
+      expect(chk.memberType).toEqual("admin");
     });
     it("handles enrichments", async () => {
       const chk = await enrichUserSearchResult(


### PR DESCRIPTION
1. Description:

Finalize search for `targetEntity: "user"` and `targetEntity: "groupMember"`

1. Instructions for testing: run tests

There are also some e2e's that verify this against the actual portal api - the groups involved are not durable, but work as of this writing

1. Closes Issues: [#7164](https://devtopia.esri.com/dc/hub/issues/7164)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
