### PR TITLE
feat(hub-discussions): adding ability to update the groups of a channel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64981,7 +64981,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.13.0",
+			"version": "14.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -814,6 +814,7 @@ export interface ICreateChannelPermissions {
 export interface IUpdateChannelPermissions {
   access?: SharingAccess;
   allowAnonymous?: boolean;
+  groups?: string[];
 }
 
 /**


### PR DESCRIPTION
1. Description: Adding `groups` to `IUpdateChannelPermissions` to allow for updating a channel's groups

1. Instructions for testing: n/a

1. Closes Issues: [#7572](https://zentopia.esri.com/workspaces/engagement-workspace-61508ae50946c40014ef574f/issues/dc/hub/7572) with hub-discussions [pr-428](https://devtopia.esri.com/dc/hub-discussions/pull/428)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
