### PR TITLE
fix: log checkPermission output if access not granted

### DIFF
--- a/packages/common/src/permissions/checkPermission.ts
+++ b/packages/common/src/permissions/checkPermission.ts
@@ -35,95 +35,95 @@ export function checkPermission(
   context: IArcGISContext,
   entity?: Record<string, any>
 ): IPermissionAccessResponse {
-  // Early Exit: Is this even a valid permission?
-  if (!isPermission(permission)) {
-    return {
-      policy: permission,
-      access: false,
-      response: "invalid-permission",
-      code: getPolicyResponseCode("invalid-permission"),
-      checks: [],
-    } as IPermissionAccessResponse;
-  }
-
-  // Get the system policy for this permission
-  const systemPolicy = getPermissionPolicy(permission);
-
-  // TODO: handle null systemPolicy
-
   // Default to granted
-  const response: IPermissionAccessResponse = {
+  let response: IPermissionAccessResponse = {
     policy: permission,
     access: true,
     response: "granted",
     code: getPolicyResponseCode("granted"),
     checks: [],
   };
+  // Is this even a valid permission?
+  if (!isPermission(permission)) {
+    response = {
+      policy: permission,
+      access: false,
+      response: "invalid-permission",
+      code: getPolicyResponseCode("invalid-permission"),
+      checks: [],
+    } as IPermissionAccessResponse;
+  } else {
+    // Get the system policy for this permission
+    const systemPolicy = getPermissionPolicy(permission);
 
-  const checks = [
-    checkParents,
-    checkServiceStatus,
-    checkEntityFeature,
-    checkAuthentication,
-    checkEnvironment,
-    checkAvailability,
-    checkLicense,
-    checkPrivileges,
-    checkOwner,
-    checkEdit,
-    checkAssertions,
-    checkAlphaGating, // TODO: Remove with Capability Refactor
-  ].reduce((acc: IPolicyCheck[], fn) => {
-    acc = [...acc, ...fn(systemPolicy, context, entity)];
-    return acc;
-  }, []);
+    // TODO: handle null systemPolicy
 
-  // For system policies, all conditions must be met, so we can
-  // iterate through the checks and set the response to the first failure
-  // while still returning all the checks for observability
-  checks.forEach((check) => {
-    if (check.response !== "granted" && response.response === "granted") {
-      response.response = check.response;
-      response.code = check.code;
-      response.access = false;
-    }
-  });
+    const checks = [
+      checkParents,
+      checkServiceStatus,
+      checkEntityFeature,
+      checkAuthentication,
+      checkEnvironment,
+      checkAvailability,
+      checkLicense,
+      checkPrivileges,
+      checkOwner,
+      checkEdit,
+      checkAssertions,
+      checkAlphaGating, // TODO: Remove with Capability Refactor
+    ].reduce((acc: IPolicyCheck[], fn) => {
+      acc = [...acc, ...fn(systemPolicy, context, entity)];
+      return acc;
+    }, []);
 
-  response.checks = checks;
-
-  // Entity policies are treated as "grants" so we only need to pass one
-  if (entity) {
-    const entityPolicies: IEntityPermissionPolicy[] = getWithDefault(
-      entity,
-      "permissions",
-      []
-    );
-
-    const entityPermissionPolicies = entityPolicies.filter(
-      (e) => e.permission === permission
-    );
-    // Entity Policies are "grants" in that only one needs to pass
-    // but we still want each check returned so we can see why they
-    // got access or got denied
-    const entityChecks = entityPermissionPolicies.map((policy) => {
-      return checkEntityPolicy(policy, context);
+    // For system policies, all conditions must be met, so we can
+    // iterate through the checks and set the response to the first failure
+    // while still returning all the checks for observability
+    checks.forEach((check) => {
+      if (check.response !== "granted" && response.response === "granted") {
+        response.response = check.response;
+        response.code = check.code;
+        response.access = false;
+      }
     });
-    // Process them to see if any grant access
-    const grantedCheck = entityChecks.find((e) => e.response === "granted");
-    // If we did not find a check that grants access, AND we've passed
-    // all the system checks, then we set the response to "not-granted"
-    // and set the access to false
-    if (
-      entityChecks.length &&
-      !grantedCheck &&
-      response.response === "granted"
-    ) {
-      response.access = false;
-      response.response = "not-granted";
+
+    response.checks = checks;
+
+    // Entity policies are treated as "grants" so we only need to pass one
+    if (entity) {
+      const entityPolicies: IEntityPermissionPolicy[] = getWithDefault(
+        entity,
+        "permissions",
+        []
+      );
+
+      const entityPermissionPolicies = entityPolicies.filter(
+        (e) => e.permission === permission
+      );
+      // Entity Policies are "grants" in that only one needs to pass
+      // but we still want each check returned so we can see why they
+      // got access or got denied
+      const entityChecks = entityPermissionPolicies.map((policy) => {
+        return checkEntityPolicy(policy, context);
+      });
+      // Process them to see if any grant access
+      const grantedCheck = entityChecks.find((e) => e.response === "granted");
+      // If we did not find a check that grants access, AND we've passed
+      // all the system checks, then we set the response to "not-granted"
+      // and set the access to false
+      if (
+        entityChecks.length &&
+        !grantedCheck &&
+        response.response === "granted"
+      ) {
+        response.access = false;
+        response.response = "not-granted";
+      }
+      // Merge in the entity checks...
+      response.checks = [...response.checks, ...entityChecks];
     }
-    // Merge in the entity checks...
-    response.checks = [...response.checks, ...entityChecks];
   }
+
   // log denied access information
   if (!response.access) {
     // tslint:disable-next-line:no-console

--- a/packages/common/src/permissions/checkPermission.ts
+++ b/packages/common/src/permissions/checkPermission.ts
@@ -124,6 +124,14 @@ export function checkPermission(
     // Merge in the entity checks...
     response.checks = [...response.checks, ...entityChecks];
   }
-  // return the response
+  // log denied access information
+  if (!response.access) {
+    // tslint:disable-next-line:no-console
+    console.info(`checkPermission: ${permission} : ${response.response}`);
+    // tslint:disable-next-line:no-console
+    console.dir(response);
+    // tslint:disable-next-line:no-console
+    console.info(`-----------------------------------------`);
+  }
   return response;
 }

--- a/packages/common/test/permissions/checkPermission.test.ts
+++ b/packages/common/test/permissions/checkPermission.test.ts
@@ -6,7 +6,11 @@ import { MOCK_AUTH } from "../mocks/mock-auth";
 describe("checkPermission:", () => {
   let authdCtxMgr: ArcGISContextManager;
   let unauthdCtxMgr: ArcGISContextManager;
+  let consoleInfoSpy: jasmine.Spy;
+  let consoleDirSpy: jasmine.Spy;
   beforeEach(async () => {
+    consoleInfoSpy = spyOn(console, "info").and.callThrough();
+    consoleDirSpy = spyOn(console, "dir").and.callThrough();
     unauthdCtxMgr = await ArcGISContextManager.create();
     // When we pass in all this information, the context
     // manager will not try to fetch anything, so no need
@@ -38,6 +42,8 @@ describe("checkPermission:", () => {
     expect(chk.access).toBe(false);
     expect(chk.response).toBe("invalid-permission");
     expect(chk.checks.length).toBe(0);
+    expect(consoleDirSpy).toHaveBeenCalled();
+    expect(consoleInfoSpy).toHaveBeenCalled();
   });
   it("runs system level permission checks that all pass", () => {
     const chk = checkPermission("hub:site:create", authdCtxMgr.context);


### PR DESCRIPTION
1. Description:

Outcome of Permission call w/ PEs was a request to log the output of failed calls to `checkPermission(...)`

1. Instructions for testing: - run tests

1. Closes Issues: n/a

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
