### PR TITLE
feat: partnered orgs added to context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22659,10 +22659,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22677,24 +22676,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22708,10 +22704,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22729,10 +22724,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64987,7 +64981,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.12.0",
+			"version": "14.13.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -83407,8 +83401,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83423,20 +83416,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83450,8 +83440,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83468,8 +83457,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -8,7 +8,7 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { HubServiceStatus } from "./core";
 import { getProp, getWithDefault } from "./objects";
 import { HubEnvironment, HubLicense, IFeatureFlags } from "./permissions/types";
-import { IHubRequestOptions } from "./types";
+import { IHubRequestOptions, IHubTrustedOrgsResponse } from "./types";
 import { getEnvironmentFromPortalUrl } from "./utils/getEnvironmentFromPortalUrl";
 
 /**
@@ -186,6 +186,16 @@ export interface IArcGISContext {
    * Hash of feature flags
    */
   featureFlags: IFeatureFlags;
+
+  /**
+   * Array of Trusted Org Ids
+   */
+  trustedOrgIds: string[];
+
+  /**
+   * Trusted orgs xhr response
+   */
+  trustedOrgs: IHubTrustedOrgsResponse[];
 }
 
 /**
@@ -242,6 +252,16 @@ export interface IArcGISContextOptions {
    * Hash of feature flags
    */
   featureFlags?: IFeatureFlags;
+
+  /**
+   * Array of Trusted Org Ids
+   */
+  trustedOrgIds?: string[];
+
+  /**
+   * Trusted orgs xhr response
+   */
+  trustedOrgs?: IHubTrustedOrgsResponse[];
 }
 
 /**
@@ -281,6 +301,10 @@ export class ArcGISContext implements IArcGISContext {
 
   private _featureFlags: IFeatureFlags = {};
 
+  private _trustedOrgIds: string[];
+
+  private _trustedOrgs: IHubTrustedOrgsResponse[];
+
   /**
    * Create a new instance of `ArcGISContext`.
    *
@@ -304,6 +328,14 @@ export class ArcGISContext implements IArcGISContext {
     }
     if (opts.properties) {
       this._properties = opts.properties;
+    }
+
+    if (opts.trustedOrgIds) {
+      this._trustedOrgIds = opts.trustedOrgIds;
+    }
+
+    if (opts.trustedOrgs) {
+      this._trustedOrgs = opts.trustedOrgs;
     }
 
     this._featureFlags = opts.featureFlags || {};
@@ -622,5 +654,19 @@ export class ArcGISContext implements IArcGISContext {
    */
   public get properties(): Record<string, any> {
     return this._properties;
+  }
+
+  /**
+   * Returns the array of Trusted Org Ids
+   */
+  public get trustedOrgIds(): string[] {
+    return this._trustedOrgIds;
+  }
+
+  /**
+   * Returns the array of Trusted Orgs
+   */
+  public get trustedOrgs(): IHubTrustedOrgsResponse[] {
+    return this._trustedOrgs;
   }
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -123,6 +123,21 @@ export interface IHubUserRequestOptions extends IHubRequestOptions {
   authentication: UserSession;
 }
 
+export interface IHubTrustedOrgsResponse {
+  from: IHubTrustedOrgsRelationship;
+  to: IHubTrustedOrgsRelationship;
+}
+
+export interface IHubTrustedOrgsRelationship {
+  orgId: string;
+  usersAccess: boolean;
+  established: number;
+  name?: string;
+  hub: boolean;
+  state: string;
+  [propName: string]: any;
+}
+
 export interface IItemResource {
   type?: string;
   url: string;


### PR DESCRIPTION
1. Description: adds partneredOrgs and partneredOrgIds to context.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
