### PR TITLE
fix(hub-common): fix fetchHubContent does not support slugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64987,7 +64987,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.12.0",
+			"version": "14.13.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/test/content/fixtures.ts
+++ b/packages/common/test/content/fixtures.ts
@@ -1,7 +1,7 @@
 import { IItem } from "@esri/arcgis-rest-portal";
 import { IFeatureServiceDefinition } from "@esri/arcgis-rest-types";
 
-export const HOSTED_FEATURE_SERVICE_GUID = "9001";
+export const HOSTED_FEATURE_SERVICE_GUID = "A1295DEF67814571B99EDDEA65748143";
 export const HOSTED_FEATURE_SERVICE_URL =
   "https://services.arcgis.com/:orgId/arcgis/rest/services/:serviceName/FeatureServer";
 export const HOSTED_FEATURE_SERVICE_ITEM: IItem = {
@@ -32,14 +32,15 @@ export const HOSTED_FEATURE_SERVICE_DEFINITION = {
   capabilities: "Extract,Query",
 } as IFeatureServiceDefinition;
 
-export const NON_HOSTED_FEATURE_SERVICE_GUID = "9002";
+export const NON_HOSTED_FEATURE_SERVICE_GUID =
+  "A1295DEF67814571B99EDDEA65748142";
 export const NON_HOSTED_FEATURE_SERVICE_ITEM: IItem = {
   ...HOSTED_FEATURE_SERVICE_ITEM,
   id: NON_HOSTED_FEATURE_SERVICE_GUID,
   typeKeywords: [],
 };
 
-export const PDF_GUID = "9003";
+export const PDF_GUID = "A1295DEF67814571B99EDDEA65748148";
 export const PDF_ITEM: IItem = {
   id: PDF_GUID,
   access: "public",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
