### PR TITLE
fix: add actionLinks arg to project view model functions

### DIFF
--- a/packages/common/src/core/behaviors/IWithCardBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithCardBehavior.ts
@@ -1,4 +1,4 @@
-import { IHubCardViewModel } from "../types/IHubCardViewModel";
+import { ICardActionLink, IHubCardViewModel } from "../types/IHubCardViewModel";
 
 export interface IWithCardBehavior {
   /**
@@ -10,6 +10,11 @@ export interface IWithCardBehavior {
    */
   convertToCardViewModel(
     target: "ago" | "view" | "workspace",
+    actionLinks: ICardActionLink[],
+    /**
+     * TODO: move transform logic to FE so we don't need to pass
+     * locale down (follow https://devtopia.esri.com/dc/hub/issues/7255)
+     */
     locale: string
   ): IHubCardViewModel;
 }

--- a/packages/common/src/core/behaviors/IWithCardBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithCardBehavior.ts
@@ -6,6 +6,7 @@ export interface IWithCardBehavior {
    * be consumed by the suite of hub gallery components
    *
    * @param target card link contextual target
+   * @param actionLinks card action links
    * @param locale internationalization locale
    */
   convertToCardViewModel(

--- a/packages/common/src/core/types/IHubCardViewModel.ts
+++ b/packages/common/src/core/types/IHubCardViewModel.ts
@@ -18,7 +18,7 @@ export interface IHubCardViewModel {
 }
 
 // structure defining a hub card badge
-interface IBadgeConfig {
+export interface IBadgeConfig {
   i18nKey?: string;
   label?: string;
   icon?: string;
@@ -26,14 +26,14 @@ interface IBadgeConfig {
 }
 
 // structure defining the additional info for a hub card
-interface IInfoConfig {
+export interface IInfoConfig {
   i18nKey?: string;
   label?: string;
   value: string;
 }
 
 // structure defining a hub card action link
-interface ICardActionLink {
+export interface ICardActionLink {
   action?: string;
   href?: string;
   i18nKey?: string;

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -21,7 +21,10 @@ import { ProjectEditorType } from "./_internal/ProjectSchema";
 import { IWithMetricsBehavior } from "../core/behaviors/IWithMetricsBehavior";
 import { getEntityMetrics } from "../metrics/getEntityMetrics";
 import { resolveMetric } from "../metrics/resolveMetric";
-import { IHubCardViewModel } from "../core/types/IHubCardViewModel";
+import {
+  ICardActionLink,
+  IHubCardViewModel,
+} from "../core/types/IHubCardViewModel";
 import { convertProjectEntityToCardViewModel } from "./view";
 
 /**
@@ -159,12 +162,18 @@ export class HubProject
    */
   convertToCardViewModel(
     target: "ago" | "view" | "workspace",
+    actionLinks: ICardActionLink[],
+    /**
+     * TODO: move transform logic to FE so we don't need to pass
+     * locale down (follow https://devtopia.esri.com/dc/hub/issues/7255)
+     */
     locale: string
   ): IHubCardViewModel {
     return convertProjectEntityToCardViewModel(
       this.entity,
       this.context,
       target,
+      actionLinks,
       locale
     );
   }

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -158,6 +158,7 @@ export class HubProject
    * be consumed by the suite of hub gallery components
    *
    * @param target card link contextual target
+   * @param actionLinks card action links
    * @param locale internationalization locale
    */
   convertToCardViewModel(

--- a/packages/common/src/projects/view.ts
+++ b/packages/common/src/projects/view.ts
@@ -6,7 +6,10 @@ import {
 } from "../content/_internal/internalContentUtils";
 import { IHubProject } from "../core";
 import { getRelativeWorkspaceUrl } from "../core/getRelativeWorkspaceUrl";
-import { IHubCardViewModel } from "../core/types/IHubCardViewModel";
+import {
+  ICardActionLink,
+  IHubCardViewModel,
+} from "../core/types/IHubCardViewModel";
 import { getItemHomeUrl } from "../urls/get-item-home-url";
 
 /**
@@ -22,6 +25,11 @@ export const convertProjectEntityToCardViewModel = (
   project: IHubProject,
   context: IArcGISContext,
   target: "ago" | "view" | "workspace" = "ago",
+  actionLinks: ICardActionLink[] = [],
+  /**
+   * TODO: move transform logic to FE so we don't need to pass
+   * locale down (follow https://devtopia.esri.com/dc/hub/issues/7255)
+   */
   locale: string = "en-US"
 ): IHubCardViewModel => {
   const titleUrl = {
@@ -32,6 +40,7 @@ export const convertProjectEntityToCardViewModel = (
 
   return {
     ...getSharedProjectCardViewModel(project, locale),
+    actionLinks,
     titleUrl,
     ...(project.thumbnailUrl && { thumbnailUrl: project.thumbnailUrl }),
   };
@@ -48,6 +57,11 @@ export const convertProjectEntityToCardViewModel = (
 export const convertProjectSearchResultToCardViewModel = (
   searchResult: IHubSearchResult,
   target: "ago" | "view" | "workspace" = "ago",
+  actionLinks: ICardActionLink[] = [],
+  /**
+   * TODO: move transform logic to FE so we don't need to pass
+   * locale down (follow https://devtopia.esri.com/dc/hub/issues/7255)
+   */
   locale: string = "en-US"
 ): IHubCardViewModel => {
   const titleUrl = {
@@ -58,6 +72,7 @@ export const convertProjectSearchResultToCardViewModel = (
 
   return {
     ...getSharedProjectCardViewModel(searchResult, locale),
+    actionLinks,
     titleUrl,
     ...(searchResult.links.thumbnail && {
       thumbnailUrl: searchResult.links.thumbnail,

--- a/packages/common/src/projects/view.ts
+++ b/packages/common/src/projects/view.ts
@@ -19,6 +19,7 @@ import { getItemHomeUrl } from "../urls/get-item-home-url";
  * @param project project entity
  * @param context auth & portal information
  * @param target card link contextual target
+ * @param actionLinks card action links
  * @param locale internationalization locale
  */
 export const convertProjectEntityToCardViewModel = (
@@ -52,6 +53,7 @@ export const convertProjectEntityToCardViewModel = (
  *
  * @param searchResult hub project search result
  * @param target card link contextual target
+ * @param actionLinks card action links
  * @param locale internationalization locale
  */
 export const convertProjectSearchResultToCardViewModel = (

--- a/packages/common/test/projects/HubProject.test.ts
+++ b/packages/common/test/projects/HubProject.test.ts
@@ -132,7 +132,7 @@ describe("HubProject Class:", () => {
       { name: "Test Project" },
       authdCtxMgr.context
     );
-    await chk.convertToCardViewModel("ago", "en-US");
+    await chk.convertToCardViewModel("ago", [], "en-US");
 
     expect(spy).toHaveBeenCalledTimes(1);
   });

--- a/packages/common/test/projects/view.test.ts
+++ b/packages/common/test/projects/view.test.ts
@@ -66,6 +66,7 @@ describe("project view module:", () => {
 
       expect(result).toEqual({
         access: PROJECT_ENTITY.access,
+        actionLinks: [],
         badges: [],
         id: PROJECT_ENTITY.id,
         family: "project",
@@ -128,6 +129,7 @@ describe("project view module:", () => {
 
       expect(result).toEqual({
         access: PROJECT_ENTITY.access,
+        actionLinks: [],
         badges: [],
         id: PROJECT_ENTITY.id,
         family: "project",


### PR DESCRIPTION
[7161](https://devtopia.esri.com/dc/hub/issues/7161)

### Description
- add `actionLinks` arg to `convertToCardViewModel` in `IWithCardBehavior` interface
- add `actionLinks` arg to all project card view model functions to be injected into the `IHubCardViewModel`

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.