### PR TITLE
fix: ensure getNextFunction handles requestOptions.authentication

### DIFF
--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -189,11 +189,11 @@ export function getNextFunction<T>(
     clonedRequest.authentication = UserSession.deserialize(
       (request.authentication as UserSession).serialize()
     );
-    // ensure that if we have requestOptions, we have also update the authentication on it
-    if (request.requestOptions) {
-      clonedRequest.requestOptions.authentication =
-        clonedRequest.authentication;
-    }
+  }
+  // ensure that if we have requestOptions, we have also update the authentication on it
+  if (request.requestOptions?.authentication) {
+    clonedRequest.requestOptions.authentication =
+      request.requestOptions.authentication;
   }
 
   // figure out the start

--- a/packages/common/test/search/utils.test.ts
+++ b/packages/common/test/search/utils.test.ts
@@ -212,10 +212,37 @@ describe("Search Utils:", () => {
       expect(opts.authentication).toEqual(MOCK_AUTH);
       expect(opts.requestOptions).not.toBeDefined();
     });
+    it("uses ro.auth on subsequent calls", async () => {
+      const request = {
+        requestOptions: { authentication: MOCK_AUTH },
+      } as unknown as ISearchOptions;
+
+      const Module = {
+        fn: <T>(r: any) => {
+          return Promise.resolve({} as unknown as ISearchResponse<T>);
+        },
+      };
+      const fnSpy = spyOn(Module, "fn").and.callThrough();
+
+      const chk = await getNextFunction<IHubSearchResult>(
+        request,
+        10,
+        20,
+        fnSpy
+      );
+      await chk();
+      expect(fnSpy).toHaveBeenCalled();
+      // verify it's called with the MOCK_AUTH
+      const opts = fnSpy.calls.mostRecent().args[0];
+      expect(opts.requestOptions.authentication).toEqual(MOCK_AUTH);
+      expect(opts.authentication).not.toBeDefined();
+    });
     it("updates requestOptions.authentication on subsequent calls", async () => {
       const request = {
         authentication: MOCK_AUTH,
-        requestOptions: {},
+        requestOptions: {
+          authentication: MOCK_AUTH,
+        },
       } as unknown as ISearchOptions;
 
       const Module = {
@@ -241,7 +268,9 @@ describe("Search Utils:", () => {
     it("can change auth on subsequent calls", async () => {
       const request = {
         authentication: MOCK_AUTH,
-        requestOptions: {},
+        requestOptions: {
+          authentication: MOCK_AUTH,
+        },
       } as unknown as ISearchOptions;
 
       const Module = {


### PR DESCRIPTION
1. Description:

`getNextFunction` needed to be tweaked to work correctly for `searchGroupMembers`

1. Instructions for testing: 
- run tests

1. Closes Issues: n/a - came up when helping @vivzhang debug an issue

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
