### PR TITLE
fix(hub-discussions): remove whitespace from IUpdateChannel documenta…

### DIFF
--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -833,7 +833,7 @@ export interface IChannel extends IWithAuthor, IWithEditor, IWithTimestamps {
  * @export
  * @interface IUpdateChannel
  * @extends {ICreateChannelSettings}
- * @extends { IUpdateChannelPermissions}
+ * @extends {IUpdateChannelPermissions}
  * @extends {Partial<IWithAuthor>}
  */
 export interface IUpdateChannel


### PR DESCRIPTION
…tion

affects: @esri/hub-discussions

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
