### PR TITLE
fix(hub-discussions): user can read channel if group is non-discussable

### DIFF
--- a/packages/discussions/src/utils/channel-permission.ts
+++ b/packages/discussions/src/utils/channel-permission.ts
@@ -132,8 +132,14 @@ export class ChannelPermission {
     return groupAccessControls.some((permission) => {
       const group = userGroupsById[permission.key];
 
-      if (!group || !isGroupDiscussable(group)) {
-        return false;
+      if (action === ChannelAction.READ_POSTS) {
+        if (!group) {
+          return false;
+        }
+      } else {
+        if (!group || !isGroupDiscussable(group)) {
+          return false;
+        }
       }
 
       return (

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -1530,6 +1530,29 @@ describe("ChannelPermission class", () => {
 
         expect(channelPermission.canReadChannel(user)).toBe(false);
       });
+
+      it("returns true if user logged in and in non-discussable group", async () => {
+        const user = buildUser({
+          groups: [buildGroup("groupND", "member", [CANNOT_DISCUSS])],
+        });
+        const channelAcl = [
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.MEMBER,
+            key: "groupND",
+            role: Role.READ, // members write
+          },
+          {
+            category: AclCategory.GROUP,
+            subCategory: AclSubCategory.ADMIN,
+            key: "groupND",
+            role: Role.READ, // members write
+          },
+        ] as IChannelAclPermission[];
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        expect(channelPermission.canReadChannel(user)).toBe(true);
+      });
     });
 
     describe("Anonymous User Permissions", () => {
@@ -1766,7 +1789,7 @@ describe("ChannelPermission class", () => {
         expect(channelPermission.canReadChannel(user)).toBe(true);
       });
 
-      it("returns false if user is group member in permissions list but the group is not discussable", async () => {
+      it("returns true if user is group member in permissions list but the group is not discussable", async () => {
         const user = buildUser({
           orgId: orgId1,
           groups: [
@@ -1790,7 +1813,7 @@ describe("ChannelPermission class", () => {
 
         const channelPermission = new ChannelPermission(channelAcl, "foo");
 
-        expect(channelPermission.canReadChannel(user)).toBe(false);
+        expect(channelPermission.canReadChannel(user)).toBe(true);
       });
 
       it("returns false if user is group admin but group is not in permissions list", async () => {


### PR DESCRIPTION
1. Description: Updated `canSomeUserGroup`to allow a user in a non-discussable group to read a channel with the `canReadChannel` function.

2. Instructions for testing: run `npm run test` to run unit updated unit tests

3. Closes Issues: [#7454](https://devtopia.esri.com/dc/hub/issues/7454)

4. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

5. [X] used semantic commit messages
  
6. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

7. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.