### PR TITLE
feat: add more support and props for Hub Group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22644,10 +22644,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22662,24 +22661,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22693,10 +22689,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22714,10 +22709,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64972,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.25.0",
+			"version": "13.28.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64997,7 +64991,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "25.7.0",
+			"version": "25.8.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -83382,8 +83376,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83398,20 +83391,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83425,8 +83415,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83443,8 +83432,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -260,6 +260,7 @@ export const getContentTypeIcon = (contentType: string) => {
     geoprocessingService: "file",
     globeLayer: "layers",
     globeService: "file",
+    group: "users",
     hubInitiative: "initiative",
     hubInitiativeTemplate: "initiative-template",
     hubPage: "browser",

--- a/packages/common/src/core/fetchHubEntity.ts
+++ b/packages/common/src/core/fetchHubEntity.ts
@@ -7,6 +7,7 @@ import { fetchSite } from "../sites/HubSites";
 import { HubEntity } from "./types/HubEntity";
 import { HubEntityType } from "./types/HubEntityType";
 import { IArcGISContext } from "../ArcGISContext";
+import { fetchHubGroup } from "../groups/HubGroups";
 
 /**
  * Fetch a Hub entity by identifier (id or slug)
@@ -39,6 +40,10 @@ export async function fetchHubEntity(
       break;
     case "content":
       result = await fetchHubContent(identifier, context.requestOptions);
+      break;
+    case "group":
+      result = await fetchHubGroup(identifier, context.userRequestOptions);
+      break;
   }
   return result;
 }

--- a/packages/common/src/core/getTypeFromEntity.ts
+++ b/packages/common/src/core/getTypeFromEntity.ts
@@ -32,6 +32,9 @@ export function getTypeFromEntity(
     case "Discussion":
       type = "discussion";
       break;
+    case "Group":
+      type = "group";
+      break;
     default:
       // TODO: other families go here? feedback? solution? template?
       const contentFamilies = ["app", "content", "dataset", "document", "map"];

--- a/packages/common/src/core/types/HubEntity.ts
+++ b/packages/common/src/core/types/HubEntity.ts
@@ -10,9 +10,5 @@ export type HubEntity =
   | IHubProject
   | IHubDiscussion
   | IHubInitiative
-  | IHubPage;
-// TODO: leave IHubGroup commented out for now
-// so the package can build w/o throwing.
-// uncomment when changes are made to the getLocationExtent
-// and getFeaturedImageUrl fns
-// | IHubGroup;
+  | IHubPage
+  | IHubGroup;

--- a/packages/common/src/core/types/IHubGroup.ts
+++ b/packages/common/src/core/types/IHubGroup.ts
@@ -25,6 +25,16 @@ export interface IHubGroup extends IHubEntityBase, IWithPermissions {
   autoJoin?: boolean;
 
   /**
+   * Whether the user can edit the group, only owners and admins can
+   */
+  canEdit: boolean;
+
+  /**
+   * Whether the user can delete the group, only owners and admins can
+   */
+  canDelete: boolean;
+
+  /**
    * Description for the group
    */
   description?: string;

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -2,9 +2,8 @@ import { EntityCapabilities, ICapabilityPermission } from "../../capabilities";
 import { IPermissionPolicy } from "../../permissions";
 
 /**
- * Default capabilities for a Group. If not listed here, the capability will not be available
- * NOTE: We do not use the group capabilities right now as we do not
- * have a data store for it yet, leaving them here for the future
+ * Default capabilities for a Group.
+ * If not listed here, the capability will not be available
  * @private
  */
 export const GroupDefaultCapabilities: EntityCapabilities = {

--- a/packages/common/src/groups/_internal/computeProps.ts
+++ b/packages/common/src/groups/_internal/computeProps.ts
@@ -54,6 +54,17 @@ export function computeProps(
     hubGroup.membershipAccess = "collaborators";
   }
 
+  hubGroup.canEdit =
+    group.userMembership.memberType === "owner" ||
+    group.userMembership.memberType === "admin";
+  hubGroup.canDelete = hubGroup.canEdit;
+
+  // Handle capabilities
+  hubGroup.capabilities = processEntityCapabilities(
+    group.data?.settings?.capabilities || {},
+    GroupDefaultCapabilities
+  );
+
   // cast b/c this takes a partial but returns a full group
   return hubGroup as IHubGroup;
 }

--- a/packages/common/test/core/fetchHubEntity.test.ts
+++ b/packages/common/test/core/fetchHubEntity.test.ts
@@ -74,4 +74,15 @@ describe("fetchHubEntity:", () => {
     await fetchHubEntity("page", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
+  it("fetches group", async () => {
+    const ctx = {
+      userRequestOptions: "fakeRequestOptions",
+    } as unknown as IArcGISContext;
+    const spy = spyOn(
+      require("../../src/groups/HubGroups"),
+      "fetchHubGroup"
+    ).and.returnValue(Promise.resolve({}));
+    await fetchHubEntity("group", "123", ctx);
+    expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
+  });
 });

--- a/packages/common/test/core/getTypeFromEntity.test.ts
+++ b/packages/common/test/core/getTypeFromEntity.test.ts
@@ -22,6 +22,7 @@ describe("getTypeFromEntity:", () => {
       "Hub Project",
       "Hub Initiative",
       "Discussion",
+      "Group",
     ];
     const expected = [
       "site",
@@ -31,6 +32,7 @@ describe("getTypeFromEntity:", () => {
       "project",
       "initiative",
       "discussion",
+      "group",
     ];
     types.forEach((type, i) => {
       const entity = { type } as unknown as HubEntity;

--- a/packages/common/test/groups/HubGroups.test.ts
+++ b/packages/common/test/groups/HubGroups.test.ts
@@ -5,6 +5,7 @@ import {
   cloneObject,
   enrichGroupSearchResult,
   IHubRequestOptions,
+  setProp,
 } from "../../src";
 import * as HubGroupsModule from "../../src/groups/HubGroups";
 import * as FetchEnrichments from "../../src/groups/_internal/enrichments";
@@ -157,6 +158,9 @@ describe("HubGroups Module:", () => {
       ).and.callFake((group: IGroup) => {
         group.id = TEST_GROUP.id;
         group.description = TEST_GROUP.description;
+        group.group.userMembership = {
+          memberType: TEST_GROUP.userMembership?.memberType,
+        };
         return Promise.resolve(group);
       });
       const chk = await HubGroupsModule.createHubGroup(

--- a/packages/common/test/groups/_internal/computeProps.test.ts
+++ b/packages/common/test/groups/_internal/computeProps.test.ts
@@ -3,80 +3,145 @@ import { MOCK_AUTH } from "../../mocks/mock-auth";
 import { ArcGISContextManager } from "../../../src/ArcGISContextManager";
 import { computeProps } from "../../../src/groups/_internal/computeProps";
 import { IHubGroup } from "../../../src/core/types/IHubGroup";
+import * as processEntitiesModule from "../../../src/capabilities";
+import { GroupDefaultCapabilities } from "../../../src/groups/_internal/GroupBusinessRules";
+import { setProp } from "../../../src";
 
 describe("groups: computeProps:", () => {
+  let group: IGroup;
+  let hubGroup: Partial<IHubGroup>;
   let authdCtxMgr: ArcGISContextManager;
+  beforeEach(async () => {
+    group = {
+      id: "3ef",
+      name: "Test group",
+      created: 123456789,
+      modified: 123456789,
+      thumbnail: "group.jpg",
+      membershipAccess: "collaboration",
+      userMembership: {
+        memberType: "admin",
+      },
+    } as unknown as IGroup;
+    hubGroup = {
+      id: "3ef",
+      name: "Test group",
+    };
+    // When we pass in all this information, the context
+    // manager will not try to fetch anything, so no need
+    // to mock those calls
+    authdCtxMgr = await ArcGISContextManager.create({
+      authentication: MOCK_AUTH,
+      currentUser: {
+        username: "casey",
+        privileges: ["portal:user:createGroup"],
+      } as unknown as IUser,
+      portal: {
+        name: "DC R&D Center",
+        id: "BRXFAKE",
+        urlKey: "fake-org",
+        properties: {
+          hub: {
+            enabled: true,
+          },
+        },
+      } as unknown as IPortal,
+      portalUrl: "https://org.maps.arcgis.com",
+    });
+  });
   describe("computeProps:", () => {
-    it("computes the correct props", async () => {
-      // When we pass in all this information, the context
-      // manager will not try to fetch anything, so no need
-      // to mock those calls
-      authdCtxMgr = await ArcGISContextManager.create({
-        authentication: MOCK_AUTH,
-        currentUser: {
-          username: "casey",
-          privileges: ["portal:user:createGroup"],
-        } as unknown as IUser,
-        portal: {
-          name: "DC R&D Center",
-          id: "BRXFAKE",
-          urlKey: "fake-org",
-          properties: {
-            hub: {
-              enabled: true,
+    describe("computed props", () => {
+      it("computes the correct props", async () => {
+        const chk = computeProps(
+          group,
+          hubGroup,
+          authdCtxMgr.context.requestOptions
+        );
+        expect(chk.createdDate).toBeDefined();
+        expect(chk.createdDateSource).toBe("group.created");
+        expect(chk.updatedDate).toBeDefined();
+        expect(chk.updatedDateSource).toBe("group.modified");
+        expect(chk.isDiscussable).toBeTruthy();
+        expect(chk.thumbnailUrl).toBe(
+          "https://fake-org.undefined/sharing/rest/community/groups/3ef/info/group.jpg?token=fake-token"
+        );
+        expect(chk.membershipAccess).toBe("collaborators");
+        authdCtxMgr = await ArcGISContextManager.create({
+          authentication: undefined,
+          currentUser: {
+            username: "casey",
+            privileges: ["portal:user:createGroup"],
+          } as unknown as IUser,
+          portal: {
+            name: "DC R&D Center",
+            id: "BRXFAKE",
+            urlKey: "fake-org",
+            properties: {
+              hub: {
+                enabled: true,
+              },
             },
-          },
-        } as unknown as IPortal,
-        portalUrl: "https://org.maps.arcgis.com",
+          } as unknown as IPortal,
+          portalUrl: "https://org.maps.arcgis.com",
+        });
+        chk = computeProps(group, hubGroup, authdCtxMgr.context.requestOptions);
+        expect(chk.thumbnailUrl).toBe(
+          "https://org.maps.arcgis.com/sharing/rest/community/groups/3ef/info/group.jpg"
+        );
       });
-      const group = {
-        id: "3ef",
-        name: "Test group",
-        created: 123456789,
-        modified: 123456789,
-        thumbnail: "group.jpg",
-        membershipAccess: "collaboration",
-      } as unknown as IGroup;
-      const hubGroup: Partial<IHubGroup> = {
-        id: "3ef",
-        name: "Test group",
-      };
-      let chk = computeProps(
-        group,
-        hubGroup,
-        authdCtxMgr.context.requestOptions
-      );
-      expect(chk.createdDate).toBeDefined();
-      expect(chk.createdDateSource).toBe("group.created");
-      expect(chk.updatedDate).toBeDefined();
-      expect(chk.updatedDateSource).toBe("group.modified");
-      expect(chk.isDiscussable).toBeTruthy();
-      expect(chk.thumbnailUrl).toBe(
-        "https://fake-org.undefined/sharing/rest/community/groups/3ef/info/group.jpg?token=fake-token"
-      );
-      expect(chk.membershipAccess).toBe("collaborators");
-      authdCtxMgr = await ArcGISContextManager.create({
-        authentication: undefined,
-        currentUser: {
-          username: "casey",
-          privileges: ["portal:user:createGroup"],
-        } as unknown as IUser,
-        portal: {
-          name: "DC R&D Center",
-          id: "BRXFAKE",
-          urlKey: "fake-org",
-          properties: {
-            hub: {
-              enabled: true,
-            },
-          },
-        } as unknown as IPortal,
-        portalUrl: "https://org.maps.arcgis.com",
+    });
+    describe("capabilities:", () => {
+      it("handles missing settings hash", () => {
+        const spy = spyOn(
+          processEntitiesModule,
+          "processEntityCapabilities"
+        ).and.returnValue({ details: true, settings: false });
+        group.data = {};
+        const chk = computeProps(
+          group,
+          hubGroup,
+          authdCtxMgr.context.requestOptions
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(chk.capabilities?.details).toBeTruthy();
+        expect(chk.capabilities?.settings).toBeFalsy();
+        expect(spy).toHaveBeenCalledWith({}, GroupDefaultCapabilities);
       });
-      chk = computeProps(group, hubGroup, authdCtxMgr.context.requestOptions);
-      expect(chk.thumbnailUrl).toBe(
-        "https://org.maps.arcgis.com/sharing/rest/community/groups/3ef/info/group.jpg"
-      );
+      it("handles missing capabilities hash", () => {
+        const spy = spyOn(
+          processEntitiesModule,
+          "processEntityCapabilities"
+        ).and.returnValue({ details: true, settings: false });
+        setProp("data.settings", {}, group);
+        const chk = computeProps(
+          group,
+          hubGroup,
+          authdCtxMgr.context.requestOptions
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(chk.capabilities?.details).toBeTruthy();
+        expect(chk.capabilities?.settings).toBeFalsy();
+        expect(spy).toHaveBeenCalledWith({}, GroupDefaultCapabilities);
+      });
+      it("passes capabilities hash", () => {
+        const spy = spyOn(
+          processEntitiesModule,
+          "processEntityCapabilities"
+        ).and.returnValue({ details: true, settings: false });
+        setProp("data.settings.capabilities.details", true, group);
+        const chk = computeProps(
+          group,
+          hubGroup,
+          authdCtxMgr.context.requestOptions
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(
+          group.data?.settings?.capabilities,
+          GroupDefaultCapabilities
+        );
+        expect(chk.capabilities?.details).toBeTruthy();
+        expect(chk.capabilities?.settings).toBeFalsy();
+      });
     });
   });
 });

--- a/packages/common/test/groups/_internal/computeProps.test.ts
+++ b/packages/common/test/groups/_internal/computeProps.test.ts
@@ -52,7 +52,7 @@ describe("groups: computeProps:", () => {
   describe("computeProps:", () => {
     describe("computed props", () => {
       it("computes the correct props", async () => {
-        const chk = computeProps(
+        let chk = computeProps(
           group,
           hubGroup,
           authdCtxMgr.context.requestOptions


### PR DESCRIPTION
1. Description:

Add more support and props for Hub Group including:
- Add fetchHubGroup to fetchHubEntity so we can fetch groups
- ... (to be added)

1. Instructions for testing:

1. Closes Issues: [7169](https://zentopia.esri.com/workspaces/collaboration-sprint-board-614f9bfc0946c40011ef574e/issues/dc/hub/7169)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
