### PR TITLE
fix: user selects none; location disappears correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22644,9 +22644,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22661,21 +22662,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22689,9 +22693,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22709,9 +22714,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64966,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.33.1",
+			"version": "13.36.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -83376,7 +83382,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83391,17 +83398,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83415,7 +83425,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83432,7 +83443,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -104,6 +104,14 @@ export async function updateContent(
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic
   const modelToUpdate = mapper.entityToStore(content, model);
+
+  // prevent map from displaying when boundary is 'none'
+  const location = modelToUpdate.item.properties?.location;
+  if (location) {
+    modelToUpdate.item.properties.boundary =
+      location?.type === "none" ? "none" : "item";
+  }
+
   // TODO: if we have resources disconnect them from the model for now.
   // if (modelToUpdate.resources) {
   //   resources = configureBaseResources(

--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -20,6 +20,7 @@ import { getPropertyMap } from "./_internal/getPropertyMap";
 import { cloneObject } from "../util";
 import { IModel } from "../types";
 import { computeProps } from "./_internal/computeProps";
+import { getProp } from "..";
 
 // TODO: move this to defaults?
 const DEFAULT_CONTENT_MODEL: IModel = {
@@ -106,11 +107,9 @@ export async function updateContent(
   const modelToUpdate = mapper.entityToStore(content, model);
 
   // prevent map from displaying when boundary is 'none'
-  const location = modelToUpdate.item.properties?.location;
-  if (location) {
-    modelToUpdate.item.properties.boundary =
-      location?.type === "none" ? "none" : "item";
-  }
+  const itemType = getProp(modelToUpdate, "item.properties.location.type");
+  modelToUpdate.item.properties.boundary =
+    itemType === "none" ? "none" : "item";
 
   // TODO: if we have resources disconnect them from the model for now.
   // if (modelToUpdate.resources) {

--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -5,7 +5,7 @@ import {
   getItem,
   removeItem,
 } from "@esri/arcgis-rest-portal";
-import { IHubContent, IHubContentEditor, IHubEditableContent } from "../core";
+import { IHubContentEditor, IHubEditableContent } from "../core";
 
 // Note - we separate these imports so we can cleanly spy on things in tests
 import {
@@ -20,7 +20,7 @@ import { getPropertyMap } from "./_internal/getPropertyMap";
 import { cloneObject } from "../util";
 import { IModel } from "../types";
 import { computeProps } from "./_internal/computeProps";
-import { getProp } from "..";
+import { getProp } from "../objects/get-prop";
 
 // TODO: move this to defaults?
 const DEFAULT_CONTENT_MODEL: IModel = {

--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -107,9 +107,9 @@ export async function updateContent(
   const modelToUpdate = mapper.entityToStore(content, model);
 
   // prevent map from displaying when boundary is 'none'
-  const itemType = getProp(modelToUpdate, "item.properties.location.type");
+  const locationType = getProp(modelToUpdate, "item.properties.location.type");
   modelToUpdate.item.properties.boundary =
-    itemType === "none" ? "none" : "item";
+    locationType === "none" ? "none" : "item";
 
   // TODO: if we have resources disconnect them from the model for now.
   // if (modelToUpdate.resources) {

--- a/packages/common/src/core/getTypeFromEntity.ts
+++ b/packages/common/src/core/getTypeFromEntity.ts
@@ -35,6 +35,9 @@ export function getTypeFromEntity(
     case "Group":
       type = "group";
       break;
+    case "Hub Content":
+      type = "content";
+      break;
     default:
       // TODO: other families go here? feedback? solution? template?
       const contentFamilies = ["app", "content", "dataset", "document", "map"];

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -4,6 +4,7 @@ import { getTypeFromEntity } from "../../getTypeFromEntity";
 
 import { ConfigurableEntity } from "./ConfigurableEntity";
 import { IHubLocation, IHubLocationOption } from "../../types/IHubLocation";
+import { IExtent } from "@esri/arcgis-rest-types";
 
 /**
  * Construct the dynamic location picker options with the entity's
@@ -22,9 +23,75 @@ export async function getLocationOptions(
   portalName: string,
   hubRequestOptions: IHubRequestOptions
 ): Promise<IHubLocationOption[]> {
-  const defaultExtent = await getGeographicOrgExtent(hubRequestOptions);
+  const defaultExtent: IExtent = await getGeographicOrgExtent(
+    hubRequestOptions
+  );
   const location: IHubLocation = entity.location;
+  const typeFromEntity: any = getTypeFromEntity(entity);
 
+  switch (typeFromEntity) {
+    case "content":
+      return getContentLocationOptions(entity, portalName, hubRequestOptions);
+    default:
+      return getDefaultLocationOptions(entity, portalName, hubRequestOptions);
+  }
+}
+
+// TODO: Refactor parameters, they are icky gross
+// TODO: Maybe move these to outside of core and into respective entities
+
+export async function getContentLocationOptions(
+  entity: ConfigurableEntity,
+  portalName: string,
+  hubRequestOptions: IHubRequestOptions
+): Promise<IHubLocationOption[]> {
+  const defaultExtent: IExtent = await getGeographicOrgExtent(
+    hubRequestOptions
+  );
+  const location: IHubLocation = entity.location;
+  return (
+    [
+      {
+        label: "{{shared.fields.location.none:translate}}",
+        location: { type: "none" },
+      },
+      {
+        label: "{{shared.fields.location.itemExtent:translate}}",
+        entityType: "content",
+        location: {
+          type: "custom",
+          // TODO: Add custom bbox option here
+          // TODO: Remove "Add another location?" notification that appears when selecting a location
+          extent: extentToBBox(defaultExtent),
+          spatialReference: defaultExtent.spatialReference,
+        },
+      },
+    ] as IHubLocationOption[]
+  ).map((option) => {
+    // TODO: Might need to clean this up if it's just for content entities
+    // If this is a new entity, select the custom option by default
+    if (!entity.id && option.location.type === "custom") {
+      option.selected = true;
+    } else if (entity.id && !location && option.location.type === "none") {
+      option.selected = true;
+    } else if (location?.type === option.location.type) {
+      option.location = location;
+      option.selected = true;
+    }
+
+    return option;
+  });
+}
+
+export async function getDefaultLocationOptions(
+  entity: ConfigurableEntity,
+  portalName: string,
+  hubRequestOptions: IHubRequestOptions
+): Promise<IHubLocationOption[]> {
+  const defaultExtent: IExtent = await getGeographicOrgExtent(
+    hubRequestOptions
+  );
+  const location: IHubLocation = entity.location;
   return (
     [
       {
@@ -64,3 +131,5 @@ export async function getLocationOptions(
     return option;
   });
 }
+
+// TODO: Add other location options here

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -51,6 +51,7 @@ export async function getContentLocationOptions(
   entity: ConfigurableEntity
 ): Promise<IHubLocationOption[]> {
   const defaultExtent: IExtent = getItemExtent(entity.extent);
+  const defaultExtentIsBBox = isBBox(entity.extent);
   const boundary = entity.boundary;
   const isNone = boundary === "none";
   return [
@@ -67,8 +68,10 @@ export async function getContentLocationOptions(
         type: "custom",
         // TODO: Add custom bbox option here
         // TODO: Remove "Add another location?" notification that appears when selecting a location
-        extent: extentToBBox(defaultExtent),
-        spatialReference: defaultExtent.spatialReference,
+        extent: defaultExtentIsBBox ? extentToBBox(defaultExtent) : undefined,
+        spatialReference: defaultExtentIsBBox
+          ? defaultExtent.spatialReference
+          : undefined,
       },
     },
   ] as IHubLocationOption[];

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -4,7 +4,6 @@ import { getTypeFromEntity } from "../../getTypeFromEntity";
 
 import { ConfigurableEntity } from "./ConfigurableEntity";
 import { IHubLocation, IHubLocationOption } from "../../types/IHubLocation";
-import { IExtent } from "@esri/arcgis-rest-types";
 
 /**
  * Construct the dynamic location picker options with the entity's
@@ -23,75 +22,9 @@ export async function getLocationOptions(
   portalName: string,
   hubRequestOptions: IHubRequestOptions
 ): Promise<IHubLocationOption[]> {
-  const defaultExtent: IExtent = await getGeographicOrgExtent(
-    hubRequestOptions
-  );
+  const defaultExtent = await getGeographicOrgExtent(hubRequestOptions);
   const location: IHubLocation = entity.location;
-  const typeFromEntity: any = getTypeFromEntity(entity);
 
-  switch (typeFromEntity) {
-    case "content":
-      return getContentLocationOptions(entity, portalName, hubRequestOptions);
-    default:
-      return getDefaultLocationOptions(entity, portalName, hubRequestOptions);
-  }
-}
-
-// TODO: Refactor parameters, they are icky gross
-// TODO: Maybe move these to outside of core and into respective entities
-
-export async function getContentLocationOptions(
-  entity: ConfigurableEntity,
-  portalName: string,
-  hubRequestOptions: IHubRequestOptions
-): Promise<IHubLocationOption[]> {
-  const defaultExtent: IExtent = await getGeographicOrgExtent(
-    hubRequestOptions
-  );
-  const location: IHubLocation = entity.location;
-  return (
-    [
-      {
-        label: "{{shared.fields.location.none:translate}}",
-        location: { type: "none" },
-      },
-      {
-        label: "{{shared.fields.location.itemExtent:translate}}",
-        entityType: "content",
-        location: {
-          type: "custom",
-          // TODO: Add custom bbox option here
-          // TODO: Remove "Add another location?" notification that appears when selecting a location
-          extent: extentToBBox(defaultExtent),
-          spatialReference: defaultExtent.spatialReference,
-        },
-      },
-    ] as IHubLocationOption[]
-  ).map((option) => {
-    // TODO: Might need to clean this up if it's just for content entities
-    // If this is a new entity, select the custom option by default
-    if (!entity.id && option.location.type === "custom") {
-      option.selected = true;
-    } else if (entity.id && !location && option.location.type === "none") {
-      option.selected = true;
-    } else if (location?.type === option.location.type) {
-      option.location = location;
-      option.selected = true;
-    }
-
-    return option;
-  });
-}
-
-export async function getDefaultLocationOptions(
-  entity: ConfigurableEntity,
-  portalName: string,
-  hubRequestOptions: IHubRequestOptions
-): Promise<IHubLocationOption[]> {
-  const defaultExtent: IExtent = await getGeographicOrgExtent(
-    hubRequestOptions
-  );
-  const location: IHubLocation = entity.location;
   return (
     [
       {
@@ -131,5 +64,3 @@ export async function getDefaultLocationOptions(
     return option;
   });
 }
-
-// TODO: Add other location options here

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -23,15 +23,11 @@ export async function getLocationOptions(
   portalName: string,
   hubRequestOptions: IHubRequestOptions
 ): Promise<IHubLocationOption[]> {
-  const defaultExtent: IExtent = await getGeographicOrgExtent(
-    hubRequestOptions
-  );
-  const location: IHubLocation = entity.location;
   const typeFromEntity: any = getTypeFromEntity(entity);
 
   switch (typeFromEntity) {
     case "content":
-      return getContentLocationOptions(entity, portalName, hubRequestOptions);
+      return getContentLocationOptions(entity, hubRequestOptions);
     default:
       return getDefaultLocationOptions(entity, portalName, hubRequestOptions);
   }
@@ -42,7 +38,6 @@ export async function getLocationOptions(
 
 export async function getContentLocationOptions(
   entity: ConfigurableEntity,
-  portalName: string,
   hubRequestOptions: IHubRequestOptions
 ): Promise<IHubLocationOption[]> {
   const defaultExtent: IExtent = await getGeographicOrgExtent(
@@ -68,7 +63,6 @@ export async function getContentLocationOptions(
       },
     ] as IHubLocationOption[]
   ).map((option) => {
-    // TODO: Might need to clean this up if it's just for content entities
     // If this is a new entity, select the custom option by default
     if (!entity.id && option.location.type === "custom") {
       option.selected = true;

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -63,14 +63,20 @@ export async function getContentLocationOptions(
       },
     ] as IHubLocationOption[]
   ).map((option) => {
-    // If this is a new entity, select the custom option by default
-    if (!entity.id && option.location.type === "custom") {
+    // new entity --> custom (with no location set)
+    // non-new entity, location type custom --> custom
+    // non-new entity, location type none --> none
+    if (
+      (entity.id && !location && option.location.type === "none") ||
+      (entity.id && location && option.location.type === "custom") ||
+      (!entity.id && option.location.type === "custom")
+    ) {
       option.selected = true;
-    } else if (entity.id && !location && option.location.type === "none") {
-      option.selected = true;
-    } else if (location?.type === option.location.type) {
+    }
+
+    // location set? --> set option location
+    if (location?.type === option.location.type) {
       option.location = location;
-      option.selected = true;
     }
 
     return option;

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -31,14 +31,9 @@ export async function getLocationOptions(
 
   switch (typeFromEntity) {
     case "content":
-      return getContentLocationOptions(entity, defaultExtent, location);
+      return getContentLocationOptions(entity, portalName, hubRequestOptions);
     default:
-      return getDefaultLocationOptions(
-        entity,
-        portalName,
-        defaultExtent,
-        location
-      );
+      return getDefaultLocationOptions(entity, portalName, hubRequestOptions);
   }
 }
 
@@ -47,9 +42,13 @@ export async function getLocationOptions(
 
 export async function getContentLocationOptions(
   entity: ConfigurableEntity,
-  defaultExtent: IExtent,
-  location: IHubLocation
+  portalName: string,
+  hubRequestOptions: IHubRequestOptions
 ): Promise<IHubLocationOption[]> {
+  const defaultExtent: IExtent = await getGeographicOrgExtent(
+    hubRequestOptions
+  );
+  const location: IHubLocation = entity.location;
   return (
     [
       {
@@ -57,7 +56,7 @@ export async function getContentLocationOptions(
         location: { type: "none" },
       },
       {
-        label: "Item's Current Extent", // TODO: Translation
+        label: "{{shared.fields.location.itemExtent:translate}}",
         entityType: "content",
         location: {
           type: "custom",
@@ -87,9 +86,12 @@ export async function getContentLocationOptions(
 export async function getDefaultLocationOptions(
   entity: ConfigurableEntity,
   portalName: string,
-  defaultExtent: IExtent,
-  location: IHubLocation
+  hubRequestOptions: IHubRequestOptions
 ): Promise<IHubLocationOption[]> {
+  const defaultExtent: IExtent = await getGeographicOrgExtent(
+    hubRequestOptions
+  );
+  const location: IHubLocation = entity.location;
   return (
     [
       {

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -4,6 +4,7 @@ import { getTypeFromEntity } from "../../getTypeFromEntity";
 
 import { ConfigurableEntity } from "./ConfigurableEntity";
 import { IHubLocation, IHubLocationOption } from "../../types/IHubLocation";
+import { IExtent } from "@esri/arcgis-rest-types";
 
 /**
  * Construct the dynamic location picker options with the entity's
@@ -22,9 +23,73 @@ export async function getLocationOptions(
   portalName: string,
   hubRequestOptions: IHubRequestOptions
 ): Promise<IHubLocationOption[]> {
-  const defaultExtent = await getGeographicOrgExtent(hubRequestOptions);
+  const defaultExtent: IExtent = await getGeographicOrgExtent(
+    hubRequestOptions
+  );
   const location: IHubLocation = entity.location;
+  const typeFromEntity: any = getTypeFromEntity(entity);
 
+  switch (typeFromEntity) {
+    case "content":
+      return getContentLocationOptions(entity, defaultExtent, location);
+    default:
+      return getDefaultLocationOptions(
+        entity,
+        portalName,
+        defaultExtent,
+        location
+      );
+  }
+}
+
+// TODO: Refactor parameters, they are icky gross
+// TODO: Maybe move these to outside of core and into respective entities
+
+export async function getContentLocationOptions(
+  entity: ConfigurableEntity,
+  defaultExtent: IExtent,
+  location: IHubLocation
+): Promise<IHubLocationOption[]> {
+  return (
+    [
+      {
+        label: "{{shared.fields.location.none:translate}}",
+        location: { type: "none" },
+      },
+      {
+        label: "Item's Current Extent", // TODO: Translation
+        entityType: "content",
+        location: {
+          type: "custom",
+          // TODO: Add custom bbox option here
+          // TODO: Remove "Add another location?" notification that appears when selecting a location
+          extent: extentToBBox(defaultExtent),
+          spatialReference: defaultExtent.spatialReference,
+        },
+      },
+    ] as IHubLocationOption[]
+  ).map((option) => {
+    // TODO: Might need to clean this up if it's just for content entities
+    // If this is a new entity, select the custom option by default
+    if (!entity.id && option.location.type === "custom") {
+      option.selected = true;
+    } else if (entity.id && !location && option.location.type === "none") {
+      option.selected = true;
+    } else if (location?.type === option.location.type) {
+      option.location = location;
+      option.selected = true;
+    }
+
+    return option;
+  });
+}
+
+export async function getDefaultLocationOptions(
+  entity: ConfigurableEntity,
+  portalName: string,
+  defaultExtent: IExtent,
+  location: IHubLocation
+): Promise<IHubLocationOption[]> {
   return (
     [
       {
@@ -64,3 +129,5 @@ export async function getLocationOptions(
     return option;
   });
 }
+
+// TODO: Add other location options here

--- a/packages/common/test/content/edit.test.ts
+++ b/packages/common/test/content/edit.test.ts
@@ -80,6 +80,7 @@ describe("content editing:", () => {
       expect(updateModelSpy.calls.count()).toBe(1);
       const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
       expect(modelToUpdate.item.description).toBe(content.description);
+      expect(modelToUpdate.item.properties.boundary).toBe("none");
     });
   });
   describe("update content with location:", () => {
@@ -125,6 +126,7 @@ describe("content editing:", () => {
       expect(updateModelSpy.calls.count()).toBe(1);
       const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
       expect(modelToUpdate.item.description).toBe(content.description);
+      expect(modelToUpdate.item.properties.boundary).toBe("item");
     });
   });
   describe("delete content", () => {

--- a/packages/common/test/content/edit.test.ts
+++ b/packages/common/test/content/edit.test.ts
@@ -70,6 +70,52 @@ describe("content editing:", () => {
         schemaVersion: 1,
         canEdit: false,
         canDelete: false,
+        location: { type: "none" },
+      };
+      const chk = await updateContent(content, { authentication: MOCK_AUTH });
+      expect(chk.id).toBe(GUID);
+      expect(chk.name).toBe("Hello World");
+      expect(chk.description).toBe("Some longer description");
+      expect(getItemSpy.calls.count()).toBe(1);
+      expect(updateModelSpy.calls.count()).toBe(1);
+      const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
+      expect(modelToUpdate.item.description).toBe(content.description);
+    });
+  });
+  describe("update content with location:", () => {
+    it("converts to a model and updates the item", async () => {
+      const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
+        Promise.resolve({
+          item: {
+            typeKeywords: [],
+          },
+        })
+      );
+      const updateModelSpy = spyOn(modelUtils, "updateModel").and.callFake(
+        (m: IModel) => {
+          return Promise.resolve(m);
+        }
+      );
+      const content: IHubEditableContent = {
+        itemControl: "edit",
+        id: GUID,
+        name: "Hello World",
+        tags: ["Transportation"],
+        description: "Some longer description",
+        slug: "dcdev-wat-blarg",
+        orgUrlKey: "dcdev",
+        owner: "dcdev_dude",
+        type: "Hub Initiative",
+        createdDate: new Date(1595878748000),
+        createdDateSource: "item.created",
+        updatedDate: new Date(1595878750000),
+        updatedDateSource: "item.modified",
+        thumbnailUrl: "",
+        permissions: [],
+        schemaVersion: 1,
+        canEdit: false,
+        canDelete: false,
+        location: { type: "item" },
       };
       const chk = await updateContent(content, { authentication: MOCK_AUTH });
       expect(chk.id).toBe(GUID);

--- a/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
+++ b/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
@@ -1,4 +1,5 @@
 import { IHubContent, IHubProject, IHubRequestOptions } from "../../../../src";
+import { ConfigurableEntity } from "../../../../src/core/schemas/internal/ConfigurableEntity";
 import { getLocationOptions } from "../../../../src/core/schemas/internal/getLocationOptions";
 import * as ExtentModule from "../../../../src/extent";
 
@@ -91,31 +92,19 @@ describe("getLocationOptions - default:", () => {
 });
 
 describe("getLocationOptions - content:", () => {
-  let orgExtentSpy: jasmine.Spy;
-  beforeEach(() => {
-    orgExtentSpy = spyOn(
-      ExtentModule,
-      "getGeographicOrgExtent"
-    ).and.returnValue(
-      Promise.resolve({
-        xmin: -180,
-        ymin: -90,
-        xmax: 180,
-        ymax: 90,
-        spatialReference: {
-          wkid: 4326,
-        },
-      })
-    );
-  });
   it("custom is selected", async () => {
-    const entity: IHubContent = {
+    const entity: ConfigurableEntity = {
       id: "00c",
       type: "Hub Content",
       location: {
         type: "custom",
       },
-    } as IHubContent;
+      boundary: "item",
+      extent: [
+        [100, 100],
+        [120, 120],
+      ],
+    } as ConfigurableEntity;
 
     const chk = await getLocationOptions(
       entity,
@@ -127,10 +116,14 @@ describe("getLocationOptions - content:", () => {
     expect(chk[1].selected).toBe(true);
   });
   it("none is selected", async () => {
-    const entity: IHubContent = {
+    const entity: ConfigurableEntity = {
       id: "00c",
       type: "Hub Content",
-    } as IHubContent;
+      location: {
+        type: "none",
+      },
+      boundary: "none",
+    } as ConfigurableEntity;
 
     const chk = await getLocationOptions(
       entity,
@@ -142,12 +135,40 @@ describe("getLocationOptions - content:", () => {
     expect(chk[0].selected).toBe(true);
   });
   it("custom is selected if entity does not have an id", async () => {
-    const entity: IHubContent = {
+    const entity: ConfigurableEntity = {
       type: "Hub Content",
       location: {
         type: "custom",
       },
-    } as IHubContent;
+      boundary: "item",
+      extent: [
+        [100, 100],
+        [120, 120],
+      ],
+    } as ConfigurableEntity;
+
+    const chk = await getLocationOptions(
+      entity,
+      "portalName",
+      {} as IHubRequestOptions
+    );
+
+    expect(chk.length).toBe(2);
+    expect(chk[1].selected).toBe(true);
+  });
+  it("custom is selected & boundary is set", async () => {
+    const entity: ConfigurableEntity = {
+      id: "00c",
+      type: "Hub Content",
+      location: {
+        type: "custom",
+      },
+      boundary: "item",
+      extent: [
+        [100, 100],
+        [120, 120],
+      ],
+    } as ConfigurableEntity;
 
     const chk = await getLocationOptions(
       entity,

--- a/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
+++ b/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
@@ -1,8 +1,8 @@
-import { IHubProject, IHubRequestOptions } from "../../../../src";
+import { IHubContent, IHubProject, IHubRequestOptions } from "../../../../src";
 import { getLocationOptions } from "../../../../src/core/schemas/internal/getLocationOptions";
 import * as ExtentModule from "../../../../src/extent";
 
-describe("getLocationOptions:", () => {
+describe("getLocationOptions - default:", () => {
   let orgExtentSpy: jasmine.Spy;
   beforeEach(() => {
     orgExtentSpy = spyOn(
@@ -87,5 +87,75 @@ describe("getLocationOptions:", () => {
 
     expect(chk.length).toBe(3);
     expect(chk[2].selected).toBe(true);
+  });
+});
+
+describe("getLocationOptions - content:", () => {
+  let orgExtentSpy: jasmine.Spy;
+  beforeEach(() => {
+    orgExtentSpy = spyOn(
+      ExtentModule,
+      "getGeographicOrgExtent"
+    ).and.returnValue(
+      Promise.resolve({
+        xmin: -180,
+        ymin: -90,
+        xmax: 180,
+        ymax: 90,
+        spatialReference: {
+          wkid: 4326,
+        },
+      })
+    );
+  });
+  it("custom is selected", async () => {
+    const entity: IHubContent = {
+      id: "00c",
+      type: "Hub Content",
+      location: {
+        type: "custom",
+      },
+    } as IHubContent;
+
+    const chk = await getLocationOptions(
+      entity,
+      "portalName",
+      {} as IHubRequestOptions
+    );
+
+    expect(chk.length).toBe(2);
+    expect(chk[1].selected).toBe(true);
+  });
+  it("none is selected", async () => {
+    const entity: IHubContent = {
+      id: "00c",
+      type: "Hub Content",
+    } as IHubContent;
+
+    const chk = await getLocationOptions(
+      entity,
+      "portalName",
+      {} as IHubRequestOptions
+    );
+
+    expect(chk.length).toBe(2);
+    expect(chk[0].selected).toBe(true);
+  });
+  it("custom is selected if entity does not have an id", async () => {
+    const entity: IHubContent = {
+      type: "Hub Content",
+      location: {
+        type: "custom",
+      },
+    } as IHubContent;
+
+    const chk = await getLocationOptions(
+      entity,
+      "portalName",
+      {} as IHubRequestOptions
+    );
+
+    expect(chk.length).toBe(2);
+    expect(chk[1].selected).toBe(true);
   });
 });


### PR DESCRIPTION
### Important
Make sure you have your opendata-ui set to https://github.com/ArcGIS/opendata-ui/pull/12378 until it merges, I added a new translation this morning.

1. Description: 
- If a user selects "none" in the location picker, it no longer appears in the /about view
- Location picker options in workspace content now properly shows two options
  - This will be further built off of in future issues and PRs that allow for a bounding box option as discussed with Tom, Dave, and Ben on Aug 10, 2023

1. Instructions for testing:
- Clone this PR and PR with updated translations: https://github.com/ArcGIS/opendata-ui/pull/12378 
- Copy the hubjs dist folder over
- `yarn hc start` -- switch back and forth between "none" and "Item's Current Extent" in content's location picker
- Double check that I haven't changed other workspace entities like projects

1. Closes Issues: #7208

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
