### PR TITLE
fix: add missing permissions

### DIFF
--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -56,6 +56,13 @@ export const DiscussionPermissions = [
   "hub:discussion:delete",
   "hub:discussion:edit",
   "hub:discussion:view",
+  "hub:discussion:workspace:overview",
+  "hub:discussion:workspace:dashboard",
+  "hub:discussion:workspace:details",
+  "hub:discussion:workspace:settings",
+  "hub:discussion:workspace:collaborators",
+  "hub:discussion:workspace:discussion",
+  "hub:discussion:workspace:metrics",
 ] as const;
 
 /**
@@ -93,5 +100,35 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:discussion"],
     entityOwner: true,
     licenses: ["hub-premium"],
+  },
+  {
+    permission: "hub:discussion:workspace:overview",
+    dependencies: ["hub:discussion:view"],
+  },
+  {
+    permission: "hub:discussion:workspace:dashboard",
+    dependencies: ["hub:discussion:view"],
+    environments: ["devext", "qaext"],
+  },
+  {
+    permission: "hub:discussion:workspace:details",
+    dependencies: ["hub:discussion:edit"],
+  },
+  {
+    permission: "hub:discussion:workspace:settings",
+    dependencies: ["hub:discussion:edit"],
+    entityOwner: true,
+  },
+  {
+    permission: "hub:discussion:workspace:collaborators",
+    dependencies: ["hub:discussion:edit"],
+  },
+  {
+    permission: "hub:discussion:workspace:discussion",
+    dependencies: ["hub:discussion:edit"],
+  },
+  {
+    permission: "hub:discussion:workspace:metrics",
+    dependencies: ["hub:discussion:edit"],
   },
 ];

--- a/packages/common/src/pages/_internal/PageBusinessRules.ts
+++ b/packages/common/src/pages/_internal/PageBusinessRules.ts
@@ -67,6 +67,7 @@ export const PagePermissions = [
   "hub:page:workspace:dashboard",
   "hub:page:workspace:details",
   "hub:page:workspace:settings",
+  "hub:page:workspace:collaborators",
 ] as const;
 
 /**
@@ -110,6 +111,10 @@ export const PagePermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:page:workspace:details",
+    dependencies: ["hub:page:edit"],
+  },
+  {
+    permission: "hub:page:workspace:collaborators",
     dependencies: ["hub:page:edit"],
   },
   {

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -81,6 +81,13 @@ export const ProjectPermissions = [
   "hub:project:events",
   "hub:project:content",
   "hub:project:discussions",
+  "hub:project:workspace:overview",
+  "hub:project:workspace:dashboard",
+  "hub:project:workspace:details",
+  "hub:project:workspace:settings",
+  "hub:project:workspace:collaborators",
+  "hub:project:workspace:content",
+  "hub:project:workspace:metrics",
 ] as const;
 
 /**


### PR DESCRIPTION
1. Description:

Previous PR missed a few permissions, which came up as I verified the changes to the WorkspaceLinks in hub-components.

1. Instructions for testing:

1. Closes Issues: n/a

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
