### PR TITLE
feat: make propertyMapper more generic

### DIFF
--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -44,7 +44,7 @@ export async function createContent(
   const content = { /* ...DEFAULT_PROJECT, */ ...partialContent };
 
   // Map project object onto a default project Model
-  const mapper = new PropertyMapper<Partial<IHubEditableContent>>(
+  const mapper = new PropertyMapper<Partial<IHubEditableContent>, IModel>(
     getPropertyMap()
   );
   // create model from object, using the default model as a starting point
@@ -88,7 +88,7 @@ export async function updateContent(
   // get the backing item & data
   const model = await getModel(content.id, requestOptions);
   // create the PropertyMapper
-  const mapper = new PropertyMapper<Partial<IHubEditableContent>>(
+  const mapper = new PropertyMapper<Partial<IHubEditableContent>, IModel>(
     getPropertyMap()
   );
   // Note: Although we are fetching the model, and applying changes onto it,

--- a/packages/common/src/content/fetch.ts
+++ b/packages/common/src/content/fetch.ts
@@ -10,7 +10,7 @@ import {
   fetchItemEnrichments,
   IItemAndEnrichments,
 } from "../items/_enrichments";
-import { IHubRequestOptions } from "../types";
+import { IHubRequestOptions, IModel } from "../types";
 import { isNil } from "../util";
 import { maybeConcat } from "../utils/_array";
 import { addContextToSlug, isSlug, parseDatasetId } from "./slugs";
@@ -247,7 +247,7 @@ export const fetchHubContent = async (
   // and then use the property mapper and computeProps() to compose the object
   const model = await fetchContent(identifier, options);
   // for now we still need property mapper to get defaults not set by composeContent()
-  const mapper = new PropertyMapper<Partial<IHubEditableContent>>(
+  const mapper = new PropertyMapper<Partial<IHubEditableContent>, IModel>(
     getPropertyMap()
   );
   const content = mapper.modelToObject(model, {}) as IHubEditableContent;

--- a/packages/common/src/discussions/edit.ts
+++ b/packages/common/src/discussions/edit.ts
@@ -3,7 +3,7 @@ import { IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
 import { IHubDiscussion } from "../core/types";
 import { createModel, getModel, updateModel } from "../models";
 import { constructSlug, getUniqueSlug, setSlugKeyword } from "../items/slugs";
-import { cloneObject, setDiscussableKeyword } from "../index";
+import { IModel, cloneObject, setDiscussableKeyword } from "../index";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 import { computeProps } from "./_internal/computeProps";
@@ -46,7 +46,9 @@ export async function createDiscussion(
     discussion.isDiscussable
   );
   // Map discussion object onto a default discussion Model
-  const mapper = new PropertyMapper<Partial<IHubDiscussion>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubDiscussion>, IModel>(
+    getPropertyMap()
+  );
   // create model from object, using the default model as a starting point
   let model = mapper.objectToModel(
     discussion,
@@ -84,7 +86,9 @@ export async function updateDiscussion(
   // get the backing item & data
   const model = await getModel(discussion.id, requestOptions);
   // create the PropertyMapper
-  const mapper = new PropertyMapper<Partial<IHubDiscussion>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubDiscussion>, IModel>(
+    getPropertyMap()
+  );
   // Note: Although we are fetching the model, and applying changes onto it,
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic

--- a/packages/common/src/discussions/fetch.ts
+++ b/packages/common/src/discussions/fetch.ts
@@ -3,7 +3,7 @@ import { IItem, getItem } from "@esri/arcgis-rest-portal";
 import { IHubDiscussion } from "../core/types";
 import { fetchModelFromItem } from "../models";
 import { getItemBySlug } from "../items/slugs";
-import { isGuid } from "../index";
+import { IModel, isGuid } from "../index";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 import { computeProps } from "./_internal/computeProps";
@@ -45,7 +45,9 @@ export async function convertItemToDiscussion(
   requestOptions: IRequestOptions
 ): Promise<IHubDiscussion> {
   const model = await fetchModelFromItem(item, requestOptions);
-  const mapper = new PropertyMapper<Partial<IHubDiscussion>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubDiscussion>, IModel>(
+    getPropertyMap()
+  );
   const discussion = mapper.modelToObject(model, {}) as IHubDiscussion;
   return computeProps(model, discussion, requestOptions);
 }

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -25,6 +25,7 @@ import {
   IHubRequestOptions,
   getItemHomeUrl,
   setDiscussableKeyword,
+  IModel,
 } from "../index";
 import {
   IItem,
@@ -81,7 +82,9 @@ export async function createInitiative(
     initiative.isDiscussable
   );
   // Map initiative object onto a default initiative Model
-  const mapper = new PropertyMapper<Partial<IHubInitiative>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubInitiative>, IModel>(
+    getPropertyMap()
+  );
   // create model from object, using the default model as a starting point
   let model = mapper.objectToModel(
     initiative,
@@ -118,7 +121,9 @@ export async function updateInitiative(
   // get the backing item & data
   const model = await getModel(initiative.id, requestOptions);
   // create the PropertyMapper
-  const mapper = new PropertyMapper<Partial<IHubInitiative>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubInitiative>, IModel>(
+    getPropertyMap()
+  );
   // Note: Although we are fetching the model, and applying changes onto it,
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic
@@ -186,7 +191,9 @@ export async function convertItemToInitiative(
   let model = await fetchModelFromItem(item, requestOptions);
   // apply migrations
   model = await applyInitiativeMigrations(model, requestOptions);
-  const mapper = new PropertyMapper<Partial<IHubInitiative>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubInitiative>, IModel>(
+    getPropertyMap()
+  );
   const prj = mapper.modelToObject(model, {}) as IHubInitiative;
   return computeProps(model, prj, requestOptions);
 }

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -21,6 +21,7 @@ import {
   IEditorConfig,
 } from "../core/behaviors/IWithEditorBehavior";
 import { setDiscussableKeyword } from "../discussions";
+import { IModel } from "../types";
 
 /**
  * @private
@@ -53,7 +54,9 @@ export async function createProject(
     project.isDiscussable
   );
   // Map project object onto a default project Model
-  const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubProject>, IModel>(
+    getPropertyMap()
+  );
   // create model from object, using the default model as a starting point
   let model = mapper.objectToModel(project, cloneObject(DEFAULT_PROJECT_MODEL));
   // create the item
@@ -89,7 +92,9 @@ export async function updateProject(
   // get the backing item & data
   const model = await getModel(project.id, requestOptions);
   // create the PropertyMapper
-  const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubProject>, IModel>(
+    getPropertyMap()
+  );
   // Note: Although we are fetching the model, and applying changes onto it,
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -11,7 +11,7 @@ import { fetchItemEnrichments } from "../items/_enrichments";
 import { fetchModelFromItem, fetchModelResources } from "../models";
 import { IHubSearchResult } from "../search";
 import { parseInclude } from "../search/_internal/parseInclude";
-import { IHubRequestOptions } from "../types";
+import { IHubRequestOptions, IModel } from "../types";
 import { isGuid, mapBy } from "../utils";
 import { computeProps } from "./_internal/computeProps";
 import { getPropertyMap } from "./_internal/getPropertyMap";
@@ -58,7 +58,9 @@ export async function convertItemToProject(
 ): Promise<IHubProject> {
   const model = await fetchModelFromItem(item, requestOptions);
   // TODO: In the future we will handle the boundary fetching from resource
-  const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubProject>, IModel>(
+    getPropertyMap()
+  );
   const prj = mapper.modelToObject(model, {}) as IHubProject;
   return computeProps(model, prj, requestOptions);
 }

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -327,7 +327,7 @@ export class HubSite
    * @returns
    */
   async createVersion(options?: ICreateVersionOptions): Promise<IVersion> {
-    const mapper = new PropertyMapper<IHubSite>(getPropertyMap());
+    const mapper = new PropertyMapper<IHubSite, IModel>(getPropertyMap());
     const model = mapper.objectToModel(this.entity, {} as IModel);
     return createVersion(model, this.context.userRequestOptions, options);
   }
@@ -338,7 +338,7 @@ export class HubSite
    * @returns
    */
   async updateVersion(version: IVersion): Promise<IVersion> {
-    const mapper = new PropertyMapper<IHubSite>(getPropertyMap());
+    const mapper = new PropertyMapper<IHubSite, IModel>(getPropertyMap());
     const model = mapper.objectToModel(this.entity, {} as IModel);
     return updateVersion(model, version, this.context.userRequestOptions);
   }

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -270,7 +270,9 @@ export async function createSite(
   );
 
   // Now convert the IHubSite into an IModel
-  const mapper = new PropertyMapper<Partial<IHubSite>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubSite>, IModel>(
+    getPropertyMap()
+  );
   let model = mapper.objectToModel(site, cloneObject(DEFAULT_SITE_MODEL));
   // create the backing item
   model = await createModel(
@@ -399,7 +401,9 @@ export function convertModelToSite(
   migrated = catalogMigration(migrated);
 
   // convert to site
-  const mapper = new PropertyMapper<Partial<IHubSite>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubSite>, IModel>(
+    getPropertyMap()
+  );
   const site = mapper.modelToObject(migrated, {}) as IHubSite;
   // compute additional properties
   return computeProps(model, site, requestOptions);
@@ -417,7 +421,7 @@ export function convertSiteToModel(
   requestOptions: IRequestOptions
 ): IModel {
   // create the mapper
-  const mapper = new PropertyMapper<IHubSite>(getPropertyMap());
+  const mapper = new PropertyMapper<IHubSite, IModel>(getPropertyMap());
   // applying the site onto the default model ensures that a minimum
   // set of properties exist, regardless what may have been done to
   // the IHubSite pojo

--- a/packages/common/test/content/edit.test.ts
+++ b/packages/common/test/content/edit.test.ts
@@ -12,8 +12,8 @@ import { cloneObject } from "../../src/util";
 
 const GUID = "9b77674e43cf4bbd9ecad5189b3f1fdc";
 
-describe("content editing", () => {
-  describe("create content", () => {
+describe("content editing:", () => {
+  describe("create content:", () => {
     it("converts to a model and creates the item", async () => {
       const createSpy = spyOn(modelUtils, "createModel").and.callFake(
         (m: IModel) => {
@@ -37,11 +37,13 @@ describe("content editing", () => {
       expect(modelToCreate.item.properties.orgUrlKey).toBe("dcdev");
     });
   });
-  describe("update content", () => {
+  describe("update content:", () => {
     it("converts to a model and updates the item", async () => {
       const getModelSpy = spyOn(modelUtils, "getModel").and.returnValue(
         Promise.resolve({
-          item: {},
+          item: {
+            typeKeywords: [],
+          },
           data: {},
         })
       );

--- a/packages/common/test/core/helpers/PropertyMapper.test.ts
+++ b/packages/common/test/core/helpers/PropertyMapper.test.ts
@@ -1,3 +1,4 @@
+import { IGroup } from "@esri/arcgis-rest-portal";
 import { CANNOT_DISCUSS, IModel } from "../../../src";
 import {
   IPropertyMap,
@@ -96,13 +97,17 @@ describe("PropertyMapper:", () => {
       expect(chk.isDiscussable).toBeFalsy();
     });
   });
-  describe("PropertyMapper", () => {
-    let pm: PropertyMapper<any>;
+  describe("PropertyMapper works with IModel", () => {
+    let pm: PropertyMapper<any, IModel>;
     const obj = {
       size: "large",
     } as any;
     const model = {
-      item: { id: "3ef", properties: { other: "prop", color: "blue" } },
+      item: {
+        id: "3ef",
+        properties: { other: "prop", color: "blue" },
+        itemControl: "update",
+      },
       data: {},
     } as unknown as IModel;
     beforeEach(() => {
@@ -125,6 +130,38 @@ describe("PropertyMapper:", () => {
     it("maps object to model", () => {
       const chk = pm.objectToModel(obj, model);
       expect(chk.item.properties.size).toBe("large");
+    });
+  });
+  describe("PropertyMapper work with IGroup", () => {
+    let pm: PropertyMapper<any, IGroup>;
+    const obj = {
+      tags: ["one", "two"],
+      name: "Red Roses",
+    } as any;
+    const grp = {
+      title: "Blue Roses",
+      tags: ["three", "four"],
+    } as unknown as IGroup;
+    beforeEach(() => {
+      const mappings: IPropertyMap[] = [
+        {
+          objectKey: "name",
+          modelKey: "title",
+        },
+        {
+          objectKey: "tags",
+          modelKey: "tags",
+        },
+      ];
+      pm = new PropertyMapper(mappings);
+    });
+    it("maps model to group", () => {
+      const chk = pm.modelToObject(grp, obj);
+      expect(chk.name).toBe("Blue Roses");
+    });
+    it("maps group to model", () => {
+      const chk = pm.objectToModel(obj, grp);
+      expect(chk.title).toBe("Red Roses");
     });
   });
 });


### PR DESCRIPTION
1. Description:

The `PropertyMapper` class accepted a Type for the Entity (object) side, but assumed `IModel` for the "model" side.

This change allows the user to specify the "model" side as well, and propagates that through the helper functions

e.g.
`new PropertyMapper<Partial<IHubEditableContent>, IModel>()`
`new PropertyMapper<IHubGroup, IGroup>()`

- Methods are now `.storeToEntity` and `.entityToStore` 


Please leave feelings / ideas

1. Instructions for testing: run tests

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
