### PR TITLE
fix: reshuffle project edit schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64966,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.30.0",
+			"version": "13.33.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -52,20 +52,6 @@ export const uiSchema: IUiSchema = {
           },
         },
         {
-          labelKey: "{{i18nScope}}.fields._thumbnail.label",
-          scope: "/properties/_thumbnail",
-          type: "Control",
-          options: {
-            control: "hub-field-input-image-picker",
-            maxWidth: 727,
-            maxHeight: 484,
-            aspectRatio: 1.5,
-            helperText: {
-              labelKey: "{{i18nScope}}.fields._thumbnail.helperText",
-            },
-          },
-        },
-        {
           labelKey: "{{i18nScope}}.fields.featuredImage.label",
           scope: "/properties/view/properties/featuredImage",
           type: "Control",
@@ -89,6 +75,47 @@ export const uiSchema: IUiSchema = {
           options: {
             helperText: {
               labelKey: "{{i18nScope}}.fields.featuredImage.altText.helperText",
+            },
+          },
+        },
+      ],
+    },
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.location.label",
+      options: {
+        helperText: {
+          labelKey: "{{i18nScope}}.sections.location.helperText",
+        },
+      },
+      elements: [
+        {
+          scope: "/properties/location",
+          type: "Control",
+          options: {
+            control: "hub-field-input-location-picker",
+          },
+        },
+      ],
+    },
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.searchDiscoverability.label",
+      elements: [
+        {
+          labelKey: "{{i18nScope}}.fields._thumbnail.label",
+          scope: "/properties/_thumbnail",
+          type: "Control",
+          options: {
+            control: "hub-field-input-image-picker",
+            maxWidth: 727,
+            maxHeight: 484,
+            aspectRatio: 1.5,
+            helperText: {
+              labelKey: "{{i18nScope}}.fields._thumbnail.helperText",
+            },
+            sizeDescription: {
+              labelKey: "{{i18nScope}}.fields._thumbnail.sizeDescription",
             },
           },
         },
@@ -116,24 +143,6 @@ export const uiSchema: IUiSchema = {
             helperText: {
               labelKey: "{{i18nScope}}.fields.categories.helperText",
             },
-          },
-        },
-      ],
-    },
-    {
-      type: "Section",
-      labelKey: "{{i18nScope}}.sections.location.label",
-      options: {
-        helperText: {
-          labelKey: "{{i18nScope}}.sections.location.helperText",
-        },
-      },
-      elements: [
-        {
-          scope: "/properties/location",
-          type: "Control",
-          options: {
-            control: "hub-field-input-location-picker",
           },
         },
       ],

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -103,23 +103,6 @@ export const uiSchema: IUiSchema = {
       labelKey: "{{i18nScope}}.sections.searchDiscoverability.label",
       elements: [
         {
-          labelKey: "{{i18nScope}}.fields._thumbnail.label",
-          scope: "/properties/_thumbnail",
-          type: "Control",
-          options: {
-            control: "hub-field-input-image-picker",
-            maxWidth: 727,
-            maxHeight: 484,
-            aspectRatio: 1.5,
-            helperText: {
-              labelKey: "{{i18nScope}}.fields._thumbnail.helperText",
-            },
-            sizeDescription: {
-              labelKey: "{{i18nScope}}.fields._thumbnail.sizeDescription",
-            },
-          },
-        },
-        {
           labelKey: "{{i18nScope}}.fields.tags.label",
           scope: "/properties/tags",
           type: "Control",
@@ -142,6 +125,23 @@ export const uiSchema: IUiSchema = {
             placeholderIcon: "select-category",
             helperText: {
               labelKey: "{{i18nScope}}.fields.categories.helperText",
+            },
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields._thumbnail.label",
+          scope: "/properties/_thumbnail",
+          type: "Control",
+          options: {
+            control: "hub-field-input-image-picker",
+            maxWidth: 727,
+            maxHeight: 484,
+            aspectRatio: 1.5,
+            helperText: {
+              labelKey: "{{i18nScope}}.fields._thumbnail.helperText",
+            },
+            sizeDescription: {
+              labelKey: "{{i18nScope}}.fields._thumbnail.sizeDescription",
             },
           },
         },


### PR DESCRIPTION
1. Description: Move Thumbnail, categories, and tags into their own section.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
