### PR TITLE
feat: add workspaceRelative to enrichGroupSearchResult

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64966,7 +64966,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.9.1",
+			"version": "14.11.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -85,10 +85,7 @@ export async function enrichGroupSearchResult(
   result.links.thumbnail = getGroupThumbnailUrl(requestOptions.portal, group);
   result.links.self = getGroupHomeUrl(result.id, requestOptions);
   result.links.siteRelative = `/teams/${result.id}`;
-  result.links.workspaceRelative = getRelativeWorkspaceUrl(
-    result.type,
-    result.id
-  );
+  result.links.workspaceRelative = getRelativeWorkspaceUrl("Group", result.id);
 
   return result;
 }

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -19,6 +19,7 @@ import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { DEFAULT_GROUP } from "./defaults";
 import { convertHubGroupToGroup } from "./_internal/convertHubGroupToGroup";
 import { convertGroupToHubGroup } from "./_internal/convertGroupToHubGroup";
+import { getRelativeWorkspaceUrl } from "../core/getRelativeWorkspaceUrl";
 
 /**
  * Enrich a generic search result
@@ -84,6 +85,10 @@ export async function enrichGroupSearchResult(
   result.links.thumbnail = getGroupThumbnailUrl(requestOptions.portal, group);
   result.links.self = getGroupHomeUrl(result.id, requestOptions);
   result.links.siteRelative = `/teams/${result.id}`;
+  result.links.workspaceRelative = getRelativeWorkspaceUrl(
+    result.type,
+    result.id
+  );
 
   return result;
 }


### PR DESCRIPTION
1. Description: We weren't determining the workspaceRelative link for groups. This implements that.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
