### PR TITLE
fix: ensure requestOptions.authentication is UserSession instance in next()

### DIFF
--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -188,6 +188,10 @@ export function getNextFunction<T>(
     clonedRequest.authentication = UserSession.deserialize(
       (request.authentication as UserSession).serialize()
     );
+    if (request.requestOptions) {
+      clonedRequest.requestOptions.authentication =
+        clonedRequest.authentication;
+    }
   }
 
   // figure out the start
@@ -196,6 +200,10 @@ export function getNextFunction<T>(
   return (authentication?: UserSession) => {
     if (authentication) {
       clonedRequest.authentication = authentication;
+      if (clonedRequest.requestOptions) {
+        clonedRequest.requestOptions.authentication =
+          clonedRequest.authentication;
+      }
     }
     return fn(clonedRequest);
   };

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -188,6 +188,7 @@ export function getNextFunction<T>(
     clonedRequest.authentication = UserSession.deserialize(
       (request.authentication as UserSession).serialize()
     );
+    // ensure that if we have requestOptions, we have also update the authentication on it
     if (request.requestOptions) {
       clonedRequest.requestOptions.authentication =
         clonedRequest.authentication;
@@ -200,6 +201,7 @@ export function getNextFunction<T>(
   return (authentication?: UserSession) => {
     if (authentication) {
       clonedRequest.authentication = authentication;
+      // ensure that if we have requestOptions, we have also update the authentication on it
       if (clonedRequest.requestOptions) {
         clonedRequest.requestOptions.authentication =
           clonedRequest.authentication;

--- a/packages/common/test/search/utils.test.ts
+++ b/packages/common/test/search/utils.test.ts
@@ -187,7 +187,7 @@ describe("Search Utils:", () => {
   });
 
   describe("get next function:", () => {
-    it("change change auth on subsequent calls", async () => {
+    it("uses auth on subsequent calls", async () => {
       const request = {
         authentication: MOCK_AUTH,
       } as unknown as ISearchOptions;
@@ -210,9 +210,63 @@ describe("Search Utils:", () => {
       // verify it's called with the MOCK_AUTH
       const opts = fnSpy.calls.mostRecent().args[0];
       expect(opts.authentication).toEqual(MOCK_AUTH);
+      expect(opts.requestOptions).not.toBeDefined();
+    });
+    it("updates requestOptions.authentication on subsequent calls", async () => {
+      const request = {
+        authentication: MOCK_AUTH,
+        requestOptions: {},
+      } as unknown as ISearchOptions;
+
+      const Module = {
+        fn: <T>(r: any) => {
+          return Promise.resolve({} as unknown as ISearchResponse<T>);
+        },
+      };
+      const fnSpy = spyOn(Module, "fn").and.callThrough();
+
+      const chk = await getNextFunction<IHubSearchResult>(
+        request,
+        10,
+        20,
+        fnSpy
+      );
+      await chk();
+      expect(fnSpy).toHaveBeenCalled();
+      // verify it's called with the MOCK_AUTH
+      const opts = fnSpy.calls.mostRecent().args[0];
+      expect(opts.authentication).toEqual(MOCK_AUTH);
+      expect(opts.requestOptions.authentication).toEqual(MOCK_AUTH);
+    });
+    it("can change auth on subsequent calls", async () => {
+      const request = {
+        authentication: MOCK_AUTH,
+        requestOptions: {},
+      } as unknown as ISearchOptions;
+
+      const Module = {
+        fn: <T>(r: any) => {
+          return Promise.resolve({} as unknown as ISearchResponse<T>);
+        },
+      };
+      const fnSpy = spyOn(Module, "fn").and.callThrough();
+
+      const chk = await getNextFunction<IHubSearchResult>(
+        request,
+        10,
+        20,
+        fnSpy
+      );
+      await chk();
+      expect(fnSpy).toHaveBeenCalled();
+      // verify it's called with the MOCK_AUTH
+      const opts = fnSpy.calls.mostRecent().args[0];
+      expect(opts.authentication).toEqual(MOCK_AUTH);
+      expect(opts.requestOptions.authentication).toEqual(MOCK_AUTH);
       await chk(mockUserSession);
       const opts2 = fnSpy.calls.mostRecent().args[0];
       expect(opts2.authentication).toEqual(mockUserSession);
+      expect(opts.requestOptions.authentication).toEqual(mockUserSession);
     });
     it("can pass auth on subsequent calls", async () => {
       const request = {} as unknown as ISearchOptions;


### PR DESCRIPTION
1. Description:

Underlying issue is inconsistencies between the params for various rest-js calls, which necessitated the `request` which is passed into `getNextFunction(...)`, also have both  `.authentication` AND `.requestOptions` properties. In the `getNextFunction(..)` we cloned the request, and then did some additional acrobatics to ensure that `.authentication` on the clone was a reference to the original `UserSession` object. This PR ensures that `.requestOptions` gets that same treatment.


1. Instructions for testing:
- pull, run a build, copy into -ui, run harnesses and validate that you can fetch additional pages of items, org users, groups and group members.

1. Closes Issues: #7575 (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
