### PR TITLE
feat: add group settings schema

### DIFF
--- a/packages/common/src/core/schemas/getEntityEditorSchemas.ts
+++ b/packages/common/src/core/schemas/getEntityEditorSchemas.ts
@@ -116,6 +116,8 @@ export const getEntityEditorSchemas = async (
       ({ uiSchema } = await {
         "hub:group:edit": () =>
           import("../../groups/_internal/GroupUiSchemaEdit"),
+        "hub:group:settings": () =>
+          import("../../groups/_internal/GroupUiSchemaSettings"),
       }[type as GroupEditorType]());
       break;
   }

--- a/packages/common/src/core/schemas/internal/getEntityEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getEntityEditorSchemas.ts
@@ -120,6 +120,8 @@ export async function getEntityEditorSchemas(
       ({ uiSchema } = await {
         "hub:group:edit": () =>
           import("../../../groups/_internal/GroupUiSchemaEdit"),
+        "hub:group:settings": () =>
+          import("../../../groups/_internal/GroupUiSchemaSettings"),
       }[type as GroupEditorType]());
       break;
   }

--- a/packages/common/src/core/schemas/shared/subschemas.ts
+++ b/packages/common/src/core/schemas/shared/subschemas.ts
@@ -100,3 +100,21 @@ export const ENTITY_TIMELINE_SCHEMA = {
     },
   },
 };
+
+export const ENTITY_CONTRIBUTE_SCHEMA = {
+  type: "boolean",
+  enum: [false, true],
+  default: false,
+};
+
+export const ENTITY_VIEW_ACCESS_SCHEMA = {
+  type: "string",
+  enum: ["private", "org", "public"],
+  default: "private",
+};
+
+export const ENTITY_MEMBERSHIP_ACCESS_SCHEMA = {
+  type: "string",
+  enum: ["organization", "collaborators", "anyone"],
+  default: "anyone",
+};

--- a/packages/common/src/groups/_internal/GroupSchema.ts
+++ b/packages/common/src/groups/_internal/GroupSchema.ts
@@ -3,10 +3,16 @@ import {
   ENTITY_IMAGE_SCHEMA,
   ENTITY_NAME_SCHEMA,
   ENTITY_SUMMARY_SCHEMA,
+  ENTITY_CONTRIBUTE_SCHEMA,
+  ENTITY_VIEW_ACCESS_SCHEMA,
+  ENTITY_MEMBERSHIP_ACCESS_SCHEMA,
 } from "../../core/schemas/shared";
 
 export type GroupEditorType = (typeof GroupEditorTypes)[number];
-export const GroupEditorTypes = ["hub:group:edit"] as const;
+export const GroupEditorTypes = [
+  "hub:group:edit",
+  "hub:group:settings",
+] as const;
 
 /**
  * Defines the JSON schema for a Hub Group's editable fields
@@ -23,5 +29,8 @@ export const GroupSchema: IConfigurationSchema = {
       maxLength: 250,
     },
     _thumbnail: ENTITY_IMAGE_SCHEMA,
+    access: ENTITY_VIEW_ACCESS_SCHEMA,
+    membershipAccess: ENTITY_MEMBERSHIP_ACCESS_SCHEMA,
+    isViewOnly: ENTITY_CONTRIBUTE_SCHEMA,
   },
 } as IConfigurationSchema;

--- a/packages/common/src/groups/_internal/GroupUiSchemaSettings.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaSettings.ts
@@ -1,0 +1,56 @@
+import { IUiSchema } from "../../core";
+
+/**
+ * Complete settings uiSchema for Hub Groups - this defines
+ * how the schema properties should be rendered in the
+ * group settings experience
+ */
+export const uiSchema: IUiSchema = {
+  type: "Layout",
+  elements: [
+    {
+      type: "Section",
+      labelKey: "{{i18nScope}}.sections.membershipAccess.label",
+      elements: [
+        {
+          labelKey: "{{i18nScope}}.fields.viewAccess.label",
+          scope: "/properties/access",
+          type: "Control",
+          options: {
+            control: "hub-field-input-radio",
+            labels: [
+              "{{i18nScope}}.fields.viewAccess.private.label",
+              "{{i18nScope}}.fields.viewAccess.org.label",
+              "{{i18nScope}}.fields.viewAccess.public.label",
+            ],
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.membershipAccess.label",
+          scope: "/properties/membershipAccess",
+          type: "Control",
+          options: {
+            control: "hub-field-input-radio",
+            labels: [
+              "{{i18nScope}}.fields.membershipAccess.org.label",
+              "{{i18nScope}}.fields.membershipAccess.collab.label",
+              "{{i18nScope}}.fields.membershipAccess.any.label",
+            ],
+          },
+        },
+        {
+          labelKey: "{{i18nScope}}.fields.contributeContent.label",
+          scope: "/properties/viewAccess",
+          type: "Control",
+          options: {
+            control: "hub-field-input-radio",
+            labels: [
+              "{{i18nScope}}.fields.contributeContent.all.label",
+              "{{i18nScope}}.fields.contributeContent.admins.label",
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/packages/common/test/groups/HubGroup.test.ts
+++ b/packages/common/test/groups/HubGroup.test.ts
@@ -330,6 +330,30 @@ describe("HubGroup class:", () => {
       );
     });
 
+    // it("getEditorConfig delegates to helper for settings", async () => {
+    //   const spy = spyOn(EditConfigModule, "getEditorConfig").and.callFake(
+    //     () => {
+    //       return Promise.resolve({ fake: "config" });
+    //     }
+    //   );
+    //   const chk = HubGroup.fromJson(
+    //     {
+    //       id: "bc3",
+    //       name: "Test Entity",
+    //     },
+    //     authdCtxMgr.context
+    //   );
+    //   const result = await chk.getEditorConfig("i18n.Scope", "hub:group:settings");
+    //   expect(result).toEqual({ fake: "config" } as any);
+    //   expect(spy).toHaveBeenCalledTimes(1);
+    //   expect(spy).toHaveBeenCalledWith(
+    //     "i18n.Scope",
+    //     "hub:group:edit",
+    //     chk.toJson(),
+    //     authdCtxMgr.context
+    //   );
+    // });
+
     it("toEditor converst entity to correct structure", () => {
       const chk = HubGroup.fromJson(
         {

--- a/packages/common/test/groups/HubGroup.test.ts
+++ b/packages/common/test/groups/HubGroup.test.ts
@@ -330,30 +330,6 @@ describe("HubGroup class:", () => {
       );
     });
 
-    // it("getEditorConfig delegates to helper for settings", async () => {
-    //   const spy = spyOn(EditConfigModule, "getEditorConfig").and.callFake(
-    //     () => {
-    //       return Promise.resolve({ fake: "config" });
-    //     }
-    //   );
-    //   const chk = HubGroup.fromJson(
-    //     {
-    //       id: "bc3",
-    //       name: "Test Entity",
-    //     },
-    //     authdCtxMgr.context
-    //   );
-    //   const result = await chk.getEditorConfig("i18n.Scope", "hub:group:settings");
-    //   expect(result).toEqual({ fake: "config" } as any);
-    //   expect(spy).toHaveBeenCalledTimes(1);
-    //   expect(spy).toHaveBeenCalledWith(
-    //     "i18n.Scope",
-    //     "hub:group:edit",
-    //     chk.toJson(),
-    //     authdCtxMgr.context
-    //   );
-    // });
-
     it("toEditor converst entity to correct structure", () => {
       const chk = HubGroup.fromJson(
         {


### PR DESCRIPTION
1. Description: Adds a groups settings uischema for the settings pane.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
