### PR TITLE
feat: Generic property mapper 

### DIFF
--- a/packages/common/src/content/_internal/getPropertyMap.ts
+++ b/packages/common/src/content/_internal/getPropertyMap.ts
@@ -18,10 +18,10 @@ export function getPropertyMap(): IPropertyMap[] {
    */
   // NOTE: we may want to move these into getBaseProprtyMap(), see:
   // https://github.com/Esri/hub.js/pull/993#discussion_r1134005511
-  map.push({ objectKey: "permissions", modelKey: "data.permissions" });
+  map.push({ entityKey: "permissions", storeKey: "data.permissions" });
   map.push({
-    objectKey: "capabilities",
-    modelKey: "data.settings.capabilities",
+    entityKey: "capabilities",
+    storeKey: "data.settings.capabilities",
   });
 
   // TODO: look into composeContent() for what we can add here

--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -48,7 +48,7 @@ export async function createContent(
     getPropertyMap()
   );
   // create model from object, using the default model as a starting point
-  let model = mapper.objectToModel(content, cloneObject(DEFAULT_CONTENT_MODEL));
+  let model = mapper.entityToStore(content, cloneObject(DEFAULT_CONTENT_MODEL));
 
   // TODO: if we have resources disconnect them from the model for now.
   // if (model.resources) {
@@ -66,7 +66,7 @@ export async function createContent(
   //   model = await upsertModelResources(model, resources, requestOptions);
   // }
   // map the model back into a IHubEditableContent
-  const newContent = mapper.modelToObject(model, {});
+  const newContent = mapper.storeToEntity(model, {});
   // TODO:
   // newContent = computeProps(model, newContent, requestOptions);
   // and return it
@@ -94,7 +94,7 @@ export async function updateContent(
   // Note: Although we are fetching the model, and applying changes onto it,
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic
-  const modelToUpdate = mapper.objectToModel(content, model);
+  const modelToUpdate = mapper.entityToStore(content, model);
   // TODO: if we have resources disconnect them from the model for now.
   // if (modelToUpdate.resources) {
   //   resources = configureBaseResources(
@@ -114,7 +114,7 @@ export async function updateContent(
   //   );
   // }
   // now map back into a project and return that
-  const updatedContent = mapper.modelToObject(updatedModel, content);
+  const updatedContent = mapper.storeToEntity(updatedModel, content);
   // updatedContent = computeProps(model, updatedContent, requestOptions);
   // the casting is needed because modelToObject returns a `Partial<T>`
   // where as this function returns a `T`

--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -44,7 +44,7 @@ export async function createContent(
   const content = { /* ...DEFAULT_PROJECT, */ ...partialContent };
 
   // Map project object onto a default project Model
-  const mapper = new PropertyMapper<Partial<IHubEditableContent>>(
+  const mapper = new PropertyMapper<Partial<IHubEditableContent>, IModel>(
     getPropertyMap()
   );
   // create model from object, using the default model as a starting point
@@ -88,7 +88,7 @@ export async function updateContent(
   // get the backing item & data
   const model = await getModel(content.id, requestOptions);
   // create the PropertyMapper
-  const mapper = new PropertyMapper<Partial<IHubEditableContent>>(
+  const mapper = new PropertyMapper<Partial<IHubEditableContent>, IModel>(
     getPropertyMap()
   );
   // Note: Although we are fetching the model, and applying changes onto it,

--- a/packages/common/src/content/fetch.ts
+++ b/packages/common/src/content/fetch.ts
@@ -250,7 +250,7 @@ export const fetchHubContent = async (
   const mapper = new PropertyMapper<Partial<IHubEditableContent>, IModel>(
     getPropertyMap()
   );
-  const content = mapper.modelToObject(model, {}) as IHubEditableContent;
+  const content = mapper.storeToEntity(model, {}) as IHubEditableContent;
   // TODO: computeProps if we end up using fetchItemAndEnrichments()
   return content;
 };

--- a/packages/common/src/content/fetch.ts
+++ b/packages/common/src/content/fetch.ts
@@ -10,7 +10,7 @@ import {
   fetchItemEnrichments,
   IItemAndEnrichments,
 } from "../items/_enrichments";
-import { IHubRequestOptions } from "../types";
+import { IHubRequestOptions, IModel } from "../types";
 import { isNil } from "../util";
 import { maybeConcat } from "../utils/_array";
 import { addContextToSlug, isSlug, parseDatasetId } from "./slugs";
@@ -247,7 +247,7 @@ export const fetchHubContent = async (
   // and then use the property mapper and computeProps() to compose the object
   const model = await fetchContent(identifier, options);
   // for now we still need property mapper to get defaults not set by composeContent()
-  const mapper = new PropertyMapper<Partial<IHubEditableContent>>(
+  const mapper = new PropertyMapper<Partial<IHubEditableContent>, IModel>(
     getPropertyMap()
   );
   const content = mapper.modelToObject(model, {}) as IHubEditableContent;

--- a/packages/common/src/core/_internal/PropertyMapper.ts
+++ b/packages/common/src/core/_internal/PropertyMapper.ts
@@ -1,16 +1,15 @@
 import { CANNOT_DISCUSS } from "../../discussions";
 import { isDiscussable } from "../../discussions/utils";
 import { deepSet, getProp, setProp } from "../../objects";
-import { IModel } from "../../types";
 import { cloneObject } from "../../util";
 
 /**
  * @private
  * Manage forward and backward property mappings to
- * streamline conversion between the Hub entities, and
- * the backing IModel
+ * streamline conversion between the Hub Entities, and
+ * the backing Store objects.
  */
-export class PropertyMapper<O, M> {
+export class PropertyMapper<E, S> {
   public mappings: IPropertyMap[];
   /**
    * Pass in the mappings between the Entity and
@@ -21,27 +20,27 @@ export class PropertyMapper<O, M> {
     this.mappings = mappings;
   }
   /**
-   * Map properties from a model on to the entity object.
+   * Map properties from a Store object, on to an Entity object.
    *
-   * Used when constructing an entity can from a fetched model,
-   * in which case the entity should be an empty object (`{}`).
+   * Used when constructing an Entity from a fetched Store object,
+   * in which case the Entity should be an empty object (`{}`).
    *
-   * Can also be used to apply changes to an entity from a model,
-   * in which case an existing entity can be passed in.
-   * @param model
-   * @param object
+   * Can also be used to apply changes to an Entity from a Store,
+   * in which case an existing Entity can be passed in.
+   * @param store
+   * @param entity
    * @returns
    */
-  modelToObject(model: M, object: O): O {
-    const obj = mapModelToObject(model, object, this.mappings);
+  storeToEntity(store: S, entity: E): E {
+    const obj = mapStoreToEntity(store, entity, this.mappings);
     // Additional Read-Only Model Level Property Mappings
 
     // ------------------------------
     // canEdit and canDelete
     // ------------------------------
     // use setProp to side-step typechecking
-    if (getProp(model, "item")) {
-      const itm = getProp(model, "item");
+    if (getProp(store, "item")) {
+      const itm = getProp(store, "item");
       setProp("canEdit", ["admin", "update"].includes(itm.itemControl), obj);
       setProp("canDelete", itm.itemControl === "admin", obj);
     }
@@ -55,75 +54,76 @@ export class PropertyMapper<O, M> {
    * Typically the model will already exist, and this
    * method is used to transfer changes to the model
    * prior to storage.
-   * @param object
-   * @param model
+   * @param entity
+   * @param store
    * @returns
    */
-  objectToModel(object: O, model: M): M {
-    return mapObjectToModel(object, model, this.mappings);
+  entityToStore(entity: E, store: S): S {
+    return mapEntityToStore(entity, store, this.mappings);
   }
 }
 
 /**
  * Property Map Entry that provides a cross-walk
- * between a property path (`name`) on the "object"
- * to a property path on a model (`item.title`).
+ * between a property path (`name`) on the entity
+ * to a property path on a store (`item.title`).
  *
  * This enables autmatic mapping of properties between
  * the two types of objects.
  */
 export interface IPropertyMap {
-  objectKey: string;
-  modelKey: string;
+  entityKey: string;
+  storeKey: string;
 }
 
 /**
  * Generic function to apply properties from an Object
  * (i.e. IHubProject) onto a Model that can be persisted to an Item
- * @param object
- * @param model
+ * @param entity
+ * @param store
  * @param mappings
  * @returns
  */
-export function mapObjectToModel<O, M>(
-  object: O,
-  model: M,
+export function mapEntityToStore<E, S>(
+  entity: E,
+  store: S,
   mappings: IPropertyMap[]
-): M {
-  if (getProp(model, "item")) {
-    const item = getProp(model, "item");
+): S {
+  if (getProp(store, "item")) {
+    const item = getProp(store, "item");
     if (item.typeKeywords) {
-      item.typeKeywords = getProp(object, "isDiscussable")
+      item.typeKeywords = getProp(entity, "isDiscussable")
         ? item.typeKeywords.filter(
             (typeKeyword: string) => typeKeyword !== CANNOT_DISCUSS
           )
         : [...item.typeKeywords, CANNOT_DISCUSS];
-      setProp("item.typeKeywords", item.typeKeywords, model);
+      setProp("item.typeKeywords", item.typeKeywords, store);
     }
   }
 
-  return mapProps(object, "objectKey", model, "modelKey", mappings);
+  return mapProps(entity, "entityKey", store, "storeKey", mappings);
 }
 
 /**
  * Generic function to apply properties from a Model
  * onto an Object (i.e. IHubProject etc)
- * @param model
- * @param object
+ * @param store
+ * @param entity
  * @param mappings
  * @returns
  */
-export function mapModelToObject<M, O>(
-  model: M,
-  object: O,
+export function mapStoreToEntity<S, E>(
+  store: S,
+  entity: E,
   mappings: IPropertyMap[]
-): O {
-  if (getProp(model, "item")) {
-    const item = getProp(model, "item");
-    setProp("isDiscussable", isDiscussable(item), object);
+): E {
+  // Item specific logic...
+  if (getProp(store, "item")) {
+    const item = getProp(store, "item");
+    setProp("isDiscussable", isDiscussable(item), entity);
   }
 
-  return mapProps(model, "modelKey", object, "objectKey", mappings);
+  return mapProps(store, "storeKey", entity, "entityKey", mappings);
 }
 
 /**
@@ -147,7 +147,7 @@ function mapProps<S, T>(
   // walk the property map array
   mappings.forEach((entry: IPropertyMap) => {
     // Verbose b/c typescript hates the use of property indexing with generics
-    // i.e. entry<T>[sourceKey] make typescript angry
+    // i.e. entry<T>[sourceKey] makes typescript angry
     const sourcePath = getProp(entry, sourceKey);
     const targetPath = getProp(entry, targetKey);
     // get the value from the source

--- a/packages/common/src/core/_internal/getBasePropertyMap.ts
+++ b/packages/common/src/core/_internal/getBasePropertyMap.ts
@@ -29,38 +29,38 @@ export function getBasePropertyMap(): IPropertyMap[] {
   const resourceProps = Object.keys(EntityResourceMap);
   const map: IPropertyMap[] = [];
   itemProps.forEach((entry) => {
-    map.push({ objectKey: entry, modelKey: `item.${entry}` });
+    map.push({ entityKey: entry, storeKey: `item.${entry}` });
   });
   dataProps.forEach((entry) => {
-    map.push({ objectKey: entry, modelKey: `data.${entry}` });
+    map.push({ entityKey: entry, storeKey: `data.${entry}` });
   });
   resourceProps.forEach((entry) => {
-    map.push({ objectKey: entry, modelKey: `resources.${entry}` });
+    map.push({ entityKey: entry, storeKey: `resources.${entry}` });
   });
   // Deeper mappings
   map.push({
-    objectKey: "slug",
-    modelKey: "item.properties.slug",
+    entityKey: "slug",
+    storeKey: "item.properties.slug",
   });
   map.push({
-    objectKey: "summary",
-    modelKey: "item.snippet",
+    entityKey: "summary",
+    storeKey: "item.snippet",
   });
   map.push({
-    objectKey: "schemaVersion",
-    modelKey: "item.properties.schemaVersion",
+    entityKey: "schemaVersion",
+    storeKey: "item.properties.schemaVersion",
   });
   map.push({
-    objectKey: "orgUrlKey",
-    modelKey: "item.properties.orgUrlKey",
+    entityKey: "orgUrlKey",
+    storeKey: "item.properties.orgUrlKey",
   });
   map.push({
-    objectKey: "name",
-    modelKey: "item.title",
+    entityKey: "name",
+    storeKey: "item.title",
   });
   map.push({
-    objectKey: "boundary",
-    modelKey: "item.properties.boundary",
+    entityKey: "boundary",
+    storeKey: "item.properties.boundary",
   });
   return map;
 }

--- a/packages/common/src/discussions/_internal/getPropertyMap.ts
+++ b/packages/common/src/discussions/_internal/getPropertyMap.ts
@@ -12,10 +12,10 @@ export function getPropertyMap(): IPropertyMap[] {
   const map = getBasePropertyMap();
 
   // Type specific mappings
-  map.push({ objectKey: "prompt", modelKey: "data.prompt" });
+  map.push({ entityKey: "prompt", storeKey: "data.prompt" });
   map.push({
-    objectKey: "location",
-    modelKey: "item.properties.location",
+    entityKey: "location",
+    storeKey: "item.properties.location",
   });
   return map;
 }

--- a/packages/common/src/discussions/edit.ts
+++ b/packages/common/src/discussions/edit.ts
@@ -3,7 +3,7 @@ import { IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
 import { IHubDiscussion } from "../core/types";
 import { createModel, getModel, updateModel } from "../models";
 import { constructSlug, getUniqueSlug, setSlugKeyword } from "../items/slugs";
-import { cloneObject, setDiscussableKeyword } from "../index";
+import { IModel, cloneObject, setDiscussableKeyword } from "../index";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 import { computeProps } from "./_internal/computeProps";
@@ -46,7 +46,9 @@ export async function createDiscussion(
     discussion.isDiscussable
   );
   // Map discussion object onto a default discussion Model
-  const mapper = new PropertyMapper<Partial<IHubDiscussion>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubDiscussion>, IModel>(
+    getPropertyMap()
+  );
   // create model from object, using the default model as a starting point
   let model = mapper.objectToModel(
     discussion,
@@ -84,7 +86,9 @@ export async function updateDiscussion(
   // get the backing item & data
   const model = await getModel(discussion.id, requestOptions);
   // create the PropertyMapper
-  const mapper = new PropertyMapper<Partial<IHubDiscussion>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubDiscussion>, IModel>(
+    getPropertyMap()
+  );
   // Note: Although we are fetching the model, and applying changes onto it,
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic

--- a/packages/common/src/discussions/edit.ts
+++ b/packages/common/src/discussions/edit.ts
@@ -50,14 +50,14 @@ export async function createDiscussion(
     getPropertyMap()
   );
   // create model from object, using the default model as a starting point
-  let model = mapper.objectToModel(
+  let model = mapper.entityToStore(
     discussion,
     cloneObject(DEFAULT_DISCUSSION_MODEL)
   );
   // create the item
   model = await createModel(model, requestOptions);
   // map the model back into a IHubDiscussion
-  let newDiscussion = mapper.modelToObject(model, {});
+  let newDiscussion = mapper.storeToEntity(model, {});
   newDiscussion = computeProps(model, newDiscussion, requestOptions);
   // and return it
   return newDiscussion as IHubDiscussion;
@@ -92,11 +92,11 @@ export async function updateDiscussion(
   // Note: Although we are fetching the model, and applying changes onto it,
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic
-  const modelToUpdate = mapper.objectToModel(discussion, model);
+  const modelToUpdate = mapper.entityToStore(discussion, model);
   // update the backing item
   const updatedModel = await updateModel(modelToUpdate, requestOptions);
   // now map back into a discussion and return that
-  let updatedDiscussion = mapper.modelToObject(updatedModel, discussion);
+  let updatedDiscussion = mapper.storeToEntity(updatedModel, discussion);
   updatedDiscussion = computeProps(model, updatedDiscussion, requestOptions);
   // the casting is needed because modelToObject returns a `Partial<T>`
   // where as this function returns a `T`

--- a/packages/common/src/discussions/fetch.ts
+++ b/packages/common/src/discussions/fetch.ts
@@ -3,7 +3,7 @@ import { IItem, getItem } from "@esri/arcgis-rest-portal";
 import { IHubDiscussion } from "../core/types";
 import { fetchModelFromItem } from "../models";
 import { getItemBySlug } from "../items/slugs";
-import { isGuid } from "../index";
+import { IModel, isGuid } from "../index";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 import { computeProps } from "./_internal/computeProps";
@@ -45,7 +45,9 @@ export async function convertItemToDiscussion(
   requestOptions: IRequestOptions
 ): Promise<IHubDiscussion> {
   const model = await fetchModelFromItem(item, requestOptions);
-  const mapper = new PropertyMapper<Partial<IHubDiscussion>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubDiscussion>, IModel>(
+    getPropertyMap()
+  );
   const discussion = mapper.modelToObject(model, {}) as IHubDiscussion;
   return computeProps(model, discussion, requestOptions);
 }

--- a/packages/common/src/discussions/fetch.ts
+++ b/packages/common/src/discussions/fetch.ts
@@ -48,6 +48,6 @@ export async function convertItemToDiscussion(
   const mapper = new PropertyMapper<Partial<IHubDiscussion>, IModel>(
     getPropertyMap()
   );
-  const discussion = mapper.modelToObject(model, {}) as IHubDiscussion;
+  const discussion = mapper.storeToEntity(model, {}) as IHubDiscussion;
   return computeProps(model, discussion, requestOptions);
 }

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -86,14 +86,14 @@ export async function createInitiative(
     getPropertyMap()
   );
   // create model from object, using the default model as a starting point
-  let model = mapper.objectToModel(
+  let model = mapper.entityToStore(
     initiative,
     cloneObject(DEFAULT_INITIATIVE_MODEL)
   );
   // create the item
   model = await createModel(model, requestOptions);
   // map the model back into a IHubInitiative
-  let newInitiative = mapper.modelToObject(model, {});
+  let newInitiative = mapper.storeToEntity(model, {});
   newInitiative = computeProps(model, newInitiative, requestOptions);
   // and return it
   return newInitiative as IHubInitiative;
@@ -127,11 +127,11 @@ export async function updateInitiative(
   // Note: Although we are fetching the model, and applying changes onto it,
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic
-  const modelToUpdate = mapper.objectToModel(initiative, model);
+  const modelToUpdate = mapper.entityToStore(initiative, model);
   // update the backing item
   const updatedModel = await updateModel(modelToUpdate, requestOptions);
   // now map back into an initiative and return that
-  let updatedInitiative = mapper.modelToObject(updatedModel, initiative);
+  let updatedInitiative = mapper.storeToEntity(updatedModel, initiative);
   updatedInitiative = computeProps(model, updatedInitiative, requestOptions);
   // the casting is needed because modelToObject returns a `Partial<T>`
   // where as this function returns a `T`
@@ -194,7 +194,7 @@ export async function convertItemToInitiative(
   const mapper = new PropertyMapper<Partial<IHubInitiative>, IModel>(
     getPropertyMap()
   );
-  const prj = mapper.modelToObject(model, {}) as IHubInitiative;
+  const prj = mapper.storeToEntity(model, {}) as IHubInitiative;
   return computeProps(model, prj, requestOptions);
 }
 

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -25,6 +25,7 @@ import {
   IHubRequestOptions,
   getItemHomeUrl,
   setDiscussableKeyword,
+  IModel,
 } from "../index";
 import {
   IItem,
@@ -81,7 +82,9 @@ export async function createInitiative(
     initiative.isDiscussable
   );
   // Map initiative object onto a default initiative Model
-  const mapper = new PropertyMapper<Partial<IHubInitiative>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubInitiative>, IModel>(
+    getPropertyMap()
+  );
   // create model from object, using the default model as a starting point
   let model = mapper.objectToModel(
     initiative,
@@ -118,7 +121,9 @@ export async function updateInitiative(
   // get the backing item & data
   const model = await getModel(initiative.id, requestOptions);
   // create the PropertyMapper
-  const mapper = new PropertyMapper<Partial<IHubInitiative>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubInitiative>, IModel>(
+    getPropertyMap()
+  );
   // Note: Although we are fetching the model, and applying changes onto it,
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic
@@ -186,7 +191,9 @@ export async function convertItemToInitiative(
   let model = await fetchModelFromItem(item, requestOptions);
   // apply migrations
   model = await applyInitiativeMigrations(model, requestOptions);
-  const mapper = new PropertyMapper<Partial<IHubInitiative>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubInitiative>, IModel>(
+    getPropertyMap()
+  );
   const prj = mapper.modelToObject(model, {}) as IHubInitiative;
   return computeProps(model, prj, requestOptions);
 }

--- a/packages/common/src/initiatives/_internal/getPropertyMap.ts
+++ b/packages/common/src/initiatives/_internal/getPropertyMap.ts
@@ -12,20 +12,20 @@ export function getPropertyMap(): IPropertyMap[] {
   const map = getBasePropertyMap();
 
   // Type specific mappings
-  map.push({ objectKey: "status", modelKey: "data.status" });
-  map.push({ objectKey: "catalog", modelKey: "data.catalog" });
-  map.push({ objectKey: "permissions", modelKey: "data.permissions" });
+  map.push({ entityKey: "status", storeKey: "data.status" });
+  map.push({ entityKey: "catalog", storeKey: "data.catalog" });
+  map.push({ entityKey: "permissions", storeKey: "data.permissions" });
   map.push({
-    objectKey: "capabilities",
-    modelKey: "data.settings.capabilities",
+    entityKey: "capabilities",
+    storeKey: "data.settings.capabilities",
   });
-  map.push({ objectKey: "contacts", modelKey: "data.contacts" });
-  map.push({ objectKey: "timeline", modelKey: "data.timeline" });
-  map.push({ objectKey: "metrics", modelKey: "item.properties.metrics" });
+  map.push({ entityKey: "contacts", storeKey: "data.contacts" });
+  map.push({ entityKey: "timeline", storeKey: "data.timeline" });
+  map.push({ entityKey: "metrics", storeKey: "item.properties.metrics" });
 
   map.push({
-    objectKey: "location",
-    modelKey: "item.properties.location",
+    entityKey: "location",
+    storeKey: "item.properties.location",
   });
 
   return map;

--- a/packages/common/src/projects/_internal/getPropertyMap.ts
+++ b/packages/common/src/projects/_internal/getPropertyMap.ts
@@ -16,18 +16,18 @@ export function getPropertyMap(): IPropertyMap[] {
    * properties from the project item's data.view into the entity's view
    * because that mapping is already defined in the base property map
    */
-  map.push({ objectKey: "status", modelKey: "data.status" });
-  map.push({ objectKey: "catalog", modelKey: "data.catalog" });
-  map.push({ objectKey: "permissions", modelKey: "data.permissions" });
+  map.push({ entityKey: "status", storeKey: "data.status" });
+  map.push({ entityKey: "catalog", storeKey: "data.catalog" });
+  map.push({ entityKey: "permissions", storeKey: "data.permissions" });
   map.push({
-    objectKey: "capabilities",
-    modelKey: "data.settings.capabilities",
+    entityKey: "capabilities",
+    storeKey: "data.settings.capabilities",
   });
   map.push({
-    objectKey: "location",
-    modelKey: "item.properties.location",
+    entityKey: "location",
+    storeKey: "item.properties.location",
   });
-  map.push({ objectKey: "metrics", modelKey: "item.properties.metrics" });
+  map.push({ entityKey: "metrics", storeKey: "item.properties.metrics" });
 
   return map;
 }

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -58,11 +58,11 @@ export async function createProject(
     getPropertyMap()
   );
   // create model from object, using the default model as a starting point
-  let model = mapper.objectToModel(project, cloneObject(DEFAULT_PROJECT_MODEL));
+  let model = mapper.entityToStore(project, cloneObject(DEFAULT_PROJECT_MODEL));
   // create the item
   model = await createModel(model, requestOptions);
   // map the model back into a IHubProject
-  let newProject = mapper.modelToObject(model, {});
+  let newProject = mapper.storeToEntity(model, {});
   newProject = computeProps(model, newProject, requestOptions);
   // and return it
   return newProject as IHubProject;
@@ -98,11 +98,11 @@ export async function updateProject(
   // Note: Although we are fetching the model, and applying changes onto it,
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic
-  const modelToUpdate = mapper.objectToModel(project, model);
+  const modelToUpdate = mapper.entityToStore(project, model);
   // update the backing item
   const updatedModel = await updateModel(modelToUpdate, requestOptions);
   // now map back into a project and return that
-  let updatedProject = mapper.modelToObject(updatedModel, project);
+  let updatedProject = mapper.storeToEntity(updatedModel, project);
   updatedProject = computeProps(model, updatedProject, requestOptions);
   // the casting is needed because modelToObject returns a `Partial<T>`
   // where as this function returns a `T`

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -21,6 +21,7 @@ import {
   IEditorConfig,
 } from "../core/behaviors/IWithEditorBehavior";
 import { setDiscussableKeyword } from "../discussions";
+import { IModel } from "../types";
 
 /**
  * @private
@@ -53,7 +54,9 @@ export async function createProject(
     project.isDiscussable
   );
   // Map project object onto a default project Model
-  const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubProject>, IModel>(
+    getPropertyMap()
+  );
   // create model from object, using the default model as a starting point
   let model = mapper.objectToModel(project, cloneObject(DEFAULT_PROJECT_MODEL));
   // create the item
@@ -89,7 +92,9 @@ export async function updateProject(
   // get the backing item & data
   const model = await getModel(project.id, requestOptions);
   // create the PropertyMapper
-  const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubProject>, IModel>(
+    getPropertyMap()
+  );
   // Note: Although we are fetching the model, and applying changes onto it,
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -61,7 +61,7 @@ export async function convertItemToProject(
   const mapper = new PropertyMapper<Partial<IHubProject>, IModel>(
     getPropertyMap()
   );
-  const prj = mapper.modelToObject(model, {}) as IHubProject;
+  const prj = mapper.storeToEntity(model, {}) as IHubProject;
   return computeProps(model, prj, requestOptions);
 }
 

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -11,7 +11,7 @@ import { fetchItemEnrichments } from "../items/_enrichments";
 import { fetchModelFromItem, fetchModelResources } from "../models";
 import { IHubSearchResult } from "../search";
 import { parseInclude } from "../search/_internal/parseInclude";
-import { IHubRequestOptions } from "../types";
+import { IHubRequestOptions, IModel } from "../types";
 import { isGuid, mapBy } from "../utils";
 import { computeProps } from "./_internal/computeProps";
 import { getPropertyMap } from "./_internal/getPropertyMap";
@@ -58,7 +58,9 @@ export async function convertItemToProject(
 ): Promise<IHubProject> {
   const model = await fetchModelFromItem(item, requestOptions);
   // TODO: In the future we will handle the boundary fetching from resource
-  const mapper = new PropertyMapper<Partial<IHubProject>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubProject>, IModel>(
+    getPropertyMap()
+  );
   const prj = mapper.modelToObject(model, {}) as IHubProject;
   return computeProps(model, prj, requestOptions);
 }

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -327,7 +327,7 @@ export class HubSite
    * @returns
    */
   async createVersion(options?: ICreateVersionOptions): Promise<IVersion> {
-    const mapper = new PropertyMapper<IHubSite>(getPropertyMap());
+    const mapper = new PropertyMapper<IHubSite, IModel>(getPropertyMap());
     const model = mapper.objectToModel(this.entity, {} as IModel);
     return createVersion(model, this.context.userRequestOptions, options);
   }
@@ -338,7 +338,7 @@ export class HubSite
    * @returns
    */
   async updateVersion(version: IVersion): Promise<IVersion> {
-    const mapper = new PropertyMapper<IHubSite>(getPropertyMap());
+    const mapper = new PropertyMapper<IHubSite, IModel>(getPropertyMap());
     const model = mapper.objectToModel(this.entity, {} as IModel);
     return updateVersion(model, version, this.context.userRequestOptions);
   }

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -328,7 +328,7 @@ export class HubSite
    */
   async createVersion(options?: ICreateVersionOptions): Promise<IVersion> {
     const mapper = new PropertyMapper<IHubSite, IModel>(getPropertyMap());
-    const model = mapper.objectToModel(this.entity, {} as IModel);
+    const model = mapper.entityToStore(this.entity, {} as IModel);
     return createVersion(model, this.context.userRequestOptions, options);
   }
 
@@ -339,7 +339,7 @@ export class HubSite
    */
   async updateVersion(version: IVersion): Promise<IVersion> {
     const mapper = new PropertyMapper<IHubSite, IModel>(getPropertyMap());
-    const model = mapper.objectToModel(this.entity, {} as IModel);
+    const model = mapper.entityToStore(this.entity, {} as IModel);
     return updateVersion(model, version, this.context.userRequestOptions);
   }
 

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -270,7 +270,9 @@ export async function createSite(
   );
 
   // Now convert the IHubSite into an IModel
-  const mapper = new PropertyMapper<Partial<IHubSite>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubSite>, IModel>(
+    getPropertyMap()
+  );
   let model = mapper.objectToModel(site, cloneObject(DEFAULT_SITE_MODEL));
   // create the backing item
   model = await createModel(
@@ -399,7 +401,9 @@ export function convertModelToSite(
   migrated = catalogMigration(migrated);
 
   // convert to site
-  const mapper = new PropertyMapper<Partial<IHubSite>>(getPropertyMap());
+  const mapper = new PropertyMapper<Partial<IHubSite>, IModel>(
+    getPropertyMap()
+  );
   const site = mapper.modelToObject(migrated, {}) as IHubSite;
   // compute additional properties
   return computeProps(model, site, requestOptions);
@@ -417,7 +421,7 @@ export function convertSiteToModel(
   requestOptions: IRequestOptions
 ): IModel {
   // create the mapper
-  const mapper = new PropertyMapper<IHubSite>(getPropertyMap());
+  const mapper = new PropertyMapper<IHubSite, IModel>(getPropertyMap());
   // applying the site onto the default model ensures that a minimum
   // set of properties exist, regardless what may have been done to
   // the IHubSite pojo

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -273,7 +273,7 @@ export async function createSite(
   const mapper = new PropertyMapper<Partial<IHubSite>, IModel>(
     getPropertyMap()
   );
-  let model = mapper.objectToModel(site, cloneObject(DEFAULT_SITE_MODEL));
+  let model = mapper.entityToStore(site, cloneObject(DEFAULT_SITE_MODEL));
   // create the backing item
   model = await createModel(
     model,
@@ -296,7 +296,7 @@ export async function createSite(
   );
 
   // convert the model into a IHubSite and return
-  return mapper.modelToObject(updatedModel, {}) as IHubSite;
+  return mapper.storeToEntity(updatedModel, {}) as IHubSite;
 }
 
 /**
@@ -404,7 +404,7 @@ export function convertModelToSite(
   const mapper = new PropertyMapper<Partial<IHubSite>, IModel>(
     getPropertyMap()
   );
-  const site = mapper.modelToObject(migrated, {}) as IHubSite;
+  const site = mapper.storeToEntity(migrated, {}) as IHubSite;
   // compute additional properties
   return computeProps(model, site, requestOptions);
 }
@@ -425,7 +425,7 @@ export function convertSiteToModel(
   // applying the site onto the default model ensures that a minimum
   // set of properties exist, regardless what may have been done to
   // the IHubSite pojo
-  return mapper.objectToModel(site, cloneObject(DEFAULT_SITE_MODEL));
+  return mapper.entityToStore(site, cloneObject(DEFAULT_SITE_MODEL));
 }
 
 /**

--- a/packages/common/src/sites/_internal/getPropertyMap.ts
+++ b/packages/common/src/sites/_internal/getPropertyMap.ts
@@ -12,11 +12,11 @@ import { getBasePropertyMap } from "../../core/_internal/getBasePropertyMap";
 export function getPropertyMap(): IPropertyMap[] {
   const map = getBasePropertyMap();
   // Site specific mappings
-  map.push({ objectKey: "feeds", modelKey: "data.feeds" });
-  map.push({ objectKey: "permissions", modelKey: "data.permissions" });
+  map.push({ entityKey: "feeds", storeKey: "data.feeds" });
+  map.push({ entityKey: "permissions", storeKey: "data.permissions" });
   map.push({
-    objectKey: "capabilities",
-    modelKey: "data.capabilities",
+    entityKey: "capabilities",
+    storeKey: "data.capabilities",
   });
   // Props stored below `data.values`
   const valueProps = [
@@ -34,40 +34,40 @@ export function getPropertyMap(): IPropertyMap[] {
     "layout",
   ];
   valueProps.forEach((entry) => {
-    map.push({ objectKey: entry, modelKey: `data.values.${entry}` });
+    map.push({ entityKey: entry, storeKey: `data.values.${entry}` });
   });
   // Deeper/Indirect mappings
   map.push({
-    objectKey: "slug",
-    modelKey: "item.properties.slug",
+    entityKey: "slug",
+    storeKey: "item.properties.slug",
   });
   map.push({
-    objectKey: "legacyCapabilities",
-    modelKey: "data.values.capabilities",
+    entityKey: "legacyCapabilities",
+    storeKey: "data.values.capabilities",
   });
   map.push({
-    objectKey: "capabilities",
-    modelKey: "data.settings.capabilities",
+    entityKey: "capabilities",
+    storeKey: "data.settings.capabilities",
   });
   map.push({
-    objectKey: "orgUrlKey",
-    modelKey: "item.properties.orgUrlKey",
+    entityKey: "orgUrlKey",
+    storeKey: "item.properties.orgUrlKey",
   });
   map.push({
-    objectKey: "name",
-    modelKey: "item.title",
+    entityKey: "name",
+    storeKey: "item.title",
   });
   map.push({
-    objectKey: "location",
-    modelKey: "item.properties.location",
+    entityKey: "location",
+    storeKey: "item.properties.location",
   });
 
   // Catalog mappings
   // Since v1.x sites use data.catalog, which is really just `{groiups: []}`
   // we can't overtly migrate data.catalog, but we can map the properties
   // so they don't collide
-  map.push({ objectKey: "catalog", modelKey: "data.catalogv2" });
-  map.push({ objectKey: "legacyCatalog", modelKey: "data.catalog" });
+  map.push({ entityKey: "catalog", storeKey: "data.catalogv2" });
+  map.push({ entityKey: "legacyCatalog", storeKey: "data.catalog" });
 
   return map;
 }

--- a/packages/common/test/content/edit.test.ts
+++ b/packages/common/test/content/edit.test.ts
@@ -12,8 +12,8 @@ import { cloneObject } from "../../src/util";
 
 const GUID = "9b77674e43cf4bbd9ecad5189b3f1fdc";
 
-describe("content editing", () => {
-  describe("create content", () => {
+describe("content editing:", () => {
+  describe("create content:", () => {
     it("converts to a model and creates the item", async () => {
       const createSpy = spyOn(modelUtils, "createModel").and.callFake(
         (m: IModel) => {
@@ -37,11 +37,13 @@ describe("content editing", () => {
       expect(modelToCreate.item.properties.orgUrlKey).toBe("dcdev");
     });
   });
-  describe("update content", () => {
+  describe("update content:", () => {
     it("converts to a model and updates the item", async () => {
       const getModelSpy = spyOn(modelUtils, "getModel").and.returnValue(
         Promise.resolve({
-          item: {},
+          item: {
+            typeKeywords: [],
+          },
           data: {},
         })
       );

--- a/packages/common/test/core/helpers/PropertyMapper.test.ts
+++ b/packages/common/test/core/helpers/PropertyMapper.test.ts
@@ -2,8 +2,8 @@ import { IGroup } from "@esri/arcgis-rest-portal";
 import { CANNOT_DISCUSS, IModel } from "../../../src";
 import {
   IPropertyMap,
-  mapObjectToModel,
-  mapModelToObject,
+  mapEntityToStore,
+  mapStoreToEntity,
   PropertyMapper,
 } from "../../../src/core/_internal/PropertyMapper";
 
@@ -20,26 +20,26 @@ describe("PropertyMapper:", () => {
     it("maps deep properties into model", () => {
       const mappings: IPropertyMap[] = [
         {
-          objectKey: "color",
-          modelKey: "item.properties.color",
+          entityKey: "color",
+          storeKey: "item.properties.color",
         },
       ];
-      const chk = mapObjectToModel(obj, model, mappings);
+      const chk = mapEntityToStore(obj, model, mappings);
       expect(chk.item.properties.color).toBe("red");
       expect(chk.item.properties.other).toBe("prop");
     });
     it("skips missing props", () => {
       const mappings: IPropertyMap[] = [
         {
-          objectKey: "color",
-          modelKey: "item.properties.color",
+          entityKey: "color",
+          storeKey: "item.properties.color",
         },
         {
-          objectKey: "missing",
-          modelKey: "item.properties.missing",
+          entityKey: "missing",
+          storeKey: "item.properties.missing",
         },
       ];
-      const chk = mapObjectToModel(obj, model, mappings);
+      const chk = mapEntityToStore(obj, model, mappings);
       expect(chk.item.properties.color).toBe("red");
       expect(chk.item.properties.other).toBe("prop");
       expect(chk.item.properties.missing).toBeUndefined();
@@ -48,13 +48,13 @@ describe("PropertyMapper:", () => {
       obj.isDiscussable = true;
       model.item.typeKeywords = [CANNOT_DISCUSS, "another prop"];
       const mappings: IPropertyMap[] = [];
-      const chk = mapObjectToModel(obj, model, mappings);
+      const chk = mapEntityToStore(obj, model, mappings);
       expect(chk.item.typeKeywords?.includes(CANNOT_DISCUSS)).toBeFalsy();
     });
     it("adds CANNOT_DISCUSS to typeKeywords when isDiscussable is false", () => {
       obj.isDiscussable = false;
       const mappings: IPropertyMap[] = [];
-      const chk = mapObjectToModel(obj, model, mappings);
+      const chk = mapEntityToStore(obj, model, mappings);
       expect(chk.item.typeKeywords?.includes(CANNOT_DISCUSS)).toBeTruthy();
     });
   });
@@ -67,25 +67,25 @@ describe("PropertyMapper:", () => {
     it("maps deep properties into object", () => {
       const mappings: IPropertyMap[] = [
         {
-          objectKey: "color",
-          modelKey: "item.properties.color",
+          entityKey: "color",
+          storeKey: "item.properties.color",
         },
       ];
-      const chk = mapModelToObject(model, obj, mappings);
+      const chk = mapStoreToEntity(model, obj, mappings);
       expect(chk.color).toBe("blue");
     });
     it("skips missing props", () => {
       const mappings: IPropertyMap[] = [
         {
-          objectKey: "color",
-          modelKey: "item.properties.color",
+          entityKey: "color",
+          storeKey: "item.properties.color",
         },
         {
-          objectKey: "missing",
-          modelKey: "item.properties.missing",
+          entityKey: "missing",
+          storeKey: "item.properties.missing",
         },
       ];
-      const chk = mapModelToObject(model, obj, mappings);
+      const chk = mapStoreToEntity(model, obj, mappings);
       expect(chk.color).toBe("blue");
       expect(chk.missing).toBeUndefined();
     });
@@ -93,7 +93,7 @@ describe("PropertyMapper:", () => {
       model.item.typeKeywords = [CANNOT_DISCUSS];
       obj.isDiscussable = true;
       const mappings: IPropertyMap[] = [];
-      const chk = mapModelToObject(model, obj, mappings);
+      const chk = mapStoreToEntity(model, obj, mappings);
       expect(chk.isDiscussable).toBeFalsy();
     });
   });
@@ -113,22 +113,22 @@ describe("PropertyMapper:", () => {
     beforeEach(() => {
       const mappings: IPropertyMap[] = [
         {
-          objectKey: "color",
-          modelKey: "item.properties.color",
+          entityKey: "color",
+          storeKey: "item.properties.color",
         },
         {
-          objectKey: "size",
-          modelKey: "item.properties.size",
+          entityKey: "size",
+          storeKey: "item.properties.size",
         },
       ];
       pm = new PropertyMapper(mappings);
     });
     it("maps model to object", () => {
-      const chk = pm.modelToObject(model, obj);
+      const chk = pm.storeToEntity(model, obj);
       expect(chk.color).toBe("blue");
     });
     it("maps object to model", () => {
-      const chk = pm.objectToModel(obj, model);
+      const chk = pm.entityToStore(obj, model);
       expect(chk.item.properties.size).toBe("large");
     });
   });
@@ -145,22 +145,22 @@ describe("PropertyMapper:", () => {
     beforeEach(() => {
       const mappings: IPropertyMap[] = [
         {
-          objectKey: "name",
-          modelKey: "title",
+          entityKey: "name",
+          storeKey: "title",
         },
         {
-          objectKey: "tags",
-          modelKey: "tags",
+          entityKey: "tags",
+          storeKey: "tags",
         },
       ];
       pm = new PropertyMapper(mappings);
     });
     it("maps model to group", () => {
-      const chk = pm.modelToObject(grp, obj);
+      const chk = pm.storeToEntity(grp, obj);
       expect(chk.name).toBe("Blue Roses");
     });
     it("maps group to model", () => {
-      const chk = pm.objectToModel(obj, grp);
+      const chk = pm.entityToStore(obj, grp);
       expect(chk.title).toBe("Red Roses");
     });
   });

--- a/packages/common/test/core/helpers/PropertyMapper.test.ts
+++ b/packages/common/test/core/helpers/PropertyMapper.test.ts
@@ -1,3 +1,4 @@
+import { IGroup } from "@esri/arcgis-rest-portal";
 import { CANNOT_DISCUSS, IModel } from "../../../src";
 import {
   IPropertyMap,
@@ -96,13 +97,17 @@ describe("PropertyMapper:", () => {
       expect(chk.isDiscussable).toBeFalsy();
     });
   });
-  describe("PropertyMapper", () => {
-    let pm: PropertyMapper<any>;
+  describe("PropertyMapper works with IModel", () => {
+    let pm: PropertyMapper<any, IModel>;
     const obj = {
       size: "large",
     } as any;
     const model = {
-      item: { id: "3ef", properties: { other: "prop", color: "blue" } },
+      item: {
+        id: "3ef",
+        properties: { other: "prop", color: "blue" },
+        itemControl: "update",
+      },
       data: {},
     } as unknown as IModel;
     beforeEach(() => {
@@ -125,6 +130,38 @@ describe("PropertyMapper:", () => {
     it("maps object to model", () => {
       const chk = pm.objectToModel(obj, model);
       expect(chk.item.properties.size).toBe("large");
+    });
+  });
+  describe("PropertyMapper work with IGroup", () => {
+    let pm: PropertyMapper<any, IGroup>;
+    const obj = {
+      tags: ["one", "two"],
+      name: "Red Roses",
+    } as any;
+    const grp = {
+      title: "Blue Roses",
+      tags: ["three", "four"],
+    } as unknown as IGroup;
+    beforeEach(() => {
+      const mappings: IPropertyMap[] = [
+        {
+          objectKey: "name",
+          modelKey: "title",
+        },
+        {
+          objectKey: "tags",
+          modelKey: "tags",
+        },
+      ];
+      pm = new PropertyMapper(mappings);
+    });
+    it("maps model to group", () => {
+      const chk = pm.modelToObject(grp, obj);
+      expect(chk.name).toBe("Blue Roses");
+    });
+    it("maps group to model", () => {
+      const chk = pm.objectToModel(obj, grp);
+      expect(chk.title).toBe("Red Roses");
     });
   });
 });


### PR DESCRIPTION
1. Description:

The `PropertyMapper` class accepted a Type for the Entity (object) side, but assumed `IModel` for the "model" side.

This change allows the user to specify the "model" side as well, and propagates that through the helper functions

e.g.
`new PropertyMapper<Partial<IHubEditableContent>, IModel>()`
`new PropertyMapper<IHubGroup, IGroup>()`

- Methods are now `.storeToEntity` and `.entityToStore` 


Please leave feelings / ideas

1. Instructions for testing: run tests

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
