### PR TITLE
feat(hub-discussions): add function updateDiscussionSetting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64972,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.22.0",
+			"version": "13.25.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -1068,6 +1068,14 @@ export interface ICreateDiscussionSetting {
 }
 
 /**
+ * @export
+ * @interface IUpdateDiscussionSetting
+ */
+export interface IUpdateDiscussionSetting {
+  settings: Partial<ISettings>;
+}
+
+/**
  * parameters for creating a discussionSetting
  *
  * @export
@@ -1089,6 +1097,19 @@ export interface ICreateDiscussionSettingParams
 export interface IFetchDiscussionSettingParams
   extends IDiscussionsRequestOptions {
   id: string;
+}
+
+/**
+ * parameters for updating a discussionSetting
+ *
+ * @export
+ * @interface IUpdateDiscussionSettingParams
+ * @extends {IDiscussionsRequestOptions}
+ */
+export interface IUpdateDiscussionSettingParams
+  extends IDiscussionsRequestOptions {
+  id: string;
+  data: IUpdateDiscussionSetting;
 }
 
 /**

--- a/packages/discussions/src/discussion-settings/discussion-settings.ts
+++ b/packages/discussions/src/discussion-settings/discussion-settings.ts
@@ -5,6 +5,7 @@ import {
   IFetchDiscussionSettingParams,
   IRemoveDiscussionSettingParams,
   IRemoveDiscussionSettingResponse,
+  IUpdateDiscussionSettingParams,
 } from "../types";
 
 /**
@@ -32,6 +33,20 @@ export function fetchDiscussionSetting(
   options: IFetchDiscussionSettingParams
 ): Promise<IDiscussionSetting> {
   options.httpMethod = "GET";
+  return request(`/discussion_settings/${options.id}`, options);
+}
+
+/**
+ * update discussion settings
+ *
+ * @export
+ * @param {IRemoveDiscussionSettingParams} options
+ * @return {*} {Promise<IDiscussionSetting>}
+ */
+export function updateDiscussionSetting(
+  options: IUpdateDiscussionSettingParams
+): Promise<IDiscussionSetting> {
+  options.httpMethod = "PATCH";
   return request(`/discussion_settings/${options.id}`, options);
 }
 

--- a/packages/discussions/src/discussion-settings/discussion-settings.ts
+++ b/packages/discussions/src/discussion-settings/discussion-settings.ts
@@ -19,7 +19,7 @@ export function createDiscussionSetting(
   options: ICreateDiscussionSettingParams
 ): Promise<IDiscussionSetting> {
   options.httpMethod = "POST";
-  return request(`/discussion_settings`, options);
+  return request(`/discussion-settings`, options);
 }
 
 /**
@@ -33,7 +33,7 @@ export function fetchDiscussionSetting(
   options: IFetchDiscussionSettingParams
 ): Promise<IDiscussionSetting> {
   options.httpMethod = "GET";
-  return request(`/discussion_settings/${options.id}`, options);
+  return request(`/discussion-settings/${options.id}`, options);
 }
 
 /**
@@ -47,7 +47,7 @@ export function updateDiscussionSetting(
   options: IUpdateDiscussionSettingParams
 ): Promise<IDiscussionSetting> {
   options.httpMethod = "PATCH";
-  return request(`/discussion_settings/${options.id}`, options);
+  return request(`/discussion-settings/${options.id}`, options);
 }
 
 /**
@@ -61,5 +61,5 @@ export function removeDiscussionSetting(
   options: IRemoveDiscussionSettingParams
 ): Promise<IRemoveDiscussionSettingResponse> {
   options.httpMethod = "DELETE";
-  return request(`/discussion_settings/${options.id}`, options);
+  return request(`/discussion-settings/${options.id}`, options);
 }

--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -79,7 +79,9 @@ export {
   ISettings,
   IRemoveDiscussionSettingResponse,
   ICreateDiscussionSetting,
+  IUpdateDiscussionSetting,
   ICreateDiscussionSettingParams,
   IFetchDiscussionSettingParams,
+  IUpdateDiscussionSettingParams,
   IRemoveDiscussionSettingParams,
 } from "@esri/hub-common";

--- a/packages/discussions/test/discussion-settings.test.ts
+++ b/packages/discussions/test/discussion-settings.test.ts
@@ -43,7 +43,7 @@ describe("discussion-settings", () => {
 
     expect(requestSpy.calls.count()).toEqual(1);
     const [url, opts] = requestSpy.calls.argsFor(0);
-    expect(url).toEqual(`/discussion_settings`);
+    expect(url).toEqual(`/discussion-settings`);
     expect(opts).toEqual({ ...options, httpMethod: "POST" });
   });
 
@@ -55,7 +55,7 @@ describe("discussion-settings", () => {
 
     expect(requestSpy.calls.count()).toEqual(1);
     const [url, opts] = requestSpy.calls.argsFor(0);
-    expect(url).toEqual(`/discussion_settings/${id}`);
+    expect(url).toEqual(`/discussion-settings/${id}`);
     expect(opts).toEqual({ ...options, httpMethod: "GET" });
   });
 
@@ -76,7 +76,7 @@ describe("discussion-settings", () => {
 
     expect(requestSpy.calls.count()).toEqual(1);
     const [url, opts] = requestSpy.calls.argsFor(0);
-    expect(url).toEqual(`/discussion_settings/${id}`);
+    expect(url).toEqual(`/discussion-settings/${id}`);
     expect(opts).toEqual({ ...options, httpMethod: "PATCH" });
   });
 
@@ -88,7 +88,7 @@ describe("discussion-settings", () => {
 
     expect(requestSpy.calls.count()).toEqual(1);
     const [url, opts] = requestSpy.calls.argsFor(0);
-    expect(url).toEqual(`/discussion_settings/${id}`);
+    expect(url).toEqual(`/discussion-settings/${id}`);
     expect(opts).toEqual({ ...options, httpMethod: "DELETE" });
   });
 });

--- a/packages/discussions/test/discussion-settings.test.ts
+++ b/packages/discussions/test/discussion-settings.test.ts
@@ -3,6 +3,7 @@ import {
   createDiscussionSetting,
   fetchDiscussionSetting,
   removeDiscussionSetting,
+  updateDiscussionSetting,
 } from "../src/discussion-settings";
 import {
   DiscussionSettingType,
@@ -10,6 +11,8 @@ import {
   ICreateDiscussionSettingParams,
   IDiscussionsRequestOptions,
   IRemoveDiscussionSettingParams,
+  IUpdateDiscussionSetting,
+  IUpdateDiscussionSettingParams,
 } from "../src/types";
 
 describe("discussion-settings", () => {
@@ -54,6 +57,27 @@ describe("discussion-settings", () => {
     const [url, opts] = requestSpy.calls.argsFor(0);
     expect(url).toEqual(`/discussion_settings/${id}`);
     expect(opts).toEqual({ ...options, httpMethod: "GET" });
+  });
+
+  it("updateDiscussionSetting", async () => {
+    const id = "uuidv4";
+    const body: IUpdateDiscussionSetting = {
+      settings: {
+        allowedChannelIds: ["aaa"],
+      },
+    };
+    const options: IUpdateDiscussionSettingParams = {
+      ...baseOpts,
+      id,
+      data: body,
+    };
+
+    await updateDiscussionSetting(options);
+
+    expect(requestSpy.calls.count()).toEqual(1);
+    const [url, opts] = requestSpy.calls.argsFor(0);
+    expect(url).toEqual(`/discussion_settings/${id}`);
+    expect(opts).toEqual({ ...options, httpMethod: "PATCH" });
   });
 
   it("removeDiscussionSetting", async () => {


### PR DESCRIPTION
1. Description: add function `updateDiscussionSetting` in the hub-discussions package and supporting interfaces in hub-common package

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
