### PR TITLE
fix: rename term to name for groupMember queries

### DIFF
--- a/packages/common/src/search/_internal/portalSearchGroupMembers.ts
+++ b/packages/common/src/search/_internal/portalSearchGroupMembers.ts
@@ -21,7 +21,8 @@ import { getProp, pickProps, setProp } from "../../objects";
 
 /**
  * Search for members of a group.
- * The group is specified via `IQuery.properties.groupId`
+ * The groupId is specified via a `group` predicate.
+ * Any `term` predicate will be re-mapped to `name`.
  *
  * The backing API is very limited in what
  * it returns so this method executes the search and then tries to fetch

--- a/packages/common/src/search/_internal/portalSearchGroupMembers.ts
+++ b/packages/common/src/search/_internal/portalSearchGroupMembers.ts
@@ -68,6 +68,14 @@ export async function portalSearchGroupMembers(
     // only `name` and `memberType` are supported
     const validPredicateKeys = ["name", "memberType"];
     filter.predicates = filter.predicates
+      .map((p) => {
+        // convert `term` to `name`
+        if (p.term) {
+          p.name = p.term;
+          delete p.term;
+        }
+        return p;
+      })
       // remove any keys that aren't supported
       .map((p) => {
         return pickProps(p, validPredicateKeys);

--- a/packages/common/test/search/_internal/portalSearchGroupMembers.test.ts
+++ b/packages/common/test/search/_internal/portalSearchGroupMembers.test.ts
@@ -162,6 +162,37 @@ describe("portalSearchGroupMembers:", () => {
       const groupId = searchSpy.calls.argsFor(0)[0];
       expect(groupId).toBe("3ef");
     });
+    it("maps term to name", async () => {
+      const searchSpy = spyOn(Portal, "searchGroupUsers").and.callFake(() => {
+        return Promise.resolve(cloneObject(GroupMembersResponse));
+      });
+      spyOn(Portal, "getUser").and.callFake((options: any) => {
+        const resp = cloneObject(SparseUser);
+        resp.username = options.username;
+        return Promise.resolve(resp);
+      });
+      // NOTE: enrichUserSearchResult is tested elsewhere so we don't assert on the results here
+      spyOn(users, "enrichUserSearchResult").and.callThrough();
+      const opts: IHubSearchOptions = {
+        num: 2,
+        requestOptions: {
+          portal: "https://www.arcgis.com/sharing/rest",
+          authentication: MOCK_AUTH,
+        },
+      };
+      const cloneQry = cloneObject(qry);
+      cloneQry.filters[0].predicates.push({ group: "3ef" });
+      cloneQry.filters[0].predicates[0].term = "steve";
+      delete cloneQry.filters[0].predicates[0].name;
+      await portalSearchGroupMembers(cloneQry, opts);
+      // validate call args
+      const groupId = searchSpy.calls.argsFor(0)[0];
+      expect(groupId).toBe("3ef");
+      const callOpts = searchSpy.calls.argsFor(
+        0
+      )[1] as Portal.ISearchGroupUsersOptions;
+      expect(callOpts.name).toBe("steve");
+    });
     it("search without auth", async () => {
       const searchSpy = spyOn(Portal, "searchGroupUsers").and.callFake(() => {
         return Promise.resolve(cloneObject(SparseGroupMembersResponse));


### PR DESCRIPTION
1. Description:

Last minor change needed for `groupMember` search. This remaps the `term` predicate to `name`. Previous prototype work had done this in the gallery, but there's no reason not to do this in hub.js.

1. Instructions for testing: - run tests


1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
