### PR TITLE
fix: await save in classes

### DIFF
--- a/packages/common/src/content/HubContent.ts
+++ b/packages/common/src/content/HubContent.ts
@@ -157,7 +157,7 @@ export class HubContent
     } else {
       // ...otherwise, update the in-memory entity and save it
       this.entity = entity;
-      this.save();
+      await this.save();
     }
 
     return this.entity;

--- a/packages/common/src/groups/HubGroup.ts
+++ b/packages/common/src/groups/HubGroup.ts
@@ -335,7 +335,7 @@ export class HubGroup
     } else {
       // ...otherwise, update the in-memory entity and save it
       this.entity = entity;
-      this.save();
+      await this.save();
     }
 
     return this.entity;

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -322,7 +322,7 @@ export class HubInitiative
     } else {
       // ...otherwise, update the in-memory entity and save it
       this.entity = entity;
-      this.save();
+      await this.save();
     }
 
     return this.entity;

--- a/packages/common/src/pages/HubPage.ts
+++ b/packages/common/src/pages/HubPage.ts
@@ -260,7 +260,7 @@ export class HubPage
     } else {
       // ...otherwise, update the in-memory entity and save it
       this.entity = entity;
-      this.save();
+      await this.save();
     }
 
     return this.entity;

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -250,7 +250,7 @@ export class HubProject
     } else {
       // ...otherwise, update the in-memory entity and save it
       this.entity = entity;
-      this.save();
+      await this.save();
     }
 
     // handle featured image

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -449,7 +449,7 @@ export class HubSite
     } else {
       // ...otherwise, update the in-memory entity and save it
       this.entity = entity;
-      this.save();
+      await this.save();
     }
 
     return this.entity;


### PR DESCRIPTION
1. Description:

@sonofflynn89 pointed out that my refactor a few weeks back missed the need for an `await` on the `this.save()` call in the `fromEditor(..)` method.

This PR simply adds that, and in doing so, resolves an issue in the workspaces where edit state was not synced between the panes.

1. Instructions for testing:

- run tests

1. Closes Issues: n/a

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
