### PR TITLE
fix: remove additionalInfo from userResultToCardModel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64966,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.37.3",
+			"version": "13.38.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/src/users/view.ts
+++ b/packages/common/src/users/view.ts
@@ -26,7 +26,7 @@ export const userResultToCardModel: ResultToCardModelFn = (
 
   const titleUrl = getCardModelUrlFromResult(searchResult, target, baseUrl);
   return {
-    ...getSharedUserCardModel(searchResult, locale),
+    ...getSharedUserCardModel(searchResult),
     actionLinks,
     ...(searchResult.index && { index: searchResult.index }),
     titleUrl,
@@ -43,33 +43,7 @@ export const userResultToCardModel: ResultToCardModelFn = (
  * @param user user search result
  * @param locale internationalization locale
  */
-const getSharedUserCardModel = (
-  user: IHubSearchResult,
-  locale: string
-): IHubCardViewModel => {
-  const additionalInfo = [
-    {
-      i18nKey: "org",
-      value: user.orgName,
-    },
-    {
-      i18nKey: "type",
-      value: user.type,
-    },
-    ...(user.tags?.length
-      ? [
-          {
-            i18nKey: "tags",
-            value: user.tags.join(", "),
-          },
-        ]
-      : []),
-    {
-      i18nKey: "dateUpdated",
-      value: user.updatedDate.toLocaleDateString(locale),
-    },
-  ];
-
+const getSharedUserCardModel = (user: IHubSearchResult): IHubCardViewModel => {
   return {
     access: user.access,
     badges: [],
@@ -79,6 +53,5 @@ const getSharedUserCardModel = (
     summary: user.summary,
     title: user.name || `@${user.id}`,
     type: user.type,
-    additionalInfo,
   };
 };

--- a/packages/common/test/users/view.test.ts
+++ b/packages/common/test/users/view.test.ts
@@ -47,29 +47,7 @@ describe("user view module:", () => {
         titleUrl: "https://mock-title-url.com",
         thumbnailUrl: USER_HUB_SEARCH_RESULT.links?.thumbnail,
         type: USER_HUB_SEARCH_RESULT.type,
-        additionalInfo: [
-          { i18nKey: "org", value: USER_HUB_SEARCH_RESULT.orgName },
-          { i18nKey: "type", value: USER_HUB_SEARCH_RESULT.type },
-          {
-            i18nKey: "tags",
-            value: USER_HUB_SEARCH_RESULT.tags?.join(", ") as string,
-          },
-          {
-            i18nKey: "dateUpdated",
-            value:
-              USER_HUB_SEARCH_RESULT.updatedDate.toLocaleDateString("en-US"),
-          },
-        ],
       });
-    });
-    it("does not include tags/categories in the view model's additional info if none are defined", () => {
-      const modifiedSearchResult = cloneObject(USER_HUB_SEARCH_RESULT);
-      modifiedSearchResult.tags = undefined;
-      modifiedSearchResult.categories = undefined;
-
-      const result = userResultToCardModel(modifiedSearchResult);
-
-      expect(result.additionalInfo?.length).toBe(3);
     });
     it("title and source fall back to expected default vals", () => {
       const modifiedSearchResult = cloneObject(USER_HUB_SEARCH_RESULT);


### PR DESCRIPTION
1. Description: removes additionalInfo from the user search result to card model conversion as it was erroneously added.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
