### PR TITLE
fix: add featured content to initiatives edit

### DIFF
--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -145,10 +145,10 @@ export const buildUiSchema = async (
       },
       {
         type: "Section",
-        labelKey: "{{i18nScope}}.sections.featuredContent.label",
+        labelKey: `${i18nScope}.sections.featuredContent.label`,
         options: {
           helperText: {
-            labelKey: "{{i18nScope}}.sections.featuredContent.helperText",
+            labelKey: `${i18nScope}.sections.featuredContent.helperText`,
           },
         },
         elements: [
@@ -161,8 +161,7 @@ export const buildUiSchema = async (
               catalogs: getFeaturedContentCatalogs(context.currentUser),
               facets: [
                 {
-                  label:
-                    "{{{{i18nScope}}.fields.featuredContent.facets.type:translate}}",
+                  label: `{{${i18nScope}.fields.featuredContent.facets.type:translate}`,
                   key: "type",
                   display: "multi-select",
                   field: "type",
@@ -171,8 +170,7 @@ export const buildUiSchema = async (
                   aggLimit: 100,
                 },
                 {
-                  label:
-                    "{{{{i18nScope}}.fields.featuredContent.facets.sharing:translate}}",
+                  label: `{{${i18nScope}.fields.featuredContent.facets.sharing:translate}`,
                   key: "access",
                   display: "multi-select",
                   field: "access",

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -5,6 +5,7 @@ import { getTagItems } from "../../core/schemas/internal/getTagItems";
 import { getCategoryItems } from "../../core/schemas/internal/getCategoryItems";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
+import { getFeaturedContentCatalogs } from "../../core/schemas/internal/getFeaturedContentCatalogs";
 
 /**
  * @private
@@ -138,6 +139,47 @@ export const buildUiSchema = async (
                 context.portal.name,
                 context.hubRequestOptions
               ),
+            },
+          },
+        ],
+      },
+      {
+        type: "Section",
+        labelKey: "{{i18nScope}}.sections.featuredContent.label",
+        options: {
+          helperText: {
+            labelKey: "{{i18nScope}}.sections.featuredContent.helperText",
+          },
+        },
+        elements: [
+          {
+            scope: "/properties/view/properties/featuredContentIds",
+            type: "Control",
+            options: {
+              control: "hub-field-input-gallery-picker",
+              targetEntity: "item",
+              catalogs: getFeaturedContentCatalogs(context.currentUser),
+              facets: [
+                {
+                  label:
+                    "{{{{i18nScope}}.fields.featuredContent.facets.type:translate}}",
+                  key: "type",
+                  display: "multi-select",
+                  field: "type",
+                  options: [],
+                  operation: "OR",
+                  aggLimit: 100,
+                },
+                {
+                  label:
+                    "{{{{i18nScope}}.fields.featuredContent.facets.sharing:translate}}",
+                  key: "access",
+                  display: "multi-select",
+                  field: "access",
+                  options: [],
+                  operation: "OR",
+                },
+              ],
             },
           },
         ],

--- a/packages/common/src/initiatives/defaults.ts
+++ b/packages/common/src/initiatives/defaults.ts
@@ -15,6 +15,9 @@ export const DEFAULT_INITIATIVE: Partial<IHubInitiative> = {
   permissions: [],
   schemaVersion: 2,
   features: InitiativeDefaultFeatures,
+  view: {
+    featuredContentIds: [],
+  },
 };
 
 /**
@@ -33,5 +36,9 @@ export const DEFAULT_INITIATIVE_MODEL: IModel = {
       schemaVersion: 2,
     },
   },
-  data: {},
+  data: {
+    view: {
+      featuredContentIds: [],
+    },
+  },
 } as unknown as IModel;

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -4,6 +4,7 @@ import * as getLocationExtentModule from "../../../src/core/schemas/internal/get
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
 import * as getCategoryItemsModule from "../../../src/core/schemas/internal/getCategoryItems";
+import * as getFeaturedContentCatalogsModule from "../../../src/core/schemas/internal/getFeaturedContentCatalogs";
 
 describe("buildUiSchema: initiative edit", () => {
   it("returns the full initiative edit uiSchema", async () => {
@@ -19,6 +20,10 @@ describe("buildUiSchema: initiative edit", () => {
     spyOn(getTagItemsModule, "getTagItems").and.returnValue(
       Promise.resolve([])
     );
+    spyOn(
+      getFeaturedContentCatalogsModule,
+      "getFeaturedContentCatalogs"
+    ).and.returnValue({});
 
     const uiSchema = await buildUiSchema(
       "some.scope",
@@ -132,6 +137,47 @@ describe("buildUiSchema: initiative edit", () => {
                 control: "hub-field-input-location-picker",
                 extent: [],
                 options: [],
+              },
+            },
+          ],
+        },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.featuredContent.label",
+          options: {
+            helperText: {
+              labelKey: "some.scope.sections.featuredContent.helperText",
+            },
+          },
+          elements: [
+            {
+              scope: "/properties/view/properties/featuredContentIds",
+              type: "Control",
+              options: {
+                control: "hub-field-input-gallery-picker",
+                targetEntity: "item",
+                catalogs: {},
+                facets: [
+                  {
+                    label:
+                      "{{some.scope.fields.featuredContent.facets.type:translate}",
+                    key: "type",
+                    display: "multi-select",
+                    field: "type",
+                    options: [],
+                    operation: "OR",
+                    aggLimit: 100,
+                  },
+                  {
+                    label:
+                      "{{some.scope.fields.featuredContent.facets.sharing:translate}",
+                    key: "access",
+                    display: "multi-select",
+                    field: "access",
+                    options: [],
+                    operation: "OR",
+                  },
+                ],
               },
             },
           ],


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
- Add featured content to initiatives edit

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
