### PR TITLE
fix(hub-common): have convertModelToSite handle invalid search categories

### DIFF
--- a/packages/common/src/sites/_internal/applyDefaultCollectionMigration.ts
+++ b/packages/common/src/sites/_internal/applyDefaultCollectionMigration.ts
@@ -83,6 +83,11 @@ export function applyDefaultCollectionMigration(model: IModel): IModel {
       (searchCategory) =>
         searchCategory.key !== "components.search.category_tabs.events"
     )
+    // Some sites have a borked `data.values.searchCategories` that explicitly includes the `all`
+    // collection. We have this check to catch that and any other weird scenarios.
+    .filter(
+      (searchCategory) => !!searchCategoryToCollection[searchCategory.key]
+    )
     .map((searchCategory) => {
       const collectionKey = searchCategoryToCollection[searchCategory.key];
       const collection = baseCollectionMap[collectionKey];


### PR DESCRIPTION

affects: @esri/hub-common

1. Description:

Main fix for [this issue](https://devtopia.esri.com/dc/hub/issues/7419) discovered by product (NOTE: this is not the hotfix)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
