### PR TITLE
fix: remove name/title string as it is not wanted

### DIFF
--- a/packages/common/src/projects/defaults.ts
+++ b/packages/common/src/projects/defaults.ts
@@ -8,7 +8,7 @@ export const HUB_PROJECT_ITEM_TYPE = "Hub Project";
  */
 export const DEFAULT_PROJECT: Partial<IHubProject> = {
   catalog: { schemaVersion: 0 },
-  name: "No title provided",
+  name: "",
   permissions: [],
   schemaVersion: 1,
   status: PROJECT_STATUSES.notStarted,
@@ -27,7 +27,7 @@ export const DEFAULT_PROJECT: Partial<IHubProject> = {
 export const DEFAULT_PROJECT_MODEL: IModel = {
   item: {
     type: HUB_PROJECT_ITEM_TYPE,
-    title: "No Title Provided",
+    title: "",
     description: "",
     snippet: "",
     tags: [],


### PR DESCRIPTION
1. Description: With Dave's work we are now properly? using project defaults as we had them outlined. However this means we are inserting in a string in the project name that we don't want. This removes that.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
