### PR TITLE
fix: get group from predicate not query.properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22644,9 +22644,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22661,21 +22662,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22689,9 +22693,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22709,9 +22714,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64966,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.13.1",
+			"version": "13.16.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64991,7 +64997,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "25.1.0",
+			"version": "25.2.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -83376,7 +83382,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83391,17 +83398,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83415,7 +83425,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83432,7 +83443,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/e2e/hub-user-search.e2e.ts
+++ b/packages/common/e2e/hub-user-search.e2e.ts
@@ -51,12 +51,12 @@ describe("Hub User search", () => {
               {
                 name: "e2e",
               },
+              {
+                group: "c08c260d3fbc4da384061b48652972e5",
+              },
             ],
           },
         ],
-        properties: {
-          groupId: "c08c260d3fbc4da384061b48652972e5",
-        },
       };
 
       const response = await hubSearch(qry, {
@@ -84,12 +84,12 @@ describe("Hub User search", () => {
               {
                 name: "e2e",
               },
+              {
+                group: ["e59cab1c38e14a79a4ee36389632106c"],
+              },
             ],
           },
         ],
-        properties: {
-          groupId: "e59cab1c38e14a79a4ee36389632106c",
-        },
       };
 
       const response = await hubSearch(qry, {

--- a/packages/common/src/search/_internal/portalSearchGroupMembers.ts
+++ b/packages/common/src/search/_internal/portalSearchGroupMembers.ts
@@ -45,10 +45,13 @@ export async function portalSearchGroupMembers(
       if (Array.isArray(prop)) {
         // get first entry from array
         groupId = prop[0];
-      }
-      if (typeof prop === "string") {
+      } else if (typeof prop === "string") {
         // get the value as a string
         groupId = prop;
+      } else if (typeof prop === "object") {
+        // get the value from the object
+        // get first entry from any or all array
+        groupId = getProp(prop, "any[0]") || getProp(prop, "all[0]");
       }
     });
   });

--- a/packages/common/test/search/_internal/portalSearchGroupMembers.test.ts
+++ b/packages/common/test/search/_internal/portalSearchGroupMembers.test.ts
@@ -5,7 +5,7 @@ import { MOCK_AUTH } from "../../mocks/mock-auth";
 import * as users from "../../../src/users";
 
 describe("portalSearchGroupMembers:", () => {
-  describe("throws if not passed IQuery.properties.group:", () => {
+  describe("throws if not passed group:", () => {
     let qry: IQuery;
     beforeEach(() => {
       qry = {
@@ -27,21 +27,22 @@ describe("portalSearchGroupMembers:", () => {
         await portalSearchGroupMembers(qry, opts);
       } catch (err) {
         expect(err.message).toEqual(
-          "Group Id required. Please pass as query.properties.groupId"
+          "Group Id required. Please pass as a predicate in the query."
         );
       }
     });
-    it("passing query.properties", async () => {
-      const opts: IHubSearchOptions = {};
-      qry.properties = {};
-      try {
-        await portalSearchGroupMembers(qry, opts);
-      } catch (err) {
-        expect(err.message).toEqual(
-          "Group Id required. Please pass as query.properties.groupId"
-        );
-      }
-    });
+    // it("passing query.properties", async () => {
+    //   const opts: IHubSearchOptions = {};
+    //   const cloneQry = cloneObject(qry);
+    //   delete cloneQry.filters[0].predicates[0];
+    //   try {
+    //     await portalSearchGroupMembers(qry, opts);
+    //   } catch (err) {
+    //     expect(err.message).toEqual(
+    //       "Group Id required. Please pass as a predicate in the query."
+    //     );
+    //   }
+    // });
   });
   describe("executes search:", () => {
     let qry: IQuery;
@@ -61,9 +62,6 @@ describe("portalSearchGroupMembers:", () => {
             ],
           },
         ],
-        properties: {
-          groupId: "3ef",
-        },
       };
     });
     it("simple search", async () => {
@@ -87,7 +85,9 @@ describe("portalSearchGroupMembers:", () => {
           authentication: MOCK_AUTH,
         },
       };
-      const response = await portalSearchGroupMembers(qry, opts);
+      const cloneQry = cloneObject(qry);
+      cloneQry.filters[0].predicates.push({ group: "3ef" });
+      const response = await portalSearchGroupMembers(cloneQry, opts);
       // validate spy calls
       expect(searchSpy.calls.count()).toBe(1, "should call searchGroupUsers");
       expect(userSpy.calls.count()).toBe(2, "should get each user");
@@ -132,7 +132,9 @@ describe("portalSearchGroupMembers:", () => {
           portal: "https://www.arcgis.com/sharing/rest",
         },
       };
-      const response = await portalSearchGroupMembers(qry, opts);
+      const cloneQry = cloneObject(qry);
+      cloneQry.filters[0].predicates.push({ group: ["3ef"] });
+      const response = await portalSearchGroupMembers(cloneQry, opts);
       // validate spy calls
       expect(searchSpy.calls.count()).toBe(1, "should call searchGroupUsers");
       expect(userSpy.calls.count()).toBe(2, "should get each user");


### PR DESCRIPTION
1. Description:

Swap `groupMember` search to pull the `groupId` from a `group` predicate vs `query.properties.group`

1. Instructions for testing: - run tests

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
