### PR TITLE
feat(hub-common): add hub:[entity]:manage permission for all entities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22644,9 +22644,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22661,21 +22662,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22689,9 +22693,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22709,9 +22714,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64966,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.3.1",
+			"version": "14.8.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -83376,7 +83382,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83391,17 +83398,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83415,7 +83425,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83432,7 +83443,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -22,6 +22,7 @@ export const ContentPermissions = [
   "hub:content:workspace:dashboard",
   "hub:content:workspace:details",
   "hub:content:workspace:settings",
+  "hub:content:manage",
 ] as const;
 
 /**
@@ -70,5 +71,9 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:content:workspace:settings",
     dependencies: ["hub:content:edit"],
     entityOwner: true,
+  },
+  {
+    permission: "hub:content:manage",
+    dependencies: ["hub:content:edit"],
   },
 ];

--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -18,6 +18,7 @@ export const DiscussionPermissions = [
   "hub:discussion:workspace:collaborators",
   "hub:discussion:workspace:discussion",
   "hub:discussion:workspace:metrics",
+  "hub:discussion:manage",
 ] as const;
 
 /**
@@ -84,6 +85,10 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:discussion:workspace:metrics",
+    dependencies: ["hub:discussion:edit"],
+  },
+  {
+    permission: "hub:discussion:manage",
     dependencies: ["hub:discussion:edit"],
   },
 ];

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -20,6 +20,7 @@ export const GroupPermissions = [
   "hub:group:workspace:content",
   "hub:group:workspace:members",
   "hub:group:shareContent",
+  "hub:group:manage",
 ] as const;
 
 /**
@@ -87,5 +88,9 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
         value: "entity:id",
       },
     ],
+  },
+  {
+    permission: "hub:group:manage",
+    dependencies: ["hub:group:edit"],
   },
 ];

--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -30,6 +30,7 @@ export const InitiativePermissions = [
   "hub:initiative:workspace:collaborators",
   "hub:initiative:workspace:content",
   "hub:initiative:workspace:metrics",
+  "hub:initiative:manage",
 ] as const;
 
 /**
@@ -106,6 +107,10 @@ export const InitiativePermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:initiative:workspace:metrics",
+    dependencies: ["hub:initiative:edit"],
+  },
+  {
+    permission: "hub:initiative:manage",
     dependencies: ["hub:initiative:edit"],
   },
 ];

--- a/packages/common/src/pages/_internal/PageBusinessRules.ts
+++ b/packages/common/src/pages/_internal/PageBusinessRules.ts
@@ -23,6 +23,7 @@ export const PagePermissions = [
   "hub:page:workspace:details",
   "hub:page:workspace:settings",
   "hub:page:workspace:collaborators",
+  "hub:page:manage",
 ] as const;
 
 /**
@@ -76,6 +77,10 @@ export const PagePermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:page:workspace:settings",
     dependencies: ["hub:page:edit"],
     entityOwner: true,
+  },
+  {
+    permission: "hub:page:manage",
+    dependencies: ["hub:page:edit"],
   },
 ];
 

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -31,6 +31,7 @@ export const ProjectPermissions = [
   "hub:project:workspace:collaborators",
   "hub:project:workspace:content",
   "hub:project:workspace:metrics",
+  "hub:project:manage",
 ] as const;
 
 /**
@@ -112,6 +113,10 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:project:workspace:metrics",
+    dependencies: ["hub:project:edit"],
+  },
+  {
+    permission: "hub:project:manage",
     dependencies: ["hub:project:edit"],
   },
 ];

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -33,6 +33,7 @@ export const SitePermissions = [
   "hub:site:workspace:followers",
   "hub:site:workspace:followers:member",
   "hub:site:workspace:followers:manager",
+  "hub:site:manage",
 ] as const;
 
 /**
@@ -135,6 +136,10 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
         value: "entity:followersGroupId",
       },
     ],
+  },
+  {
+    permission: "hub:site:manage",
+    dependencies: ["hub:site:edit"],
   },
 ];
 


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
