### PR TITLE
fix: add support for group members "joined" field

### DIFF
--- a/packages/common/src/search/_internal/portalSearchGroupMembers.ts
+++ b/packages/common/src/search/_internal/portalSearchGroupMembers.ts
@@ -66,8 +66,8 @@ export async function portalSearchGroupMembers(
 
   // Expand the individual predicates in each filter
   query.filters = query.filters.map((filter) => {
-    // only `name` and `memberType` are supported
-    const validPredicateKeys = ["name", "memberType"];
+    // only `name`, `memberType` and `joined` are supported
+    const validPredicateKeys = ["name", "memberType", "joined"];
     filter.predicates = filter.predicates
       .map((p) => {
         // convert `term` to `name`

--- a/packages/common/src/search/serializeQueryForPortal.ts
+++ b/packages/common/src/search/serializeQueryForPortal.ts
@@ -103,6 +103,7 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
     "categoriesAsParam",
     "categoryFilter",
     "bbox",
+    "joined",
   ];
   const specialProps = [
     "filterType",
@@ -173,7 +174,14 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
           so.q = `${key}:${value}`;
         }
         if (passThroughProps.includes(key)) {
-          so[key] = value;
+          // Because the API takes a specific format for `joined` (dates)
+          // for group members, we have to add a separate `joined` field
+          // with the specific format for the value
+          if (key === "joined") {
+            so[key] = `${value.from},${value.to}`;
+          } else {
+            so[key] = value;
+          }
         }
         if (key === "term") {
           so.q = value;

--- a/packages/common/src/search/serializeQueryForPortal.ts
+++ b/packages/common/src/search/serializeQueryForPortal.ts
@@ -174,9 +174,9 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
           so.q = `${key}:${value}`;
         }
         if (passThroughProps.includes(key)) {
-          // Because the API takes a specific format for `joined` (dates)
-          // for group members, we have to add a separate `joined` field
-          // with the specific format for the value
+          // Because the groups/:id/userlist API takes a specific format for
+          // `joined` (dates), therefore for group members, we have to
+          // add a separate `joined` field with the specific format for the value
           if (key === "joined") {
             so[key] = `${value.from},${value.to}`;
           } else {

--- a/packages/common/test/search/serializeQueryForPortal.test.ts
+++ b/packages/common/test/search/serializeQueryForPortal.test.ts
@@ -326,6 +326,10 @@ describe("ifilter-utils:", () => {
       const p: IPredicate = {
         searchUserAccess: "groupMember",
         searchUserName: "dave",
+        joined: {
+          from: 1691478000000,
+          to: 1692255599999,
+        },
       };
 
       const query: IQuery = {
@@ -342,6 +346,7 @@ describe("ifilter-utils:", () => {
 
       expect(chk.searchUserAccess).toEqual("groupMember");
       expect(chk.searchUserName).toEqual("dave");
+      expect(chk.joined).toEqual("1691478000000,1692255599999");
     });
   });
 });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Add support for group members "joined" field so we can sort/search by the joined dates

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
