### PR TITLE
feat(): migrate summary stat function

### DIFF
--- a/packages/common/src/core/types/Metrics.ts
+++ b/packages/common/src/core/types/Metrics.ts
@@ -183,7 +183,17 @@ export interface IResolvedMetric {
  * Expression by which a metric can be filtered before aggregation, i.e. a clause of a where statement
  */
 export interface IExpression {
+  /**
+   * Field that the expression filters on
+   */
   field?: IField;
+  /**
+   * The values that the where clause will be using on the right-hand side of the statement: this can be an array of strings, numbers, or dates.
+   * These values will be used in conjunction with the field to construct a where clause.
+   */
   values?: Array<string | number | Date>;
+  /**
+   * A special identifier given to the expression when it is created
+   */
   key?: string;
 }

--- a/packages/common/src/core/types/Metrics.ts
+++ b/packages/common/src/core/types/Metrics.ts
@@ -1,4 +1,5 @@
 import { IQuery } from "../../search/types/IHubCatalog";
+import { IField } from "@esri/arcgis-rest-types";
 import { ServiceAggregation } from "./DynamicValues";
 import { IReference } from "./IReference";
 
@@ -176,4 +177,13 @@ export interface IMetricFeature {
 export interface IResolvedMetric {
   features: IMetricFeature[];
   generatedAt: number;
+}
+
+/**
+ * Expression by which a metric can be filtered before aggregation, i.e. a clause of a where statement
+ */
+export interface IExpression {
+  field?: IField;
+  values?: Array<string | number | Date>;
+  key?: string;
 }

--- a/packages/common/src/sites/_internal/_migrate-summary-stat-card-configs.ts
+++ b/packages/common/src/sites/_internal/_migrate-summary-stat-card-configs.ts
@@ -15,7 +15,6 @@ import { IExpression } from "../../core/types/Metrics";
 export function _migrateSummaryStatCardConfigs<T extends IModel | IDraft>(
   model: T
 ): T {
-  // TODO: fill in
   // attempt migration for 1.7 schema version
   const migratedModel = _migrateSummaryStatSchemaVersion1_7(model);
   return migratedModel;

--- a/packages/common/src/sites/_internal/_migrate-summary-stat-card-configs.ts
+++ b/packages/common/src/sites/_internal/_migrate-summary-stat-card-configs.ts
@@ -56,6 +56,7 @@ function _migrateSummaryStatSchemaVersion1_7<T extends IModel | IDraft>(
                     values.url?.lastIndexOf("FeatureServer") + 13
                   ),
               expressionSet: whereToExpressionSet(values.where),
+              allowExpressionSet: !!values.where,
             },
             serverTimeout: values.timeout,
             textAlign: migrateTextAlign(values.statValueAlign),

--- a/packages/common/src/sites/_internal/_migrate-summary-stat-card-configs.ts
+++ b/packages/common/src/sites/_internal/_migrate-summary-stat-card-configs.ts
@@ -1,0 +1,101 @@
+import { setProp } from "../../objects";
+import { IModel, IDraft } from "../../types";
+import { cloneObject } from "../../util";
+
+/**
+ * Reconfigure summary stat card properties to align with the
+ * new web component card.
+ * @private
+ * @param {Object} model Site Model
+ * @returns {Object}
+ */
+export function _migrateSummaryStatCardConfigs<T extends IModel | IDraft>(
+  model: T
+): T {
+  // TODO: fill in
+  // attempt migration for _______ schema version
+  const migratedModel = _migrateSummaryStatSchemaVersion1_7(model);
+  return migratedModel;
+}
+
+function _migrateSummaryStatSchemaVersion1_7<T extends IModel | IDraft>(
+  model: T
+): T {
+  // do nothing if migration already applied
+  if (model.item.properties?.schemaVersion >= 1.7) return model;
+
+  // apply migration
+  const clone = cloneObject(model);
+  clone.data.values.layout.sections.map((section: any) => ({
+    ...section,
+    rows: (section.rows || []).map((row: any) => ({
+      ...row,
+      cards: (row.cards || []).map((card: any) => {
+        if (card.component.name === "summary-statistic-card") {
+          const values = card.component.settings;
+          card.component.settings = {
+            type: "dynamic",
+            cardTitle: values.title,
+            dynamicMetric: {
+              itemId: [values.itemId],
+              layerId: values.layerId?.toString(),
+              field: values.statFieldName,
+              fieldType: values.statFieldType,
+              statistic: values.statType,
+              serviceUrl: values.url?.endsWith("FeatureServer")
+                ? values.url
+                : values.url?.slice(
+                    0,
+                    values.url?.lastIndexOf("FeatureServer") + 13
+                  ),
+            },
+            serverTimeout: values.serverTimeout,
+            where: values.where,
+            textAlign: migrateTextAlign(values.statValueAlign),
+            valueColor:
+              values.statValueColor === null
+                ? undefined
+                : values.statValueColor,
+            trailingText: values.trailingText,
+            cardId: values.cardId,
+
+            // did not exist on old stat card
+            allowUnitFormatting: false,
+            allowLink: false,
+          };
+
+          delete card.component.settings.title;
+          delete card.component.settings.statFieldName;
+          delete card.component.settings.statFieldType;
+          delete card.component.settings.statType;
+          delete card.component.settings.statValueAlign;
+          delete card.component.settings.statValueColor;
+          delete card.component.settings.itemTitle;
+          delete card.component.settings.layerName;
+          delete card.component.settings.currencyCode;
+          delete card.component.settings.decimalPlaces;
+          delete card.component.settings.formatNumberGroupings;
+          delete card.component.settings.leadingText;
+          delete card.component.settings.showAsCurrency;
+          delete card.component.settings.titleAlign;
+          delete card.component.settings.trailingTextAlign;
+        }
+        return card;
+      }),
+    })),
+  }));
+
+  setProp("item.properties.schemaVersion", 1.6, clone);
+  return clone;
+}
+
+function migrateTextAlign(align: string): string {
+  switch (align) {
+    case "left":
+      return "start";
+    case "center":
+      return "center";
+    case "right":
+      return "end";
+  }
+}

--- a/packages/common/src/sites/_internal/_migrate-summary-stat-card-configs.ts
+++ b/packages/common/src/sites/_internal/_migrate-summary-stat-card-configs.ts
@@ -3,12 +3,7 @@ import { IModel, IDraft } from "../../types";
 import { cloneObject } from "../../util";
 import { IField } from "@esri/arcgis-rest-feature-layer";
 import { FieldType } from "@esri/arcgis-rest-types";
-
-interface IExpression {
-  field?: IField;
-  values?: Array<string | number | Date>;
-  key?: string;
-}
+import { IExpression } from "../../core/types/Metrics";
 
 /**
  * Reconfigure summary stat card properties to align with the

--- a/packages/common/src/sites/_internal/_migrate-summary-stat-card-configs.ts
+++ b/packages/common/src/sites/_internal/_migrate-summary-stat-card-configs.ts
@@ -1,6 +1,13 @@
 import { setProp } from "../../objects";
 import { IModel, IDraft } from "../../types";
 import { cloneObject } from "../../util";
+import { IField } from "@esri/arcgis-rest-feature-layer";
+
+interface IExpression {
+  field?: IField;
+  values?: Array<string | number | Date>;
+  key?: string;
+}
 
 /**
  * Reconfigure summary stat card properties to align with the
@@ -48,9 +55,9 @@ function _migrateSummaryStatSchemaVersion1_7<T extends IModel | IDraft>(
                     0,
                     values.url?.lastIndexOf("FeatureServer") + 13
                   ),
+              expressionSet: whereToExpressionSet(values.where),
             },
-            serverTimeout: values.serverTimeout,
-            where: values.where,
+            serverTimeout: values.timeout,
             textAlign: migrateTextAlign(values.statValueAlign),
             valueColor:
               values.statValueColor === null
@@ -63,29 +70,13 @@ function _migrateSummaryStatSchemaVersion1_7<T extends IModel | IDraft>(
             allowUnitFormatting: false,
             allowLink: false,
           };
-
-          delete card.component.settings.title;
-          delete card.component.settings.statFieldName;
-          delete card.component.settings.statFieldType;
-          delete card.component.settings.statType;
-          delete card.component.settings.statValueAlign;
-          delete card.component.settings.statValueColor;
-          delete card.component.settings.itemTitle;
-          delete card.component.settings.layerName;
-          delete card.component.settings.currencyCode;
-          delete card.component.settings.decimalPlaces;
-          delete card.component.settings.formatNumberGroupings;
-          delete card.component.settings.leadingText;
-          delete card.component.settings.showAsCurrency;
-          delete card.component.settings.titleAlign;
-          delete card.component.settings.trailingTextAlign;
         }
         return card;
       }),
     })),
   }));
 
-  setProp("item.properties.schemaVersion", 1.6, clone);
+  setProp("item.properties.schemaVersion", 1.7, clone);
   return clone;
 }
 
@@ -98,4 +89,128 @@ function migrateTextAlign(align: string): string {
     case "right":
       return "end";
   }
+}
+
+/**
+ * Takes a where clause from a summary statistic card and transforms it into
+ * the new expression set array for usage in the new summary stat card.
+ *
+ * This is a brittle function to be used just for the migration of the <=1.6 of the summary stat card into
+ * the 1.7 version of the summary stat card.
+ * @param where A where clause as a string. Ex: "Category = 'abc' AND date <= TIMESTAMP '2023-01-01 00:00:00"
+ * @returns IExpression[] expression set of the where clause, broken down into individual expressions
+ */
+export function whereToExpressionSet(where: string): IExpression[] {
+  let expressionSet: IExpression[] = [];
+  if (where) {
+    const whereClauses = where.split("AND");
+    expressionSet = whereClauses.map((clause) => {
+      let expression: IExpression;
+
+      // could be number or date
+      if (clause.includes(">=")) {
+        const { fieldName, value } = handleClauseSplit(clause, ">=");
+        const finalValue = value.includes("TIMESTAMP")
+          ? handleDateInClause(value)
+          : value;
+        const fieldType = value.includes("TIMESTAMP")
+          ? "esriFieldTypeDate"
+          : undefined;
+        expression = makeExpression(fieldName, fieldType, [finalValue]);
+      }
+
+      // could be number or date AND value is second in values array
+      else if (clause.includes("<=")) {
+        const { fieldName, value } = handleClauseSplit(clause, "<=");
+        const finalValue = value.includes("TIMESTAMP")
+          ? handleDateInClause(value)
+          : value;
+        const fieldType = value.includes("TIMESTAMP")
+          ? "esriFieldTypeDate"
+          : undefined;
+        expression = makeExpression(fieldName, fieldType, [
+          undefined,
+          finalValue,
+        ]);
+      }
+
+      // string match
+      else if (clause.includes("=")) {
+        const { fieldName, value } = handleClauseSplit(clause, "=");
+        const cleanedValue = removeQuotesAroundValue(value);
+        expression = makeExpression(fieldName, "esriFieldTypeString", [
+          cleanedValue,
+        ]);
+      }
+
+      return expression;
+    });
+  }
+  return expressionSet;
+}
+
+/**
+ * Splits a clause by a given parameter.
+ * @param clause String to split into pieces
+ * @param splitBy How to split the string
+ * @returns The field name and value from the clause, split
+ */
+function handleClauseSplit(
+  clause: string,
+  splitBy: string = ""
+): { fieldName: string; value: string } {
+  let result = { fieldName: "", value: "" };
+  const pieces = clause.split(splitBy);
+
+  if (pieces.length === 2) {
+    const fieldName = pieces[0].trim();
+    const value = pieces[1].trim();
+    result = { fieldName, value };
+  }
+
+  return result;
+}
+
+/**
+ * Takes a piece of a where clause with a date in it, and extracts just the YYYY-MM-DD.
+ * @param value - where clause piece with value
+ * @returns YYYY-MM-DD as string
+ */
+function handleDateInClause(value: string): string {
+  const dateAndTimePieces = value.split("'");
+  const dateAndTime = dateAndTimePieces[1].trim();
+  const date = dateAndTime.split(" ")[0].trim();
+  return date;
+}
+
+/**
+ * Makes an expression for the expression set.
+ * @param fieldName Name of IField
+ * @param fieldType Type of IField
+ * @param values Values in clause
+ * @returns IExpression to be used in an expression set.
+ */
+function makeExpression(
+  fieldName: string,
+  fieldType: string,
+  values: Array<string | number | Date>
+): IExpression {
+  const expression = {
+    field: {
+      name: fieldName,
+      type: fieldType,
+    } as IField,
+    values,
+  };
+  return expression;
+}
+
+/**
+ * Removes single quotes around a value. Used to remove the leading and trailing
+ * single quotes around a string value for a where clause.
+ * @param value string value with single quotes around it
+ * @returns string value without leading or trailing single quotes
+ */
+function removeQuotesAroundValue(value: string) {
+  return value.replace(/^\'+|\'+$/g, "");
 }

--- a/packages/common/src/sites/index.ts
+++ b/packages/common/src/sites/index.ts
@@ -1,6 +1,7 @@
 export * from "./_internal/_ensure-telemetry";
 export * from "./_internal/_migrate-feed-config";
 export * from "./_internal/_migrate-event-list-card-configs";
+export * from "./_internal/_migrate-summary-stat-card-configs";
 export * from "./domains";
 export * from "./drafts";
 export * from "./fetchSiteModel";

--- a/packages/common/src/sites/site-schema-version.ts
+++ b/packages/common/src/sites/site-schema-version.ts
@@ -1,1 +1,1 @@
-export const SITE_SCHEMA_VERSION = 1.6;
+export const SITE_SCHEMA_VERSION = 1.7;

--- a/packages/common/src/sites/upgrade-site-schema.ts
+++ b/packages/common/src/sites/upgrade-site-schema.ts
@@ -8,6 +8,7 @@ import { _purgeNonGuidsFromCatalog } from "./_internal/_purge-non-guids-from-cat
 import { _ensureTelemetry } from "./_internal/_ensure-telemetry";
 import { _migrateFeedConfig } from "./_internal/_migrate-feed-config";
 import { _migrateEventListCardConfigs } from "./_internal/_migrate-event-list-card-configs";
+import { _migrateSummaryStatCardConfigs } from "./_internal/_migrate-summary-stat-card-configs";
 
 /**
  * Upgrades the schema upgrades
@@ -25,6 +26,7 @@ export function upgradeSiteSchema(model: IModel) {
     model = _ensureTelemetry<IModel>(model);
     model = _migrateFeedConfig(model);
     model = _migrateEventListCardConfigs(model);
+    model = _migrateSummaryStatCardConfigs(model);
     // WARNING - If you are writing a site schema migration,
     // you probably need to apply it to site drafts as well!
     // See https://github.com/Esri/hub.js/issues/498 for more details.

--- a/packages/common/test/sites/_internal/_migrateSummaryStatCardConfig.test.ts
+++ b/packages/common/test/sites/_internal/_migrateSummaryStatCardConfig.test.ts
@@ -1,7 +1,7 @@
 import { _migrateSummaryStatCardConfigs } from "../../../src/sites/_internal/_migrate-summary-stat-card-configs";
 import { IModel, cloneObject, IDraft, setProp } from "../../../src";
 
-function getSiteModel(cardSettings) {
+function getSiteModel(cardSettings: Record<string, any>) {
   return {
     item: {
       id: "3ef",
@@ -85,7 +85,7 @@ function getCardSettings(
 
 function getExpectedCardSettings(
   textAlign: string,
-  expressionSet,
+  expressionSet: Record<string, any>,
   color: string | undefined
 ) {
   return {
@@ -290,7 +290,7 @@ describe("_ensure-summary-stat-card", () => {
       const where = "Float <= 4.55";
       const expressionSet = [
         {
-          field: { name: "Float", type: undefined },
+          field: { name: "Float" },
           values: [undefined, "4.55"],
         },
       ];
@@ -305,7 +305,7 @@ describe("_ensure-summary-stat-card", () => {
     });
 
     it("handles an empty where clause", () => {
-      const expressionSet = [];
+      const expressionSet: Array<Record<string, any>> = [];
       model = cloneObject(
         getSiteModel(getCardSettings("left", undefined, null))
       );

--- a/packages/common/test/sites/_internal/_migrateSummaryStatCardConfig.test.ts
+++ b/packages/common/test/sites/_internal/_migrateSummaryStatCardConfig.test.ts
@@ -99,6 +99,7 @@ function getExpectedCardSettings(
       serviceUrl:
         "https://servicesqa.arcgis.com/Xj56SBi2udA78cC9/arcgis/rest/services/Field_Type_Table/FeatureServer",
       expressionSet,
+      allowExpressionSet: !!expressionSet.length,
     },
     type: "dynamic",
     cardTitle: "Statistic Title",
@@ -108,7 +109,6 @@ function getExpectedCardSettings(
     trailingText: "trailing text...",
     allowUnitFormatting: false,
     allowLink: false,
-    allowExpressionSet: !!expressionSet,
   };
 }
 
@@ -148,7 +148,7 @@ describe("_ensure-summary-stat-card", () => {
     let model: IModel;
 
     it("does not apply changes if schemaVersion is already 1.7", function () {
-      model = cloneObject(getSiteModel(getCardSettings("left", "", null)));
+      model = cloneObject(getSiteModel(getCardSettings("left", "1=1", null)));
       setProp("item.properties.schemaVersion", 1.7, model);
       const expected: IModel = cloneObject(model);
       const results = _migrateSummaryStatCardConfigs<IModel>(model);
@@ -156,7 +156,7 @@ describe("_ensure-summary-stat-card", () => {
     });
 
     it("does not apply changes if invalid model", function () {
-      model = cloneObject(getSiteModel(getCardSettings("left", "", null)));
+      model = cloneObject(getSiteModel(getCardSettings("left", "1=1", null)));
       const expected: IModel = cloneObject(modelWithBadLayout);
       setProp("item.properties.schemaVersion", 1.7, expected);
       const results =
@@ -233,11 +233,11 @@ describe("_ensure-summary-stat-card", () => {
           values: [undefined, "2023-01-03"],
         },
         {
-          field: { name: "SmInteger", type: undefined },
+          field: { name: "SmInteger" },
           values: ["1"],
         },
         {
-          field: { name: "SmInteger", type: undefined },
+          field: { name: "SmInteger" },
           values: [undefined, "1"],
         },
       ];
@@ -256,7 +256,7 @@ describe("_ensure-summary-stat-card", () => {
         " Float <= 4.55 AND Field Name = 'This is a string' AND Date >= TIMESTAMP '2023-07-17 00:00:00' AND Float >= 3.99 AND Date <= TIMESTAMP '2023-07-17 23:59:59'";
       const expressionSet = [
         {
-          field: { name: "Float", type: undefined },
+          field: { name: "Float" },
           values: [undefined, "4.55"],
         },
         {
@@ -268,7 +268,7 @@ describe("_ensure-summary-stat-card", () => {
           values: ["2023-07-17"],
         },
         {
-          field: { name: "Float", type: undefined },
+          field: { name: "Float" },
           values: ["3.99"],
         },
         {
@@ -309,6 +309,19 @@ describe("_ensure-summary-stat-card", () => {
       model = cloneObject(
         getSiteModel(getCardSettings("left", undefined, null))
       );
+
+      const expected: IModel = cloneObject(
+        getSiteModel(getExpectedCardSettings("start", expressionSet, undefined))
+      );
+      setProp("item.properties.schemaVersion", 1.7, expected);
+      const results = _migrateSummaryStatCardConfigs<IModel>(model);
+      expect(results).toEqual(expected);
+    });
+
+    it("handles where 1=1", () => {
+      const where = "1=1";
+      const expressionSet: Array<Record<string, any>> = [];
+      model = cloneObject(getSiteModel(getCardSettings("left", where, null)));
 
       const expected: IModel = cloneObject(
         getSiteModel(getExpectedCardSettings("start", expressionSet, undefined))

--- a/packages/common/test/sites/_internal/_migrateSummaryStatCardConfig.test.ts
+++ b/packages/common/test/sites/_internal/_migrateSummaryStatCardConfig.test.ts
@@ -108,6 +108,7 @@ function getExpectedCardSettings(
     trailingText: "trailing text...",
     allowUnitFormatting: false,
     allowLink: false,
+    allowExpressionSet: !!expressionSet,
   };
 }
 

--- a/packages/common/test/sites/_internal/_migrateSummaryStatCardConfig.test.ts
+++ b/packages/common/test/sites/_internal/_migrateSummaryStatCardConfig.test.ts
@@ -1,5 +1,6 @@
 import { _migrateSummaryStatCardConfigs } from "../../../src/sites/_internal/_migrate-summary-stat-card-configs";
 import { IModel, cloneObject, setProp } from "../../../src";
+import * as utils from "../../../src/util";
 
 function getSiteModel(cardSettings: Record<string, any>) {
   return {
@@ -215,6 +216,9 @@ describe("_ensure-summary-stat-card", () => {
 
     it("handles an empty settings object", function () {
       model = cloneObject(getSiteModel({}));
+      const createIdSpy: jasmine.Spy = spyOn(utils, "createId").and.returnValue(
+        "mockCardId"
+      );
       const expected: IModel = cloneObject(
         getSiteModel({
           type: "dynamic",
@@ -233,7 +237,7 @@ describe("_ensure-summary-stat-card", () => {
           serverTimeout: undefined,
           valueColor: undefined,
           trailingText: undefined,
-          cardId: undefined,
+          cardId: "mockCardId",
           allowUnitFormatting: false,
           allowLink: false,
         })
@@ -241,9 +245,13 @@ describe("_ensure-summary-stat-card", () => {
       const result = _migrateSummaryStatCardConfigs<IModel>(model);
       setProp("item.properties.schemaVersion", 1.7, expected);
       expect(result).toEqual(expected);
+      expect(createIdSpy).toHaveBeenCalledTimes(1);
     });
 
     it("handles formatting of url", function () {
+      const createIdSpy: jasmine.Spy = spyOn(utils, "createId").and.returnValue(
+        "mockCardId"
+      );
       model = cloneObject(
         getSiteModel({
           url: "https://servicesqa.arcgis.com/Xj56SBi2udA78cC9/arcgis/rest/services/Field_Type_Table/FeatureServer",
@@ -268,7 +276,7 @@ describe("_ensure-summary-stat-card", () => {
           serverTimeout: undefined,
           valueColor: undefined,
           trailingText: undefined,
-          cardId: undefined,
+          cardId: "mockCardId",
           allowUnitFormatting: false,
           allowLink: false,
         })
@@ -276,6 +284,44 @@ describe("_ensure-summary-stat-card", () => {
       const result = _migrateSummaryStatCardConfigs<IModel>(model);
       setProp("item.properties.schemaVersion", 1.7, expected);
       expect(result).toEqual(expected);
+      expect(createIdSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("handles formatting of url with MapServer url", function () {
+      const createIdSpy: jasmine.Spy = spyOn(utils, "createId").and.returnValue(
+        "mockCardId"
+      );
+      model = getSiteModel({
+        url: "https://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Demographic_WebMercator/MapServer/40",
+      });
+      const expected: IModel = cloneObject(
+        getSiteModel({
+          type: "dynamic",
+          cardTitle: undefined,
+          dynamicMetric: {
+            allowExpressionSet: false,
+            itemId: [undefined],
+            layerId: undefined,
+            field: undefined,
+            fieldType: undefined,
+            statistic: undefined,
+            serviceUrl:
+              "https://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Demographic_WebMercator/MapServer",
+            expressionSet: [],
+          },
+          textAlign: "start",
+          serverTimeout: undefined,
+          valueColor: undefined,
+          trailingText: undefined,
+          cardId: "mockCardId",
+          allowUnitFormatting: false,
+          allowLink: false,
+        })
+      );
+      const result = _migrateSummaryStatCardConfigs<IModel>(model);
+      setProp("item.properties.schemaVersion", 1.7, expected);
+      expect(result).toEqual(expected);
+      expect(createIdSpy).toHaveBeenCalledTimes(1);
     });
 
     describe("text align & color variations", function () {

--- a/packages/common/test/sites/_internal/_migrateSummaryStatCardConfig.test.ts
+++ b/packages/common/test/sites/_internal/_migrateSummaryStatCardConfig.test.ts
@@ -1,0 +1,320 @@
+import { _migrateSummaryStatCardConfigs } from "../../../src/sites/_internal/_migrate-summary-stat-card-configs";
+import { IModel, cloneObject, IDraft, setProp } from "../../../src";
+
+function getSiteModel(cardSettings) {
+  return {
+    item: {
+      id: "3ef",
+      title: "Some Site",
+      type: "Hub Site",
+      properties: {
+        schemaVersion: 1.6,
+      },
+    },
+    data: {
+      values: {
+        layout: {
+          sections: [
+            {
+              rows: [
+                {
+                  cards: [
+                    {
+                      component: {
+                        name: "summary-statistic-card",
+                        settings: cardSettings,
+                      },
+                      width: 12,
+                    },
+                  ],
+                },
+                {
+                  cards: [
+                    {
+                      component: {
+                        name: "markdown-card",
+                        settings: {
+                          schemaVersion: 2.1,
+                          markdown:
+                            '<h4 style="color: rgb(0, 0, 0);"><b>Dataset Type Items</b></h4>',
+                        },
+                      },
+                      width: 12,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  } as unknown as IModel;
+}
+
+function getCardSettings(
+  align: string,
+  where: string | undefined,
+  color: string | null
+) {
+  return {
+    cardId: "cmmqtolwk",
+    currencyCode: "USD",
+    decimalPlaces: 2,
+    formatNumberGroupings: true,
+    itemId: "60dfdb1f778c4480b8c4135b1e9a2ecb",
+    itemTitle: "Field Type Table",
+    layerId: 0,
+    layerName: "Table",
+    leadingText: "",
+    showAsCurrency: false,
+    statFieldName: "Float",
+    statFieldType: "esriFieldTypeDouble",
+    statType: "sum",
+    statValueAlign: align,
+    statValueColor: color,
+    timeout: 30,
+    title: "Statistic Title",
+    titleAlign: "left",
+    trailingText: "trailing text...",
+    trailingTextRight: "right",
+    url: "https://servicesqa.arcgis.com/Xj56SBi2udA78cC9/arcgis/rest/services/Field_Type_Table/FeatureServer/0",
+    where,
+  };
+}
+
+function getExpectedCardSettings(
+  textAlign: string,
+  expressionSet,
+  color: string | undefined
+) {
+  return {
+    cardId: "cmmqtolwk",
+    dynamicMetric: {
+      itemId: ["60dfdb1f778c4480b8c4135b1e9a2ecb"],
+      layerId: "0",
+      field: "Float",
+      fieldType: "esriFieldTypeDouble",
+      statistic: "sum",
+      serviceUrl:
+        "https://servicesqa.arcgis.com/Xj56SBi2udA78cC9/arcgis/rest/services/Field_Type_Table/FeatureServer",
+      expressionSet,
+    },
+    type: "dynamic",
+    cardTitle: "Statistic Title",
+    serverTimeout: 30,
+    textAlign,
+    valueColor: color,
+    trailingText: "trailing text...",
+    allowUnitFormatting: false,
+    allowLink: false,
+  };
+}
+
+const modelWithBadLayout = {
+  item: {
+    properties: {
+      schemaVersion: 1.5,
+    },
+  },
+  data: {
+    values: {
+      layout: {
+        sections: [
+          {
+            rows: [
+              {
+                cards: [],
+              },
+              {
+                otherProp:
+                  "This is an invalid row, lacking a .cards prop - it should be ignored",
+              },
+            ],
+          },
+          {
+            otherProp:
+              "this is an invalid section lacking a .rows prop - it should just be ignored",
+          },
+        ],
+      },
+    },
+  },
+} as unknown as IModel;
+
+describe("_ensure-summary-stat-card", () => {
+  describe("Site model", function () {
+    let model: IModel;
+
+    it("does not apply changes if schemaVersion is already 1.7", function () {
+      model = cloneObject(getSiteModel(getCardSettings("left", "", null)));
+      setProp("item.properties.schemaVersion", 1.7, model);
+      const expected: IModel = cloneObject(model);
+      const results = _migrateSummaryStatCardConfigs<IModel>(model);
+      expect(results).toEqual(expected);
+    });
+
+    it("does not apply changes if invalid model", function () {
+      model = cloneObject(getSiteModel(getCardSettings("left", "", null)));
+      const expected: IModel = cloneObject(modelWithBadLayout);
+      setProp("item.properties.schemaVersion", 1.7, expected);
+      const results =
+        _migrateSummaryStatCardConfigs<IModel>(modelWithBadLayout);
+      expect(results).toEqual(expected);
+    });
+
+    describe("text align & color variations", function () {
+      it('sets a site model accurately: align = left, where = "", color = null', () => {
+        model = cloneObject(getSiteModel(getCardSettings("left", "", null)));
+        const expected: IModel = cloneObject(
+          getSiteModel(getExpectedCardSettings("start", [], undefined))
+        );
+        setProp("item.properties.schemaVersion", 1.7, expected);
+        const results = _migrateSummaryStatCardConfigs<IModel>(model);
+        expect(results).toEqual(expected);
+      });
+
+      it('sets a site model accurately: align = center, where = "", color = null', () => {
+        model = cloneObject(getSiteModel(getCardSettings("center", "", null)));
+        const expected: IModel = cloneObject(
+          getSiteModel(getExpectedCardSettings("center", [], undefined))
+        );
+        setProp("item.properties.schemaVersion", 1.7, expected);
+        const results = _migrateSummaryStatCardConfigs<IModel>(model);
+        expect(results).toEqual(expected);
+      });
+
+      it('sets a site model accurately: align = right, where = "", color = null', () => {
+        model = cloneObject(getSiteModel(getCardSettings("right", "", null)));
+        const expected: IModel = cloneObject(
+          getSiteModel(getExpectedCardSettings("end", [], undefined))
+        );
+        setProp("item.properties.schemaVersion", 1.7, expected);
+        const results = _migrateSummaryStatCardConfigs<IModel>(model);
+        expect(results).toEqual(expected);
+      });
+
+      it('sets a site model accurately: align = left, where = "", color = "#a4a4a4"', () => {
+        model = cloneObject(
+          getSiteModel(getCardSettings("left", "", "#a4a4a4"))
+        );
+        const expected: IModel = cloneObject(
+          getSiteModel(getExpectedCardSettings("start", [], "#a4a4a4"))
+        );
+        setProp("item.properties.schemaVersion", 1.7, expected);
+        const results = _migrateSummaryStatCardConfigs<IModel>(model);
+        expect(results).toEqual(expected);
+      });
+    });
+  });
+
+  describe("Site draft", function () {
+    // TODO: once site draft is implemented (two PRs needed), write these
+  });
+
+  describe("WhereToExpressionSet", function () {
+    let model: IModel;
+
+    it("handles a case of a string, dates, and numbers", () => {
+      const where =
+        "String = 'a' AND Date >= TIMESTAMP '2023-01-01 00:00:00' AND Date <= TIMESTAMP '2023-01-03 23:59:59' AND SmInteger >= 1 AND SmInteger <= 1";
+      const expressionSet = [
+        {
+          field: { name: "String", type: "esriFieldTypeString" },
+          values: ["a"],
+        },
+        {
+          field: { name: "Date", type: "esriFieldTypeDate" },
+          values: ["2023-01-01"],
+        },
+        {
+          field: { name: "Date", type: "esriFieldTypeDate" },
+          values: [undefined, "2023-01-03"],
+        },
+        {
+          field: { name: "SmInteger", type: undefined },
+          values: ["1"],
+        },
+        {
+          field: { name: "SmInteger", type: undefined },
+          values: [undefined, "1"],
+        },
+      ];
+      model = cloneObject(getSiteModel(getCardSettings("left", where, null)));
+
+      const expected: IModel = cloneObject(
+        getSiteModel(getExpectedCardSettings("start", expressionSet, undefined))
+      );
+      setProp("item.properties.schemaVersion", 1.7, expected);
+      const results = _migrateSummaryStatCardConfigs<IModel>(model);
+      expect(results).toEqual(expected);
+    });
+
+    it("handles a case of string, dates, and numbers case 2", () => {
+      const where =
+        " Float <= 4.55 AND Field Name = 'This is a string' AND Date >= TIMESTAMP '2023-07-17 00:00:00' AND Float >= 3.99 AND Date <= TIMESTAMP '2023-07-17 23:59:59'";
+      const expressionSet = [
+        {
+          field: { name: "Float", type: undefined },
+          values: [undefined, "4.55"],
+        },
+        {
+          field: { name: "Field Name", type: "esriFieldTypeString" },
+          values: ["This is a string"],
+        },
+        {
+          field: { name: "Date", type: "esriFieldTypeDate" },
+          values: ["2023-07-17"],
+        },
+        {
+          field: { name: "Float", type: undefined },
+          values: ["3.99"],
+        },
+        {
+          field: { name: "Date", type: "esriFieldTypeDate" },
+          values: [undefined, "2023-07-17"],
+        },
+      ];
+      model = cloneObject(getSiteModel(getCardSettings("left", where, null)));
+
+      const expected: IModel = cloneObject(
+        getSiteModel(getExpectedCardSettings("start", expressionSet, undefined))
+      );
+      setProp("item.properties.schemaVersion", 1.7, expected);
+      const results = _migrateSummaryStatCardConfigs<IModel>(model);
+      expect(results).toEqual(expected);
+    });
+
+    it("handles a case of one clause", () => {
+      const where = "Float <= 4.55";
+      const expressionSet = [
+        {
+          field: { name: "Float", type: undefined },
+          values: [undefined, "4.55"],
+        },
+      ];
+      model = cloneObject(getSiteModel(getCardSettings("left", where, null)));
+
+      const expected: IModel = cloneObject(
+        getSiteModel(getExpectedCardSettings("start", expressionSet, undefined))
+      );
+      setProp("item.properties.schemaVersion", 1.7, expected);
+      const results = _migrateSummaryStatCardConfigs<IModel>(model);
+      expect(results).toEqual(expected);
+    });
+
+    it("handles an empty where clause", () => {
+      const expressionSet = [];
+      model = cloneObject(
+        getSiteModel(getCardSettings("left", undefined, null))
+      );
+
+      const expected: IModel = cloneObject(
+        getSiteModel(getExpectedCardSettings("start", expressionSet, undefined))
+      );
+      setProp("item.properties.schemaVersion", 1.7, expected);
+      const results = _migrateSummaryStatCardConfigs<IModel>(model);
+      expect(results).toEqual(expected);
+    });
+  });
+});

--- a/packages/common/test/sites/upgrade-site-schema.test.ts
+++ b/packages/common/test/sites/upgrade-site-schema.test.ts
@@ -6,6 +6,7 @@ import * as _purgeNonGuidsFromCatalogModule from "../../src/sites/_internal/_pur
 import * as _ensureTelemetryModule from "../../src/sites/_internal/_ensure-telemetry";
 import * as _migrateFeedConfigModule from "../../src/sites/_internal/_migrate-feed-config";
 import * as _migrateEventListCardConfigs from "../../src/sites/_internal/_migrate-event-list-card-configs";
+import * as _migrateSummaryStatCardConfigs from "../../src/sites/_internal/_migrate-summary-stat-card-configs";
 import { IModel } from "../../src";
 import { SITE_SCHEMA_VERSION } from "../../src/sites/site-schema-version";
 import { expectAllCalled, expectAll } from "./test-helpers.test";
@@ -18,6 +19,7 @@ describe("upgradeSiteSchema", () => {
   let ensureTelemetrySpy: jasmine.Spy;
   let migrateFeedConfigSpy: jasmine.Spy;
   let migrateEventListCardConfigsSpy: jasmine.Spy;
+  let _migrateSummaryStatCardConfigsSpy: jasmine.Spy;
   beforeEach(() => {
     applySpy = spyOn(_applySiteSchemaModule, "_applySiteSchema").and.callFake(
       (model: IModel) => model
@@ -45,6 +47,10 @@ describe("upgradeSiteSchema", () => {
     migrateEventListCardConfigsSpy = spyOn(
       _migrateEventListCardConfigs,
       "_migrateEventListCardConfigs"
+    ).and.callFake((model: IModel) => model);
+    _migrateSummaryStatCardConfigsSpy = spyOn(
+      _migrateSummaryStatCardConfigs,
+      "_migrateSummaryStatCardConfigs"
     ).and.callFake((model: IModel) => model);
   });
 

--- a/packages/sites/src/drafts/upgrade-draft-schema.ts
+++ b/packages/sites/src/drafts/upgrade-draft-schema.ts
@@ -28,6 +28,7 @@ export function upgradeDraftSchema(draft: IDraft) {
     migrated = _ensureTelemetry<IDraft>(draft);
     migrated = _migrateFeedConfig<IDraft>(draft);
     migrated = _migrateEventListCardConfigs<IDraft>(draft);
+    // TODO: add summary stat migration here once in hub-common
     return migrated;
   }
 }

--- a/packages/sites/src/drafts/upgrade-draft-schema.ts
+++ b/packages/sites/src/drafts/upgrade-draft-schema.ts
@@ -4,6 +4,7 @@ import {
   _ensureTelemetry,
   _migrateFeedConfig,
   _migrateEventListCardConfigs,
+  _migrateSummaryStatCardConfigs,
 } from "@esri/hub-common";
 
 const schemaVersionPath = "item.properties.schemaVersion";
@@ -28,7 +29,7 @@ export function upgradeDraftSchema(draft: IDraft) {
     migrated = _ensureTelemetry<IDraft>(draft);
     migrated = _migrateFeedConfig<IDraft>(draft);
     migrated = _migrateEventListCardConfigs<IDraft>(draft);
-    // TODO: add summary stat migration here once in hub-common
+    migrated = _migrateSummaryStatCardConfigs<IDraft>(draft);
     return migrated;
   }
 }

--- a/packages/sites/test/drafts/upgrade-draft-schema.test.ts
+++ b/packages/sites/test/drafts/upgrade-draft-schema.test.ts
@@ -9,6 +9,7 @@ describe("upgradeDraftSchema", () => {
   let ensureTelemetrySpy: jasmine.Spy;
   let migrateFeedConfigSpy: jasmine.Spy;
   let migrateEventListCardConfigsSpy: jasmine.Spy;
+  let migrateSummaryStatCardConfigsSpy: jasmine.Spy;
   beforeEach(() => {
     ensureTelemetrySpy = spyOn(commonModule, "_ensureTelemetry").and.callFake(
       (model: IModel) => model
@@ -20,6 +21,10 @@ describe("upgradeDraftSchema", () => {
     migrateEventListCardConfigsSpy = spyOn(
       commonModule,
       "_migrateEventListCardConfigs"
+    ).and.callFake((model: IModel) => model);
+    migrateSummaryStatCardConfigsSpy = spyOn(
+      commonModule,
+      "_migrateSummaryStatCardConfigs"
     ).and.callFake((model: IModel) => model);
   });
 
@@ -39,6 +44,7 @@ describe("upgradeDraftSchema", () => {
         ensureTelemetrySpy,
         migrateFeedConfigSpy,
         migrateEventListCardConfigsSpy,
+        migrateSummaryStatCardConfigsSpy,
       ],
       expect
     );
@@ -58,6 +64,7 @@ describe("upgradeDraftSchema", () => {
         ensureTelemetrySpy,
         migrateFeedConfigSpy,
         migrateEventListCardConfigsSpy,
+        migrateSummaryStatCardConfigsSpy,
       ],
       expect
     );
@@ -79,6 +86,7 @@ describe("upgradeDraftSchema", () => {
         ensureTelemetrySpy,
         migrateFeedConfigSpy,
         migrateEventListCardConfigsSpy,
+        migrateSummaryStatCardConfigsSpy,
       ],
       expect
     );
@@ -100,6 +108,7 @@ describe("upgradeDraftSchema", () => {
         ensureTelemetrySpy,
         migrateFeedConfigSpy,
         migrateEventListCardConfigsSpy,
+        migrateSummaryStatCardConfigsSpy,
       ],
       "toHaveBeenCalled",
       false,


### PR DESCRIPTION
TODO:
- This PR:
   - [x] Create migration function
   - [x] Add to site upgrade schema
   - [x] Update tests to include coverage
   - [x] Test with od-ui
- Next PR:
   - [ ] Bump hub-common peer dep in drafts 
   - [ ] Add to draft upgrade schema
   - [ ] Update tests to include coverage
   - [ ] Test with od-ui

1. Description:
Introduces a migration for the site model/draft schema for the summary stat card updates.
1. Instructions for testing:

1. Closes Issues: #7158 (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
