### PR TITLE
feat(hub-common): add unified "links" hash as an optional property for all entities

### DIFF
--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -1,11 +1,15 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
-import { IHubEditableContent, IHubLocation } from "../../core";
 import { IModel } from "../../types";
 import { bBoxToExtent, extentToPolygon, isBBox } from "../../extent";
 import { IExtent } from "@esri/arcgis-rest-types";
 import Geometry = __esri.Geometry;
+import { getItemHomeUrl } from "../../urls/get-item-home-url";
+import { getHubRelativeUrl } from "./internalContentUtils";
+import { IHubLocation } from "../../core/types/IHubLocation";
+import { IHubEditableContent } from "../../core/types/IHubEditableContent";
+import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
 
 // if called and valid, set 3 things -- else just return type custom
 export const getItemExtent = (itemExtent: number[][]): IExtent => {
@@ -40,7 +44,19 @@ export function computeProps(
     token = session.token;
   }
   // thumbnail url
-  content.thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
+  const thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
+  // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead
+  content.thumbnailUrl = thumbnailUrl;
+  content.links = {
+    self: getItemHomeUrl(content.id, requestOptions),
+    siteRelative: getHubRelativeUrl(
+      content.type,
+      content.slug || content.id,
+      content.typeKeywords
+    ),
+    workspaceRelative: getRelativeWorkspaceUrl("content", content.id),
+    thumbnail: thumbnailUrl,
+  };
   content.licenseInfo = model.item.licenseInfo;
 
   if (!content.location) {

--- a/packages/common/src/core/types/IHubEntityBase.ts
+++ b/packages/common/src/core/types/IHubEntityBase.ts
@@ -1,7 +1,23 @@
 /**
+ * Simple interface for Links
+ */
+export interface ILink {
+  /**
+   * Link url
+   */
+  href: string;
+  /**
+   * Additional optional properties
+   */
+  [key: string]: string;
+}
+
+/**
  * Base properties for Hub Entities
- * This is a subset of `IItem`, that can apply to
- * models that are not backed by items.
+ * This includes a subset of `IItem`, that can apply to
+ * models that are not backed by items. It also includes
+ * properties that can be derived for all entity types,
+ * such as `links`
  */
 export interface IHubEntityBase {
   /**
@@ -48,4 +64,37 @@ export interface IHubEntityBase {
    * result to be attributed to something other than "owner"
    */
   source?: string;
+
+  /**
+   * Links to related things
+   */
+  links?: {
+    /**
+     * Url to Thumbnail. May not include a token
+     * TODO: Why should we not include the token?
+     */
+    thumbnail?: string;
+    /**
+     * Url to the entities canonical "self"
+     * For Items/Groups/Users, this will be the Home App url
+     * For other entities, it will be the canonical url
+     */
+    self: string;
+    /**
+     * Relative url of the entity, within a site
+     */
+    siteRelative?: string;
+    /**
+     * Relative workspace url of the entity, within a site
+     */
+    workspaceRelative?: string;
+    /**
+     * Relative url to the entity's layout editing experience
+     */
+    layoutRelative?: string;
+    /**
+     * Additional urls
+     */
+    [key: string]: string | ILink;
+  };
 }

--- a/packages/common/src/core/types/IHubItemEntity.ts
+++ b/packages/common/src/core/types/IHubItemEntity.ts
@@ -60,6 +60,9 @@ export interface IHubItemEntity
   owner: string;
 
   /**
+   * TODO: change this property to store item.url. Store the
+   * canonical url in IHubEntityBase.links.self instead.
+   *
    * Canonical Url for the Entity
    */
   url?: string;
@@ -76,7 +79,8 @@ export interface IHubItemEntity
   tags: string[];
 
   /**
-   * Thumbnail Uril (read-only)
+   * TODO: Deprecate this in favor of IHubEntityBase.links.thumbnail
+   * Thumbnail Url (read-only)
    */
   thumbnailUrl?: string;
 

--- a/packages/common/src/pages/_internal/computeProps.ts
+++ b/packages/common/src/pages/_internal/computeProps.ts
@@ -1,11 +1,14 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
-import { IHubPage } from "../../core";
 import { IModel } from "../../types";
 
 import { processEntityFeatures } from "../../permissions/_internal/processEntityFeatures";
 import { PageDefaultFeatures } from "./PageBusinessRules";
+import { getItemHomeUrl } from "../../urls/get-item-home-url";
+import { IHubPage } from "../../core/types/IHubPage";
+import { getHubRelativeUrl } from "../../content/_internal/internalContentUtils";
+import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
 
 /**
  * Given a model and a page, set various computed properties that can't be directly mapped
@@ -26,7 +29,16 @@ export function computeProps(
     token = session.token;
   }
   // thumbnail url
-  page.thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
+  const thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
+  // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead
+  page.thumbnailUrl = thumbnailUrl;
+  page.links = {
+    self: getItemHomeUrl(page.id, requestOptions),
+    siteRelative: `/pages/${page.id}`,
+    workspaceRelative: getRelativeWorkspaceUrl("page", page.id),
+    layoutRelative: `/pages/${page.id}/edit`,
+    thumbnail: thumbnailUrl,
+  };
 
   // Handle Dates
   page.createdDate = new Date(model.item.created);

--- a/packages/common/src/search/types/IHubSearchResult.ts
+++ b/packages/common/src/search/types/IHubSearchResult.ts
@@ -2,20 +2,6 @@ import { AccessLevel, IHubEntityBase } from "../../core";
 import { HubFamily, IHubGeography } from "../../types";
 
 /**
- * Simple interface for Links
- */
-export interface ILink {
-  /**
-   * Link url
-   */
-  href: string;
-  /**
-   * Additional optional properties
-   */
-  [key: string]: string;
-}
-
-/**
  * Standardized light-weight search result structure, applicable to all
  * types of search results - users, groups, content, events etc
  */
@@ -49,34 +35,6 @@ export interface IHubSearchResult extends IHubEntityBase {
    * TypeKeywords; Applies to Items
    */
   typeKeywords?: string[];
-
-  /**
-   * Links to related things
-   */
-  links?: {
-    /**
-     * Url to Thumbnail. Will not include a token
-     */
-    thumbnail?: string;
-    /**
-     * Url to the entities canonical "self"
-     * For Items/Groups/Users, this will be the Home App url
-     * For other entities, it will be the canonical url
-     */
-    self: string;
-    /**
-     * Relative url of the entity, within a site
-     */
-    siteRelative: string;
-    /**
-     * Relative workspace url of the entity, within a site
-     */
-    workspaceRelative?: string;
-    /**
-     * Additional urls
-     */
-    [key: string]: string | ILink;
-  };
 
   /**
    * Geometry connected to this entity

--- a/packages/common/src/sites/_internal/computeProps.ts
+++ b/packages/common/src/sites/_internal/computeProps.ts
@@ -1,12 +1,14 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
-import { IHubSite } from "../../core";
 import { IModel } from "../../types";
 import { upgradeCatalogSchema } from "../../search/upgradeCatalogSchema";
 import { isDiscussable } from "../../discussions";
 import { processEntityFeatures } from "../../permissions/_internal/processEntityFeatures";
 import { SiteDefaultFeatures } from "./SiteBusinessRules";
+import { getItemHomeUrl } from "../../urls/get-item-home-url";
+import { IHubSite } from "../../core/types/IHubSite";
+import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
 
 /**
  * Given a model and a site, set various computed properties that can't be directly mapped
@@ -27,7 +29,16 @@ export function computeProps(
     token = session.token;
   }
   // thumbnail url
-  site.thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
+  const thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
+  // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead
+  site.thumbnailUrl = thumbnailUrl;
+  site.links = {
+    self: getItemHomeUrl(site.id, requestOptions),
+    siteRelative: "/",
+    workspaceRelative: getRelativeWorkspaceUrl("site", site.id),
+    layoutRelative: "/edit",
+    thumbnail: thumbnailUrl,
+  };
 
   // Handle Dates
   site.createdDate = new Date(model.item.created);

--- a/packages/common/test/content/fetch.test.ts
+++ b/packages/common/test/content/fetch.test.ts
@@ -662,7 +662,10 @@ describe("fetchHubContent", () => {
       "fetchContent"
     ).and.returnValue(
       Promise.resolve({
-        item: {},
+        item: {
+          type: "Feature Service",
+          id: "9001",
+        },
       })
     );
     const fakeRequestOptions = {};

--- a/packages/common/test/pages/_internal/computeProps.test.ts
+++ b/packages/common/test/pages/_internal/computeProps.test.ts
@@ -1,35 +1,18 @@
-import { IPortal, IUser } from "@esri/arcgis-rest-portal";
-import { MOCK_AUTH } from "../../mocks/mock-auth";
-import { ArcGISContextManager } from "../../../src/ArcGISContextManager";
+import { MOCK_HUB_REQOPTS } from "../../mocks/mock-auth";
 import { computeProps } from "../../../src/pages/_internal/computeProps";
-import { IHubPage, IModel } from "../../../src";
+import {
+  cloneObject,
+  IHubPage,
+  IHubRequestOptions,
+  IModel,
+} from "../../../src";
 import * as processEntitiesModule from "../../../src/permissions/_internal/processEntityFeatures";
 import { PageDefaultFeatures } from "../../../src/pages/_internal/PageBusinessRules";
 
 describe("Pages: computeProps:", () => {
-  let authdCtxMgr: ArcGISContextManager;
+  let requestOptions: IHubRequestOptions;
   beforeEach(async () => {
-    // When we pass in all this information, the context
-    // manager will not try to fetch anything, so no need
-    // to mock those calls
-    authdCtxMgr = await ArcGISContextManager.create({
-      authentication: MOCK_AUTH,
-      currentUser: {
-        username: "casey",
-        privileges: ["portal:user:createItem"],
-      } as unknown as IUser,
-      portal: {
-        name: "DC R&D Center",
-        id: "BRXFAKE",
-        urlKey: "fake-org",
-        properties: {
-          hub: {
-            enabled: true,
-          },
-        },
-      } as unknown as IPortal,
-      portalUrl: "https://org.maps.arcgis.com",
-    });
+    requestOptions = cloneObject(MOCK_HUB_REQOPTS);
   });
   describe("features:", () => {
     let spy: jasmine.Spy;
@@ -52,7 +35,7 @@ describe("Pages: computeProps:", () => {
         data: {},
       } as IModel;
       const init: Partial<IHubPage> = {};
-      const chk = computeProps(model, init, authdCtxMgr.context.requestOptions);
+      const chk = computeProps(model, init, requestOptions);
       expect(chk.features?.details).toBeTruthy();
       expect(chk.features?.settings).toBeFalsy();
       expect(spy.calls.argsFor(0)[0]).toEqual({});
@@ -70,7 +53,7 @@ describe("Pages: computeProps:", () => {
         },
       } as unknown as IModel;
       const init: Partial<IHubPage> = {};
-      const chk = computeProps(model, init, authdCtxMgr.context.requestOptions);
+      const chk = computeProps(model, init, requestOptions);
 
       expect(chk.features?.details).toBeTruthy();
       expect(chk.features?.settings).toBeFalsy();
@@ -93,11 +76,26 @@ describe("Pages: computeProps:", () => {
         },
       } as unknown as IModel;
       const init: Partial<IHubPage> = {};
-      const chk = computeProps(model, init, authdCtxMgr.context.requestOptions);
+      const chk = computeProps(model, init, requestOptions);
 
       expect(chk.features?.details).toBeTruthy();
       expect(chk.features?.settings).toBeFalsy();
       expect(spy.calls.argsFor(0)[0]).toEqual({ details: true });
     });
+  });
+  it("creates links", () => {
+    const model: IModel = {
+      item: {
+        id: "3ef",
+        type: "Hub Page",
+        created: new Date().getTime(),
+        modified: new Date().getTime(),
+      },
+      data: {},
+    } as unknown as IModel;
+    const init: Partial<IHubPage> = { id: "3ef" };
+    const chk = computeProps(model, init, requestOptions);
+    expect(chk.links.siteRelative).toBe("/pages/3ef");
+    expect(chk.links.layoutRelative).toBe("/pages/3ef/edit");
   });
 });

--- a/packages/common/test/sites/_internal/computeProps.test.ts
+++ b/packages/common/test/sites/_internal/computeProps.test.ts
@@ -1,34 +1,17 @@
-import { IPortal, IUser } from "@esri/arcgis-rest-portal";
-import { MOCK_AUTH } from "../../mocks/mock-auth";
-import { ArcGISContextManager } from "../../../src/ArcGISContextManager";
+import { MOCK_HUB_REQOPTS } from "../../mocks/mock-auth";
 import { computeProps } from "../../../src/sites/_internal/computeProps";
-import { IHubSite, IModel } from "../../../src";
+import {
+  cloneObject,
+  IHubRequestOptions,
+  IHubSite,
+  IModel,
+} from "../../../src";
 import { SiteDefaultFeatures } from "../../../src/sites/_internal/SiteBusinessRules";
 import * as processEntitiesModule from "../../../src/permissions/_internal/processEntityFeatures";
 describe("sites: computeProps:", () => {
-  let authdCtxMgr: ArcGISContextManager;
+  let requestOptions: IHubRequestOptions;
   beforeEach(async () => {
-    // When we pass in all this information, the context
-    // manager will not try to fetch anything, so no need
-    // to mock those calls
-    authdCtxMgr = await ArcGISContextManager.create({
-      authentication: MOCK_AUTH,
-      currentUser: {
-        username: "casey",
-        privileges: ["portal:user:createItem"],
-      } as unknown as IUser,
-      portal: {
-        name: "DC R&D Center",
-        id: "BRXFAKE",
-        urlKey: "fake-org",
-        properties: {
-          hub: {
-            enabled: true,
-          },
-        },
-      } as unknown as IPortal,
-      portalUrl: "https://org.maps.arcgis.com",
-    });
+    requestOptions = cloneObject(MOCK_HUB_REQOPTS);
   });
   describe("features:", () => {
     let spy: jasmine.Spy;
@@ -51,7 +34,7 @@ describe("sites: computeProps:", () => {
         data: {},
       } as IModel;
       const init: Partial<IHubSite> = {};
-      const chk = computeProps(model, init, authdCtxMgr.context.requestOptions);
+      const chk = computeProps(model, init, requestOptions);
       expect(chk.features?.details).toBeTruthy();
       expect(chk.features?.settings).toBeFalsy();
       expect(spy.calls.argsFor(0)[0]).toEqual({});
@@ -69,7 +52,7 @@ describe("sites: computeProps:", () => {
         },
       } as unknown as IModel;
       const init: Partial<IHubSite> = {};
-      const chk = computeProps(model, init, authdCtxMgr.context.requestOptions);
+      const chk = computeProps(model, init, requestOptions);
 
       expect(chk.features?.details).toBeTruthy();
       expect(chk.features?.settings).toBeFalsy();
@@ -92,11 +75,25 @@ describe("sites: computeProps:", () => {
         },
       } as unknown as IModel;
       const init: Partial<IHubSite> = {};
-      const chk = computeProps(model, init, authdCtxMgr.context.requestOptions);
+      const chk = computeProps(model, init, requestOptions);
 
       expect(chk.features?.details).toBeTruthy();
       expect(chk.features?.settings).toBeFalsy();
       expect(spy.calls.argsFor(0)[0]).toEqual({ details: true });
     });
+  });
+  it("creates links", () => {
+    const model: IModel = {
+      item: {
+        id: "9001",
+        created: new Date().getTime(),
+        modified: new Date().getTime(),
+      },
+      data: {},
+    } as IModel;
+    const init: Partial<IHubSite> = { id: "9001" };
+    const chk = computeProps(model, init, requestOptions);
+    expect(chk.links.siteRelative).toBe("/");
+    expect(chk.links.layoutRelative).toBe("/edit");
   });
 });


### PR DESCRIPTION
1. Description:
Part of https://devtopia.esri.com/dc/hub/issues/7521

Moves the "links" property into IHubEntityBase and adds "layoutRelative" as an option.

Before this PR,  "links" was part of IHubSearchResult. Since IHubSearchResult extends IHubEntityBase, no
change is needed on the search side. However, by moving "links" to IHubEntityBase, we are laying the
foundation for IHubSearchResults and IHubEntitys to have the same link structure.

I started by implementing basic links for IHubPage, IHubSite and IHubEditableContent.

Longer term, we'll want to figure out some basic questions like:
- should thumbnail have the token appended?
- should link generation be abstracted into a function or be created ad-hoc in each entity's `computeProps` function?
- should IHubSearchResults always populate the same links as fetchHubEntity? How does ^^^ relate to that goal?
- What's our migration strategy for removing `thumbnailUrl` and moving to `links.thumbnail`?
- Should `IHubItemEntity.url` actually be the `item.url`? How do we migrate usage to `links.self` instead?

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
