### PR TITLE
fix: uiSchema translation keys

### DIFF
--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
@@ -123,7 +123,7 @@ export const buildUiSchema = async (
                 options: {
                   control: "arcgis-hub-access-level-controls",
                   orgName: context.portal.name,
-                  itemType: `{{${i18nScope}.fields.access.itemType:translate}`,
+                  itemType: `{{${i18nScope}.fields.access.itemType:translate}}`,
                 },
               },
               {

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -161,7 +161,7 @@ export const buildUiSchema = async (
               catalogs: getFeaturedContentCatalogs(context.currentUser),
               facets: [
                 {
-                  label: `{{${i18nScope}.fields.featuredContent.facets.type:translate}`,
+                  label: `{{${i18nScope}.fields.featuredContent.facets.type:translate}}`,
                   key: "type",
                   display: "multi-select",
                   field: "type",
@@ -170,7 +170,7 @@ export const buildUiSchema = async (
                   aggLimit: 100,
                 },
                 {
-                  label: `{{${i18nScope}.fields.featuredContent.facets.sharing:translate}`,
+                  label: `{{${i18nScope}.fields.featuredContent.facets.sharing:translate}}`,
                   key: "access",
                   display: "multi-select",
                   field: "access",

--- a/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
@@ -131,7 +131,7 @@ export const buildUiSchema = async (
                 options: {
                   control: "arcgis-hub-access-level-controls",
                   orgName: context.portal.name,
-                  itemType: `{{${i18nScope}.fields.access.itemType:translate}`,
+                  itemType: `{{${i18nScope}.fields.access.itemType:translate}}`,
                 },
               },
               {

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -230,7 +230,7 @@ export const buildUiSchema = async (
               catalogs: getFeaturedContentCatalogs(context.currentUser),
               facets: [
                 {
-                  label: `{{${i18nScope}.fields.featuredContent.facets.type:translate}`,
+                  label: `{{${i18nScope}.fields.featuredContent.facets.type:translate}}`,
                   key: "type",
                   display: "multi-select",
                   field: "type",
@@ -239,7 +239,7 @@ export const buildUiSchema = async (
                   aggLimit: 100,
                 },
                 {
-                  label: `{{${i18nScope}.fields.featuredContent.facets.sharing:translate}`,
+                  label: `{{${i18nScope}.fields.featuredContent.facets.sharing:translate}}`,
                   key: "access",
                   display: "multi-select",
                   field: "access",

--- a/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
@@ -123,7 +123,7 @@ export const buildUiSchema = async (
                 options: {
                   control: "arcgis-hub-access-level-controls",
                   orgName: context.portal.name,
-                  itemType: `{{${i18nScope}.fields.access.itemType:translate}`,
+                  itemType: `{{${i18nScope}.fields.access.itemType:translate}}`,
                 },
               },
               {

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
@@ -117,7 +117,7 @@ describe("buildUiSchema: initiative create", () => {
                   options: {
                     control: "arcgis-hub-access-level-controls",
                     orgName: "My org",
-                    itemType: "{{some.scope.fields.access.itemType:translate}",
+                    itemType: "{{some.scope.fields.access.itemType:translate}}",
                   },
                 },
                 {

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -160,7 +160,7 @@ describe("buildUiSchema: initiative edit", () => {
                 facets: [
                   {
                     label:
-                      "{{some.scope.fields.featuredContent.facets.type:translate}",
+                      "{{some.scope.fields.featuredContent.facets.type:translate}}",
                     key: "type",
                     display: "multi-select",
                     field: "type",
@@ -170,7 +170,7 @@ describe("buildUiSchema: initiative edit", () => {
                   },
                   {
                     label:
-                      "{{some.scope.fields.featuredContent.facets.sharing:translate}",
+                      "{{some.scope.fields.featuredContent.facets.sharing:translate}}",
                     key: "access",
                     display: "multi-select",
                     field: "access",

--- a/packages/common/test/projects/_internal/ProjectUiSchemaCreate.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaCreate.test.ts
@@ -128,7 +128,7 @@ describe("buildUiSchema: project create", () => {
                   options: {
                     control: "arcgis-hub-access-level-controls",
                     orgName: "My org",
-                    itemType: "{{some.scope.fields.access.itemType:translate}",
+                    itemType: "{{some.scope.fields.access.itemType:translate}}",
                   },
                 },
                 {

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -233,7 +233,7 @@ describe("buildUiSchema: project edit", () => {
                 facets: [
                   {
                     label:
-                      "{{some.scope.fields.featuredContent.facets.type:translate}",
+                      "{{some.scope.fields.featuredContent.facets.type:translate}}",
                     key: "type",
                     display: "multi-select",
                     field: "type",
@@ -243,7 +243,7 @@ describe("buildUiSchema: project edit", () => {
                   },
                   {
                     label:
-                      "{{some.scope.fields.featuredContent.facets.sharing:translate}",
+                      "{{some.scope.fields.featuredContent.facets.sharing:translate}}",
                     key: "access",
                     display: "multi-select",
                     field: "access",

--- a/packages/common/test/sites/_internal/SiteUiSchemaCreate.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaCreate.test.ts
@@ -117,7 +117,7 @@ describe("buildUiSchema: site create", () => {
                   options: {
                     control: "arcgis-hub-access-level-controls",
                     orgName: "My org",
-                    itemType: "{{some.scope.fields.access.itemType:translate}",
+                    itemType: "{{some.scope.fields.access.itemType:translate}}",
                   },
                 },
                 {


### PR DESCRIPTION
[7926](https://devtopia.esri.com/dc/hub/issues/7926)

1. Description:
when transitioning `uiSchemas` to export a function rather than a `const`, I missed a few "}" in the `uiSchema` translation keys

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.