### PR TITLE
feat: item extent now selectable, savable, and reflects in old and new view

### DIFF
--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -74,7 +74,7 @@ export async function computeProps(
   // 2. then saved their content with the item's extent in the old view
 
   const modelBoundary = model.item.properties?.boundary;
-  const modelLocationType = model.item.properties?.location.type;
+  const modelLocationType = model.item.properties?.location?.type;
   const modelBoundaryIsItem = modelBoundary === "item";
   const forLoadedSelection =
     (modelLocationType === "org" || modelLocationType === "custom") &&

--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -13,24 +13,21 @@ import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
 import { IHubLocationType } from "../../core/types/types";
 
 // if called and valid, set 3 things -- else just return type custom
-export const getItemExtent = (itemExtent: number[][]): IExtent => {
+export const getExtentObject = (itemExtent: number[][]): IExtent => {
   return isBBox(itemExtent)
     ? ({ ...bBoxToExtent(itemExtent), type: "extent" } as unknown as IExtent)
     : undefined;
 };
 
-export function deriveLocationFromItemExtent(
-  locationType: IHubLocationType,
-  itemExtent?: number[][]
-) {
-  const location: IHubLocation = { type: locationType };
-  const geometry: any = getItemExtent(itemExtent); // TODO: this needs to be fixed -tom
+export function deriveLocationFromItemExtent(itemExtent?: number[][]) {
+  const location: IHubLocation = { type: "item" };
+  const geometry: any = getExtentObject(itemExtent); // TODO: this needs to be fixed -tom
   if (geometry) {
-    const convertedPolygon = {
+    const convertedExtent = {
       ...extentToPolygon(geometry),
-      type: "polygon",
+      type: "extent",
     } as unknown as Geometry;
-    location.geometries = [convertedPolygon];
+    location.geometries = [convertedExtent];
     location.spatialReference = geometry.spatialReference;
     location.extent = itemExtent;
   }
@@ -71,7 +68,7 @@ export function computeProps(
     content.location =
       model.item.properties?.boundary === "none"
         ? { type: "none" }
-        : deriveLocationFromItemExtent("item", model.item.extent);
+        : deriveLocationFromItemExtent(model.item.extent);
   }
 
   return content as IHubEditableContent;

--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -24,12 +24,12 @@ export const getExtentObject = (itemExtent: number[][]): IExtent => {
 };
 
 export function deriveLocationFromItemExtent(itemExtent?: number[][]) {
-  const location: IHubLocation = { type: "item" };
+  const location: IHubLocation = { type: "custom" };
   const geometry: any = getExtentObject(itemExtent); // TODO: this needs to be fixed -tom
   if (geometry) {
     const convertedExtent = {
       ...extentToPolygon(geometry),
-      type: "extent",
+      type: "polygon",
     } as unknown as Geometry;
     location.geometries = [convertedExtent];
     location.spatialReference = geometry.spatialReference;

--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -37,11 +37,11 @@ export function deriveLocationFromItemExtent(
   return location;
 }
 
-export async function computeProps(
+export function computeProps(
   model: IModel,
   content: Partial<IHubEditableContent>,
   requestOptions: IRequestOptions
-): Promise<IHubEditableContent> {
+): IHubEditableContent {
   let token: string;
   if (requestOptions.authentication) {
     const session: UserSession = requestOptions.authentication as UserSession;

--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -66,39 +66,13 @@ export function computeProps(
   // error that doesn't let us save the form
   content.licenseInfo = model.item.licenseInfo || "";
 
-  // If modelLocationType === "custom" and modelBoundaryIsItem is true
-  // BUT THE EXTENTS AS BBOX'S DO NOT MATCH
-  // use item rather than custom
-  // this is a weird edge case where someone has:
-  // 1. saved their content with a custom location in the new view
-  // 2. then saved their content with the item's extent in the old view
-
-  const modelBoundary = model.item.properties?.boundary;
-  const modelLocationType = model.item.properties?.location?.type;
-  const modelBoundaryIsItem = modelBoundary === "item";
-  const forLoadedSelection =
-    (modelLocationType === "org" || modelLocationType === "custom") &&
-    modelBoundaryIsItem
-      ? modelLocationType
-      : modelBoundary;
-
-  if (forLoadedSelection === "none") {
-    content.location = { type: "none" };
-  } else if (
-    (modelLocationType === "custom" || modelLocationType === "org") &&
-    modelBoundaryIsItem &&
-    !(model.item.extent === model.item.properties?.location.extent)
-  ) {
-    // if the two extents do not match, then that signifies it was saved
-    //   in the old view after being saved in the new
-    content.location = deriveLocationFromItemExtent("item", model.extent);
-  } else if (forLoadedSelection === "item" || forLoadedSelection === "org") {
-    content.location = deriveLocationFromItemExtent(
-      forLoadedSelection,
-      model.item.extent
-    );
+  if (!content.location) {
+    // build location if one does not exist based off of the boundary and the item's extent
+    content.location =
+      model.item.properties?.boundary === "none"
+        ? { type: "none" }
+        : deriveLocationFromItemExtent("item", model.item.extent);
   }
-  // custom has already been through the ropes and doesn't need any adjustments
 
   return content as IHubEditableContent;
 }

--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -106,11 +106,6 @@ export async function updateContent(
   // but this is where we would apply that sort of logic
   const modelToUpdate = mapper.entityToStore(content, model);
 
-  // prevent map from displaying when boundary is 'none'
-  const locationType = getProp(modelToUpdate, "item.properties.location.type");
-  modelToUpdate.item.properties.boundary =
-    locationType === "none" ? "none" : "item";
-
   // TODO: if we have resources disconnect them from the model for now.
   // if (modelToUpdate.resources) {
   //   resources = configureBaseResources(

--- a/packages/common/src/core/getTypeFromEntity.ts
+++ b/packages/common/src/core/getTypeFromEntity.ts
@@ -1,6 +1,3 @@
-// import { HubEntity } from "./types/HubEntity";
-// import { HubEntityType } from "./types/HubEntityType";
-
 import { getFamily } from "../content/get-family";
 import { ConfigurableEntity } from "./schemas/internal/ConfigurableEntity";
 import { HubEntity, IHubItemEntity, HubEntityType } from "./types";
@@ -35,9 +32,9 @@ export function getTypeFromEntity(
     case "Group":
       type = "group";
       break;
-    // case "Hub Content": // needed for future ticket in getLocationOptions
-    //   type = "content";
-    //   break;
+    case "Hub Content":
+      type = "content";
+      break;
     default:
       // TODO: other families go here? feedback? solution? template?
       const contentFamilies = ["app", "content", "dataset", "document", "map"];

--- a/packages/common/src/core/getTypeFromEntity.ts
+++ b/packages/common/src/core/getTypeFromEntity.ts
@@ -32,9 +32,6 @@ export function getTypeFromEntity(
     case "Group":
       type = "group";
       break;
-    case "Hub Content":
-      type = "content";
-      break;
     default:
       // TODO: other families go here? feedback? solution? template?
       const contentFamilies = ["app", "content", "dataset", "document", "map"];

--- a/packages/common/src/core/schemas/internal/getLocationExtent.ts
+++ b/packages/common/src/core/schemas/internal/getLocationExtent.ts
@@ -1,4 +1,4 @@
-import { bBoxToExtent, getGeographicOrgExtent } from "../../../extent";
+import { bBoxToExtent, orgExtent } from "../../../extent";
 import { IHubRequestOptions } from "../../../types";
 import { ConfigurableEntity } from "./ConfigurableEntity";
 /**
@@ -11,5 +11,5 @@ export async function getLocationExtent(
 ) {
   return entity.location?.extent?.length
     ? bBoxToExtent(entity.location.extent)
-    : await getGeographicOrgExtent(hubRequestOptions);
+    : await orgExtent(hubRequestOptions);
 }

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -4,22 +4,6 @@ import { getTypeFromEntity } from "../../getTypeFromEntity";
 import { ConfigurableEntity } from "./ConfigurableEntity";
 import { IHubLocation, IHubLocationOption } from "../../types/IHubLocation";
 import { IExtent } from "@esri/arcgis-rest-types";
-import { getExtentObject } from "../../../content/_internal/computeProps";
-
-export async function getLocationOptions(
-  entity: ConfigurableEntity,
-  portalName: string,
-  hubRequestOptions: IHubRequestOptions
-): Promise<IHubLocationOption[]> {
-  const typeFromEntity = getTypeFromEntity(entity);
-
-  switch (typeFromEntity) {
-    case "content":
-      return getOptions(entity, portalName, hubRequestOptions, true);
-    default:
-      return getOptions(entity, portalName, hubRequestOptions);
-  }
-}
 
 /**
  * Construct the dynamic location picker options with the entity's
@@ -33,11 +17,10 @@ export async function getLocationOptions(
  * current option, select it and update the option with the entity's
  * location
  */
-export async function getOptions(
+export async function getLocationOptions(
   entity: ConfigurableEntity,
   portalName: string,
-  hubRequestOptions: IHubRequestOptions,
-  includeItemExtentOption: boolean = false
+  hubRequestOptions: IHubRequestOptions
 ): Promise<IHubLocationOption[]> {
   const defaultExtent: IExtent = await getGeographicOrgExtent(
     hubRequestOptions
@@ -70,21 +53,12 @@ export async function getOptions(
     },
   ] as IHubLocationOption[];
 
-  // Item's extent
-  if (includeItemExtentOption) {
-    const itemExtent: IExtent = getExtentObject(entity.extent);
-    const itemExtentOption: IHubLocationOption = {
-      label: "{{shared.fields.location.itemExtent:translate}}",
-      entityType: getTypeFromEntity(entity),
-      location: {
-        type: "item",
-        extent: extentToBBox(itemExtent),
-        spatialReference: itemExtent.spatialReference,
-      },
-    };
-
-    optionsArray.splice(2, 0, itemExtentOption);
-  }
+  // In the future, if we want to include other options
+  // on a per entity basis, they can be added right here
+  // with an optional parameter and splicing the extra option
+  // into the options array. This function was changed into
+  // this format when we were considering adding an
+  // "Item's extent" option for content entities.
 
   return optionsArray.map((option) => {
     // If this is a new entity, select the custom option by default
@@ -100,5 +74,3 @@ export async function getOptions(
     return option;
   });
 }
-
-// TODO: Add other location options here

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -1,4 +1,4 @@
-import { extentToBBox, getGeographicOrgExtent } from "../../../extent";
+import { extentToBBox, orgExtent as orgExtent } from "../../../extent";
 import { IHubRequestOptions } from "../../../types";
 import { getTypeFromEntity } from "../../getTypeFromEntity";
 import { ConfigurableEntity } from "./ConfigurableEntity";
@@ -22,9 +22,7 @@ export async function getLocationOptions(
   portalName: string,
   hubRequestOptions: IHubRequestOptions
 ): Promise<IHubLocationOption[]> {
-  const defaultExtent: IExtent = await getGeographicOrgExtent(
-    hubRequestOptions
-  );
+  const defaultExtent: IExtent = await orgExtent(hubRequestOptions);
   const location: IHubLocation = entity.location;
 
   // Base options

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -4,7 +4,7 @@ import { getTypeFromEntity } from "../../getTypeFromEntity";
 import { ConfigurableEntity } from "./ConfigurableEntity";
 import { IHubLocation, IHubLocationOption } from "../../types/IHubLocation";
 import { IExtent } from "@esri/arcgis-rest-types";
-import { getItemExtent } from "../../../content/_internal/computeProps";
+import { getExtentObject } from "../../../content/_internal/computeProps";
 
 export async function getLocationOptions(
   entity: ConfigurableEntity,
@@ -72,7 +72,7 @@ export async function getOptions(
 
   // Item's extent
   if (includeItemExtentOption) {
-    const itemExtent: IExtent = getItemExtent(entity.extent);
+    const itemExtent: IExtent = getExtentObject(entity.extent);
     const itemExtentOption: IHubLocationOption = {
       label: "{{shared.fields.location.itemExtent:translate}}",
       entityType: getTypeFromEntity(entity),

--- a/packages/common/src/extent.ts
+++ b/packages/common/src/extent.ts
@@ -67,24 +67,24 @@ export const GLOBAL_EXTENT: IExtent = {
  * Gets the geographic extent for an org
  * @param hubRequestOptions
  */
-export function getGeographicOrgExtent(
+export function orgExtent(
   hubRequestOptions: IHubRequestOptions
 ): Promise<IExtent> {
   const portal = hubRequestOptions.portalSelf;
-  const orgExtent = portal.defaultExtent;
+  const organizationExtent = portal.defaultExtent;
   const geometryServiceUrl = getProp(portal, "helperServices.geometry.url");
   // Define a default global extent object
   if (!geometryServiceUrl) {
     return Promise.resolve(GLOBAL_EXTENT);
   }
-  if (!orgExtent) {
+  if (!organizationExtent) {
     return Promise.resolve(GLOBAL_EXTENT);
   }
   const url = `${geometryServiceUrl}/project`;
   // geometry params...
   const geometryParam = {
     geometryType: "esriGeometryEnvelope",
-    geometries: [orgExtent],
+    geometries: [organizationExtent],
   };
   const options: IRequestOptions = {
     httpMethod: "POST",
@@ -92,7 +92,7 @@ export function getGeographicOrgExtent(
       geometries: JSON.stringify(geometryParam),
       transformForward: false,
       transformation: "",
-      inSR: orgExtent.spatialReference.wkid,
+      inSR: organizationExtent.spatialReference.wkid,
       outSR: 4326,
       f: "json",
     },
@@ -126,9 +126,7 @@ export function getGeographicOrgExtent(
 export function getOrgExtentAsBBox(
   hubRequestOptions: IHubRequestOptions
 ): Promise<BBox> {
-  return getGeographicOrgExtent(hubRequestOptions).then((extent) =>
-    extentToBBox(extent)
-  );
+  return orgExtent(hubRequestOptions).then((extent) => extentToBBox(extent));
 }
 
 /**

--- a/packages/common/test/content/computeProps.test.ts
+++ b/packages/common/test/content/computeProps.test.ts
@@ -1,7 +1,7 @@
 import {
   computeProps,
   deriveLocationFromItemExtent,
-  getItemExtent,
+  getExtentObject,
 } from "../../src/content/_internal/computeProps";
 import { IHubEditableContent } from "../../src/core/types/IHubEditableContent";
 import { IHubRequestOptions, IModel } from "../../src/types";
@@ -118,7 +118,7 @@ describe("content computeProps", () => {
 
 describe("getItemExtent", () => {
   it("getItemExtent isBBox is true", () => {
-    const chk = getItemExtent([
+    const chk = getExtentObject([
       [100, 100],
       [120, 120],
     ]);
@@ -131,7 +131,7 @@ describe("getItemExtent", () => {
 
 describe("deriveLocationFromItemExtent", () => {
   it("deriveLocationFromItemExtent valid extent", () => {
-    const chk = deriveLocationFromItemExtent("item", [
+    const chk = deriveLocationFromItemExtent([
       [100, 100],
       [120, 120],
     ]);

--- a/packages/common/test/content/computeProps.test.ts
+++ b/packages/common/test/content/computeProps.test.ts
@@ -36,7 +36,7 @@ describe("content computeProps", () => {
 
     const chk = computeProps(model, content, requestOptions);
 
-    expect(chk.location?.type).toBe("custom");
+    expect(chk.location?.type).toBe("item");
   });
 
   it("computeProps boundary defined as none", () => {
@@ -131,11 +131,11 @@ describe("getItemExtent", () => {
 
 describe("deriveLocationFromItemExtent", () => {
   it("deriveLocationFromItemExtent valid extent", () => {
-    const chk = deriveLocationFromItemExtent([
+    const chk = deriveLocationFromItemExtent("item", [
       [100, 100],
       [120, 120],
     ]);
     expect(chk.geometries?.length).toBe(1);
-    expect(chk.type).toBe("custom");
+    expect(chk.type).toBe("item");
   });
 });

--- a/packages/common/test/content/computeProps.test.ts
+++ b/packages/common/test/content/computeProps.test.ts
@@ -33,7 +33,7 @@ describe("content computeProps", () => {
 
     const chk = computeProps(model, content, requestOptions);
 
-    expect(chk.location?.type).toBe("item");
+    expect(chk.location?.type).toBe("custom");
   });
 
   it("handles when boundary is undefined", () => {
@@ -57,7 +57,7 @@ describe("content computeProps", () => {
 
     const chk = computeProps(model, content, requestOptions);
 
-    expect(chk.location?.type).toBe("item");
+    expect(chk.location?.type).toBe("custom");
   });
 
   it("handles when boundary defined as none", () => {
@@ -197,6 +197,6 @@ describe("deriveLocationFromItemExtent", () => {
       [120, 120],
     ]);
     expect(chk.geometries?.length).toBe(1);
-    expect(chk.type).toBe("item");
+    expect(chk.type).toBe("custom");
   });
 });

--- a/packages/common/test/content/computeProps.test.ts
+++ b/packages/common/test/content/computeProps.test.ts
@@ -57,7 +57,7 @@ describe("content computeProps", () => {
 
     const chk = computeProps(model, content, requestOptions);
 
-    expect(chk.location?.type).toBe("custom");
+    expect(chk.location?.type).toBe("item");
   });
 
   it("handles when boundary defined as none", () => {

--- a/packages/common/test/content/edit.test.ts
+++ b/packages/common/test/content/edit.test.ts
@@ -102,7 +102,6 @@ describe("content editing:", () => {
       expect(updateModelSpy.calls.count()).toBe(1);
       const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
       expect(modelToUpdate.item.description).toBe(content.description);
-      expect(modelToUpdate.item.properties.boundary).toBe("none");
       // No service is associated with Hub Initiatives
       expect(getServiceSpy).not.toHaveBeenCalled();
       expect(updateServiceSpy).not.toHaveBeenCalled();
@@ -138,7 +137,6 @@ describe("content editing:", () => {
       expect(updateModelSpy.calls.count()).toBe(1);
       const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
       expect(modelToUpdate.item.description).toBe(content.description);
-      expect(modelToUpdate.item.properties.boundary).toBe("item");
       // No service is associated with Hub Initiatives
       expect(getServiceSpy).not.toHaveBeenCalled();
       expect(updateServiceSpy).not.toHaveBeenCalled();

--- a/packages/common/test/content/edit.test.ts
+++ b/packages/common/test/content/edit.test.ts
@@ -81,7 +81,6 @@ describe("content editing:", () => {
       expect(updateModelSpy.calls.count()).toBe(1);
       const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
       expect(modelToUpdate.item.description).toBe(content.description);
-      expect(modelToUpdate.item.properties.boundary).toBe("none");
     });
   });
   describe("update content with location:", () => {
@@ -128,7 +127,6 @@ describe("content editing:", () => {
       expect(updateModelSpy.calls.count()).toBe(1);
       const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
       expect(modelToUpdate.item.description).toBe(content.description);
-      expect(modelToUpdate.item.properties.boundary).toBe("item");
     });
   });
   describe("delete content", () => {

--- a/packages/common/test/core/schemas/internal/getLocationExtent.test.ts
+++ b/packages/common/test/core/schemas/internal/getLocationExtent.test.ts
@@ -5,10 +5,7 @@ import * as ExtentModule from "../../../../src/extent";
 describe("getLocationExtent", () => {
   let orgExtentSpy: jasmine.Spy;
   beforeEach(() => {
-    orgExtentSpy = spyOn(
-      ExtentModule,
-      "getGeographicOrgExtent"
-    ).and.returnValue(
+    orgExtentSpy = spyOn(ExtentModule, "orgExtent").and.returnValue(
       Promise.resolve({
         xmin: -180,
         ymin: -90,

--- a/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
+++ b/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
@@ -3,7 +3,7 @@ import { ConfigurableEntity } from "../../../../src/core/schemas/internal/Config
 import { getLocationOptions } from "../../../../src/core/schemas/internal/getLocationOptions";
 import * as ExtentModule from "../../../../src/extent";
 
-describe("getLocationOptions - default:", () => {
+describe("getLocationOptions:", () => {
   let orgExtentSpy: jasmine.Spy;
   beforeEach(() => {
     orgExtentSpy = spyOn(
@@ -87,6 +87,30 @@ describe("getLocationOptions - default:", () => {
     );
 
     expect(chk.length).toBe(3);
+    expect(chk[2].selected).toBe(true);
+  });
+  it("content entity should include item extent option", async () => {
+    const entity: ConfigurableEntity = {
+      id: "00c",
+      type: "Hub Content",
+      location: {
+        type: "item",
+      },
+      boundary: "item",
+      extent: [
+        [100, 100],
+        [120, 120],
+      ],
+    } as ConfigurableEntity;
+
+    const chk = await getLocationOptions(
+      entity,
+      "portalName",
+      {} as IHubRequestOptions
+    );
+
+    expect(chk.length).toBe(4);
+    expect(chk[2].location.type).toBe("item");
     expect(chk[2].selected).toBe(true);
   });
 });

--- a/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
+++ b/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
@@ -89,30 +89,6 @@ describe("getLocationOptions:", () => {
     expect(chk.length).toBe(3);
     expect(chk[2].selected).toBe(true);
   });
-  it("content entity should include item extent option", async () => {
-    const entity: ConfigurableEntity = {
-      id: "00c",
-      type: "Hub Content",
-      location: {
-        type: "item",
-      },
-      boundary: "item",
-      extent: [
-        [100, 100],
-        [120, 120],
-      ],
-    } as ConfigurableEntity;
-
-    const chk = await getLocationOptions(
-      entity,
-      "portalName",
-      {} as IHubRequestOptions
-    );
-
-    expect(chk.length).toBe(4);
-    expect(chk[2].location.type).toBe("item");
-    expect(chk[2].selected).toBe(true);
-  });
 });
 
 // Leaving this in for future work when we need

--- a/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
+++ b/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
@@ -6,10 +6,7 @@ import * as ExtentModule from "../../../../src/extent";
 describe("getLocationOptions:", () => {
   let orgExtentSpy: jasmine.Spy;
   beforeEach(() => {
-    orgExtentSpy = spyOn(
-      ExtentModule,
-      "getGeographicOrgExtent"
-    ).and.returnValue(
+    orgExtentSpy = spyOn(ExtentModule, "orgExtent").and.returnValue(
       Promise.resolve({
         xmin: -180,
         ymin: -90,

--- a/packages/common/test/extent/get-geographic-org-extent.test.ts
+++ b/packages/common/test/extent/get-geographic-org-extent.test.ts
@@ -1,19 +1,15 @@
 import * as request from "@esri/arcgis-rest-request";
 import { mockUserSession } from "../test-helpers/fake-user-session";
-import {
-  IHubRequestOptions,
-  getGeographicOrgExtent,
-  GLOBAL_EXTENT
-} from "../../src";
+import { IHubRequestOptions, orgExtent, GLOBAL_EXTENT } from "../../src";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 
-describe("getGeographicOrgExtent", function() {
-  it("fetches extent when geometryServiceUrl and orgExtent are provided", async function() {
+describe("orgExtent", function () {
+  it("fetches extent when geometryServiceUrl and orgExtent are provided", async function () {
     const geom = {
       xmin: 132,
       ymin: 435,
       xmax: 429,
-      ymax: 192
+      ymax: 192,
     };
 
     const geometryServiceUrl = "geometry-service-url";
@@ -26,27 +22,27 @@ describe("getGeographicOrgExtent", function() {
         name: "some-portal",
         defaultExtent: {
           spatialReference: {
-            wkid: orgWkid
-          }
+            wkid: orgWkid,
+          },
         },
         helperServices: {
           geometry: {
-            url: geometryServiceUrl
-          }
-        }
+            url: geometryServiceUrl,
+          },
+        },
       },
       isPortal: false,
       hubApiUrl: "some-url",
-      authentication: mockUserSession
+      authentication: mockUserSession,
     };
 
     const requestSpy = spyOn(request, "request").and.returnValue(
       Promise.resolve({
-        geometries: [geom]
+        geometries: [geom],
       })
     );
 
-    const result = await getGeographicOrgExtent(requestOpts);
+    const result = await orgExtent(requestOpts);
 
     expect(result.xmax).toBe(geom.xmax, "correct xmax");
     expect(result.ymax).toBe(geom.ymax, "correct ymax");
@@ -96,12 +92,12 @@ describe("getGeographicOrgExtent", function() {
     );
   });
 
-  it("returns global extent when geometryServiceUrl or orgExtent are absent", async function() {
+  it("returns global extent when geometryServiceUrl or orgExtent are absent", async function () {
     const geom = {
       xmin: 132,
       ymin: 435,
       xmax: 429,
-      ymax: 192
+      ymax: 192,
     };
 
     const optsWithoutOrgExtent: IHubRequestOptions = {
@@ -112,22 +108,22 @@ describe("getGeographicOrgExtent", function() {
         name: "some-portal",
         helperServices: {
           geometry: {
-            url: "some-url"
-          }
-        }
+            url: "some-url",
+          },
+        },
       },
       isPortal: false,
       hubApiUrl: "some-url",
-      authentication: mockUserSession
+      authentication: mockUserSession,
     };
 
     const requestSpy = spyOn(request, "request").and.returnValue(
       Promise.resolve({
-        geometries: [geom]
+        geometries: [geom],
       })
     );
 
-    const result = await getGeographicOrgExtent(optsWithoutOrgExtent);
+    const result = await orgExtent(optsWithoutOrgExtent);
 
     expect(requestSpy.calls.count()).toBe(0, "request not called");
     expect(result).toEqual(GLOBAL_EXTENT, "resolved to global extent");
@@ -141,25 +137,25 @@ describe("getGeographicOrgExtent", function() {
         name: "some-portal",
         defaultExtent: {
           spatialReference: {
-            wkid: 1234
-          }
+            wkid: 1234,
+          },
         },
         helperServices: {
-          geometry: {}
-        }
+          geometry: {},
+        },
       },
       isPortal: false,
       hubApiUrl: "some-url",
-      authentication: mockUserSession
+      authentication: mockUserSession,
     };
 
-    const result2 = await getGeographicOrgExtent(optsWithoutGeoUrl);
+    const result2 = await orgExtent(optsWithoutGeoUrl);
 
     expect(requestSpy.calls.count()).toBe(0, "request not called");
     expect(result2).toEqual(GLOBAL_EXTENT, "resolved to global extent");
   });
 
-  it("returns global extent when network call fails", async function() {
+  it("returns global extent when network call fails", async function () {
     const optsWithoutOrgExtent: IHubRequestOptions = {
       portalSelf: {
         user: {},
@@ -168,25 +164,25 @@ describe("getGeographicOrgExtent", function() {
         name: "some-portal",
         defaultExtent: {
           spatialReference: {
-            wkid: 1234
-          }
+            wkid: 1234,
+          },
         },
         helperServices: {
           geometry: {
-            url: "some-url"
-          }
-        }
+            url: "some-url",
+          },
+        },
       },
       isPortal: false,
       hubApiUrl: "some-url",
-      authentication: null
+      authentication: null,
     };
 
     const requestSpy = spyOn(request, "request").and.returnValue(
       Promise.reject(Error("network request failed"))
     );
 
-    const result = await getGeographicOrgExtent(optsWithoutOrgExtent);
+    const result = await orgExtent(optsWithoutOrgExtent);
 
     expect(requestSpy.calls.count()).toBe(1, "request called");
     expect(result).toEqual(GLOBAL_EXTENT, "resolved to global extent");

--- a/packages/common/test/extent/get-org-extent-as-bbox.test.ts
+++ b/packages/common/test/extent/get-org-extent-as-bbox.test.ts
@@ -2,27 +2,30 @@ import { IHubRequestOptions, getOrgExtentAsBBox } from "../../src";
 import * as getOrgExtent from "../../src/extent";
 import { mockUserSession } from "../test-helpers/fake-user-session";
 
-describe("getOrgExtentAsBBox", function() {
-  it("gets the extent as a BBox", async function() {
+describe("getOrgExtentAsBBox", function () {
+  it("gets the extent as a BBox", async function () {
     const requestOpts: IHubRequestOptions = {
       portalSelf: {
         user: {},
         id: "123",
         isPortal: false,
-        name: "some-portal"
+        name: "some-portal",
       },
       isPortal: false,
       hubApiUrl: "some-url",
-      authentication: mockUserSession
+      authentication: mockUserSession,
     };
 
-    spyOn(getOrgExtent, "getGeographicOrgExtent").and.returnValue(
+    spyOn(getOrgExtent, "orgExtent").and.returnValue(
       Promise.resolve(getOrgExtent.GLOBAL_EXTENT)
     );
 
     const result = await getOrgExtentAsBBox(requestOpts);
 
     const { xmin, ymin, xmax, ymax } = getOrgExtent.GLOBAL_EXTENT;
-    expect(result).toEqual([[xmin, ymin], [xmax, ymax]]);
+    expect(result).toEqual([
+      [xmin, ymin],
+      [xmax, ymax],
+    ]);
   });
 });


### PR DESCRIPTION
WIP

OD-UI: https://github.com/ArcGIS/opendata-ui/pull/12520

1. Description: Item extent now selectable in location picker for content items only.

1. Instructions for testing:
- Test saving and refreshing for items in old view
- Test saving and refresh for items in new view
- Test item never saved in new view before properly loads in as "none" or "item"
- Test item saved in new view translates correctly to "none" or "item" when in old view
- Test item saved in new view and then in old view ports item back in correctly in new view
  - i.e. save a custom location -- view it as a bbox in old view -- edit bbox in old view -- check that it is now saved as item extent with that bbox in new view


Test saving:
- Workspaces: http://localhost:3333/html/arcgis-hub-workspace/entity-workspace-harness.html?type=content&identifier=149a98f532194836a1fac77c71a495ab
- Old: https://download-test-qa-pre-a-hub.hubqa.arcgis.com/datasets/149a98f532194836a1fac77c71a495ab/edit


Test new notice (DO NOT SAVE THIS ITEM PLEASE):
- Workspaces: http://localhost:3333/html/arcgis-hub-workspace/entity-workspace-harness.html?type=content&identifier=24603693376d414aad8c8d4a32ed1328
- Old: https://download-test-qa-pre-a-hub.hubqa.arcgis.com/datasets/24603693376d414aad8c8d4a32ed1328/about

1. Closes Issues: [#7527](https://devtopia.esri.com/dc/hub/issues/7527)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
