### PR TITLE
fix: add new SortOption type

### DIFF
--- a/packages/common/src/search/types/types.ts
+++ b/packages/common/src/search/types/types.ts
@@ -15,6 +15,17 @@ export interface ISortOption {
 }
 
 /**
+ * Sort options supported
+ */
+export type SortOption =
+  | "relavance"
+  | "title"
+  | "created"
+  | "modified"
+  | "username"
+  | "joined";
+
+/**
  * Defines a span of time by specifying a `from` and `to` Date
  * as either a number or a ISO string
  */


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Add new `SortOption` type

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
