### PR TITLE
docs: keep all uiSchemas @private to avoid issues generating docs

### DIFF
--- a/docs/build-typedoc.js
+++ b/docs/build-typedoc.js
@@ -158,17 +158,40 @@ const md = new MarkdownIt();
       });
     })
     .then(declarations => {
-      const excludeList = ['encodeAgoQuery', 'downloadableAgg', 'downloadableFilter', 'collectionAgg',
-      'collectionFilter', 'createAggs', 'format', 'hasApiAgg', 'buildFilter', 'createFilters',
-      'encodeFilters', 'groupIds', 'handleFilter', 'hasApiFilter', 'computeItemsFacets',
-      'formatItem', 'calcHighlights', 'getSortField', 'isFilterable', 'generateFilter',
-      'agoFormatItemCollection', 'encodeParams', 'getPaths', 'getItems'];
+      const excludeList = [
+        "encodeAgoQuery",
+        "downloadableAgg",
+        "downloadableFilter",
+        "collectionAgg",
+        "collectionFilter",
+        "createAggs",
+        "format",
+        "hasApiAgg",
+        "buildFilter",
+        "createFilters",
+        "encodeFilters",
+        "groupIds",
+        "handleFilter",
+        "hasApiFilter",
+        "computeItemsFacets",
+        "formatItem",
+        "calcHighlights",
+        "getSortField",
+        "isFilterable",
+        "generateFilter",
+        "agoFormatItemCollection",
+        "encodeParams",
+        "getPaths",
+        "getItems",
+      ];
       /**
        * Next we remove any declarations we want to excludeList from the API ref
+       * and anything with u/UiSchema in the name (these files cause issues with Acetate)
        */
-      return declarations.filter(
-        declaration => !excludeList.includes(declaration.name)
-      );
+      return declarations
+        .filter((declaration) => !excludeList.includes(declaration.name))
+        .filter((d) => !d.name.includes("uiSchema"))
+        .filter((d) => !d.name.includes("UiSchema"));
     })
     .then(declarations => {
       /**

--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -597,6 +597,6 @@
 {% if isDev %}
   <details class="leader-1">
     <summary>Debug Info</summary>
-    <pre><code>{{signatures[0].comment.tags | inspect}}</code></pre>
+    <pre><code>{{sources[0] | inspect}}</code></pre>
   </details>
 {% endif %}

--- a/docs/src/api/index.html
+++ b/docs/src/api/index.html
@@ -11,6 +11,6 @@ layout: "api/_layout:content"
   {% set declarations = package.declarations %}
   {% set url = package.pageUrl %}
   {% include "api/_package.html" %}
-
+  <small>v{{pkg.version}}</small>
 {% endfor %}
 </div>

--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -1,5 +1,8 @@
 import { IUiSchema } from "../../core";
 
+/**
+ * @private
+ */
 export const uiSchema: IUiSchema = {
   type: "Layout",
   elements: [

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaCreate.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaCreate.ts
@@ -1,6 +1,7 @@
 import { IUiSchema, UiSchemaRuleEffects } from "../../core";
 
 /**
+ * @private
  * create uiSchema for Hub Discussions - this
  * defines how the schema properties should be
  * rendered in the Discussions creation experience

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -1,6 +1,7 @@
 import { IUiSchema } from "../../core";
 
 /**
+ * @private
  * complete edit uiSchema for Hub discussions - this defines
  * how the schema properties should be rendered in the
  * discussion editing experience

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -1,6 +1,7 @@
 import { IUiSchema } from "../../core";
 
 /**
+ * @private
  * Complete edit uiSchema for Hub Groups - this defines
  * how the schema properties should be rendered in the
  * group editing experience

--- a/packages/common/src/groups/_internal/GroupUiSchemaSettings.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaSettings.ts
@@ -1,6 +1,7 @@
 import { IUiSchema } from "../../core";
 
 /**
+ * @private
  * Complete settings uiSchema for Hub Groups - this defines
  * how the schema properties should be rendered in the
  * group settings experience

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
@@ -1,6 +1,7 @@
 import { IUiSchema, UiSchemaRuleEffects } from "../../core";
 
 /**
+ * @private
  * minimal create uiSchema for Hub Projects - this defines
  * how the schema properties should be rendered in the
  * project creation experience

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -1,6 +1,7 @@
 import { IUiSchema } from "../../core";
 
 /**
+ * @private
  * complete edit UI Schema for Hub Initiatives
  */
 export const uiSchema: IUiSchema = {

--- a/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
+++ b/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
@@ -1,6 +1,7 @@
 import { IUiSchema } from "../../core";
 
 /**
+ * @private
  * complete edit uiSchema for Hub Projects - this defines
  * how the schema properties should be rendered in the
  * project editing experience

--- a/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
@@ -1,6 +1,7 @@
 import { IUiSchema, UiSchemaRuleEffects } from "../../core";
 
 /**
+ * @private
  * minimal create uiSchema for Hub Projects - this defines
  * how the schema properties should be rendered in the
  * project creation experience

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -1,6 +1,7 @@
 import { IUiSchema } from "../../core";
 
 /**
+ * @private
  * complete edit uiSchema for Hub Projects - this defines
  * how the schema properties should be rendered in the
  * project editing experience

--- a/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
@@ -1,6 +1,7 @@
 import { IUiSchema, UiSchemaRuleEffects } from "../../core";
 
 /**
+ * @private
  * minimal create uiSchema for Hub Projects - this defines
  * how the schema properties should be rendered in the
  * project creation experience

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -1,6 +1,7 @@
 import { IUiSchema } from "../../core";
 
 /**
+ * @private
  * complete edit uiSchema for Hub Projects - this defines
  * how the schema properties should be rendered in the
  * project editing experience


### PR DESCRIPTION
1. Description:

Acetate was silently failing due to some `{{{{...}}}}` stuff in the Ui Schema files.

This PR marks all those as `@private`, AND filters out `uiSchema` & `UiSchema` files from the tsdoc.json before getting into acetate.

Also adds the package version to the TOC as a means to help know when the doc is stale

![image](https://github.com/Esri/hub.js/assets/119129/2288d753-f3b1-4619-922f-985696aa37d0)


1. Instructions for testing:

build docs?

1. Closes Issues: n/a

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
