### PR TITLE
feat: add a base item entity schema

### DIFF
--- a/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
+++ b/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
@@ -13,8 +13,8 @@ import {
 } from "./subschemas";
 
 /**
- * Defines a shared subschema for an IHubItemEntity's editiable
- * fields. All item entity schemas should "extend" this subschema
+ * Defines a shared schema for an IHubItemEntity's editiable
+ * fields. All item entity schemas should "extend" this schema
  */
 export const HubItemEntitySchema: IConfigurationSchema = {
   type: "object",

--- a/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
+++ b/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
@@ -13,8 +13,9 @@ import {
 } from "./subschemas";
 
 /**
- * Defines a shared schema for an IHubItemEntity's editiable
- * fields. All item entity schemas should "extend" this schema
+ * Defines a default schema for an IHubItemEntity's editiable fields.
+ * All item entity schemas should leverage this base schema.
+ * Reference the Project or Initiative schemas as an example
  */
 export const HubItemEntitySchema: IConfigurationSchema = {
   type: "object",

--- a/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
+++ b/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
@@ -16,7 +16,7 @@ import {
  * Defines a shared subschema for an IHubItemEntity's editiable
  * fields. All item entity schemas should "extend" this subschema
  */
-export const HubItemEntitySubschema: IConfigurationSchema = {
+export const HubItemEntitySchema: IConfigurationSchema = {
   type: "object",
   required: ["name"],
   properties: {

--- a/packages/common/src/core/schemas/shared/HubItemEntitySubschema.ts
+++ b/packages/common/src/core/schemas/shared/HubItemEntitySubschema.ts
@@ -1,0 +1,42 @@
+import { IConfigurationSchema } from "../types";
+import {
+  ENTITY_ACCESS_SCHEMA,
+  ENTITY_CATEGORIES_SCHEMA,
+  ENTITY_FEATURED_CONTENT_SCHEMA,
+  ENTITY_IMAGE_SCHEMA,
+  ENTITY_IS_DISCUSSABLE_SCHEMA,
+  ENTITY_LOCATION_SCHEMA,
+  ENTITY_NAME_SCHEMA,
+  ENTITY_SUMMARY_SCHEMA,
+  ENTITY_TAGS_SCHEMA,
+  ENTITY_TIMELINE_SCHEMA,
+} from "./subschemas";
+
+/**
+ * Defines a shared subschema for an IHubItemEntity's editiable
+ * fields. All item entity schemas should "extend" this subschema
+ */
+export const HubItemEntitySubschema: IConfigurationSchema = {
+  type: "object",
+  required: ["name"],
+  properties: {
+    name: ENTITY_NAME_SCHEMA,
+    summary: ENTITY_SUMMARY_SCHEMA,
+    description: { type: "string" },
+    access: ENTITY_ACCESS_SCHEMA,
+    location: ENTITY_LOCATION_SCHEMA,
+    tags: ENTITY_TAGS_SCHEMA,
+    categories: ENTITY_CATEGORIES_SCHEMA,
+    isDiscussable: ENTITY_IS_DISCUSSABLE_SCHEMA,
+    view: {
+      type: "object",
+      properties: {
+        featuredContentIds: ENTITY_FEATURED_CONTENT_SCHEMA,
+        featuredImage: ENTITY_IMAGE_SCHEMA,
+        featuredImageAltText: { type: "string" },
+        featuredImageName: { type: "string" },
+        timeline: ENTITY_TIMELINE_SCHEMA,
+      },
+    },
+  },
+} as IConfigurationSchema;

--- a/packages/common/src/core/schemas/shared/subschemas.ts
+++ b/packages/common/src/core/schemas/shared/subschemas.ts
@@ -34,14 +34,38 @@ export const ENTITY_CATEGORIES_SCHEMA = {
   },
 };
 
-export const ENTITY_EXTENT_SCHEMA = {
+export const ENTITY_IS_DISCUSSABLE_SCHEMA = {
+  type: "boolean",
+  enum: [true, false],
+  default: true,
+};
+
+export const ENTITY_FEATURED_CONTENT_SCHEMA = {
+  type: "array",
+  maxItems: 4,
+  items: {
+    type: "string",
+  },
+};
+
+export const ENTITY_LOCATION_SCHEMA = {
+  type: "object",
+  default: { type: "none" },
+};
+
+export const ENTITY_IMAGE_SCHEMA = {
   type: "object",
   properties: {
-    spatialReference: { type: "object" },
-    xmax: { type: ["number", "null"] },
-    xmin: { type: ["number", "null"] },
-    ymax: { type: ["number", "null"] },
-    ymin: { type: ["number", "null"] },
+    base64: { type: "string" },
+    format: { type: "string" },
+    fileName: { type: "string" },
+    blob: {
+      type: "object",
+      properties: {
+        type: { type: "string" },
+        size: { type: "number" },
+      },
+    },
   },
 };
 

--- a/packages/common/src/core/traits/IWithViewSettings.ts
+++ b/packages/common/src/core/traits/IWithViewSettings.ts
@@ -22,6 +22,10 @@ export interface IWithViewSettings {
    */
   featuredImageAltText?: string;
   /**
+   * name of an entity's featured image
+   */
+  featuredImageName?: string;
+  /**
    * whether the entity should render it's location on a map
    */
   showMap?: boolean;

--- a/packages/common/src/discussions/_internal/DiscussionSchema.ts
+++ b/packages/common/src/discussions/_internal/DiscussionSchema.ts
@@ -1,5 +1,5 @@
 import { IConfigurationSchema } from "../../core";
-import { HubItemEntitySubschema } from "../../core/schemas/shared/hubItemEntitySubschema";
+import { HubItemEntitySchema } from "../../core/schemas/shared/HubItemEntitySchema";
 
 export type DiscussionEditorType = (typeof DiscussionEditorTypes)[number];
 export const DiscussionEditorTypes = [
@@ -11,9 +11,9 @@ export const DiscussionEditorTypes = [
  * defines the JSON schema for a Discussion's editable fields
  */
 export const DiscussionSchema: IConfigurationSchema = {
-  ...HubItemEntitySubschema,
+  ...HubItemEntitySchema,
   properties: {
-    ...HubItemEntitySubschema.properties,
+    ...HubItemEntitySchema.properties,
     prompt: {
       type: "string",
       default: "We want to hear from you!",

--- a/packages/common/src/discussions/_internal/DiscussionSchema.ts
+++ b/packages/common/src/discussions/_internal/DiscussionSchema.ts
@@ -1,10 +1,5 @@
 import { IConfigurationSchema } from "../../core";
-import {
-  ENTITY_ACCESS_SCHEMA,
-  ENTITY_CATEGORIES_SCHEMA,
-  ENTITY_NAME_SCHEMA,
-  ENTITY_TAGS_SCHEMA,
-} from "../../core/schemas/shared";
+import { HubItemEntitySubschema } from "../../core/schemas/shared/hubItemEntitySubschema";
 
 export type DiscussionEditorType = (typeof DiscussionEditorTypes)[number];
 export const DiscussionEditorTypes = [
@@ -16,43 +11,12 @@ export const DiscussionEditorTypes = [
  * defines the JSON schema for a Discussion's editable fields
  */
 export const DiscussionSchema: IConfigurationSchema = {
-  required: ["name"],
-  type: "object",
+  ...HubItemEntitySubschema,
   properties: {
-    name: ENTITY_NAME_SCHEMA,
+    ...HubItemEntitySubschema.properties,
     prompt: {
       type: "string",
       default: "We want to hear from you!",
     },
-    summary: {
-      type: "string",
-    },
-    description: {
-      type: "string",
-    },
-    location: {
-      type: "object",
-    },
-    tags: ENTITY_TAGS_SCHEMA,
-    categories: ENTITY_CATEGORIES_SCHEMA,
-    isDiscussable: {
-      type: "boolean",
-      enum: [true, false],
-      default: true,
-    },
-    view: {
-      type: "object",
-      properties: {
-        featuredImage: {
-          type: "object",
-        },
-        featuredImageName: {
-          type: "string",
-        },
-        featuredImageAltText: {
-          type: "string",
-        },
-      },
-    },
   },
-} as unknown as IConfigurationSchema;
+} as IConfigurationSchema;

--- a/packages/common/src/initiatives/_internal/InitiativeSchema.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeSchema.ts
@@ -1,5 +1,5 @@
 import { IConfigurationSchema } from "../../core";
-import { HubItemEntitySubschema } from "../../core/schemas/shared/hubItemEntitySubschema";
+import { HubItemEntitySchema } from "../../core/schemas/shared/HubItemEntitySchema";
 
 export type InitiativeEditorType = (typeof InitiativeEditorTypes)[number];
 export const InitiativeEditorTypes = ["hub:initiative:edit"] as const;
@@ -8,5 +8,5 @@ export const InitiativeEditorTypes = ["hub:initiative:edit"] as const;
  * defines the JSON schema for a Hub Initiative's editable fields
  */
 export const InitiativeSchema: IConfigurationSchema = {
-  ...HubItemEntitySubschema,
+  ...HubItemEntitySchema,
 } as IConfigurationSchema;

--- a/packages/common/src/initiatives/_internal/InitiativeSchema.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeSchema.ts
@@ -1,10 +1,5 @@
 import { IConfigurationSchema } from "../../core";
-import {
-  ENTITY_ACCESS_SCHEMA,
-  ENTITY_CATEGORIES_SCHEMA,
-  ENTITY_NAME_SCHEMA,
-  ENTITY_TAGS_SCHEMA,
-} from "../../core/schemas/shared";
+import { HubItemEntitySubschema } from "../../core/schemas/shared/hubItemEntitySubschema";
 
 export type InitiativeEditorType = (typeof InitiativeEditorTypes)[number];
 export const InitiativeEditorTypes = ["hub:initiative:edit"] as const;
@@ -13,28 +8,5 @@ export const InitiativeEditorTypes = ["hub:initiative:edit"] as const;
  * defines the JSON schema for a Hub Initiative's editable fields
  */
 export const InitiativeSchema: IConfigurationSchema = {
-  required: ["name"],
-  type: "object",
-  properties: {
-    name: ENTITY_NAME_SCHEMA,
-    summary: {
-      type: "string",
-    },
-    description: {
-      type: "string",
-    },
-    access: ENTITY_ACCESS_SCHEMA,
-    groups: {
-      type: "array",
-      items: {
-        type: "string",
-      },
-    },
-
-    location: {
-      type: "object",
-    },
-    tags: ENTITY_TAGS_SCHEMA,
-    categories: ENTITY_CATEGORIES_SCHEMA,
-  },
-} as unknown as IConfigurationSchema;
+  ...HubItemEntitySubschema,
+} as IConfigurationSchema;

--- a/packages/common/src/projects/_internal/ProjectSchema.ts
+++ b/packages/common/src/projects/_internal/ProjectSchema.ts
@@ -1,12 +1,5 @@
 import { PROJECT_STATUSES, IConfigurationSchema } from "../../core";
-import {
-  ENTITY_ACCESS_SCHEMA,
-  ENTITY_CATEGORIES_SCHEMA,
-  ENTITY_NAME_SCHEMA,
-  ENTITY_SUMMARY_SCHEMA,
-  ENTITY_TAGS_SCHEMA,
-  ENTITY_TIMELINE_SCHEMA,
-} from "../../core/schemas/shared";
+import { HubItemEntitySubschema } from "../../core/schemas/shared/hubItemEntitySubschema";
 
 export type ProjectEditorType = (typeof ProjectEditorTypes)[number];
 export const ProjectEditorTypes = [
@@ -18,50 +11,17 @@ export const ProjectEditorTypes = [
  * defines the JSON schema for a Hub Project's editable fields
  */
 export const ProjectSchema: IConfigurationSchema = {
-  required: ["name"],
-  type: "object",
+  ...HubItemEntitySubschema,
   properties: {
-    name: ENTITY_NAME_SCHEMA,
-    summary: ENTITY_SUMMARY_SCHEMA,
-    description: {
-      type: "string",
-    },
-    access: ENTITY_ACCESS_SCHEMA,
+    ...HubItemEntitySubschema.properties,
     groups: {
       type: "array",
-      items: {
-        type: "string",
-      },
+      items: { type: "string" },
     },
     status: {
       type: "string",
       default: PROJECT_STATUSES.notStarted,
       enum: Object.keys(PROJECT_STATUSES),
     },
-    location: {
-      type: "object",
-      default: { type: "none" },
-    },
-    tags: ENTITY_TAGS_SCHEMA,
-    categories: ENTITY_CATEGORIES_SCHEMA,
-    view: {
-      type: "object",
-      properties: {
-        featuredContentIds: {
-          type: "array",
-          maxItems: 4,
-          items: {
-            type: "string",
-          },
-        },
-        featuredImage: {
-          type: "object",
-        },
-        featuredImageAltText: {
-          type: "string",
-        },
-        timeline: ENTITY_TIMELINE_SCHEMA,
-      },
-    },
   },
-} as unknown as IConfigurationSchema;
+} as IConfigurationSchema;

--- a/packages/common/src/projects/_internal/ProjectSchema.ts
+++ b/packages/common/src/projects/_internal/ProjectSchema.ts
@@ -1,5 +1,5 @@
 import { PROJECT_STATUSES, IConfigurationSchema } from "../../core";
-import { HubItemEntitySubschema } from "../../core/schemas/shared/hubItemEntitySubschema";
+import { HubItemEntitySchema } from "../../core/schemas/shared/HubItemEntitySchema";
 
 export type ProjectEditorType = (typeof ProjectEditorTypes)[number];
 export const ProjectEditorTypes = [
@@ -11,9 +11,9 @@ export const ProjectEditorTypes = [
  * defines the JSON schema for a Hub Project's editable fields
  */
 export const ProjectSchema: IConfigurationSchema = {
-  ...HubItemEntitySubschema,
+  ...HubItemEntitySchema,
   properties: {
-    ...HubItemEntitySubschema.properties,
+    ...HubItemEntitySchema.properties,
     groups: {
       type: "array",
       items: { type: "string" },

--- a/packages/common/src/sites/_internal/SiteSchema.ts
+++ b/packages/common/src/sites/_internal/SiteSchema.ts
@@ -1,5 +1,5 @@
 import { IConfigurationSchema } from "../../core";
-import { HubItemEntitySubschema } from "../../core/schemas/shared/hubItemEntitySubschema";
+import { HubItemEntitySchema } from "../../core/schemas/shared/HubItemEntitySchema";
 
 export type SiteEditorType = (typeof SiteEditorTypes)[number];
 export const SiteEditorTypes = ["hub:site:edit"] as const;
@@ -8,5 +8,5 @@ export const SiteEditorTypes = ["hub:site:edit"] as const;
  * defines the JSON schema for a Hub Site's editable fields
  */
 export const SiteSchema: IConfigurationSchema = {
-  ...HubItemEntitySubschema,
+  ...HubItemEntitySchema,
 } as IConfigurationSchema;

--- a/packages/common/src/sites/_internal/SiteSchema.ts
+++ b/packages/common/src/sites/_internal/SiteSchema.ts
@@ -1,10 +1,5 @@
 import { IConfigurationSchema } from "../../core";
-import {
-  ENTITY_ACCESS_SCHEMA,
-  ENTITY_CATEGORIES_SCHEMA,
-  ENTITY_NAME_SCHEMA,
-  ENTITY_TAGS_SCHEMA,
-} from "../../core/schemas/shared";
+import { HubItemEntitySubschema } from "../../core/schemas/shared/hubItemEntitySubschema";
 
 export type SiteEditorType = (typeof SiteEditorTypes)[number];
 export const SiteEditorTypes = ["hub:site:edit"] as const;
@@ -13,27 +8,5 @@ export const SiteEditorTypes = ["hub:site:edit"] as const;
  * defines the JSON schema for a Hub Site's editable fields
  */
 export const SiteSchema: IConfigurationSchema = {
-  required: ["name"],
-  type: "object",
-  properties: {
-    name: ENTITY_NAME_SCHEMA,
-    summary: {
-      type: "string",
-    },
-    description: {
-      type: "string",
-    },
-    access: ENTITY_ACCESS_SCHEMA,
-    groups: {
-      type: "array",
-      items: {
-        type: "string",
-      },
-    },
-    location: {
-      type: "object",
-    },
-    tags: ENTITY_TAGS_SCHEMA,
-    categories: ENTITY_CATEGORIES_SCHEMA,
-  },
-} as unknown as IConfigurationSchema;
+  ...HubItemEntitySubschema,
+} as IConfigurationSchema;


### PR DESCRIPTION
[7094](https://devtopia.esri.com/dc/hub/issues/7094)

### Description:
- add a shared `HubItemEntitySchema` that all item entities can "extend"
- update all existing item entity schemas to leverage the `HubItemEntitySchema`

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
