### PR TITLE
fix: ungate group settings pane from being only owner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64972,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.39.1",
+			"version": "13.46.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -65096,7 +65096,7 @@
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "13.0.1",
+			"version": "13.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -109,7 +109,6 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:group:workspace:settings",
     dependencies: ["hub:group:edit"],
-    entityOwner: true,
   },
   {
     permission: "hub:group:workspace:content",


### PR DESCRIPTION
1. Description: We were gating the groups settings panel to canEdit, which is correct, but then also adding a check for if they were owners which was incorrect.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
