### PR TITLE
feat(): add dashboard capability to content, discussions,initiatives

### DIFF
--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -11,6 +11,7 @@ export const ContentDefaultCapabilities: EntityCapabilities = {
   overview: true,
   details: true,
   settings: true,
+  dashboard: true,
 };
 
 /**
@@ -24,6 +25,11 @@ export const ContentCapabilityPermissions: ICapabilityPermission[] = [
     entity: "content",
     capability: "overview",
     permissions: ["hub:content:view"],
+  },
+  {
+    entity: "content",
+    capability: "dashboard",
+    permissions: ["hub:content:edit"],
   },
   {
     entity: "content",

--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -11,6 +11,7 @@ export const DiscussionDefaultCapabilities: EntityCapabilities = {
   overview: true,
   details: true,
   settings: true,
+  dashboard: true,
 };
 
 /**
@@ -24,6 +25,11 @@ export const DiscussionCapabilityPermissions: ICapabilityPermission[] = [
     entity: "discussion",
     capability: "overview",
     permissions: ["hub:discussion:view"],
+  },
+  {
+    entity: "discussion",
+    capability: "dashboard",
+    permissions: ["hub:discussion:edit"],
   },
   {
     entity: "discussion",

--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -12,6 +12,7 @@ export const InitiativeDefaultCapabilities: EntityCapabilities = {
   details: true,
   settings: true,
   content: true,
+  dashboard: true,
 };
 
 /**
@@ -25,6 +26,11 @@ export const InitiativeCapabilityPermissions: ICapabilityPermission[] = [
     entity: "initiative",
     capability: "overview",
     permissions: ["hub:initiative:view"],
+  },
+  {
+    entity: "initiative",
+    capability: "dashboard",
+    permissions: ["hub:initiative:edit"],
   },
   {
     entity: "initiative",


### PR DESCRIPTION
1. Description:
Adds dashboard capability to content, discussions, and initiatives workspaces

1. Instructions for testing:

1. Closes Issues: [#7362](https://zentopia.esri.com/workspaces/sites-sprint-board-614a18b38a61a3001196c48d/issues/dc/hub/7326)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
