### PR TITLE
feat(hub-common): add icon for Discussion content type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64966,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.46.1",
+			"version": "14.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -64991,32 +64991,32 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "25.8.0",
+			"version": "26.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "^13.0.0"
+				"@esri/hub-common": "^14.0.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "13.0.0",
+			"version": "14.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65024,18 +65024,18 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "^12.4.0 || 13"
+				"@esri/hub-common": "^14.0.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "13.0.0",
+			"version": "14.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65044,18 +65044,18 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0 || 13"
+				"@esri/hub-common": "^14.0.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "13.0.0",
+			"version": "14.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -65063,18 +65063,18 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^13"
+				"@esri/hub-common": "^14.0.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "13.0.0",
+			"version": "14.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -65085,40 +65085,40 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0 || 13"
+				"@esri/hub-common": "^14.0.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "13.1.0",
+			"version": "14.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
-				"@esri/hub-initiatives": "^13.0.0",
-				"@esri/hub-teams": "^13.0.0",
+				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-initiatives": "^14.0.0",
+				"@esri/hub-teams": "^14.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^13",
-				"@esri/hub-initiatives": "^13.0.0",
-				"@esri/hub-teams": "^13.0.0"
+				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-initiatives": "^14.0.0",
+				"@esri/hub-teams": "^14.0.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "13.0.0",
+			"version": "14.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65127,18 +65127,18 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0 || 13"
+				"@esri/hub-common": "^14.0.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "13.0.0",
+			"version": "14.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65146,7 +65146,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^12.4.0 || 13"
+				"@esri/hub-common": "^14.0.0"
 			}
 		}
 	},
@@ -68710,7 +68710,7 @@
 		"@esri/hub-discussions": {
 			"version": "file:packages/discussions",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68719,7 +68719,7 @@
 		"@esri/hub-downloads": {
 			"version": "file:packages/downloads",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68728,7 +68728,7 @@
 		"@esri/hub-events": {
 			"version": "file:packages/events",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68736,7 +68736,7 @@
 		"@esri/hub-initiatives": {
 			"version": "file:packages/initiatives",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68745,7 +68745,7 @@
 		"@esri/hub-search": {
 			"version": "file:packages/search",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -68755,9 +68755,9 @@
 		"@esri/hub-sites": {
 			"version": "file:packages/sites",
 			"requires": {
-				"@esri/hub-common": "*",
-				"@esri/hub-initiatives": "^13.0.0",
-				"@esri/hub-teams": "^13.0.0",
+				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-initiatives": "^14.0.0",
+				"@esri/hub-teams": "^14.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68765,7 +68765,7 @@
 		"@esri/hub-surveys": {
 			"version": "file:packages/surveys",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68773,7 +68773,7 @@
 		"@esri/hub-teams": {
 			"version": "file:packages/teams",
 			"requires": {
-				"@esri/hub-common": "*",
+				"@esri/hub-common": "^14.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -243,6 +243,7 @@ export const getContentTypeIcon = (contentType: string) => {
     cSVCollection: "file-csv",
     dashboard: "dashboard",
     desktopApplication: "desktop",
+    discussion: "speech-bubbles",
     documentLink: "link",
     excaliburImageryProject: "file",
     explorerMap: "file",


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 7640

1. Description: Adds icon for discussion content type on hub cards.

1. Instructions for testing:

1. Closes Issues: 7640

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
