### PR TITLE
fix: properly translate radio button labels

### DIFF
--- a/packages/common/src/groups/_internal/GroupUiSchemaSettings.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaSettings.ts
@@ -19,9 +19,9 @@ export const uiSchema: IUiSchema = {
           options: {
             control: "hub-field-input-radio",
             labels: [
-              "{{i18nScope}}.fields.membershipAccess.org.label",
-              "{{i18nScope}}.fields.membershipAccess.collab.label",
-              "{{i18nScope}}.fields.membershipAccess.any.label",
+              "{{{{i18nScope}}.fields.membershipAccess.org:translate}}",
+              "{{{{i18nScope}}.fields.membershipAccess.collab:translate}}",
+              "{{{{i18nScope}}.fields.membershipAccess.any:translate}}",
             ],
           },
         },
@@ -32,8 +32,8 @@ export const uiSchema: IUiSchema = {
           options: {
             control: "hub-field-input-radio",
             labels: [
-              "{{i18nScope}}.fields.contributeContent.all.label",
-              "{{i18nScope}}.fields.contributeContent.admins.label",
+              "{{{{i18nScope}}.fields.contributeContent.all:translate}}",
+              "{{{{i18nScope}}.fields.contributeContent.admins:translate}}",
             ],
           },
         },


### PR DESCRIPTION
1. Description: Previously the labels weren't be translated, they were missing `:translate` and needed angle brackets. Previously the paths were being dropped into the ui.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
