### PR TITLE
feat: added location picker to content details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64966,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.30.0",
+			"version": "13.33.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @esri/hub-common [13.32.2](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.32.1...@esri/hub-common@13.32.2) (2023-08-04)
+
+
+### Bug Fixes
+
+* remove name/title string as it is not wanted ([#1148](https://github.com/Esri/hub.js/issues/1148)) ([01018c9](https://github.com/Esri/hub.js/commit/01018c9a621db305d1e899631f8b3290cfa9f886))
+
 ## @esri/hub-common [13.32.1](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.32.0...@esri/hub-common@13.32.1) (2023-08-04)
 
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @esri/hub-common [13.33.2](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.33.1...@esri/hub-common@13.33.2) (2023-08-07)
+
+
+### Bug Fixes
+
+* reshuffle project edit schema ([#1149](https://github.com/Esri/hub.js/issues/1149)) ([13cb7ab](https://github.com/Esri/hub.js/commit/13cb7ab720eb495620f1f666e2f10d15c103a802))
+
 ## @esri/hub-common [13.33.1](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.33.0...@esri/hub-common@13.33.1) (2023-08-07)
 
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,10 @@
+# @esri/hub-common [13.32.0](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.31.0...@esri/hub-common@13.32.0) (2023-08-03)
+
+
+### Features
+
+* **hub-common:** persist modifications to site collections via updateSite ([#1139](https://github.com/Esri/hub.js/issues/1139)) ([147b7fc](https://github.com/Esri/hub.js/commit/147b7fce1856aec3c6c830b6196d0856d8458626))
+
 # @esri/hub-common [13.31.0](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.30.0...@esri/hub-common@13.31.0) (2023-08-03)
 
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,10 @@
+# @esri/hub-common [13.33.0](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.32.2...@esri/hub-common@13.33.0) (2023-08-07)
+
+
+### Features
+
+* add more support and props for Hub Group ([#1143](https://github.com/Esri/hub.js/issues/1143)) ([bbdc300](https://github.com/Esri/hub.js/commit/bbdc300a8c74641929d6e4e68869866ef2401ee8))
+
 ## @esri/hub-common [13.32.2](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.32.1...@esri/hub-common@13.32.2) (2023-08-04)
 
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @esri/hub-common [13.32.1](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.32.0...@esri/hub-common@13.32.1) (2023-08-04)
+
+
+### Bug Fixes
+
+* actually export new function from index ([#1147](https://github.com/Esri/hub.js/issues/1147)) ([5d515d4](https://github.com/Esri/hub.js/commit/5d515d451a84dbe2d86c6070a0c97fb4b7ecee9e))
+
 # @esri/hub-common [13.32.0](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.31.0...@esri/hub-common@13.32.0) (2023-08-03)
 
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @esri/hub-common [13.33.1](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.33.0...@esri/hub-common@13.33.1) (2023-08-07)
+
+
+### Bug Fixes
+
+* handle new discussion entity ([#1146](https://github.com/Esri/hub.js/issues/1146)) ([2f395bc](https://github.com/Esri/hub.js/commit/2f395bccd94ca5f26cb82b8cbcd766de5b8752b8))
+
 # @esri/hub-common [13.33.0](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.32.2...@esri/hub-common@13.33.0) (2023-08-07)
 
 

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.33.1",
+  "version": "13.33.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@esri/hub-common",
-      "version": "13.33.1",
+      "version": "13.33.2",
       "license": "Apache-2.0",
       "dependencies": {
         "abab": "^2.0.5",

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.31.0",
+  "version": "13.32.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@esri/hub-common",
-      "version": "13.31.0",
+      "version": "13.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "abab": "^2.0.5",

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.32.1",
+  "version": "13.32.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@esri/hub-common",
-      "version": "13.32.1",
+      "version": "13.32.2",
       "license": "Apache-2.0",
       "dependencies": {
         "abab": "^2.0.5",

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.32.0",
+  "version": "13.32.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@esri/hub-common",
-      "version": "13.32.0",
+      "version": "13.32.1",
       "license": "Apache-2.0",
       "dependencies": {
         "abab": "^2.0.5",

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.32.2",
+  "version": "13.33.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@esri/hub-common",
-      "version": "13.32.2",
+      "version": "13.33.0",
       "license": "Apache-2.0",
       "dependencies": {
         "abab": "^2.0.5",

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.33.0",
+  "version": "13.33.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@esri/hub-common",
-      "version": "13.33.0",
+      "version": "13.33.1",
       "license": "Apache-2.0",
       "dependencies": {
         "abab": "^2.0.5",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.33.1",
+  "version": "13.33.2",
   "description": "Common TypeScript types and utility functions for @esri/hub.js.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.32.0",
+  "version": "13.32.1",
   "description": "Common TypeScript types and utility functions for @esri/hub.js.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.33.0",
+  "version": "13.33.1",
   "description": "Common TypeScript types and utility functions for @esri/hub.js.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.32.2",
+  "version": "13.33.0",
   "description": "Common TypeScript types and utility functions for @esri/hub.js.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.32.1",
+  "version": "13.32.2",
   "description": "Common TypeScript types and utility functions for @esri/hub.js.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.31.0",
+  "version": "13.32.0",
   "description": "Common TypeScript types and utility functions for @esri/hub.js.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",

--- a/packages/common/src/content/HubContent.ts
+++ b/packages/common/src/content/HubContent.ts
@@ -14,6 +14,7 @@ import { IWithStoreBehavior } from "../core/behaviors/IWithStoreBehavior";
 import { getEditorConfig } from "../core/schemas/getEditorConfig";
 import { IEntityEditorContext } from "../core/types/HubEntityEditor";
 import { cloneObject } from "../util";
+import { editorToContent } from "./edit";
 
 export class HubContent
   extends HubItemEntity<IHubEditableContent>
@@ -145,7 +146,7 @@ export class HubContent
 
     // convert back to an entity. Apply any reverse transforms used in
     // of the toEditor method
-    const entity = cloneObject(editor) as IHubEditableContent;
+    const entity = editorToContent(editor, this.context.portal);
 
     // copy the location extent up one level
     entity.extent = editor.location?.extent;

--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -97,23 +97,24 @@ export const uiSchema: IUiSchema = {
         },
       ],
     },
-    // { // TODO: in another PR
-    //   type: "Section",
-    //   labelKey: "{{i18nScope}}.sections.location.label",
-    //   options: {
-    //     helperText: {
-    //       labelKey: "{{i18nScope}}.sections.location.helperText",
-    //     },
-    //   },
-    //   elements: [
-    //     {
-    //       scope: "/properties/location",
-    //       type: "Control",
-    //       options: {
-    //         control: "hub-field-input-location-picker",
-    //       },
-    //     },
-    //   ],
-    // },
+    // location section
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.location.label",
+      options: {
+        helperText: {
+          labelKey: "{{i18nScope}}.sections.location.helperText",
+        },
+      },
+      elements: [
+        {
+          scope: "/properties/location",
+          type: "Control",
+          options: {
+            control: "hub-field-input-location-picker",
+          },
+        },
+      ],
+    },
   ],
 };

--- a/packages/common/src/content/_internal/getPropertyMap.ts
+++ b/packages/common/src/content/_internal/getPropertyMap.ts
@@ -24,11 +24,10 @@ export function getPropertyMap(): IPropertyMap[] {
     storeKey: "data.settings.capabilities",
   });
 
-  // TODO: (Aaron) looking ahead for adding location, I'm pretty sure we'll want this in the next PR
-  // map.push({
-  //   entityKey: "location",
-  //   storeKey: "item.properties.location",
-  // });
+  map.push({
+    entityKey: "location",
+    storeKey: "item.properties.location",
+  });
 
   // TODO: look into composeContent() for what we can add here
 

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -260,6 +260,7 @@ export const getContentTypeIcon = (contentType: string) => {
     geoprocessingService: "file",
     globeLayer: "layers",
     globeService: "file",
+    group: "users",
     hubInitiative: "initiative",
     hubInitiativeTemplate: "initiative-template",
     hubPage: "browser",

--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -1,10 +1,11 @@
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import {
+  IPortal,
   IUserItemOptions,
   getItem,
   removeItem,
 } from "@esri/arcgis-rest-portal";
-import { IHubEditableContent } from "../core";
+import { IHubContent, IHubContentEditor, IHubEditableContent } from "../core";
 
 // Note - we separate these imports so we can cleanly spy on things in tests
 import {
@@ -142,4 +143,26 @@ export async function deleteContent(
   const ro = { ...requestOptions, ...{ id } } as IUserItemOptions;
   await removeItem(ro);
   return;
+}
+
+/**
+ * Convert a IHubContentEditor back to an IHubContent
+ * @param editor
+ * @param portal
+ * @returns
+ */
+export function editorToContent(
+  editor: IHubContentEditor,
+  portal: IPortal
+): IHubEditableContent {
+  // remove the ephemeral props we graft on for the editor
+  // delete editor._groups; // don't think we need this?
+  // clone into a HubProject
+  const content = cloneObject(editor) as IHubEditableContent;
+  // ensure there's an org url key
+  // content.orgUrlKey = editor.orgUrlKey ? editor.orgUrlKey : portal.urlKey; // don't think we need this?
+  // copy the location extent up one level
+  content.extent = editor.location?.extent;
+  // return with a cast
+  return content;
 }

--- a/packages/common/src/core/fetchHubEntity.ts
+++ b/packages/common/src/core/fetchHubEntity.ts
@@ -7,6 +7,7 @@ import { fetchSite } from "../sites/HubSites";
 import { HubEntity } from "./types/HubEntity";
 import { HubEntityType } from "./types/HubEntityType";
 import { IArcGISContext } from "../ArcGISContext";
+import { fetchHubGroup } from "../groups/HubGroups";
 
 /**
  * Fetch a Hub entity by identifier (id or slug)
@@ -39,6 +40,10 @@ export async function fetchHubEntity(
       break;
     case "content":
       result = await fetchHubContent(identifier, context.requestOptions);
+      break;
+    case "group":
+      result = await fetchHubGroup(identifier, context.userRequestOptions);
+      break;
   }
   return result;
 }

--- a/packages/common/src/core/getTypeFromEntity.ts
+++ b/packages/common/src/core/getTypeFromEntity.ts
@@ -32,6 +32,9 @@ export function getTypeFromEntity(
     case "Discussion":
       type = "discussion";
       break;
+    case "Group":
+      type = "group";
+      break;
     default:
       // TODO: other families go here? feedback? solution? template?
       const contentFamilies = ["app", "content", "dataset", "document", "map"];

--- a/packages/common/src/core/types/HubEntity.ts
+++ b/packages/common/src/core/types/HubEntity.ts
@@ -10,9 +10,5 @@ export type HubEntity =
   | IHubProject
   | IHubDiscussion
   | IHubInitiative
-  | IHubPage;
-// TODO: leave IHubGroup commented out for now
-// so the package can build w/o throwing.
-// uncomment when changes are made to the getLocationExtent
-// and getFeaturedImageUrl fns
-// | IHubGroup;
+  | IHubPage
+  | IHubGroup;

--- a/packages/common/src/core/types/IHubGroup.ts
+++ b/packages/common/src/core/types/IHubGroup.ts
@@ -25,6 +25,16 @@ export interface IHubGroup extends IHubEntityBase, IWithPermissions {
   autoJoin?: boolean;
 
   /**
+   * Whether the user can edit the group, only owners and admins can
+   */
+  canEdit: boolean;
+
+  /**
+   * Whether the user can delete the group, only owners and admins can
+   */
+  canDelete: boolean;
+
+  /**
    * Description for the group
    */
   description?: string;

--- a/packages/common/src/discussions/HubDiscussion.ts
+++ b/packages/common/src/discussions/HubDiscussion.ts
@@ -187,8 +187,6 @@ export class HubDiscussion
    * @returns
    */
   async fromEditor(editor: IHubDiscussionEditor): Promise<IHubDiscussion> {
-    const isCreate = !editor.id;
-
     // Setting the thumbnailCache will ensure that
     // the thumbnail is updated on next save
     if (editor._thumbnail) {
@@ -214,14 +212,9 @@ export class HubDiscussion
     // copy the location extent up one level
     entity.extent = editor.location?.extent;
 
-    // create it if it does not yet exist...
-    if (isCreate) {
-      throw new Error("Cannot create content using the Editor.");
-    } else {
-      // ...otherwise, update the in-memory entity and save it
-      this.entity = entity;
-      this.save();
-    }
+    // Save, which will also create new content if new
+    this.entity = entity;
+    await this.save();
 
     return this.entity;
   }

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -2,9 +2,8 @@ import { EntityCapabilities, ICapabilityPermission } from "../../capabilities";
 import { IPermissionPolicy } from "../../permissions";
 
 /**
- * Default capabilities for a Group. If not listed here, the capability will not be available
- * NOTE: We do not use the group capabilities right now as we do not
- * have a data store for it yet, leaving them here for the future
+ * Default capabilities for a Group.
+ * If not listed here, the capability will not be available
  * @private
  */
 export const GroupDefaultCapabilities: EntityCapabilities = {

--- a/packages/common/src/groups/_internal/computeProps.ts
+++ b/packages/common/src/groups/_internal/computeProps.ts
@@ -54,6 +54,17 @@ export function computeProps(
     hubGroup.membershipAccess = "collaborators";
   }
 
+  hubGroup.canEdit =
+    group.userMembership.memberType === "owner" ||
+    group.userMembership.memberType === "admin";
+  hubGroup.canDelete = hubGroup.canEdit;
+
+  // Handle capabilities
+  hubGroup.capabilities = processEntityCapabilities(
+    group.data?.settings?.capabilities || {},
+    GroupDefaultCapabilities
+  );
+
   // cast b/c this takes a partial but returns a full group
   return hubGroup as IHubGroup;
 }

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -52,20 +52,6 @@ export const uiSchema: IUiSchema = {
           },
         },
         {
-          labelKey: "{{i18nScope}}.fields._thumbnail.label",
-          scope: "/properties/_thumbnail",
-          type: "Control",
-          options: {
-            control: "hub-field-input-image-picker",
-            maxWidth: 727,
-            maxHeight: 484,
-            aspectRatio: 1.5,
-            helperText: {
-              labelKey: "{{i18nScope}}.fields._thumbnail.helperText",
-            },
-          },
-        },
-        {
           labelKey: "{{i18nScope}}.fields.featuredImage.label",
           scope: "/properties/view/properties/featuredImage",
           type: "Control",
@@ -92,6 +78,30 @@ export const uiSchema: IUiSchema = {
             },
           },
         },
+      ],
+    },
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.location.label",
+      options: {
+        helperText: {
+          labelKey: "{{i18nScope}}.sections.location.helperText",
+        },
+      },
+      elements: [
+        {
+          scope: "/properties/location",
+          type: "Control",
+          options: {
+            control: "hub-field-input-location-picker",
+          },
+        },
+      ],
+    },
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.searchDiscoverability.label",
+      elements: [
         {
           labelKey: "{{i18nScope}}.fields.tags.label",
           scope: "/properties/tags",
@@ -118,22 +128,21 @@ export const uiSchema: IUiSchema = {
             },
           },
         },
-      ],
-    },
-    {
-      type: "Section",
-      labelKey: "{{i18nScope}}.sections.location.label",
-      options: {
-        helperText: {
-          labelKey: "{{i18nScope}}.sections.location.helperText",
-        },
-      },
-      elements: [
         {
-          scope: "/properties/location",
+          labelKey: "{{i18nScope}}.fields._thumbnail.label",
+          scope: "/properties/_thumbnail",
           type: "Control",
           options: {
-            control: "hub-field-input-location-picker",
+            control: "hub-field-input-image-picker",
+            maxWidth: 727,
+            maxHeight: 484,
+            aspectRatio: 1.5,
+            helperText: {
+              labelKey: "{{i18nScope}}.fields._thumbnail.helperText",
+            },
+            sizeDescription: {
+              labelKey: "{{i18nScope}}.fields._thumbnail.sizeDescription",
+            },
           },
         },
       ],

--- a/packages/common/src/projects/defaults.ts
+++ b/packages/common/src/projects/defaults.ts
@@ -8,7 +8,7 @@ export const HUB_PROJECT_ITEM_TYPE = "Hub Project";
  */
 export const DEFAULT_PROJECT: Partial<IHubProject> = {
   catalog: { schemaVersion: 0 },
-  name: "No title provided",
+  name: "",
   permissions: [],
   schemaVersion: 1,
   status: PROJECT_STATUSES.notStarted,
@@ -27,7 +27,7 @@ export const DEFAULT_PROJECT: Partial<IHubProject> = {
 export const DEFAULT_PROJECT_MODEL: IModel = {
   item: {
     type: HUB_PROJECT_ITEM_TYPE,
-    title: "No Title Provided",
+    title: "",
     description: "",
     snippet: "",
     tags: [],

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -35,6 +35,7 @@ import { getItemThumbnailUrl } from "../resources/get-item-thumbnail-url";
 import { applyCatalogStructureMigration } from "./_internal/applyCatalogStructureMigration";
 import { setDiscussableKeyword } from "../discussions";
 import { applyDefaultCollectionMigration } from "./_internal/applyDefaultCollectionMigration";
+import { reflectCollectionsToSearchCategories } from "./_internal/reflectCollectionsToSearchCategories";
 export const HUB_SITE_ITEM_TYPE = "Hub Site Application";
 export const ENTERPRISE_SITE_ITEM_TYPE = "Site Application";
 
@@ -326,17 +327,22 @@ export async function updateSite(
   const mapper = new PropertyMapper<Partial<IHubSite>, IModel>(
     getPropertyMap()
   );
-  const modelToUpdate = mapper.entityToStore(site, currentModel);
+  let modelToUpdate = mapper.entityToStore(site, currentModel);
 
   // handle any domain changes
   await handleDomainChanges(modelToUpdate, currentModel, requestOptions);
 
-  // The following props are currently affected by in-memory migrations,
-  // so we replace them with their canonical values so as to not overwrite
-  // them. Eventually these changes will be persisted in AGO.
+  // Because some old (but critical) application code still uses `data.values.searchCategories`
+  // as the source of truth for collection display configuration, we port all display changes
+  // in `data.catalog.collections` to the search category format.
+  // TODO: Remove once the app no longer relies on `data.values.searchCategories`
+  modelToUpdate = reflectCollectionsToSearchCategories(modelToUpdate);
+  // At this point `data.catalog` has become a full IHubCatalog object due to an in-memory
+  // migration. However, we can't persist an IHubCatalog in `data.catalog` without breaking
+  // the application, since most of the app relies on the old catalog structure. As such,
+  // we just persist the old catalog structure from the most current model.
+  // TODO: Remove once the application is plumbed to work off an IHubCatalog
   modelToUpdate.data.catalog = currentModel.data.catalog;
-  modelToUpdate.data.values.searchCategories =
-    currentModel.data.values.searchCategories;
 
   // send updates to the Portal API and get back the updated site model
   const updatedSiteModel = await updateModel(

--- a/packages/common/src/sites/_internal/reflectCollectionsToSearchCategories.ts
+++ b/packages/common/src/sites/_internal/reflectCollectionsToSearchCategories.ts
@@ -1,0 +1,68 @@
+import { WellKnownCollection } from "../../search";
+import { IHubCollectionPersistance } from "../../search/types/IHubCatalog";
+import { IModel } from "../../types";
+import { cloneObject } from "../../util";
+import { SearchCategories } from "./types";
+
+/**
+ * Reflects changes from a site model's collections to the `site.data.values.searchCategories`
+ * legacy property. This is a needed stop-gap since old search page will coexist for a time with
+ * the new workspaces UI and the old search page (among others) still rely on the `searchCategories`
+ * construct.
+ *
+ * @param model a site item model
+ * @returns a model with the catalog collections and search categories in sync
+ */
+export function reflectCollectionsToSearchCategories(model: IModel) {
+  const clone = cloneObject(model);
+  const collectionToSearchCategory: Partial<
+    Record<WellKnownCollection, SearchCategories>
+  > = {
+    dataset: SearchCategories.DATA,
+    // NOTE: the `searchCategories` construct actually has two possible labels for the
+    // `site` collection: "Sites" or "Initiatives". "Sites" is used if a site was created
+    // with Hub Basic, "Initiatives" was used if a site was created with Hub Premium.
+    // Since the new search page only uses "Sites", we've opted to ignore "Initiatives"
+    site: SearchCategories.SITES,
+    appAndMap: SearchCategories.APPS_AND_MAPS,
+    document: SearchCategories.DOCUMENTS,
+  };
+
+  const searchCategoryToQueryParam: Partial<Record<SearchCategories, string>> =
+    {
+      [SearchCategories.DATA]: "Dataset",
+      [SearchCategories.SITES]: "Site",
+      [SearchCategories.APPS_AND_MAPS]: "App,Map",
+      [SearchCategories.DOCUMENTS]: "Document",
+    };
+  const collections: IHubCollectionPersistance[] =
+    clone.data.catalog.collections;
+
+  const updatedSearchCategories = collections
+    // We don't want to persist any non-standard collection as a search category,
+    // such as the "all" collection
+    .filter((c) => !!collectionToSearchCategory[c.key as WellKnownCollection])
+    .map((c) => {
+      const searchCategoryKey =
+        collectionToSearchCategory[c.key as WellKnownCollection];
+      const updated: any = {
+        hidden: c.hidden,
+        key: searchCategoryKey,
+        queryParams: {
+          collection: searchCategoryToQueryParam[searchCategoryKey],
+        },
+      };
+
+      // If `c.label` is falsy, we assume that the UI should display the
+      // default translated label for that collection. We also assume that if
+      // `c.label` _does_ have a value, then it must be a configured override.
+      if (c.label) {
+        updated.overrideText = c.label;
+      }
+
+      return updated;
+    });
+
+  clone.data.values.searchCategories = updatedSearchCategories;
+  return clone;
+}

--- a/packages/common/src/sites/_internal/types.ts
+++ b/packages/common/src/sites/_internal/types.ts
@@ -1,0 +1,10 @@
+export enum SearchCategories {
+  DATA = "components.search.category_tabs.data",
+  SITES = "components.search.category_tabs.sites",
+  DOCUMENTS = "components.search.category_tabs.documents",
+  APPS_AND_MAPS = "components.search.category_tabs.apps_and_maps",
+
+  // The following entries are currently used, but will be phased out
+  EVENTS = "components.search.category_tabs.events",
+  INITIATIVES = "components.search.category_tabs.initiatives",
+}

--- a/packages/common/src/users/index.ts
+++ b/packages/common/src/users/index.ts
@@ -1,1 +1,2 @@
 export * from "./HubUsers";
+export * from "./view";

--- a/packages/common/test/core/fetchHubEntity.test.ts
+++ b/packages/common/test/core/fetchHubEntity.test.ts
@@ -74,4 +74,15 @@ describe("fetchHubEntity:", () => {
     await fetchHubEntity("page", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
+  it("fetches group", async () => {
+    const ctx = {
+      userRequestOptions: "fakeRequestOptions",
+    } as unknown as IArcGISContext;
+    const spy = spyOn(
+      require("../../src/groups/HubGroups"),
+      "fetchHubGroup"
+    ).and.returnValue(Promise.resolve({}));
+    await fetchHubEntity("group", "123", ctx);
+    expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
+  });
 });

--- a/packages/common/test/core/getTypeFromEntity.test.ts
+++ b/packages/common/test/core/getTypeFromEntity.test.ts
@@ -22,6 +22,7 @@ describe("getTypeFromEntity:", () => {
       "Hub Project",
       "Hub Initiative",
       "Discussion",
+      "Group",
     ];
     const expected = [
       "site",
@@ -31,6 +32,7 @@ describe("getTypeFromEntity:", () => {
       "project",
       "initiative",
       "discussion",
+      "group",
     ];
     types.forEach((type, i) => {
       const entity = { type } as unknown as HubEntity;

--- a/packages/common/test/groups/HubGroups.test.ts
+++ b/packages/common/test/groups/HubGroups.test.ts
@@ -5,6 +5,7 @@ import {
   cloneObject,
   enrichGroupSearchResult,
   IHubRequestOptions,
+  setProp,
 } from "../../src";
 import * as HubGroupsModule from "../../src/groups/HubGroups";
 import * as FetchEnrichments from "../../src/groups/_internal/enrichments";
@@ -157,6 +158,9 @@ describe("HubGroups Module:", () => {
       ).and.callFake((group: IGroup) => {
         group.id = TEST_GROUP.id;
         group.description = TEST_GROUP.description;
+        group.group.userMembership = {
+          memberType: TEST_GROUP.userMembership?.memberType,
+        };
         return Promise.resolve(group);
       });
       const chk = await HubGroupsModule.createHubGroup(

--- a/packages/common/test/groups/_internal/computeProps.test.ts
+++ b/packages/common/test/groups/_internal/computeProps.test.ts
@@ -3,80 +3,145 @@ import { MOCK_AUTH } from "../../mocks/mock-auth";
 import { ArcGISContextManager } from "../../../src/ArcGISContextManager";
 import { computeProps } from "../../../src/groups/_internal/computeProps";
 import { IHubGroup } from "../../../src/core/types/IHubGroup";
+import * as processEntitiesModule from "../../../src/capabilities";
+import { GroupDefaultCapabilities } from "../../../src/groups/_internal/GroupBusinessRules";
+import { setProp } from "../../../src";
 
 describe("groups: computeProps:", () => {
+  let group: IGroup;
+  let hubGroup: Partial<IHubGroup>;
   let authdCtxMgr: ArcGISContextManager;
+  beforeEach(async () => {
+    group = {
+      id: "3ef",
+      name: "Test group",
+      created: 123456789,
+      modified: 123456789,
+      thumbnail: "group.jpg",
+      membershipAccess: "collaboration",
+      userMembership: {
+        memberType: "admin",
+      },
+    } as unknown as IGroup;
+    hubGroup = {
+      id: "3ef",
+      name: "Test group",
+    };
+    // When we pass in all this information, the context
+    // manager will not try to fetch anything, so no need
+    // to mock those calls
+    authdCtxMgr = await ArcGISContextManager.create({
+      authentication: MOCK_AUTH,
+      currentUser: {
+        username: "casey",
+        privileges: ["portal:user:createGroup"],
+      } as unknown as IUser,
+      portal: {
+        name: "DC R&D Center",
+        id: "BRXFAKE",
+        urlKey: "fake-org",
+        properties: {
+          hub: {
+            enabled: true,
+          },
+        },
+      } as unknown as IPortal,
+      portalUrl: "https://org.maps.arcgis.com",
+    });
+  });
   describe("computeProps:", () => {
-    it("computes the correct props", async () => {
-      // When we pass in all this information, the context
-      // manager will not try to fetch anything, so no need
-      // to mock those calls
-      authdCtxMgr = await ArcGISContextManager.create({
-        authentication: MOCK_AUTH,
-        currentUser: {
-          username: "casey",
-          privileges: ["portal:user:createGroup"],
-        } as unknown as IUser,
-        portal: {
-          name: "DC R&D Center",
-          id: "BRXFAKE",
-          urlKey: "fake-org",
-          properties: {
-            hub: {
-              enabled: true,
+    describe("computed props", () => {
+      it("computes the correct props", async () => {
+        let chk = computeProps(
+          group,
+          hubGroup,
+          authdCtxMgr.context.requestOptions
+        );
+        expect(chk.createdDate).toBeDefined();
+        expect(chk.createdDateSource).toBe("group.created");
+        expect(chk.updatedDate).toBeDefined();
+        expect(chk.updatedDateSource).toBe("group.modified");
+        expect(chk.isDiscussable).toBeTruthy();
+        expect(chk.thumbnailUrl).toBe(
+          "https://fake-org.undefined/sharing/rest/community/groups/3ef/info/group.jpg?token=fake-token"
+        );
+        expect(chk.membershipAccess).toBe("collaborators");
+        authdCtxMgr = await ArcGISContextManager.create({
+          authentication: undefined,
+          currentUser: {
+            username: "casey",
+            privileges: ["portal:user:createGroup"],
+          } as unknown as IUser,
+          portal: {
+            name: "DC R&D Center",
+            id: "BRXFAKE",
+            urlKey: "fake-org",
+            properties: {
+              hub: {
+                enabled: true,
+              },
             },
-          },
-        } as unknown as IPortal,
-        portalUrl: "https://org.maps.arcgis.com",
+          } as unknown as IPortal,
+          portalUrl: "https://org.maps.arcgis.com",
+        });
+        chk = computeProps(group, hubGroup, authdCtxMgr.context.requestOptions);
+        expect(chk.thumbnailUrl).toBe(
+          "https://org.maps.arcgis.com/sharing/rest/community/groups/3ef/info/group.jpg"
+        );
       });
-      const group = {
-        id: "3ef",
-        name: "Test group",
-        created: 123456789,
-        modified: 123456789,
-        thumbnail: "group.jpg",
-        membershipAccess: "collaboration",
-      } as unknown as IGroup;
-      const hubGroup: Partial<IHubGroup> = {
-        id: "3ef",
-        name: "Test group",
-      };
-      let chk = computeProps(
-        group,
-        hubGroup,
-        authdCtxMgr.context.requestOptions
-      );
-      expect(chk.createdDate).toBeDefined();
-      expect(chk.createdDateSource).toBe("group.created");
-      expect(chk.updatedDate).toBeDefined();
-      expect(chk.updatedDateSource).toBe("group.modified");
-      expect(chk.isDiscussable).toBeTruthy();
-      expect(chk.thumbnailUrl).toBe(
-        "https://fake-org.undefined/sharing/rest/community/groups/3ef/info/group.jpg?token=fake-token"
-      );
-      expect(chk.membershipAccess).toBe("collaborators");
-      authdCtxMgr = await ArcGISContextManager.create({
-        authentication: undefined,
-        currentUser: {
-          username: "casey",
-          privileges: ["portal:user:createGroup"],
-        } as unknown as IUser,
-        portal: {
-          name: "DC R&D Center",
-          id: "BRXFAKE",
-          urlKey: "fake-org",
-          properties: {
-            hub: {
-              enabled: true,
-            },
-          },
-        } as unknown as IPortal,
-        portalUrl: "https://org.maps.arcgis.com",
+    });
+    describe("capabilities:", () => {
+      it("handles missing settings hash", () => {
+        const spy = spyOn(
+          processEntitiesModule,
+          "processEntityCapabilities"
+        ).and.returnValue({ details: true, settings: false });
+        group.data = {};
+        const chk = computeProps(
+          group,
+          hubGroup,
+          authdCtxMgr.context.requestOptions
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(chk.capabilities?.details).toBeTruthy();
+        expect(chk.capabilities?.settings).toBeFalsy();
+        expect(spy).toHaveBeenCalledWith({}, GroupDefaultCapabilities);
       });
-      chk = computeProps(group, hubGroup, authdCtxMgr.context.requestOptions);
-      expect(chk.thumbnailUrl).toBe(
-        "https://org.maps.arcgis.com/sharing/rest/community/groups/3ef/info/group.jpg"
-      );
+      it("handles missing capabilities hash", () => {
+        const spy = spyOn(
+          processEntitiesModule,
+          "processEntityCapabilities"
+        ).and.returnValue({ details: true, settings: false });
+        setProp("data.settings", {}, group);
+        const chk = computeProps(
+          group,
+          hubGroup,
+          authdCtxMgr.context.requestOptions
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(chk.capabilities?.details).toBeTruthy();
+        expect(chk.capabilities?.settings).toBeFalsy();
+        expect(spy).toHaveBeenCalledWith({}, GroupDefaultCapabilities);
+      });
+      it("passes capabilities hash", () => {
+        const spy = spyOn(
+          processEntitiesModule,
+          "processEntityCapabilities"
+        ).and.returnValue({ details: true, settings: false });
+        setProp("data.settings.capabilities.details", true, group);
+        const chk = computeProps(
+          group,
+          hubGroup,
+          authdCtxMgr.context.requestOptions
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(
+          group.data?.settings?.capabilities,
+          GroupDefaultCapabilities
+        );
+        expect(chk.capabilities?.details).toBeTruthy();
+        expect(chk.capabilities?.settings).toBeFalsy();
+      });
     });
   });
 });

--- a/packages/common/test/sites/_internal/applyDefaultCollectionMigration.test.ts
+++ b/packages/common/test/sites/_internal/applyDefaultCollectionMigration.test.ts
@@ -1,0 +1,157 @@
+import { IHubCollectionPersistance } from "../../../src/search/types/IHubCatalog";
+import { applyDefaultCollectionMigration } from "../../../src/sites/_internal/applyDefaultCollectionMigration";
+import { SearchCategories } from "../../../src/sites/_internal/types";
+import { IModel } from "../../../src/types";
+import { cloneObject } from "../../../src/util";
+
+const BASE_MODEL = {
+  data: {
+    catalog: {
+      schemaVersion: 1,
+      title: "Default Site Catalog",
+      scopes: {
+        item: {
+          targetEntity: "item",
+          filters: [],
+        },
+      },
+      collections: [],
+    },
+    values: {},
+  },
+} as unknown as IModel;
+
+describe("applyDefaultCollectionMigration", () => {
+  let site: IModel;
+
+  beforeEach(() => {
+    site = cloneObject(BASE_MODEL);
+  });
+
+  it("Adds untouched default collections when no search categories are configured", () => {
+    const result = applyDefaultCollectionMigration(site);
+    const collectionKeys = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.key
+    );
+    expect(collectionKeys).toEqual([
+      "all",
+      "site",
+      "dataset",
+      "document",
+      "appAndMap",
+    ]);
+    const collectionLabels = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.label
+    );
+    expect(collectionLabels).toEqual([null, null, null, null, null]);
+    const hiddenStatuses = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.hidden
+    );
+    expect(hiddenStatuses).toEqual([
+      undefined,
+      true,
+      undefined,
+      undefined,
+      undefined,
+    ]);
+  });
+
+  it("Reorders, re-labels, and hides default collections when search categories are configured", () => {
+    site.data.values.searchCategories = [
+      {
+        key: SearchCategories.APPS_AND_MAPS,
+      },
+      {
+        key: SearchCategories.DOCUMENTS,
+        hidden: true,
+      },
+      {
+        overrideText: "My Sites",
+        key: SearchCategories.SITES,
+        hidden: false,
+      },
+      {
+        overrideText: "My Data",
+        key: SearchCategories.DATA,
+        hidden: false,
+      },
+    ];
+    const result = applyDefaultCollectionMigration(site);
+    const collectionKeys = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.key
+    );
+    // Note: 'all' collection is always prepended
+    expect(collectionKeys).toEqual([
+      "all",
+      "appAndMap",
+      "document",
+      "site",
+      "dataset",
+    ]);
+
+    const collectionLabels = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.label
+    );
+    expect(collectionLabels).toEqual([null, null, null, "My Sites", "My Data"]);
+
+    const hiddenStatuses = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.hidden
+    );
+    expect(hiddenStatuses).toEqual([undefined, undefined, true, false, false]);
+  });
+
+  it("Handles when a site has the 'initiatives' search category saved", () => {
+    site.data.values.searchCategories = [
+      {
+        overrideText: "My Initiatives",
+        key: SearchCategories.INITIATIVES,
+        hidden: true,
+      },
+    ];
+    const result = applyDefaultCollectionMigration(site);
+    const collectionKeys = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.key
+    );
+    // Note: 'all' collection is always prepended
+    expect(collectionKeys).toEqual(["all", "site"]);
+
+    const collectionLabels = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.label
+    );
+    expect(collectionLabels).toEqual([null, "My Initiatives"]);
+
+    const hiddenStatuses = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.hidden
+    );
+    expect(hiddenStatuses).toEqual([undefined, true]);
+  });
+
+  it("Omits unsupported search categories, like an explicit 'all' or events", () => {
+    site.data.values.searchCategories = [
+      {
+        key: SearchCategories.EVENTS,
+      },
+      {
+        overrideText: "Bad Title",
+        key: "components.search.category_tabs.all",
+        hidden: true,
+      },
+    ];
+    const result = applyDefaultCollectionMigration(site);
+    const collectionKeys = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.key
+    );
+    // Note: 'all' collection can never be relabeled, hidden, or reordered
+    expect(collectionKeys).toEqual(["all"]);
+
+    const collectionLabels = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.label
+    );
+    expect(collectionLabels).toEqual([null]);
+
+    const hiddenStatuses = result.data.catalog.collections.map(
+      (c: IHubCollectionPersistance) => c.hidden
+    );
+    expect(hiddenStatuses).toEqual([undefined]);
+  });
+});

--- a/packages/common/test/sites/_internal/reflectCollectionsToSearchCategories.test.ts
+++ b/packages/common/test/sites/_internal/reflectCollectionsToSearchCategories.test.ts
@@ -1,0 +1,170 @@
+import { IHubCollectionPersistance } from "../../../src/search/types/IHubCatalog";
+import { WellKnownCollection } from "../../../src/search/wellKnownCatalog";
+import { reflectCollectionsToSearchCategories } from "../../../src/sites/_internal/reflectCollectionsToSearchCategories";
+import { SearchCategories } from "../../../src/sites/_internal/types";
+import { IModel } from "../../../src/types";
+import { cloneObject } from "../../../src/util";
+
+const BASE_MODEL = {
+  data: {
+    catalog: {
+      schemaVersion: 1,
+      title: "Default Site Catalog",
+      scopes: {
+        item: {
+          targetEntity: "item",
+          filters: [],
+        },
+      },
+      collections: [],
+    },
+    values: {},
+  },
+} as unknown as IModel;
+
+describe("reflectCollectionsToSearchCategories", () => {
+  let site: IModel;
+  beforeEach(() => {
+    site = cloneObject(BASE_MODEL);
+  });
+  it('handles the collection "hidden" configuration', () => {
+    site.data.catalog.collections = [
+      {
+        label: null,
+        key: "dataset",
+        targetEntity: "item",
+        hidden: true,
+        scope: {
+          targetEntity: "item",
+          collection: "dataset",
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+      {
+        label: null,
+        key: "document",
+        targetEntity: "item",
+        hidden: false,
+        scope: {
+          targetEntity: "item",
+          collection: "document",
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+    ];
+
+    const result = reflectCollectionsToSearchCategories(site);
+    expect(result.data.values.searchCategories).toEqual([
+      {
+        key: SearchCategories.DATA,
+        hidden: true,
+        queryParams: {
+          collection: "Dataset",
+        },
+      },
+      {
+        key: SearchCategories.DOCUMENTS,
+        hidden: false,
+        queryParams: {
+          collection: "Document",
+        },
+      },
+    ]);
+  });
+  it("handles re-labeled collections", () => {
+    site.data.catalog.collections = [
+      {
+        label: "My Cool Sites!",
+        key: "site",
+        targetEntity: "item",
+        hidden: false,
+        scope: {
+          targetEntity: "item",
+          collection: "site",
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+      {
+        label: "Apps & Maps",
+        key: "appAndMap",
+        targetEntity: "item",
+        hidden: false,
+        scope: {
+          targetEntity: "item",
+          collection: "appAndMap",
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+    ];
+
+    const result = reflectCollectionsToSearchCategories(site);
+    expect(result.data.values.searchCategories).toEqual([
+      {
+        overrideText: "My Cool Sites!",
+        key: SearchCategories.SITES,
+        hidden: false,
+        queryParams: {
+          collection: "Site",
+        },
+      },
+      {
+        overrideText: "Apps & Maps",
+        key: SearchCategories.APPS_AND_MAPS,
+        hidden: false,
+        queryParams: {
+          collection: "App,Map",
+        },
+      },
+    ]);
+  });
+  it("filters out collections that searchCategories does not support", () => {
+    site.data.catalog.collections = [
+      // Can be converted to search category, will be persisted
+      {
+        label: null,
+        key: "dataset",
+        targetEntity: "item",
+        hidden: false,
+        scope: {
+          targetEntity: "item",
+          collection: "dataset",
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+      // 'all' _can_ be converted to a search category, but we explicitly do not persist it
+      {
+        label: null,
+        key: "all",
+        targetEntity: "item",
+        hidden: false,
+        scope: {
+          targetEntity: "item",
+          collection: "all" as WellKnownCollection,
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+      // Customer-defined collection, cannot be converted to search category
+      {
+        label: "My Custom Collection",
+        key: "custom-collection",
+        targetEntity: "event",
+        hidden: false,
+        scope: {
+          targetEntity: "event",
+          filters: [],
+        },
+      } as IHubCollectionPersistance,
+    ];
+
+    const result = reflectCollectionsToSearchCategories(site);
+    expect(result.data.values.searchCategories).toEqual([
+      {
+        key: SearchCategories.DATA,
+        hidden: false,
+        queryParams: {
+          collection: "Dataset",
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
OD-UI PR: https://github.com/ArcGIS/opendata-ui/pull/12342

1. Description: Added the location picker for workspace content details

1. Instructions for testing:
- Old: https://green-up-foco-qa-pre-a-hub.hubqa.arcgis.com/datasets/56c097cc2654416aaf8be93d5d1600ad/edit
- New: https://green-up-foco-qa-pre-a-hub.hubqa.arcgis.com:4200/workspace/content/56c097cc2654416aaf8be93d5d1600ad/details

1. Closes Issues: [7208](https://devtopia.esri.com/dc/hub/issues/7208)


1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
