### PR TITLE
fix: account for index values that are 0 in card view models

### DIFF
--- a/packages/common/src/initiatives/view.ts
+++ b/packages/common/src/initiatives/view.ts
@@ -70,7 +70,7 @@ export const initiativeResultToCardModel: ResultToCardModelFn = (
   return {
     ...getSharedInitiativeCardModel(searchResult, locale),
     actionLinks,
-    ...(searchResult.index && { index: searchResult.index }),
+    ...(!isNaN(searchResult.index) && { index: searchResult.index }),
     titleUrl,
     ...(searchResult.links.thumbnail && {
       thumbnailUrl: searchResult.links.thumbnail,

--- a/packages/common/src/projects/view.ts
+++ b/packages/common/src/projects/view.ts
@@ -66,7 +66,7 @@ export const projectResultToCardModel: ResultToCardModelFn = (
   return {
     ...getSharedProjectCardModel(searchResult, locale),
     actionLinks,
-    ...(searchResult.index && { index: searchResult.index }),
+    ...(!isNaN(searchResult.index) && { index: searchResult.index }),
     titleUrl,
     ...(searchResult.links.thumbnail && {
       thumbnailUrl: searchResult.links.thumbnail,

--- a/packages/common/src/users/view.ts
+++ b/packages/common/src/users/view.ts
@@ -29,7 +29,7 @@ export const userResultToCardModel: ResultToCardModelFn = (
   return {
     ...getSharedUserCardModel(searchResult),
     actionLinks,
-    ...(searchResult.index && { index: searchResult.index }),
+    ...(!isNaN(searchResult.index) && { index: searchResult.index }),
     titleUrl,
     ...(searchResult.links.thumbnail && {
       thumbnailUrl: searchResult.links.thumbnail,


### PR DESCRIPTION
### Description
Currently if a search result has an index of 0, it doesn't get added to the card view model because 0 is a `falsey` value. Instead of checking the truthiness of `searchResult.index`, we need to check whether `searchResult.index` is a number. If it is, we add it to the view model. 

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.