### PR TITLE
fix(hub-common): re-adds the discussion permissions to validPermissio…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64981,7 +64981,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.15.0",
+			"version": "14.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -24,6 +24,7 @@ const validPermissions = [
   ...PagePermissions,
   ...PlatformPermissions,
   ...TempPermissions,
+  ...DiscussionPermissions,
 ] as const;
 
 /**
@@ -37,7 +38,8 @@ export type Permission =
   | (typeof GroupPermissions)[number]
   | (typeof PagePermissions)[number]
   | (typeof PlatformPermissions)[number]
-  | (typeof TempPermissions)[number];
+  | (typeof TempPermissions)[number]
+  | (typeof DiscussionPermissions)[number];
 
 /**
  * Validate a Permission

--- a/packages/common/test/permissions/types/isPermission.test.ts
+++ b/packages/common/test/permissions/types/isPermission.test.ts
@@ -1,8 +1,30 @@
 import { isPermission } from "../../../src";
+import { ProjectPermissions } from "../../../src/projects/_internal/ProjectBusinessRules";
+import { SitePermissions } from "../../../src/sites/_internal/SiteBusinessRules";
+import { InitiativePermissions } from "../../../src/initiatives/_internal/InitiativeBusinessRules";
+import { DiscussionPermissions } from "../../../src/discussions/_internal/DiscussionBusinessRules";
+import { ContentPermissions } from "../../../src/content/_internal/ContentBusinessRules";
+import { GroupPermissions } from "../../../src/groups/_internal/GroupBusinessRules";
+import { PagePermissions } from "../../../src/pages/_internal/PageBusinessRules";
+import { PlatformPermissions } from "../../../src/permissions/PlatformPermissionPolicies";
 
 describe("isPermission:", () => {
-  it("returns true for valid permission", () => {
-    expect(isPermission("hub:site:create")).toBe(true);
+  const allPermissions = [
+    ...SitePermissions,
+    ...ProjectPermissions,
+    ...InitiativePermissions,
+    ...ContentPermissions,
+    ...GroupPermissions,
+    ...PagePermissions,
+    ...PlatformPermissions,
+    ...DiscussionPermissions,
+    "temp:workspace:released",
+  ];
+
+  allPermissions.forEach((permission) => {
+    it(`returns true for ${permission} permission`, () => {
+      expect(isPermission(permission)).toBe(true);
+    });
   });
 
   it("returns fails for invalid permission", () => {


### PR DESCRIPTION
…ns array

affects: @esri/hub-common

1. Description:
[PR-1213](https://github.com/Esri/hub.js/pull/1213) removed the discussion permissions from the `validPermissions` array which introduced some regressions concerning being able to navigate to a Discussion workspace, and being incorrectly routed to the Discussion Board live view after successfully creating a new Discussion Board item from the `New` menu.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
