### PR TITLE
feat(hub-discussions): add function fetchDiscussionSetting and associ…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64972,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.16.0",
+			"version": "13.17.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64997,7 +64997,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "25.2.1",
+			"version": "25.3.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/discussions/src/discussion-settings/discussion-settings.ts
+++ b/packages/discussions/src/discussion-settings/discussion-settings.ts
@@ -2,7 +2,9 @@ import { request } from "../request";
 import {
   ICreateDiscussionSettingParams,
   IDiscussionSetting,
+  IFetchDiscussionSettingParams,
   IRemoveDiscussionSettingParams,
+  IRemoveDiscussionSettingResponse,
 } from "../types";
 
 /**
@@ -20,15 +22,29 @@ export function createDiscussionSetting(
 }
 
 /**
+ * fetch discussion settings
+ *
+ * @export
+ * @param {IFetchDiscussionSettingParams} options
+ * @return {*} {Promise<IDiscussionSetting>}
+ */
+export function fetchDiscussionSetting(
+  options: IFetchDiscussionSettingParams
+): Promise<IDiscussionSetting> {
+  options.httpMethod = "GET";
+  return request(`/discussion_settings/${options.id}`, options);
+}
+
+/**
  * remove discussion settings
  *
  * @export
  * @param {IRemoveDiscussionSettingParams} options
- * @return {*} {Promise<IDiscussionSetting>}
+ * @return {*} {Promise<IRemoveDiscussionSettingResponse>}
  */
 export function removeDiscussionSetting(
   options: IRemoveDiscussionSettingParams
-): Promise<IDiscussionSetting> {
+): Promise<IRemoveDiscussionSettingResponse> {
   options.httpMethod = "DELETE";
   return request(`/discussion_settings/${options.id}`, options);
 }

--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -1080,6 +1080,18 @@ export interface ICreateDiscussionSettingParams
 }
 
 /**
+ * parameters for fetching a discussionSetting
+ *
+ * @export
+ * @interface IFetchDiscussionSettingParams
+ * @extends {IDiscussionsRequestOptions}
+ */
+export interface IFetchDiscussionSettingParams
+  extends IDiscussionsRequestOptions {
+  id: string;
+}
+
+/**
  * parameters for removing a discussionSetting
  *
  * @export

--- a/packages/discussions/test/discussion-settings.test.ts
+++ b/packages/discussions/test/discussion-settings.test.ts
@@ -1,6 +1,7 @@
 import * as req from "../src/request";
 import {
   createDiscussionSetting,
+  fetchDiscussionSetting,
   removeDiscussionSetting,
 } from "../src/discussion-settings";
 import {
@@ -41,6 +42,18 @@ describe("discussion-settings", () => {
     const [url, opts] = requestSpy.calls.argsFor(0);
     expect(url).toEqual(`/discussion_settings`);
     expect(opts).toEqual({ ...options, httpMethod: "POST" });
+  });
+
+  it("fetchDiscussionSetting", async () => {
+    const id = "uuidv4";
+    const options: IRemoveDiscussionSettingParams = { ...baseOpts, id };
+
+    await fetchDiscussionSetting(options);
+
+    expect(requestSpy.calls.count()).toEqual(1);
+    const [url, opts] = requestSpy.calls.argsFor(0);
+    expect(url).toEqual(`/discussion_settings/${id}`);
+    expect(opts).toEqual({ ...options, httpMethod: "GET" });
   });
 
   it("removeDiscussionSetting", async () => {


### PR DESCRIPTION
…ated interfaces

affects: @esri/hub-discussions

1. Description: add function `fetchDiscussionSetting` with interfaces. This function calls into the discussions service `GET /discussion_settings/:id`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
