### PR TITLE
feat(hub-discussions): add createDiscussionSetting function and assoc…

### DIFF
--- a/packages/discussions/src/discussion-settings/discussion-settings.ts
+++ b/packages/discussions/src/discussion-settings/discussion-settings.ts
@@ -1,0 +1,9 @@
+import { request } from "../request";
+import { ICreateDiscussionSettingParams, IDiscussionSetting } from "../types";
+
+export function createDiscussionSetting(
+  options: ICreateDiscussionSettingParams
+): Promise<IDiscussionSetting> {
+  options.httpMethod = "POST";
+  return request(`/discussion_settings`, options);
+}

--- a/packages/discussions/src/discussion-settings/index.ts
+++ b/packages/discussions/src/discussion-settings/index.ts
@@ -1,0 +1,1 @@
+export * from "./discussion-settings";

--- a/packages/discussions/src/index.ts
+++ b/packages/discussions/src/index.ts
@@ -3,6 +3,7 @@
 
 export * from "./posts";
 export * from "./channels";
+export * from "./discussion-settings";
 export * from "./reactions";
 export * from "./types";
 

--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -985,3 +985,43 @@ export interface IRemoveChannelActivityParams
   extends IDiscussionsRequestOptions {
   channelId: string;
 }
+
+/**
+ * representation of a discussion setting record from the service
+ *
+ * @export
+ * @interface IDiscussionSetting
+ * @extends {IWithAuthor}
+ * @extends {IWithEditor}
+ * @extends {IWithTimestamps}
+ */
+export interface IDiscussionSetting
+  extends IWithAuthor,
+    IWithEditor,
+    IWithTimestamps {
+  id: string;
+  type: DiscussionSettingType;
+  settings: ISettings;
+}
+
+export enum DiscussionSettingType {
+  CONTENT = "content",
+}
+
+export interface ISettings {
+  allowedChannelIds: string[] | null;
+}
+
+/**
+ * parameters for creating a discussionSetting
+ */
+export interface ICreateDiscussionSetting {
+  id: string;
+  type: DiscussionSettingType;
+  settings: ISettings;
+}
+
+export interface ICreateDiscussionSettingParams
+  extends IDiscussionsRequestOptions {
+  data: ICreateDiscussionSetting;
+}

--- a/packages/discussions/test/discussion-settings.test.ts
+++ b/packages/discussions/test/discussion-settings.test.ts
@@ -1,0 +1,41 @@
+import * as req from "../src/request";
+import { createDiscussionSetting } from "../src/discussion-settings";
+import {
+  DiscussionSettingType,
+  ICreateDiscussionSetting,
+  ICreateDiscussionSettingParams,
+  IDiscussionsRequestOptions,
+} from "../src/types";
+
+describe("discussion-settings", () => {
+  let requestSpy: any;
+  const response = new Response("ok", { status: 200 });
+  const baseOpts: IDiscussionsRequestOptions = {
+    hubApiUrl: "https://hub.arcgis.com/api",
+    authentication: undefined,
+  };
+
+  beforeEach(() => {
+    requestSpy = spyOn(req, "request").and.returnValue(
+      Promise.resolve(response)
+    );
+  });
+
+  it("creates a discussionSetting", async () => {
+    const body: ICreateDiscussionSetting = {
+      id: "uuidv4",
+      type: DiscussionSettingType.CONTENT,
+      settings: {
+        allowedChannelIds: ["aaa"],
+      },
+    };
+    const options: ICreateDiscussionSettingParams = { ...baseOpts, data: body };
+
+    await createDiscussionSetting(options);
+
+    expect(requestSpy.calls.count()).toEqual(1);
+    const [url, opts] = requestSpy.calls.argsFor(0);
+    expect(url).toEqual(`/discussion_settings`);
+    expect(opts).toEqual({ ...options, httpMethod: "POST" });
+  });
+});


### PR DESCRIPTION
…iated interfaces

affects: @esri/hub-discussions

1. Description: add new method `createDiscussionSetting` for a POST request to the discussions service `/discussion_settings` with associated interfaces

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
