### PR TITLE
feat(): include discussion routes

### DIFF
--- a/packages/common/src/content/_internal/internalContentUtils.ts
+++ b/packages/common/src/content/_internal/internalContentUtils.ts
@@ -152,6 +152,7 @@ export const getHubRelativeUrl = (
       "map",
       "template",
       "project",
+      "discussion",
     ];
     // default to the catchall content route
     let path = "/content";

--- a/packages/common/src/content/get-family.ts
+++ b/packages/common/src/content/get-family.ts
@@ -43,6 +43,9 @@ export function getFamily(type: string) {
     case "hub project":
       family = "project";
       break;
+    case "discussion":
+      family = "discussion";
+      break;
     case "hub initiative":
       family = "initiative";
       break;
@@ -109,6 +112,9 @@ export function getFamilyTypes(family: HubFamily): string[] {
       break;
     case "project":
       types = ["Hub Project"];
+      break;
+    case "discussion":
+      types = ["Discussion"];
       break;
     case "initiative":
       types = ["Hub Initiative"];

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -176,7 +176,8 @@ export type HubFamily =
   | "team"
   | "template"
   | "project"
-  | "channel";
+  | "channel"
+  | "discussion";
 
 /**
  * Visibility levels of a Hub resource

--- a/packages/common/test/content/content.test.ts
+++ b/packages/common/test/content/content.test.ts
@@ -439,6 +439,9 @@ describe("get item family", () => {
   it("returns project for hub project", () => {
     expect(getFamily("Hub Project")).toBe("project");
   });
+  it("returns project for discussion board", () => {
+    expect(getFamily("Discussion")).toBe("discussion");
+  });
   it("returns content for other specific types", () => {
     expect(getFamily("CAD Drawing")).toBe("content");
     expect(getFamily("Feature Collection Template")).toBe("content");
@@ -859,6 +862,10 @@ describe("internal", () => {
     it("should handle feedback", () => {
       const result = getHubRelativeUrl("Form", identifier);
       expect(result).toBe(`/feedback/surveys/${identifier}`);
+    });
+    it("should handle discussion", () => {
+      const result = getHubRelativeUrl("Discussion", identifier);
+      expect(result).toBe(`/discussions/${identifier}`);
     });
   });
   describe("isSiteType", () => {

--- a/packages/common/test/content/get-family.test.ts
+++ b/packages/common/test/content/get-family.test.ts
@@ -61,6 +61,13 @@ describe("getFamily", () => {
       expect(types.includes("Hub Project")).toBeTruthy();
     });
 
+    it("can get 'discussion' types", () => {
+      const types = getFamilyTypes("discussion");
+      expect(Array.isArray(types)).toBeTruthy();
+      expect(types.length).toBe(1);
+      expect(types.includes("Discussion")).toBeTruthy();
+    });
+
     it("can get 'initiative' types", () => {
       const types = getFamilyTypes("initiative");
       expect(Array.isArray(types)).toBeTruthy();


### PR DESCRIPTION
1. Description: Updates to allow Discussion Boards `type: Discussion` to use `/discussions/:id` route.

1. Closes Issues: 7623

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
