### PR TITLE
fix: ensure featured content catalogs are returned as an array

### DIFF
--- a/packages/common/src/core/schemas/internal/getFeaturedContentCatalogs.ts
+++ b/packages/common/src/core/schemas/internal/getFeaturedContentCatalogs.ts
@@ -3,13 +3,14 @@ import {
   WellKnownCatalog,
   getWellKnownCatalog,
 } from "../../../search/wellKnownCatalog";
+import { IHubCatalog } from "../../../search/types/IHubCatalog";
 
 /**
  * Return a catalog structured for picking featured content.
  * @param user
  * @returns
  */
-export function getFeaturedContentCatalogs(user: IUser) {
+export function getFeaturedContentCatalogs(user: IUser): IHubCatalog[] {
   const catalogNames: WellKnownCatalog[] = [
     "myContent",
     "favorites",
@@ -27,5 +28,5 @@ export function getFeaturedContentCatalogs(user: IUser) {
     return catalog;
   });
 
-  return { catalogs };
+  return catalogs;
 }

--- a/packages/common/test/core/schemas/internal/getFeaturedContentCatalogs.test.ts
+++ b/packages/common/test/core/schemas/internal/getFeaturedContentCatalogs.test.ts
@@ -4,10 +4,10 @@ import { getFeaturedContentCatalogs } from "../../../../src/core/schemas/interna
 describe("getFeaturedContentCatalogs:", () => {
   it("adds user into catalog", () => {
     const user: IUser = { username: "darth" } as unknown as IUser;
-    const chk = getFeaturedContentCatalogs(user);
-    expect(chk.catalogs.length).toBe(4);
-    const myContent = chk.catalogs[0];
-    expect(myContent.scopes.item.filters[0].predicates[0]).toEqual({
+    const catalogs = getFeaturedContentCatalogs(user);
+    expect(catalogs.length).toBe(4);
+    const myContent = catalogs[0];
+    expect(myContent.scopes?.item?.filters[0].predicates[0]).toEqual({
       owner: "darth",
     });
   });


### PR DESCRIPTION
### Description:
The internal function `getFeaturedContentCatalogs` should return an array of `IHubCatalogs`. It was previously implemented to return `{ catalogs }` to support the old implementation of `getEntityEditorOptions` which has since been refactored

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.