### PR TITLE
feat: add member role badges to user card model

### DIFF
--- a/packages/common/src/core/types/IHubCardViewModel.ts
+++ b/packages/common/src/core/types/IHubCardViewModel.ts
@@ -23,8 +23,18 @@ export interface IHubCardViewModel {
 export interface IBadgeConfig {
   i18nKey?: string;
   label?: string;
+  /**
+   * whether the label or translated i18nKey
+   * should actually render or just be used
+   * for a11y purposes
+   */
+  showLabel?: boolean;
   icon?: string;
   color: string;
+  tooltip?: {
+    i18nKey?: string;
+    label?: string;
+  };
 }
 
 // structure defining the additional info for a hub card
@@ -40,6 +50,11 @@ export interface ICardActionLink {
   href?: string;
   i18nKey?: string;
   label?: string;
+  /**
+   * whether the label or translated i18nKey
+   * should actually render or just be used
+   * for a11y purposes
+   */
   showLabel?: boolean;
   icon?: string;
   buttonStyle?: "outline" | "outline-fill" | "solid" | "transparent";

--- a/packages/common/src/core/types/IHubCardViewModel.ts
+++ b/packages/common/src/core/types/IHubCardViewModel.ts
@@ -26,9 +26,10 @@ export interface IBadgeConfig {
   /**
    * whether the label or translated i18nKey
    * should actually render or just be used
-   * for a11y purposes
+   * for a11y purposes. By default, the label
+   * IS rendered
    */
-  showLabel?: boolean;
+  hideLabel?: boolean;
   icon?: string;
   color: string;
   tooltip?: {

--- a/packages/common/src/search/_internal/portalSearchGroupMembers.ts
+++ b/packages/common/src/search/_internal/portalSearchGroupMembers.ts
@@ -133,7 +133,7 @@ async function searchGroupMembers(
   // over the includes and requestOptions
   const fn = (member: IGroupMember) => {
     return memberToSearchResult(
-      { ...member, isOwner: resp.owner?.username === member.username },
+      { ...member, isOwner: resp.owner.username === member.username },
       searchOptions.include,
       searchOptions.requestOptions
     );

--- a/packages/common/src/search/_internal/portalSearchGroupMembers.ts
+++ b/packages/common/src/search/_internal/portalSearchGroupMembers.ts
@@ -133,7 +133,7 @@ async function searchGroupMembers(
   // over the includes and requestOptions
   const fn = (member: IGroupMember) => {
     return memberToSearchResult(
-      member,
+      { ...member, isOwner: resp.owner?.username === member.username },
       searchOptions.include,
       searchOptions.requestOptions
     );
@@ -179,7 +179,7 @@ interface IGroupMember {
  * @returns
  */
 async function memberToSearchResult(
-  member: IGroupMember,
+  member: IGroupMember & { isOwner: boolean },
   include: string[] = [],
   requestOptions?: IHubRequestOptions
 ): Promise<IHubSearchResult> {
@@ -199,6 +199,7 @@ async function memberToSearchResult(
     thumbnail: null,
     created: null,
     modified: null,
+    isOwner: member.isOwner,
   };
 
   const fsGetUser = failSafe(getUser, user);

--- a/packages/common/src/search/_internal/portalSearchGroupMembers.ts
+++ b/packages/common/src/search/_internal/portalSearchGroupMembers.ts
@@ -133,7 +133,7 @@ async function searchGroupMembers(
   // over the includes and requestOptions
   const fn = (member: IGroupMember) => {
     return memberToSearchResult(
-      { ...member, isOwner: resp.owner.username === member.username },
+      { ...member, isGroupOwner: resp.owner.username === member.username },
       searchOptions.include,
       searchOptions.requestOptions
     );
@@ -179,7 +179,7 @@ interface IGroupMember {
  * @returns
  */
 async function memberToSearchResult(
-  member: IGroupMember & { isOwner: boolean },
+  member: IGroupMember & { isGroupOwner: boolean },
   include: string[] = [],
   requestOptions?: IHubRequestOptions
 ): Promise<IHubSearchResult> {
@@ -199,7 +199,7 @@ async function memberToSearchResult(
     thumbnail: null,
     created: null,
     modified: null,
-    isOwner: member.isOwner,
+    isGroupOwner: member.isGroupOwner,
   };
 
   const fsGetUser = failSafe(getUser, user);

--- a/packages/common/src/users/HubUsers.ts
+++ b/packages/common/src/users/HubUsers.ts
@@ -26,6 +26,13 @@ export async function enrichUserSearchResult(
     access: user.access as AccessLevel,
     id: user.username,
     type: "User",
+    /**
+     * We need to return a valid IHubSearchResult, so we store
+     * IUser information where it makes the most sense - e.g.
+     * we store the user's full name under the "name" property,
+     * and since users don't have an owner, we fill that property
+     * with the user's username
+     */
     name: user.fullName,
     owner: user.username,
     // A private user will not have a description prop at all
@@ -42,10 +49,10 @@ export async function enrichUserSearchResult(
       thumbnail: null,
     },
   };
-  // Group Memberships need these properties
+  // Group Memberships need these additional properties
   if (user.memberType) {
     result.memberType = user.memberType;
-    result.isOwner = user.isOwner;
+    result.isGroupOwner = user.isGroupOwner;
   }
 
   // Informal Enrichments - basically adding type-specific props

--- a/packages/common/src/users/HubUsers.ts
+++ b/packages/common/src/users/HubUsers.ts
@@ -42,9 +42,10 @@ export async function enrichUserSearchResult(
       thumbnail: null,
     },
   };
-  // Group Memberships need this prop
+  // Group Memberships need these properties
   if (user.memberType) {
     result.memberType = user.memberType;
+    result.isOwner = user.isOwner;
   }
 
   // Informal Enrichments - basically adding type-specific props

--- a/packages/common/src/users/view.ts
+++ b/packages/common/src/users/view.ts
@@ -44,9 +44,42 @@ export const userResultToCardModel: ResultToCardModelFn = (
  * @param locale internationalization locale
  */
 const getSharedUserCardModel = (user: IHubSearchResult): IHubCardViewModel => {
+  const badges = [];
+  const memberType = user.memberType;
+
+  /**
+   * for group members, we want to configure
+   * member type badges to render in the user
+   * card
+   */
+  if (memberType) {
+    if (user.isOwner) {
+      badges.push({
+        icon: "user-key",
+        color: "gray",
+        showLabel: false,
+        tooltip: { i18nKey: "memberBadges.owner" },
+      });
+    } else if (memberType === "admin") {
+      badges.push({
+        icon: "user-up",
+        color: "gray",
+        showLabel: false,
+        tooltip: { i18nKey: "memberBadges.admin" },
+      });
+    } else {
+      badges.push({
+        icon: "user",
+        color: "gray",
+        showLabel: false,
+        tooltip: { i18nKey: "memberBadges.member" },
+      });
+    }
+  }
+
   return {
     access: user.access,
-    badges: [],
+    badges,
     family: user.family,
     id: user.id,
     source: user.name ? `@${user.id}` : undefined,

--- a/packages/common/src/users/view.ts
+++ b/packages/common/src/users/view.ts
@@ -1,6 +1,7 @@
 import { IHubSearchResult } from "..";
 import { ResultToCardModelFn } from "../core";
 import {
+  IBadgeConfig,
   IConvertToCardModelOpts,
   IHubCardViewModel,
 } from "../core/types/IHubCardViewModel";
@@ -44,7 +45,7 @@ export const userResultToCardModel: ResultToCardModelFn = (
  * @param locale internationalization locale
  */
 const getSharedUserCardModel = (user: IHubSearchResult): IHubCardViewModel => {
-  const badges = [];
+  const badges = [] as IBadgeConfig[];
   const memberType = user.memberType;
 
   /**
@@ -57,22 +58,25 @@ const getSharedUserCardModel = (user: IHubSearchResult): IHubCardViewModel => {
       badges.push({
         icon: "user-key",
         color: "gray",
-        showLabel: false,
-        tooltip: { i18nKey: "memberBadges.owner" },
+        i18nKey: "badges.members.owner",
+        hideLabel: true,
+        tooltip: { i18nKey: "badges.members.owner" },
       });
     } else if (memberType === "admin") {
       badges.push({
         icon: "user-up",
         color: "gray",
-        showLabel: false,
-        tooltip: { i18nKey: "memberBadges.admin" },
+        i18nKey: "badges.members.admin",
+        hideLabel: true,
+        tooltip: { i18nKey: "badges.members.admin" },
       });
     } else {
       badges.push({
         icon: "user",
         color: "gray",
-        showLabel: false,
-        tooltip: { i18nKey: "memberBadges.member" },
+        i18nKey: "badges.members.member",
+        hideLabel: true,
+        tooltip: { i18nKey: "badges.members.member" },
       });
     }
   }

--- a/packages/common/src/users/view.ts
+++ b/packages/common/src/users/view.ts
@@ -54,7 +54,7 @@ const getSharedUserCardModel = (user: IHubSearchResult): IHubCardViewModel => {
    * card
    */
   if (memberType) {
-    if (user.isOwner) {
+    if (user.isGroupOwner) {
       badges.push({
         icon: "user-key",
         color: "gray",

--- a/packages/common/test/users/view.test.ts
+++ b/packages/common/test/users/view.test.ts
@@ -61,7 +61,7 @@ describe("user view module:", () => {
     describe("membership badges", () => {
       it("adds an owner badge if the user is the group owner", () => {
         const GROUP_MEMBER_RESULT = cloneObject(USER_HUB_SEARCH_RESULT);
-        GROUP_MEMBER_RESULT.isOwner = true;
+        GROUP_MEMBER_RESULT.isGroupOwner = true;
         GROUP_MEMBER_RESULT.memberType = "admin";
 
         const result = userResultToCardModel(GROUP_MEMBER_RESULT);

--- a/packages/common/test/users/view.test.ts
+++ b/packages/common/test/users/view.test.ts
@@ -58,5 +58,53 @@ describe("user view module:", () => {
       expect(result.title).toBe(`@${USER_HUB_SEARCH_RESULT.owner}`);
       expect(result.source).toBeFalsy();
     });
+    describe("membership badges", () => {
+      it("adds an owner badge if the user is the group owner", () => {
+        const GROUP_MEMBER_RESULT = cloneObject(USER_HUB_SEARCH_RESULT);
+        GROUP_MEMBER_RESULT.isOwner = true;
+        GROUP_MEMBER_RESULT.memberType = "admin";
+
+        const result = userResultToCardModel(GROUP_MEMBER_RESULT);
+
+        expect(result.badges).toEqual([
+          {
+            icon: "user-key",
+            color: "gray",
+            showLabel: false,
+            tooltip: { i18nKey: "memberBadges.owner" },
+          },
+        ]);
+      });
+      it("adds an amin badge if the user is a group admin", () => {
+        const GROUP_MEMBER_RESULT = cloneObject(USER_HUB_SEARCH_RESULT);
+        GROUP_MEMBER_RESULT.memberType = "admin";
+
+        const result = userResultToCardModel(GROUP_MEMBER_RESULT);
+
+        expect(result.badges).toEqual([
+          {
+            icon: "user-up",
+            color: "gray",
+            showLabel: false,
+            tooltip: { i18nKey: "memberBadges.admin" },
+          },
+        ]);
+      });
+      it("adds a member badge if the user is a group member", () => {
+        const GROUP_MEMBER_RESULT = cloneObject(USER_HUB_SEARCH_RESULT);
+        GROUP_MEMBER_RESULT.memberType = "member";
+
+        const result = userResultToCardModel(GROUP_MEMBER_RESULT);
+
+        expect(result.badges).toEqual([
+          {
+            icon: "user",
+            color: "gray",
+            showLabel: false,
+            tooltip: { i18nKey: "memberBadges.member" },
+          },
+        ]);
+      });
+    });
   });
 });

--- a/packages/common/test/users/view.test.ts
+++ b/packages/common/test/users/view.test.ts
@@ -70,8 +70,9 @@ describe("user view module:", () => {
           {
             icon: "user-key",
             color: "gray",
-            showLabel: false,
-            tooltip: { i18nKey: "memberBadges.owner" },
+            i18nKey: "badges.members.owner",
+            hideLabel: true,
+            tooltip: { i18nKey: "badges.members.owner" },
           },
         ]);
       });
@@ -85,8 +86,9 @@ describe("user view module:", () => {
           {
             icon: "user-up",
             color: "gray",
-            showLabel: false,
-            tooltip: { i18nKey: "memberBadges.admin" },
+            i18nKey: "badges.members.admin",
+            hideLabel: true,
+            tooltip: { i18nKey: "badges.members.admin" },
           },
         ]);
       });
@@ -100,8 +102,9 @@ describe("user view module:", () => {
           {
             icon: "user",
             color: "gray",
-            showLabel: false,
-            tooltip: { i18nKey: "memberBadges.member" },
+            i18nKey: "badges.members.member",
+            hideLabel: true,
+            tooltip: { i18nKey: "badges.members.member" },
           },
         ]);
       });


### PR DESCRIPTION
[7654](https://devtopia.esri.com/dc/hub/issues/7654)

### Description:
- add `isGroupOwner` property to group member results
- add tooltip configuration to the `IBadgeConfig` interface
- conditionally add member type badges to the user card model

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.