### PR TITLE
fix: small updates to group details schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22644,9 +22644,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22661,21 +22662,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22689,9 +22693,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22709,9 +22714,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64966,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.38.0",
+			"version": "13.39.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -83376,7 +83382,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83391,17 +83398,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83415,7 +83425,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83432,7 +83443,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/groups/_internal/GroupSchema.ts
+++ b/packages/common/src/groups/_internal/GroupSchema.ts
@@ -2,6 +2,7 @@ import { IConfigurationSchema } from "../../core";
 import {
   ENTITY_IMAGE_SCHEMA,
   ENTITY_NAME_SCHEMA,
+  ENTITY_SUMMARY_SCHEMA,
 } from "../../core/schemas/shared";
 
 export type GroupEditorType = (typeof GroupEditorTypes)[number];
@@ -16,7 +17,10 @@ export const GroupSchema: IConfigurationSchema = {
   properties: {
     name: ENTITY_NAME_SCHEMA,
     summary: {
-      type: "string",
+      ...ENTITY_SUMMARY_SCHEMA,
+      // group snippets (mapped to summary on the entity) have
+      // a max char limit of 250
+      maxLength: 250,
     },
     _thumbnail: ENTITY_IMAGE_SCHEMA,
   },

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -48,6 +48,9 @@ export const uiSchema: IUiSchema = {
             helperText: {
               labelKey: "{{i18nScope}}.fields._thumbnail.helperText",
             },
+            sizeDescription: {
+              labelKey: "{{i18nScope}}.fields._thumbnail.sizeDescription",
+            },
           },
         },
       ],

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -34,9 +34,6 @@ export const uiSchema: IUiSchema = {
           options: {
             control: "hub-field-input-input",
             type: "textarea",
-            helperText: {
-              labelKey: "{{i18nScope}}.fields.summary.helperText",
-            },
           },
         },
         {
@@ -47,7 +44,7 @@ export const uiSchema: IUiSchema = {
             control: "hub-field-input-image-picker",
             maxWidth: 727,
             maxHeight: 484,
-            aspectRatio: 1.5,
+            aspectRatio: 1,
             helperText: {
               labelKey: "{{i18nScope}}.fields._thumbnail.helperText",
             },


### PR DESCRIPTION
[7275](https://devtopia.esri.com/dc/hub/issues/7275)

### Description
updates the group details (edit) `schema`/`uiSchema` with a couple minor changes
- changes aspect ratio of thumbnail to 1
- removes helper text from the summary field
- adds a size description to the thumbnail
- constrains the summary field to 250 chars

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.