### PR TITLE
feat(hub-common): enriches channel with groups via hub search includes

### DIFF
--- a/packages/common/src/search/_internal/hubSearchChannels.ts
+++ b/packages/common/src/search/_internal/hubSearchChannels.ts
@@ -13,6 +13,7 @@ import {
   ISearchChannels,
   ISearchChannelsParams,
 } from "../../discussions";
+import { getGroup } from "@esri/arcgis-rest-portal";
 
 /**
  * @private
@@ -111,14 +112,16 @@ export const processSearchParams = (
  * @param {IHubSearchOptions} options
  * @returns IHubSearchResponse<IHubSearchResult>
  */
-export const toHubSearchResult = (
+export const toHubSearchResult = async (
   channelsResponse: IPagedResponse<IChannel>,
   query: IQuery,
   options: IHubSearchOptions
-): IHubSearchResponse<IHubSearchResult> => {
+): Promise<IHubSearchResponse<IHubSearchResult>> => {
   const { total, items, nextStart } = channelsResponse;
   // Convert IChannel to IHubSearchResult
-  const channelToSearchResult = (channel: IChannel): IHubSearchResult => {
+  const channelToSearchResult = async (
+    channel: IChannel
+  ): Promise<IHubSearchResult> => {
     return {
       ...channel,
       id: channel.id,
@@ -137,11 +140,31 @@ export const toHubSearchResult = (
         self: null,
         siteRelative: null,
       },
+      includes: {
+        // when 'include' requests 'groups' enrichment, get group details
+        groups: options?.include?.includes("groups")
+          ? await Promise.all(
+              channel.groups.map(async (groupId) => {
+                let group;
+                try {
+                  group = await getGroup(groupId, options.requestOptions);
+                } catch (e) {
+                  /* tslint:disable-next-line: no-console */
+                  console.warn(
+                    `Cannot fetch group enhancement for id = ${groupId}`,
+                    e
+                  );
+                }
+                return group;
+              })
+            )
+          : [],
+      },
     };
   };
   return {
     total,
-    results: items.map(channelToSearchResult),
+    results: await Promise.all(items.map(channelToSearchResult)),
     hasNext: nextStart > -1,
     next: () => {
       return hubSearchChannels(query, {

--- a/packages/common/src/search/_internal/hubSearchChannels.ts
+++ b/packages/common/src/search/_internal/hubSearchChannels.ts
@@ -149,6 +149,7 @@ export const toHubSearchResult = async (
                 try {
                   group = await getGroup(groupId, options.requestOptions);
                 } catch (e) {
+                  group = null;
                   /* tslint:disable-next-line: no-console */
                   console.warn(
                     `Cannot fetch group enhancement for id = ${groupId}`,

--- a/packages/common/src/search/_internal/hubSearchChannels.ts
+++ b/packages/common/src/search/_internal/hubSearchChannels.ts
@@ -142,7 +142,7 @@ export const toHubSearchResult = async (
       },
       includes: {
         // when 'include' requests 'groups' enrichment, get group details
-        groups: options?.include?.includes("groups")
+        groups: options.include?.includes("groups")
           ? await Promise.all(
               channel.groups.map(async (groupId) => {
                 let group;

--- a/packages/common/test/search/_internal/hubSearchChannels.test.ts
+++ b/packages/common/test/search/_internal/hubSearchChannels.test.ts
@@ -30,6 +30,7 @@ describe("discussionsSearchItems Module |", () => {
     getGroupSpy = spyOn(arcgisRestPortal, "getGroup").and.callFake(() => {
       return Promise.resolve();
     });
+    spyOn(console, "warn");
   });
 
   it("calls searchChannels", async () => {
@@ -187,7 +188,7 @@ describe("discussionsSearchItems Module |", () => {
         token: "my-secret-token",
       } as IHubRequestOptions,
     };
-    const result = await hubSearchChannels.hubSearchChannels(qry, opts);
+    await hubSearchChannels.hubSearchChannels(qry, opts);
     expect(getGroupSpy).not.toHaveBeenCalled();
   });
   it("includes group enrichment when include groups requested", async () => {
@@ -216,7 +217,39 @@ describe("discussionsSearchItems Module |", () => {
       } as IHubRequestOptions,
       include: ["groups"],
     };
+    await hubSearchChannels.hubSearchChannels(qry, opts);
+    expect(getGroupSpy).toHaveBeenCalled();
+  });
+  it("handes error when group is inacessible", async () => {
+    getGroupSpy.and.throwError("groups is inaccessible");
+    const qry: IQuery = {
+      targetEntity: "channel",
+      filters: [
+        {
+          predicates: [
+            {
+              access: "private",
+              groups: ["cb0ddfc90f4f45b899c076c88d3fdc84"],
+              foo: "bar",
+            },
+          ],
+        },
+      ],
+    };
+    const opts: IHubSearchOptions = {
+      num: 10,
+      sortField: "createdAt",
+      sortOrder: "desc",
+      requestOptions: {
+        isPortal: false,
+        hubApiUrl: "https://hubqa.arcgis.com/api",
+        token: "my-secret-token",
+      } as IHubRequestOptions,
+      include: ["groups"],
+    };
     const result = await hubSearchChannels.hubSearchChannels(qry, opts);
     expect(getGroupSpy).toHaveBeenCalled();
+    /* tslint:disable-next-line: no-console */
+    expect(console.warn).toHaveBeenCalled();
   });
 });

--- a/packages/common/test/search/_internal/hubSearchChannels.test.ts
+++ b/packages/common/test/search/_internal/hubSearchChannels.test.ts
@@ -28,7 +28,7 @@ describe("discussionsSearchItems Module |", () => {
       return Promise.resolve(SEARCH_CHANNELS_RESPONSE);
     });
     getGroupSpy = spyOn(arcgisRestPortal, "getGroup").and.callFake(() => {
-      return Promise.resolve();
+      return Promise.resolve({ title: "My Group Title" });
     });
     spyOn(console, "warn");
   });
@@ -163,7 +163,7 @@ describe("discussionsSearchItems Module |", () => {
       name: ["Foo"],
     } as any as ISearchChannels);
   });
-  it("exclodes group enrichment when include groups not requested", async () => {
+  it("excludes group enrichment when include groups not requested", async () => {
     const qry: IQuery = {
       targetEntity: "channel",
       filters: [
@@ -188,8 +188,9 @@ describe("discussionsSearchItems Module |", () => {
         token: "my-secret-token",
       } as IHubRequestOptions,
     };
-    await hubSearchChannels.hubSearchChannels(qry, opts);
+    const result = await hubSearchChannels.hubSearchChannels(qry, opts);
     expect(getGroupSpy).not.toHaveBeenCalled();
+    expect(result.results[0].includes).toEqual({ groups: [] });
   });
   it("includes group enrichment when include groups requested", async () => {
     const qry: IQuery = {
@@ -217,10 +218,13 @@ describe("discussionsSearchItems Module |", () => {
       } as IHubRequestOptions,
       include: ["groups"],
     };
-    await hubSearchChannels.hubSearchChannels(qry, opts);
+    const result = await hubSearchChannels.hubSearchChannels(qry, opts);
     expect(getGroupSpy).toHaveBeenCalled();
+    expect(result.results[0].includes).toEqual({
+      groups: [{ title: "My Group Title" }],
+    });
   });
-  it("handes error when group is inacessible", async () => {
+  it("handles error when group is inaccessible", async () => {
     getGroupSpy.and.throwError("groups is inaccessible");
     const qry: IQuery = {
       targetEntity: "channel",
@@ -251,5 +255,6 @@ describe("discussionsSearchItems Module |", () => {
     expect(getGroupSpy).toHaveBeenCalled();
     /* tslint:disable-next-line: no-console */
     expect(console.warn).toHaveBeenCalled();
+    expect(result.results[0].includes).toEqual({ groups: [null] });
   });
 });


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: #7405

1. Description: Enriches channel result from hubSearch with group information when `include: ['groups']` is requested from `options: IHubSearchOptions`.

1. Instructions for testing: `hubSearchChannels.test.ts`

1. Closes Issues: #7405

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
