### PR TITLE
feat(hub-common): persist modifications to site collections via updateSite

### DIFF
--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -35,6 +35,7 @@ import { getItemThumbnailUrl } from "../resources/get-item-thumbnail-url";
 import { applyCatalogStructureMigration } from "./_internal/applyCatalogStructureMigration";
 import { setDiscussableKeyword } from "../discussions";
 import { applyDefaultCollectionMigration } from "./_internal/applyDefaultCollectionMigration";
+import { reflectCollectionsToSearchCategories } from "./_internal/reflectCollectionsToSearchCategories";
 export const HUB_SITE_ITEM_TYPE = "Hub Site Application";
 export const ENTERPRISE_SITE_ITEM_TYPE = "Site Application";
 
@@ -326,17 +327,22 @@ export async function updateSite(
   const mapper = new PropertyMapper<Partial<IHubSite>, IModel>(
     getPropertyMap()
   );
-  const modelToUpdate = mapper.entityToStore(site, currentModel);
+  let modelToUpdate = mapper.entityToStore(site, currentModel);
 
   // handle any domain changes
   await handleDomainChanges(modelToUpdate, currentModel, requestOptions);
 
-  // The following props are currently affected by in-memory migrations,
-  // so we replace them with their canonical values so as to not overwrite
-  // them. Eventually these changes will be persisted in AGO.
+  // Because some old (but critical) application code still uses `data.values.searchCategories`
+  // as the source of truth for collection display configuration, we port all display changes
+  // in `data.catalog.collections` to the search category format.
+  // TODO: Remove once the app no longer relies on `data.values.searchCategories`
+  modelToUpdate = reflectCollectionsToSearchCategories(modelToUpdate);
+  // At this point `data.catalog` has become a full IHubCatalog object due to an in-memory
+  // migration. However, we can't persist an IHubCatalog in `data.catalog` without breaking
+  // the application, since most of the app relies on the old catalog structure. As such,
+  // we just persist the old catalog structure from the most current model.
+  // TODO: Remove once the application is plumbed to work off an IHubCatalog
   modelToUpdate.data.catalog = currentModel.data.catalog;
-  modelToUpdate.data.values.searchCategories =
-    currentModel.data.values.searchCategories;
 
   // send updates to the Portal API and get back the updated site model
   const updatedSiteModel = await updateModel(

--- a/packages/common/src/sites/_internal/applyDefaultCollectionMigration.ts
+++ b/packages/common/src/sites/_internal/applyDefaultCollectionMigration.ts
@@ -1,7 +1,7 @@
-import { getProp } from "../../objects/get-prop";
 import { IHubCollectionPersistance } from "../../search/types/IHubCatalog";
 import { WellKnownCollection } from "../../search/wellKnownCatalog";
 import { IModel } from "../../types";
+import { SearchCategories } from "./types";
 
 /**
  * In-Memory migration that adds default collections to site models that have the
@@ -55,41 +55,42 @@ export function applyDefaultCollectionMigration(model: IModel): IModel {
     };
     return map;
   }, {} as Record<string, IHubCollectionPersistance>);
-  const searchCategoryToCollection: Record<string, WellKnownCollection> = {
-    "components.search.category_tabs.data": "dataset",
+  const searchCategoryToCollection: Partial<
+    Record<SearchCategories, WellKnownCollection>
+  > = {
+    [SearchCategories.DATA]: "dataset",
     // Unfortunately, the "site" search category has different keys depending on if the catalog
     // was created for a hub basic or hub premium site. As such, we just account for both.
-    "components.search.category_tabs.initiatives": "site",
-    "components.search.category_tabs.sites": "site",
-    "components.search.category_tabs.documents": "document",
-    "components.search.category_tabs.apps_and_maps": "appAndMap",
+    [SearchCategories.INITIATIVES]: "site",
+    [SearchCategories.SITES]: "site",
+    [SearchCategories.DOCUMENTS]: "document",
+    [SearchCategories.APPS_AND_MAPS]: "appAndMap",
   };
   // Not every site has `data.values.searchCategories` saved, so we have to keep a bare-bones
   // copy of what the default objects are in opendata-ui.
   // NOTE: The `event` search category has been explicitly omitted. While the classic search view
   // allows for the searching of `events`, the new search view does not.
   const DEFAULT_SEARCH_CATEGORIES: any[] = [
-    { key: "components.search.category_tabs.data" },
-    { key: "components.search.category_tabs.sites" },
-    { key: "components.search.category_tabs.documents" },
-    { key: "components.search.category_tabs.apps_and_maps" },
+    { key: SearchCategories.DATA },
+    { key: SearchCategories.SITES },
+    { key: SearchCategories.DOCUMENTS },
+    { key: SearchCategories.APPS_AND_MAPS },
   ];
   const legacySearchCategories: any[] =
     model.data.values.searchCategories || DEFAULT_SEARCH_CATEGORIES;
 
   const configuredCollections = legacySearchCategories
     // The new search view doesn't currently allow for searching events
-    .filter(
-      (searchCategory) =>
-        searchCategory.key !== "components.search.category_tabs.events"
-    )
+    .filter((searchCategory) => searchCategory.key !== SearchCategories.EVENTS)
     // Some sites have a borked `data.values.searchCategories` that explicitly includes the `all`
     // collection. We have this check to catch that and any other weird scenarios.
     .filter(
-      (searchCategory) => !!searchCategoryToCollection[searchCategory.key]
+      (searchCategory) =>
+        !!searchCategoryToCollection[searchCategory.key as SearchCategories]
     )
     .map((searchCategory) => {
-      const collectionKey = searchCategoryToCollection[searchCategory.key];
+      const collectionKey =
+        searchCategoryToCollection[searchCategory.key as SearchCategories];
       const collection = baseCollectionMap[collectionKey];
       collection.label = searchCategory.overrideText || null;
       collection.hidden = searchCategory.hidden;

--- a/packages/common/src/sites/_internal/applyDefaultCollectionMigration.ts
+++ b/packages/common/src/sites/_internal/applyDefaultCollectionMigration.ts
@@ -71,7 +71,7 @@ export function applyDefaultCollectionMigration(model: IModel): IModel {
   // NOTE: The `event` search category has been explicitly omitted. While the classic search view
   // allows for the searching of `events`, the new search view does not.
   const DEFAULT_SEARCH_CATEGORIES: any[] = [
-    { key: SearchCategories.SITES },
+    { key: SearchCategories.SITES, hidden: true },
     { key: SearchCategories.DATA },
     { key: SearchCategories.DOCUMENTS },
     { key: SearchCategories.APPS_AND_MAPS },

--- a/packages/common/src/sites/_internal/applyDefaultCollectionMigration.ts
+++ b/packages/common/src/sites/_internal/applyDefaultCollectionMigration.ts
@@ -71,8 +71,8 @@ export function applyDefaultCollectionMigration(model: IModel): IModel {
   // NOTE: The `event` search category has been explicitly omitted. While the classic search view
   // allows for the searching of `events`, the new search view does not.
   const DEFAULT_SEARCH_CATEGORIES: any[] = [
-    { key: SearchCategories.DATA },
     { key: SearchCategories.SITES },
+    { key: SearchCategories.DATA },
     { key: SearchCategories.DOCUMENTS },
     { key: SearchCategories.APPS_AND_MAPS },
   ];

--- a/packages/common/src/sites/_internal/reflectCollectionsToSearchCategories.ts
+++ b/packages/common/src/sites/_internal/reflectCollectionsToSearchCategories.ts
@@ -6,7 +6,7 @@ import { SearchCategories } from "./types";
 
 /**
  * Reflects changes from a site model's collections to the `site.data.values.searchCategories`
- * legacy property. This is needed stop-gap since old search page will coexist for a time with
+ * legacy property. This is a needed stop-gap since old search page will coexist for a time with
  * the new workspaces UI and the old search page (among others) still rely on the `searchCategories`
  * construct.
  *

--- a/packages/common/src/sites/_internal/reflectCollectionsToSearchCategories.ts
+++ b/packages/common/src/sites/_internal/reflectCollectionsToSearchCategories.ts
@@ -1,0 +1,68 @@
+import { WellKnownCollection } from "../../search";
+import { IHubCollectionPersistance } from "../../search/types/IHubCatalog";
+import { IModel } from "../../types";
+import { cloneObject } from "../../util";
+import { SearchCategories } from "./types";
+
+/**
+ * Reflects changes from a site model's collections to the `site.data.values.searchCategories`
+ * legacy property. This is needed stop-gap since old search page will coexist for a time with
+ * the new workspaces UI and the old search page (among others) still rely on the `searchCategories`
+ * construct.
+ *
+ * @param model a site item model
+ * @returns a model with the catalog collections and search categories in sync
+ */
+export function reflectCollectionsToSearchCategories(model: IModel) {
+  const clone = cloneObject(model);
+  const collectionToSearchCategory: Partial<
+    Record<WellKnownCollection, SearchCategories>
+  > = {
+    dataset: SearchCategories.DATA,
+    // NOTE: the `searchCategories` construct actually has two possible labels for the
+    // `site` collection: "Sites" or "Initiatives". "Sites" is used if a site was created
+    // with Hub Basic, "Initiatives" was used if a site was created with Hub Premium.
+    // Since the new search page only uses "Sites", we've opted to ignore "Initiatives"
+    site: SearchCategories.SITES,
+    appAndMap: SearchCategories.APPS_AND_MAPS,
+    document: SearchCategories.DOCUMENTS,
+  };
+
+  const searchCategoryToQueryParam: Partial<Record<SearchCategories, string>> =
+    {
+      [SearchCategories.DATA]: "Dataset",
+      [SearchCategories.SITES]: "Site",
+      [SearchCategories.APPS_AND_MAPS]: "App,Map",
+      [SearchCategories.DOCUMENTS]: "Document",
+    };
+  const collections: IHubCollectionPersistance[] =
+    clone.data.catalog.collections;
+
+  const updatedSearchCategories = collections
+    // We don't want to persist any non-standard collection as a search category,
+    // such as the "all" collection
+    .filter((c) => !!collectionToSearchCategory[c.key as WellKnownCollection])
+    .map((c) => {
+      const searchCategoryKey =
+        collectionToSearchCategory[c.key as WellKnownCollection];
+      const updated: any = {
+        hidden: c.hidden,
+        key: searchCategoryKey,
+        queryParams: {
+          collection: searchCategoryToQueryParam[searchCategoryKey],
+        },
+      };
+
+      // If `c.label` is falsy, we assume that the UI should display the
+      // default translated label for that collection. We also assume that if
+      // `c.label` _does_ have a value, then it must be a configured override.
+      if (c.label) {
+        updated.overrideText = c.label;
+      }
+
+      return updated;
+    });
+
+  clone.data.values.searchCategories = updatedSearchCategories;
+  return clone;
+}

--- a/packages/common/src/sites/_internal/types.ts
+++ b/packages/common/src/sites/_internal/types.ts
@@ -1,0 +1,10 @@
+export enum SearchCategories {
+  DATA = "components.search.category_tabs.data",
+  SITES = "components.search.category_tabs.sites",
+  DOCUMENTS = "components.search.category_tabs.documents",
+  APPS_AND_MAPS = "components.search.category_tabs.apps_and_maps",
+
+  // The following entries are currently used, but will be phased out
+  EVENTS = "components.search.category_tabs.events",
+  INITIATIVES = "components.search.category_tabs.initiatives",
+}

--- a/packages/common/test/sites/_internal/applyDefaultCollectionMigration.test.ts
+++ b/packages/common/test/sites/_internal/applyDefaultCollectionMigration.test.ts
@@ -35,8 +35,8 @@ describe("applyDefaultCollectionMigration", () => {
     );
     expect(collectionKeys).toEqual([
       "all",
-      "dataset",
       "site",
+      "dataset",
       "document",
       "appAndMap",
     ]);

--- a/packages/common/test/sites/_internal/applyDefaultCollectionMigration.test.ts
+++ b/packages/common/test/sites/_internal/applyDefaultCollectionMigration.test.ts
@@ -44,6 +44,16 @@ describe("applyDefaultCollectionMigration", () => {
       (c: IHubCollectionPersistance) => c.label
     );
     expect(collectionLabels).toEqual([null, null, null, null, null]);
+    const hiddenStatuses = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.hidden
+    );
+    expect(hiddenStatuses).toEqual([
+      undefined,
+      true,
+      undefined,
+      undefined,
+      undefined,
+    ]);
   });
 
   it("Reorders, re-labels, and hides default collections when search categories are configured", () => {
@@ -58,7 +68,7 @@ describe("applyDefaultCollectionMigration", () => {
       {
         overrideText: "My Sites",
         key: SearchCategories.SITES,
-        hidden: true,
+        hidden: false,
       },
       {
         overrideText: "My Data",
@@ -87,7 +97,7 @@ describe("applyDefaultCollectionMigration", () => {
     const hiddenStatuses = result.data.catalog.collections.map(
       (c: IHubCollectionPersistance) => c.hidden
     );
-    expect(hiddenStatuses).toEqual([undefined, undefined, true, true, false]);
+    expect(hiddenStatuses).toEqual([undefined, undefined, true, false, false]);
   });
 
   it("Handles when a site has the 'initiatives' search category saved", () => {

--- a/packages/common/test/sites/_internal/applyDefaultCollectionMigration.test.ts
+++ b/packages/common/test/sites/_internal/applyDefaultCollectionMigration.test.ts
@@ -1,0 +1,147 @@
+import { IHubCollectionPersistance } from "../../../src/search/types/IHubCatalog";
+import { applyDefaultCollectionMigration } from "../../../src/sites/_internal/applyDefaultCollectionMigration";
+import { SearchCategories } from "../../../src/sites/_internal/types";
+import { IModel } from "../../../src/types";
+import { cloneObject } from "../../../src/util";
+
+const BASE_MODEL = {
+  data: {
+    catalog: {
+      schemaVersion: 1,
+      title: "Default Site Catalog",
+      scopes: {
+        item: {
+          targetEntity: "item",
+          filters: [],
+        },
+      },
+      collections: [],
+    },
+    values: {},
+  },
+} as unknown as IModel;
+
+describe("applyDefaultCollectionMigration", () => {
+  let site: IModel;
+
+  beforeEach(() => {
+    site = cloneObject(BASE_MODEL);
+  });
+
+  it("Adds untouched default collections when no search categories are configured", () => {
+    const result = applyDefaultCollectionMigration(site);
+    const collectionKeys = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.key
+    );
+    expect(collectionKeys).toEqual([
+      "all",
+      "dataset",
+      "site",
+      "document",
+      "appAndMap",
+    ]);
+    const collectionLabels = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.label
+    );
+    expect(collectionLabels).toEqual([null, null, null, null, null]);
+  });
+
+  it("Reorders, re-labels, and hides default collections when search categories are configured", () => {
+    site.data.values.searchCategories = [
+      {
+        key: SearchCategories.APPS_AND_MAPS,
+      },
+      {
+        key: SearchCategories.DOCUMENTS,
+        hidden: true,
+      },
+      {
+        overrideText: "My Sites",
+        key: SearchCategories.SITES,
+        hidden: true,
+      },
+      {
+        overrideText: "My Data",
+        key: SearchCategories.DATA,
+        hidden: false,
+      },
+    ];
+    const result = applyDefaultCollectionMigration(site);
+    const collectionKeys = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.key
+    );
+    // Note: 'all' collection is always prepended
+    expect(collectionKeys).toEqual([
+      "all",
+      "appAndMap",
+      "document",
+      "site",
+      "dataset",
+    ]);
+
+    const collectionLabels = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.label
+    );
+    expect(collectionLabels).toEqual([null, null, null, "My Sites", "My Data"]);
+
+    const hiddenStatuses = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.hidden
+    );
+    expect(hiddenStatuses).toEqual([undefined, undefined, true, true, false]);
+  });
+
+  it("Handles when a site has the 'initiatives' search category saved", () => {
+    site.data.values.searchCategories = [
+      {
+        overrideText: "My Initiatives",
+        key: SearchCategories.INITIATIVES,
+        hidden: true,
+      },
+    ];
+    const result = applyDefaultCollectionMigration(site);
+    const collectionKeys = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.key
+    );
+    // Note: 'all' collection is always prepended
+    expect(collectionKeys).toEqual(["all", "site"]);
+
+    const collectionLabels = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.label
+    );
+    expect(collectionLabels).toEqual([null, "My Initiatives"]);
+
+    const hiddenStatuses = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.hidden
+    );
+    expect(hiddenStatuses).toEqual([undefined, true]);
+  });
+
+  it("Omits unsupported search categories, like an explicit 'all' or events", () => {
+    site.data.values.searchCategories = [
+      {
+        key: SearchCategories.EVENTS,
+      },
+      {
+        overrideText: "Bad Title",
+        key: "components.search.category_tabs.all",
+        hidden: true,
+      },
+    ];
+    const result = applyDefaultCollectionMigration(site);
+    const collectionKeys = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.key
+    );
+    // Note: 'all' collection can never be relabeled, hidden, or reordered
+    expect(collectionKeys).toEqual(["all"]);
+
+    const collectionLabels = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.label
+    );
+    expect(collectionLabels).toEqual([null]);
+
+    const hiddenStatuses = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.hidden
+    );
+    expect(hiddenStatuses).toEqual([undefined]);
+  });
+});

--- a/packages/common/test/sites/_internal/reflectCollectionsToSearchCategories.test.ts
+++ b/packages/common/test/sites/_internal/reflectCollectionsToSearchCategories.test.ts
@@ -1,0 +1,170 @@
+import { IHubCollectionPersistance } from "../../../src/search/types/IHubCatalog";
+import { WellKnownCollection } from "../../../src/search/wellKnownCatalog";
+import { reflectCollectionsToSearchCategories } from "../../../src/sites/_internal/reflectCollectionsToSearchCategories";
+import { SearchCategories } from "../../../src/sites/_internal/types";
+import { IModel } from "../../../src/types";
+import { cloneObject } from "../../../src/util";
+
+const BASE_MODEL = {
+  data: {
+    catalog: {
+      schemaVersion: 1,
+      title: "Default Site Catalog",
+      scopes: {
+        item: {
+          targetEntity: "item",
+          filters: [],
+        },
+      },
+      collections: [],
+    },
+    values: {},
+  },
+} as unknown as IModel;
+
+describe("reflectCollectionsToSearchCategories", () => {
+  let site: IModel;
+  beforeEach(() => {
+    site = cloneObject(BASE_MODEL);
+  });
+  it('handles the collection "hidden" configuration', () => {
+    site.data.catalog.collections = [
+      {
+        label: null,
+        key: "dataset",
+        targetEntity: "item",
+        hidden: true,
+        scope: {
+          targetEntity: "item",
+          collection: "dataset",
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+      {
+        label: null,
+        key: "document",
+        targetEntity: "item",
+        hidden: false,
+        scope: {
+          targetEntity: "item",
+          collection: "document",
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+    ];
+
+    const result = reflectCollectionsToSearchCategories(site);
+    expect(result.data.values.searchCategories).toEqual([
+      {
+        key: SearchCategories.DATA,
+        hidden: true,
+        queryParams: {
+          collection: "Dataset",
+        },
+      },
+      {
+        key: SearchCategories.DOCUMENTS,
+        hidden: false,
+        queryParams: {
+          collection: "Document",
+        },
+      },
+    ]);
+  });
+  it("handles re-labeled collections", () => {
+    site.data.catalog.collections = [
+      {
+        label: "My Cool Sites!",
+        key: "site",
+        targetEntity: "item",
+        hidden: false,
+        scope: {
+          targetEntity: "item",
+          collection: "site",
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+      {
+        label: "Apps & Maps",
+        key: "appAndMap",
+        targetEntity: "item",
+        hidden: false,
+        scope: {
+          targetEntity: "item",
+          collection: "appAndMap",
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+    ];
+
+    const result = reflectCollectionsToSearchCategories(site);
+    expect(result.data.values.searchCategories).toEqual([
+      {
+        overrideText: "My Cool Sites!",
+        key: SearchCategories.SITES,
+        hidden: false,
+        queryParams: {
+          collection: "Site",
+        },
+      },
+      {
+        overrideText: "Apps & Maps",
+        key: SearchCategories.APPS_AND_MAPS,
+        hidden: false,
+        queryParams: {
+          collection: "App,Map",
+        },
+      },
+    ]);
+  });
+  it("filters out collections that searchCategories does not support", () => {
+    site.data.catalog.collections = [
+      // Can be converted to search category, will be persisted
+      {
+        label: null,
+        key: "dataset",
+        targetEntity: "item",
+        hidden: false,
+        scope: {
+          targetEntity: "item",
+          collection: "dataset",
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+      // 'all' _can_ be converted to a search category, but we explicitly do not persist it
+      {
+        label: null,
+        key: "all",
+        targetEntity: "item",
+        hidden: false,
+        scope: {
+          targetEntity: "item",
+          collection: "all" as WellKnownCollection,
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+      // Customer-defined collection, cannot be converted to search category
+      {
+        label: "My Custom Collection",
+        key: "custom-collection",
+        targetEntity: "event",
+        hidden: false,
+        scope: {
+          targetEntity: "event",
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+    ];
+
+    const result = reflectCollectionsToSearchCategories(site);
+    expect(result.data.values.searchCategories).toEqual([
+      {
+        key: SearchCategories.DATA,
+        hidden: false,
+        queryParams: {
+          collection: "Dataset",
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
1. Description:
Persisting logic for configuring site collections in workspaces, part of [7181](https://devtopia.esri.com/dc/hub/issues/7181)
Implements the site saving portion of [this ADR](https://confluencewikidev.esri.com/pages/viewpage.action?pageId=272826648)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
