### PR TITLE
feat: add workspace pane permissions for all entities

### DIFF
--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -56,6 +56,10 @@ export const ContentPermissions = [
   // "hub:content:delete",
   "hub:content:edit",
   "hub:content:view",
+  "hub:content:workspace:overview",
+  "hub:content:workspace:dashboard",
+  "hub:content:workspace:details",
+  "hub:content:workspace:settings",
 ] as const;
 
 /**
@@ -89,4 +93,21 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
   //   entityOwner: true,
   //   licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
   // },
+  {
+    permission: "hub:content:workspace:overview",
+    dependencies: ["hub:content:view"],
+  },
+  {
+    permission: "hub:content:workspace:dashboard",
+    dependencies: ["hub:content:view"],
+  },
+  {
+    permission: "hub:content:workspace:details",
+    dependencies: ["hub:content:edit"],
+  },
+  {
+    permission: "hub:content:workspace:settings",
+    dependencies: ["hub:content:edit"],
+    entityOwner: true,
+  },
 ];

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -56,6 +56,13 @@ export const GroupPermissions = [
   "hub:group:edit",
   "hub:group:view",
   "hub:group:owner",
+  "hub:group:workspace:overview",
+  "hub:group:workspace:dashboard",
+  "hub:group:workspace:details",
+  "hub:group:workspace:settings",
+  "hub:group:workspace:collaborators",
+  "hub:group:workspace:content",
+  "hub:group:workspace:members",
 ] as const;
 
 /**
@@ -94,5 +101,22 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:group"],
     authenticated: true,
     entityOwner: true,
+  },
+  {
+    permission: "hub:group:workspace:details",
+    dependencies: ["hub:group:edit"],
+  },
+  {
+    permission: "hub:group:workspace:settings",
+    dependencies: ["hub:group:edit"],
+    entityOwner: true,
+  },
+  {
+    permission: "hub:group:workspace:content",
+    dependencies: ["hub:group:edit"],
+  },
+  {
+    permission: "hub:group:workspace:members",
+    dependencies: ["hub:group:edit"],
   },
 ];

--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -74,6 +74,13 @@ export const InitiativePermissions = [
   "hub:initiative:events",
   "hub:initiative:content",
   "hub:initiative:discussions",
+  "hub:initiative:workspace:overview",
+  "hub:initiative:workspace:dashboard",
+  "hub:initiative:workspace:details",
+  "hub:initiative:workspace:settings",
+  "hub:initiative:workspace:collaborators",
+  "hub:initiative:workspace:content",
+  "hub:initiative:workspace:metrics",
 ] as const;
 
 /**
@@ -122,5 +129,34 @@ export const InitiativePermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:initiative:discussions",
     dependencies: ["hub:initiative:view"],
+  },
+  {
+    permission: "hub:initiative:workspace:overview",
+    dependencies: ["hub:initiative:view"],
+  },
+  {
+    permission: "hub:initiative:workspace:dashboard",
+    dependencies: ["hub:initiative:view"],
+  },
+  {
+    permission: "hub:initiative:workspace:details",
+    dependencies: ["hub:initiative:edit"],
+  },
+  {
+    permission: "hub:initiative:workspace:settings",
+    dependencies: ["hub:initiative:edit"],
+    entityOwner: true,
+  },
+  {
+    permission: "hub:initiative:workspace:collaborators",
+    dependencies: ["hub:initiative:edit"],
+  },
+  {
+    permission: "hub:initiative:workspace:content",
+    dependencies: ["hub:initiative:edit"],
+  },
+  {
+    permission: "hub:initiative:workspace:metrics",
+    dependencies: ["hub:initiative:edit"],
   },
 ];

--- a/packages/common/src/pages/_internal/PageBusinessRules.ts
+++ b/packages/common/src/pages/_internal/PageBusinessRules.ts
@@ -63,6 +63,10 @@ export const PagePermissions = [
   "hub:page:delete",
   "hub:page:edit",
   "hub:page:view",
+  "hub:page:workspace:overview",
+  "hub:page:workspace:dashboard",
+  "hub:page:workspace:details",
+  "hub:page:workspace:settings",
 ] as const;
 
 /**
@@ -94,6 +98,23 @@ export const PagePermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:page:delete",
     dependencies: ["hub:page"],
     authenticated: true,
+    entityOwner: true,
+  },
+  {
+    permission: "hub:page:workspace:overview",
+    dependencies: ["hub:page:view"],
+  },
+  {
+    permission: "hub:page:workspace:dashboard",
+    dependencies: ["hub:page:view"],
+  },
+  {
+    permission: "hub:page:workspace:details",
+    dependencies: ["hub:page:edit"],
+  },
+  {
+    permission: "hub:page:workspace:settings",
+    dependencies: ["hub:page:edit"],
     entityOwner: true,
   },
 ];

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -134,4 +134,34 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:project:discussions",
     dependencies: ["hub:project:view"],
   },
+  {
+    permission: "hub:project:workspace:overview",
+    dependencies: ["hub:project:view"],
+  },
+  {
+    permission: "hub:project:workspace:dashboard",
+    dependencies: ["hub:project:view"],
+    environments: ["devext", "qaext"],
+  },
+  {
+    permission: "hub:project:workspace:details",
+    dependencies: ["hub:project:edit"],
+  },
+  {
+    permission: "hub:project:workspace:settings",
+    dependencies: ["hub:project:edit"],
+    entityOwner: true,
+  },
+  {
+    permission: "hub:project:workspace:collaborators",
+    dependencies: ["hub:project:edit"],
+  },
+  {
+    permission: "hub:project:workspace:content",
+    dependencies: ["hub:project:edit"],
+  },
+  {
+    permission: "hub:project:workspace:metrics",
+    dependencies: ["hub:project:edit"],
+  },
 ];

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -74,6 +74,13 @@ export const SitePermissions = [
   "hub:site:events",
   "hub:site:content",
   "hub:site:discussions",
+  "hub:site:workspace:overview",
+  "hub:site:workspace:dashboard",
+  "hub:site:workspace:details",
+  "hub:site:workspace:settings",
+  "hub:site:workspace:collaborators",
+  "hub:site:workspace:content",
+  "hub:site:workspace:metrics",
 ] as const;
 
 /**
@@ -120,6 +127,36 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:site:discussions",
     dependencies: ["hub:site:view"],
+  },
+  {
+    permission: "hub:site:workspace:overview",
+    dependencies: ["hub:site:view"],
+  },
+  {
+    permission: "hub:site:workspace:dashboard",
+    dependencies: ["hub:site:view"],
+  },
+  {
+    permission: "hub:site:workspace:details",
+    dependencies: ["hub:site:edit"],
+  },
+  {
+    permission: "hub:site:workspace:settings",
+    dependencies: ["hub:site:edit"],
+    entityOwner: true,
+  },
+  {
+    permission: "hub:site:workspace:collaborators",
+    dependencies: ["hub:site:edit"],
+  },
+  {
+    permission: "hub:site:workspace:content",
+    dependencies: ["hub:site:edit"],
+  },
+  {
+    permission: "hub:site:workspace:metrics",
+    dependencies: ["hub:site:edit"],
+    environments: ["devext", "qaext"],
   },
 ];
 


### PR DESCRIPTION
1. Description: 
Adding permissions like hub:<entity>:workspace:<pane> into hub.js. These will "delegate" (via dependencies) to the same permission checks used today (hub:<entity>:edit etc) but allow us the option to apply per-pane gating (qa vs dev, alpha, beta etc)

1. Instructions for testing: run tests

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/7624

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
