### PR TITLE
fix: added default empty quotes for computeProps

### DIFF
--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -57,7 +57,10 @@ export function computeProps(
     workspaceRelative: getRelativeWorkspaceUrl("content", content.id),
     thumbnail: thumbnailUrl,
   };
-  content.licenseInfo = model.item.licenseInfo;
+
+  // cannot be null otherwise we'd get a validation
+  // error that doesn't let us save the form
+  content.licenseInfo = model.item.licenseInfo || "";
 
   if (!content.location) {
     // build location if one does not exist based off of the boundary and the item's extent


### PR DESCRIPTION
1. Description: When loading content that has a licenseInfo set to `null`, the save button will show a validation error but without any description. To avoid this, I just added a pair of default empty quotes which is what the licenseInfo would be set to if the user previously cleared a selected license.

1. Instructions for testing: Try this item out before and after this PR -- 
- `yarn hc start`: http://localhost:3333/html/arcgis-hub-workspace/entity-workspace-harness.html?identifier=cd0d468f480244339b894ae2b65705b8&type=content
- `yarn start`: https://download-test-qa-pre-a-hub.hubqa.arcgis.com:4200/workspace/content/cd0d468f480244339b894ae2b65705b8/details

1. Closes Issues: [#7721](https://devtopia.esri.com/dc/hub/issues/7721)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
