### PR TITLE
feat(hub-discussions): add function removeDiscussionSetting with asso…

### DIFF
--- a/packages/discussions/src/channels/channels.ts
+++ b/packages/discussions/src/channels/channels.ts
@@ -59,8 +59,8 @@ export function fetchChannel(options: IFetchChannelParams): Promise<IChannel> {
 
 /**
  * update channel
- * NOTE: only updates channel settings properties (softDelete, allowedReactions, etc). A Channel's
- * access and groups cannot be updated.
+ * NOTE: only updates channel settings properties and access (softDelete, allowedReactions, etc). A Channel's
+ * groups cannot be updated.
  *
  * @export
  * @param {IUpdateChannelParams} options

--- a/packages/discussions/src/discussion-settings/discussion-settings.ts
+++ b/packages/discussions/src/discussion-settings/discussion-settings.ts
@@ -1,9 +1,34 @@
 import { request } from "../request";
-import { ICreateDiscussionSettingParams, IDiscussionSetting } from "../types";
+import {
+  ICreateDiscussionSettingParams,
+  IDiscussionSetting,
+  IRemoveDiscussionSettingParams,
+} from "../types";
 
+/**
+ * create discussion settings
+ *
+ * @export
+ * @param {ICreateDiscussionSettingParams} options
+ * @return {*} {Promise<IDiscussionSetting>}
+ */
 export function createDiscussionSetting(
   options: ICreateDiscussionSettingParams
 ): Promise<IDiscussionSetting> {
   options.httpMethod = "POST";
   return request(`/discussion_settings`, options);
+}
+
+/**
+ * remove discussion settings
+ *
+ * @export
+ * @param {IRemoveDiscussionSettingParams} options
+ * @return {*} {Promise<IDiscussionSetting>}
+ */
+export function removeDiscussionSetting(
+  options: IRemoveDiscussionSettingParams
+): Promise<IDiscussionSetting> {
+  options.httpMethod = "DELETE";
+  return request(`/discussion_settings/${options.id}`, options);
 }

--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -1048,6 +1048,10 @@ export interface ISettings {
   allowedChannelIds: string[] | null;
 }
 
+/**
+ * @export
+ * @interface IRemoveDiscussionSettingResponse
+ */
 export interface IRemoveDiscussionSettingResponse {
   id: string;
   success: boolean;

--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -167,10 +167,9 @@ export enum ChannelFilter {
   HAS_USER_POSTS = "has_user_posts",
 }
 
-// sorting
-
 /**
- * Common sorting fields
+ * @export
+ * @enum {string}
  */
 export enum CommonSort {
   CREATED_AT = "createdAt",
@@ -296,7 +295,7 @@ export interface IChannelNotificationOptOut {
  * options for making requests against Discussion API
  *
  * @export
- * @interface IRequestOptions
+ * @interface IDiscussionsRequestOptions
  * @extends {RequestInit}
  */
 // NOTE: this is as close to implementing @esri/hub-common IHubRequestOptions as possible
@@ -330,6 +329,9 @@ export enum Role {
 /**
  * Interface representing the meta data associated with a discussions
  * mention email
+ *
+ * @export
+ * @interface IDiscussionsMentionMeta
  */
 export interface IDiscussionsMentionMeta {
   channelId: string;
@@ -338,6 +340,11 @@ export interface IDiscussionsMentionMeta {
   replyId?: string;
 }
 
+/**
+ * @export
+ * @interface IDiscussionsUser
+ * @extends {IUser}
+ */
 export interface IDiscussionsUser extends IUser {
   username?: string | null;
 }
@@ -405,6 +412,7 @@ export interface IRemoveReactionResponse {
 /**
  * Post sorting fields
  *
+ * @export
  * @enum {string}
  */
 export enum PostSort {
@@ -424,6 +432,7 @@ export enum PostSort {
 /**
  * Post types
  *
+ * @export
  * @enum{string}
  */
 export enum PostType {
@@ -596,7 +605,7 @@ export interface IUpdatePost {
  *
  * @export
  * @interface ISearchPostsParams
- * @extends {IHubRequestOptions}
+ * @extends {IDiscussionsRequestOptions}
  */
 export interface ISearchPostsParams extends IDiscussionsRequestOptions {
   data?: ISearchPosts;
@@ -607,7 +616,7 @@ export interface ISearchPostsParams extends IDiscussionsRequestOptions {
  *
  * @export
  * @interface IFetchPostParams
- * @extends {IHubRequestOptions}
+ * @extends {IDiscussionsRequestOptions}
  */
 export interface IFetchPostParams extends IDiscussionsRequestOptions {
   postId: string;
@@ -619,7 +628,7 @@ export interface IFetchPostParams extends IDiscussionsRequestOptions {
  *
  * @export
  * @interface IUpdatePostParams
- * @extends {IHubRequestOptions}
+ * @extends {IDiscussionsRequestOptions}
  */
 export interface IUpdatePostParams extends IDiscussionsRequestOptions {
   postId: string;
@@ -632,7 +641,7 @@ export interface IUpdatePostParams extends IDiscussionsRequestOptions {
  *
  * @export
  * @interface IUpdatePostStatusParams
- * @extends {IHubRequestOptions}
+ * @extends {IDiscussionsRequestOptions}
  */
 export interface IUpdatePostStatusParams extends IDiscussionsRequestOptions {
   postId: string;
@@ -644,7 +653,7 @@ export interface IUpdatePostStatusParams extends IDiscussionsRequestOptions {
  *
  * @export
  * @interface IRemovePostParams
- * @extends {IHubRequestOptions}
+ * @extends {IDiscussionsRequestOptions}
  */
 export interface IRemovePostParams extends IDiscussionsRequestOptions {
   postId: string;
@@ -687,6 +696,10 @@ export enum ChannelRelation {
   CHANNEL_ACL = "channelAcl",
 }
 
+/**
+ * @export
+ * @enum {string}
+ */
 export enum AclCategory {
   GROUP = "group",
   ORG = "org",
@@ -695,6 +708,10 @@ export enum AclCategory {
   AUTHENTICATED_USER = "authenticatedUser",
 }
 
+/**
+ * @export
+ * @enum {string}
+ */
 export enum AclSubCategory {
   ADMIN = "admin",
   MEMBER = "member",
@@ -702,6 +719,9 @@ export enum AclSubCategory {
 
 /**
  * request option for creating a channel ACL permission
+ *
+ * @export
+ * @interface IChannelAclPermissionDefinition
  */
 export interface IChannelAclPermissionDefinition {
   category: AclCategory;
@@ -713,6 +733,10 @@ export interface IChannelAclPermissionDefinition {
 
 /**
  * request option for updating a channel ACL permission
+ *
+ * @export
+ * @interface IChannelAclPermissionUpdateDefinition
+ * @extends {IChannelAclPermissionDefinition}
  */
 export interface IChannelAclPermissionUpdateDefinition
   extends IChannelAclPermissionDefinition {
@@ -755,6 +779,10 @@ export interface ICreateChannelSettings {
   softDelete?: boolean;
 }
 
+/**
+ * @export
+ * @interface IChannelMetadata
+ */
 export interface IChannelMetadata {
   guidelineUrl?: string | null;
 }
@@ -1004,16 +1032,30 @@ export interface IDiscussionSetting
   settings: ISettings;
 }
 
+/**
+ * @export
+ * @enum {string}
+ */
 export enum DiscussionSettingType {
   CONTENT = "content",
 }
 
+/**
+ * @export
+ * @interface ISettings
+ */
 export interface ISettings {
   allowedChannelIds: string[] | null;
 }
 
+export interface IRemoveDiscussionSettingResponse {
+  id: string;
+  success: boolean;
+}
+
 /**
- * parameters for creating a discussionSetting
+ * @export
+ * @interface ICreateDiscussionSetting
  */
 export interface ICreateDiscussionSetting {
   id: string;
@@ -1021,7 +1063,26 @@ export interface ICreateDiscussionSetting {
   settings: ISettings;
 }
 
+/**
+ * parameters for creating a discussionSetting
+ *
+ * @export
+ * @interface ICreateDiscussionSettingParams
+ * @extends {IDiscussionsRequestOptions}
+ */
 export interface ICreateDiscussionSettingParams
   extends IDiscussionsRequestOptions {
   data: ICreateDiscussionSetting;
+}
+
+/**
+ * parameters for removing a discussionSetting
+ *
+ * @export
+ * @interface IRemoveDiscussionSettingParams
+ * @extends {IDiscussionsRequestOptions}
+ */
+export interface IRemoveDiscussionSettingParams
+  extends IDiscussionsRequestOptions {
+  id: string;
 }

--- a/packages/discussions/test/discussion-settings.test.ts
+++ b/packages/discussions/test/discussion-settings.test.ts
@@ -1,10 +1,14 @@
 import * as req from "../src/request";
-import { createDiscussionSetting } from "../src/discussion-settings";
+import {
+  createDiscussionSetting,
+  removeDiscussionSetting,
+} from "../src/discussion-settings";
 import {
   DiscussionSettingType,
   ICreateDiscussionSetting,
   ICreateDiscussionSettingParams,
   IDiscussionsRequestOptions,
+  IRemoveDiscussionSettingParams,
 } from "../src/types";
 
 describe("discussion-settings", () => {
@@ -21,7 +25,7 @@ describe("discussion-settings", () => {
     );
   });
 
-  it("creates a discussionSetting", async () => {
+  it("createDiscussionSetting", async () => {
     const body: ICreateDiscussionSetting = {
       id: "uuidv4",
       type: DiscussionSettingType.CONTENT,
@@ -37,5 +41,17 @@ describe("discussion-settings", () => {
     const [url, opts] = requestSpy.calls.argsFor(0);
     expect(url).toEqual(`/discussion_settings`);
     expect(opts).toEqual({ ...options, httpMethod: "POST" });
+  });
+
+  it("removeDiscussionSetting", async () => {
+    const id = "uuidv4";
+    const options: IRemoveDiscussionSettingParams = { ...baseOpts, id };
+
+    await removeDiscussionSetting(options);
+
+    expect(requestSpy.calls.count()).toEqual(1);
+    const [url, opts] = requestSpy.calls.argsFor(0);
+    expect(url).toEqual(`/discussion_settings/${id}`);
+    expect(opts).toEqual({ ...options, httpMethod: "DELETE" });
   });
 });


### PR DESCRIPTION
…ciated interfaces

affects: @esri/hub-discussions

1. Description: add function`removeDiscussionSetting` that calls route `DELETE /disucssion_settings` in the discussions service. Include new interfaces.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
