### PR TITLE
feat(): ungate dashboard from projects workspace

### DIFF
--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -91,7 +91,6 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:project:workspace:dashboard",
     dependencies: ["hub:project:view"],
-    environments: ["devext", "qaext"],
   },
   {
     permission: "hub:project:workspace:details",


### PR DESCRIPTION
1. Description:
Ungates the dashboard pane from the Projects workspace. 

1. Instructions for testing:

1. Closes Issues: works to close [7658](https://zentopia.esri.com/workspaces/collaboration-sprint-board-614f9bfc0946c40011ef574e/issues/dc/hub/7658)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
