### PR TITLE
fix(): make scope optional for IUiSchemaRule

### DIFF
--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -43,7 +43,7 @@ export interface IValidationResult {
 export interface IUiSchemaRule {
   effect: UiSchemaRuleEffects;
   condition: {
-    scope: string;
+    scope?: string;
     schema: IConfigurationSchema;
   };
 }


### PR DESCRIPTION
1. Description:
Allows for rule scopes in UiSchema's to be optional. This allows for multiple conditions on one rule. 

1. Instructions for testing:

1. Closes Issues: helps to close #6356

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
