### PR TITLE
fix: shouldClearEmptyFields now accounts for licenseInfo

### DIFF
--- a/packages/common/src/models/index.ts
+++ b/packages/common/src/models/index.ts
@@ -291,7 +291,7 @@ export async function fetchModelResources(
  * @return {*} boolean
  */
 function shouldClearEmptyFields(item: IItem): boolean {
-  return ["description", "snippet", "tags", "categories"].some(
+  return ["description", "snippet", "tags", "categories", "licenseInfo"].some(
     (field) => item[field] === "" || item[field]?.length === 0
   );
 }


### PR DESCRIPTION
OD-UI PR: https://github.com/ArcGIS/opendata-ui/pull/12472

1. Description: Quick bug fix for clearing the license field where it would only clear if one of the other text fields was empty.

1. Instructions for testing: 
- Open a content item
- Set the license and add content to all fields
- Save
- Refresh
- Clear the license
- Refresh => the license should now disappear correctly, regardless of other fields

1. Closes Issues: [#https://devtopia.esri.com/dc/hub/issues/7209](https://devtopia.esri.com/dc/hub/issues/7209)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
