### PR TITLE
B/7208 revert temp

### DIFF
--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -5,6 +5,7 @@ import { IHubEditableContent, IHubLocation } from "../../core";
 import { IModel } from "../../types";
 import { bBoxToExtent, extentToPolygon, isBBox } from "../../extent";
 import { IExtent } from "@esri/arcgis-rest-types";
+import { Geometry } from "esri/geometry";
 
 // if called and valid, set 3 things -- else just return type custom
 const getItemExtent = (itemExtent: number[][]): IExtent => {
@@ -17,9 +18,11 @@ function deriveLocationFromItemExtent(itemExtent?: number[][]) {
   const location: IHubLocation = { type: "custom" };
   const geometry: any = getItemExtent(itemExtent); // TODO: this needs to be fixed -tom
   if (geometry) {
-    geometry.type = "polgyon";
-    geometry.rings = extentToPolygon(geometry).rings;
-    location.geometries = [geometry];
+    const convertedPolygon = {
+      ...extentToPolygon(geometry),
+      type: "polygon",
+    } as unknown as Geometry;
+    location.geometries = [convertedPolygon];
     location.spatialReference = geometry.spatialReference;
     location.extent = itemExtent;
   }

--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -1,8 +1,30 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
-import { IHubEditableContent } from "../../core";
+import { IHubEditableContent, IHubLocation } from "../../core";
 import { IModel } from "../../types";
+import { bBoxToExtent, extentToPolygon, isBBox } from "../../extent";
+import { IExtent } from "@esri/arcgis-rest-types";
+
+// if called and valid, set 3 things -- else just return type custom
+const getItemExtent = (itemExtent: number[][]): IExtent => {
+  return isBBox(itemExtent)
+    ? ({ ...bBoxToExtent(itemExtent), type: "extent" } as unknown as IExtent)
+    : undefined;
+};
+
+function deriveLocationFromItemExtent(itemExtent?: number[][]) {
+  const location: IHubLocation = { type: "custom" };
+  const geometry: any = getItemExtent(itemExtent); // TODO: this needs to be fixed -tom
+  if (geometry) {
+    geometry.type = "polgyon";
+    geometry.rings = extentToPolygon(geometry).rings;
+    location.geometries = [geometry];
+    location.spatialReference = geometry.spatialReference;
+    location.extent = itemExtent;
+  }
+  return location;
+}
 
 export function computeProps(
   model: IModel,
@@ -16,6 +38,14 @@ export function computeProps(
   }
   // thumbnail url
   content.thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
+
+  if (!content.location) {
+    // build location if one does not exist based off of the boundary and the item's extent
+    content.location =
+      model.item.properties?.boundary === "none"
+        ? { type: "none" }
+        : deriveLocationFromItemExtent(model.item.extent);
+  }
 
   return content as IHubEditableContent;
 }

--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -5,16 +5,16 @@ import { IHubEditableContent, IHubLocation } from "../../core";
 import { IModel } from "../../types";
 import { bBoxToExtent, extentToPolygon, isBBox } from "../../extent";
 import { IExtent } from "@esri/arcgis-rest-types";
-import { Geometry } from "esri/geometry";
+import Geometry = __esri.Geometry;
 
 // if called and valid, set 3 things -- else just return type custom
-const getItemExtent = (itemExtent: number[][]): IExtent => {
+export const getItemExtent = (itemExtent: number[][]): IExtent => {
   return isBBox(itemExtent)
     ? ({ ...bBoxToExtent(itemExtent), type: "extent" } as unknown as IExtent)
     : undefined;
 };
 
-function deriveLocationFromItemExtent(itemExtent?: number[][]) {
+export function deriveLocationFromItemExtent(itemExtent?: number[][]) {
   const location: IHubLocation = { type: "custom" };
   const geometry: any = getItemExtent(itemExtent); // TODO: this needs to be fixed -tom
   if (geometry) {

--- a/packages/common/src/content/fetch.ts
+++ b/packages/common/src/content/fetch.ts
@@ -252,6 +252,5 @@ export const fetchHubContent = async (
     getPropertyMap()
   );
   const content = mapper.storeToEntity(model, {}) as IHubEditableContent;
-  // TODO: computeProps if we end up using fetchItemAndEnrichments()
   return computeProps(model, content, requestOptions);
 };

--- a/packages/common/src/core/getTypeFromEntity.ts
+++ b/packages/common/src/core/getTypeFromEntity.ts
@@ -35,9 +35,9 @@ export function getTypeFromEntity(
     case "Group":
       type = "group";
       break;
-    case "Hub Content":
-      type = "content";
-      break;
+    // case "Hub Content": // needed for future ticket in getLocationOptions
+    //   type = "content";
+    //   break;
     default:
       // TODO: other families go here? feedback? solution? template?
       const contentFamilies = ["app", "content", "dataset", "document", "map"];

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -1,9 +1,4 @@
-import {
-  bBoxToExtent,
-  extentToBBox,
-  getGeographicOrgExtent,
-  isBBox,
-} from "../../../extent";
+import { extentToBBox, getGeographicOrgExtent } from "../../../extent";
 import { IHubRequestOptions } from "../../../types";
 import { getTypeFromEntity } from "../../getTypeFromEntity";
 
@@ -11,11 +6,11 @@ import { ConfigurableEntity } from "./ConfigurableEntity";
 import { IHubLocation, IHubLocationOption } from "../../types/IHubLocation";
 import { IExtent } from "@esri/arcgis-rest-types";
 
-const getItemExtent = (itemExtent: number[][]): IExtent => {
+/*const getItemExtent = (itemExtent: number[][]): IExtent => {
   return isBBox(itemExtent)
     ? ({ ...bBoxToExtent(itemExtent), type: "extent" } as unknown as IExtent)
     : undefined;
-};
+};*/
 
 /**
  * Construct the dynamic location picker options with the entity's
@@ -37,8 +32,8 @@ export async function getLocationOptions(
   const typeFromEntity = getTypeFromEntity(entity);
 
   switch (typeFromEntity) {
-    case "content":
-      return getContentLocationOptions(entity);
+    // case "content":
+    //   return getContentLocationOptions(entity);
     default:
       return getDefaultLocationOptions(entity, portalName, hubRequestOptions);
   }
@@ -47,7 +42,9 @@ export async function getLocationOptions(
 // TODO: Refactor parameters, they are icky gross
 // TODO: Maybe move these to outside of core and into respective entities
 
-export async function getContentLocationOptions(
+// Leaving this in for future work when we need
+// dynamic options set for different entities
+/*export async function getContentLocationOptions(
   entity: ConfigurableEntity
 ): Promise<IHubLocationOption[]> {
   const defaultExtent: IExtent = getItemExtent(entity.extent);
@@ -68,14 +65,15 @@ export async function getContentLocationOptions(
         type: "custom",
         // TODO: Add custom bbox option here
         // TODO: Remove "Add another location?" notification that appears when selecting a location
-        extent: defaultExtentIsBBox ? extentToBBox(defaultExtent) : undefined,
+        // TODO: The lines below are causing a bug where custom extents don't render after save+reload
+        extent: defaultExtentIsBBox ? extentToBBox(defaultExtent) : undefined, 
         spatialReference: defaultExtentIsBBox
           ? defaultExtent.spatialReference
           : undefined,
       },
     },
   ] as IHubLocationOption[];
-}
+}*/
 
 export async function getDefaultLocationOptions(
   entity: ConfigurableEntity,

--- a/packages/common/test/content/computeProps.test.ts
+++ b/packages/common/test/content/computeProps.test.ts
@@ -34,25 +34,6 @@ describe("content computeProps", () => {
       portalUrl: "https://org.maps.arcgis.com",
     });
   });
-  it("getItemExtent isBBox is true", () => {
-    const chk = getItemExtent([
-      [100, 100],
-      [120, 120],
-    ]);
-    expect(chk.xmin).toBe(100);
-    expect(chk.ymin).toBe(100);
-    expect(chk.xmax).toBe(120);
-    expect(chk.ymax).toBe(120);
-  });
-
-  it("deriveLocationFromItemExtent valid extent", () => {
-    const chk = deriveLocationFromItemExtent([
-      [100, 100],
-      [120, 120],
-    ]);
-    expect(chk.geometries?.length).toBe(1);
-    expect(chk.type).toBe("custom");
-  });
 
   it("computeProps model boundary undefined", () => {
     const model: IModel = {
@@ -102,5 +83,29 @@ describe("content computeProps", () => {
     );
 
     expect(chk.location?.type).toBe("none");
+  });
+});
+
+describe("getItemExtent", () => {
+  it("getItemExtent isBBox is true", () => {
+    const chk = getItemExtent([
+      [100, 100],
+      [120, 120],
+    ]);
+    expect(chk.xmin).toBe(100);
+    expect(chk.ymin).toBe(100);
+    expect(chk.xmax).toBe(120);
+    expect(chk.ymax).toBe(120);
+  });
+});
+
+describe("deriveLocationFromItemExtent", () => {
+  it("deriveLocationFromItemExtent valid extent", () => {
+    const chk = deriveLocationFromItemExtent([
+      [100, 100],
+      [120, 120],
+    ]);
+    expect(chk.geometries?.length).toBe(1);
+    expect(chk.type).toBe("custom");
   });
 });

--- a/packages/common/test/content/computeProps.test.ts
+++ b/packages/common/test/content/computeProps.test.ts
@@ -1,0 +1,106 @@
+import {
+  computeProps,
+  deriveLocationFromItemExtent,
+  getItemExtent,
+} from "../../src/content/_internal/computeProps";
+import { MOCK_AUTH } from "../mocks/mock-auth";
+import { ArcGISContextManager } from "../../src/ArcGISContextManager";
+import { IPortal } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
+import { IHubEditableContent, IModel } from "../../src";
+
+describe("content computeProps", () => {
+  let authdCtxMgr: ArcGISContextManager;
+  beforeEach(async () => {
+    // When we pass in all this information, the context
+    // manager will not try to fetch anything, so no need
+    // to mock those calls
+    authdCtxMgr = await ArcGISContextManager.create({
+      authentication: MOCK_AUTH,
+      currentUser: {
+        username: "casey",
+        privileges: ["portal:user:createItem"],
+      } as unknown as IUser,
+      portal: {
+        name: "DC R&D Center",
+        id: "BRXFAKE",
+        urlKey: "fake-org",
+        properties: {
+          hub: {
+            enabled: true,
+          },
+        },
+      } as unknown as IPortal,
+      portalUrl: "https://org.maps.arcgis.com",
+    });
+  });
+  it("getItemExtent isBBox is true", () => {
+    const chk = getItemExtent([
+      [100, 100],
+      [120, 120],
+    ]);
+    expect(chk.xmin).toBe(100);
+    expect(chk.ymin).toBe(100);
+    expect(chk.xmax).toBe(120);
+    expect(chk.ymax).toBe(120);
+  });
+
+  it("deriveLocationFromItemExtent valid extent", () => {
+    const chk = deriveLocationFromItemExtent([
+      [100, 100],
+      [120, 120],
+    ]);
+    expect(chk.geometries?.length).toBe(1);
+    expect(chk.type).toBe("custom");
+  });
+
+  it("computeProps model boundary undefined", () => {
+    const model: IModel = {
+      item: {
+        created: new Date().getTime(),
+        modified: new Date().getTime(),
+        properties: {
+          // nothing set in properties
+        },
+      },
+      data: {},
+      // no boundary set
+    } as IModel;
+    const content: Partial<IHubEditableContent> = {
+      // no location set
+    };
+
+    const chk = computeProps(
+      model,
+      content,
+      authdCtxMgr.context.requestOptions
+    );
+
+    expect(chk.location?.type).toBe("custom");
+  });
+
+  it("computeProps boundary defined as none", () => {
+    const model: IModel = {
+      item: {
+        created: new Date().getTime(),
+        modified: new Date().getTime(),
+        properties: {
+          boundary: "none",
+        },
+      },
+      data: {},
+      // no boundary set
+    } as IModel;
+    const content: Partial<IHubEditableContent> = {
+      // no location set
+    };
+
+    const chk = computeProps(
+      model,
+      content,
+      authdCtxMgr.context.requestOptions
+    );
+
+    expect(chk.location?.type).toBe("none");
+  });
+});

--- a/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
+++ b/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
@@ -91,92 +91,95 @@ describe("getLocationOptions - default:", () => {
   });
 });
 
-describe("getLocationOptions - content:", () => {
-  it("custom is selected", async () => {
-    const entity: ConfigurableEntity = {
-      id: "00c",
-      type: "Hub Content",
-      location: {
-        type: "custom",
-      },
-      boundary: "item",
-      extent: [
-        [100, 100],
-        [120, 120],
-      ],
-    } as ConfigurableEntity;
+// Leaving this in for future work when we need
+// dynamic options set for different entities
 
-    const chk = await getLocationOptions(
-      entity,
-      "portalName",
-      {} as IHubRequestOptions
-    );
+// describe("getLocationOptions - content:", () => {
+//   it("custom is selected", async () => {
+//     const entity: ConfigurableEntity = {
+//       id: "00c",
+//       type: "Hub Content",
+//       location: {
+//         type: "custom",
+//       },
+//       boundary: "item",
+//       extent: [
+//         [100, 100],
+//         [120, 120],
+//       ],
+//     } as ConfigurableEntity;
 
-    expect(chk.length).toBe(2);
-    expect(chk[1].selected).toBe(true);
-  });
-  it("none is selected", async () => {
-    const entity: ConfigurableEntity = {
-      id: "00c",
-      type: "Hub Content",
-      location: {
-        type: "none",
-      },
-      boundary: "none",
-    } as ConfigurableEntity;
+//     const chk = await getLocationOptions(
+//       entity,
+//       "portalName",
+//       {} as IHubRequestOptions
+//     );
 
-    const chk = await getLocationOptions(
-      entity,
-      "portalName",
-      {} as IHubRequestOptions
-    );
+//     expect(chk.length).toBe(2);
+//     expect(chk[1].selected).toBe(true);
+//   });
+//   it("none is selected", async () => {
+//     const entity: ConfigurableEntity = {
+//       id: "00c",
+//       type: "Hub Content",
+//       location: {
+//         type: "none",
+//       },
+//       boundary: "none",
+//     } as ConfigurableEntity;
 
-    expect(chk.length).toBe(2);
-    expect(chk[0].selected).toBe(true);
-  });
-  it("custom is selected if entity does not have an id", async () => {
-    const entity: ConfigurableEntity = {
-      type: "Hub Content",
-      location: {
-        type: "custom",
-      },
-      boundary: "item",
-      extent: [
-        [100, 100],
-        [120, 120],
-      ],
-    } as ConfigurableEntity;
+//     const chk = await getLocationOptions(
+//       entity,
+//       "portalName",
+//       {} as IHubRequestOptions
+//     );
 
-    const chk = await getLocationOptions(
-      entity,
-      "portalName",
-      {} as IHubRequestOptions
-    );
+//     expect(chk.length).toBe(2);
+//     expect(chk[0].selected).toBe(true);
+//   });
+//   it("custom is selected if entity does not have an id", async () => {
+//     const entity: ConfigurableEntity = {
+//       type: "Hub Content",
+//       location: {
+//         type: "custom",
+//       },
+//       boundary: "item",
+//       extent: [
+//         [100, 100],
+//         [120, 120],
+//       ],
+//     } as ConfigurableEntity;
 
-    expect(chk.length).toBe(2);
-    expect(chk[1].selected).toBe(true);
-  });
-  it("custom is selected & boundary is set", async () => {
-    const entity: ConfigurableEntity = {
-      id: "00c",
-      type: "Hub Content",
-      location: {
-        type: "custom",
-      },
-      boundary: "item",
-      extent: [
-        [100, 100],
-        [120, 120],
-      ],
-    } as ConfigurableEntity;
+//     const chk = await getLocationOptions(
+//       entity,
+//       "portalName",
+//       {} as IHubRequestOptions
+//     );
 
-    const chk = await getLocationOptions(
-      entity,
-      "portalName",
-      {} as IHubRequestOptions
-    );
+//     expect(chk.length).toBe(2);
+//     expect(chk[1].selected).toBe(true);
+//   });
+//   it("custom is selected & boundary is set", async () => {
+//     const entity: ConfigurableEntity = {
+//       id: "00c",
+//       type: "Hub Content",
+//       location: {
+//         type: "custom",
+//       },
+//       boundary: "item",
+//       extent: [
+//         [100, 100],
+//         [120, 120],
+//       ],
+//     } as ConfigurableEntity;
 
-    expect(chk.length).toBe(2);
-    expect(chk[1].selected).toBe(true);
-  });
-});
+//     const chk = await getLocationOptions(
+//       entity,
+//       "portalName",
+//       {} as IHubRequestOptions
+//     );
+
+//     expect(chk.length).toBe(2);
+//     expect(chk[1].selected).toBe(true);
+//   });
+// });


### PR DESCRIPTION

1. Instructions for testing:
- No location (never been saved in workspace) -- http://localhost:3333/html/arcgis-hub-workspace/entity-workspace-harness.html?identifier=5274dc3dff494b3ea1ac7424d29a9fe9&type=content
- Custom location (never been saved in workspace) -- http://localhost:3333/html/arcgis-hub-workspace/entity-workspace-harness.html?identifier=a76e7f5bcf7a4f75904ffbd51f3963cf&type=content
- Custom location (has been saved in workspace) -- http://localhost:3333/html/arcgis-hub-workspace/entity-workspace-harness.html?identifier=e22404f554fb455aa8b53c30ea7fc7f8&type=content
- Custom location not set (never been saved in workspace) -- http://localhost:3333/html/arcgis-hub-workspace/entity-workspace-harness.html?identifier=3c5e02dc7f684ba383fc79c28df0e6b0&type=content

1. Closes Issues: #7208 

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
