### PR TITLE
fix(): handle new discussion entity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64966,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.28.0",
+			"version": "13.30.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/src/discussions/HubDiscussion.ts
+++ b/packages/common/src/discussions/HubDiscussion.ts
@@ -187,8 +187,6 @@ export class HubDiscussion
    * @returns
    */
   async fromEditor(editor: IHubDiscussionEditor): Promise<IHubDiscussion> {
-    const isCreate = !editor.id;
-
     // Setting the thumbnailCache will ensure that
     // the thumbnail is updated on next save
     if (editor._thumbnail) {
@@ -214,14 +212,9 @@ export class HubDiscussion
     // copy the location extent up one level
     entity.extent = editor.location?.extent;
 
-    // create it if it does not yet exist...
-    if (isCreate) {
-      throw new Error("Cannot create content using the Editor.");
-    } else {
-      // ...otherwise, update the in-memory entity and save it
-      this.entity = entity;
-      this.save();
-    }
+    // Save, which will also create new content if new
+    this.entity = entity;
+    await this.save();
 
     return this.entity;
   }


### PR DESCRIPTION
1. Description:

Fixes bug that was introduced on this [commit](https://github.com/Esri/hub.js/commit/0ea3d9229ef9f3f3a7ede7651244941f51265998) that prohibited new Discussion Board items to be created. 

Updates to use existing `save()` method which will handle both `create` and `update`.

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
