### PR TITLE
feat(hub-discussions): add function updateDiscussionSetting and assoc…

### DIFF
--- a/packages/discussions/src/discussion-settings/discussion-settings.ts
+++ b/packages/discussions/src/discussion-settings/discussion-settings.ts
@@ -5,6 +5,7 @@ import {
   IFetchDiscussionSettingParams,
   IRemoveDiscussionSettingParams,
   IRemoveDiscussionSettingResponse,
+  IUpdateDiscussionSettingParams,
 } from "../types";
 
 /**
@@ -32,6 +33,19 @@ export function fetchDiscussionSetting(
   options: IFetchDiscussionSettingParams
 ): Promise<IDiscussionSetting> {
   options.httpMethod = "GET";
+  return request(`/discussion_settings/${options.id}`, options);
+}
+/**
+ * update discussion settings
+ *
+ * @export
+ * @param {IRemoveDiscussionSettingParams} options
+ * @return {*} {Promise<IDiscussionSetting>}
+ */
+export function updateDiscussionSetting(
+  options: IUpdateDiscussionSettingParams
+): Promise<IDiscussionSetting> {
+  options.httpMethod = "PATCH";
   return request(`/discussion_settings/${options.id}`, options);
 }
 

--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -1068,6 +1068,14 @@ export interface ICreateDiscussionSetting {
 }
 
 /**
+ * @export
+ * @interface IUpdateDiscussionSetting
+ */
+export interface IUpdateDiscussionSetting {
+  settings: Partial<ISettings>;
+}
+
+/**
  * parameters for creating a discussionSetting
  *
  * @export
@@ -1089,6 +1097,19 @@ export interface ICreateDiscussionSettingParams
 export interface IFetchDiscussionSettingParams
   extends IDiscussionsRequestOptions {
   id: string;
+}
+
+/**
+ * parameters for updating a discussionSetting
+ *
+ * @export
+ * @interface IUpdateDiscussionSettingParams
+ * @extends {IDiscussionsRequestOptions}
+ */
+export interface IUpdateDiscussionSettingParams
+  extends IDiscussionsRequestOptions {
+  id: string;
+  data: IUpdateDiscussionSetting;
 }
 
 /**

--- a/packages/discussions/test/discussion-settings.test.ts
+++ b/packages/discussions/test/discussion-settings.test.ts
@@ -3,6 +3,7 @@ import {
   createDiscussionSetting,
   fetchDiscussionSetting,
   removeDiscussionSetting,
+  updateDiscussionSetting,
 } from "../src/discussion-settings";
 import {
   DiscussionSettingType,
@@ -10,6 +11,8 @@ import {
   ICreateDiscussionSettingParams,
   IDiscussionsRequestOptions,
   IRemoveDiscussionSettingParams,
+  IUpdateDiscussionSetting,
+  IUpdateDiscussionSettingParams,
 } from "../src/types";
 
 describe("discussion-settings", () => {
@@ -54,6 +57,27 @@ describe("discussion-settings", () => {
     const [url, opts] = requestSpy.calls.argsFor(0);
     expect(url).toEqual(`/discussion_settings/${id}`);
     expect(opts).toEqual({ ...options, httpMethod: "GET" });
+  });
+
+  it("updateDiscussionSetting", async () => {
+    const id = "uuidv4";
+    const body: IUpdateDiscussionSetting = {
+      settings: {
+        allowedChannelIds: ["aaa"],
+      },
+    };
+    const options: IUpdateDiscussionSettingParams = {
+      ...baseOpts,
+      id,
+      data: body,
+    };
+
+    await updateDiscussionSetting(options);
+
+    expect(requestSpy.calls.count()).toEqual(1);
+    const [url, opts] = requestSpy.calls.argsFor(0);
+    expect(url).toEqual(`/discussion_settings/${id}`);
+    expect(opts).toEqual({ ...options, httpMethod: "PATCH" });
   });
 
   it("removeDiscussionSetting", async () => {


### PR DESCRIPTION
…iated interfaces

affects: @esri/hub-discussions

1. Description: add function `updateDiscussionSetting` with interfaces. This function calls into the discussions service `PATCH /discussion_settings/:id`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
