### PR TITLE
fix: reverting changes for uniform product

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22644,10 +22644,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22662,24 +22661,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22693,10 +22689,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22714,10 +22709,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64972,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.36.1",
+			"version": "13.37.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -83382,8 +83376,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83398,20 +83391,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83425,8 +83415,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83443,8 +83432,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64966,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.37.3",
+			"version": "13.38.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @esri/hub-common [13.38.1](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.38.0...@esri/hub-common@13.38.1) (2023-08-16)
+
+
+### Bug Fixes
+
+* remove additionalInfo from userResultToCardModel ([#1162](https://github.com/Esri/hub.js/issues/1162)) ([c4c72c8](https://github.com/Esri/hub.js/commit/c4c72c8fd4a8f92fdd6e4400f0d4f923c06d0293))
+
 # @esri/hub-common [13.38.0](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.37.3...@esri/hub-common@13.38.0) (2023-08-15)
 
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,15 @@
+# @esri/hub-common [13.38.0](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.37.3...@esri/hub-common@13.38.0) (2023-08-15)
+
+
+### Bug Fixes
+
+* export ihubgroup ([#1160](https://github.com/Esri/hub.js/issues/1160)) ([0d29518](https://github.com/Esri/hub.js/commit/0d2951875adc7331e2f93058b3fb2356a427a1eb))
+
+
+### Features
+
+* permission parents, deprecations for Capabilities ([#1158](https://github.com/Esri/hub.js/issues/1158)) ([83659b1](https://github.com/Esri/hub.js/commit/83659b1c42d73ebf4504d4b160b449565767161c))
+
 ## @esri/hub-common [13.37.3](https://github.com/Esri/hub.js/compare/@esri/hub-common@13.37.2...@esri/hub-common@13.37.3) (2023-08-14)
 
 

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.37.3",
+  "version": "13.38.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@esri/hub-common",
-      "version": "13.37.3",
+      "version": "13.38.0",
       "license": "Apache-2.0",
       "dependencies": {
         "abab": "^2.0.5",

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.38.0",
+  "version": "13.38.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@esri/hub-common",
-      "version": "13.38.0",
+      "version": "13.38.1",
       "license": "Apache-2.0",
       "dependencies": {
         "abab": "^2.0.5",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.38.0",
+  "version": "13.38.1",
   "description": "Common TypeScript types and utility functions for @esri/hub.js.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/hub-common",
-  "version": "13.37.3",
+  "version": "13.38.0",
   "description": "Common TypeScript types and utility functions for @esri/hub.js.",
   "main": "dist/node/index.js",
   "module": "dist/esm/index.js",

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -5,10 +5,11 @@ import {
 } from "@esri/arcgis-rest-auth";
 import { IPortal } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { HubSystemStatus } from "./core";
+import { HubServiceStatus, HubSystemStatus } from "./core";
 import { getProp, getWithDefault } from "./objects";
-import { HubLicense } from "./permissions/types";
+import { HubEnvironment, HubLicense } from "./permissions/types";
 import { IHubRequestOptions } from "./types";
+import { getEnvironmentFromPortalUrl } from "./utils/getEnvironmentFromPortalUrl";
 
 /**
  * Hash of Hub API end points so updates
@@ -160,15 +161,30 @@ export interface IArcGISContext {
    */
   properties: Record<string, any>;
   /**
-   * System status
+   * DEPRECATED: System status
    */
   systemStatus: HubSystemStatus;
+
+  /**
+   * Hub Service Status
+   */
+  serviceStatus: HubServiceStatus;
 
   /**
    * Is this user in a Hub Alpha org?
    * Derived from properties.alphaOrgs
    */
   isAlphaOrg: boolean;
+  /**
+   * Is this user in a Hub Beta org?
+   * Derived from properties.betaOrgs
+   */
+  isBetaOrg: boolean;
+
+  /**
+   * What environment is this running in?
+   */
+  environment: HubEnvironment;
 }
 
 /**
@@ -216,9 +232,15 @@ export interface IArcGISContextOptions {
    */
   properties?: Record<string, any>;
   /**
-   * Option to pass in system status vs fetching it
+   * DEPRECATED: Option to pass in system status vs fetching it
+   * TODO: Remove with Capabilities
    */
   systemStatus?: HubSystemStatus;
+
+  /**
+   * Option to pass in service status vs fetching it
+   */
+  serviceStatus?: HubServiceStatus;
 }
 
 /**
@@ -254,7 +276,10 @@ export class ArcGISContext implements IArcGISContext {
 
   private _properties: Record<string, any>;
 
+  // TODO: Remove with Capabilities
   private _systemStatus: HubSystemStatus;
+
+  private _serviceStatus: HubServiceStatus;
 
   /**
    * Create a new instance of `ArcGISContext`.
@@ -266,6 +291,7 @@ export class ArcGISContext implements IArcGISContext {
     this._portalUrl = opts.portalUrl;
     this._hubUrl = opts.hubUrl;
     this._systemStatus = opts.systemStatus;
+    this._serviceStatus = opts.serviceStatus;
     if (opts.authentication) {
       this._authentication = opts.authentication;
     }
@@ -308,6 +334,27 @@ export class ArcGISContext implements IArcGISContext {
       result = orgs.includes(orgId);
     }
     return result;
+  }
+
+  /**
+   * Is the users org in the beta orgs list?
+   * Beta orgs are passed in via properties.betaOrgs
+   */
+  public get isBetaOrg(): boolean {
+    let result = false;
+    const orgs = this._properties?.betaOrgs || [];
+    const orgId = this._portalSelf?.id;
+    if (orgs.length && orgId) {
+      result = orgs.includes(orgId);
+    }
+    return result;
+  }
+
+  /**
+   * Return the HubEnvironment of the current context
+   */
+  public get environment(): HubEnvironment {
+    return getEnvironmentFromPortalUrl(this._portalUrl);
   }
 
   /**
@@ -416,9 +463,21 @@ export class ArcGISContext implements IArcGISContext {
 
   /**
    * Returns the current hub system status information
+   * TODO: Remove with Capabilities
    */
   get systemStatus(): HubSystemStatus {
+    // tslint:disable-next-line: no-console
+    console.warn(
+      `DEPRECATED: context.systemStatus is deprecated use context.serviceStatus instead`
+    );
     return this._systemStatus;
+  }
+
+  /**
+   * Returns the current hub service status information
+   */
+  get serviceStatus(): HubServiceStatus {
+    return this._serviceStatus;
   }
 
   /**

--- a/packages/common/src/capabilities/_internal/checkCapabilityAccess.ts
+++ b/packages/common/src/capabilities/_internal/checkCapabilityAccess.ts
@@ -15,6 +15,10 @@ export function checkCapabilityAccess(
   context: IArcGISContext,
   entity: IHubItemEntity | HubEntity
 ): ICapabilityAccessResponse {
+  // tslint:disable-next-line: no-console
+  console.warn(
+    `DEPRECATION: checkCapabilityAccess is deprecated. Use checkFeatureAccess instead.`
+  );
   // check if the capability is disabled for the entity; we default to false
   const value = entity.capabilities[rule.capability] || false;
   // if disabled, then access is denied

--- a/packages/common/src/capabilities/checkCapability.ts
+++ b/packages/common/src/capabilities/checkCapability.ts
@@ -26,6 +26,10 @@ export function checkCapability(
   context: IArcGISContext,
   entity: IHubItemEntity | HubEntity
 ): ICapabilityAccessResponse {
+  /* tslint:disable-next-line: no-console */
+  console.warn(
+    `DEPRECATION: checkCapability is deprecated. Use checkPermission instead.`
+  );
   const entityType: HubEntityType = getTypeFromEntity(entity);
   // Find the rule for the given entity type and capability
   const isValid = isCapability(capability);

--- a/packages/common/src/capabilities/getWorkspaceCapabilities.ts
+++ b/packages/common/src/capabilities/getWorkspaceCapabilities.ts
@@ -26,7 +26,7 @@ export const CapabilityPermissions: ICapabilityPermission[] = [
 ];
 
 /**
- * Return the capabilities that are granted to the current user for a given entity
+ * DEPRECATED: Return the capabilities that are granted to the current user for a given entity
  * This is used by the Hub Components to determine which Workspace Navigation Links to show
  * @param entity
  * @param context
@@ -36,6 +36,10 @@ export function getWorkspaceCapabilities(
   entity: HubEntity,
   context: IArcGISContext
 ): IWorkspaceCapabilityResponse {
+  /* tslint:disable-next-line: no-console */
+  console.warn(
+    `DEPRECATION: Capabilities is deprecated. Use Permissions instead.`
+  );
   const entityType: HubEntityType = getTypeFromEntity(entity);
   // filter to the rules for the given entity type
   const capabilityAccessRules = CapabilityPermissions.filter(

--- a/packages/common/src/capabilities/processEntityCapabilities.ts
+++ b/packages/common/src/capabilities/processEntityCapabilities.ts
@@ -10,6 +10,10 @@ export function processEntityCapabilities(
   entityCapabilities: EntityCapabilities,
   defaultCapabilities: EntityCapabilities
 ): EntityCapabilities {
+  /* tslint:disable-next-line: no-console */
+  console.warn(
+    `DEPRECATION: Capabilities is deprecated. Use Permissions instead.`
+  );
   // Extend the default capabilities with the entity capabilities
   const capabilities = { ...defaultCapabilities, ...entityCapabilities };
 

--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -6,6 +6,7 @@ import { IPermissionPolicy } from "../../permissions";
  * This hash is combined with the capabilities hash stored in the item data. Regardless of what
  * properties are defined in the item data, only the capabilities defined here will be available
  * @private
+ * TODO: remove with Capabilities
  */
 export const ContentDefaultCapabilities: EntityCapabilities = {
   overview: true,
@@ -18,6 +19,7 @@ export const ContentDefaultCapabilities: EntityCapabilities = {
  * List of all the Content Capability Permissions
  * These are considered Hub Business Rules and are not intended
  * to be modified by consumers
+ * TODO: remove with Capabilities
  * @private
  */
 export const ContentCapabilityPermissions: ICapabilityPermission[] = [
@@ -58,28 +60,26 @@ export const ContentPermissions = [
 
 /**
  * Content permission policies
+ * No need to specify license for permissions that are available to all licenses
  * @private
  */
 export const ContentPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:content:create",
-    subsystems: ["content"],
+    services: ["portal"],
     authenticated: true,
     privileges: ["portal:user:createItem"],
-    licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
   },
   {
     permission: "hub:content:view",
-    subsystems: ["content"],
+    services: ["portal"],
     authenticated: false,
-    licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
   },
   {
     permission: "hub:content:edit",
     authenticated: true,
-    subsystems: ["content"],
+    services: ["portal"],
     entityEdit: true,
-    licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
   },
   // TODO: verify if this is needed
   // {

--- a/packages/common/src/content/_internal/getPropertyMap.ts
+++ b/packages/common/src/content/_internal/getPropertyMap.ts
@@ -19,6 +19,7 @@ export function getPropertyMap(): IPropertyMap[] {
   // NOTE: we may want to move these into getBaseProprtyMap(), see:
   // https://github.com/Esri/hub.js/pull/993#discussion_r1134005511
   map.push({ entityKey: "permissions", storeKey: "data.permissions" });
+  // TODO: remove with Capabilities
   map.push({
     entityKey: "capabilities",
     storeKey: "data.settings.capabilities",

--- a/packages/common/src/core/HubItemEntity.ts
+++ b/packages/common/src/core/HubItemEntity.ts
@@ -108,10 +108,15 @@ export abstract class HubItemEntity<T extends IHubItemEntity>
   }
 
   /**
+   * DEPRECATED: use checkPermission instead
    * Check if the current user can access a specific capability
    * @param capability
    */
   checkCapability(capability: Capability): ICapabilityAccessResponse {
+    /* tslint:disable-next-line: no-console */
+    console.warn(
+      `DEPRECATED: checkCapability is deprecated. Use checkPermission instead`
+    );
     return checkCapability(capability, this.context, this.entity);
   }
 

--- a/packages/common/src/core/_internal/getBasePropertyMap.ts
+++ b/packages/common/src/core/_internal/getBasePropertyMap.ts
@@ -24,6 +24,7 @@ export function getBasePropertyMap(): IPropertyMap[] {
     "thumbnail",
     "url",
     "orgId",
+    "protected",
   ];
   const dataProps = ["display", "geometry", "view"];
   const resourceProps = Object.keys(EntityResourceMap);

--- a/packages/common/src/core/behaviors/IWithPermissionBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithPermissionBehavior.ts
@@ -37,6 +37,9 @@ export interface IWithPermissionBehavior {
   removePermissionPolicy(permission: Permission, id: string): void;
 }
 
+/**
+ * DEPRECATED: Composable behavior that adds capabilities to an entity
+ */
 export interface IWithCapabilityBehavior {
   /**
    * Is a specific capability available and enabled for the this entity?

--- a/packages/common/src/core/getTypeFromEntity.ts
+++ b/packages/common/src/core/getTypeFromEntity.ts
@@ -35,9 +35,9 @@ export function getTypeFromEntity(
     case "Group":
       type = "group";
       break;
-    case "Hub Content":
-      type = "content";
-      break;
+    // case "Hub Content": // needed for future ticket in getLocationOptions
+    //   type = "content";
+    //   break;
     default:
       // TODO: other families go here? feedback? solution? template?
       const contentFamilies = ["app", "content", "dataset", "document", "map"];

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -1,9 +1,4 @@
-import {
-  bBoxToExtent,
-  extentToBBox,
-  getGeographicOrgExtent,
-  isBBox,
-} from "../../../extent";
+import { extentToBBox, getGeographicOrgExtent } from "../../../extent";
 import { IHubRequestOptions } from "../../../types";
 import { getTypeFromEntity } from "../../getTypeFromEntity";
 
@@ -11,11 +6,11 @@ import { ConfigurableEntity } from "./ConfigurableEntity";
 import { IHubLocation, IHubLocationOption } from "../../types/IHubLocation";
 import { IExtent } from "@esri/arcgis-rest-types";
 
-const getItemExtent = (itemExtent: number[][]): IExtent => {
+/*const getItemExtent = (itemExtent: number[][]): IExtent => {
   return isBBox(itemExtent)
     ? ({ ...bBoxToExtent(itemExtent), type: "extent" } as unknown as IExtent)
     : undefined;
-};
+};*/
 
 /**
  * Construct the dynamic location picker options with the entity's
@@ -37,8 +32,8 @@ export async function getLocationOptions(
   const typeFromEntity = getTypeFromEntity(entity);
 
   switch (typeFromEntity) {
-    case "content":
-      return getContentLocationOptions(entity);
+    // case "content":
+    //   return getContentLocationOptions(entity);
     default:
       return getDefaultLocationOptions(entity, portalName, hubRequestOptions);
   }
@@ -47,7 +42,9 @@ export async function getLocationOptions(
 // TODO: Refactor parameters, they are icky gross
 // TODO: Maybe move these to outside of core and into respective entities
 
-export async function getContentLocationOptions(
+// Leaving this in for future work when we need
+// dynamic options set for different entities
+/*export async function getContentLocationOptions(
   entity: ConfigurableEntity
 ): Promise<IHubLocationOption[]> {
   const defaultExtent: IExtent = getItemExtent(entity.extent);
@@ -68,14 +65,15 @@ export async function getContentLocationOptions(
         type: "custom",
         // TODO: Add custom bbox option here
         // TODO: Remove "Add another location?" notification that appears when selecting a location
-        extent: defaultExtentIsBBox ? extentToBBox(defaultExtent) : undefined,
+        // TODO: The lines below are causing a bug where custom extents don't render after save+reload
+        extent: defaultExtentIsBBox ? extentToBBox(defaultExtent) : undefined, 
         spatialReference: defaultExtentIsBBox
           ? defaultExtent.spatialReference
           : undefined,
       },
     },
   ] as IHubLocationOption[];
-}
+}*/
 
 export async function getDefaultLocationOptions(
   entity: ConfigurableEntity,

--- a/packages/common/src/core/traits/IWithPermissions.ts
+++ b/packages/common/src/core/traits/IWithPermissions.ts
@@ -1,4 +1,4 @@
-import { IEntityPermissionPolicy } from "../../permissions";
+import { IEntityFeatures, IEntityPermissionPolicy } from "../../permissions";
 import { EntityCapabilities } from "../../capabilities";
 
 /**
@@ -9,5 +9,15 @@ export interface IWithPermissions {
    * Array of permission policies that apply to the entity
    */
   permissions?: IEntityPermissionPolicy[];
+
+  /**
+   * We need a means to enable / disable the "feature/capability" represented by a permission
+   * for an entity. e.g. we want to disable events for a site, so we have `hub:site:events`: false
+   */
+  features?: IEntityFeatures;
+
+  /**
+   * DEPRECATEDL use `features` instead
+   */
   capabilities?: EntityCapabilities;
 }

--- a/packages/common/src/core/types/IHubItemEntity.ts
+++ b/packages/common/src/core/types/IHubItemEntity.ts
@@ -118,4 +118,9 @@ export interface IHubItemEntity
    * The orgId of the Entity, if available
    */
   orgId?: string;
+
+  /**
+   * Is the item protected?
+   */
+  protected?: boolean;
 }

--- a/packages/common/src/core/types/ISystemStatus.ts
+++ b/packages/common/src/core/types/ISystemStatus.ts
@@ -8,6 +8,7 @@ export type SystemStatus =
   | "not-available";
 
 /**
+ * DEPRECATED: use HubServiceStatus instead
  * Hash of subsystems and their status
  */
 export type HubSystemStatus = {
@@ -30,15 +31,49 @@ const validSubsystems = [
   "platform",
 ] as const;
 /**
+ * * DEPRECATED: use HubService instead
  * Defines values for HubSubsystem
  */
 export type HubSubsystem = (typeof validSubsystems)[number];
 
 /**
+ * * DEPRECATED: use isHubService instead
  * Validate a Subsystem
  * @param subsystem
  * @returns
  */
 export function isSubsystem(maybeSubsystem: string): boolean {
+  // tslint:disable-next-line: no-console
+  console.warn(
+    `DEPRECATION: isSubsystem is deprecated. Use isHubService instead.`
+  );
   return validSubsystems.includes(maybeSubsystem as HubSubsystem);
+}
+
+/**
+ * Hash of subsystems and their status
+ */
+export type HubServiceStatus = {
+  [key in HubService]: SystemStatus;
+};
+
+const validServices = [
+  "portal",
+  "discussions",
+  "events",
+  "metrics",
+  "notifications",
+  "hub-search",
+  "domains",
+] as const;
+
+export type HubService = (typeof validServices)[number];
+
+/**
+ * Validate a Service
+ * @param service
+ * @returns
+ */
+export function isHubService(maybeService: string): boolean {
+  return validServices.includes(maybeService as HubService);
 }

--- a/packages/common/src/core/types/index.ts
+++ b/packages/common/src/core/types/index.ts
@@ -8,6 +8,7 @@ export * from "./IHubDiscussion";
 export * from "./IHubEditableContent";
 export * from "./IHubEntityBase";
 export * from "./IHubEvent";
+export * from "./IHubGroup";
 export * from "./IHubImage";
 export * from "./IHubInitiative";
 export * from "./IHubItemEntity";

--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -6,6 +6,7 @@ import { IPermissionPolicy } from "../../permissions";
  * This hash is combined with the capabilities hash stored in the item data. Regardless of what
  * properties are defined in the item data, only the capabilities defined here will be available
  * @private
+ * TODO: Remove capabilities
  */
 export const DiscussionDefaultCapabilities: EntityCapabilities = {
   overview: true,
@@ -18,6 +19,7 @@ export const DiscussionDefaultCapabilities: EntityCapabilities = {
  * List of all the Discussion Capability Permissions
  * These are considered Hub Business Rules and are not intended
  * to be modified by consumers
+ * TODO: Remove capabilities
  * @private
  */
 export const DiscussionCapabilityPermissions: ICapabilityPermission[] = [
@@ -49,6 +51,7 @@ export const DiscussionCapabilityPermissions: ICapabilityPermission[] = [
  * @private
  */
 export const DiscussionPermissions = [
+  "hub:discussion",
   "hub:discussion:create",
   "hub:discussion:delete",
   "hub:discussion:edit",
@@ -61,29 +64,33 @@ export const DiscussionPermissions = [
  */
 export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
   {
+    permission: "hub:discussion",
+    services: ["discussions"],
+  },
+  {
     permission: "hub:discussion:create",
-    subsystems: ["discussions"],
+    dependencies: ["hub:discussion"],
     authenticated: true,
     privileges: ["portal:user:createItem"],
     licenses: ["hub-premium"],
   },
   {
     permission: "hub:discussion:view",
-    subsystems: ["discussions"],
+    dependencies: ["hub:discussion"],
     authenticated: false,
     licenses: ["hub-premium"],
   },
   {
     permission: "hub:discussion:edit",
     authenticated: true,
-    subsystems: ["discussions"],
+    dependencies: ["hub:discussion"],
     entityEdit: true,
     licenses: ["hub-premium"],
   },
   {
     permission: "hub:discussion:delete",
     authenticated: true,
-    subsystems: ["discussions"],
+    dependencies: ["hub:discussion"],
     entityOwner: true,
     licenses: ["hub-premium"],
   },

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -4,6 +4,7 @@ import { IPermissionPolicy } from "../../permissions";
 /**
  * Default capabilities for a Group.
  * If not listed here, the capability will not be available
+ * TODO: Remove capabilities
  * @private
  */
 export const GroupDefaultCapabilities: EntityCapabilities = {
@@ -17,6 +18,7 @@ export const GroupDefaultCapabilities: EntityCapabilities = {
  * List of all the Group Capability Permissions
  * These are considered Hub Business Rules and are not intended
  * to be modified by consumers
+ * TODO: Remove capabilities
  * @private
  */
 export const GroupCapabilityPermissions: ICapabilityPermission[] = [
@@ -48,6 +50,7 @@ export const GroupCapabilityPermissions: ICapabilityPermission[] = [
  * @private
  */
 export const GroupPermissions = [
+  "hub:group",
   "hub:group:create",
   "hub:group:delete",
   "hub:group:edit",
@@ -61,32 +64,35 @@ export const GroupPermissions = [
  */
 export const GroupPermissionPolicies: IPermissionPolicy[] = [
   {
+    permission: "hub:group",
+    services: ["portal"],
+  },
+  {
     permission: "hub:group:create",
-    subsystems: ["groups"],
+    dependencies: ["hub:group"],
     authenticated: true,
     privileges: ["portal:user:createGroup"],
   },
   {
     permission: "hub:group:view",
-    subsystems: ["groups"],
-    authenticated: false,
+    dependencies: ["hub:group"],
   },
   {
     permission: "hub:group:edit",
+    dependencies: ["hub:group"],
     authenticated: true,
-    subsystems: ["groups"],
     entityEdit: true,
   },
   {
     permission: "hub:group:delete",
+    dependencies: ["hub:group"],
     authenticated: true,
-    subsystems: ["groups"],
     entityOwner: true,
   },
   {
     permission: "hub:group:owner",
+    dependencies: ["hub:group"],
     authenticated: true,
-    subsystems: ["groups"],
     entityOwner: true,
   },
 ];

--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -1,5 +1,5 @@
 import { EntityCapabilities, ICapabilityPermission } from "../../capabilities";
-import { IPermissionPolicy } from "../../permissions";
+import { IEntityFeatures, IPermissionPolicy } from "../../permissions";
 
 /**
  * Default capabilities for a Initiative. If not listed here, the capability will not be available
@@ -7,6 +7,7 @@ import { IPermissionPolicy } from "../../permissions";
  * properties are defined in the item data, only the capabilities defined here will be available
  * @private
  */
+// TODO: Remove capabilities
 export const InitiativeDefaultCapabilities: EntityCapabilities = {
   overview: true,
   details: true,
@@ -21,6 +22,7 @@ export const InitiativeDefaultCapabilities: EntityCapabilities = {
  * to be modified by consumers
  * @private
  */
+// TODO: Remove capabilities
 export const InitiativeCapabilityPermissions: ICapabilityPermission[] = [
   {
     entity: "initiative",
@@ -50,15 +52,28 @@ export const InitiativeCapabilityPermissions: ICapabilityPermission[] = [
 ];
 
 /**
+ * Default features for a Initiative. These are the features that can be enabled / disabled by the entity owner
+ */
+export const InitiativeDefaultFeatures: IEntityFeatures = {
+  "hub:initiative:events": false,
+  "hub:initiative:content": true,
+  "hub:initiative:discussions": false,
+};
+
+/**
  * Initiative Permission Policies
  * These define the requirements any user must meet to perform related actions
  * @private
  */
 export const InitiativePermissions = [
+  "hub:initiative",
   "hub:initiative:create",
   "hub:initiative:delete",
   "hub:initiative:edit",
   "hub:initiative:view",
+  "hub:initiative:events",
+  "hub:initiative:content",
+  "hub:initiative:discussions",
 ] as const;
 
 /**
@@ -67,30 +82,45 @@ export const InitiativePermissions = [
  */
 export const InitiativePermissionPolicies: IPermissionPolicy[] = [
   {
+    permission: "hub:initiative",
+    services: ["portal"],
+    licenses: ["hub-premium"],
+  },
+  {
     permission: "hub:initiative:create",
-    subsystems: ["projects"],
+    dependencies: ["hub:initiative"],
     authenticated: true,
     privileges: ["portal:user:createItem"],
-    licenses: ["hub-premium"],
   },
   {
     permission: "hub:initiative:view",
-    subsystems: ["projects"],
+    services: ["portal"],
     authenticated: false,
-    licenses: ["hub-premium"],
+    licenses: ["hub-premium", "hub-basic"],
   },
   {
     permission: "hub:initiative:edit",
+    dependencies: ["hub:initiative"],
     authenticated: true,
-    subsystems: ["projects"],
     entityEdit: true,
-    licenses: ["hub-premium"],
   },
   {
     permission: "hub:initiative:delete",
+    dependencies: ["hub:initiative"],
     authenticated: true,
-    subsystems: ["projects"],
+
     entityOwner: true,
-    licenses: ["hub-premium"],
+  },
+  {
+    permission: "hub:initiative:events",
+    dependencies: ["hub:initiative:view"],
+  },
+  {
+    permission: "hub:initiative:content",
+    dependencies: ["hub:initiative:edit"],
+  },
+  {
+    permission: "hub:initiative:discussions",
+    dependencies: ["hub:initiative:view"],
   },
 ];

--- a/packages/common/src/initiatives/_internal/computeProps.ts
+++ b/packages/common/src/initiatives/_internal/computeProps.ts
@@ -3,9 +3,13 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
 import { processEntityCapabilities } from "../../capabilities";
 import { IModel } from "../../types";
-import { InitiativeDefaultCapabilities } from "./InitiativeBusinessRules";
+import {
+  InitiativeDefaultCapabilities,
+  InitiativeDefaultFeatures,
+} from "./InitiativeBusinessRules";
 import { IHubInitiative } from "../../core";
 import { isDiscussable } from "../../discussions";
+import { processEntityFeatures } from "../../permissions/_internal/processEntityFeatures";
 
 /**
  * Given a model and an Initiative, set various computed properties that can't be directly mapped
@@ -40,9 +44,18 @@ export function computeProps(
   initiative.isDiscussable = isDiscussable(initiative);
 
   // Handle capabilities
+  // TODO: Remove capabilities
   initiative.capabilities = processEntityCapabilities(
     model.data.settings?.capabilities || {},
     InitiativeDefaultCapabilities
+  );
+
+  /**
+   * Features that can be disabled by the entity owner
+   */
+  initiative.features = processEntityFeatures(
+    model.data.settings?.features || {},
+    InitiativeDefaultFeatures
   );
 
   // cast b/c this takes a partial but returns a full object

--- a/packages/common/src/initiatives/defaults.ts
+++ b/packages/common/src/initiatives/defaults.ts
@@ -1,5 +1,6 @@
 import { IHubInitiative } from "../core/types";
 import { IModel } from "../types";
+import { InitiativeDefaultFeatures } from "./_internal/InitiativeBusinessRules";
 
 export const HUB_INITIATIVE_ITEM_TYPE = "Hub Initiative";
 
@@ -13,6 +14,7 @@ export const DEFAULT_INITIATIVE: Partial<IHubInitiative> = {
   catalog: { schemaVersion: 0 },
   permissions: [],
   schemaVersion: 2,
+  features: InitiativeDefaultFeatures,
 };
 
 /**

--- a/packages/common/src/pages/_internal/PageBusinessRules.ts
+++ b/packages/common/src/pages/_internal/PageBusinessRules.ts
@@ -1,11 +1,12 @@
 import { EntityCapabilities, ICapabilityPermission } from "../../capabilities";
-import { IPermissionPolicy } from "../../permissions";
+import { IEntityFeatures, IPermissionPolicy } from "../../permissions";
 
 /**
  * Default capabilities for a Page. If not listed here, the capability will not be available
  * This hash is combined with the capabilities hash stored in the item data. Regardless of what
  * properties are defined in the item data, only the capabilities defined here will be available
  * @private
+ * TODO: Remove capabilities
  */
 export const PageDefaultCapabilities: EntityCapabilities = {
   overview: true,
@@ -18,6 +19,7 @@ export const PageDefaultCapabilities: EntityCapabilities = {
  * List of all the Page Capability Permissions
  * These are considered Hub Business Rules and are not intended
  * to be modified by consumers
+ * TODO: Remove capabilities
  * @private
  */
 export const PageCapabilityPermissions: ICapabilityPermission[] = [
@@ -44,11 +46,19 @@ export const PageCapabilityPermissions: ICapabilityPermission[] = [
 ];
 
 /**
+ * Default features for a Project. These are the features that can be enabled / disabled by the entity owner
+ */
+export const PageDefaultFeatures: IEntityFeatures = {
+  // Intentally empty as this prevents overriding and adding features
+};
+
+/**
  * Page Permission Policies
  * These define the requirements any user must meet to perform related actions
  * @private
  */
 export const PagePermissions = [
+  "hub:page",
   "hub:page:create",
   "hub:page:delete",
   "hub:page:edit",
@@ -61,33 +71,30 @@ export const PagePermissions = [
  */
 export const PagePermissionPolicies: IPermissionPolicy[] = [
   {
+    permission: "hub:page",
+    services: ["portal"],
+  },
+  {
     permission: "hub:page:create",
-    subsystems: ["pages", "sites"],
+    dependencies: ["hub:page"],
     authenticated: true,
     privileges: ["portal:user:createItem"],
-    licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
   },
   {
     permission: "hub:page:view",
-    subsystems: ["pages", "sites"],
-    authenticated: false,
-    licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
+    dependencies: ["hub:page"],
   },
   {
     permission: "hub:page:edit",
+    dependencies: ["hub:page"],
     authenticated: true,
-    subsystems: ["pages", "sites"],
     entityEdit: true,
-    // privileges: ["portal:admin:updateItems"], // maybe this too?
-    licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
   },
   {
     permission: "hub:page:delete",
+    dependencies: ["hub:page"],
     authenticated: true,
-    subsystems: ["pages", "sites"],
     entityOwner: true,
-    // privileges: ["portal:admin:deleteItems"], // maybe this too?
-    licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
   },
 ];
 

--- a/packages/common/src/pages/_internal/computeProps.ts
+++ b/packages/common/src/pages/_internal/computeProps.ts
@@ -3,8 +3,12 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
 import { IHubPage } from "../../core";
 import { IModel } from "../../types";
-import { PageDefaultCapabilities } from "./PageBusinessRules";
+import {
+  PageDefaultCapabilities,
+  PageDefaultFeatures,
+} from "./PageBusinessRules";
 import { processEntityCapabilities } from "../../capabilities";
+import { processEntityFeatures } from "../../permissions/_internal/processEntityFeatures";
 
 /**
  * Given a model and a page, set various computed properties that can't be directly mapped
@@ -34,9 +38,19 @@ export function computeProps(
   page.updatedDateSource = "item.modified";
 
   // // Handle capabilities
+  // TODO: Remove capabilities
   page.capabilities = processEntityCapabilities(
     model.data.settings?.capabilities || {},
     PageDefaultCapabilities
+  );
+
+  /**
+   * Features that can be disabled by the entity owner
+   * NOTE: Pages do not have any features that can be disabled
+   */
+  page.features = processEntityFeatures(
+    model.data.settings?.features || {},
+    PageDefaultFeatures
   );
 
   // cast b/c this takes a partial but returns a full page

--- a/packages/common/src/permissions/_internal/checkAlphaGating.ts
+++ b/packages/common/src/permissions/_internal/checkAlphaGating.ts
@@ -12,11 +12,16 @@ import { getPolicyResponseCode } from "./getPolicyResponseCode";
 export function checkAlphaGating(
   policy: IPermissionPolicy,
   context: IArcGISContext,
-  entity?: Record<string, any>
+  _entity?: Record<string, any>
 ): IPolicyCheck[] {
   const checks = [] as IPolicyCheck[];
   // Only return a check if the policy is defined
   if (policy.alpha) {
+    /* tslint:disable-next-line: no-console */
+    console.log(
+      "DEPRECATED: alpha policy is deprecated, please use gatedAvailability: alpha instead"
+    );
+
     const result: PolicyResponse = context.isAlphaOrg
       ? "granted"
       : "not-alpha-org";

--- a/packages/common/src/permissions/_internal/checkAvailability.ts
+++ b/packages/common/src/permissions/_internal/checkAvailability.ts
@@ -1,0 +1,56 @@
+import { IArcGISContext } from "../../ArcGISContext";
+import { HubAvailability, IPermissionPolicy } from "../types/IPermissionPolicy";
+import { IPolicyCheck } from "../types/IPolicyCheck";
+import { PolicyResponse } from "../types/PolicyResponse";
+import { getPolicyResponseCode } from "./getPolicyResponseCode";
+
+/**
+ * @internal
+ * Verify that the policy.availability requirement is met.
+ * If a value is specified in the policy, the current context must be one of those values.
+ * @param policy
+ * @param context
+ * @param entity
+ * @returns
+ */
+export function checkAvailability(
+  policy: IPermissionPolicy,
+  context: IArcGISContext,
+  _entity?: Record<string, any>
+): IPolicyCheck[] {
+  let checks = [] as IPolicyCheck[];
+  if (policy.availability && policy.availability.length) {
+    // Build array of the context's availability values
+    // based on the isAlphaOrg and isBetaOrg properties
+    const contextAvailability: HubAvailability[] = [];
+    if (context.isAlphaOrg) {
+      contextAvailability.push("alpha");
+    }
+    if (context.isBetaOrg) {
+      contextAvailability.push("beta");
+    }
+    // if we have no values in the array, then we push in "ga"
+    if (!contextAvailability.length) {
+      contextAvailability.push("general");
+    }
+
+    // reduce over the policy.availability array, adding a check for each
+    // value that is not included in the contextAvailability array
+    checks = policy.availability.reduce((acc: IPolicyCheck[], value) => {
+      let result: PolicyResponse = "granted";
+      if (!contextAvailability.includes(value)) {
+        result = `not-${value}-org` as PolicyResponse;
+      }
+      const check: IPolicyCheck = {
+        name: `user in ${value} org`,
+        value: contextAvailability.join(", "),
+        code: getPolicyResponseCode(result),
+        response: result,
+      };
+      acc.push(check);
+
+      return acc;
+    }, []);
+  }
+  return checks;
+}

--- a/packages/common/src/permissions/_internal/checkEntityFeature.ts
+++ b/packages/common/src/permissions/_internal/checkEntityFeature.ts
@@ -1,0 +1,39 @@
+import { IArcGISContext } from "../../ArcGISContext";
+import { getWithDefault } from "../../objects/get-with-default";
+import { IEntityFeatures, IPermissionPolicy } from "../types/IPermissionPolicy";
+import { IPolicyCheck } from "../types/IPolicyCheck";
+import { PolicyResponse } from "../types/PolicyResponse";
+import { getPolicyResponseCode } from "./getPolicyResponseCode";
+
+export function checkEntityFeature(
+  policy: IPermissionPolicy,
+  _entitycontext: IArcGISContext,
+  entity?: Record<string, any>
+): IPolicyCheck[] {
+  const checks = [] as IPolicyCheck[];
+  // Only check things if the policy can be configured by the entity
+  // This prevents arbitrary checks from being overriden by the entity
+  if (entity && policy.entityConfigurable) {
+    const result = "feature-enabled" as PolicyResponse;
+    // create the check, default to enabled
+    const check: IPolicyCheck = {
+      name: `entity feature enabled`,
+      value: `entity feature ${policy.permission} check`,
+      code: getPolicyResponseCode(result),
+      response: result,
+    };
+
+    // Check if the feature is enabled for the entity defaulting to true
+    const isFeatureEnabled = getWithDefault(
+      entity,
+      `features.${policy.permission}`,
+      true
+    );
+    if (!isFeatureEnabled) {
+      check.response = "feature-disabled";
+      check.code = getPolicyResponseCode("feature-disabled");
+    }
+    checks.push(check);
+  }
+  return checks;
+}

--- a/packages/common/src/permissions/_internal/checkEnvironment.ts
+++ b/packages/common/src/permissions/_internal/checkEnvironment.ts
@@ -1,0 +1,37 @@
+import { IArcGISContext } from "../../ArcGISContext";
+import { IPermissionPolicy } from "../types/IPermissionPolicy";
+import { IPolicyCheck } from "../types/IPolicyCheck";
+import { PolicyResponse } from "../types/PolicyResponse";
+import { getPolicyResponseCode } from "./getPolicyResponseCode";
+
+/**
+ * @internal
+ * Verify that the policy.environment requirement is met.
+ *
+ * @param policy
+ * @param context
+ * @param entity
+ * @returns
+ */
+export function checkEnvironment(
+  policy: IPermissionPolicy,
+  context: IArcGISContext,
+  _entity?: Record<string, any>
+): IPolicyCheck[] {
+  const checks = [] as IPolicyCheck[];
+  if (policy.environments && policy.environments.length) {
+    let result: PolicyResponse = "granted";
+
+    if (!policy.environments.includes(context.environment)) {
+      result = "not-in-environment";
+    }
+    const check: IPolicyCheck = {
+      name: `user in ${policy.environments.join(",")} org`,
+      value: context.environment,
+      code: getPolicyResponseCode(result),
+      response: result,
+    };
+    checks.push(check);
+  }
+  return checks;
+}

--- a/packages/common/src/permissions/_internal/checkParents.ts
+++ b/packages/common/src/permissions/_internal/checkParents.ts
@@ -1,0 +1,29 @@
+import { IArcGISContext } from "../../ArcGISContext";
+import { checkPermission } from "../checkPermission";
+import { IPermissionPolicy } from "../types/IPermissionPolicy";
+import { IPolicyCheck } from "../types/IPolicyCheck";
+
+/**
+ * @internal
+ * Check the parent policies for the given policy
+ * @param policy
+ * @param context
+ * @param entity
+ * @returns
+ */
+export function checkParents(
+  policy: IPermissionPolicy,
+  context: IArcGISContext,
+  entity?: Record<string, any>
+): IPolicyCheck[] {
+  let checks = [] as IPolicyCheck[];
+  if (policy.dependencies?.length) {
+    // map over the parents array of permissions and check each one
+    checks = policy.dependencies.reduce((acc, parent) => {
+      const result = checkPermission(parent, context, entity);
+      acc = [...acc, ...result.checks];
+      return acc;
+    }, [] as IPolicyCheck[]);
+  }
+  return checks;
+}

--- a/packages/common/src/permissions/_internal/checkServiceStatus.ts
+++ b/packages/common/src/permissions/_internal/checkServiceStatus.ts
@@ -1,0 +1,34 @@
+import { IArcGISContext } from "../../ArcGISContext";
+import { PolicyResponse } from "../types";
+import { IPermissionPolicy } from "../types/IPermissionPolicy";
+import { IPolicyCheck } from "../types/IPolicyCheck";
+import { getPolicyResponseCode } from "./getPolicyResponseCode";
+
+export function checkServiceStatus(
+  policy: IPermissionPolicy,
+  context: IArcGISContext,
+  _entity?: Record<string, any>
+): IPolicyCheck[] {
+  let checks = [] as IPolicyCheck[];
+  if (policy.services) {
+    const services = context.serviceStatus;
+    // we need each service to have a status of "online"
+    // and if not, return status info
+    checks = policy.services.map((service) => {
+      let result: PolicyResponse = "granted";
+      if (services[service] !== "online") {
+        result = `service-${services[service]}` as PolicyResponse;
+      }
+
+      const check: IPolicyCheck = {
+        name: `service ${service} online`,
+        value: `service is ${services[service]}`,
+        code: getPolicyResponseCode(result),
+        response: result,
+      };
+      return check;
+    });
+  }
+
+  return checks;
+}

--- a/packages/common/src/permissions/_internal/getPolicyResponseCode.ts
+++ b/packages/common/src/permissions/_internal/getPolicyResponseCode.ts
@@ -24,8 +24,12 @@ const policyResponseCodes: IPolicyLookup[] = [
   { response: "edit-access", code: "PC113" },
   { response: "invalid-permission", code: "PC114" },
   { response: "privilege-required", code: "PC115" },
+  // ----------- TODO Remove with Capabilities
   { response: "system-offline", code: "PC116" },
   { response: "system-maintenance", code: "PC117" },
+  // -------------------------------------------
+  { response: "service-offline", code: "PC116" },
+  { response: "service-maintenance", code: "PC117" },
   { response: "entity-required", code: "PC118" },
   { response: "not-authenticated", code: "PC119" },
   { response: "not-alpha-org", code: "PC120" },
@@ -41,6 +45,10 @@ const policyResponseCodes: IPolicyLookup[] = [
   { response: "assertion-failed", code: "PC130" },
   { response: "assertion-requires-numeric-values", code: "PC131" },
   { response: "property-match", code: "PC132" },
+  { response: "not-beta-org", code: "PC133" },
+  { response: "not-in-environment", code: "PC134" },
+  { response: "feature-disabled", code: "PC135" },
+  { response: "feature-enabled", code: "PC136" },
 ];
 
 /**

--- a/packages/common/src/permissions/_internal/processEntityFeatures.ts
+++ b/packages/common/src/permissions/_internal/processEntityFeatures.ts
@@ -1,0 +1,32 @@
+import { IEntityFeatures } from "../types/IPermissionPolicy";
+import { Permission } from "../types/Permission";
+
+/**
+ * Take an entity's features and merge them with the default features ensuring
+ * that only the featires defined in the business rules are allowed through.
+ * @param entityFeatures
+ * @param defaultFeatures
+ * @returns
+ */
+export function processEntityFeatures(
+  entityFeatures: IEntityFeatures,
+  defaultFeatures: IEntityFeatures
+): IEntityFeatures {
+  // Extend the defaults with the entity values
+  const features = { ...defaultFeatures, ...entityFeatures };
+
+  // Remove any features that are not in the default features hash.
+  // this prevents enabling features that are not defined in hub business rules
+  const defaultKeys = Object.keys(defaultFeatures);
+  const keysToRemove = Object.keys(features).reduce((acc, key) => {
+    if (!defaultKeys.includes(key)) {
+      acc.push(key as Permission);
+    }
+    return acc;
+  }, []);
+  // remove any keys that are not in the default hash
+  keysToRemove.forEach((key: Permission) => {
+    delete features[key];
+  });
+  return features;
+}

--- a/packages/common/src/permissions/checkPermission.ts
+++ b/packages/common/src/permissions/checkPermission.ts
@@ -17,6 +17,11 @@ import { checkEdit } from "./_internal/checkEdit";
 import { checkPrivileges } from "./_internal/checkPrivileges";
 import { checkEntityPolicy } from "./_internal/checkEntityPolicy";
 import { checkAssertions } from "./_internal/checkAssertions";
+import { checkParents } from "./_internal/checkParents";
+import { checkEnvironment } from "./_internal/checkEnvironment";
+import { checkAvailability } from "./_internal/checkAvailability";
+import { checkEntityFeature } from "./_internal/checkEntityFeature";
+import { checkServiceStatus } from "./_internal/checkServiceStatus";
 
 /**
  * Check a permission against the system policies, and possibly an entity policy
@@ -56,13 +61,18 @@ export function checkPermission(
   };
 
   const checks = [
+    checkParents,
+    checkServiceStatus,
+    checkEntityFeature,
     checkAuthentication,
+    checkEnvironment,
+    checkAvailability,
     checkLicense,
     checkPrivileges,
     checkOwner,
     checkEdit,
     checkAssertions,
-    checkAlphaGating,
+    checkAlphaGating, // TODO: Remove with Capability Refactor
   ].reduce((acc: IPolicyCheck[], fn) => {
     acc = [...acc, ...fn(systemPolicy, context, entity)];
     return acc;
@@ -88,6 +98,7 @@ export function checkPermission(
       "permissions",
       []
     );
+
     const entityPermissionPolicies = entityPolicies.filter(
       (e) => e.permission === permission
     );

--- a/packages/common/src/permissions/types/IPermissionPolicy.ts
+++ b/packages/common/src/permissions/types/IPermissionPolicy.ts
@@ -1,8 +1,7 @@
 import { HubLicense } from "./HubLicense";
-import { HubSubsystem } from "../../core/types/ISystemStatus";
+import { HubService, HubSubsystem } from "../../core/types/ISystemStatus";
 import { Permission } from "./Permission";
 import { PlatformPrivilege } from "./PlatformPrivilege";
-import { IEntityPermissionPolicy } from "./IEntityPermissionPolicy";
 
 /**
  * Defines a system level policy for a specific permission.
@@ -16,10 +15,22 @@ export interface IPermissionPolicy {
    * Permission being defined
    */
   permission: Permission;
+
   /**
-   * What subsystems are required to be online for this permission to be granted
+   * Parent permissions this permission is dependent on
    */
-  subsystems: HubSubsystem[];
+  dependencies?: Permission[];
+
+  /**
+   * DEPRECATED: What subsystems are required to be online for this permission to be granted
+   */
+  subsystems?: HubSubsystem[];
+
+  /**
+   * What services are required to be online for this permission to be granted
+   */
+  services?: HubService[];
+
   /**
    * Must the user authenticated?
    */
@@ -30,11 +41,29 @@ export interface IPermissionPolicy {
    * e.g. If a user is in a Partner "hub-basic" org, they can not create "premium" entities (e.g. Projects)
    */
   licenses?: HubLicense[];
+
+  /**
+   * Is this permission gated to a specific availability?
+   * This is used to limit access to features that are not yet available in production
+   */
+  availability?: HubAvailability[];
+
+  /**
+   * Is this permission gated to a specific environment? (e.g. devext, qaext)
+   * This is used to limit access to features that are not yet available in production
+   */
+  environments?: HubEnvironment[];
+
   /**
    * Any platform level privileges required for this permission to be granted
    * e.g. "portal:user:createItem"
    */
   privileges?: PlatformPrivilege[];
+
+  /**
+   * Can an entity provide additional conditions to further limit access?
+   */
+  entityConfigurable?: boolean;
 
   /**
    * Is the user an owner of the entity being accessed?
@@ -47,21 +76,58 @@ export interface IPermissionPolicy {
   entityOwner?: boolean;
 
   /**
-   * Is this gated to alpha orgs?
+   * DEPRECATED: Use `gatedAvailability: "alpha"` instead
    */
   alpha?: boolean;
   /**
    * More complex policies can be defined with a set of assertions
    */
   assertions?: IPolicyAssertion[];
+
+  /**
+   * Value set by the feature flagging system to override the default permission behavior. This can be used to
+   * demo features to specific users or groups, during a specific user session.
+   * If `true`, the permission will be granted as long as the license and privilege requirements are met.
+   * If `false`, the permission will be denied for all users - typically as a means to check for graceful degradation
+   * if a system is offline.
+   */
+  flagValue?: boolean;
 }
 
+/**
+ * Hash of features for an entity which can be used to determine if a feature is enabled for the entity
+ * This can be applied to any permissin, enabling a lot of flexibility in how features are described and enabled
+ * If the value is set to false, then the permission will alway be set to false for all users.
+ */
+export interface IEntityFeatures extends Record<Permission, boolean> {}
+
+/**
+ * Hub Availability levels
+ */
+export type HubAvailability = "alpha" | "beta" | "general";
+
+/**
+ * Hub Run-time environments
+ */
+export type HubEnvironment =
+  | "devext"
+  | "qaext"
+  | "production"
+  | "enterprise"
+  | "enterprise-k8s";
+
+/**
+ * Assertion used to define more complex permission policies
+ */
 export interface IPolicyAssertion {
   property: string;
   type: AssertionType;
   value: any;
 }
 
+/**
+ * Assertion types which define the comparison operation to be performed
+ */
 export type AssertionType =
   | "eq"
   | "neq"

--- a/packages/common/src/permissions/types/PolicyResponse.ts
+++ b/packages/common/src/permissions/types/PolicyResponse.ts
@@ -20,11 +20,17 @@ export type PolicyResponse =
   | "invalid-permission" // permission is invalid
   | "invalid-capability" // capability is invalid
   | "privilege-required" // user does not have required privilege
+  // ----------- TODO Remove with Capabilities
   | "system-offline" // subsystem is offline
   | "system-maintenance" // subsystem is in maintenance mode
+  // -------------------------------------------
+  | "service-offline" // service is offline
+  | "service-maintenance" // service is in maintenance mode
+  | "service-not-available" // service is not available in this environment
   | "entity-required" // entity is required but not passed
   | "not-authenticated" // user is not authenticated
   | "not-alpha-org" // user is not in an alpha org
+  | "not-beta-org" // user is not in a beta org
   | "property-missing" // assertion requires property but is missing from entity
   | "property-not-array" // assertion requires array property
   | "array-contains-invalid-value" // assertion specifies a value not be included
@@ -36,4 +42,7 @@ export type PolicyResponse =
   | "assertion-property-not-found"
   | "assertion-failed" // assertion condition was not met
   | "assertion-requires-numeric-values" // assertion requires numeric values
-  | "property-match";
+  | "property-match"
+  | "feature-disabled" // feature has been disabled for the entity
+  | "feature-enabled" // feature has been enabled for the entity
+  | "not-in-environment"; // user is not in an allowed environment

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -1,11 +1,12 @@
 import { EntityCapabilities, ICapabilityPermission } from "../../capabilities";
-import { IPermissionPolicy } from "../../permissions";
+import { IEntityFeatures, IPermissionPolicy } from "../../permissions";
 
 /**
  * Default capabilities for a Project. If not listed here, the capability will not be available
  * This hash is combined with the capabilities hash stored in the item data. Regardless of what
  * properties are defined in the item data, only the capabilities defined here will be available
  * @private
+ * TODO: Remove capabilities
  */
 export const ProjectDefaultCapabilities: EntityCapabilities = {
   overview: true,
@@ -20,6 +21,7 @@ export const ProjectDefaultCapabilities: EntityCapabilities = {
  * List of all the Project Capability Permissions
  * These are considered Hub Business Rules and are not intended
  * to be modified by consumers
+ * TODO: Remove capabilities
  * @private
  */
 export const ProjectCapabilityPermissions: ICapabilityPermission[] = [
@@ -56,16 +58,29 @@ export const ProjectCapabilityPermissions: ICapabilityPermission[] = [
 ];
 
 /**
+ * Default features for a Project. These are the features that can be enabled / disabled by the entity owner
+ */
+export const ProjectDefaultFeatures: IEntityFeatures = {
+  "hub:project:events": false,
+  "hub:project:content": true,
+  "hub:project:discussions": false,
+};
+
+/**
  * Project Permission Policies
  * These define the requirements any user must meet to perform related actions
  * @private
  */
 export const ProjectPermissions = [
+  "hub:project",
   "hub:project:create",
   "hub:project:delete",
   "hub:project:edit",
   "hub:project:view",
   "hub:project:owner",
+  "hub:project:events",
+  "hub:project:content",
+  "hub:project:discussions",
 ] as const;
 
 /**
@@ -74,37 +89,49 @@ export const ProjectPermissions = [
  */
 export const ProjectPermissionPolicies: IPermissionPolicy[] = [
   {
-    permission: "hub:project:create",
-    subsystems: ["projects"],
-    authenticated: true,
-    privileges: ["portal:user:createItem"],
+    permission: "hub:project",
+    services: ["portal"],
     licenses: ["hub-premium"],
   },
   {
+    permission: "hub:project:create",
+    authenticated: true,
+    dependencies: ["hub:project"],
+    privileges: ["portal:user:createItem"],
+  },
+  {
+    // Anyone can view a project
     permission: "hub:project:view",
-    subsystems: ["projects"],
-    authenticated: false,
-    licenses: ["hub-basic", "hub-premium"],
+    subsystems: ["platform"],
   },
   {
     permission: "hub:project:edit",
+    dependencies: ["hub:project"],
     authenticated: true,
-    subsystems: ["projects"],
     entityEdit: true,
-    licenses: ["hub-basic", "hub-premium"],
   },
   {
     permission: "hub:project:delete",
+    dependencies: ["hub:project"],
     authenticated: true,
-    subsystems: ["projects"],
     entityOwner: true,
-    licenses: ["hub-premium"],
   },
   {
     permission: "hub:project:owner",
+    dependencies: ["hub:project"],
     authenticated: true,
-    subsystems: ["projects"],
     entityOwner: true,
-    licenses: ["hub-premium"],
+  },
+  {
+    permission: "hub:project:events",
+    dependencies: ["hub:project:view"],
+  },
+  {
+    permission: "hub:project:content",
+    dependencies: ["hub:project:edit"],
+  },
+  {
+    permission: "hub:project:discussions",
+    dependencies: ["hub:project:view"],
   },
 ];

--- a/packages/common/src/projects/_internal/computeProps.ts
+++ b/packages/common/src/projects/_internal/computeProps.ts
@@ -3,9 +3,13 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
 import { IHubProject } from "../../core";
 import { IModel } from "../../types";
-import { ProjectDefaultCapabilities } from "./ProjectBusinessRules";
+import {
+  ProjectDefaultCapabilities,
+  ProjectDefaultFeatures,
+} from "./ProjectBusinessRules";
 import { processEntityCapabilities } from "../../capabilities";
 import { isDiscussable } from "../../discussions";
+import { processEntityFeatures } from "../../permissions/_internal/processEntityFeatures";
 
 /**
  * Given a model and a project, set various computed properties that can't be directly mapped
@@ -36,9 +40,18 @@ export function computeProps(
   project.isDiscussable = isDiscussable(project);
 
   // Handle capabilities
+  // TODO: Remove capabilities
   project.capabilities = processEntityCapabilities(
     model.data.settings?.capabilities || {},
     ProjectDefaultCapabilities
+  );
+
+  /**
+   * Features that can be disabled by the entity owner
+   */
+  project.features = processEntityFeatures(
+    model.data.settings?.features || {},
+    ProjectDefaultFeatures
   );
 
   // cast b/c this takes a partial but returns a full project

--- a/packages/common/src/projects/defaults.ts
+++ b/packages/common/src/projects/defaults.ts
@@ -1,4 +1,5 @@
 import { IHubProject, PROJECT_STATUSES } from "../core";
+import { InitiativeDefaultFeatures } from "../initiatives/_internal/InitiativeBusinessRules";
 import { IModel } from "../types";
 
 export const HUB_PROJECT_ITEM_TYPE = "Hub Project";
@@ -19,6 +20,7 @@ export const DEFAULT_PROJECT: Partial<IHubProject> = {
     featuredContentIds: [],
     showMap: true,
   },
+  features: InitiativeDefaultFeatures,
 };
 
 /**

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -1,7 +1,8 @@
 import { EntityCapabilities, ICapabilityPermission } from "../../capabilities";
-import { IPermissionPolicy } from "../../permissions/types";
+import { IEntityFeatures, IPermissionPolicy } from "../../permissions/types";
 
 /**
+ * DEPRECATED
  * Default capabilities for a Site. If not listed here, the capability will not be available
  * This hash is combined with the capabilities hash stored in the item data. Regardless of what
  * properties are defined in the item data, only the capabilities defined here will be available
@@ -16,9 +17,11 @@ export const SiteDefaultCapabilities: EntityCapabilities = {
 };
 
 /**
+ * DEPRECATED
  * List of all the Site Capability Permissions
  * These are considered Hub Business Rules and are not intended
  * to be modified by consumers
+ * @private
  */
 export const SiteCapabilityPermissions: ICapabilityPermission[] = [
   {
@@ -49,14 +52,28 @@ export const SiteCapabilityPermissions: ICapabilityPermission[] = [
 ];
 
 /**
+ * Default features for a Site. These are the features that can be enabled / disabled by the entity owner
+ */
+export const SiteDefaultFeatures: IEntityFeatures = {
+  "hub:site:events": false,
+  "hub:site:content": true,
+  "hub:site:discussions": false,
+};
+
+/**
  * Site Permissions
  * This feeds into the Permissions type
  */
 export const SitePermissions = [
+  "hub:site",
   "hub:site:create",
   "hub:site:delete",
   "hub:site:edit",
   "hub:site:view",
+  "hub:site:owner",
+  "hub:site:events",
+  "hub:site:content",
+  "hub:site:discussions",
 ] as const;
 
 /**
@@ -65,31 +82,44 @@ export const SitePermissions = [
  */
 export const SitesPermissionPolicies: IPermissionPolicy[] = [
   {
+    permission: "hub:site",
+    services: ["portal"],
+    licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
+  },
+  {
     permission: "hub:site:create",
-    subsystems: ["sites"],
+    dependencies: ["hub:site"],
     authenticated: true,
     privileges: ["portal:user:createItem"],
-    licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
   },
   {
     permission: "hub:site:view",
-    subsystems: ["sites"],
+    dependencies: ["hub:site"],
     authenticated: false,
-    licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
   },
   {
     permission: "hub:site:delete",
-    subsystems: ["sites"],
+    dependencies: ["hub:site"],
     authenticated: true,
-    licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
     entityOwner: true,
   },
   {
     permission: "hub:site:edit",
     entityEdit: true,
-    subsystems: ["sites"],
+    dependencies: ["hub:site"],
     authenticated: true,
-    licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
+  },
+  {
+    permission: "hub:site:events",
+    dependencies: ["hub:site:view"],
+  },
+  {
+    permission: "hub:site:content",
+    dependencies: ["hub:site:edit"],
+  },
+  {
+    permission: "hub:site:discussions",
+    dependencies: ["hub:site:view"],
   },
 ];
 

--- a/packages/common/src/sites/_internal/computeProps.ts
+++ b/packages/common/src/sites/_internal/computeProps.ts
@@ -3,10 +3,14 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
 import { IHubSite } from "../../core";
 import { IModel } from "../../types";
-import { SiteDefaultCapabilities } from "./SiteBusinessRules";
+import {
+  SiteDefaultCapabilities,
+  SiteDefaultFeatures,
+} from "./SiteBusinessRules";
 import { processEntityCapabilities } from "../../capabilities";
 import { upgradeCatalogSchema } from "../../search/upgradeCatalogSchema";
 import { isDiscussable } from "../../discussions";
+import { processEntityFeatures } from "../../permissions/_internal/processEntityFeatures";
 
 /**
  * Given a model and a site, set various computed properties that can't be directly mapped
@@ -38,9 +42,18 @@ export function computeProps(
 
   // Handle capabilities
   // NOTE: This does not currently contain the older "capabilities" values!
+  // TODO: Remove capabilities
   site.capabilities = processEntityCapabilities(
     model.data.settings?.capabilities || {},
     SiteDefaultCapabilities
+  );
+
+  /**
+   * Features that can be disabled by the entity owner
+   */
+  site.features = processEntityFeatures(
+    model.data.settings?.features || {},
+    SiteDefaultFeatures
   );
 
   // Perform schema upgrades on the new catalog structure

--- a/packages/common/src/sites/defaults.ts
+++ b/packages/common/src/sites/defaults.ts
@@ -1,5 +1,6 @@
 import { IHubSite } from "../core";
 import { IModel } from "../types";
+import { SiteDefaultFeatures } from "./_internal/SiteBusinessRules";
 
 export const HUB_SITE_ITEM_TYPE = "Hub Site Application";
 
@@ -13,6 +14,7 @@ export const DEFAULT_SITE: Partial<IHubSite> = {
   catalog: { schemaVersion: 0 },
   permissions: [],
   schemaVersion: 1,
+  features: SiteDefaultFeatures,
 };
 
 /**

--- a/packages/common/src/users/view.ts
+++ b/packages/common/src/users/view.ts
@@ -26,7 +26,7 @@ export const userResultToCardModel: ResultToCardModelFn = (
 
   const titleUrl = getCardModelUrlFromResult(searchResult, target, baseUrl);
   return {
-    ...getSharedUserCardModel(searchResult, locale),
+    ...getSharedUserCardModel(searchResult),
     actionLinks,
     ...(searchResult.index && { index: searchResult.index }),
     titleUrl,
@@ -43,33 +43,7 @@ export const userResultToCardModel: ResultToCardModelFn = (
  * @param user user search result
  * @param locale internationalization locale
  */
-const getSharedUserCardModel = (
-  user: IHubSearchResult,
-  locale: string
-): IHubCardViewModel => {
-  const additionalInfo = [
-    {
-      i18nKey: "org",
-      value: user.orgName,
-    },
-    {
-      i18nKey: "type",
-      value: user.type,
-    },
-    ...(user.tags?.length
-      ? [
-          {
-            i18nKey: "tags",
-            value: user.tags.join(", "),
-          },
-        ]
-      : []),
-    {
-      i18nKey: "dateUpdated",
-      value: user.updatedDate.toLocaleDateString(locale),
-    },
-  ];
-
+const getSharedUserCardModel = (user: IHubSearchResult): IHubCardViewModel => {
   return {
     access: user.access,
     badges: [],
@@ -79,6 +53,5 @@ const getSharedUserCardModel = (
     summary: user.summary,
     title: user.name || `@${user.id}`,
     type: user.type,
-    additionalInfo,
   };
 };

--- a/packages/common/src/utils/getEnvironmentFromPortalUrl.ts
+++ b/packages/common/src/utils/getEnvironmentFromPortalUrl.ts
@@ -1,0 +1,26 @@
+import { HubEnvironment } from "../permissions";
+
+export function getEnvironmentFromPortalUrl(portalUrl: string): HubEnvironment {
+  // default to enterprise because we don't know the patterns for that
+  // other than it's _not_ arcgis.com
+  let env: HubEnvironment = "enterprise";
+  // if we're on arcgis.com, we can assume prod...
+  if (portalUrl.includes("arcgis.com")) {
+    env = "production";
+  }
+  // unless we're on a subdomain which suggest we might be in a dev or qa environment
+  if (
+    portalUrl.includes("qaext.arcgis.com") ||
+    portalUrl.includes("mapsqa.arcgis.com")
+  ) {
+    env = "qaext";
+  }
+  if (
+    portalUrl.includes("devext.arcgis.com") ||
+    portalUrl.includes("mapsdev.arcgis.com")
+  ) {
+    env = "devext";
+  }
+
+  return env;
+}

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -21,3 +21,4 @@ export * from "./sessionLocalStorage";
 export * from "./dasherize";
 export * from "./titleize";
 export * from "./memoize";
+export * from "./getEnvironmentFromPortalUrl";

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -1,6 +1,7 @@
 import { ArcGISContextManager } from "../src/ArcGISContextManager";
 import {
   cloneObject,
+  HubServiceStatus,
   HubSystemStatus,
   IHubRequestOptionsPortalSelf,
   Level,
@@ -201,6 +202,8 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.helperServices).toBeUndefined();
       expect(mgr.context.hubEnabled).toBeFalsy();
       expect(mgr.context.isAlphaOrg).toBeFalsy();
+      expect(mgr.context.isBetaOrg).toBeFalsy();
+      expect(mgr.context.environment).toBe("production");
       // Hub Urls
       const base = mgr.context.hubUrl;
       expect(mgr.context.discussionsServiceUrl).toBe(
@@ -211,6 +214,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.hubRequestOptions).toBeDefined();
       expect(mgr.context.hubRequestOptions.authentication).toBeUndefined();
       expect(mgr.context.systemStatus).toBeDefined();
+      expect(mgr.context.serviceStatus).toBeDefined();
       expect(mgr.context.hubLicense).toBe("hub-basic");
     });
     it("verify props when passed portalUrl", async () => {
@@ -244,6 +248,7 @@ describe("ArcGISContext:", () => {
         properties: { site },
       });
       expect(mgr.context.id).toBeGreaterThanOrEqual(t);
+      expect(mgr.context.environment).toBe("enterprise");
       expect(mgr.context.properties.site).toEqual(site);
     });
     it("verify props when passed session", async () => {
@@ -324,7 +329,7 @@ describe("ArcGISContext:", () => {
         onlinePortalSelfResponse as unknown as IPortal
       );
     });
-    it("verify props when passed session, portalSelf, User and systemStatus", async () => {
+    it("verify props when passed session, portalSelf, User, and serviceStatus", async () => {
       const selfSpy = spyOn(portalModule, "getSelf").and.callFake(() => {
         return Promise.resolve(cloneObject(onlinePortalSelfResponse));
       });
@@ -336,9 +341,12 @@ describe("ArcGISContext:", () => {
         authentication: MOCK_AUTH,
         portal: onlinePortalSelfResponse,
         currentUser: onlineUserResponse,
+        // TODO: Remove with Capabilities
         systemStatus: { discussions: "offline" } as HubSystemStatus,
+        serviceStatus: { domains: "online" } as HubServiceStatus,
         properties: {
           alphaOrgs: ["FAKEID", "FOTHERID"],
+          betaOrgs: ["FAKEID"],
         },
       });
       expect(selfSpy.calls.count()).toBe(0);
@@ -349,8 +357,12 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.systemStatus).toEqual({
         discussions: "offline",
       } as HubSystemStatus);
+      expect(mgr.context.serviceStatus).toEqual({
+        domains: "online",
+      } as HubServiceStatus);
       expect(mgr.context.properties.alphaOrgs).toEqual(["FAKEID", "FOTHERID"]);
       expect(mgr.context.isAlphaOrg).toBeTruthy();
+      expect(mgr.context.isBetaOrg).toBeTruthy();
     });
     it("verify props update setting session after", async () => {
       spyOn(portalModule, "getSelf").and.callFake(() => {

--- a/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
+++ b/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
@@ -91,92 +91,95 @@ describe("getLocationOptions - default:", () => {
   });
 });
 
-describe("getLocationOptions - content:", () => {
-  it("custom is selected", async () => {
-    const entity: ConfigurableEntity = {
-      id: "00c",
-      type: "Hub Content",
-      location: {
-        type: "custom",
-      },
-      boundary: "item",
-      extent: [
-        [100, 100],
-        [120, 120],
-      ],
-    } as ConfigurableEntity;
+// Leaving this in for future work when we need
+// dynamic options set for different entities
 
-    const chk = await getLocationOptions(
-      entity,
-      "portalName",
-      {} as IHubRequestOptions
-    );
+// describe("getLocationOptions - content:", () => {
+//   it("custom is selected", async () => {
+//     const entity: ConfigurableEntity = {
+//       id: "00c",
+//       type: "Hub Content",
+//       location: {
+//         type: "custom",
+//       },
+//       boundary: "item",
+//       extent: [
+//         [100, 100],
+//         [120, 120],
+//       ],
+//     } as ConfigurableEntity;
 
-    expect(chk.length).toBe(2);
-    expect(chk[1].selected).toBe(true);
-  });
-  it("none is selected", async () => {
-    const entity: ConfigurableEntity = {
-      id: "00c",
-      type: "Hub Content",
-      location: {
-        type: "none",
-      },
-      boundary: "none",
-    } as ConfigurableEntity;
+//     const chk = await getLocationOptions(
+//       entity,
+//       "portalName",
+//       {} as IHubRequestOptions
+//     );
 
-    const chk = await getLocationOptions(
-      entity,
-      "portalName",
-      {} as IHubRequestOptions
-    );
+//     expect(chk.length).toBe(2);
+//     expect(chk[1].selected).toBe(true);
+//   });
+//   it("none is selected", async () => {
+//     const entity: ConfigurableEntity = {
+//       id: "00c",
+//       type: "Hub Content",
+//       location: {
+//         type: "none",
+//       },
+//       boundary: "none",
+//     } as ConfigurableEntity;
 
-    expect(chk.length).toBe(2);
-    expect(chk[0].selected).toBe(true);
-  });
-  it("custom is selected if entity does not have an id", async () => {
-    const entity: ConfigurableEntity = {
-      type: "Hub Content",
-      location: {
-        type: "custom",
-      },
-      boundary: "item",
-      extent: [
-        [100, 100],
-        [120, 120],
-      ],
-    } as ConfigurableEntity;
+//     const chk = await getLocationOptions(
+//       entity,
+//       "portalName",
+//       {} as IHubRequestOptions
+//     );
 
-    const chk = await getLocationOptions(
-      entity,
-      "portalName",
-      {} as IHubRequestOptions
-    );
+//     expect(chk.length).toBe(2);
+//     expect(chk[0].selected).toBe(true);
+//   });
+//   it("custom is selected if entity does not have an id", async () => {
+//     const entity: ConfigurableEntity = {
+//       type: "Hub Content",
+//       location: {
+//         type: "custom",
+//       },
+//       boundary: "item",
+//       extent: [
+//         [100, 100],
+//         [120, 120],
+//       ],
+//     } as ConfigurableEntity;
 
-    expect(chk.length).toBe(2);
-    expect(chk[1].selected).toBe(true);
-  });
-  it("custom is selected & boundary is set", async () => {
-    const entity: ConfigurableEntity = {
-      id: "00c",
-      type: "Hub Content",
-      location: {
-        type: "custom",
-      },
-      boundary: "item",
-      extent: [
-        [100, 100],
-        [120, 120],
-      ],
-    } as ConfigurableEntity;
+//     const chk = await getLocationOptions(
+//       entity,
+//       "portalName",
+//       {} as IHubRequestOptions
+//     );
 
-    const chk = await getLocationOptions(
-      entity,
-      "portalName",
-      {} as IHubRequestOptions
-    );
+//     expect(chk.length).toBe(2);
+//     expect(chk[1].selected).toBe(true);
+//   });
+//   it("custom is selected & boundary is set", async () => {
+//     const entity: ConfigurableEntity = {
+//       id: "00c",
+//       type: "Hub Content",
+//       location: {
+//         type: "custom",
+//       },
+//       boundary: "item",
+//       extent: [
+//         [100, 100],
+//         [120, 120],
+//       ],
+//     } as ConfigurableEntity;
 
-    expect(chk.length).toBe(2);
-    expect(chk[1].selected).toBe(true);
-  });
-});
+//     const chk = await getLocationOptions(
+//       entity,
+//       "portalName",
+//       {} as IHubRequestOptions
+//     );
+
+//     expect(chk.length).toBe(2);
+//     expect(chk[1].selected).toBe(true);
+//   });
+// });

--- a/packages/common/test/core/types/ISystemStatus.test.ts
+++ b/packages/common/test/core/types/ISystemStatus.test.ts
@@ -1,4 +1,7 @@
-import { isSubsystem } from "../../../src/core/types/ISystemStatus";
+import {
+  isHubService,
+  isSubsystem,
+} from "../../../src/core/types/ISystemStatus";
 
 describe("isSubsystem", () => {
   it("should return true for a valid subsystem", () => {
@@ -7,5 +10,15 @@ describe("isSubsystem", () => {
 
   it("should return false for an invalid subsystem", () => {
     expect(isSubsystem("discussion")).toBe(false);
+  });
+});
+
+describe("isHubService", () => {
+  it("should return true for a valid subsystem", () => {
+    expect(isHubService("discussions")).toBe(true);
+  });
+
+  it("should return false for an invalid subsystem", () => {
+    expect(isHubService("discussion")).toBe(false);
   });
 });

--- a/packages/common/test/permissions/_internal/checkAvailability.test.ts
+++ b/packages/common/test/permissions/_internal/checkAvailability.test.ts
@@ -1,0 +1,83 @@
+import { IArcGISContext, IPermissionPolicy } from "../../../src";
+import { checkAvailability } from "../../../src/permissions/_internal/checkAvailability";
+
+describe("checkAvailability: ", () => {
+  const policyAlpha: IPermissionPolicy = {
+    permission: "hub:project",
+    availability: ["alpha"],
+  };
+
+  const policyBeta: IPermissionPolicy = {
+    permission: "hub:project",
+    availability: ["beta"],
+  };
+
+  const policyGA: IPermissionPolicy = {
+    permission: "hub:project",
+    availability: ["general"],
+  };
+
+  const contextAlpha: IArcGISContext = {
+    isAlphaOrg: true,
+  } as IArcGISContext;
+
+  const contextBeta: IArcGISContext = {
+    isBetaOrg: true,
+  } as IArcGISContext;
+
+  const contextGA: IArcGISContext = {
+    isBetaOrg: false,
+    isAlphaOrg: false,
+  } as IArcGISContext;
+
+  it("if gating matches, should return granted - alpha ", () => {
+    const checks = checkAvailability(policyAlpha, contextAlpha);
+    expect(checks.length).toBe(1);
+    expect(checks[0].name).toBe("user in alpha org");
+    expect(checks[0].response).toBe("granted");
+  });
+
+  it("if gating matches, should return granted - beta ", () => {
+    const checks = checkAvailability(policyBeta, contextBeta);
+    expect(checks.length).toBe(1);
+    expect(checks[0].name).toBe("user in beta org");
+    expect(checks[0].response).toBe("granted");
+  });
+
+  it("if gating matches, should return granted - ga ", () => {
+    const checks = checkAvailability(policyGA, contextGA);
+    expect(checks.length).toBe(1);
+    expect(checks[0].name).toBe("user in general org");
+    expect(checks[0].response).toBe("granted");
+  });
+
+  it("fails check when policy is alpha, context is ga or beta", () => {
+    const checks = checkAvailability(policyAlpha, contextBeta);
+    expect(checks.length).toBe(1);
+    expect(checks[0].name).toBe("user in alpha org");
+    expect(checks[0].response).toBe("not-alpha-org");
+
+    const checks2 = checkAvailability(policyBeta, contextAlpha);
+    expect(checks2.length).toBe(1);
+    expect(checks2[0].name).toBe("user in beta org");
+    expect(checks2[0].response).toBe("not-beta-org");
+
+    const checks3 = checkAvailability(policyBeta, contextGA);
+    expect(checks3.length).toBe(1);
+    expect(checks3[0].name).toBe("user in beta org");
+    expect(checks3[0].response).toBe("not-beta-org");
+
+    const checks4 = checkAvailability(policyAlpha, contextGA);
+    expect(checks4.length).toBe(1);
+    expect(checks4[0].name).toBe("user in alpha org");
+    expect(checks4[0].response).toBe("not-alpha-org");
+  });
+
+  it("should return an empty array when available is not defined in the policy", () => {
+    const policy: IPermissionPolicy = {
+      permission: "hub:project",
+    };
+    const checks = checkAvailability(policy, contextGA);
+    expect(checks.length).toBe(0);
+  });
+});

--- a/packages/common/test/permissions/_internal/checkEntityFeature.test.ts
+++ b/packages/common/test/permissions/_internal/checkEntityFeature.test.ts
@@ -1,0 +1,72 @@
+import { IPermissionPolicy } from "../../../src";
+import { IArcGISContext } from "../../../src/ArcGISContext";
+import { checkEntityFeature } from "../../../src/permissions/_internal/checkEntityFeature";
+
+describe("checkEntityFeatures:", () => {
+  it("no check if entity not passed", () => {
+    const ctx = {
+      isAlphaOrg: true,
+    } as unknown as IArcGISContext;
+    const policy = {
+      licenses: ["hub-premium"],
+    } as unknown as IPermissionPolicy;
+
+    const chks = checkEntityFeature(policy, ctx);
+    expect(chks.length).toBe(0);
+  });
+  it("no check added if policy is not configurable", () => {
+    const ctx = {
+      isAlphaOrg: true,
+    } as unknown as IArcGISContext;
+    const policy = {
+      permission: "hub:events",
+      isEntityConfigurable: false,
+      licenses: ["hub-premium"],
+    } as IPermissionPolicy;
+
+    const entity = {
+      features: {
+        "hub:events": false,
+      },
+    };
+
+    const chks = checkEntityFeature(policy, ctx, entity);
+    expect(chks.length).toBe(0);
+  });
+  it("check returns if disabled on entity", () => {
+    const ctx = {} as unknown as IArcGISContext;
+    const policy = {
+      permission: "hub:project:events",
+      entityConfigurable: true,
+      licenses: ["hub-premium"],
+    } as IPermissionPolicy;
+    const entity = {
+      features: {
+        "hub:project:events": false,
+      },
+    };
+
+    const chks = checkEntityFeature(policy, ctx, entity);
+    expect(chks.length).toBe(1);
+    expect(chks[0].name).toBe("entity feature enabled");
+    expect(chks[0].response).toBe("feature-disabled");
+  });
+  it("check returns if enabled on entity", () => {
+    const ctx = {} as unknown as IArcGISContext;
+    const policy = {
+      permission: "hub:project:events",
+      entityConfigurable: true,
+      licenses: ["hub-premium"],
+    } as IPermissionPolicy;
+    const entity = {
+      features: {
+        "hub:project:events": true,
+      },
+    };
+
+    const chks = checkEntityFeature(policy, ctx, entity);
+    expect(chks.length).toBe(1);
+    expect(chks[0].name).toBe("entity feature enabled");
+    expect(chks[0].response).toBe("feature-enabled");
+  });
+});

--- a/packages/common/test/permissions/_internal/checkEnvironment.test.ts
+++ b/packages/common/test/permissions/_internal/checkEnvironment.test.ts
@@ -1,0 +1,79 @@
+import { IPermissionPolicy, IArcGISContext } from "../../../src";
+import { checkEnvironment } from "../../../src/permissions/_internal/checkEnvironment";
+
+describe("checkEnvironment: ", () => {
+  it("should return a policy check with granted response when context environment matches gated environment", () => {
+    const policy: IPermissionPolicy = {
+      permission: "hub:project",
+      environments: ["qaext"],
+    };
+
+    const context: IArcGISContext = {
+      environment: "qaext",
+    } as IArcGISContext;
+
+    const checks = checkEnvironment(policy, context);
+    expect(checks.length).toBe(1);
+    expect(checks[0].name).toBe("user in qaext org");
+    expect(checks[0].response).toBe("granted");
+  });
+
+  it("should return a policy check with not-qaext-org response when context environment does not match gated environment and gated environment is qaext", () => {
+    const policy: IPermissionPolicy = {
+      permission: "hub:project",
+      environments: ["qaext"],
+    };
+    const contextDev: IArcGISContext = {
+      environment: "devext",
+    } as IArcGISContext;
+    const checks = checkEnvironment(policy, contextDev);
+    expect(checks.length).toBe(1);
+    expect(checks[0].name).toBe("user in qaext org");
+    expect(checks[0].response).toBe("not-in-environment");
+  });
+
+  it("should return a policy check with not-devext-org response when context environment does not match gated environment and gated environment is devext", () => {
+    const policyDev: IPermissionPolicy = {
+      permission: "hub:project",
+      environments: ["devext"],
+    };
+
+    const contextQa: IArcGISContext = {
+      environment: "qaext",
+    } as IArcGISContext;
+
+    const checks = checkEnvironment(policyDev, contextQa);
+    expect(checks.length).toBe(1);
+    expect(checks[0].name).toBe("user in devext org");
+    expect(checks[0].response).toBe("not-in-environment");
+  });
+  it("should return a policy check for each env", () => {
+    const policyBoth: IPermissionPolicy = {
+      permission: "hub:project",
+      environments: ["devext", "qaext"],
+    };
+
+    const contextQa: IArcGISContext = {
+      environment: "qaext",
+    } as IArcGISContext;
+
+    const checks = checkEnvironment(policyBoth, contextQa);
+    expect(checks.length).toBe(1);
+    expect(checks[0].name).toBe("user in devext,qaext org");
+    expect(checks[0].response).toBe("granted");
+  });
+
+  it("should returns an empty array when environment is not defined in the policy", () => {
+    const policy: IPermissionPolicy = {
+      permission: "hub:project",
+      licenses: ["hub-premium"],
+    };
+
+    const context: IArcGISContext = {
+      environment: "qaext",
+    } as IArcGISContext;
+
+    const checks = checkEnvironment(policy, context);
+    expect(checks.length).toBe(0);
+  });
+});

--- a/packages/common/test/permissions/_internal/checkParents.test.ts
+++ b/packages/common/test/permissions/_internal/checkParents.test.ts
@@ -1,0 +1,46 @@
+import { IPermissionPolicy } from "../../../src";
+import { IArcGISContext } from "../../../src/ArcGISContext";
+import { checkParents } from "../../../src/permissions/_internal/checkParents";
+import * as CheckPermissionModule from "../../../src/permissions/checkPermission";
+
+describe("checkParents:", () => {
+  it("no check if parents not in policy", () => {
+    const ctx = {
+      isAlphaOrg: true,
+    } as unknown as IArcGISContext;
+    const policy = {
+      licenses: ["hub-premium"],
+    } as unknown as IPermissionPolicy;
+
+    const chks = checkParents(policy, ctx);
+    expect(chks.length).toBe(0);
+  });
+  it("no check if parents is empty", () => {
+    const ctx = {
+      isAlphaOrg: true,
+    } as unknown as IArcGISContext;
+    const policy = {
+      licenses: ["hub-premium"],
+      dependencies: [],
+    } as unknown as IPermissionPolicy;
+
+    const chks = checkParents(policy, ctx);
+    expect(chks.length).toBe(0);
+  });
+  it("delegates to checkPermission for parent entries", () => {
+    const ctx = {
+      isAlphaOrg: true,
+    } as unknown as IArcGISContext;
+    const policy = {
+      dependencies: ["hub:project"],
+    } as unknown as IPermissionPolicy;
+
+    const spy = spyOn(CheckPermissionModule, "checkPermission").and.returnValue(
+      { checks: [{}] }
+    );
+
+    const chks = checkParents(policy, ctx);
+    expect(spy).toHaveBeenCalled();
+    expect(chks.length).toBe(1);
+  });
+});

--- a/packages/common/test/permissions/_internal/checkServiceStatus.test.ts
+++ b/packages/common/test/permissions/_internal/checkServiceStatus.test.ts
@@ -1,0 +1,98 @@
+import { IPermissionPolicy } from "../../../src/permissions/types/IPermissionPolicy";
+import { checkServiceStatus } from "../../../src/permissions/_internal/checkServiceStatus";
+import { IArcGISContext } from "../../../src/ArcGISContext";
+describe("checkServiceStatus:", () => {
+  it("returns not checks if policy does not specify services", () => {
+    const policy: IPermissionPolicy = {
+      permission: "hub:project",
+    };
+    const context: IArcGISContext = {
+      serviceStatus: {
+        portal: "online",
+      },
+    } as IArcGISContext;
+    const checks = checkServiceStatus(policy, context);
+    expect(checks.length).toBe(0);
+  });
+  it("returns granted if service online", () => {
+    const policy: IPermissionPolicy = {
+      permission: "hub:project",
+      services: ["portal"],
+    };
+    const context: IArcGISContext = {
+      serviceStatus: {
+        portal: "online",
+      },
+    } as IArcGISContext;
+    const checks = checkServiceStatus(policy, context);
+    expect(checks.length).toBe(1);
+    expect(checks[0].name).toBe("service portal online");
+    expect(checks[0].response).toBe("granted");
+  });
+  it("does not return granted if service offline", () => {
+    const policy: IPermissionPolicy = {
+      permission: "hub:project",
+      services: ["portal"],
+    };
+    const context: IArcGISContext = {
+      serviceStatus: {
+        portal: "offline",
+      },
+    } as IArcGISContext;
+    const checks = checkServiceStatus(policy, context);
+    expect(checks.length).toBe(1);
+    expect(checks[0].name).toBe("service portal online");
+    expect(checks[0].response).toBe("service-offline");
+  });
+  it("does not return granted if service maintainance", () => {
+    const policy: IPermissionPolicy = {
+      permission: "hub:project",
+      services: ["portal"],
+    };
+    const context: IArcGISContext = {
+      serviceStatus: {
+        portal: "maintenance",
+      },
+    } as IArcGISContext;
+    const checks = checkServiceStatus(policy, context);
+    expect(checks.length).toBe(1);
+    expect(checks[0].name).toBe("service portal online");
+    expect(checks[0].response).toBe("service-maintenance");
+  });
+  it("does not return granted if service not-available", () => {
+    const policy: IPermissionPolicy = {
+      permission: "hub:project",
+      services: ["portal", "domains"],
+    };
+    const context: IArcGISContext = {
+      serviceStatus: {
+        portal: "online",
+        domains: "not-available",
+      },
+    } as IArcGISContext;
+    const checks = checkServiceStatus(policy, context);
+    expect(checks.length).toBe(2);
+    expect(checks[0].name).toBe("service portal online");
+    expect(checks[0].response).toBe("granted");
+    expect(checks[1].name).toBe("service domains online");
+    expect(checks[1].response).toBe("service-not-available");
+  });
+  it("returns granted if multiple services online", () => {
+    const policy: IPermissionPolicy = {
+      permission: "hub:site",
+      services: ["portal", "domains"],
+    };
+    const context: IArcGISContext = {
+      serviceStatus: {
+        portal: "online",
+        domains: "online",
+      },
+    } as IArcGISContext;
+    const checks = checkServiceStatus(policy, context);
+    expect(checks.length).toBe(2);
+    expect(checks[0].name).toBe("service portal online");
+    expect(checks[0].response).toBe("granted");
+    expect(checks[1].name).toBe("service domains online");
+    expect(checks[1].response).toBe("granted");
+  });
+});

--- a/packages/common/test/permissions/_internal/processEntityFeatures.test.ts
+++ b/packages/common/test/permissions/_internal/processEntityFeatures.test.ts
@@ -1,0 +1,30 @@
+import { IEntityFeatures } from "../../../src";
+import { processEntityFeatures } from "../../../src/permissions/_internal/processEntityFeatures";
+
+describe("processEntityFeatures:", () => {
+  it("merged entity values with defaults", () => {
+    const defaults = {
+      "hub:project:events": true,
+      "hub:project:metrics": false,
+    } as IEntityFeatures;
+    const entity = {} as IEntityFeatures;
+    const chk = processEntityFeatures(entity, defaults);
+    expect(chk["hub:project:events"]).toBe(true);
+    expect(chk["hub:project:metrics"]).toBe(false);
+  });
+  it("removes values not in defaults", () => {
+    const defaults = {
+      "hub:project:events": true,
+      "hub:project:metrics": false,
+    } as IEntityFeatures;
+    const entity = {
+      "hub:project:events": false,
+      "hub:project:metrics": true,
+      "hub:project:overview": false,
+    } as IEntityFeatures;
+    const chk = processEntityFeatures(entity, defaults);
+    expect(chk["hub:project:events"]).toBe(false);
+    expect(chk["hub:project:metrics"]).toBe(true);
+    expect(chk["hub:project:overview"]).not.toBeDefined();
+  });
+});

--- a/packages/common/test/permissions/checkPermission.test.ts
+++ b/packages/common/test/permissions/checkPermission.test.ts
@@ -43,13 +43,15 @@ describe("checkPermission:", () => {
     const chk = checkPermission("hub:site:create", authdCtxMgr.context);
     expect(chk.access).toBe(true);
     expect(chk.response).toBe("granted");
-    expect(chk.checks.length).toBe(3);
+    expect(chk.checks.length).toBe(4);
+    // verify that the service check is run
+    expect(chk.checks[0].name).toBe("service portal online");
   });
   it("runs system level permission checks fail", () => {
     const chk = checkPermission("hub:project:create", authdCtxMgr.context);
     expect(chk.access).toBe(false);
     expect(chk.response).toBe("not-licensed");
-    expect(chk.checks.length).toBe(3);
+    expect(chk.checks.length).toBe(4);
   });
   it("runs entity level permission checks passing", () => {
     const entity = {
@@ -65,7 +67,7 @@ describe("checkPermission:", () => {
     const chk = checkPermission("hub:site:edit", authdCtxMgr.context, entity);
     expect(chk.access).toBe(true);
     expect(chk.response).toBe("granted");
-    expect(chk.checks.length).toBe(4);
+    expect(chk.checks.length).toBe(5);
   });
   it("runs entity level checks on entity without permissions", () => {
     const entity = {
@@ -74,7 +76,7 @@ describe("checkPermission:", () => {
     const chk = checkPermission("hub:site:edit", authdCtxMgr.context, entity);
     expect(chk.access).toBe(true);
     expect(chk.response).toBe("granted");
-    expect(chk.checks.length).toBe(3);
+    expect(chk.checks.length).toBe(4);
   });
   it("runs entity level permission checks failing", () => {
     const entity = {
@@ -90,6 +92,6 @@ describe("checkPermission:", () => {
     const chk = checkPermission("hub:site:edit", authdCtxMgr.context, entity);
     expect(chk.access).toBe(false);
     expect(chk.response).toBe("not-granted");
-    expect(chk.checks.length).toBe(4);
+    expect(chk.checks.length).toBe(5);
   });
 });

--- a/packages/common/test/users/view.test.ts
+++ b/packages/common/test/users/view.test.ts
@@ -47,29 +47,7 @@ describe("user view module:", () => {
         titleUrl: "https://mock-title-url.com",
         thumbnailUrl: USER_HUB_SEARCH_RESULT.links?.thumbnail,
         type: USER_HUB_SEARCH_RESULT.type,
-        additionalInfo: [
-          { i18nKey: "org", value: USER_HUB_SEARCH_RESULT.orgName },
-          { i18nKey: "type", value: USER_HUB_SEARCH_RESULT.type },
-          {
-            i18nKey: "tags",
-            value: USER_HUB_SEARCH_RESULT.tags?.join(", ") as string,
-          },
-          {
-            i18nKey: "dateUpdated",
-            value:
-              USER_HUB_SEARCH_RESULT.updatedDate.toLocaleDateString("en-US"),
-          },
-        ],
       });
-    });
-    it("does not include tags/categories in the view model's additional info if none are defined", () => {
-      const modifiedSearchResult = cloneObject(USER_HUB_SEARCH_RESULT);
-      modifiedSearchResult.tags = undefined;
-      modifiedSearchResult.categories = undefined;
-
-      const result = userResultToCardModel(modifiedSearchResult);
-
-      expect(result.additionalInfo?.length).toBe(3);
     });
     it("title and source fall back to expected default vals", () => {
       const modifiedSearchResult = cloneObject(USER_HUB_SEARCH_RESULT);

--- a/packages/common/test/utils/getEnvironmentFromPortalUrl.test.ts
+++ b/packages/common/test/utils/getEnvironmentFromPortalUrl.test.ts
@@ -1,0 +1,33 @@
+import { getEnvironmentFromPortalUrl } from "../../src";
+
+describe("getEnvironmentFromPortalUrl:", () => {
+  it('should return "prod" for portalUrl containing "arcgis.com"', () => {
+    const portalUrl = "https://www.arcgis.com";
+    const env = getEnvironmentFromPortalUrl(portalUrl);
+    expect(env).toBe("production");
+  });
+
+  it('should return "qaext" for portalUrl containing "qaext.arcgis.com" or "mapsqa.arcgis.com"', () => {
+    const portalUrl1 = "https://qaext.arcgis.com";
+    const portalUrl2 = "https://www.mapsqa.arcgis.com";
+    const env1 = getEnvironmentFromPortalUrl(portalUrl1);
+    const env2 = getEnvironmentFromPortalUrl(portalUrl2);
+    expect(env1).toBe("qaext");
+    expect(env2).toBe("qaext");
+  });
+
+  it('should return "devext" for portalUrl containing "devext.arcgis.com" or "mapsdev.arcgis.com"', () => {
+    const portalUrl1 = "https://devext.arcgis.com";
+    const portalUrl2 = "https://www.mapsdev.arcgis.com";
+    const env1 = getEnvironmentFromPortalUrl(portalUrl1);
+    const env2 = getEnvironmentFromPortalUrl(portalUrl2);
+    expect(env1).toBe("devext");
+    expect(env2).toBe("devext");
+  });
+
+  it('should return "enterprise" for portalUrl not containing "arcgis.com"', () => {
+    const portalUrl = "https://myportal.com";
+    const env = getEnvironmentFromPortalUrl(portalUrl);
+    expect(env).toBe("enterprise");
+  });
+});


### PR DESCRIPTION
Reverting getLocationOptions changes to be uniform with other workspace entities.

@tomwayson Should I fully remove commented code? Or is it fine leaving it in for future tickets?

@thomas-hervey Content now saves correctly and three options display. 

1. Closes Issues: #7208

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
