### PR TITLE
feat: add option to enrich an entity 

### DIFF
--- a/packages/common/src/content/HubContent.ts
+++ b/packages/common/src/content/HubContent.ts
@@ -15,7 +15,7 @@ import { IEntityEditorContext } from "../core/types/HubEntityEditor";
 import { cloneObject } from "../util";
 import { editorToContent } from "./edit";
 import { ContentEditorType } from "./_internal/ContentSchema";
-import { enrichEntity } from "../core/schemas/internal/enrichEntity";
+import { enrichEntity } from "../core/enrichEntity";
 
 export class HubContent
   extends HubItemEntity<IHubEditableContent>

--- a/packages/common/src/content/HubContent.ts
+++ b/packages/common/src/content/HubContent.ts
@@ -15,6 +15,7 @@ import { IEntityEditorContext } from "../core/types/HubEntityEditor";
 import { cloneObject } from "../util";
 import { editorToContent } from "./edit";
 import { ContentEditorType } from "./_internal/ContentSchema";
+import { enrichEntity } from "../core/schemas/internal/enrichEntity";
 
 export class HubContent
   extends HubItemEntity<IHubEditableContent>
@@ -110,13 +111,20 @@ export class HubContent
    * @returns
    */
   async toEditor(
-    editorContext: IEntityEditorContext = {}
+    editorContext: IEntityEditorContext = {},
+    include: string[] = []
   ): Promise<IHubContentEditor> {
-    // Cast the entity to it's editor
-    const editor = cloneObject(this.entity) as IHubContentEditor;
+    // 1. optionally enrich entity and cast to editor
+    const editor = include.length
+      ? ((await enrichEntity(
+          cloneObject(this.entity),
+          include,
+          this.context.hubRequestOptions
+        )) as IHubContentEditor)
+      : (cloneObject(this.entity) as IHubContentEditor);
 
-    // Add other transforms here...
-    // NOTE: Be sure to add tests for any transforms in the test suite
+    // 2. Apply transforms to relevant entity values so they
+    // can be consumed by the editor
     return editor;
   }
 

--- a/packages/common/src/content/HubContent.ts
+++ b/packages/common/src/content/HubContent.ts
@@ -109,7 +109,9 @@ export class HubContent
    * @param editorContext
    * @returns
    */
-  toEditor(editorContext: IEntityEditorContext = {}): IHubContentEditor {
+  async toEditor(
+    editorContext: IEntityEditorContext = {}
+  ): Promise<IHubContentEditor> {
     // Cast the entity to it's editor
     const editor = cloneObject(this.entity) as IHubContentEditor;
 

--- a/packages/common/src/core/EntityEditor.ts
+++ b/packages/common/src/core/EntityEditor.ts
@@ -58,9 +58,15 @@ export class EntityEditor {
     return this.instance.getEditorConfig(i18nScope, type);
   }
 
-  toEditor(editorContext: IEntityEditorContext = {}): HubEntityEditor {
+  toEditor(
+    editorContext: IEntityEditorContext = {},
+    include: string[] = []
+  ): HubEntityEditor {
     // This is ugly but it's the only way to get the type to be correct
-    return this.instance.toEditor(editorContext) as unknown as HubEntityEditor;
+    return this.instance.toEditor(
+      editorContext,
+      include
+    ) as unknown as HubEntityEditor;
   }
 
   async save(editor: HubEntityEditor): Promise<HubEntity> {

--- a/packages/common/src/core/behaviors/IWithEditorBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithEditorBehavior.ts
@@ -28,7 +28,10 @@ export interface IWithEditorBehavior {
    * This should only be used by the arcgis-hub-entity-editor component.
    * For general use, see the `toJson():<T>` method
    */
-  toEditor(editorContext: IEntityEditorContext): Promise<HubEntityEditor>;
+  toEditor(
+    editorContext: IEntityEditorContext,
+    include?: string[]
+  ): Promise<HubEntityEditor>;
 
   /**
    * Update the internal Entity from the "Editor" structure.

--- a/packages/common/src/core/behaviors/IWithEditorBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithEditorBehavior.ts
@@ -28,7 +28,7 @@ export interface IWithEditorBehavior {
    * This should only be used by the arcgis-hub-entity-editor component.
    * For general use, see the `toJson():<T>` method
    */
-  toEditor(editorContext: IEntityEditorContext): HubEntityEditor;
+  toEditor(editorContext: IEntityEditorContext): Promise<HubEntityEditor>;
 
   /**
    * Update the internal Entity from the "Editor" structure.

--- a/packages/common/src/core/enrichEntity.ts
+++ b/packages/common/src/core/enrichEntity.ts
@@ -55,6 +55,9 @@ const fetchEntityEnrichments = async (
   enrichments: EntityEnrichment[],
   requestOptions?: IHubRequestOptions
 ): Promise<IEntityEnrichments> => {
+  // Note: we chose to keep this simple for now and not create
+  // an operation pipeline - if this becomes more widely used
+  // or we run into issues debugging, we can implement
   const operations = enrichments.reduce((ops, enrichment) => {
     const operation = {
       followersGroup: fetchFollowersGroupEnrichment,
@@ -81,6 +84,15 @@ const fetchFollowersGroupEnrichment = async (
   entity: HubEntity,
   requestOptions: IHubRequestOptions
 ): Promise<IGroup> => {
-  const followersGroupId = getProp(entity, "followersGroupId");
-  return getGroup(followersGroupId, requestOptions);
+  let group = {} as IGroup;
+  try {
+    const followersGroupId = getProp(entity, "followersGroupId");
+    if (followersGroupId) {
+      group = await getGroup(followersGroupId, requestOptions);
+    }
+  } catch (error) {
+    return {} as IGroup;
+  }
+
+  return group;
 };

--- a/packages/common/src/core/enrichEntity.ts
+++ b/packages/common/src/core/enrichEntity.ts
@@ -1,21 +1,20 @@
 import { IGroup } from "@esri/arcgis-rest-types";
-import { HubEntity } from "../../types";
-import { IHubRequestOptions } from "../../../types";
-import { mapBy } from "../../../utils";
-import { getProp, setProp } from "../../../objects";
+import { HubEntity } from "./types";
+import { IHubRequestOptions } from "../types";
+import { mapBy } from "../utils";
+import { getProp, setProp } from "../objects";
 import { getGroup } from "@esri/arcgis-rest-portal";
-import { parseInclude } from "../../../search/_internal/parseInclude";
-import { unique } from "../../../util";
+import { parseInclude } from "../search/_internal/parseInclude";
+import { unique } from "../util";
 
-type EntityEditorEnrichment = keyof IEntityEditorEnrichments;
-interface IEntityEditorEnrichments {
+type EntityEnrichment = keyof IEntityEnrichments;
+interface IEntityEnrichments {
   followersGroup?: IGroup;
 }
 
 /**
- * Function to enrich an entity. This is used within
- * the toEditor functionlity to enrich an entity with
- * additional information that the editor may need.
+ * Function to enrich an entity with information that
+ * requires an additional XHR
  *
  * @param entity Hub entity
  * @param include Array of enrichment strings
@@ -25,14 +24,14 @@ export const enrichEntity = async (
   entity: HubEntity,
   include: string[],
   requestOptions: IHubRequestOptions
-): Promise<HubEntity & IEntityEditorEnrichments> => {
+): Promise<HubEntity & IEntityEnrichments> => {
   const specs = include.map(parseInclude);
   const enrichments = mapBy("enrichment", specs).filter(unique);
 
   // delegate to fetch enrichments if any have been defined
-  let enrichmentResults: IEntityEditorEnrichments = {};
+  let enrichmentResults: IEntityEnrichments = {};
   if (enrichments.length) {
-    enrichmentResults = await fetchEnrichments(
+    enrichmentResults = await fetchEntityEnrichments(
       entity,
       enrichments,
       requestOptions
@@ -51,11 +50,11 @@ export const enrichEntity = async (
  * This function delegates out to other helper functions
  * to fetch the entity enrichments.
  */
-const fetchEnrichments = async (
+const fetchEntityEnrichments = async (
   entity: HubEntity,
-  enrichments: EntityEditorEnrichment[],
+  enrichments: EntityEnrichment[],
   requestOptions?: IHubRequestOptions
-): Promise<IEntityEditorEnrichments> => {
+): Promise<IEntityEnrichments> => {
   const operations = enrichments.reduce((ops, enrichment) => {
     const operation = {
       followersGroup: fetchFollowersGroupEnrichment,

--- a/packages/common/src/core/schemas/internal/enrichEntity.ts
+++ b/packages/common/src/core/schemas/internal/enrichEntity.ts
@@ -1,0 +1,87 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import { HubEntity } from "../../types";
+import { IHubRequestOptions } from "../../../types";
+import { mapBy } from "../../../utils";
+import { getProp, setProp } from "../../../objects";
+import { getGroup } from "@esri/arcgis-rest-portal";
+import { parseInclude } from "../../../search/_internal/parseInclude";
+import { unique } from "../../../util";
+
+type EntityEditorEnrichment = keyof IEntityEditorEnrichments;
+interface IEntityEditorEnrichments {
+  followersGroup?: IGroup;
+}
+
+/**
+ * Function to enrich an entity. This is used within
+ * the toEditor functionlity to enrich an entity with
+ * additional information that the editor may need.
+ *
+ * @param entity Hub entity
+ * @param include Array of enrichment strings
+ * @param requestOptions Hub request options
+ */
+export const enrichEntity = async (
+  entity: HubEntity,
+  include: string[],
+  requestOptions: IHubRequestOptions
+): Promise<HubEntity & IEntityEditorEnrichments> => {
+  const specs = include.map(parseInclude);
+  const enrichments = mapBy("enrichment", specs).filter(unique);
+
+  // delegate to fetch enrichments if any have been defined
+  let enrichmentResults: IEntityEditorEnrichments = {};
+  if (enrichments.length) {
+    enrichmentResults = await fetchEnrichments(
+      entity,
+      enrichments,
+      requestOptions
+    );
+  }
+
+  // add the enrichments back to the entity based on the enrichment spec
+  specs.forEach((spec) => {
+    setProp(spec.prop, getProp(enrichmentResults, spec.path), entity);
+  });
+
+  return entity;
+};
+
+/**
+ * This function delegates out to other helper functions
+ * to fetch the entity enrichments.
+ */
+const fetchEnrichments = async (
+  entity: HubEntity,
+  enrichments: EntityEditorEnrichment[],
+  requestOptions?: IHubRequestOptions
+): Promise<IEntityEditorEnrichments> => {
+  const operations = enrichments.reduce((ops, enrichment) => {
+    const operation = {
+      followersGroup: fetchFollowersGroupEnrichment,
+    }[enrichment];
+
+    operation && ops.push({ enrichment, operation });
+    return ops;
+  }, []);
+
+  const enrichmentFns = operations.map(({ operation }) =>
+    operation(entity, requestOptions)
+  );
+  const enrichmentResults = await Promise.all(enrichmentFns);
+  return enrichmentResults.reduce((acc, result, idx) => {
+    acc[operations[idx].enrichment] = result;
+    return acc;
+  }, {});
+};
+
+/**
+ * fetch the entity's followers group
+ */
+const fetchFollowersGroupEnrichment = async (
+  entity: HubEntity,
+  requestOptions: IHubRequestOptions
+): Promise<IGroup> => {
+  const followersGroupId = getProp(entity, "followersGroupId");
+  return getGroup(followersGroupId, requestOptions);
+};

--- a/packages/common/src/core/types/IHubDiscussion.ts
+++ b/packages/common/src/core/types/IHubDiscussion.ts
@@ -1,5 +1,5 @@
 import { IWithPermissions, IWithSlug } from "../traits";
-import { IHubItemEntity } from "./IHubItemEntity";
+import { IHubItemEntity, IHubItemEntityEditor } from "./IHubItemEntity";
 
 /**
  * DRAFT: Under development and more properties will likely be added
@@ -10,10 +10,4 @@ export interface IHubDiscussion
     IWithSlug,
     IWithPermissions {}
 
-export type IHubDiscussionEditor = Omit<IHubDiscussion, "extent"> & {
-  /**
-   * Thumbnail image. This is only used on the Editor and is
-   * persisted in the fromEditor method on the Class
-   */
-  _thumbnail?: any;
-};
+export type IHubDiscussionEditor = IHubItemEntityEditor<IHubDiscussion> & {};

--- a/packages/common/src/core/types/IHubEditableContent.ts
+++ b/packages/common/src/core/types/IHubEditableContent.ts
@@ -1,5 +1,5 @@
 import { IWithPermissions, IWithSlug } from "../traits/index";
-import { IHubItemEntity } from "./IHubItemEntity";
+import { IHubItemEntity, IHubItemEntityEditor } from "./IHubItemEntity";
 
 /**
  * Defines the properties of an editable Hub Content object
@@ -28,10 +28,4 @@ export interface IHubEditableContent
   hostedDownloads?: boolean;
 }
 
-export type IHubContentEditor = Omit<IHubEditableContent, "extent"> & {
-  /**
-   * Thumbnail image. This is only used on the Editor and is
-   * persisted in the fromEditor method on the Class
-   */
-  _thumbnail?: any;
-};
+export type IHubContentEditor = IHubItemEntityEditor<IHubEditableContent> & {};

--- a/packages/common/src/core/types/IHubInitiative.ts
+++ b/packages/common/src/core/types/IHubInitiative.ts
@@ -6,7 +6,7 @@ import {
 } from "../traits";
 import {} from "../traits/IWithCatalog";
 import { IWithMetrics } from "../traits/IWithMetrics";
-import { IHubItemEntity } from "./IHubItemEntity";
+import { IHubItemEntity, IHubItemEntityEditor } from "./IHubItemEntity";
 
 /**
  * DRAFT: Under development and more properties will likely be added
@@ -19,10 +19,4 @@ export interface IHubInitiative
     IWithMetrics,
     IWithPermissions {}
 
-export type IHubInitiativeEditor = Omit<IHubInitiative, "extent"> & {
-  /**
-   * Thumbnail image. This is only used on the Editor and is
-   * persisted in the fromEditor method on the Class
-   */
-  _thumbnail?: any;
-};
+export type IHubInitiativeEditor = IHubItemEntityEditor<IHubInitiative> & {};

--- a/packages/common/src/core/types/IHubItemEntity.ts
+++ b/packages/common/src/core/types/IHubItemEntity.ts
@@ -132,6 +132,9 @@ export interface IHubItemEntity
 }
 
 export type IHubItemEntityEditor<T> = Omit<T, "extent"> & {
+  view: {
+    featuredImage?: any;
+  };
   /**
    * Thumbnail image. This is only used on the Editor and is
    * persisted in the fromEditor method on the Class

--- a/packages/common/src/core/types/IHubPage.ts
+++ b/packages/common/src/core/types/IHubPage.ts
@@ -1,4 +1,4 @@
-import { IHubItemEntity } from "./IHubItemEntity";
+import { IHubItemEntity, IHubItemEntityEditor } from "./IHubItemEntity";
 import { IWithLayout, IWithPermissions, IWithSlug } from "../traits";
 /**
  * DRAFT: Under development and more properties will likely be added
@@ -10,10 +10,4 @@ export interface IHubPage
     IWithPermissions,
     IWithSlug {}
 
-export type IHubPageEditor = Omit<IHubPage, "extent"> & {
-  /**
-   * Thumbnail image. This is only used on the Editor and is
-   * persisted in the fromEditor method on the Class
-   */
-  _thumbnail?: any;
-};
+export type IHubPageEditor = IHubItemEntityEditor<IHubPage> & {};

--- a/packages/common/src/core/types/IHubProject.ts
+++ b/packages/common/src/core/types/IHubProject.ts
@@ -5,7 +5,7 @@ import {
   IWithSlug,
   IWithCatalog,
 } from "../traits/index";
-import { IHubItemEntity } from "./IHubItemEntity";
+import { IHubItemEntity, IHubItemEntityEditor } from "./IHubItemEntity";
 import { IExtent } from "@esri/arcgis-rest-feature-layer";
 
 /**
@@ -32,16 +32,7 @@ export enum PROJECT_STATUSES {
  * This type redefines the IHubProject interface in such a way
  * that it can be consumed by the entity editor.
  */
-export type IHubProjectEditor = Omit<IHubProject, "extent"> & {
-  /**
-   * Thumbnail image. This is only used on the Editor and is
-   * persisted in the fromEditor method on the Class
-   */
-  _thumbnail?: any;
-  // extent: IExtent | number[][];
-  view: {
-    featuredImage?: any;
-  };
+export type IHubProjectEditor = IHubItemEntityEditor<IHubProject> & {
   // Groups is an ephemeral property, so we prefix with _
   _groups?: string[];
 };

--- a/packages/common/src/discussions/HubDiscussion.ts
+++ b/packages/common/src/discussions/HubDiscussion.ts
@@ -173,7 +173,9 @@ export class HubDiscussion
    * @param editorContext
    * @returns
    */
-  toEditor(editorContext: IEntityEditorContext = {}): IHubDiscussionEditor {
+  async toEditor(
+    editorContext: IEntityEditorContext = {}
+  ): Promise<IHubDiscussionEditor> {
     // Cast the entity to it's editor
     const editor = cloneObject(this.entity) as IHubDiscussionEditor;
 

--- a/packages/common/src/discussions/HubDiscussion.ts
+++ b/packages/common/src/discussions/HubDiscussion.ts
@@ -15,6 +15,7 @@ import {
 } from "../core/behaviors/IWithEditorBehavior";
 import { cloneObject } from "../util";
 import { DiscussionEditorType } from "./_internal/DiscussionSchema";
+import { enrichEntity } from "../core/schemas/internal/enrichEntity";
 /**
  * Hub Discussion Class
  */
@@ -174,12 +175,20 @@ export class HubDiscussion
    * @returns
    */
   async toEditor(
-    editorContext: IEntityEditorContext = {}
+    editorContext: IEntityEditorContext = {},
+    include: string[] = []
   ): Promise<IHubDiscussionEditor> {
-    // Cast the entity to it's editor
-    const editor = cloneObject(this.entity) as IHubDiscussionEditor;
+    // 1. optionally enrich entity and cast to editor
+    const editor = include.length
+      ? ((await enrichEntity(
+          cloneObject(this.entity),
+          include,
+          this.context.hubRequestOptions
+        )) as IHubDiscussionEditor)
+      : (cloneObject(this.entity) as IHubDiscussionEditor);
 
-    // Add other transforms here...
+    // 2. Apply transforms to relevant entity values so they
+    // can be consumed by the editor
     return editor;
   }
 

--- a/packages/common/src/discussions/HubDiscussion.ts
+++ b/packages/common/src/discussions/HubDiscussion.ts
@@ -15,7 +15,7 @@ import {
 } from "../core/behaviors/IWithEditorBehavior";
 import { cloneObject } from "../util";
 import { DiscussionEditorType } from "./_internal/DiscussionSchema";
-import { enrichEntity } from "../core/schemas/internal/enrichEntity";
+import { enrichEntity } from "../core/enrichEntity";
 /**
  * Hub Discussion Class
  */

--- a/packages/common/src/groups/HubGroup.ts
+++ b/packages/common/src/groups/HubGroup.ts
@@ -262,7 +262,7 @@ export class HubGroup
   /**
    * Return the group as an editor object
    */
-  toEditor(): IHubGroupEditor {
+  async toEditor(): Promise<IHubGroupEditor> {
     // cast the entity to it's editor
     const editor = cloneObject(this.entity) as IHubGroupEditor;
     return editor;

--- a/packages/common/src/groups/HubGroup.ts
+++ b/packages/common/src/groups/HubGroup.ts
@@ -28,6 +28,8 @@ import { setGroupThumbnail } from "./setGroupThumbnail";
 import { getGroupThumbnailUrl } from "../search/utils";
 import { deleteGroupThumbnail } from "./deleteGroupThumbnail";
 import { GroupEditorType } from "./_internal/GroupSchema";
+import { IEntityEditorContext } from "../core";
+import { enrichEntity } from "../core/schemas/internal/enrichEntity";
 
 /**
  * Hub Group Class
@@ -262,9 +264,22 @@ export class HubGroup
   /**
    * Return the group as an editor object
    */
-  async toEditor(): Promise<IHubGroupEditor> {
-    // cast the entity to it's editor
-    const editor = cloneObject(this.entity) as IHubGroupEditor;
+  async toEditor(
+    editorContext: IEntityEditorContext = {},
+    include: string[] = []
+  ): Promise<IHubGroupEditor> {
+    // 1. optionally enrich entity and cast to editor
+    const editor = include.length
+      ? ((await enrichEntity(
+          cloneObject(this.entity),
+          include,
+          this.context.hubRequestOptions
+        )) as IHubGroupEditor)
+      : (cloneObject(this.entity) as IHubGroupEditor);
+
+    // 2. Apply transforms to relevant entity values so they
+    // can be consumed by the editor
+
     return editor;
   }
 

--- a/packages/common/src/groups/HubGroup.ts
+++ b/packages/common/src/groups/HubGroup.ts
@@ -29,7 +29,7 @@ import { getGroupThumbnailUrl } from "../search/utils";
 import { deleteGroupThumbnail } from "./deleteGroupThumbnail";
 import { GroupEditorType } from "./_internal/GroupSchema";
 import { IEntityEditorContext } from "../core";
-import { enrichEntity } from "../core/schemas/internal/enrichEntity";
+import { enrichEntity } from "../core/enrichEntity";
 
 /**
  * Hub Group Class

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -32,6 +32,7 @@ import {
   IWithEditorBehavior,
   IHubInitiativeEditor,
 } from "../core";
+import { enrichEntity } from "../core/schemas/internal/enrichEntity";
 
 /**
  * Hub Initiative Class
@@ -254,12 +255,21 @@ export class HubInitiative
    * @returns
    */
   async toEditor(
-    editorContext: IEntityEditorContext = {}
+    editorContext: IEntityEditorContext = {},
+    include: string[] = []
   ): Promise<IHubInitiativeEditor> {
-    // Cast the entity to it's editor
-    const editor = cloneObject(this.entity) as IHubInitiativeEditor;
+    // 1. optionally enrich entity and cast to editor
+    const editor = include.length
+      ? ((await enrichEntity(
+          cloneObject(this.entity),
+          include,
+          this.context.hubRequestOptions
+        )) as IHubInitiativeEditor)
+      : (cloneObject(this.entity) as IHubInitiativeEditor);
 
-    // Add other transforms here...
+    // 2. Apply transforms to relevant entity values so they
+    // can be consumed by the editor
+
     return editor;
   }
 

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -32,7 +32,7 @@ import {
   IWithEditorBehavior,
   IHubInitiativeEditor,
 } from "../core";
-import { enrichEntity } from "../core/schemas/internal/enrichEntity";
+import { enrichEntity } from "../core/enrichEntity";
 
 /**
  * Hub Initiative Class

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -253,7 +253,9 @@ export class HubInitiative
    * @param editorContext
    * @returns
    */
-  toEditor(editorContext: IEntityEditorContext = {}): IHubInitiativeEditor {
+  async toEditor(
+    editorContext: IEntityEditorContext = {}
+  ): Promise<IHubInitiativeEditor> {
     // Cast the entity to it's editor
     const editor = cloneObject(this.entity) as IHubInitiativeEditor;
 

--- a/packages/common/src/pages/HubPage.ts
+++ b/packages/common/src/pages/HubPage.ts
@@ -202,7 +202,9 @@ export class HubPage
    * @param editorContext
    * @returns
    */
-  toEditor(editorContext: IEntityEditorContext = {}): IHubPageEditor {
+  async toEditor(
+    editorContext: IEntityEditorContext = {}
+  ): Promise<IHubPageEditor> {
     // Cast the entity to it's editor
     const editor = cloneObject(this.entity) as IHubPageEditor;
 

--- a/packages/common/src/pages/HubPage.ts
+++ b/packages/common/src/pages/HubPage.ts
@@ -23,7 +23,7 @@ import { createPage, deletePage, fetchPage, updatePage } from "./HubPages";
 
 import { PageEditorType } from "./_internal/PageSchema";
 import { cloneObject } from "../util";
-import { enrichEntity } from "../core/schemas/internal/enrichEntity";
+import { enrichEntity } from "../core/enrichEntity";
 
 /*
   TODO:

--- a/packages/common/src/pages/HubPage.ts
+++ b/packages/common/src/pages/HubPage.ts
@@ -23,6 +23,7 @@ import { createPage, deletePage, fetchPage, updatePage } from "./HubPages";
 
 import { PageEditorType } from "./_internal/PageSchema";
 import { cloneObject } from "../util";
+import { enrichEntity } from "../core/schemas/internal/enrichEntity";
 
 /*
   TODO:
@@ -203,12 +204,21 @@ export class HubPage
    * @returns
    */
   async toEditor(
-    editorContext: IEntityEditorContext = {}
+    editorContext: IEntityEditorContext = {},
+    include: string[] = []
   ): Promise<IHubPageEditor> {
-    // Cast the entity to it's editor
-    const editor = cloneObject(this.entity) as IHubPageEditor;
+    // 1. optionally enrich entity and cast to editor
+    const editor = include.length
+      ? ((await enrichEntity(
+          cloneObject(this.entity),
+          include,
+          this.context.hubRequestOptions
+        )) as IHubPageEditor)
+      : (cloneObject(this.entity) as IHubPageEditor);
 
-    // Add other transforms here...
+    // 2. Apply transforms to relevant entity values so they
+    // can be consumed by the editor
+
     return editor;
   }
 

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -179,7 +179,9 @@ export class HubProject
    * @param editorContext
    * @returns
    */
-  toEditor(editorContext: IEntityEditorContext = {}): IHubProjectEditor {
+  async toEditor(
+    editorContext: IEntityEditorContext = {}
+  ): Promise<IHubProjectEditor> {
     // cast the entity to it's editor
     const editor = cloneObject(this.entity) as IHubProjectEditor;
     // add the groups array that we'll use to auto-share on save

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -35,6 +35,7 @@ import { projectToCardModel } from "./view";
 import { cloneObject, maybePush } from "../util";
 import { createProject, editorToProject, updateProject } from "./edit";
 import { ProjectEditorType } from "./_internal/ProjectSchema";
+import { enrichEntity } from "../core/schemas/internal/enrichEntity";
 
 /**
  * Hub Project Class
@@ -180,13 +181,23 @@ export class HubProject
    * @returns
    */
   async toEditor(
-    editorContext: IEntityEditorContext = {}
+    editorContext: IEntityEditorContext = {},
+    include: string[] = []
   ): Promise<IHubProjectEditor> {
-    // cast the entity to it's editor
-    const editor = cloneObject(this.entity) as IHubProjectEditor;
+    // 1. optionally enrich entity and cast to editor
+    const editor = include.length
+      ? ((await enrichEntity(
+          cloneObject(this.entity),
+          include,
+          this.context.hubRequestOptions
+        )) as IHubProjectEditor)
+      : (cloneObject(this.entity) as IHubProjectEditor);
+
     // add the groups array that we'll use to auto-share on save
     editor._groups = [];
 
+    // 2. Apply transforms to relevant entity values so they
+    // can be consumed by the editor
     /**
      * on project creation, we want to pre-populate the sharing
      * field with the core and collaboration groups if the user

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -35,7 +35,7 @@ import { projectToCardModel } from "./view";
 import { cloneObject, maybePush } from "../util";
 import { createProject, editorToProject, updateProject } from "./edit";
 import { ProjectEditorType } from "./_internal/ProjectSchema";
-import { enrichEntity } from "../core/schemas/internal/enrichEntity";
+import { enrichEntity } from "../core/enrichEntity";
 
 /**
  * Hub Project Class

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -402,7 +402,9 @@ export class HubSite
    * @param editorContext
    * @returns
    */
-  toEditor(editorContext: IEntityEditorContext = {}): IHubSiteEditor {
+  async toEditor(
+    editorContext: IEntityEditorContext = {}
+  ): Promise<IHubSiteEditor> {
     // 1. Cast entity to editor
     const editor = cloneObject(this.entity) as IHubSiteEditor;
 

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -11,7 +11,7 @@ import { Catalog } from "../search";
 import { IArcGISContext } from "../ArcGISContext";
 import { HubItemEntity } from "../core/HubItemEntity";
 import { getEditorConfig } from "../core/schemas/getEditorConfig";
-import { enrichEntity } from "../core/schemas/internal/enrichEntity";
+import { enrichEntity } from "../core/enrichEntity";
 import {
   IEditorConfig,
   IWithEditorBehavior,

--- a/packages/common/test/content/HubContent.test.ts
+++ b/packages/common/test/content/HubContent.test.ts
@@ -6,7 +6,7 @@ import { HubContent } from "../../src/content/HubContent";
 import * as editModule from "../../src/content/edit";
 import * as EditConfigModule from "../../src/core/schemas/getEditorConfig";
 import { getProp } from "../../src/objects/get-prop";
-import { spy } from "fetch-mock";
+import * as EnrichEntityModule from "../../src/core/schemas/internal/enrichEntity";
 
 describe("HubContent class", () => {
   let authdCtxMgr: ArcGISContextManager;
@@ -142,20 +142,34 @@ describe("HubContent class", () => {
       );
     });
 
-    it("toEditor converst entity to correct structure", async () => {
-      const chk = HubContent.fromJson(
-        {
-          id: "bc3",
-          name: "Test Content",
-          thumbnailUrl: "https://myserver.com/thumbnail.png",
-        },
-        authdCtxMgr.context
-      );
-      const result = await chk.toEditor();
-      // NOTE: If additional transforms are added in the class they should have tests here
-      expect(result.id).toEqual("bc3");
-      expect(result.name).toEqual("Test Content");
-      expect(result.thumbnailUrl).toEqual("https://myserver.com/thumbnail.png");
+    describe("toEditor:", () => {
+      it("optionally enriches the entity", async () => {
+        const enrichEntitySpy = spyOn(
+          EnrichEntityModule,
+          "enrichEntity"
+        ).and.returnValue(Promise.resolve({}));
+        const chk = HubContent.fromJson({ id: "bc3" }, authdCtxMgr.context);
+        await chk.toEditor({}, ["someEnrichment AS _someEnrichment"]);
+
+        expect(enrichEntitySpy).toHaveBeenCalledTimes(1);
+      });
+      it("converts entity to correct structure", async () => {
+        const chk = HubContent.fromJson(
+          {
+            id: "bc3",
+            name: "Test Content",
+            thumbnailUrl: "https://myserver.com/thumbnail.png",
+          },
+          authdCtxMgr.context
+        );
+        const result = await chk.toEditor();
+        // NOTE: If additional transforms are added in the class they should have tests here
+        expect(result.id).toEqual("bc3");
+        expect(result.name).toEqual("Test Content");
+        expect(result.thumbnailUrl).toEqual(
+          "https://myserver.com/thumbnail.png"
+        );
+      });
     });
 
     describe("fromEditor:", () => {

--- a/packages/common/test/content/HubContent.test.ts
+++ b/packages/common/test/content/HubContent.test.ts
@@ -6,7 +6,7 @@ import { HubContent } from "../../src/content/HubContent";
 import * as editModule from "../../src/content/edit";
 import * as EditConfigModule from "../../src/core/schemas/getEditorConfig";
 import { getProp } from "../../src/objects/get-prop";
-import * as EnrichEntityModule from "../../src/core/schemas/internal/enrichEntity";
+import * as EnrichEntityModule from "../../src/core/enrichEntity";
 
 describe("HubContent class", () => {
   let authdCtxMgr: ArcGISContextManager;

--- a/packages/common/test/content/HubContent.test.ts
+++ b/packages/common/test/content/HubContent.test.ts
@@ -142,7 +142,7 @@ describe("HubContent class", () => {
       );
     });
 
-    it("toEditor converst entity to correct structure", () => {
+    it("toEditor converst entity to correct structure", async () => {
       const chk = HubContent.fromJson(
         {
           id: "bc3",
@@ -151,7 +151,7 @@ describe("HubContent class", () => {
         },
         authdCtxMgr.context
       );
-      const result = chk.toEditor();
+      const result = await chk.toEditor();
       // NOTE: If additional transforms are added in the class they should have tests here
       expect(result.id).toEqual("bc3");
       expect(result.name).toEqual("Test Content");
@@ -171,7 +171,7 @@ describe("HubContent class", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         // call fromEditor
         const result = await chk.fromEditor(editor);
@@ -192,7 +192,7 @@ describe("HubContent class", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {
           blob: "fake blob",
@@ -219,7 +219,7 @@ describe("HubContent class", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {};
         // call fromEditor
@@ -246,7 +246,7 @@ describe("HubContent class", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor.location = {
           extent: [
@@ -275,7 +275,7 @@ describe("HubContent class", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         // call fromEditor
         try {

--- a/packages/common/test/core/EntityEditor.test.ts
+++ b/packages/common/test/core/EntityEditor.test.ts
@@ -87,7 +87,7 @@ describe("EntityEditor:", () => {
         "someScope",
         "hub:project:edit"
       );
-      const chk = editor.toEditor();
+      const chk = await editor.toEditor();
       expect(toEditorSpy).toHaveBeenCalled();
       expect(chk.id).toBe("00c");
       await editor.save(chk);
@@ -120,7 +120,7 @@ describe("EntityEditor:", () => {
       expect(fromJsonSpy).toHaveBeenCalled();
       await editor.getConfig("someScope", "hub:page:edit");
       expect(getConfigSpy).toHaveBeenCalledWith("someScope", "hub:page:edit");
-      const chk = editor.toEditor();
+      const chk = await editor.toEditor();
       expect(toEditorSpy).toHaveBeenCalled();
       expect(chk.id).toBe("00c");
       await editor.save(chk);
@@ -164,7 +164,7 @@ describe("EntityEditor:", () => {
         "someScope",
         "hub:discussion:edit"
       );
-      const chk = editor.toEditor();
+      const chk = await editor.toEditor();
       expect(toEditorSpy).toHaveBeenCalled();
       expect(chk.id).toBe("00c");
       await editor.save(chk);
@@ -201,7 +201,7 @@ describe("EntityEditor:", () => {
       expect(fromJsonSpy).toHaveBeenCalled();
       await editor.getConfig("someScope", "hub:site:edit");
       expect(getConfigSpy).toHaveBeenCalledWith("someScope", "hub:site:edit");
-      const chk = editor.toEditor();
+      const chk = await editor.toEditor();
       expect(toEditorSpy).toHaveBeenCalled();
       expect(chk.id).toBe("00c");
       await editor.save(chk);
@@ -242,7 +242,7 @@ describe("EntityEditor:", () => {
         "someScope",
         "hub:content:edit"
       );
-      const chk = editor.toEditor();
+      const chk = await editor.toEditor();
       expect(toEditorSpy).toHaveBeenCalled();
       expect(chk.id).toBe("00c");
       await editor.save(chk);
@@ -286,7 +286,7 @@ describe("EntityEditor:", () => {
         "someScope",
         "hub:initiative:edit"
       );
-      const chk = editor.toEditor();
+      const chk = await editor.toEditor();
       expect(toEditorSpy).toHaveBeenCalled();
       expect(chk.id).toBe("00c");
       await editor.save(chk);
@@ -323,7 +323,7 @@ describe("EntityEditor:", () => {
       expect(fromJsonSpy).toHaveBeenCalled();
       await editor.getConfig("someScope", "hub:group:edit");
       expect(getConfigSpy).toHaveBeenCalledWith("someScope", "hub:group:edit");
-      const chk = editor.toEditor();
+      const chk = await editor.toEditor();
       expect(toEditorSpy).toHaveBeenCalled();
       expect(chk.id).toBe("00c");
       await editor.save(chk);

--- a/packages/common/test/core/enrichEntity.test.ts
+++ b/packages/common/test/core/enrichEntity.test.ts
@@ -1,7 +1,7 @@
-import { ArcGISContextManager, HubEntity, getProp } from "../../../../src";
-import { enrichEntity } from "../../../../src/core/schemas/internal/enrichEntity";
+import { ArcGISContextManager, HubEntity, getProp } from "../../src";
+import { enrichEntity } from "../../src/core/enrichEntity";
 import * as PortalModule from "@esri/arcgis-rest-portal";
-import { MOCK_AUTH } from "../../../mocks/mock-auth";
+import { MOCK_AUTH } from "../mocks/mock-auth";
 
 describe("enrichEntity", () => {
   let authdCtxMgr: ArcGISContextManager;

--- a/packages/common/test/core/schemas/internal/enrichEntity.test.ts
+++ b/packages/common/test/core/schemas/internal/enrichEntity.test.ts
@@ -1,0 +1,75 @@
+import { ArcGISContextManager, HubEntity, getProp } from "../../../../src";
+import { enrichEntity } from "../../../../src/core/schemas/internal/enrichEntity";
+import * as PortalModule from "@esri/arcgis-rest-portal";
+import { MOCK_AUTH } from "../../../mocks/mock-auth";
+
+describe("enrichEntity", () => {
+  let authdCtxMgr: ArcGISContextManager;
+  beforeEach(async () => {
+    authdCtxMgr = await ArcGISContextManager.create({
+      authentication: MOCK_AUTH,
+      currentUser: {
+        username: "casey",
+      } as unknown as PortalModule.IUser,
+      portal: {
+        name: "DC R&D Center",
+        id: "BRXFAKE",
+        urlKey: "fake-org",
+      } as unknown as PortalModule.IPortal,
+      portalUrl: "https://fake-org.maps.arcgis.com",
+    });
+  });
+
+  it("doesn't add anything to the entity if no enrichments are requested", async () => {
+    const chk = await enrichEntity(
+      {} as HubEntity,
+      [],
+      authdCtxMgr.context.hubRequestOptions
+    );
+
+    expect(chk).toEqual({} as HubEntity);
+  });
+  it("enriches the entity based on the enrichment spec", async () => {
+    spyOn(PortalModule, "getGroup").and.returnValue(
+      Promise.resolve({
+        id: "00c",
+        access: "public",
+      })
+    );
+
+    const chk = await enrichEntity(
+      { followersGroupId: "followers_00c" } as HubEntity,
+      ["followersGroup.access AS _followersGroup.access"],
+      authdCtxMgr.context.hubRequestOptions
+    );
+
+    expect(getProp(chk, "_followersGroup.access")).toBe("public");
+  });
+
+  describe("followersGroup enrichment", () => {
+    let getGroupSpy: any;
+    const mockFollowersGroup = {
+      id: "00c",
+      access: "public",
+    };
+    beforeEach(() => {
+      getGroupSpy = spyOn(PortalModule, "getGroup").and.returnValue(
+        Promise.resolve(mockFollowersGroup)
+      );
+    });
+    it("enriches the entity with the followers group", async () => {
+      const chk = await enrichEntity(
+        { followersGroupId: "followers_00c" } as HubEntity,
+        ["followersGroup AS _followersGroup"],
+        authdCtxMgr.context.hubRequestOptions
+      );
+
+      expect(getGroupSpy).toHaveBeenCalledTimes(1);
+      expect(getGroupSpy).toHaveBeenCalledWith(
+        "followers_00c",
+        authdCtxMgr.context.hubRequestOptions
+      );
+      expect(getProp(chk, "_followersGroup")).toBe(mockFollowersGroup);
+    });
+  });
+});

--- a/packages/common/test/discussions/HubDiscussion.test.ts
+++ b/packages/common/test/discussions/HubDiscussion.test.ts
@@ -6,6 +6,7 @@ import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as discussionsFetchModule from "../../src/discussions/fetch";
 import * as discussionsEditModule from "../../src/discussions/edit";
 import * as EditConfigModule from "../../src/core/schemas/getEditorConfig";
+import * as EnrichEntityModule from "../../src/core/schemas/internal/enrichEntity";
 
 describe("HubDiscussion Class:", () => {
   let authdCtxMgr: ArcGISContextManager;
@@ -240,20 +241,34 @@ describe("HubDiscussion Class:", () => {
       );
     });
 
-    it("toEditor converst entity to correct structure", async () => {
-      const chk = HubDiscussion.fromJson(
-        {
-          id: "bc3",
-          name: "Test Entity",
-          thumbnailUrl: "https://myserver.com/thumbnail.png",
-        },
-        authdCtxMgr.context
-      );
-      const result = await chk.toEditor();
-      // NOTE: If additional transforms are added in the class they should have tests here
-      expect(result.id).toEqual("bc3");
-      expect(result.name).toEqual("Test Entity");
-      expect(result.thumbnailUrl).toEqual("https://myserver.com/thumbnail.png");
+    describe("toEditor:", () => {
+      it("optionally enriches the entity", async () => {
+        const enrichEntitySpy = spyOn(
+          EnrichEntityModule,
+          "enrichEntity"
+        ).and.returnValue(Promise.resolve({}));
+        const chk = HubDiscussion.fromJson({ id: "bc3" }, authdCtxMgr.context);
+        await chk.toEditor({}, ["someEnrichment AS _someEnrichment"]);
+
+        expect(enrichEntitySpy).toHaveBeenCalledTimes(1);
+      });
+      it("converts entity to correct structure", async () => {
+        const chk = HubDiscussion.fromJson(
+          {
+            id: "bc3",
+            name: "Test Entity",
+            thumbnailUrl: "https://myserver.com/thumbnail.png",
+          },
+          authdCtxMgr.context
+        );
+        const result = await chk.toEditor();
+        // NOTE: If additional transforms are added in the class they should have tests here
+        expect(result.id).toEqual("bc3");
+        expect(result.name).toEqual("Test Entity");
+        expect(result.thumbnailUrl).toEqual(
+          "https://myserver.com/thumbnail.png"
+        );
+      });
     });
 
     describe("fromEditor:", () => {

--- a/packages/common/test/discussions/HubDiscussion.test.ts
+++ b/packages/common/test/discussions/HubDiscussion.test.ts
@@ -240,7 +240,7 @@ describe("HubDiscussion Class:", () => {
       );
     });
 
-    it("toEditor converst entity to correct structure", () => {
+    it("toEditor converst entity to correct structure", async () => {
       const chk = HubDiscussion.fromJson(
         {
           id: "bc3",
@@ -249,7 +249,7 @@ describe("HubDiscussion Class:", () => {
         },
         authdCtxMgr.context
       );
-      const result = chk.toEditor();
+      const result = await chk.toEditor();
       // NOTE: If additional transforms are added in the class they should have tests here
       expect(result.id).toEqual("bc3");
       expect(result.name).toEqual("Test Entity");
@@ -269,7 +269,7 @@ describe("HubDiscussion Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         // call fromEditor
         const result = await chk.fromEditor(editor);
@@ -290,7 +290,7 @@ describe("HubDiscussion Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {
           blob: "fake blob",
@@ -317,7 +317,7 @@ describe("HubDiscussion Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {};
         // call fromEditor
@@ -344,7 +344,7 @@ describe("HubDiscussion Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor.location = {
           extent: [
@@ -373,7 +373,7 @@ describe("HubDiscussion Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         // call fromEditor
         try {

--- a/packages/common/test/discussions/HubDiscussion.test.ts
+++ b/packages/common/test/discussions/HubDiscussion.test.ts
@@ -6,7 +6,7 @@ import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as discussionsFetchModule from "../../src/discussions/fetch";
 import * as discussionsEditModule from "../../src/discussions/edit";
 import * as EditConfigModule from "../../src/core/schemas/getEditorConfig";
-import * as EnrichEntityModule from "../../src/core/schemas/internal/enrichEntity";
+import * as EnrichEntityModule from "../../src/core/enrichEntity";
 
 describe("HubDiscussion Class:", () => {
   let authdCtxMgr: ArcGISContextManager;

--- a/packages/common/test/groups/HubGroup.test.ts
+++ b/packages/common/test/groups/HubGroup.test.ts
@@ -9,7 +9,7 @@ import { IEntityPermissionPolicy } from "../../dist/types/permissions/types/IEnt
 import * as EditConfigModule from "../../src/core/schemas/getEditorConfig";
 import { getProp } from "../../src/objects/get-prop";
 import * as SearchUtils from "../../src/search/utils";
-import * as EnrichEntityModule from "../../src/core/schemas/internal/enrichEntity";
+import * as EnrichEntityModule from "../../src/core/enrichEntity";
 
 describe("HubGroup class:", () => {
   let authdCtxMgr: ArcGISContextManager;

--- a/packages/common/test/groups/HubGroup.test.ts
+++ b/packages/common/test/groups/HubGroup.test.ts
@@ -330,7 +330,7 @@ describe("HubGroup class:", () => {
       );
     });
 
-    it("toEditor converst entity to correct structure", () => {
+    it("toEditor converst entity to correct structure", async () => {
       const chk = HubGroup.fromJson(
         {
           id: "bc3",
@@ -339,7 +339,7 @@ describe("HubGroup class:", () => {
         },
         authdCtxMgr.context
       );
-      const result = chk.toEditor();
+      const result = await chk.toEditor();
       // NOTE: If additional transforms are added in the class they should have tests here
       expect(result.id).toEqual("bc3");
       expect(result.name).toEqual("Test Entity");
@@ -359,7 +359,7 @@ describe("HubGroup class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         // get the group loaded from the editor
         const result = await chk.fromEditor(editor);
@@ -380,7 +380,7 @@ describe("HubGroup class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         // get the group loaded from the editor
         try {
           await await chk.fromEditor(editor);
@@ -412,7 +412,7 @@ describe("HubGroup class:", () => {
           "setGroupThumbnail"
         ).and.returnValue(Promise.resolve({}));
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {
           blob: "fake blob",
@@ -447,7 +447,7 @@ describe("HubGroup class:", () => {
           "deleteGroupThumbnail"
         ).and.returnValue(Promise.resolve({}));
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {};
         // get the group loaded from the editor

--- a/packages/common/test/initiatives/HubInitiative.test.ts
+++ b/packages/common/test/initiatives/HubInitiative.test.ts
@@ -14,6 +14,7 @@ import * as HubInitiativesModule from "../../src/initiatives/HubInitiatives";
 import * as ResolveMetricModule from "../../src/metrics/resolveMetric";
 import * as viewModule from "../../src/initiatives/view";
 import * as EditConfigModule from "../../src/core/schemas/getEditorConfig";
+import * as EnrichEntityModule from "../../src/core/schemas/internal/enrichEntity";
 
 describe("HubInitiative Class:", () => {
   let authdCtxMgr: ArcGISContextManager;
@@ -338,20 +339,34 @@ describe("HubInitiative Class:", () => {
       );
     });
 
-    it("toEditor converst entity to correct structure", async () => {
-      const chk = HubInitiative.fromJson(
-        {
-          id: "bc3",
-          name: "Test Entity",
-          thumbnailUrl: "https://myserver.com/thumbnail.png",
-        },
-        authdCtxMgr.context
-      );
-      const result = await chk.toEditor();
-      // NOTE: If additional transforms are added in the class they should have tests here
-      expect(result.id).toEqual("bc3");
-      expect(result.name).toEqual("Test Entity");
-      expect(result.thumbnailUrl).toEqual("https://myserver.com/thumbnail.png");
+    describe("toEditor:", () => {
+      it("optionally enriches the entity", async () => {
+        const enrichEntitySpy = spyOn(
+          EnrichEntityModule,
+          "enrichEntity"
+        ).and.returnValue(Promise.resolve({}));
+        const chk = HubInitiative.fromJson({ id: "bc3" }, authdCtxMgr.context);
+        await chk.toEditor({}, ["someEnrichment AS _someEnrichment"]);
+
+        expect(enrichEntitySpy).toHaveBeenCalledTimes(1);
+      });
+      it("converts entity to correct structure", async () => {
+        const chk = HubInitiative.fromJson(
+          {
+            id: "bc3",
+            name: "Test Entity",
+            thumbnailUrl: "https://myserver.com/thumbnail.png",
+          },
+          authdCtxMgr.context
+        );
+        const result = await chk.toEditor();
+        // NOTE: If additional transforms are added in the class they should have tests here
+        expect(result.id).toEqual("bc3");
+        expect(result.name).toEqual("Test Entity");
+        expect(result.thumbnailUrl).toEqual(
+          "https://myserver.com/thumbnail.png"
+        );
+      });
     });
 
     describe("fromEditor:", () => {

--- a/packages/common/test/initiatives/HubInitiative.test.ts
+++ b/packages/common/test/initiatives/HubInitiative.test.ts
@@ -14,7 +14,7 @@ import * as HubInitiativesModule from "../../src/initiatives/HubInitiatives";
 import * as ResolveMetricModule from "../../src/metrics/resolveMetric";
 import * as viewModule from "../../src/initiatives/view";
 import * as EditConfigModule from "../../src/core/schemas/getEditorConfig";
-import * as EnrichEntityModule from "../../src/core/schemas/internal/enrichEntity";
+import * as EnrichEntityModule from "../../src/core/enrichEntity";
 
 describe("HubInitiative Class:", () => {
   let authdCtxMgr: ArcGISContextManager;

--- a/packages/common/test/initiatives/HubInitiative.test.ts
+++ b/packages/common/test/initiatives/HubInitiative.test.ts
@@ -338,7 +338,7 @@ describe("HubInitiative Class:", () => {
       );
     });
 
-    it("toEditor converst entity to correct structure", () => {
+    it("toEditor converst entity to correct structure", async () => {
       const chk = HubInitiative.fromJson(
         {
           id: "bc3",
@@ -347,7 +347,7 @@ describe("HubInitiative Class:", () => {
         },
         authdCtxMgr.context
       );
-      const result = chk.toEditor();
+      const result = await chk.toEditor();
       // NOTE: If additional transforms are added in the class they should have tests here
       expect(result.id).toEqual("bc3");
       expect(result.name).toEqual("Test Entity");
@@ -367,7 +367,7 @@ describe("HubInitiative Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         // call fromEditor
         const result = await chk.fromEditor(editor);
@@ -388,7 +388,7 @@ describe("HubInitiative Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {
           blob: "fake blob",
@@ -415,7 +415,7 @@ describe("HubInitiative Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {};
         // call fromEditor
@@ -442,7 +442,7 @@ describe("HubInitiative Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor.location = {
           extent: [
@@ -471,7 +471,7 @@ describe("HubInitiative Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         // call fromEditor
         try {

--- a/packages/common/test/pages/HubPage.test.ts
+++ b/packages/common/test/pages/HubPage.test.ts
@@ -5,6 +5,7 @@ import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as HubPagesModule from "../../src/pages/HubPages";
 import { IHubPage, getProp } from "../../src";
 import * as EditConfigModule from "../../src/core/schemas/getEditorConfig";
+import * as EnrichEntityModule from "../../src/core/schemas/internal/enrichEntity";
 
 describe("HubPage Class:", () => {
   let authdCtxMgr: ArcGISContextManager;
@@ -229,20 +230,34 @@ describe("HubPage Class:", () => {
       );
     });
 
-    it("toEditor converst entity to correct structure", async () => {
-      const chk = HubPage.fromJson(
-        {
-          id: "bc3",
-          name: "Test Entity",
-          thumbnailUrl: "https://myserver.com/thumbnail.png",
-        },
-        authdCtxMgr.context
-      );
-      const result = await chk.toEditor();
-      // NOTE: If additional transforms are added in the class they should have tests here
-      expect(result.id).toEqual("bc3");
-      expect(result.name).toEqual("Test Entity");
-      expect(result.thumbnailUrl).toEqual("https://myserver.com/thumbnail.png");
+    describe("toEditor:", () => {
+      it("optionally enriches the entity", async () => {
+        const enrichEntitySpy = spyOn(
+          EnrichEntityModule,
+          "enrichEntity"
+        ).and.returnValue(Promise.resolve({}));
+        const chk = HubPage.fromJson({ id: "bc3" }, authdCtxMgr.context);
+        await chk.toEditor({}, ["someEnrichment AS _someEnrichment"]);
+
+        expect(enrichEntitySpy).toHaveBeenCalledTimes(1);
+      });
+      it("toEditor converst entity to correct structure", async () => {
+        const chk = HubPage.fromJson(
+          {
+            id: "bc3",
+            name: "Test Entity",
+            thumbnailUrl: "https://myserver.com/thumbnail.png",
+          },
+          authdCtxMgr.context
+        );
+        const result = await chk.toEditor();
+        // NOTE: If additional transforms are added in the class they should have tests here
+        expect(result.id).toEqual("bc3");
+        expect(result.name).toEqual("Test Entity");
+        expect(result.thumbnailUrl).toEqual(
+          "https://myserver.com/thumbnail.png"
+        );
+      });
     });
 
     describe("fromEditor:", () => {

--- a/packages/common/test/pages/HubPage.test.ts
+++ b/packages/common/test/pages/HubPage.test.ts
@@ -5,7 +5,7 @@ import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as HubPagesModule from "../../src/pages/HubPages";
 import { IHubPage, getProp } from "../../src";
 import * as EditConfigModule from "../../src/core/schemas/getEditorConfig";
-import * as EnrichEntityModule from "../../src/core/schemas/internal/enrichEntity";
+import * as EnrichEntityModule from "../../src/core/enrichEntity";
 
 describe("HubPage Class:", () => {
   let authdCtxMgr: ArcGISContextManager;

--- a/packages/common/test/pages/HubPage.test.ts
+++ b/packages/common/test/pages/HubPage.test.ts
@@ -229,7 +229,7 @@ describe("HubPage Class:", () => {
       );
     });
 
-    it("toEditor converst entity to correct structure", () => {
+    it("toEditor converst entity to correct structure", async () => {
       const chk = HubPage.fromJson(
         {
           id: "bc3",
@@ -238,7 +238,7 @@ describe("HubPage Class:", () => {
         },
         authdCtxMgr.context
       );
-      const result = chk.toEditor();
+      const result = await chk.toEditor();
       // NOTE: If additional transforms are added in the class they should have tests here
       expect(result.id).toEqual("bc3");
       expect(result.name).toEqual("Test Entity");
@@ -258,7 +258,7 @@ describe("HubPage Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         // call fromEditor
         const result = await chk.fromEditor(editor);
@@ -279,7 +279,7 @@ describe("HubPage Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {
           blob: "fake blob",
@@ -306,7 +306,7 @@ describe("HubPage Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {};
         // call fromEditor
@@ -333,7 +333,7 @@ describe("HubPage Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor.location = {
           extent: [
@@ -362,7 +362,7 @@ describe("HubPage Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         // call fromEditor
         try {

--- a/packages/common/test/projects/HubProject.test.ts
+++ b/packages/common/test/projects/HubProject.test.ts
@@ -351,7 +351,7 @@ describe("HubProject Class:", () => {
       );
     });
 
-    it("toEditor converst entity to correct structure", () => {
+    it("toEditor converst entity to correct structure", async () => {
       const chk = HubProject.fromJson(
         {
           id: "bc3",
@@ -360,7 +360,7 @@ describe("HubProject Class:", () => {
         },
         authdCtxMgr.context
       );
-      const result = chk.toEditor();
+      const result = await chk.toEditor();
       // NOTE: If additional transforms are added in the class they should have tests here
       expect(result.id).toEqual("bc3");
       expect(result.name).toEqual("Test Entity");
@@ -393,7 +393,7 @@ describe("HubProject Class:", () => {
           },
           authdCtxMgr.context
         );
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.view = {
           featuredImage: {
             blob: "fake blob",
@@ -418,7 +418,7 @@ describe("HubProject Class:", () => {
           },
           authdCtxMgr.context
         );
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.view = {
           featuredImage: {}, // Will clear b/c .blob is not defined
         };
@@ -438,7 +438,7 @@ describe("HubProject Class:", () => {
           },
           authdCtxMgr.context
         );
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
 
         editor.access = "org";
 
@@ -460,7 +460,7 @@ describe("HubProject Class:", () => {
           },
           authdCtxMgr.context
         );
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor._groups = ["3ef"];
         editor.access = "org";
         const accessSpy = spyOn(
@@ -491,7 +491,7 @@ describe("HubProject Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         delete editor._groups;
         // call fromEditor
@@ -513,7 +513,7 @@ describe("HubProject Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {
           blob: "fake blob",
@@ -540,7 +540,7 @@ describe("HubProject Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {};
         // call fromEditor
@@ -567,7 +567,7 @@ describe("HubProject Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor.location = {
           extent: [

--- a/packages/common/test/projects/HubProject.test.ts
+++ b/packages/common/test/projects/HubProject.test.ts
@@ -10,7 +10,7 @@ import * as viewModule from "../../src/projects/view";
 import * as EditConfigModule from "../../src/core/schemas/getEditorConfig";
 import * as ResolveMetricModule from "../../src/metrics/resolveMetric";
 import { HubItemEntity } from "../../src/core/HubItemEntity";
-import * as EnrichEntityModule from "../../src/core/schemas/internal/enrichEntity";
+import * as EnrichEntityModule from "../../src/core/enrichEntity";
 
 describe("HubProject Class:", () => {
   let authdCtxMgr: ArcGISContextManager;

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../../src";
 import { Catalog } from "../../src/search";
 import * as ContainsModule from "../../src/core/_internal/deepContains";
-import * as EnrichEntityModule from "../../src/core/schemas/internal/enrichEntity";
+import * as EnrichEntityModule from "../../src/core/enrichEntity";
 
 describe("HubSite Class:", () => {
   let authdCtxMgr: ArcGISContextManager;

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../../src";
 import { Catalog } from "../../src/search";
 import * as ContainsModule from "../../src/core/_internal/deepContains";
+import * as EnrichEntityModule from "../../src/core/schemas/internal/enrichEntity";
 
 describe("HubSite Class:", () => {
   let authdCtxMgr: ArcGISContextManager;
@@ -572,20 +573,34 @@ describe("HubSite Class:", () => {
       );
     });
 
-    it("toEditor converst entity to correct structure", async () => {
-      const chk = HubSite.fromJson(
-        {
-          id: "bc3",
-          name: "Test Entity",
-          thumbnailUrl: "https://myserver.com/thumbnail.png",
-        },
-        authdCtxMgr.context
-      );
-      const result = await chk.toEditor();
-      // NOTE: If additional transforms are added in the class they should have tests here
-      expect(result.id).toEqual("bc3");
-      expect(result.name).toEqual("Test Entity");
-      expect(result.thumbnailUrl).toEqual("https://myserver.com/thumbnail.png");
+    describe("toEditor:", () => {
+      it("optionally enriches the entity", async () => {
+        const enrichEntitySpy = spyOn(
+          EnrichEntityModule,
+          "enrichEntity"
+        ).and.returnValue(Promise.resolve({}));
+        const chk = HubSite.fromJson({ id: "bc3" }, authdCtxMgr.context);
+        await chk.toEditor({}, ["someEnrichment AS _someEnrichment"]);
+
+        expect(enrichEntitySpy).toHaveBeenCalledTimes(1);
+      });
+      it("converts entity to correct structure", async () => {
+        const chk = HubSite.fromJson(
+          {
+            id: "bc3",
+            name: "Test Entity",
+            thumbnailUrl: "https://myserver.com/thumbnail.png",
+          },
+          authdCtxMgr.context
+        );
+        const result = await chk.toEditor();
+        // NOTE: If additional transforms are added in the class they should have tests here
+        expect(result.id).toEqual("bc3");
+        expect(result.name).toEqual("Test Entity");
+        expect(result.thumbnailUrl).toEqual(
+          "https://myserver.com/thumbnail.png"
+        );
+      });
     });
 
     describe("fromEditor:", () => {

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -572,7 +572,7 @@ describe("HubSite Class:", () => {
       );
     });
 
-    it("toEditor converst entity to correct structure", () => {
+    it("toEditor converst entity to correct structure", async () => {
       const chk = HubSite.fromJson(
         {
           id: "bc3",
@@ -581,7 +581,7 @@ describe("HubSite Class:", () => {
         },
         authdCtxMgr.context
       );
-      const result = chk.toEditor();
+      const result = await chk.toEditor();
       // NOTE: If additional transforms are added in the class they should have tests here
       expect(result.id).toEqual("bc3");
       expect(result.name).toEqual("Test Entity");
@@ -601,7 +601,7 @@ describe("HubSite Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         // call fromEditor
         const result = await chk.fromEditor(editor);
@@ -622,7 +622,7 @@ describe("HubSite Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {
           blob: "fake blob",
@@ -649,7 +649,7 @@ describe("HubSite Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor._thumbnail = {};
         // call fromEditor
@@ -666,7 +666,7 @@ describe("HubSite Class:", () => {
         let setFollowersGroupAccessSpy: any;
         let editor: IHubSiteEditor;
 
-        beforeEach(() => {
+        beforeEach(async () => {
           chk = HubSite.fromJson(
             {
               id: "bc3",
@@ -679,7 +679,7 @@ describe("HubSite Class:", () => {
             chk,
             "setFollowersGroupAccess"
           ).and.returnValue(Promise.resolve());
-          editor = chk.toEditor();
+          editor = await chk.toEditor();
         });
         it("does nothing if followers information is not present on the editor values", async () => {
           editor._followers = undefined;
@@ -713,7 +713,7 @@ describe("HubSite Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         editor.location = {
           extent: [
@@ -742,7 +742,7 @@ describe("HubSite Class:", () => {
         // spy on the instance .save method and retrn void
         const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
         // make changes to the editor
-        const editor = chk.toEditor();
+        const editor = await chk.toEditor();
         editor.name = "new name";
         // call fromEditor
         try {


### PR DESCRIPTION
[7621](https://devtopia.esri.com/dc/hub/issues/7621)

### Description
- make `toEditor` in `IWithEditorBehavior` and all associated class methods async
- add new arg, `include`, to the `toEditor` class method
- add `enrichEntity` util that delegates to helper functions to add async enrichments to the entity. For now, only a followers group enrichment is supported. `enrichEntity` gets called from all `toEditor` class methods with the array of `include` strings provided

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.