### PR TITLE
fix(): update clientKey to empty string in updateDomain/addDomain

### DIFF
--- a/packages/common/src/sites/domains/add-domain.ts
+++ b/packages/common/src/sites/domains/add-domain.ts
@@ -25,10 +25,10 @@ export function addDomain(
   if (typeof title === "number") {
     domainEntry.siteTitle = title.toString();
   }
-  // update client key to empty string if we have one, as it won't pass schema validation
-  if (domainEntry?.clientKey) {
-    domainEntry.clientKey = "";
-  }
+  // // update client key to empty string if we have one, as it won't pass schema validation
+  // if (domainEntry?.clientKey) {
+  //   domainEntry.clientKey = "";
+  // }
   return fetch(url, {
     method: "POST",
     headers,

--- a/packages/common/src/sites/domains/add-domain.ts
+++ b/packages/common/src/sites/domains/add-domain.ts
@@ -25,6 +25,7 @@ export function addDomain(
   if (typeof title === "number") {
     domainEntry.siteTitle = title.toString();
   }
+  // update client key to empty string if we have one, as it won't pass schema validation
   if (domainEntry?.clientKey) {
     domainEntry.clientKey = "";
   }

--- a/packages/common/src/sites/domains/add-domain.ts
+++ b/packages/common/src/sites/domains/add-domain.ts
@@ -25,6 +25,9 @@ export function addDomain(
   if (typeof title === "number") {
     domainEntry.siteTitle = title.toString();
   }
+  if (domainEntry?.clientKey) {
+    domainEntry.clientKey = "";
+  }
   return fetch(url, {
     method: "POST",
     headers,

--- a/packages/common/src/sites/domains/add-domain.ts
+++ b/packages/common/src/sites/domains/add-domain.ts
@@ -25,10 +25,10 @@ export function addDomain(
   if (typeof title === "number") {
     domainEntry.siteTitle = title.toString();
   }
-  // // update client key to empty string if we have one, as it won't pass schema validation
-  // if (domainEntry?.clientKey) {
-  //   domainEntry.clientKey = "";
-  // }
+  // update client key to empty string if we have one, as it won't pass schema validation
+  if (domainEntry.clientKey) {
+    domainEntry.clientKey = "";
+  }
   return fetch(url, {
     method: "POST",
     headers,

--- a/packages/common/src/sites/domains/update-domain.ts
+++ b/packages/common/src/sites/domains/update-domain.ts
@@ -29,7 +29,7 @@ export function updateDomain(
     domainEntry.siteTitle = title.toString();
   }
 
-  // delete client key if we have one, as it won't pass schema validation
+  // update client key to empty string if we have one, as it won't pass schema validation
   if (domainEntry.clientKey) {
     domainEntry.clientKey = "";
   }

--- a/packages/common/src/sites/domains/update-domain.ts
+++ b/packages/common/src/sites/domains/update-domain.ts
@@ -28,6 +28,12 @@ export function updateDomain(
   if (typeof title === "number") {
     domainEntry.siteTitle = title.toString();
   }
+
+  // delete client key if we have one, as it won't pass schema validation
+  if (domainEntry.clientKey) {
+    domainEntry.clientKey = "";
+  }
+
   return fetch(url, {
     method: "PUT",
     headers,

--- a/packages/common/test/sites/domains/add-domain.test.ts
+++ b/packages/common/test/sites/domains/add-domain.test.ts
@@ -70,11 +70,11 @@ describe("addDomain", function () {
       "1234",
       "should coerce numeric title to a string"
     );
-    expect(res.success).toBeTruthy("json parsed and response returned");
     expect(getProp(body, "clientKey")).toBe(
       "",
       "should update clientKey to empty string"
     );
+    expect(res.success).toBeTruthy("json parsed and response returned");
   });
 
   it("converts title to string without client key", async function () {
@@ -138,7 +138,10 @@ describe("addDomain", function () {
     expect(res.success).toBeTruthy("json parsed and response returned");
     const opts = fetchMock.lastOptions("end:api/v3/domains");
     const body = JSON.parse(opts.body as string);
-    expect(getProp(body, "clientKey")).toBe(null, "should not have clientKey");
+    expect(getProp(body, "clientKey")).toBe(
+      undefined,
+      "should not have clientKey"
+    );
   });
 
   it("throws error on portal", async function () {

--- a/packages/common/test/sites/domains/add-domain.test.ts
+++ b/packages/common/test/sites/domains/add-domain.test.ts
@@ -67,6 +67,34 @@ describe("addDomain", function () {
     expect(res.success).toBeTruthy("json parsed and response returned");
   });
 
+  it("handles not having a client key", async function () {
+    const ro = { isPortal: false } as IHubRequestOptions;
+
+    spyOn(
+      _checkStatusAndParseJsonModule,
+      "_checkStatusAndParseJson"
+    ).and.returnValue(Promise.resolve({ success: true }));
+
+    fetchMock.post("end:api/v3/domains", {});
+
+    const entry = {
+      domain: "zebra-dc.hubqa.arcgis.com",
+      hostname: "zebra-dc.hubqa.arcgis.com",
+      id: "146663",
+      orgId: "97KLIFOSt5CxbiRI",
+      orgKey: "dc",
+      orgTitle: "Washington, DC R&D Center (QA)",
+      permanentRedirect: false,
+      siteId: "9697f67b6d6343fa823dcdbe2d172073",
+      siteTitle: "Zebra",
+      sslOnly: true,
+    };
+
+    const res = await addDomain(entry, ro);
+    expect(fetchMock.done()).toBeTruthy("fetch should have been called once");
+    expect(res.success).toBeTruthy("json parsed and response returned");
+  });
+
   it("throws error on portal", async function () {
     const ro = { isPortal: true } as IHubRequestOptions;
 

--- a/packages/common/test/sites/domains/add-domain.test.ts
+++ b/packages/common/test/sites/domains/add-domain.test.ts
@@ -107,6 +107,10 @@ describe("addDomain", function () {
       "1234",
       "should coerce numeric title to a string"
     );
+    expect(getProp(body, "clientKey")).toBe(
+      undefined,
+      "should not have client key"
+    );
     expect(res.success).toBeTruthy("json parsed and response returned");
   });
 

--- a/packages/common/test/sites/domains/add-domain.test.ts
+++ b/packages/common/test/sites/domains/add-domain.test.ts
@@ -31,6 +31,12 @@ describe("addDomain", function () {
     const res = await addDomain(domainEntry, ro);
     expect(fetchMock.done()).toBeTruthy("fetch should have been called once");
     expect(res.success).toBeTruthy("json parsed and response returned");
+    const opts = fetchMock.lastOptions("end:api/v3/domains");
+    const body = JSON.parse(opts.body as string);
+    expect(getProp(body, "clientKey")).toBe(
+      "",
+      "should update clientKey to empty string"
+    );
   });
 
   it("converts title to string", async function () {
@@ -65,6 +71,10 @@ describe("addDomain", function () {
       "should coerce numeric title to a string"
     );
     expect(res.success).toBeTruthy("json parsed and response returned");
+    expect(getProp(body, "clientKey")).toBe(
+      "",
+      "should update clientKey to empty string"
+    );
   });
 
   it("converts title to string without client key", async function () {

--- a/packages/common/test/sites/domains/add-domain.test.ts
+++ b/packages/common/test/sites/domains/add-domain.test.ts
@@ -67,7 +67,7 @@ describe("addDomain", function () {
     expect(res.success).toBeTruthy("json parsed and response returned");
   });
 
-  it("converts title to string", async function () {
+  it("converts title to string without client key", async function () {
     const entry = {
       domain: "zebra-dc.hubqa.arcgis.com",
       hostname: "zebra-dc.hubqa.arcgis.com",

--- a/packages/common/test/sites/domains/add-domain.test.ts
+++ b/packages/common/test/sites/domains/add-domain.test.ts
@@ -67,6 +67,39 @@ describe("addDomain", function () {
     expect(res.success).toBeTruthy("json parsed and response returned");
   });
 
+  it("converts title to string", async function () {
+    const entry = {
+      domain: "zebra-dc.hubqa.arcgis.com",
+      hostname: "zebra-dc.hubqa.arcgis.com",
+      id: "146663",
+      orgId: "97KLIFOSt5CxbiRI",
+      orgKey: "dc",
+      orgTitle: "Washington, DC R&D Center (QA)",
+      permanentRedirect: false,
+      siteId: "9697f67b6d6343fa823dcdbe2d172073",
+      siteTitle: 1234,
+      sslOnly: true,
+    } as unknown as IDomainEntry;
+    const ro = { isPortal: false } as IHubRequestOptions;
+
+    spyOn(
+      _checkStatusAndParseJsonModule,
+      "_checkStatusAndParseJson"
+    ).and.returnValue(Promise.resolve({ success: true }));
+
+    fetchMock.post("end:api/v3/domains", {});
+
+    const res = await addDomain(entry, ro);
+    expect(fetchMock.done()).toBeTruthy("fetch should have been called once");
+    const opts = fetchMock.lastOptions("end:api/v3/domains");
+    const body = JSON.parse(opts.body as string);
+    expect(getProp(body, "siteTitle")).toBe(
+      "1234",
+      "should coerce numeric title to a string"
+    );
+    expect(res.success).toBeTruthy("json parsed and response returned");
+  });
+
   it("handles not having a client key", async function () {
     const ro = { isPortal: false } as IHubRequestOptions;
 

--- a/packages/common/test/sites/domains/add-domain.test.ts
+++ b/packages/common/test/sites/domains/add-domain.test.ts
@@ -110,7 +110,7 @@ describe("addDomain", function () {
     expect(res.success).toBeTruthy("json parsed and response returned");
   });
 
-  it("handles not having a client key", async function () {
+  it("function runs as expected without a client key (code coverage)", async function () {
     const ro = { isPortal: false } as IHubRequestOptions;
 
     spyOn(
@@ -136,6 +136,9 @@ describe("addDomain", function () {
     const res = await addDomain(entry, ro);
     expect(fetchMock.done()).toBeTruthy("fetch should have been called once");
     expect(res.success).toBeTruthy("json parsed and response returned");
+    const opts = fetchMock.lastOptions("end:api/v3/domains");
+    const body = JSON.parse(opts.body as string);
+    expect(getProp(body, "clientKey")).toBe(null, "should not have clientKey");
   });
 
   it("throws error on portal", async function () {

--- a/packages/common/test/sites/domains/update-domain.test.ts
+++ b/packages/common/test/sites/domains/update-domain.test.ts
@@ -107,6 +107,10 @@ describe("updateDomain", function () {
       "1234",
       "should coerce numeric title to a string"
     );
+    expect(getProp(body, "clientKey")).toBe(
+      undefined,
+      "should not have client key"
+    );
     expect(res.success).toBeTruthy("json parsed and response returned");
   });
 

--- a/packages/common/test/sites/domains/update-domain.test.ts
+++ b/packages/common/test/sites/domains/update-domain.test.ts
@@ -84,4 +84,31 @@ describe("updateDomain", function () {
       "fetch should NOT have been called"
     );
   });
+
+  it("updates domain when no client key is passed in", async function () {
+    const ro = { isPortal: false } as IHubRequestOptions;
+
+    spyOn(
+      _checkStatusAndParseJsonModule,
+      "_checkStatusAndParseJson"
+    ).and.returnValue(Promise.resolve({ success: true }));
+
+    const entry = {
+      domain: "zebra-dc.hubqa.arcgis.com",
+      hostname: "zebra-dc.hubqa.arcgis.com",
+      id: "146663",
+      orgId: "97KLIFOSt5CxbiRI",
+      orgKey: "dc",
+      orgTitle: "Washington, DC R&D Center (QA)",
+      permanentRedirect: false,
+      siteId: "9697f67b6d6343fa823dcdbe2d172073",
+      siteTitle: "Zebra",
+      sslOnly: true,
+    };
+    fetchMock.put(`end:api/v3/domains/${entry.id}`, {});
+
+    const res = await updateDomain(entry, ro);
+    expect(fetchMock.done()).toBeTruthy("fetch should have been called once");
+    expect(res.success).toBeTruthy("json parsed and response returned");
+  });
 });

--- a/packages/common/test/sites/domains/update-domain.test.ts
+++ b/packages/common/test/sites/domains/update-domain.test.ts
@@ -67,6 +67,39 @@ describe("updateDomain", function () {
     expect(res.success).toBeTruthy("json parsed and response returned");
   });
 
+  it("converts title to a string", async function () {
+    const entry = {
+      domain: "zebra-dc.hubqa.arcgis.com",
+      hostname: "zebra-dc.hubqa.arcgis.com",
+      id: "146663",
+      orgId: "97KLIFOSt5CxbiRI",
+      orgKey: "dc",
+      orgTitle: "Washington, DC R&D Center (QA)",
+      permanentRedirect: false,
+      siteId: "9697f67b6d6343fa823dcdbe2d172073",
+      siteTitle: 1234,
+      sslOnly: true,
+    } as unknown as IDomainEntry;
+    const ro = { isPortal: false } as IHubRequestOptions;
+
+    spyOn(
+      _checkStatusAndParseJsonModule,
+      "_checkStatusAndParseJson"
+    ).and.returnValue(Promise.resolve({ success: true }));
+
+    fetchMock.put(`end:api/v3/domains/${entry.id}`, {});
+
+    const res = await updateDomain(entry, ro);
+    expect(fetchMock.done()).toBeTruthy("fetch should have been called once");
+    const opts = fetchMock.lastOptions(`end:api/v3/domains/${entry.id}`);
+    const body = JSON.parse(opts.body as string);
+    expect(getProp(body, "siteTitle")).toBe(
+      "1234",
+      "should coerce numeric title to a string"
+    );
+    expect(res.success).toBeTruthy("json parsed and response returned");
+  });
+
   it("throws error on portal", async function () {
     const ro = { isPortal: true } as IHubRequestOptions;
 

--- a/packages/common/test/sites/domains/update-domain.test.ts
+++ b/packages/common/test/sites/domains/update-domain.test.ts
@@ -153,8 +153,11 @@ describe("updateDomain", function () {
     const res = await updateDomain(entry, ro);
     expect(fetchMock.done()).toBeTruthy("fetch should have been called once");
     expect(res.success).toBeTruthy("json parsed and response returned");
-    const opts = fetchMock.lastOptions("end:api/v3/domains");
+    const opts = fetchMock.lastOptions(`end:api/v3/domains/${entry.id}`);
     const body = JSON.parse(opts.body as string);
-    expect(getProp(body, "clientKey")).toBe(null, "should not have clientKey");
+    expect(getProp(body, "clientKey")).toBe(
+      undefined,
+      "should not have clientKey"
+    );
   });
 });

--- a/packages/common/test/sites/domains/update-domain.test.ts
+++ b/packages/common/test/sites/domains/update-domain.test.ts
@@ -31,6 +31,12 @@ describe("updateDomain", function () {
     const res = await updateDomain(domainEntry, ro);
     expect(fetchMock.done()).toBeTruthy("fetch should have been called once");
     expect(res.success).toBeTruthy("json parsed and response returned");
+    const opts = fetchMock.lastOptions(`end:api/v3/domains/${domainEntry.id}`);
+    const body = JSON.parse(opts.body as string);
+    expect(getProp(body, "clientKey")).toBe(
+      "",
+      "should update clientKey to empty string"
+    );
   });
 
   it("converts title to a string", async function () {
@@ -63,6 +69,10 @@ describe("updateDomain", function () {
     expect(getProp(body, "siteTitle")).toBe(
       "1234",
       "should coerce numeric title to a string"
+    );
+    expect(getProp(body, "clientKey")).toBe(
+      "",
+      "should update clientKey to empty string"
     );
     expect(res.success).toBeTruthy("json parsed and response returned");
   });

--- a/packages/common/test/sites/domains/update-domain.test.ts
+++ b/packages/common/test/sites/domains/update-domain.test.ts
@@ -128,7 +128,7 @@ describe("updateDomain", function () {
     );
   });
 
-  it("updates domain when no client key is passed in", async function () {
+  it("function runs as expected without a client key (code coverage)", async function () {
     const ro = { isPortal: false } as IHubRequestOptions;
 
     spyOn(
@@ -153,5 +153,8 @@ describe("updateDomain", function () {
     const res = await updateDomain(entry, ro);
     expect(fetchMock.done()).toBeTruthy("fetch should have been called once");
     expect(res.success).toBeTruthy("json parsed and response returned");
+    const opts = fetchMock.lastOptions("end:api/v3/domains");
+    const body = JSON.parse(opts.body as string);
+    expect(getProp(body, "clientKey")).toBe(null, "should not have clientKey");
   });
 });

--- a/packages/common/test/sites/domains/update-domain.test.ts
+++ b/packages/common/test/sites/domains/update-domain.test.ts
@@ -67,7 +67,7 @@ describe("updateDomain", function () {
     expect(res.success).toBeTruthy("json parsed and response returned");
   });
 
-  it("converts title to a string", async function () {
+  it("converts title to a string without client key", async function () {
     const entry = {
       domain: "zebra-dc.hubqa.arcgis.com",
       hostname: "zebra-dc.hubqa.arcgis.com",


### PR DESCRIPTION
1. Description:
Updates the client key to an empty string before calling add or update domain. 

1. Instructions for testing:

1. Closes Issues: works to close 7460 and 7559

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
