### PR TITLE
fix: add GroupSchema, GroupUiSchema and other support for groups details pane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64966,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.33.1",
+			"version": "13.36.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/src/core/EntityEditor.ts
+++ b/packages/common/src/core/EntityEditor.ts
@@ -1,6 +1,7 @@
 import { IArcGISContext } from "../ArcGISContext";
 import { HubContent } from "../content/HubContent";
 import { HubDiscussion } from "../discussions/HubDiscussion";
+import { HubGroup } from "../groups/HubGroup";
 import { HubInitiative } from "../initiatives/HubInitiative";
 import { HubPage } from "../pages/HubPage";
 import { HubProject } from "../projects/HubProject";
@@ -39,6 +40,12 @@ export class EntityEditor {
     }
     if (entityType === "discussion") {
       editor = HubDiscussion.fromJson(entity, context) as IWithEditorBehavior;
+    }
+    if (entityType === "group") {
+      editor = HubGroup.fromJson(
+        entity as unknown as HubGroup,
+        context
+      ) as IWithEditorBehavior;
     }
     if (editor) {
       return new EntityEditor(editor);

--- a/packages/common/src/core/schemas/getEntityEditorSchemas.ts
+++ b/packages/common/src/core/schemas/getEntityEditorSchemas.ts
@@ -10,6 +10,7 @@ import { SiteEditorType } from "../../sites/_internal/SiteSchema";
 import { DiscussionEditorType } from "../../discussions/_internal/DiscussionSchema";
 import { PageEditorType } from "../../pages/_internal/PageSchema";
 import { ContentEditorType } from "../../content/_internal/ContentSchema";
+import { GroupEditorType } from "../../groups/_internal/GroupSchema";
 
 /**
  * DEPRECATED: please use getEditorConfig instead
@@ -105,6 +106,17 @@ export const getEntityEditorSchemas = async (
         "hub:content:edit": () =>
           import("../../content/_internal/ContentUiSchemaEdit"),
       }[type as ContentEditorType]());
+      break;
+    case "group":
+      const { GroupSchema } = await import(
+        "../../groups/_internal/GroupSchema"
+      );
+      schema = cloneObject(GroupSchema);
+
+      ({ uiSchema } = await {
+        "hub:group:edit": () =>
+          import("../../groups/_internal/GroupUiSchemaEdit"),
+      }[type as GroupEditorType]());
       break;
   }
 

--- a/packages/common/src/core/schemas/internal/getEditorConfigOptions.ts
+++ b/packages/common/src/core/schemas/internal/getEditorConfigOptions.ts
@@ -35,8 +35,16 @@ export async function getEditorConfigOptions(
     initiative: [...standardOptions, "featuredImage"],
     site: [...standardOptions],
     page: [...standardOptions],
+    group: ["access", "thumbnail"],
   };
 
+  if (!options[entityType]) {
+    // Adding this warning because this is very difficult to find
+    /* tslint:disable no-console */
+    console.warn(
+      `The entity type: ${entityType} does not have an editor config option defined.`
+    );
+  }
   const entityOptions = options[entityType] || [];
 
   return getConfigOptions(entityOptions, entity, context);

--- a/packages/common/src/core/schemas/internal/getEntityEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getEntityEditorSchemas.ts
@@ -10,6 +10,7 @@ import { DiscussionEditorType } from "../../../discussions/_internal/DiscussionS
 import { PageEditorType } from "../../../pages/_internal/PageSchema";
 import { ContentEditorType } from "../../../content/_internal/ContentSchema";
 import { interpolate } from "../../../items/interpolate";
+import { GroupEditorType } from "../../../groups/_internal/GroupSchema";
 
 /**
  * get the editor schema and uiSchema defined for an entity.
@@ -109,6 +110,17 @@ export async function getEntityEditorSchemas(
         "hub:content:edit": () =>
           import("../../../content/_internal/ContentUiSchemaEdit"),
       }[type as ContentEditorType]());
+      break;
+    case "group":
+      const { GroupSchema } = await import(
+        "../../../groups/_internal/GroupSchema"
+      );
+      schema = cloneObject(GroupSchema);
+
+      ({ uiSchema } = await {
+        "hub:group:edit": () =>
+          import("../../../groups/_internal/GroupUiSchemaEdit"),
+      }[type as GroupEditorType]());
       break;
   }
 

--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -7,6 +7,7 @@ import { SiteEditorTypes } from "../../sites/_internal/SiteSchema";
 import { DiscussionEditorTypes } from "../../discussions/_internal/DiscussionSchema";
 import { PageEditorTypes } from "../../pages/_internal/PageSchema";
 import { ContentEditorTypes } from "../../content/_internal/ContentSchema";
+import { GroupEditorTypes } from "../../groups/_internal/GroupSchema";
 
 /**
  * Defines the possible editor type values - these correspond
@@ -20,6 +21,7 @@ export const validEditorTypes = [
   ...SiteEditorTypes,
   ...DiscussionEditorTypes,
   ...PageEditorTypes,
+  ...GroupEditorTypes,
 ] as const;
 
 export enum UiSchemaRuleEffects {

--- a/packages/common/src/core/types/IHubGroup.ts
+++ b/packages/common/src/core/types/IHubGroup.ts
@@ -2,10 +2,10 @@ import { IWithPermissions } from "../traits";
 import { IHubEntityBase } from "./IHubEntityBase";
 import {
   GroupSortField,
-  SettableAccessLevel,
   MemberType,
   MembershipAccess,
   PlatformSortOrder,
+  AccessLevel,
 } from "./types";
 
 /**
@@ -16,8 +16,11 @@ export interface IHubGroup extends IHubEntityBase, IWithPermissions {
   /**
    * Access level of the group
    * ("private" | "org" | "public")
+   * we are using AccessLevel instead of SettableAccessLevel
+   * intentionally due to the Portal API being inconsistent
+   * between .access on items vs groups
    */
-  access: SettableAccessLevel;
+  access: AccessLevel;
 
   /**
    * Whether members can auto join the group
@@ -119,3 +122,15 @@ export interface IHubGroup extends IHubEntityBase, IWithPermissions {
    */
   _clearEmptyFields?: boolean;
 }
+
+/**
+ * This type redefines the IHubGroup interface in such a way
+ * that it can be consumed by the entity editor.
+ */
+export type IHubGroupEditor = Omit<IHubGroup, "extent"> & {
+  /**
+   * Thumbnail image. This is only used on the Editor and is
+   * persisted in the fromEditor method on the Class
+   */
+  _thumbnail?: any;
+};

--- a/packages/common/src/core/types/IHubGroup.ts
+++ b/packages/common/src/core/types/IHubGroup.ts
@@ -127,7 +127,7 @@ export interface IHubGroup extends IHubEntityBase, IWithPermissions {
  * This type redefines the IHubGroup interface in such a way
  * that it can be consumed by the entity editor.
  */
-export type IHubGroupEditor = Omit<IHubGroup, "extent"> & {
+export type IHubGroupEditor = IHubGroup & {
   /**
    * Thumbnail image. This is only used on the Editor and is
    * persisted in the fromEditor method on the Class

--- a/packages/common/src/groups/HubGroup.ts
+++ b/packages/common/src/groups/HubGroup.ts
@@ -3,8 +3,8 @@ import {
   updateHubGroup,
   fetchHubGroup,
   deleteHubGroup,
-  convertHubGroupToGroup,
 } from "./HubGroups";
+import { convertHubGroupToGroup } from "./_internal/convertHubGroupToGroup";
 import { IHubGroup, IHubGroupEditor } from "../core/types/IHubGroup";
 import { DEFAULT_GROUP } from "./defaults";
 import {

--- a/packages/common/src/groups/HubGroup.ts
+++ b/packages/common/src/groups/HubGroup.ts
@@ -4,7 +4,7 @@ import {
   fetchHubGroup,
   deleteHubGroup,
 } from "./HubGroups";
-import { IHubGroup } from "../core/types/IHubGroup";
+import { IHubGroup, IHubGroupEditor } from "../core/types/IHubGroup";
 import { DEFAULT_GROUP } from "./defaults";
 import {
   IEntityPermissionPolicy,
@@ -17,17 +17,30 @@ import {
 import { IWithStoreBehavior } from "../core/behaviors/IWithStoreBehavior";
 import { IWithPermissionBehavior } from "../core/behaviors/IWithPermissionBehavior";
 import { IArcGISContext } from "../ArcGISContext";
-import { cloneObject } from "../util";
+import { cloneObject, maybePush } from "../util";
+import {
+  IEditorConfig,
+  IWithEditorBehavior,
+} from "../core/behaviors/IWithEditorBehavior";
+import { EditorType } from "../core/schemas/types";
+import { getEditorConfig } from "../core/schemas/getEditorConfig";
+import { IEntityEditorContext } from "../core/types/HubEntityEditor";
+import { SettableAccessLevel } from "../core/types/types";
 
 /**
  * Hub Group Class
  */
 export class HubGroup
-  implements IWithStoreBehavior<IHubGroup>, IWithPermissionBehavior
+  implements
+    IWithStoreBehavior<IHubGroup>,
+    IWithPermissionBehavior,
+    IWithEditorBehavior
 {
   protected context: IArcGISContext;
   protected entity: IHubGroup;
   protected isDestroyed = false;
+  protected thumbnailCache: { file?: any; filename?: string; clear?: boolean } =
+    null;
 
   private constructor(group: IHubGroup, context: IArcGISContext) {
     this.entity = group;
@@ -231,5 +244,70 @@ export class HubGroup
       permission,
       id
     );
+  }
+
+  /*
+   * Get the editor config for the HubGroup entity.
+   * @param i18nScope translation scope to be interpolated into the uiSchema
+   * @param type editor type - corresonds to the returned uiSchema
+   * @param options optional hash of dynamic uiSchema element options
+   */
+  async getEditorConfig(
+    i18nScope: string,
+    type: EditorType
+  ): Promise<IEditorConfig> {
+    // delegate to the schema subsystem
+    return getEditorConfig(i18nScope, type, this.entity, this.context);
+  }
+
+  /**
+   * Return the group as an editor object
+   */
+  toEditor(): IHubGroupEditor {
+    // cast the entity to it's editor
+    const editor = cloneObject(this.entity) as IHubGroupEditor;
+    return editor;
+  }
+
+  /**
+   * Load the group from the editor object
+   * @param editor
+   * @returns
+   */
+  async fromEditor(editor: IHubGroupEditor): Promise<IHubGroup> {
+    const isCreate = !editor.id;
+
+    // Setting the thumbnailCache will ensure that
+    // the thumbnail is updated on next save
+    if (editor._thumbnail) {
+      if (editor._thumbnail.blob) {
+        this.thumbnailCache = {
+          file: editor._thumbnail.blob,
+          filename: editor._thumbnail.fileName,
+          clear: false,
+        };
+      } else {
+        this.thumbnailCache = {
+          clear: true,
+        };
+      }
+    }
+
+    delete editor._thumbnail;
+
+    // convert back to an entity. Apply any reverse transforms used in
+    // of the toEditor method
+    const entity = cloneObject(editor) as IHubGroup;
+
+    // create it if it does not yet exist...
+    if (isCreate) {
+      throw new Error("Cannot create group using the Editor.");
+    } else {
+      // ...otherwise, update the in-memory entity and save it
+      this.entity = entity;
+      this.save();
+    }
+
+    return this.entity;
   }
 }

--- a/packages/common/src/groups/HubGroup.ts
+++ b/packages/common/src/groups/HubGroup.ts
@@ -248,25 +248,6 @@ export class HubGroup
     );
   }
 
-  /**
-   * Return the full url to the thumbnail, optionally with a width parameter
-   * @param width
-   */
-  // getThumbnailUrl(width: number = 200): string {
-  //   const minimalGroup = {
-  //     id: this.entity.id,
-  //     access: this.entity.access,
-  //     thumbnail: this.entity.thumbnail,
-  //   } as unknown as IGroup;
-
-  //   const opts: IThumbnailOptions = {
-  //     token: this.context.session.token,
-  //     width,
-  //   };
-
-  //   return getGroupThumbnailUrl(minimalGroup, this.context.requestOptions, opts);
-  // }
-
   /*
    * Get the editor config for the HubGroup entity.
    * @param i18nScope translation scope to be interpolated into the uiSchema

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -186,7 +186,7 @@ function convertGroupToHubGroup(
  * Convert a Hub Group to an IGroup
  * @param hubGroup
  */
-function convertHubGroupToGroup(hubGroup: IHubGroup): IGroup {
+export function convertHubGroupToGroup(hubGroup: IHubGroup): IGroup {
   const mapper = new PropertyMapper<Partial<IHubGroup>, IGroup>(
     getPropertyMap()
   );

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -1,5 +1,4 @@
 import { EntityCapabilities, ICapabilityPermission } from "../../capabilities";
-import { itemPropsNotInTemplates } from "../../items";
 import { IPermissionPolicy } from "../../permissions";
 
 /**

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -1,4 +1,5 @@
 import { EntityCapabilities, ICapabilityPermission } from "../../capabilities";
+import { itemPropsNotInTemplates } from "../../items";
 import { IPermissionPolicy } from "../../permissions";
 
 /**

--- a/packages/common/src/groups/_internal/GroupSchema.ts
+++ b/packages/common/src/groups/_internal/GroupSchema.ts
@@ -8,7 +8,7 @@ export type GroupEditorType = (typeof GroupEditorTypes)[number];
 export const GroupEditorTypes = ["hub:group:edit"] as const;
 
 /**
- * defines the JSON schema for a Hub Group's editable fields
+ * Defines the JSON schema for a Hub Group's editable fields
  */
 export const GroupSchema: IConfigurationSchema = {
   required: ["name"],

--- a/packages/common/src/groups/_internal/GroupSchema.ts
+++ b/packages/common/src/groups/_internal/GroupSchema.ts
@@ -1,0 +1,23 @@
+import { IConfigurationSchema } from "../../core";
+import {
+  ENTITY_IMAGE_SCHEMA,
+  ENTITY_NAME_SCHEMA,
+} from "../../core/schemas/shared";
+
+export type GroupEditorType = (typeof GroupEditorTypes)[number];
+export const GroupEditorTypes = ["hub:group:edit"] as const;
+
+/**
+ * defines the JSON schema for a Hub Group's editable fields
+ */
+export const GroupSchema: IConfigurationSchema = {
+  required: ["name"],
+  type: "object",
+  properties: {
+    name: ENTITY_NAME_SCHEMA,
+    summary: {
+      type: "string",
+    },
+    _thumbnail: ENTITY_IMAGE_SCHEMA,
+  },
+} as unknown as IConfigurationSchema;

--- a/packages/common/src/groups/_internal/GroupSchema.ts
+++ b/packages/common/src/groups/_internal/GroupSchema.ts
@@ -20,4 +20,4 @@ export const GroupSchema: IConfigurationSchema = {
     },
     _thumbnail: ENTITY_IMAGE_SCHEMA,
   },
-} as unknown as IConfigurationSchema;
+} as IConfigurationSchema;

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -1,0 +1,59 @@
+import { IUiSchema } from "../../core";
+
+/**
+ * complete edit uiSchema for Hub Groups - this defines
+ * how the schema properties should be rendered in the
+ * group editing experience
+ */
+export const uiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.basicInfo.label",
+      elements: [
+        {
+          labelKey: "{{i18nScope}}.fields.name.label",
+          scope: "/properties/name",
+          type: "Control",
+          options: {
+            messages: [
+              {
+                type: "ERROR",
+                keyword: "required",
+                icon: true,
+                labelKey: "{{i18nScope}}.fields.name.requiredError",
+              },
+            ],
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.summary.label",
+          scope: "/properties/summary",
+          type: "Control",
+          options: {
+            control: "hub-field-input-input",
+            type: "textarea",
+            helperText: {
+              labelKey: "{{i18nScope}}.fields.summary.helperText",
+            },
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields._thumbnail.label",
+          scope: "/properties/_thumbnail",
+          type: "Control",
+          options: {
+            control: "hub-field-input-image-picker",
+            maxWidth: 727,
+            maxHeight: 484,
+            aspectRatio: 1.5,
+            helperText: {
+              labelKey: "{{i18nScope}}.fields._thumbnail.helperText",
+            },
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -40,8 +40,8 @@ export const uiSchema: IUiSchema = {
           },
         },
         {
-          labelKey: "{{i18nScope}}.fields._thumbnail.label",
-          scope: "/properties/_thumbnail",
+          labelKey: "{{i18nScope}}.fields.thumbnail.label",
+          scope: "/properties/thumbnail",
           type: "Control",
           options: {
             control: "hub-field-input-image-picker",
@@ -49,7 +49,7 @@ export const uiSchema: IUiSchema = {
             maxHeight: 484,
             aspectRatio: 1.5,
             helperText: {
-              labelKey: "{{i18nScope}}.fields._thumbnail.helperText",
+              labelKey: "{{i18nScope}}.fields.thumbnail.helperText",
             },
           },
         },

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -1,7 +1,7 @@
 import { IUiSchema } from "../../core";
 
 /**
- * complete edit uiSchema for Hub Groups - this defines
+ * Complete edit uiSchema for Hub Groups - this defines
  * how the schema properties should be rendered in the
  * group editing experience
  */

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -40,8 +40,8 @@ export const uiSchema: IUiSchema = {
           },
         },
         {
-          labelKey: "{{i18nScope}}.fields.thumbnail.label",
-          scope: "/properties/thumbnail",
+          labelKey: "{{i18nScope}}.fields._thumbnail.label",
+          scope: "/properties/_thumbnail",
           type: "Control",
           options: {
             control: "hub-field-input-image-picker",
@@ -49,7 +49,7 @@ export const uiSchema: IUiSchema = {
             maxHeight: 484,
             aspectRatio: 1.5,
             helperText: {
-              labelKey: "{{i18nScope}}.fields.thumbnail.helperText",
+              labelKey: "{{i18nScope}}.fields._thumbnail.helperText",
             },
           },
         },

--- a/packages/common/src/groups/_internal/convertGroupToHubGroup.ts
+++ b/packages/common/src/groups/_internal/convertGroupToHubGroup.ts
@@ -1,0 +1,23 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import { PropertyMapper } from "../../core/_internal/PropertyMapper";
+import { IHubGroup } from "../../core/types/IHubGroup";
+import { computeProps } from "./computeProps";
+import { getPropertyMap } from "./getPropertyMap";
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+
+/**
+ * Convert an IGroup to a Hub Group
+ * @param group
+ * @param requestOptions
+ */
+
+export function convertGroupToHubGroup(
+  group: IGroup,
+  requestOptions: IUserRequestOptions
+): IHubGroup {
+  const mapper = new PropertyMapper<Partial<IHubGroup>, IGroup>(
+    getPropertyMap()
+  );
+  const hubGroup = mapper.storeToEntity(group, {}) as IHubGroup;
+  return computeProps(group, hubGroup, requestOptions);
+}

--- a/packages/common/src/groups/_internal/convertHubGroupToGroup.ts
+++ b/packages/common/src/groups/_internal/convertHubGroupToGroup.ts
@@ -1,0 +1,34 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import { PropertyMapper } from "../../core/_internal/PropertyMapper";
+import { IHubGroup } from "../../core/types/IHubGroup";
+import { getPropertyMap } from "./getPropertyMap";
+
+/**
+ * Convert a Hub Group to an IGroup
+ * @param hubGroup
+ */
+
+export function convertHubGroupToGroup(hubGroup: IHubGroup): IGroup {
+  const mapper = new PropertyMapper<Partial<IHubGroup>, IGroup>(
+    getPropertyMap()
+  );
+  const group = mapper.entityToStore(
+    hubGroup,
+    {} as unknown as IGroup
+  ) as IGroup;
+  // convert the values for membershipAccess back to
+  // the ones the API accepts
+  if (group.membershipAccess === "organization") {
+    group.membershipAccess = "org";
+  }
+  if (group.membershipAccess === "collaborators") {
+    group.membershipAccess = "collaboration";
+  }
+  // since we are setting null to a prop, we need to
+  // send clearEmptyFields: true to the updateGroup call
+  if (group.membershipAccess === "anyone") {
+    group.membershipAccess = null;
+    group._clearEmptyFields = true;
+  }
+  return group;
+}

--- a/packages/common/src/groups/deleteGroupThumbnail.ts
+++ b/packages/common/src/groups/deleteGroupThumbnail.ts
@@ -1,0 +1,18 @@
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import { request } from "@esri/arcgis-rest-request";
+
+/**
+ * Delete a group's thumbnail
+ * @param id
+ * @param owner
+ * @param requestOptions
+ * @returns
+ */
+export async function deleteGroupThumbnail(
+  id: string,
+  requestOptions: IUserRequestOptions
+) {
+  const { portal } = requestOptions;
+  const urlPath = `${portal}/sharing/rest/community/groups/${id}/deleteThumbnail`;
+  return request(urlPath, requestOptions);
+}

--- a/packages/common/src/groups/deleteGroupThumbnail.ts
+++ b/packages/common/src/groups/deleteGroupThumbnail.ts
@@ -13,6 +13,6 @@ export async function deleteGroupThumbnail(
   requestOptions: IUserRequestOptions
 ) {
   const { portal } = requestOptions;
-  const urlPath = `${portal}/sharing/rest/community/groups/${id}/deleteThumbnail`;
+  const urlPath = `${portal}/community/groups/${id}/deleteThumbnail`;
   return request(urlPath, requestOptions);
 }

--- a/packages/common/src/groups/setGroupThumbnail.ts
+++ b/packages/common/src/groups/setGroupThumbnail.ts
@@ -1,0 +1,49 @@
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import { updateGroup } from "@esri/arcgis-rest-portal";
+import HubError from "../HubError";
+
+/**
+ * Upload a file to be used as the thumbnail for a group
+ * @param id
+ * @param file
+ * @param filename
+ * @param requestOptions
+ */
+export async function setGroupThumbnail(
+  id: string,
+  file: any,
+  filename: string,
+  requestOptions: IUserRequestOptions,
+  owner: string
+): Promise<void> {
+  const opts = {
+    group: {
+      id,
+    },
+    owner,
+    params: {
+      thumbnail: file,
+      fileName: filename,
+    },
+    filename,
+    ...requestOptions,
+  };
+  try {
+    const response = await updateGroup(opts);
+    if (!response.success) {
+      throw new HubError(
+        "Set Group Thumbnail",
+        "Unknown error setting thumbnail."
+      );
+    }
+  } catch (err) {
+    if (err instanceof Error) {
+      throw new HubError("Set Group Thumbnail", err.message, err);
+    } else {
+      throw new HubError(
+        "Set Group Thumbnail",
+        "Unknown error setting thumbnail."
+      );
+    }
+  }
+}

--- a/packages/common/test/core/EntityEditor.test.ts
+++ b/packages/common/test/core/EntityEditor.test.ts
@@ -3,6 +3,7 @@ import {
   EntityEditor,
   HubContent,
   HubDiscussion,
+  HubGroup,
   HubInitiative,
   HubPage,
   HubProject,
@@ -15,6 +16,7 @@ import {
   IHubSite,
   getProp,
 } from "../../src";
+import { IHubGroup } from "../../src/core/types/IHubGroup";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as PortalModule from "@esri/arcgis-rest-portal";
 
@@ -284,6 +286,43 @@ describe("EntityEditor:", () => {
         "someScope",
         "hub:initiative:edit"
       );
+      const chk = editor.toEditor();
+      expect(toEditorSpy).toHaveBeenCalled();
+      expect(chk.id).toBe("00c");
+      await editor.save(chk);
+      expect(fromEditorSpy).toHaveBeenCalledWith(chk);
+    });
+  });
+
+  describe("supports groups:", () => {
+    let fromJsonSpy: jasmine.Spy;
+    let getConfigSpy: jasmine.Spy;
+    let toEditorSpy: jasmine.Spy;
+    let fromEditorSpy: jasmine.Spy;
+    beforeEach(() => {
+      fromJsonSpy = spyOn(HubGroup, "fromJson").and.callThrough();
+      getConfigSpy = spyOn(HubGroup.prototype, "getEditorConfig").and.callFake(
+        () => {
+          return Promise.resolve({} as any);
+        }
+      );
+      toEditorSpy = spyOn(HubGroup.prototype, "toEditor").and.callThrough();
+      fromEditorSpy = spyOn(HubGroup.prototype, "fromEditor").and.callFake(
+        () => {
+          return Promise.resolve({} as any);
+        }
+      );
+    });
+
+    it("verify EntityEditor with Group", async () => {
+      const g: IHubGroup = {
+        id: "00c",
+        type: "Group",
+      } as IHubGroup;
+      const editor = EntityEditor.fromEntity(g, authdCtxMgr.context);
+      expect(fromJsonSpy).toHaveBeenCalled();
+      await editor.getConfig("someScope", "hub:group:edit");
+      expect(getConfigSpy).toHaveBeenCalledWith("someScope", "hub:group:edit");
       const chk = editor.toEditor();
       expect(toEditorSpy).toHaveBeenCalled();
       expect(chk.id).toBe("00c");

--- a/packages/common/test/core/schemas/getEntityEditorSchema.test.ts
+++ b/packages/common/test/core/schemas/getEntityEditorSchema.test.ts
@@ -9,6 +9,7 @@ import * as applyOptionsModule from "../../../src/core/schemas/internal/applyUiS
 import * as filterSchemaModule from "../../../src/core/schemas/internal/filterSchemaToUiSchema";
 import * as itemsModule from "../../../src/items";
 import { UiSchemaElementOptions } from "../../../src";
+import { GroupEditorTypes } from "../../../src/groups/_internal/GroupSchema";
 
 describe("getEntityEditorSchemas", () => {
   it("returns a schema & uiSchema for a given entity and editor type", () => {
@@ -19,6 +20,7 @@ describe("getEntityEditorSchemas", () => {
       ...DiscussionEditorTypes,
       ...ContentEditorTypes,
       ...PageEditorTypes,
+      ...GroupEditorTypes,
     ].forEach(async (type, idx) => {
       const { schema, uiSchema } = await getEntityEditorSchemas(
         "some.scope",

--- a/packages/common/test/core/schemas/internal/getEntityEditorSchemas.test.ts
+++ b/packages/common/test/core/schemas/internal/getEntityEditorSchemas.test.ts
@@ -8,6 +8,7 @@ import { PageEditorTypes } from "../../../../src/pages/_internal/PageSchema";
 import * as applyOptionsModule from "../../../../src/core/schemas/internal/applyUiSchemaElementOptions";
 import * as filterSchemaModule from "../../../../src/core/schemas/internal/filterSchemaToUiSchema";
 import { UiSchemaElementOptions } from "../../../../src";
+import { GroupEditorTypes } from "../../../../src/groups/_internal/GroupSchema";
 
 describe("getEntityEditorSchemas: ", () => {
   it("returns a schema & uiSchema for a given entity and editor type", () => {
@@ -18,6 +19,7 @@ describe("getEntityEditorSchemas: ", () => {
       ...DiscussionEditorTypes,
       ...ContentEditorTypes,
       ...PageEditorTypes,
+      ...GroupEditorTypes,
     ].forEach(async (type, idx) => {
       const { schema, uiSchema } = await getEntityEditorSchemas(
         "some.scope",

--- a/packages/common/test/groups/HubGroup.test.ts
+++ b/packages/common/test/groups/HubGroup.test.ts
@@ -369,6 +369,29 @@ describe("HubGroup class:", () => {
         expect(result.name).toEqual("new name");
       });
 
+      it("throws when is create", async () => {
+        const chk = HubGroup.fromJson(
+          {
+            name: "Test Entity",
+            thumbnailUrl: "https://myserver.com/thumbnail.png",
+          },
+          authdCtxMgr.context
+        );
+        // spy on the instance .save method and retrn void
+        const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
+        // make changes to the editor
+        const editor = chk.toEditor();
+        // get the group loaded from the editor
+        try {
+          await await chk.fromEditor(editor);
+        } catch (e) {
+          expect(getProp(e, "message")).toBe(
+            "Cannot create group using the Editor."
+          );
+        }
+        expect(saveSpy).toHaveBeenCalledTimes(0);
+      });
+
       it("handles thumbnail change", async () => {
         const chk = HubGroup.fromJson(
           {

--- a/packages/common/test/groups/HubGroup.test.ts
+++ b/packages/common/test/groups/HubGroup.test.ts
@@ -1,11 +1,14 @@
 import { IGroup } from "@esri/arcgis-rest-portal";
 import * as PortalModule from "@esri/arcgis-rest-portal";
 import { MOCK_AUTH } from "../mocks/mock-auth";
-import { HubGroup } from "../../src/groups/HubGroup";
+import { HubGroup } from "../../src";
 import { ArcGISContextManager } from "../../src/ArcGISContextManager";
 import * as HubGroupsModule from "../../src/groups/HubGroups";
 import { IHubGroup } from "../../src/core/types/IHubGroup";
 import { IEntityPermissionPolicy } from "../../dist/types/permissions/types/IEntityPermissionPolicy";
+import * as EditConfigModule from "../../src/core/schemas/getEditorConfig";
+import { getProp } from "../../src/objects/get-prop";
+import * as SearchUtils from "../../src/search/utils";
 
 describe("HubGroup class:", () => {
   let authdCtxMgr: ArcGISContextManager;
@@ -299,6 +302,141 @@ describe("HubGroup class:", () => {
       const chk = instance.checkPermission("hub:group:create");
       expect(chk.access).toBeTruthy();
       expect(checkPermissionSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("IWithEditorBehavior:", () => {
+    it("getEditorConfig delegates to helper", async () => {
+      const spy = spyOn(EditConfigModule, "getEditorConfig").and.callFake(
+        () => {
+          return Promise.resolve({ fake: "config" });
+        }
+      );
+      const chk = HubGroup.fromJson(
+        {
+          id: "bc3",
+          name: "Test Entity",
+        },
+        authdCtxMgr.context
+      );
+      const result = await chk.getEditorConfig("i18n.Scope", "hub:group:edit");
+      expect(result).toEqual({ fake: "config" } as any);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(
+        "i18n.Scope",
+        "hub:group:edit",
+        chk.toJson(),
+        authdCtxMgr.context
+      );
+    });
+
+    it("toEditor converst entity to correct structure", () => {
+      const chk = HubGroup.fromJson(
+        {
+          id: "bc3",
+          name: "Test Entity",
+          thumbnailUrl: "https://myserver.com/thumbnail.png",
+        },
+        authdCtxMgr.context
+      );
+      const result = chk.toEditor();
+      // NOTE: If additional transforms are added in the class they should have tests here
+      expect(result.id).toEqual("bc3");
+      expect(result.name).toEqual("Test Entity");
+      expect(result.thumbnailUrl).toEqual("https://myserver.com/thumbnail.png");
+    });
+
+    describe("fromEditor:", () => {
+      it("handles simple prop change", async () => {
+        const chk = HubGroup.fromJson(
+          {
+            id: "bc3",
+            name: "Test Entity",
+            thumbnailUrl: "https://myserver.com/thumbnail.png",
+          },
+          authdCtxMgr.context
+        );
+        // spy on the instance .save method and retrn void
+        const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
+        // make changes to the editor
+        const editor = chk.toEditor();
+        editor.name = "new name";
+        // get the group loaded from the editor
+        const result = await chk.fromEditor(editor);
+        // expect the save method to have been called
+        expect(saveSpy).toHaveBeenCalledTimes(1);
+        // expect the name to have been updated
+        expect(result.name).toEqual("new name");
+      });
+
+      it("handles thumbnail change", async () => {
+        const chk = HubGroup.fromJson(
+          {
+            id: "bc3",
+            name: "Test Entity",
+            thumbnailUrl: "https://myserver.com/thumbnail.png",
+          },
+          authdCtxMgr.context
+        );
+        // spy on the instance .save method and retrn void
+        const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
+        const getGroupThumbnailUrlSpy = spyOn(
+          SearchUtils,
+          "getGroupThumbnailUrl"
+        );
+        const setGroupThumbnailSpy = spyOn(
+          require("../../src/groups/setGroupThumbnail"),
+          "setGroupThumbnail"
+        ).and.returnValue(Promise.resolve({}));
+        // make changes to the editor
+        const editor = chk.toEditor();
+        editor.name = "new name";
+        editor._thumbnail = {
+          blob: "fake blob",
+          filename: "thumbnail.png",
+        };
+        // get the group loaded from the editor
+        const result = await chk.fromEditor(editor);
+        // expect the save method to have been called
+        expect(saveSpy).toHaveBeenCalledTimes(1);
+        // expect getGroupThumbnailUrl to have been called
+        expect(getGroupThumbnailUrlSpy).toHaveBeenCalledTimes(1);
+        // expect setGroupThumbnail to have been called
+        expect(setGroupThumbnailSpy).toHaveBeenCalledTimes(1);
+        expect(result.name).toBe("new name");
+        expect(result.thumbnailUrl).toBe("https://myserver.com/thumbnail.png");
+        expect(getProp(result, "_thumbnail")).not.toBeDefined();
+      });
+
+      it("handles thumbnail clear", async () => {
+        const chk = HubGroup.fromJson(
+          {
+            id: "bc3",
+            name: "Test Entity",
+            thumbnailUrl: "https://myserver.com/thumbnail.png",
+          },
+          authdCtxMgr.context
+        );
+        // spy on the instance .save method and retrn void
+        const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
+        const deleteGroupThumbnailSpy = spyOn(
+          require("../../src/groups/deleteGroupThumbnail"),
+          "deleteGroupThumbnail"
+        ).and.returnValue(Promise.resolve({}));
+        // make changes to the editor
+        const editor = chk.toEditor();
+        editor.name = "new name";
+        editor._thumbnail = {};
+        // get the group loaded from the editor
+        const result = await chk.fromEditor(editor);
+        // expect the save method to have been called
+        expect(saveSpy).toHaveBeenCalledTimes(1);
+        // expect the deleteGroupThumbnail method to have been called
+        expect(deleteGroupThumbnailSpy).toHaveBeenCalledTimes(1);
+        // since thumbnailCache is protected we can't really test that it's set
+        // other than via code-coverage
+        expect(getProp(result, "_thumbnail")).not.toBeDefined();
+      });
     });
   });
 });

--- a/packages/common/test/groups/_internal/convertGroupToHubGroup.test.ts
+++ b/packages/common/test/groups/_internal/convertGroupToHubGroup.test.ts
@@ -1,0 +1,49 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import { MOCK_AUTH } from "../../mocks/mock-auth";
+import { ArcGISContextManager } from "../../../src/ArcGISContextManager";
+import * as PortalModule from "@esri/arcgis-rest-portal";
+import { convertGroupToHubGroup } from "../../../src/groups/_internal/convertGroupToHubGroup";
+
+describe("groups: convertGroupToHubGroup:", () => {
+  it("converts an IGroup to a HubGroup", async () => {
+    const group = {
+      id: "3ef",
+      name: "Test group",
+      created: 123456789,
+      modified: 123456789,
+      thumbnail: "group.jpg",
+      membershipAccess: "collaboration",
+      userMembership: {
+        memberType: "admin",
+      },
+      capabilities: ["updateitemcontrol"],
+    } as unknown as IGroup;
+    // When we pass in all this information, the context
+    // manager will not try to fetch anything, so no need
+    // to mock those calls
+    const authdCtxMgr = await ArcGISContextManager.create({
+      authentication: MOCK_AUTH,
+      currentUser: {
+        username: "casey",
+      } as unknown as PortalModule.IUser,
+      portal: {
+        name: "DC R&D Center",
+        id: "BRXFAKE",
+        urlKey: "fake-org",
+      } as unknown as PortalModule.IPortal,
+      portalUrl: "https://myserver.com",
+    });
+    const chk = convertGroupToHubGroup(
+      group,
+      authdCtxMgr.context.userRequestOptions
+    );
+    expect(chk.id).toBe("3ef");
+    // we convert some props in IGroup to something else
+    // in HubGroup, checking them is a good way to
+    // varify the IGroup -> Hubgroup convertion
+    expect(chk.membershipAccess).toBe("collaborators");
+    expect(chk.isSharedUpdate).toBeTruthy();
+    expect(chk.canEdit).toBeTruthy();
+    expect(chk.canDelete).toBeTruthy();
+  });
+});

--- a/packages/common/test/groups/_internal/convertHubGroupToGroup.test.ts
+++ b/packages/common/test/groups/_internal/convertHubGroupToGroup.test.ts
@@ -1,0 +1,32 @@
+import { convertHubGroupToGroup } from "../../../src/groups/_internal/convertHubGroupToGroup";
+import { IHubGroup } from "../../../src/core/types/IHubGroup";
+
+describe("groups: convertHubGroupToGroup:", () => {
+  let hubGroup: any;
+  beforeEach(() => {
+    hubGroup = {
+      id: "3ef",
+      access: "org",
+      canEdit: true,
+      name: "Test group",
+      thumbnail: "group.jpg",
+      membershipAccess: "collaborators",
+    } as unknown as IHubGroup;
+  });
+  it("converts an HubGroup to a IGroup", async () => {
+    const chk = convertHubGroupToGroup(hubGroup);
+    // we convert some props in HubGroup to something else
+    // in IGroup, checking them is a good way to
+    // varify the HubGroup -> IGroup convertion
+    expect(chk.id).toBe("3ef");
+    expect(chk.access).toBe("org");
+    expect(chk.membershipAccess).toBe("collaboration");
+  });
+  it("clears empty fields", async () => {
+    hubGroup.membershipAccess = "anyone";
+    const chk = convertHubGroupToGroup(hubGroup);
+    expect(chk.id).toBe("3ef");
+    expect(chk.membershipAccess).toBeFalsy();
+    expect(chk._clearEmptyFields).toBeTruthy();
+  });
+});

--- a/packages/common/test/groups/deleteGroupThumbnail.test.ts
+++ b/packages/common/test/groups/deleteGroupThumbnail.test.ts
@@ -1,0 +1,20 @@
+import * as RequestModule from "@esri/arcgis-rest-request";
+import { deleteGroupThumbnail } from "../../src/groups/deleteGroupThumbnail";
+
+describe("deleteGroupThumbnail:", () => {
+  it("makes request to API", async () => {
+    const spy = spyOn(RequestModule, "request").and.returnValue(
+      Promise.resolve({})
+    );
+    await deleteGroupThumbnail("3ef", {
+      authentication: {},
+      portal: "https://www.arcgis.com/sharing/rest",
+    } as any);
+    expect(spy.calls.count()).toBe(1);
+    const args = spy.calls.argsFor(0)[0];
+
+    expect(args).toBe(
+      "https://www.arcgis.com/sharing/rest/community/groups/3ef/deleteThumbnail"
+    );
+  });
+});

--- a/packages/common/test/groups/setGroupThumbnail.test.ts
+++ b/packages/common/test/groups/setGroupThumbnail.test.ts
@@ -1,0 +1,80 @@
+import { setGroupThumbnail } from "../../src/groups/setGroupThumbnail";
+import * as portalModule from "@esri/arcgis-rest-portal";
+import { MOCK_AUTH } from "../mocks/mock-auth";
+
+describe("setGroupThumbnail:", () => {
+  it("calls updateGroup with expected params", async () => {
+    const updateSpy = spyOn(portalModule, "updateGroup").and.returnValues(
+      Promise.resolve({ success: true })
+    );
+    await setGroupThumbnail(
+      "3ef",
+      "fakeFile",
+      "mything.png",
+      {
+        authentication: MOCK_AUTH,
+      },
+      "fakeOwner"
+    );
+    expect(updateSpy.calls.count()).toBe(1);
+    const args = updateSpy.calls.argsFor(0)[0];
+    expect(args.group.id).toBe("3ef");
+    expect(args.params.thumbnail).toEqual("fakeFile");
+    expect(args.authentication).toEqual(MOCK_AUTH);
+  });
+
+  it("throws hub error if update fails", async () => {
+    spyOn(portalModule, "updateGroup").and.returnValues(
+      Promise.resolve({ success: false })
+    );
+    try {
+      await setGroupThumbnail(
+        "3ef",
+        "fakeFile",
+        "mything.png",
+        {
+          authentication: MOCK_AUTH,
+        },
+        "fakeOwner"
+      );
+    } catch (err) {
+      expect(err.name).toBe("HubError");
+    }
+  });
+  it("throws hub error if update rejects with error", async () => {
+    spyOn(portalModule, "updateGroup").and.returnValues(
+      Promise.reject(new Error("Fake Rejection"))
+    );
+    try {
+      await setGroupThumbnail(
+        "3ef",
+        "fakeFile",
+        "mything.png",
+        {
+          authentication: MOCK_AUTH,
+        },
+        "fakeOwner"
+      );
+    } catch (err) {
+      expect(err.name).toBe("HubError");
+    }
+  });
+  it("throws hub error if update rejects", async () => {
+    spyOn(portalModule, "updateGroup").and.returnValues(
+      Promise.reject("something else")
+    );
+    try {
+      await setGroupThumbnail(
+        "3ef",
+        "fakeFile",
+        "mything.png",
+        {
+          authentication: MOCK_AUTH,
+        },
+        "fakeOwner"
+      );
+    } catch (err) {
+      expect(err.name).toBe("HubError");
+    }
+  });
+});


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Add GroupSchema, GroupUiSchema and other support for Hub Groups so the group workspace details pane could be set up

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
