### PR TITLE
feat: added location picker to content details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64992,7 +64992,6 @@
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
 			"version": "25.8.0",
-			"version": "25.8.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -64992,6 +64992,7 @@
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
 			"version": "25.8.0",
+			"version": "25.8.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/src/content/HubContent.ts
+++ b/packages/common/src/content/HubContent.ts
@@ -14,6 +14,7 @@ import { IWithStoreBehavior } from "../core/behaviors/IWithStoreBehavior";
 import { getEditorConfig } from "../core/schemas/getEditorConfig";
 import { IEntityEditorContext } from "../core/types/HubEntityEditor";
 import { cloneObject } from "../util";
+import { editorToContent } from "./edit";
 
 export class HubContent
   extends HubItemEntity<IHubEditableContent>
@@ -145,7 +146,7 @@ export class HubContent
 
     // convert back to an entity. Apply any reverse transforms used in
     // of the toEditor method
-    const entity = cloneObject(editor) as IHubEditableContent;
+    const entity = editorToContent(editor, this.context.portal);
 
     // copy the location extent up one level
     entity.extent = editor.location?.extent;

--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -97,23 +97,24 @@ export const uiSchema: IUiSchema = {
         },
       ],
     },
-    // { // TODO: in another PR
-    //   type: "Section",
-    //   labelKey: "{{i18nScope}}.sections.location.label",
-    //   options: {
-    //     helperText: {
-    //       labelKey: "{{i18nScope}}.sections.location.helperText",
-    //     },
-    //   },
-    //   elements: [
-    //     {
-    //       scope: "/properties/location",
-    //       type: "Control",
-    //       options: {
-    //         control: "hub-field-input-location-picker",
-    //       },
-    //     },
-    //   ],
-    // },
+    // location section
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.location.label",
+      options: {
+        helperText: {
+          labelKey: "{{i18nScope}}.sections.location.helperText",
+        },
+      },
+      elements: [
+        {
+          scope: "/properties/location",
+          type: "Control",
+          options: {
+            control: "hub-field-input-location-picker",
+          },
+        },
+      ],
+    },
   ],
 };

--- a/packages/common/src/content/_internal/getPropertyMap.ts
+++ b/packages/common/src/content/_internal/getPropertyMap.ts
@@ -24,11 +24,10 @@ export function getPropertyMap(): IPropertyMap[] {
     storeKey: "data.settings.capabilities",
   });
 
-  // TODO: (Aaron) looking ahead for adding location, I'm pretty sure we'll want this in the next PR
-  // map.push({
-  //   entityKey: "location",
-  //   storeKey: "item.properties.location",
-  // });
+  map.push({
+    entityKey: "location",
+    storeKey: "item.properties.location",
+  });
 
   // TODO: look into composeContent() for what we can add here
 

--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -1,10 +1,11 @@
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import {
+  IPortal,
   IUserItemOptions,
   getItem,
   removeItem,
 } from "@esri/arcgis-rest-portal";
-import { IHubEditableContent } from "../core";
+import { IHubContent, IHubContentEditor, IHubEditableContent } from "../core";
 
 // Note - we separate these imports so we can cleanly spy on things in tests
 import {
@@ -142,4 +143,26 @@ export async function deleteContent(
   const ro = { ...requestOptions, ...{ id } } as IUserItemOptions;
   await removeItem(ro);
   return;
+}
+
+/**
+ * Convert a IHubContentEditor back to an IHubContent
+ * @param editor
+ * @param portal
+ * @returns
+ */
+export function editorToContent(
+  editor: IHubContentEditor,
+  portal: IPortal
+): IHubEditableContent {
+  // remove the ephemeral props we graft on for the editor
+  // delete editor._groups; // don't think we need this?
+  // clone into a HubProject
+  const content = cloneObject(editor) as IHubEditableContent;
+  // ensure there's an org url key
+  // content.orgUrlKey = editor.orgUrlKey ? editor.orgUrlKey : portal.urlKey; // don't think we need this?
+  // copy the location extent up one level
+  content.extent = editor.location?.extent;
+  // return with a cast
+  return content;
 }

--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -155,14 +155,11 @@ export function editorToContent(
   editor: IHubContentEditor,
   portal: IPortal
 ): IHubEditableContent {
-  // remove the ephemeral props we graft on for the editor
-  // delete editor._groups; // don't think we need this?
-  // clone into a HubProject
+  // clone into a IHubContentEditor
   const content = cloneObject(editor) as IHubEditableContent;
-  // ensure there's an org url key
-  // content.orgUrlKey = editor.orgUrlKey ? editor.orgUrlKey : portal.urlKey; // don't think we need this?
+
   // copy the location extent up one level
   content.extent = editor.location?.extent;
-  // return with a cast
+
   return content;
 }


### PR DESCRIPTION
OD-UI PR: https://github.com/ArcGIS/opendata-ui/pull/12342

1. Description: Adds location picker to workspace content details

1. Closes Issues: [#7208 ](https://devtopia.esri.com/dc/hub/issues/7208)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
