### PR TITLE
fix: defaultHostname and customHostname editing on site entity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64966,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.9.0",
+			"version": "13.13.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64991,7 +64991,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "24.4.0",
+			"version": "25.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65004,7 +65004,7 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "^12.4.0 || 13"
+				"@esri/hub-common": "^13.0.0"
 			}
 		},
 		"packages/downloads": {

--- a/packages/common/src/sites/_internal/handleDomainChanges.ts
+++ b/packages/common/src/sites/_internal/handleDomainChanges.ts
@@ -30,8 +30,8 @@ export async function handleDomainChanges(
   };
 
   ["customHostname", "defaultHostname"].forEach((key) => {
-    const currentValue = getProp(currentModel, `data.values.${key}`);
-    const updatedValue = getProp(updatedModel, `data.values.${key}`);
+    const currentValue = getProp(currentModel, `data.values.${key}`) || "";
+    const updatedValue = getProp(updatedModel, `data.values.${key}`) || "";
     if (updatedValue !== currentValue) {
       domainChanges.remove.push(currentValue);
       domainChanges.add.push(updatedValue);

--- a/packages/common/test/sites/_internal/handleDomainChanges.test.ts
+++ b/packages/common/test/sites/_internal/handleDomainChanges.test.ts
@@ -46,4 +46,28 @@ describe("handleDomainChanges", () => {
     expect(addSpy.calls.count()).toBe(1);
     expect(removeSpy.calls.count()).toBe(1);
   });
+
+  it("does not attempt to update domains that have not changed", async () => {
+    const addSpy = spyOn(domainModule, "addDomain").and.returnValue(
+      Promise.resolve()
+    );
+    const removeSpy = spyOn(
+      domainModule,
+      "removeDomainByHostname"
+    ).and.returnValue(Promise.resolve());
+    const c = cloneObject(currentModel);
+    (c as any).data.values = {
+      customHostname: "site.city.gov",
+    };
+    const u = cloneObject(updatedModel);
+    (u as any).data.values = {
+      customHostname: "site.city.gov",
+      defaultHostname: "",
+    };
+
+    await handleDomainChanges(u, c, MOCK_HUB_REQOPTS);
+
+    expect(addSpy.calls.count()).toBe(0);
+    expect(removeSpy.calls.count()).toBe(0);
+  });
 });


### PR DESCRIPTION
1. Description: Fixes a small issue with editing customHostname and defaultHostname

1. Instructions for testing: well, you can't easily. You'd have to add the appropriate schemas to SiteSchema.ts and SiteUiShcemaEdit.ts and we don't want to do that yet.

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
