### PR TITLE
docs: add timestamp into html as meta header

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,8 +1,12 @@
 name: Deploy Documentation
-# After a push to master, redeploy the docs
+# This is called from the release workflow so that the
+# docs are updated and stamped with the version numbers 
+# from the current release instead of the previous release
 on:
-  push:
-    branches: [master]
+  workflow_call:
+   
+  # push:
+  #   branches: [master]
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run release
+
+  deploy-docs:
+    name: 'Deploy Documentation'
+    uses: ./.github/workflows/deploy-docs.yml
+    needs:
+      - release

--- a/docs/build-typedoc.js
+++ b/docs/build-typedoc.js
@@ -429,10 +429,12 @@ const md = new MarkdownIt();
       return api;
     })
     .then(api => {
+      api.generatedAt = new Date().toISOString();
       /**
        * Our final object looks like this:
        *
        * {
+       *   generated: '2023-09-18T19:46:07.314Z'
        *   packages: [Array of packages.],
        *   declarations: [Array of each exported declaration accross all source files.]
        *   index: { Object mapping each declaration.id as a key with the declaration as its value}
@@ -441,7 +443,7 @@ const md = new MarkdownIt();
        * We now export this to the Acetate source directory.
        */
       return new Promise((resolve, reject) => {
-        writeFile(OUTPUT, JSON.stringify(api, null, 2), e => {
+        writeFile(OUTPUT, JSON.stringify(api, null, 2), (e) => {
           if (e) {
             reject(e);
             return;

--- a/docs/src/_layout.html
+++ b/docs/src/_layout.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width, user-scalable=no">
+    <meta name="date" content="{{data.typedoc.generatedAt}}">
     <title>{{title if title}}{{" | " + titleSegments | join(" |") if titleSegments}}{{" | " if title}}@esri/hub.js</title>
     {% if description %}
     <meta name="description" content="A modular, high quality toolkit for working with ArcGIS Hub">


### PR DESCRIPTION
1. Description:
- Change GH actions so the deploy-docs workflow fires _after_ the release workflow. This should ensure that the latest package version number is in the docs, vs the previous version as it is now.
- also inject a date into a meta tag in the page so we can get a better idea when pages were updated
`<meta name="date" content="2023-09-18T19:57:15.426Z">`

1. Instructions for testing: n/a

1. Closes Issues: n/a

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
