### PR TITLE
feat: adds getChannelUsersQuery method, bumps to @esri/arcgis-rest-port…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64981,7 +64981,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.19.0",
+			"version": "14.20.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"@commitlint/prompt": "^11.0.0",
 				"@esri/arcgis-rest-auth": "^3.1.1",
 				"@esri/arcgis-rest-feature-layer": "^3.4.3",
-				"@esri/arcgis-rest-portal": "^3.5.0",
+				"@esri/arcgis-rest-portal": "^3.7.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-service-admin": "^3.6.0",
 				"@esri/arcgis-rest-types": "^3.1.1",
@@ -4974,11 +4974,11 @@
 			}
 		},
 		"node_modules/@esri/arcgis-rest-portal": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.6.0.tgz",
-			"integrity": "sha512-TPLcbQn+PfKqGlkCvlDYs2AQs7KdTKnM17AhGytnQkqYamNlhkZMAlgC4qq5/H7URTIqlQx52fx/OOfTfO0ABw==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.7.0.tgz",
+			"integrity": "sha512-KEdBHNmoYqbN1tmfCTwRq6AJ/Dl2rMSYgDFR1ODOKwicJ4PZPzfjHwUkSTS77eDEL/+ziRiSp5hJceJfDWzAgw==",
 			"dependencies": {
-				"@esri/arcgis-rest-types": "^3.6.0",
+				"@esri/arcgis-rest-types": "^3.7.0",
 				"tslib": "^1.13.0"
 			},
 			"peerDependencies": {
@@ -65038,7 +65038,7 @@
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^3.1.0",
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
-				"@esri/arcgis-rest-portal": "^3.5.0",
+				"@esri/arcgis-rest-portal": "^3.7.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
 				"@esri/hub-common": "^14.0.0"
 			}
@@ -68688,11 +68688,11 @@
 			}
 		},
 		"@esri/arcgis-rest-portal": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.6.0.tgz",
-			"integrity": "sha512-TPLcbQn+PfKqGlkCvlDYs2AQs7KdTKnM17AhGytnQkqYamNlhkZMAlgC4qq5/H7URTIqlQx52fx/OOfTfO0ABw==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.7.0.tgz",
+			"integrity": "sha512-KEdBHNmoYqbN1tmfCTwRq6AJ/Dl2rMSYgDFR1ODOKwicJ4PZPzfjHwUkSTS77eDEL/+ziRiSp5hJceJfDWzAgw==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^3.6.0",
+				"@esri/arcgis-rest-types": "^3.7.0",
 				"tslib": "^1.13.0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"@commitlint/prompt": "^11.0.0",
     "@esri/arcgis-rest-auth": "^3.1.1",
     "@esri/arcgis-rest-feature-layer": "^3.4.3",
-    "@esri/arcgis-rest-portal": "^3.5.0",
+    "@esri/arcgis-rest-portal": "^3.7.0",
     "@esri/arcgis-rest-request": "^3.1.1",
 		"@esri/arcgis-rest-service-admin": "^3.6.0",
     "@esri/arcgis-rest-types": "^3.1.1",

--- a/packages/common/src/discussions/utils.ts
+++ b/packages/common/src/discussions/utils.ts
@@ -198,9 +198,9 @@ export function searchChannelUsers(
     filters: [
       {
         operation: "OR",
-        predicates: users.reduce(
+        predicates: users.reduce<IPredicate[]>(
           (acc, user) => [...acc, { username: user }, { fullname: user }],
-          [] as IPredicate[]
+          []
         ),
       },
       ...filters,

--- a/packages/common/src/discussions/utils.ts
+++ b/packages/common/src/discussions/utils.ts
@@ -87,9 +87,7 @@ export function isOrgChannel(channel: IChannel): boolean {
  * @returns true if the channel is considered `private`
  */
 export function isPrivateChannel(channel: IChannel): boolean {
-  return channel.channelAcl
-    ? channel.channelAcl.every(({ category }) => category === AclCategory.GROUP)
-    : channel.access === SharingAccess.PRIVATE;
+  return !isPublicChannel(channel) && !isOrgChannel(channel);
 }
 
 /**

--- a/packages/common/src/discussions/utils.ts
+++ b/packages/common/src/discussions/utils.ts
@@ -143,8 +143,8 @@ export function getChannelGroupIds(channel: IChannel): string[] {
  * A utility method used to search for users that are permitted to be at-mentioned by the currently authenticated user
  * for the given channel.
  * @param data An object of query-related values
+ * @param data.users An array of strings to search for. Each string is mapped to `username` and `fullname`, filters as an OR condition
  * @param data.channel An IChannel record
- * @param data.groups The channel group ids
  * @param data.currentUsername The currently authenticated user's username
  * @param options An IHubSearchOptions object
  * @returns a promise that resolves an IHubSearchResponse<IHubSearchResult>

--- a/packages/common/src/discussions/utils.ts
+++ b/packages/common/src/discussions/utils.ts
@@ -71,7 +71,12 @@ export function isPublicChannel(channel: IChannel): boolean {
  */
 export function isOrgChannel(channel: IChannel): boolean {
   return channel.channelAcl
-    ? channel.channelAcl.some(({ category }) => category === AclCategory.ORG)
+    ? !isPublicChannel(channel) &&
+        channel.channelAcl.some(
+          ({ category, subCategory }) =>
+            category === AclCategory.ORG &&
+            subCategory === AclSubCategory.MEMBER
+        )
     : channel.access === SharingAccess.ORG;
 }
 
@@ -82,7 +87,9 @@ export function isOrgChannel(channel: IChannel): boolean {
  * @returns true if the channel is considered `private`
  */
 export function isPrivateChannel(channel: IChannel): boolean {
-  return !isPublicChannel(channel) && !isOrgChannel(channel);
+  return channel.channelAcl
+    ? channel.channelAcl.every(({ category }) => category === AclCategory.GROUP)
+    : channel.access === SharingAccess.PRIVATE;
 }
 
 /**

--- a/packages/common/src/search/_internal/portalSearchGroupMembers.ts
+++ b/packages/common/src/search/_internal/portalSearchGroupMembers.ts
@@ -218,5 +218,9 @@ async function memberToSearchResult(
     }
   });
 
-  return enrichUserSearchResult(user, include, requestOptions);
+  return enrichUserSearchResult(
+    user,
+    ["org.name as OrgName", ...include],
+    requestOptions
+  );
 }

--- a/packages/common/src/search/_internal/portalSearchUsers.ts
+++ b/packages/common/src/search/_internal/portalSearchUsers.ts
@@ -1,7 +1,9 @@
 import {
   ISearchOptions,
+  ISearchResult,
   IUserSearchOptions,
   searchUsers,
+  searchCommunityUsers,
 } from "@esri/arcgis-rest-portal";
 import { IUser } from "@esri/arcgis-rest-types";
 import { enrichUserSearchResult } from "../../users";
@@ -16,41 +18,34 @@ import {
 } from "../types";
 import { getNextFunction } from "../utils";
 import { expandPredicate } from "./expandPredicate";
+import { cloneObject } from "../../util";
 
-/**
- * @private
- * Portal Search Implementation for Users
- * @param filterGroups
- * @param options
- * @returns
- */
-export async function portalSearchUsers(
+function buildSearchOptions(
   query: IQuery,
-  options: IHubSearchOptions
-): Promise<IHubSearchResponse<IHubSearchResult>> {
+  options: IHubSearchOptions,
+  operation: string
+): IUserSearchOptions {
   // requestOptions is always required and user must be authd
   if (!options.requestOptions) {
     throw new HubError(
-      "portalSearchUsers",
+      operation,
       "requestOptions: IHubRequestOptions is required."
     );
   }
 
   if (!options.requestOptions.authentication) {
-    throw new HubError(
-      "portalSearchUsers",
-      "requestOptions must pass authentication."
-    );
+    throw new HubError(operation, "requestOptions must pass authentication.");
   }
 
+  const clonedQuery = cloneObject(query);
   // Expand the individual predicates in each filter
-  query.filters = query.filters.map((filter) => {
+  clonedQuery.filters = clonedQuery.filters.map((filter) => {
     filter.predicates = filter.predicates.map(expandPredicate);
     return filter;
   });
 
   // Serialize the all the groups for portal
-  const so = serializeQueryForPortal(query);
+  const so = serializeQueryForPortal(clonedQuery);
   // Array of properties we want to copy from IHubSearchOptions to the ISearchOptions
   const props: Array<keyof IHubSearchOptions> = [
     "num",
@@ -71,8 +66,102 @@ export async function portalSearchUsers(
   // so we set it directly
   so.authentication = options.requestOptions.authentication;
 
+  return so as IUserSearchOptions;
+}
+
+/**
+ * @private
+ *
+ * Portal Search Implementation for Users within the currently authenticated user's organization.
+ * Automatically adds "org.name as OrgName" enrichment
+ *
+ * DEPRECATED: This method will be deprecated in a future release, as it's no ideal to impose enrichments for all cases.
+ *
+ * @param query An IQuery object representing the query to serialize
+ * @param options An IHubSearchOptions of search options
+ * @returns a promise that resolves an IHubSearchResponse<IHubSearchResult> of users results
+ */
+export function portalSearchUsersLegacy(
+  query: IQuery,
+  options: IHubSearchOptions
+): Promise<IHubSearchResponse<IHubSearchResult>> {
+  const searchOptions = buildSearchOptions(
+    query,
+    options,
+    "portalSearchUsersLegacy"
+  );
   // Execute search
-  return searchPortal(so as IUserSearchOptions);
+  return searchPortal({
+    ...searchOptions,
+    include: ["org.name as OrgName", ...(searchOptions.include || [])],
+  });
+}
+
+/**
+ * @private
+ *
+ * Portal Search Implementation for Users within the currently authenticated user's organization.
+ * No enrichments added by default.
+ *
+ * @param query An IQuery object representing the query to serialize
+ * @param options An IHubSearchOptions of search options
+ * @returns a promise that resolves an IHubSearchResponse<IHubSearchResult> of users results
+ */
+export function portalSearchUsers(
+  query: IQuery,
+  options: IHubSearchOptions
+): Promise<IHubSearchResponse<IHubSearchResult>> {
+  const searchOptions = buildSearchOptions(
+    query,
+    options,
+    "portalSearchUsersLegacy"
+  );
+  // Execute search
+  return searchPortal(searchOptions);
+}
+
+/**
+ * @private
+ *
+ * Community Search Implementation for Users within in any organization.
+ * No enrichments added by default.
+ *
+ * @param query An IQuery object representing the query to serialize
+ * @param options An IHubSearchOptions of search options
+ * @returns a promise that resolves an IHubSearchResponse<IHubSearchResult> of users results
+ */
+export function communitySearchUsers(
+  query: IQuery,
+  options: IHubSearchOptions
+): Promise<IHubSearchResponse<IHubSearchResult>> {
+  const searchOptions = buildSearchOptions(
+    query,
+    options,
+    "communitySearchUsers"
+  );
+  // Execute search
+  return searchCommunity(searchOptions);
+}
+
+/**
+ * @private
+ * @param searchOptions An IUserSearchOptions object
+ * @param searchResponse A ISearchResult<IUser> object
+ * @returns
+ */
+function mapUsersToSearchResults(
+  searchOptions: IUserSearchOptions,
+  searchResponse: ISearchResult<IUser>
+): Promise<IHubSearchResult[]> {
+  // create mappable fn that will close
+  // over the includes and requestOptions
+  const fn = (user: IUser) =>
+    userToSearchResult(
+      user,
+      searchOptions.include,
+      searchOptions.requestOptions
+    );
+  return Promise.all(searchResponse.results.map(fn));
 }
 
 /**
@@ -80,27 +169,15 @@ export async function portalSearchUsers(
  * handling enrichments & includes along the way
  *
  * @param searchOptions
- * @returns
+ * @returns a promise that resolves enriched internal portal user search results
  */
 async function searchPortal(
   searchOptions: IUserSearchOptions
 ): Promise<IHubSearchResponse<IHubSearchResult>> {
   // Execute portal search
   const resp = await searchUsers(searchOptions);
-
-  // create mappable fn that will close
-  // over the includes and requestOptions
-  const fn = (user: IUser) => {
-    return userToSearchResult(
-      user,
-      searchOptions.include,
-      searchOptions.requestOptions
-    );
-  };
-
   // map over results
-  const results = await Promise.all(resp.results.map(fn));
-
+  const results = await mapUsersToSearchResults(searchOptions, resp);
   // Group Search does not support aggregations
   // Construct the return
   return {
@@ -117,6 +194,35 @@ async function searchPortal(
 }
 
 /**
+ * Community search, which then converts `IGroup`s to `IHubSearchResult`s
+ * handling enrichments & includes along the way
+ *
+ * @param searchOptions
+ * @returns a promise that resolves enriched community user search results
+ */
+async function searchCommunity(
+  searchOptions: IUserSearchOptions
+): Promise<IHubSearchResponse<IHubSearchResult>> {
+  // Execute portal search
+  const resp = await searchCommunityUsers(searchOptions);
+  // map over results
+  const results = await mapUsersToSearchResults(searchOptions, resp);
+  // Group Search does not support aggregations
+  // Construct the return
+  return {
+    total: resp.total,
+    results,
+    hasNext: resp.nextStart > -1,
+    next: getNextFunction<IHubSearchResult>(
+      searchOptions,
+      resp.nextStart,
+      resp.total,
+      searchCommunity
+    ),
+  };
+}
+
+/**
  * Convert an Item to a IHubSearchResult
  * Fetches the includes and attaches them to the item
  * @param item
@@ -124,7 +230,7 @@ async function searchPortal(
  * @param requestOptions
  * @returns
  */
-async function userToSearchResult(
+function userToSearchResult(
   user: IUser,
   include: string[] = [],
   requestOptions?: IHubRequestOptions

--- a/packages/common/src/search/hubSearch.ts
+++ b/packages/common/src/search/hubSearch.ts
@@ -8,11 +8,10 @@ import {
   IQuery,
 } from "./types";
 import { getApi } from "./_internal/commonHelpers/getApi";
-
 import { portalSearchGroupMembers } from "./_internal/portalSearchGroupMembers";
 import { portalSearchItems } from "./_internal/portalSearchItems";
 import { portalSearchGroups } from "./_internal/portalSearchGroups";
-import { portalSearchUsers } from "./_internal/portalSearchUsers";
+import { portalSearchUsers, portalSearchUsersLegacy, communitySearchUsers } from "./_internal/portalSearchUsers";
 import { hubSearchItems } from "./_internal/hubSearchItems";
 import { hubSearchChannels } from "./_internal/hubSearchChannels";
 
@@ -74,7 +73,9 @@ export async function hubSearch(
     arcgis: {
       item: portalSearchItems,
       group: portalSearchGroups,
-      user: portalSearchUsers,
+      user: portalSearchUsersLegacy,
+      portalUser: portalSearchUsers,
+      communityUser: communitySearchUsers,
       groupMember: portalSearchGroupMembers,
     },
     "arcgis-hub": {

--- a/packages/common/src/search/hubSearch.ts
+++ b/packages/common/src/search/hubSearch.ts
@@ -11,7 +11,7 @@ import { getApi } from "./_internal/commonHelpers/getApi";
 import { portalSearchGroupMembers } from "./_internal/portalSearchGroupMembers";
 import { portalSearchItems } from "./_internal/portalSearchItems";
 import { portalSearchGroups } from "./_internal/portalSearchGroups";
-import { portalSearchUsers, portalSearchUsersLegacy, communitySearchUsers } from "./_internal/portalSearchUsers";
+import { searchPortalUsersLegacy, searchPortalUsers, searchCommunityUsers } from "./_internal/portalSearchUsers";
 import { hubSearchItems } from "./_internal/hubSearchItems";
 import { hubSearchChannels } from "./_internal/hubSearchChannels";
 
@@ -73,9 +73,9 @@ export async function hubSearch(
     arcgis: {
       item: portalSearchItems,
       group: portalSearchGroups,
-      user: portalSearchUsersLegacy,
-      portalUser: portalSearchUsers,
-      communityUser: communitySearchUsers,
+      user: searchPortalUsersLegacy,
+      portalUser: searchPortalUsers,
+      communityUser: searchCommunityUsers,
       groupMember: portalSearchGroupMembers,
     },
     "arcgis-hub": {

--- a/packages/common/src/search/serializeQueryForPortal.ts
+++ b/packages/common/src/search/serializeQueryForPortal.ts
@@ -164,11 +164,8 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
         if (!specialProps.includes(key) && key !== "term") {
           so.q = serializeMatchOptions(key, value);
         }
-        if (dateProps.includes(key)) {
-          so.q = serializeDateRange(
-            key,
-            value as unknown as IDateRange<number>
-          );
+        if (dateProps.includes(key) || isRange(value)) {
+          so.q = serializeRange(key, value as unknown as IDateRange<number>);
         }
         if (boolProps.includes(key)) {
           so.q = `${key}:${value}`;
@@ -230,12 +227,12 @@ function serializeMatchOptions(key: string, value: IMatchOptions): string {
 }
 
 /**
- * Serialize a date-range into Portal syntax
+ * Serialize a range into Portal syntax
  * @param key
  * @param range
  * @returns
  */
-function serializeDateRange(key: string, range: IDateRange<number>): string {
+function serializeRange(key: string, range: IDateRange<number>): string {
   return `${key}:[${range.from} TO ${range.to}]`;
 }
 
@@ -261,4 +258,17 @@ function serializeStringOrArray(
     q = `${key}:"${value}"`;
   }
   return q;
+}
+
+/**
+ * Determines if the given value is a range object
+ * @param value A search param value
+ * @returns true when the value is a range object, e.g. { from: '0', to: '{' }
+ */
+function isRange(value: any): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    ["from", "to"].every((key) => typeof value[key] !== "undefined")
+  );
 }

--- a/packages/common/src/search/types/IHubCatalog.ts
+++ b/packages/common/src/search/types/IHubCatalog.ts
@@ -57,6 +57,8 @@ export type EntityType =
   | "item"
   | "group"
   | "user"
+  | "portalUser"
+  | "communityUser"
   | "groupMember"
   | "event"
   | "channel";

--- a/packages/common/src/users/HubUsers.ts
+++ b/packages/common/src/users/HubUsers.ts
@@ -56,16 +56,8 @@ export async function enrichUserSearchResult(
     result.isGroupOwner = user.isGroupOwner;
   }
 
-  // Informal Enrichments - basically adding type-specific props
-  // derived directly from the entity
-
-  // default includes
-  const DEFAULTS: string[] = ["org.name AS orgName"];
-
-  // merge includes
-  include = [...DEFAULTS, ...include].filter(unique);
   // Parse the includes into a valid set of enrichments
-  const specs = include.map(parseInclude);
+  const specs = include.filter(unique).map(parseInclude);
   // Extract out the low-level enrichments needed
   const enrichments = mapBy("enrichment", specs).filter(unique);
   // fetch the enrichments

--- a/packages/common/test/discussions/utils.test.ts
+++ b/packages/common/test/discussions/utils.test.ts
@@ -5,6 +5,15 @@ import {
   searchChannelUsers,
   SharingAccess,
   IHubRequestOptions,
+  isPublicChannel,
+  isOrgChannel,
+  isPrivateChannel,
+  getChannelAccess,
+  getChannelGroupIds,
+  getChannelOrgIds,
+  IChannel,
+  AclCategory,
+  AclSubCategory,
 } from "../../src";
 import * as hubSearchModule from "../../src/search";
 
@@ -40,6 +49,160 @@ describe("discussions utils", () => {
       expect(result).toEqual([CANNOT_DISCUSS]);
     });
   });
+  describe("isPublicChannel", () => {
+    it("should return true for legacy permissions", () => {
+      expect(
+        isPublicChannel({ access: SharingAccess.PUBLIC } as IChannel)
+      ).toBe(true);
+    });
+    it("should return false for legacy permissions", () => {
+      expect(isPublicChannel({ access: SharingAccess.ORG } as IChannel)).toBe(
+        false
+      );
+    });
+    it("should return true for acl", () => {
+      expect(
+        isPublicChannel({
+          channelAcl: [{ category: AclCategory.AUTHENTICATED_USER }],
+        } as IChannel)
+      ).toBe(true);
+    });
+    it("should return false for acl", () => {
+      expect(
+        isPublicChannel({
+          channelAcl: [{ category: AclCategory.ORG }],
+        } as IChannel)
+      ).toBe(false);
+    });
+  });
+  describe("isOrgChannel", () => {
+    it("should return true for legacy permissions", () => {
+      expect(isOrgChannel({ access: SharingAccess.ORG } as IChannel)).toBe(
+        true
+      );
+    });
+    it("should return false for legacy permissions", () => {
+      expect(isOrgChannel({ access: SharingAccess.PUBLIC } as IChannel)).toBe(
+        false
+      );
+    });
+    it("should return true for acl", () => {
+      expect(
+        isOrgChannel({
+          channelAcl: [{ category: AclCategory.ORG }],
+        } as IChannel)
+      ).toBe(true);
+    });
+    it("should return false for acl", () => {
+      expect(
+        isOrgChannel({
+          channelAcl: [{ category: AclCategory.GROUP }],
+        } as IChannel)
+      ).toBe(false);
+    });
+  });
+  describe("isPrivateChannel", () => {
+    it("should return true for legacy permissions", () => {
+      expect(
+        isPrivateChannel({ access: SharingAccess.PRIVATE } as IChannel)
+      ).toBe(true);
+    });
+    it("should return false for legacy permissions", () => {
+      expect(
+        isPrivateChannel({ access: SharingAccess.PUBLIC } as IChannel)
+      ).toBe(false);
+    });
+    it("should return true for acl", () => {
+      expect(
+        isPrivateChannel({
+          channelAcl: [{ category: AclCategory.GROUP }],
+        } as IChannel)
+      ).toBe(true);
+    });
+    it("should return false for acl", () => {
+      expect(
+        isPrivateChannel({
+          channelAcl: [{ category: AclCategory.ORG }],
+        } as IChannel)
+      ).toBe(false);
+    });
+  });
+  describe("getChannelAccess", () => {
+    it("should return public for legacy permissions", () => {
+      expect(
+        getChannelAccess({ access: SharingAccess.PUBLIC } as IChannel)
+      ).toBe(SharingAccess.PUBLIC);
+    });
+    it("should return public for acl", () => {
+      expect(
+        getChannelAccess({
+          channelAcl: [{ category: AclCategory.AUTHENTICATED_USER }],
+        } as IChannel)
+      ).toBe(SharingAccess.PUBLIC);
+    });
+    it("should return org for legacy permissions", () => {
+      expect(getChannelAccess({ access: SharingAccess.ORG } as IChannel)).toBe(
+        SharingAccess.ORG
+      );
+    });
+    it("should return org for acl", () => {
+      expect(
+        getChannelAccess({
+          channelAcl: [{ category: AclCategory.ORG }],
+        } as IChannel)
+      ).toBe(SharingAccess.ORG);
+    });
+    it("should return private for legacy permissions", () => {
+      expect(
+        getChannelAccess({ access: SharingAccess.PRIVATE } as IChannel)
+      ).toBe(SharingAccess.PRIVATE);
+    });
+    it("should return private for acl", () => {
+      expect(
+        getChannelAccess({
+          channelAcl: [{ category: AclCategory.GROUP }],
+        } as IChannel)
+      ).toBe(SharingAccess.PRIVATE);
+    });
+  });
+  describe("getChannelOrgIds", () => {
+    it("should return channel.orgs for legacy permissions", () => {
+      expect(getChannelOrgIds({ orgs: ["31c"] } as IChannel)).toEqual(["31c"]);
+    });
+    it("should return org ids from acl records", () => {
+      expect(
+        getChannelOrgIds({
+          channelAcl: [
+            {
+              category: AclCategory.ORG,
+              subCategory: AclSubCategory.MEMBER,
+              key: "31c",
+            },
+          ],
+        } as IChannel)
+      ).toEqual(["31c"]);
+    });
+  });
+  describe("getChannelGroupIds", () => {
+    it("should return channel.groups for legacy permissions", () => {
+      expect(getChannelGroupIds({ groups: ["31c"] } as IChannel)).toEqual([
+        "31c",
+      ]);
+    });
+    it("should return group ids from acl records", () => {
+      expect(
+        getChannelGroupIds({
+          channelAcl: [
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.MEMBER,
+              key: "31c",
+            },
+          ],
+        } as IChannel)
+      ).toEqual(["31c"]);
+    });
+  });
   describe("searchChannelUsers", () => {
     const results: hubSearchModule.IHubSearchResponse<hubSearchModule.IHubSearchResult> =
       {
@@ -67,243 +230,448 @@ describe("discussions utils", () => {
       hubSearchSpy.calls.reset();
     });
 
-    it("should search for users for a private channel", async () => {
-      const res = await searchChannelUsers(
-        {
-          users: ["user1", "user2"],
-          access: SharingAccess.PRIVATE,
-          orgs: ["org1", "org2"],
-          groups: ["group1", "group2"],
-          currentUsername: "currentUser",
-        },
-        searchOptions
-      );
-      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
-      expect(hubSearchSpy).toHaveBeenCalledWith(
-        {
-          targetEntity: "communityUser",
-          filters: [
-            {
-              operation: "OR",
-              predicates: [
-                { username: "user1" },
-                { fullname: "user1" },
-                { username: "user2" },
-                { fullname: "user2" },
-              ],
-            },
-            {
-              operation: "AND",
-              predicates: [{ group: ["group1", "group2"] }],
-            },
-            {
-              operation: "AND",
-              predicates: [{ username: { not: "currentUser" } }],
-            },
-          ],
-        },
-        searchOptions
-      );
-      expect(res).toEqual(results);
+    describe("legacy permissions", () => {
+      it("should search for users for a private channel", async () => {
+        const res = await searchChannelUsers(
+          {
+            users: ["user1", "user2"],
+            channel: {
+              access: SharingAccess.PRIVATE,
+              orgs: ["org1", "org2"],
+              groups: ["group1", "group2"],
+            } as IChannel,
+            currentUsername: "currentUser",
+          },
+          searchOptions
+        );
+        expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+        expect(hubSearchSpy).toHaveBeenCalledWith(
+          {
+            targetEntity: "communityUser",
+            filters: [
+              {
+                operation: "OR",
+                predicates: [
+                  { username: "user1" },
+                  { fullname: "user1" },
+                  { username: "user2" },
+                  { fullname: "user2" },
+                ],
+              },
+              {
+                operation: "AND",
+                predicates: [{ group: ["group1", "group2"] }],
+              },
+              {
+                operation: "AND",
+                predicates: [{ username: { not: "currentUser" } }],
+              },
+            ],
+          },
+          searchOptions
+        );
+        expect(res).toEqual(results);
+      });
+      it("should search for users for an org-only channel", async () => {
+        const res = await searchChannelUsers(
+          {
+            users: ["user1", "user2"],
+            channel: {
+              access: SharingAccess.ORG,
+              orgs: ["org1", "org2"],
+              groups: [] as string[],
+            } as IChannel,
+            currentUsername: "currentUser",
+          },
+          searchOptions
+        );
+        expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+        expect(hubSearchSpy).toHaveBeenCalledWith(
+          {
+            targetEntity: "communityUser",
+            filters: [
+              {
+                operation: "OR",
+                predicates: [
+                  { username: "user1" },
+                  { fullname: "user1" },
+                  { username: "user2" },
+                  { fullname: "user2" },
+                ],
+              },
+              {
+                operation: "OR",
+                predicates: [{ orgid: ["org1", "org2"] }, null],
+              },
+              {
+                operation: "AND",
+                predicates: [{ username: { not: "currentUser" } }],
+              },
+            ],
+          },
+          searchOptions
+        );
+        expect(res).toEqual(results);
+      });
+      it("should search for users for an org channel with groups", async () => {
+        const res = await searchChannelUsers(
+          {
+            users: ["user1", "user2"],
+            channel: {
+              access: SharingAccess.ORG,
+              orgs: ["org1", "org2"],
+              groups: ["group1", "group2"],
+            } as IChannel,
+            currentUsername: "currentUser",
+          },
+          searchOptions
+        );
+        expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+        expect(hubSearchSpy).toHaveBeenCalledWith(
+          {
+            targetEntity: "communityUser",
+            filters: [
+              {
+                operation: "OR",
+                predicates: [
+                  { username: "user1" },
+                  { fullname: "user1" },
+                  { username: "user2" },
+                  { fullname: "user2" },
+                ],
+              },
+              {
+                operation: "OR",
+                predicates: [
+                  { orgid: ["org1", "org2"] },
+                  { group: ["group1", "group2"] },
+                ],
+              },
+              {
+                operation: "AND",
+                predicates: [{ username: { not: "currentUser" } }],
+              },
+            ],
+          },
+          searchOptions
+        );
+        expect(res).toEqual(results);
+      });
+      it("should search for users for an public channel", async () => {
+        const res = await searchChannelUsers(
+          {
+            users: ["user1", "user2"],
+            channel: {
+              access: SharingAccess.PUBLIC,
+              orgs: ["org1", "org2"],
+              groups: [] as string[],
+            } as IChannel,
+            currentUsername: "currentUser",
+          },
+          searchOptions
+        );
+        expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+        expect(hubSearchSpy).toHaveBeenCalledWith(
+          {
+            targetEntity: "communityUser",
+            filters: [
+              {
+                operation: "OR",
+                predicates: [
+                  { username: "user1" },
+                  { fullname: "user1" },
+                  { username: "user2" },
+                  { fullname: "user2" },
+                ],
+              },
+              {
+                operation: "OR",
+                predicates: [{ orgid: { from: "0", to: "{" } }],
+              },
+              {
+                operation: "AND",
+                predicates: [{ username: { not: "currentUser" } }],
+              },
+            ],
+          },
+          searchOptions
+        );
+        expect(res).toEqual(results);
+      });
+      it("should search for users and not filter out the authenticated user", async () => {
+        const res = await searchChannelUsers(
+          {
+            users: ["user1", "user2"],
+            channel: {
+              access: SharingAccess.PUBLIC,
+              orgs: ["org1", "org2"],
+              groups: ["group1", "group2"],
+            } as IChannel,
+          },
+          searchOptions
+        );
+        expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+        expect(hubSearchSpy).toHaveBeenCalledWith(
+          {
+            targetEntity: "communityUser",
+            filters: [
+              {
+                operation: "OR",
+                predicates: [
+                  { username: "user1" },
+                  { fullname: "user1" },
+                  { username: "user2" },
+                  { fullname: "user2" },
+                ],
+              },
+              {
+                operation: "OR",
+                predicates: [{ orgid: { from: "0", to: "{" } }],
+              },
+            ],
+          },
+          searchOptions
+        );
+        expect(res).toEqual(results);
+      });
     });
-    it("should search for users for an org-only channel", async () => {
-      const res = await searchChannelUsers(
-        {
-          users: ["user1", "user2"],
-          access: SharingAccess.ORG,
-          orgs: ["org1", "org2"],
-          groups: [],
-          currentUsername: "currentUser",
-        },
-        searchOptions
-      );
-      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
-      expect(hubSearchSpy).toHaveBeenCalledWith(
-        {
-          targetEntity: "communityUser",
-          filters: [
-            {
-              operation: "OR",
-              predicates: [
-                { username: "user1" },
-                { fullname: "user1" },
-                { username: "user2" },
-                { fullname: "user2" },
+    describe("acl", () => {
+      it("should search for users for a private channel", async () => {
+        const res = await searchChannelUsers(
+          {
+            users: ["user1", "user2"],
+            channel: {
+              channelAcl: [
+                {
+                  category: AclCategory.GROUP,
+                  subCategory: AclSubCategory.MEMBER,
+                  key: "group1",
+                },
+                {
+                  category: AclCategory.GROUP,
+                  subCategory: AclSubCategory.MEMBER,
+                  key: "group2",
+                },
               ],
-            },
-            {
-              operation: "OR",
-              predicates: [{ orgid: ["org1", "org2"] }, null],
-            },
-            {
-              operation: "AND",
-              predicates: [{ username: { not: "currentUser" } }],
-            },
-          ],
-        },
-        searchOptions
-      );
-      expect(res).toEqual(results);
-    });
-    it("should search for users for an org channel with groups", async () => {
-      const res = await searchChannelUsers(
-        {
-          users: ["user1", "user2"],
-          access: SharingAccess.ORG,
-          orgs: ["org1", "org2"],
-          groups: ["group1", "group2"],
-          currentUsername: "currentUser",
-        },
-        searchOptions
-      );
-      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
-      expect(hubSearchSpy).toHaveBeenCalledWith(
-        {
-          targetEntity: "communityUser",
-          filters: [
-            {
-              operation: "OR",
-              predicates: [
-                { username: "user1" },
-                { fullname: "user1" },
-                { username: "user2" },
-                { fullname: "user2" },
+            } as IChannel,
+            currentUsername: "currentUser",
+          },
+          searchOptions
+        );
+        expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+        expect(hubSearchSpy).toHaveBeenCalledWith(
+          {
+            targetEntity: "communityUser",
+            filters: [
+              {
+                operation: "OR",
+                predicates: [
+                  { username: "user1" },
+                  { fullname: "user1" },
+                  { username: "user2" },
+                  { fullname: "user2" },
+                ],
+              },
+              {
+                operation: "AND",
+                predicates: [{ group: ["group1", "group2"] }],
+              },
+              {
+                operation: "AND",
+                predicates: [{ username: { not: "currentUser" } }],
+              },
+            ],
+          },
+          searchOptions
+        );
+        expect(res).toEqual(results);
+      });
+      it("should search for users for an org-only channel", async () => {
+        const res = await searchChannelUsers(
+          {
+            users: ["user1", "user2"],
+            channel: {
+              channelAcl: [
+                {
+                  category: AclCategory.ORG,
+                  subCategory: AclSubCategory.MEMBER,
+                  key: "org1",
+                },
+                {
+                  category: AclCategory.ORG,
+                  subCategory: AclSubCategory.MEMBER,
+                  key: "org2",
+                },
               ],
-            },
-            {
-              operation: "OR",
-              predicates: [
-                { orgid: ["org1", "org2"] },
-                { group: ["group1", "group2"] },
+            } as IChannel,
+            currentUsername: "currentUser",
+          },
+          searchOptions
+        );
+        expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+        expect(hubSearchSpy).toHaveBeenCalledWith(
+          {
+            targetEntity: "communityUser",
+            filters: [
+              {
+                operation: "OR",
+                predicates: [
+                  { username: "user1" },
+                  { fullname: "user1" },
+                  { username: "user2" },
+                  { fullname: "user2" },
+                ],
+              },
+              {
+                operation: "OR",
+                predicates: [{ orgid: ["org1", "org2"] }, null],
+              },
+              {
+                operation: "AND",
+                predicates: [{ username: { not: "currentUser" } }],
+              },
+            ],
+          },
+          searchOptions
+        );
+        expect(res).toEqual(results);
+      });
+      it("should search for users for an org channel with groups", async () => {
+        const res = await searchChannelUsers(
+          {
+            users: ["user1", "user2"],
+            channel: {
+              channelAcl: [
+                {
+                  category: AclCategory.ORG,
+                  subCategory: AclSubCategory.MEMBER,
+                  key: "org1",
+                },
+                {
+                  category: AclCategory.ORG,
+                  subCategory: AclSubCategory.MEMBER,
+                  key: "org2",
+                },
+                {
+                  category: AclCategory.GROUP,
+                  subCategory: AclSubCategory.MEMBER,
+                  key: "group1",
+                },
+                {
+                  category: AclCategory.GROUP,
+                  subCategory: AclSubCategory.MEMBER,
+                  key: "group2",
+                },
               ],
-            },
-            {
-              operation: "AND",
-              predicates: [{ username: { not: "currentUser" } }],
-            },
-          ],
-        },
-        searchOptions
-      );
-      expect(res).toEqual(results);
-    });
-    it("should search for users for an public-only channel", async () => {
-      const res = await searchChannelUsers(
-        {
-          users: ["user1", "user2"],
-          access: SharingAccess.PUBLIC,
-          orgs: ["org1", "org2"],
-          groups: [],
-          currentUsername: "currentUser",
-        },
-        searchOptions
-      );
-      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
-      expect(hubSearchSpy).toHaveBeenCalledWith(
-        {
-          targetEntity: "communityUser",
-          filters: [
-            {
-              operation: "OR",
-              predicates: [
-                { username: "user1" },
-                { fullname: "user1" },
-                { username: "user2" },
-                { fullname: "user2" },
-              ],
-            },
-            {
-              operation: "OR",
-              predicates: [{ orgid: { from: "0", to: "{" } }, null],
-            },
-            {
-              operation: "AND",
-              predicates: [{ username: { not: "currentUser" } }],
-            },
-          ],
-        },
-        searchOptions
-      );
-      expect(res).toEqual(results);
-    });
-    it("should search for users for an public channel with groups", async () => {
-      const res = await searchChannelUsers(
-        {
-          users: ["user1", "user2"],
-          access: SharingAccess.PUBLIC,
-          orgs: ["org1", "org2"],
-          groups: ["group1", "group2"],
-          currentUsername: "currentUser",
-        },
-        searchOptions
-      );
-      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
-      expect(hubSearchSpy).toHaveBeenCalledWith(
-        {
-          targetEntity: "communityUser",
-          filters: [
-            {
-              operation: "OR",
-              predicates: [
-                { username: "user1" },
-                { fullname: "user1" },
-                { username: "user2" },
-                { fullname: "user2" },
-              ],
-            },
-            {
-              operation: "OR",
-              predicates: [
-                { orgid: { from: "0", to: "{" } },
-                { group: ["group1", "group2"] },
-              ],
-            },
-            {
-              operation: "AND",
-              predicates: [{ username: { not: "currentUser" } }],
-            },
-          ],
-        },
-        searchOptions
-      );
-      expect(res).toEqual(results);
-    });
-    it("should search for users and not filter out the authenticated user", async () => {
-      const res = await searchChannelUsers(
-        {
-          users: ["user1", "user2"],
-          access: SharingAccess.PUBLIC,
-          orgs: ["org1", "org2"],
-          groups: ["group1", "group2"],
-        },
-        searchOptions
-      );
-      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
-      expect(hubSearchSpy).toHaveBeenCalledWith(
-        {
-          targetEntity: "communityUser",
-          filters: [
-            {
-              operation: "OR",
-              predicates: [
-                { username: "user1" },
-                { fullname: "user1" },
-                { username: "user2" },
-                { fullname: "user2" },
-              ],
-            },
-            {
-              operation: "OR",
-              predicates: [
-                { orgid: { from: "0", to: "{" } },
-                { group: ["group1", "group2"] },
-              ],
-            },
-          ],
-        },
-        searchOptions
-      );
-      expect(res).toEqual(results);
+            } as IChannel,
+            currentUsername: "currentUser",
+          },
+          searchOptions
+        );
+        expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+        expect(hubSearchSpy).toHaveBeenCalledWith(
+          {
+            targetEntity: "communityUser",
+            filters: [
+              {
+                operation: "OR",
+                predicates: [
+                  { username: "user1" },
+                  { fullname: "user1" },
+                  { username: "user2" },
+                  { fullname: "user2" },
+                ],
+              },
+              {
+                operation: "OR",
+                predicates: [
+                  { orgid: ["org1", "org2"] },
+                  { group: ["group1", "group2"] },
+                ],
+              },
+              {
+                operation: "AND",
+                predicates: [{ username: { not: "currentUser" } }],
+              },
+            ],
+          },
+          searchOptions
+        );
+        expect(res).toEqual(results);
+      });
+      it("should search for users for an public channel", async () => {
+        const res = await searchChannelUsers(
+          {
+            users: ["user1", "user2"],
+            channel: {
+              channelAcl: [{ category: AclCategory.AUTHENTICATED_USER }],
+            } as IChannel,
+            currentUsername: "currentUser",
+          },
+          searchOptions
+        );
+        expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+        expect(hubSearchSpy).toHaveBeenCalledWith(
+          {
+            targetEntity: "communityUser",
+            filters: [
+              {
+                operation: "OR",
+                predicates: [
+                  { username: "user1" },
+                  { fullname: "user1" },
+                  { username: "user2" },
+                  { fullname: "user2" },
+                ],
+              },
+              {
+                operation: "OR",
+                predicates: [{ orgid: { from: "0", to: "{" } }],
+              },
+              {
+                operation: "AND",
+                predicates: [{ username: { not: "currentUser" } }],
+              },
+            ],
+          },
+          searchOptions
+        );
+        expect(res).toEqual(results);
+      });
+      it("should search for users and not filter out the authenticated user", async () => {
+        const res = await searchChannelUsers(
+          {
+            users: ["user1", "user2"],
+            channel: {
+              channelAcl: [{ category: AclCategory.AUTHENTICATED_USER }],
+            } as IChannel,
+          },
+          searchOptions
+        );
+        expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+        expect(hubSearchSpy).toHaveBeenCalledWith(
+          {
+            targetEntity: "communityUser",
+            filters: [
+              {
+                operation: "OR",
+                predicates: [
+                  { username: "user1" },
+                  { fullname: "user1" },
+                  { username: "user2" },
+                  { fullname: "user2" },
+                ],
+              },
+              {
+                operation: "OR",
+                predicates: [{ orgid: { from: "0", to: "{" } }],
+              },
+            ],
+          },
+          searchOptions
+        );
+        expect(res).toEqual(results);
+      });
     });
   });
 });

--- a/packages/common/test/discussions/utils.test.ts
+++ b/packages/common/test/discussions/utils.test.ts
@@ -2,7 +2,11 @@ import {
   CANNOT_DISCUSS,
   isDiscussable,
   setDiscussableKeyword,
+  searchChannelUsers,
+  SharingAccess,
+  IHubRequestOptions,
 } from "../../src";
+import * as hubSearchModule from "../../src/search";
 
 describe("discussions utils", () => {
   describe("isDiscussable", () => {
@@ -34,6 +38,272 @@ describe("discussions utils", () => {
     it("returns array with CANNOT_DISCUSS when isDiscussable is false", () => {
       const result = setDiscussableKeyword([], false);
       expect(result).toEqual([CANNOT_DISCUSS]);
+    });
+  });
+  describe("searchChannelUsers", () => {
+    const results: hubSearchModule.IHubSearchResponse<hubSearchModule.IHubSearchResult> =
+      {
+        total: 0,
+        results: [],
+        hasNext: false,
+        next: () => Promise.resolve(results),
+      };
+    const searchOptions: hubSearchModule.IHubSearchOptions = {
+      num: 10,
+      start: 1,
+      sortField: "fullName",
+      sortOrder: "desc",
+      requestOptions: { isPortal: false },
+    };
+    let hubSearchSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      hubSearchSpy = spyOn(hubSearchModule, "hubSearch").and.returnValue(
+        Promise.resolve(results)
+      );
+    });
+
+    afterEach(() => {
+      hubSearchSpy.calls.reset();
+    });
+
+    it("should search for users for a private channel", async () => {
+      const res = await searchChannelUsers(
+        {
+          users: ["user1", "user2"],
+          access: SharingAccess.PRIVATE,
+          orgs: ["org1", "org2"],
+          groups: ["group1", "group2"],
+          currentUsername: "currentUser",
+        },
+        searchOptions
+      );
+      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+      expect(hubSearchSpy).toHaveBeenCalledWith(
+        {
+          targetEntity: "communityUser",
+          filters: [
+            {
+              operation: "OR",
+              predicates: [
+                { username: "user1" },
+                { fullname: "user1" },
+                { username: "user2" },
+                { fullname: "user2" },
+              ],
+            },
+            {
+              operation: "AND",
+              predicates: [{ group: ["group1", "group2"] }],
+            },
+            {
+              operation: "AND",
+              predicates: [{ username: { not: "currentUser" } }],
+            },
+          ],
+        },
+        searchOptions
+      );
+      expect(res).toEqual(results);
+    });
+    it("should search for users for an org-only channel", async () => {
+      const res = await searchChannelUsers(
+        {
+          users: ["user1", "user2"],
+          access: SharingAccess.ORG,
+          orgs: ["org1", "org2"],
+          groups: [],
+          currentUsername: "currentUser",
+        },
+        searchOptions
+      );
+      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+      expect(hubSearchSpy).toHaveBeenCalledWith(
+        {
+          targetEntity: "communityUser",
+          filters: [
+            {
+              operation: "OR",
+              predicates: [
+                { username: "user1" },
+                { fullname: "user1" },
+                { username: "user2" },
+                { fullname: "user2" },
+              ],
+            },
+            {
+              operation: "OR",
+              predicates: [{ orgid: ["org1", "org2"] }, null],
+            },
+            {
+              operation: "AND",
+              predicates: [{ username: { not: "currentUser" } }],
+            },
+          ],
+        },
+        searchOptions
+      );
+      expect(res).toEqual(results);
+    });
+    it("should search for users for an org channel with groups", async () => {
+      const res = await searchChannelUsers(
+        {
+          users: ["user1", "user2"],
+          access: SharingAccess.ORG,
+          orgs: ["org1", "org2"],
+          groups: ["group1", "group2"],
+          currentUsername: "currentUser",
+        },
+        searchOptions
+      );
+      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+      expect(hubSearchSpy).toHaveBeenCalledWith(
+        {
+          targetEntity: "communityUser",
+          filters: [
+            {
+              operation: "OR",
+              predicates: [
+                { username: "user1" },
+                { fullname: "user1" },
+                { username: "user2" },
+                { fullname: "user2" },
+              ],
+            },
+            {
+              operation: "OR",
+              predicates: [
+                { orgid: ["org1", "org2"] },
+                { group: ["group1", "group2"] },
+              ],
+            },
+            {
+              operation: "AND",
+              predicates: [{ username: { not: "currentUser" } }],
+            },
+          ],
+        },
+        searchOptions
+      );
+      expect(res).toEqual(results);
+    });
+    it("should search for users for an public-only channel", async () => {
+      const res = await searchChannelUsers(
+        {
+          users: ["user1", "user2"],
+          access: SharingAccess.PUBLIC,
+          orgs: ["org1", "org2"],
+          groups: [],
+          currentUsername: "currentUser",
+        },
+        searchOptions
+      );
+      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+      expect(hubSearchSpy).toHaveBeenCalledWith(
+        {
+          targetEntity: "communityUser",
+          filters: [
+            {
+              operation: "OR",
+              predicates: [
+                { username: "user1" },
+                { fullname: "user1" },
+                { username: "user2" },
+                { fullname: "user2" },
+              ],
+            },
+            {
+              operation: "OR",
+              predicates: [{ orgid: { from: "0", to: "{" } }, null],
+            },
+            {
+              operation: "AND",
+              predicates: [{ username: { not: "currentUser" } }],
+            },
+          ],
+        },
+        searchOptions
+      );
+      expect(res).toEqual(results);
+    });
+    it("should search for users for an public channel with groups", async () => {
+      const res = await searchChannelUsers(
+        {
+          users: ["user1", "user2"],
+          access: SharingAccess.PUBLIC,
+          orgs: ["org1", "org2"],
+          groups: ["group1", "group2"],
+          currentUsername: "currentUser",
+        },
+        searchOptions
+      );
+      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+      expect(hubSearchSpy).toHaveBeenCalledWith(
+        {
+          targetEntity: "communityUser",
+          filters: [
+            {
+              operation: "OR",
+              predicates: [
+                { username: "user1" },
+                { fullname: "user1" },
+                { username: "user2" },
+                { fullname: "user2" },
+              ],
+            },
+            {
+              operation: "OR",
+              predicates: [
+                { orgid: { from: "0", to: "{" } },
+                { group: ["group1", "group2"] },
+              ],
+            },
+            {
+              operation: "AND",
+              predicates: [{ username: { not: "currentUser" } }],
+            },
+          ],
+        },
+        searchOptions
+      );
+      expect(res).toEqual(results);
+    });
+    it("should search for users and not filter out the authenticated user", async () => {
+      const res = await searchChannelUsers(
+        {
+          users: ["user1", "user2"],
+          access: SharingAccess.PUBLIC,
+          orgs: ["org1", "org2"],
+          groups: ["group1", "group2"],
+        },
+        searchOptions
+      );
+      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+      expect(hubSearchSpy).toHaveBeenCalledWith(
+        {
+          targetEntity: "communityUser",
+          filters: [
+            {
+              operation: "OR",
+              predicates: [
+                { username: "user1" },
+                { fullname: "user1" },
+                { username: "user2" },
+                { fullname: "user2" },
+              ],
+            },
+            {
+              operation: "OR",
+              predicates: [
+                { orgid: { from: "0", to: "{" } },
+                { group: ["group1", "group2"] },
+              ],
+            },
+          ],
+        },
+        searchOptions
+      );
+      expect(res).toEqual(results);
     });
   });
 });

--- a/packages/common/test/discussions/utils.test.ts
+++ b/packages/common/test/discussions/utils.test.ts
@@ -125,7 +125,9 @@ describe("discussions utils", () => {
     it("should return false for acl", () => {
       expect(
         isPrivateChannel({
-          channelAcl: [{ category: AclCategory.ORG }],
+          channelAcl: [
+            { category: AclCategory.ORG, subCategory: AclSubCategory.MEMBER },
+          ],
         } as IChannel)
       ).toBe(false);
     });

--- a/packages/common/test/discussions/utils.test.ts
+++ b/packages/common/test/discussions/utils.test.ts
@@ -4,7 +4,6 @@ import {
   setDiscussableKeyword,
   searchChannelUsers,
   SharingAccess,
-  IHubRequestOptions,
   isPublicChannel,
   isOrgChannel,
   isPrivateChannel,
@@ -89,14 +88,18 @@ describe("discussions utils", () => {
     it("should return true for acl", () => {
       expect(
         isOrgChannel({
-          channelAcl: [{ category: AclCategory.ORG }],
+          channelAcl: [
+            { category: AclCategory.ORG, subCategory: AclSubCategory.MEMBER },
+          ],
         } as IChannel)
       ).toBe(true);
     });
     it("should return false for acl", () => {
       expect(
         isOrgChannel({
-          channelAcl: [{ category: AclCategory.GROUP }],
+          channelAcl: [
+            { category: AclCategory.GROUP, subCategory: AclSubCategory.MEMBER },
+          ],
         } as IChannel)
       ).toBe(false);
     });
@@ -148,7 +151,9 @@ describe("discussions utils", () => {
     it("should return org for acl", () => {
       expect(
         getChannelAccess({
-          channelAcl: [{ category: AclCategory.ORG }],
+          channelAcl: [
+            { category: AclCategory.ORG, subCategory: AclSubCategory.MEMBER },
+          ],
         } as IChannel)
       ).toBe(SharingAccess.ORG);
     });

--- a/packages/common/test/search/_internal/portalSearchUsers.test.ts
+++ b/packages/common/test/search/_internal/portalSearchUsers.test.ts
@@ -1,16 +1,16 @@
 import { cloneObject, IHubSearchOptions, IQuery } from "../../../src";
 import {
-  portalSearchUsers,
-  communitySearchUsers,
-  portalSearchUsersLegacy,
+  searchPortalUsers,
+  searchCommunityUsers,
+  searchPortalUsersLegacy,
 } from "../../../src/search/_internal/portalSearchUsers";
 import * as Portal from "@esri/arcgis-rest-portal";
 import * as users from "../../../src/users";
 import { MOCK_AUTH } from "../../mocks/mock-auth";
 import * as SimpleResponse from "../../mocks/user-search/simple-response.json";
 
-describe("portalSearchUsersLegacy module:", () => {
-  describe("portalSearchUsersLegacy:", () => {
+describe("searchPortalUsersLegacy module:", () => {
+  describe("searchPortalUsersLegacy:", () => {
     it("throws if requestOptions not passed in IHubSearchOptions", async () => {
       const qry: IQuery = {
         targetEntity: "user",
@@ -27,7 +27,7 @@ describe("portalSearchUsersLegacy module:", () => {
       const opts: IHubSearchOptions = {};
 
       try {
-        await portalSearchUsersLegacy(qry, opts);
+        await searchPortalUsersLegacy(qry, opts);
       } catch (err) {
         expect(err.name).toBe("HubError");
         expect(err.message).toBe(
@@ -55,7 +55,7 @@ describe("portalSearchUsersLegacy module:", () => {
       };
 
       try {
-        await portalSearchUsersLegacy(qry, opts);
+        await searchPortalUsersLegacy(qry, opts);
       } catch (err) {
         expect(err.name).toBe("HubError");
         expect(err.message).toBe("requestOptions must pass authentication.");
@@ -89,7 +89,7 @@ describe("portalSearchUsersLegacy module:", () => {
         },
       };
 
-      await portalSearchUsersLegacy(qry, opts);
+      await searchPortalUsersLegacy(qry, opts);
 
       expect(searchUsersSpy.calls.count()).toBe(1, "should call searchItems");
       const [expectedParams] = searchUsersSpy.calls.argsFor(0);
@@ -105,7 +105,7 @@ describe("portalSearchUsersLegacy module:", () => {
       );
     });
   });
-  describe("portalSearchUsers:", () => {
+  describe("searchPortalUsers:", () => {
     it("throws if requestOptions not passed in IHubSearchOptions", async () => {
       const qry: IQuery = {
         targetEntity: "user",
@@ -122,7 +122,7 @@ describe("portalSearchUsersLegacy module:", () => {
       const opts: IHubSearchOptions = {};
 
       try {
-        await portalSearchUsers(qry, opts);
+        await searchPortalUsers(qry, opts);
       } catch (err) {
         expect(err.name).toBe("HubError");
         expect(err.message).toBe(
@@ -150,7 +150,7 @@ describe("portalSearchUsersLegacy module:", () => {
       };
 
       try {
-        await portalSearchUsers(qry, opts);
+        await searchPortalUsers(qry, opts);
       } catch (err) {
         expect(err.name).toBe("HubError");
         expect(err.message).toBe("requestOptions must pass authentication.");
@@ -184,7 +184,7 @@ describe("portalSearchUsersLegacy module:", () => {
         },
       };
 
-      await portalSearchUsers(qry, opts);
+      await searchPortalUsers(qry, opts);
 
       expect(searchUsersSpy.calls.count()).toBe(1, "should call searchItems");
       const [expectedParams] = searchUsersSpy.calls.argsFor(0);
@@ -200,7 +200,7 @@ describe("portalSearchUsersLegacy module:", () => {
       );
     });
   });
-  describe("communitySearchUsers:", () => {
+  describe("searchCommunityUsers:", () => {
     it("throws if requestOptions not passed in IHubSearchOptions", async () => {
       const qry: IQuery = {
         targetEntity: "user",
@@ -217,7 +217,7 @@ describe("portalSearchUsersLegacy module:", () => {
       const opts: IHubSearchOptions = {};
 
       try {
-        await communitySearchUsers(qry, opts);
+        await searchCommunityUsers(qry, opts);
       } catch (err) {
         expect(err.name).toBe("HubError");
         expect(err.message).toBe(
@@ -245,7 +245,7 @@ describe("portalSearchUsersLegacy module:", () => {
       };
 
       try {
-        await communitySearchUsers(qry, opts);
+        await searchCommunityUsers(qry, opts);
       } catch (err) {
         expect(err.name).toBe("HubError");
         expect(err.message).toBe("requestOptions must pass authentication.");
@@ -282,7 +282,7 @@ describe("portalSearchUsersLegacy module:", () => {
         },
       };
 
-      await communitySearchUsers(qry, opts);
+      await searchCommunityUsers(qry, opts);
 
       expect(searchCommunityUsersSpy.calls.count()).toBe(
         1,

--- a/packages/common/test/search/_internal/portalSearchUsers.test.ts
+++ b/packages/common/test/search/_internal/portalSearchUsers.test.ts
@@ -1,11 +1,110 @@
 import { cloneObject, IHubSearchOptions, IQuery } from "../../../src";
-import { portalSearchUsers } from "../../../src/search/_internal/portalSearchUsers";
+import {
+  portalSearchUsers,
+  communitySearchUsers,
+  portalSearchUsersLegacy,
+} from "../../../src/search/_internal/portalSearchUsers";
 import * as Portal from "@esri/arcgis-rest-portal";
 import * as users from "../../../src/users";
 import { MOCK_AUTH } from "../../mocks/mock-auth";
 import * as SimpleResponse from "../../mocks/user-search/simple-response.json";
 
-describe("portalSearchUsers module:", () => {
+describe("portalSearchUsersLegacy module:", () => {
+  describe("portalSearchUsersLegacy:", () => {
+    it("throws if requestOptions not passed in IHubSearchOptions", async () => {
+      const qry: IQuery = {
+        targetEntity: "user",
+        filters: [
+          {
+            predicates: [
+              {
+                term: "water",
+              },
+            ],
+          },
+        ],
+      };
+      const opts: IHubSearchOptions = {};
+
+      try {
+        await portalSearchUsersLegacy(qry, opts);
+      } catch (err) {
+        expect(err.name).toBe("HubError");
+        expect(err.message).toBe(
+          "requestOptions: IHubRequestOptions is required."
+        );
+      }
+    });
+    it("throws if requestOptions.auth not passed in IHubSearchOptions", async () => {
+      const qry: IQuery = {
+        targetEntity: "user",
+        filters: [
+          {
+            predicates: [
+              {
+                term: "water",
+              },
+            ],
+          },
+        ],
+      };
+      const opts: IHubSearchOptions = {
+        requestOptions: {
+          portal: "https://myserver.com/sharing/rest",
+        },
+      };
+
+      try {
+        await portalSearchUsersLegacy(qry, opts);
+      } catch (err) {
+        expect(err.name).toBe("HubError");
+        expect(err.message).toBe("requestOptions must pass authentication.");
+      }
+    });
+    it("simple search", async () => {
+      const searchUsersSpy = spyOn(Portal, "searchUsers").and.callFake(() => {
+        return Promise.resolve(cloneObject(SimpleResponse));
+      });
+      // NOTE: enrichUserSearchResult is tested elsewhere so we don't assert on the results here
+      const enrichUserSearchResultSpy = spyOn(
+        users,
+        "enrichUserSearchResult"
+      ).and.callFake(() => Promise.resolve({}));
+      const qry: IQuery = {
+        targetEntity: "user",
+        filters: [
+          {
+            predicates: [
+              {
+                firstname: "Jane",
+              },
+            ],
+          },
+        ],
+      };
+      const opts: IHubSearchOptions = {
+        requestOptions: {
+          portal: "https://www.arcgis.com/sharing/rest",
+          authentication: MOCK_AUTH,
+        },
+      };
+
+      await portalSearchUsersLegacy(qry, opts);
+
+      expect(searchUsersSpy.calls.count()).toBe(1, "should call searchItems");
+      const [expectedParams] = searchUsersSpy.calls.argsFor(0);
+      expect(expectedParams.portal).toBeUndefined();
+      expect(expectedParams.q).toEqual(`(firstname:"Jane")`);
+      expect(expectedParams.authentication).toEqual(
+        opts.requestOptions?.authentication
+      );
+      expect(expectedParams.countFields).not.toBeDefined();
+      expect(enrichUserSearchResultSpy.calls.count()).toBe(
+        10,
+        "should call enrichUserSearchResult for each result"
+      );
+    });
+  });
   describe("portalSearchUsers:", () => {
     it("throws if requestOptions not passed in IHubSearchOptions", async () => {
       const qry: IQuery = {
@@ -89,6 +188,107 @@ describe("portalSearchUsers module:", () => {
 
       expect(searchUsersSpy.calls.count()).toBe(1, "should call searchItems");
       const [expectedParams] = searchUsersSpy.calls.argsFor(0);
+      expect(expectedParams.portal).toBeUndefined();
+      expect(expectedParams.q).toEqual(`(firstname:"Jane")`);
+      expect(expectedParams.authentication).toEqual(
+        opts.requestOptions?.authentication
+      );
+      expect(expectedParams.countFields).not.toBeDefined();
+      expect(enrichUserSearchResultSpy.calls.count()).toBe(
+        10,
+        "should call enrichUserSearchResult for each result"
+      );
+    });
+  });
+  describe("communitySearchUsers:", () => {
+    it("throws if requestOptions not passed in IHubSearchOptions", async () => {
+      const qry: IQuery = {
+        targetEntity: "user",
+        filters: [
+          {
+            predicates: [
+              {
+                term: "water",
+              },
+            ],
+          },
+        ],
+      };
+      const opts: IHubSearchOptions = {};
+
+      try {
+        await communitySearchUsers(qry, opts);
+      } catch (err) {
+        expect(err.name).toBe("HubError");
+        expect(err.message).toBe(
+          "requestOptions: IHubRequestOptions is required."
+        );
+      }
+    });
+    it("throws if requestOptions.auth not passed in IHubSearchOptions", async () => {
+      const qry: IQuery = {
+        targetEntity: "user",
+        filters: [
+          {
+            predicates: [
+              {
+                term: "water",
+              },
+            ],
+          },
+        ],
+      };
+      const opts: IHubSearchOptions = {
+        requestOptions: {
+          portal: "https://myserver.com/sharing/rest",
+        },
+      };
+
+      try {
+        await communitySearchUsers(qry, opts);
+      } catch (err) {
+        expect(err.name).toBe("HubError");
+        expect(err.message).toBe("requestOptions must pass authentication.");
+      }
+    });
+    it("simple search", async () => {
+      const searchCommunityUsersSpy = spyOn(
+        Portal,
+        "searchCommunityUsers"
+      ).and.callFake(() => {
+        return Promise.resolve(cloneObject(SimpleResponse));
+      });
+      // NOTE: enrichUserSearchResult is tested elsewhere so we don't assert on the results here
+      const enrichUserSearchResultSpy = spyOn(
+        users,
+        "enrichUserSearchResult"
+      ).and.callFake(() => Promise.resolve({}));
+      const qry: IQuery = {
+        targetEntity: "user",
+        filters: [
+          {
+            predicates: [
+              {
+                firstname: "Jane",
+              },
+            ],
+          },
+        ],
+      };
+      const opts: IHubSearchOptions = {
+        requestOptions: {
+          portal: "https://www.arcgis.com/sharing/rest",
+          authentication: MOCK_AUTH,
+        },
+      };
+
+      await communitySearchUsers(qry, opts);
+
+      expect(searchCommunityUsersSpy.calls.count()).toBe(
+        1,
+        "should call searchItems"
+      );
+      const [expectedParams] = searchCommunityUsersSpy.calls.argsFor(0);
       expect(expectedParams.portal).toBeUndefined();
       expect(expectedParams.q).toEqual(`(firstname:"Jane")`);
       expect(expectedParams.authentication).toEqual(

--- a/packages/common/test/search/serializeQueryForPortal.test.ts
+++ b/packages/common/test/search/serializeQueryForPortal.test.ts
@@ -30,6 +30,27 @@ describe("ifilter-utils:", () => {
         '(water AND modified:[1689716790912 TO 1652808629198] AND (type:"Web Map" OR type:"Hub Project"))'
       );
     });
+    it("handles non-date ranges", () => {
+      const p: IPredicate = {
+        // orgid: "[0 TO {]",
+        orgid: { from: "0", to: "{" },
+        type: "Web Map",
+      };
+
+      const query: IQuery = {
+        targetEntity: "item",
+        filters: [
+          {
+            operation: "AND",
+            predicates: [p],
+          },
+        ],
+      };
+
+      const chk = serializeQueryForPortal(query);
+
+      expect(chk.q).toEqual('(orgid:[0 TO {] AND type:"Web Map")');
+    });
     it("handles categories", () => {
       const p: IPredicate = {
         term: "water",

--- a/packages/common/test/users/HubUsers.test.ts
+++ b/packages/common/test/users/HubUsers.test.ts
@@ -68,9 +68,39 @@ describe("HubUsers Module:", () => {
         hubRo
       );
       expect(enrichmentSpy.calls.count()).toBe(
-        1,
-        "should fetch default enrichment"
+        0,
+        "should not fetch enrichments"
       );
+
+      const USR = cloneObject(TEST_USER);
+      expect(chk.access).toEqual(USR.access);
+      expect(chk.id).toEqual(USR.username);
+      expect(chk.type).toEqual("User");
+      expect(chk.name).toEqual(USR.fullName);
+      expect(chk.owner).toEqual(USR.username);
+      expect(chk.summary).toEqual(USR.description);
+      expect(chk.createdDate).toEqual(new Date(USR.created));
+      expect(chk.createdDateSource).toEqual("user.created");
+      expect(chk.updatedDate).toEqual(new Date(USR.modified));
+      expect(chk.updatedDateSource).toEqual("user.modified");
+      expect(chk.family).toEqual("people");
+
+      expect(chk.links.self).toEqual(
+        `https://some-server.com/gis/home/user.html?user=${USR.username}`
+      );
+      expect(chk.links.siteRelative).toEqual(`/people/${USR.username}`);
+      expect(chk.links.thumbnail).toEqual(
+        `${hubRo.portal}/community/users/${USR.username}/info/${USR.thumbnail}?token=fake-token`
+      );
+    });
+
+    it("converts user to search result and fetches enrichments", async () => {
+      const chk = await enrichUserSearchResult(
+        cloneObject(TEST_USER),
+        ["org.name as OrgName"],
+        hubRo
+      );
+      expect(enrichmentSpy.calls.count()).toBe(1, "should fetch enrichments");
 
       const USR = cloneObject(TEST_USER);
       expect(chk.access).toEqual(USR.access);

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -14,7 +14,7 @@
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.0",
     "@esri/arcgis-rest-feature-layer": "^3.1.0",
-    "@esri/arcgis-rest-portal": "^3.5.0",
+    "@esri/arcgis-rest-portal": "^3.7.0",
     "@esri/arcgis-rest-request": "^3.1.0",
     "@esri/hub-common": "^14.0.0"
   },


### PR DESCRIPTION
…al@3.7.0, adds support for sear

affects: @esri/hub-common, @esri/hub-downloads

ISSUES CLOSED: 7720

1. Description:

* bumps `@esri/arcgis-rest-portal` to `3.7.0`
* unlocks ability to search for users outside the current user's org
* adds new `portalUser` and `communityUser` targetEntity support to `hubSearch`, which _DO NOT_ force the portal record enrichment
* renames `portalSearchUsers` => `portalSearchUsersLegacy` while preserving _existing_ `user` targetEntity behavior (still forces the portal record enrichment)
* expands support for searching for non-date related ranges, e.g. `orgid:[0 TO {]`
* adds `getChannelUsersQuery` method to build an `IQuery` to search for users within the context of specific channel configurations

1. Instructions for testing:

1. Closes Issues: #7720

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
