### PR TITLE
feat: 7162 initiative card funcs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22644,10 +22644,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22662,24 +22661,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22693,10 +22689,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22714,10 +22709,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64997,7 +64991,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "25.3.0",
+			"version": "25.5.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -83382,8 +83376,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83398,20 +83391,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83425,8 +83415,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83443,8 +83432,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/content/get-family.ts
+++ b/packages/common/src/content/get-family.ts
@@ -110,6 +110,9 @@ export function getFamilyTypes(family: HubFamily): string[] {
     case "project":
       types = ["Hub Project"];
       break;
+    case "initiative":
+      types = ["Hub Initiative"];
+      break;
     default:
       types = getCollectionTypes(family.toLowerCase());
   }

--- a/packages/common/src/content/get-family.ts
+++ b/packages/common/src/content/get-family.ts
@@ -43,6 +43,9 @@ export function getFamily(type: string) {
     case "hub project":
       family = "project";
       break;
+    case "hub initiative":
+      family = "initiative";
+      break;
     default:
       // by default derive from collection
       family = collectionToFamily(getCollection(type));

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -24,6 +24,11 @@ import { InitiativeEditorType } from "./_internal/InitiativeSchema";
 import { IWithMetricsBehavior } from "../core/behaviors/IWithMetricsBehavior";
 import { getEntityMetrics } from "../metrics/getEntityMetrics";
 import { resolveMetric } from "../metrics/resolveMetric";
+import {
+  ICardActionLink,
+  IHubCardViewModel,
+} from "../core/types/IHubCardViewModel";
+import { convertInitiativeToCardViewModel } from "./view";
 
 /**
  * Hub Initiative Class
@@ -230,5 +235,31 @@ export class HubInitiative
     } else {
       throw new Error(`Metric ${metricId} not found.`);
     }
+  }
+
+  /**
+   * Convert the initiative entity into a card view model that
+   * can be consumed by the suit of hub gallery components
+   *
+   * @param target card link contextual target
+   * @param actionLinks card action links
+   * @param locale internationalization locale
+   */
+  convertToCardViewModel(
+    target: "ago" | "view" | "workspace",
+    actionLinks: ICardActionLink[],
+    /**
+     * TODO: move transform logic to FE so we don't need to pass
+     * locale down (follow https://devtopia.esri.com/dc/hub/issues/7255)
+     */
+    locale: string
+  ): IHubCardViewModel {
+    return convertInitiativeToCardViewModel(
+      this.entity,
+      this.context,
+      target,
+      actionLinks,
+      locale
+    );
   }
 }

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -28,7 +28,7 @@ import {
   ICardActionLink,
   IHubCardViewModel,
 } from "../core/types/IHubCardViewModel";
-import { convertInitiativeToCardViewModel } from "./view";
+import { convertInitiativeEntityToCardViewModel } from "./view";
 
 /**
  * Hub Initiative Class
@@ -254,7 +254,7 @@ export class HubInitiative
      */
     locale: string
   ): IHubCardViewModel {
-    return convertInitiativeToCardViewModel(
+    return convertInitiativeEntityToCardViewModel(
       this.entity,
       this.context,
       target,

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -45,6 +45,7 @@ import { DEFAULT_INITIATIVE, DEFAULT_INITIATIVE_MODEL } from "./defaults";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 import { computeProps } from "./_internal/computeProps";
 import { applyInitiativeMigrations } from "./_internal/applyInitiativeMigrations";
+import { getRelativeWorkspaceUrl } from "../core/getRelativeWorkspaceUrl";
 
 /**
  * @private
@@ -228,6 +229,7 @@ export async function enrichInitiativeSearchResult(
       self: "not-implemented",
       siteRelative: "not-implemented",
       thumbnail: "not-implemented",
+      workspaceRelative: "not-implemented",
     },
   };
 
@@ -264,6 +266,10 @@ export async function enrichInitiativeSearchResult(
     result.type,
     identifier,
     item.typeKeywords
+  );
+  result.links.workspaceRelative = getRelativeWorkspaceUrl(
+    result.type,
+    identifier
   );
 
   return result;

--- a/packages/common/src/initiatives/index.ts
+++ b/packages/common/src/initiatives/index.ts
@@ -1,2 +1,3 @@
 export * from "./HubInitiative";
 export * from "./HubInitiatives";
+export * from "./view";

--- a/packages/common/src/initiatives/view.ts
+++ b/packages/common/src/initiatives/view.ts
@@ -21,7 +21,7 @@ import { getRelativeWorkspaceUrl } from "../core/getRelativeWorkspaceUrl";
  * @param actionLinks card action links
  * @param locale internationalization locale
  */
-export const convertInitiativeToCardViewModel = (
+export const convertInitiativeEntityToCardViewModel = (
   initiative: IHubInitiative,
   context: IArcGISContext,
   target: "ago" | "view" | "workspace" = "ago",
@@ -66,17 +66,17 @@ export const convertInitiativeSearchResultToCardViewModel = (
   locale: string = "en-US"
 ): IHubCardViewModel => {
   const titleUrl = {
-    ago: searchResult.links?.self,
-    view: searchResult.links?.siteRelative,
-    workspace: searchResult.links?.workspaceRelative,
+    ago: searchResult.links.self,
+    view: searchResult.links.siteRelative,
+    workspace: searchResult.links.workspaceRelative,
   }[target];
 
   return {
     ...getSharedInitiativeCardViewModel(searchResult, locale),
     actionLinks,
     titleUrl,
-    ...(searchResult.links?.thumbnail && {
-      thumbnailUrl: searchResult.links?.thumbnail,
+    ...(searchResult.links.thumbnail && {
+      thumbnailUrl: searchResult.links.thumbnail,
     }),
   };
 };

--- a/packages/common/src/initiatives/view.ts
+++ b/packages/common/src/initiatives/view.ts
@@ -1,0 +1,139 @@
+import { IArcGISContext, IHubSearchResult, getFamily } from "..";
+import {
+  getHubRelativeUrl,
+  getShortenedCategories,
+} from "../content/_internal/internalContentUtils";
+import { IHubInitiative } from "../core";
+import {
+  ICardActionLink,
+  IHubCardViewModel,
+} from "../core/types/IHubCardViewModel";
+import { getItemHomeUrl } from "../urls/get-item-home-url";
+import { getRelativeWorkspaceUrl } from "../core/getRelativeWorkspaceUrl";
+
+/**
+ * Convert an initiative entity in a card view model
+ * that can be consumed by the suite of hub gallery components
+ *
+ * @param initiative initiative entity
+ * @param context auth & portal information
+ * @param target card link contextual target
+ * @param actionLinks card action links
+ * @param locale internationalization locale
+ */
+export const convertInitiativeToCardViewModel = (
+  initiative: IHubInitiative,
+  context: IArcGISContext,
+  target: "ago" | "view" | "workspace" = "ago",
+  actionLinks: ICardActionLink[] = [],
+  /**
+   * TODO: move transform logic to FE so we don't need to pass
+   * locale down (follow https://devtopia.esri.com/dc/hub/issues/7255)
+   */
+  locale: string = "en-US"
+): IHubCardViewModel => {
+  const titleUrl = {
+    ago: getItemHomeUrl(initiative.id, context.hubRequestOptions),
+    view: getHubRelativeUrl(initiative.type, initiative.id),
+    workspace: getRelativeWorkspaceUrl(initiative.type, initiative.id),
+  }[target];
+
+  return {
+    ...getSharedInitiativeCardViewModel(initiative, locale),
+    actionLinks,
+    titleUrl,
+    ...(initiative.thumbnailUrl && { thumbnailUrl: initiative.thumbnailUrl }),
+  };
+};
+
+/**
+ * Conver an initiative search result into a card view model
+ * that can be consumed by the suite of hub gallery components
+ *
+ * @param searchResult hub initiative search result
+ * @param target card link contextual target
+ * @param actionLinks card action links
+ * @param locale internationalization locale
+ */
+export const convertInitiativeSearchResultToCardViewModel = (
+  searchResult: IHubSearchResult,
+  target: "ago" | "view" | "workspace" = "ago",
+  actionLinks: ICardActionLink[] = [],
+  /**
+   * TODO: move transform logic to FE so we don't need to pass
+   * locale down (follow https://devtopia.esri.com/dc/hub/issues/7255)
+   */
+  locale: string = "en-US"
+): IHubCardViewModel => {
+  const titleUrl = {
+    ago: searchResult.links?.self,
+    view: searchResult.links?.siteRelative,
+    workspace: searchResult.links?.workspaceRelative,
+  }[target];
+
+  return {
+    ...getSharedInitiativeCardViewModel(searchResult, locale),
+    actionLinks,
+    titleUrl,
+    ...(searchResult.links?.thumbnail && {
+      thumbnailUrl: searchResult.links?.thumbnail,
+    }),
+  };
+};
+
+/**
+ * Given an initiative entiy OR hub search result, construct the
+ * initiative's shared card view model properties
+ *
+ * @param entityOrSearchResult intiative entity or hub search result
+ * @param locale internationalization locale
+ */
+const getSharedInitiativeCardViewModel = (
+  entityOrSearchResult: IHubInitiative | IHubSearchResult,
+  locale: string
+): IHubCardViewModel => {
+  const additionalInfo = [
+    {
+      i18nKey: "type",
+      value: entityOrSearchResult.type,
+    },
+    {
+      i18nKey: "dateUpdated",
+      value: entityOrSearchResult.updatedDate.toLocaleDateString(locale),
+    },
+    ...(entityOrSearchResult.tags?.length
+      ? [
+          {
+            i18nKey: "tags",
+            value: entityOrSearchResult.tags.join(", "),
+          },
+        ]
+      : []),
+    ...(entityOrSearchResult.categories?.length
+      ? [
+          {
+            i18nKey: "categories",
+            value: getShortenedCategories(entityOrSearchResult.categories).join(
+              ", "
+            ),
+          },
+        ]
+      : []),
+    {
+      i18nKey: "dateCreated",
+      value: entityOrSearchResult.createdDate.toLocaleDateString(locale),
+    },
+  ];
+
+  return {
+    access: entityOrSearchResult.access,
+    badges: [],
+    id: entityOrSearchResult.id,
+    family: getFamily(entityOrSearchResult.type),
+    source: entityOrSearchResult.owner,
+    summary: entityOrSearchResult.summary,
+    title: entityOrSearchResult.name,
+    type: entityOrSearchResult.type,
+    additionalInfo,
+  };
+};

--- a/packages/common/test/content/get-family.test.ts
+++ b/packages/common/test/content/get-family.test.ts
@@ -61,6 +61,13 @@ describe("getFamily", () => {
       expect(types.includes("Hub Project")).toBeTruthy();
     });
 
+    it("can get 'initiative' types", () => {
+      const types = getFamilyTypes("initiative");
+      expect(Array.isArray(types)).toBeTruthy();
+      expect(types.length).toBe(1);
+      expect(types.includes("Hub Initiative")).toBeTruthy();
+    });
+
     it("can get types any other valid family", () => {
       const types = getFamilyTypes("site");
       expect(Array.isArray(types)).toBeTruthy();

--- a/packages/common/test/initiatives/HubInitiative.test.ts
+++ b/packages/common/test/initiatives/HubInitiative.test.ts
@@ -12,6 +12,7 @@ import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as HubInitiativesModule from "../../src/initiatives/HubInitiatives";
 import * as schemasModule from "../../src/core/schemas/getEntityEditorSchemas";
 import * as ResolveMetricModule from "../../src/metrics/resolveMetric";
+import * as viewModule from "../../src/initiatives/view";
 
 describe("HubInitiative Class:", () => {
   let authdCtxMgr: ArcGISContextManager;
@@ -274,6 +275,18 @@ describe("HubInitiative Class:", () => {
     chk.update({ catalog: { schemaVersion: 2 } });
     expect(chk.toJson().catalog).toEqual({ schemaVersion: 2 });
     expect(chk.catalog.schemaVersion).toEqual(2);
+  });
+
+  it("convertToCardViewModel: delegates to the convertInitiativeEntityToCardViewModel util", async () => {
+    const spy = spyOn(viewModule, "convertInitiativeEntityToCardViewModel");
+
+    const chk = await HubInitiative.fromJson(
+      { name: "Test Initiative" },
+      authdCtxMgr.context
+    );
+    await chk.convertToCardViewModel("ago", [], "en-us");
+
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   describe("resolveMetrics:", () => {

--- a/packages/common/test/initiatives/fixtures.ts
+++ b/packages/common/test/initiatives/fixtures.ts
@@ -1,0 +1,190 @@
+import { IItem, IUser } from "@esri/arcgis-rest-types";
+import {
+  ArcGISContext,
+  IHubCatalog,
+  IHubInitiative,
+  IHubLocation,
+  IHubSearchResult,
+  IModel,
+} from "../../src";
+import { MOCK_AUTH } from "../mocks/mock-auth";
+import { IPortal } from "@esri/arcgis-rest-portal";
+
+export const GUID = "9b77674e43cf4bbd9ecad5189b3f1fdc";
+
+export const INITIATIVE_LOCATION: IHubLocation = {
+  type: "custom",
+  extent: [
+    [-77.32808191324128, 38.74173655216708],
+    [-76.8191059305754, 39.08220981728297],
+  ],
+  spatialReference: {
+    wkid: 4326,
+  },
+  geometries: [
+    {
+      type: "polygon",
+      spatialReference: {
+        wkid: 4326,
+      },
+      rings: [
+        [
+          [-77.32808191324128, 38.74173655216708],
+          [-76.8191059305754, 39.08220981728297],
+        ],
+      ],
+    } as unknown as __esri.Geometry,
+  ],
+};
+
+export const INITIATIVE_ENTITY: IHubInitiative = {
+  access: "public",
+  canEdit: true,
+  canDelete: true,
+  categories: ["Basemap imagery", "Creative maps"],
+  catalog: {} as IHubCatalog,
+  createdDate: new Date(1652819949000),
+  createdDateSource: "item.created",
+  description: "This is a mock description",
+  extent: [
+    [-87.76875870296065, 41.82501713512609],
+    [-87.74262594052858, 41.83922261453605],
+  ],
+  id: GUID,
+  itemControl: "admin",
+  name: "Mock Initiative",
+  orgUrlKey: "qa-pre-a-hub",
+  owner: "dev_pre_hub_admin",
+  schemaVersion: 1,
+  slug: "qa-pre-a-hub|mock-initiative",
+  summary: "this is a initiative snippet",
+  tags: ["tag1", "tag2"],
+  thumbnail: "thumbnail/mock-thumbnail.png",
+  thumbnailUrl: "https://thumbnail/mock-thumbnail.png",
+  type: "Hub Initiative",
+  typeKeywords: ["Hub", "Hub Initiative", "slug|qa-pre-a-hub|mock-initiative"],
+  updatedDate: new Date(1652819949000),
+  updatedDateSource: "item.modified",
+  location: INITIATIVE_LOCATION,
+  view: {
+    featuredImageUrl:
+      "https://qa-pre-a-hub.mapsqa.arcgis.com/sharing/rest/content/items/320d5995b77c4e2eae27c85faa75e1e2/resources/featuredImage.png",
+    featuredContentIds: [
+      "0003b14f3f1b41c8898181a64558503c",
+      "2da121b858704d0e8cf1e1668d6c96ba",
+      "246b43396c6749038fbe96eade69e253",
+    ],
+    timeline: {
+      schemaVersion: 1,
+      title: "",
+      description: "",
+      canCollapse: false,
+      stages: [
+        {
+          key: "stage1683657342609",
+          title: "This is step 1!",
+          timeframe: "tomorrow",
+          stageDescription: "this is step 1 description",
+          status: "complete",
+        },
+        {
+          key: "stage1683661509458",
+          title: "This is step 2",
+          timeframe: "next month",
+          stageDescription: "this is step 2 description",
+          status: "inProgress",
+        },
+      ],
+    },
+  },
+};
+
+export const INITIATIVE_ITEM: IItem = {
+  id: GUID,
+  access: "public",
+  owner: "dev_pre_hub_admin",
+  created: 1652819949000,
+  modified: 1652819949000,
+  description: "This is a mock description",
+  snippet: "this is a initiative snippet",
+  isOrgItem: true,
+  title: "Mock Initiative",
+  type: "Hub Initiative",
+  typeKeywords: ["Hub", "Hub Initiative", "slug|qa-pre-a-hub|mock-initiative"],
+  tags: ["tag1", "tag2"],
+  categories: ["Basemap imagery", "Creative maps"],
+  thumbnail: "thumbnail/mock-thumbnail.png",
+  extent: [],
+  licenseInfo: "CC-BY-SA",
+  culture: "en-us",
+  contentOrigin: "self",
+  numViews: 10,
+  size: 0,
+  properties: {
+    schemaVersion: 1,
+    location: INITIATIVE_LOCATION,
+  },
+};
+
+export const INITIATIVE_HUB_SEARCH_RESULT: IHubSearchResult = {
+  access: "public",
+  id: GUID,
+  type: "Hub Initiative",
+  name: "Mock Initiative",
+  owner: "dev_pre_hub_admin",
+  typeKeywords: ["Hub", "Hub Initiative", "slug|qa-pre-a-hub|mock-initiative"],
+  tags: ["tag1", "tag2"],
+  categories: ["Basemap imagery", "Creative maps"],
+  summary: "this is a initiative snippet",
+  createdDate: new Date(1652819949000),
+  createdDateSource: "item.created",
+  updatedDate: new Date(1652819949000),
+  updatedDateSource: "item.modified",
+  family: "initiative",
+  links: {
+    self: "https://mock-home-url.com",
+    siteRelative: "/mock-hub-relative-url",
+    thumbnail: "https://thumbnail/mock-thumbnail.png",
+    workspaceRelative: "/mock-relative-workspace-url",
+  },
+};
+
+export const INITIATIVE_DATA = {
+  timeline: {},
+};
+
+export const INITIATIVE_MODEL = {
+  item: INITIATIVE_ITEM,
+  data: INITIATIVE_DATA,
+} as IModel;
+
+const USER: IUser = {
+  username: "mock_user",
+  fullName: "Mock User",
+  firstName: "Mock",
+  lastName: "User",
+  preferredView: null,
+  description: "You may also know me as Mock User.",
+  email: "mock_user@esri.com",
+  orgId: "org_id_1",
+  role: "org_admin",
+  privileges: [],
+  roleId: "role_id_1",
+  access: "public",
+  created: 1558412566000,
+  modified: 1616690771000,
+  provider: "arcgis",
+};
+
+export const CONTEXT: ArcGISContext = new ArcGISContext({
+  id: 123,
+  currentUser: USER,
+  portalUrl: "https://qaext.arcgis.com/sharing/rest",
+  authentication: MOCK_AUTH,
+  portalSelf: {
+    id: "123",
+    name: "My org",
+    isPortal: false,
+    urlKey: "www",
+  } as IPortal,
+});

--- a/packages/common/test/initiatives/view.test.ts
+++ b/packages/common/test/initiatives/view.test.ts
@@ -1,0 +1,186 @@
+import {
+  cloneObject,
+  convertInitiativeEntityToCardViewModel,
+  convertInitiativeSearchResultToCardViewModel,
+} from "../../src";
+import {
+  CONTEXT,
+  INITIATIVE_ENTITY,
+  INITIATIVE_HUB_SEARCH_RESULT,
+} from "./fixtures";
+import * as getItemHomeUrlModule from "../../src/urls/get-item-home-url";
+import * as internalContentUtils from "../../src/content/_internal/internalContentUtils";
+import * as getRelativeWorkspaceUrlModule from "../../src/core/getRelativeWorkspaceUrl";
+
+describe("initiative view module:", () => {
+  let getShortenedCategoriesSpy: any;
+
+  beforeEach(() => {
+    getShortenedCategoriesSpy = spyOn(
+      internalContentUtils,
+      "getShortenedCategories"
+    ).and.returnValue(["category1", "category2"]);
+  });
+
+  describe("convertInitiativeEntityToCardViewModel:", () => {
+    let getItemHomeUrlSpy: any;
+    let getRelativeWorkspaceUrlSpy: any;
+    let getHubRelativeUrlSpy: any;
+
+    beforeEach(() => {
+      getItemHomeUrlSpy = spyOn(
+        getItemHomeUrlModule,
+        "getItemHomeUrl"
+      ).and.returnValue("https://mock-home-url.com");
+      getRelativeWorkspaceUrlSpy = spyOn(
+        getRelativeWorkspaceUrlModule,
+        "getRelativeWorkspaceUrl"
+      ).and.returnValue("/mock-relative-workspace-url");
+      getHubRelativeUrlSpy = spyOn(
+        internalContentUtils,
+        "getHubRelativeUrl"
+      ).and.returnValue("/mock-hub-relative-url");
+    });
+
+    it("returns the card view model from the intiative entity", () => {
+      const result = convertInitiativeEntityToCardViewModel(
+        INITIATIVE_ENTITY,
+        CONTEXT
+      );
+
+      expect(getItemHomeUrlSpy).toHaveBeenCalledTimes(1);
+      expect(getItemHomeUrlSpy).toHaveBeenCalledWith(
+        INITIATIVE_ENTITY.id,
+        CONTEXT.hubRequestOptions
+      );
+      expect(getHubRelativeUrlSpy).toHaveBeenCalledTimes(1);
+      expect(getHubRelativeUrlSpy).toHaveBeenCalledWith(
+        INITIATIVE_ENTITY.type,
+        INITIATIVE_ENTITY.id
+      );
+      expect(getRelativeWorkspaceUrlSpy).toHaveBeenCalledTimes(1);
+      expect(getRelativeWorkspaceUrlSpy).toHaveBeenCalledWith(
+        INITIATIVE_ENTITY.type,
+        INITIATIVE_ENTITY.id
+      );
+      expect(getShortenedCategoriesSpy).toHaveBeenCalledTimes(1);
+      expect(getShortenedCategoriesSpy).toHaveBeenCalledWith(
+        INITIATIVE_ENTITY.categories
+      );
+
+      expect(result).toEqual({
+        access: INITIATIVE_ENTITY.access,
+        actionLinks: [],
+        badges: [],
+        id: INITIATIVE_ENTITY.id,
+        family: "initiative",
+        source: INITIATIVE_ENTITY.owner,
+        summary: INITIATIVE_ENTITY.summary,
+        title: INITIATIVE_ENTITY.name,
+        titleUrl: "https://mock-home-url.com",
+        thumbnailUrl: INITIATIVE_ENTITY.thumbnailUrl,
+        type: INITIATIVE_ENTITY.type,
+        additionalInfo: [
+          { i18nKey: "type", value: INITIATIVE_ENTITY.type },
+          {
+            i18nKey: "dateUpdated",
+            value: INITIATIVE_ENTITY.updatedDate.toLocaleDateString("en-US"),
+          },
+          { i18nKey: "tags", value: INITIATIVE_ENTITY.tags.join(", ") },
+          { i18nKey: "categories", value: "category1, category2" },
+          {
+            i18nKey: "dateCreated",
+            value: INITIATIVE_ENTITY.createdDate.toLocaleDateString("en-US"),
+          },
+        ],
+      });
+    });
+    it("does not include tags/categories in the view model's additional info if none are defined", () => {
+      const modifiedEntity = cloneObject(INITIATIVE_ENTITY);
+      modifiedEntity.tags = [];
+      modifiedEntity.categories = [];
+
+      const result = convertInitiativeEntityToCardViewModel(
+        modifiedEntity,
+        CONTEXT
+      );
+
+      expect(result.additionalInfo?.length).toBe(3);
+    });
+    it('target = "view": returns the correct title url', () => {
+      const result = convertInitiativeEntityToCardViewModel(
+        INITIATIVE_ENTITY,
+        CONTEXT,
+        "view"
+      );
+      expect(result.titleUrl).toBe("/mock-hub-relative-url");
+    });
+    it('target = "workspace": returns the correct title url', () => {
+      const result = convertInitiativeEntityToCardViewModel(
+        INITIATIVE_ENTITY,
+        CONTEXT,
+        "workspace"
+      );
+      expect(result.titleUrl).toBe("/mock-relative-workspace-url");
+    });
+  });
+
+  describe("convertInitiativeSearchResultToCardViewModel", () => {
+    it("returns the card view model from the hub search result", () => {
+      const result = convertInitiativeSearchResultToCardViewModel(
+        INITIATIVE_HUB_SEARCH_RESULT
+      );
+
+      expect(result).toEqual({
+        access: INITIATIVE_ENTITY.access,
+        actionLinks: [],
+        badges: [],
+        id: INITIATIVE_ENTITY.id,
+        family: "initiative",
+        source: INITIATIVE_ENTITY.owner,
+        summary: INITIATIVE_ENTITY.summary,
+        title: INITIATIVE_ENTITY.name,
+        titleUrl: "https://mock-home-url.com",
+        thumbnailUrl: INITIATIVE_ENTITY.thumbnailUrl,
+        type: INITIATIVE_ENTITY.type,
+        additionalInfo: [
+          { i18nKey: "type", value: INITIATIVE_ENTITY.type },
+          {
+            i18nKey: "dateUpdated",
+            value: INITIATIVE_ENTITY.updatedDate.toLocaleDateString("en-US"),
+          },
+          { i18nKey: "tags", value: INITIATIVE_ENTITY.tags.join(", ") },
+          { i18nKey: "categories", value: "category1, category2" },
+          {
+            i18nKey: "dateCreated",
+            value: INITIATIVE_ENTITY.createdDate.toLocaleDateString("en-US"),
+          },
+        ],
+      });
+    });
+    it("does not include tags/categories in the view model's additional info if none are defined", () => {
+      const modifiedSearchResult = cloneObject(INITIATIVE_HUB_SEARCH_RESULT);
+      modifiedSearchResult.tags = undefined;
+      modifiedSearchResult.categories = undefined;
+
+      const result =
+        convertInitiativeSearchResultToCardViewModel(modifiedSearchResult);
+
+      expect(result.additionalInfo?.length).toBe(3);
+    });
+    it('target = "view": returns the correct title url', () => {
+      const result = convertInitiativeSearchResultToCardViewModel(
+        INITIATIVE_HUB_SEARCH_RESULT,
+        "view"
+      );
+      expect(result.titleUrl).toBe("/mock-hub-relative-url");
+    });
+    it('target = "workspace": returns the correct title url', () => {
+      const result = convertInitiativeSearchResultToCardViewModel(
+        INITIATIVE_HUB_SEARCH_RESULT,
+        "workspace"
+      );
+      expect(result.titleUrl).toBe("/mock-relative-workspace-url");
+    });
+  });
+});


### PR DESCRIPTION
1. Description: adds conversion functions for converting initiative/initiative search resutls to card view model

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
