### PR TITLE
fix: auto-populating groups in project creation

### DIFF
--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -36,6 +36,8 @@ import { cloneObject, maybePush } from "../util";
 import { createProject, editorToProject, updateProject } from "./edit";
 import { ProjectEditorType } from "./_internal/ProjectSchema";
 import { enrichEntity } from "../core/enrichEntity";
+import { getProp } from "../objects";
+import { IGroup } from "@esri/arcgis-rest-types";
 
 /**
  * Hub Project Class
@@ -202,17 +204,30 @@ export class HubProject
      * on project creation, we want to pre-populate the sharing
      * field with the core and collaboration groups if the user
      * has the appropriate shareToGroup portal privilege
+     *
+     * TODO: we should re-evaluate this "auto-populate" pattern
      */
     const { access: canShare } = this.checkPermission(
       "platform:portal:user:shareToGroup"
     );
     if (!editor.id && canShare) {
-      // TODO: at what point can we remove this "auto-share" behavior?
-      editor._groups = maybePush(editorContext.contentGroupId, editor._groups);
-      editor._groups = maybePush(
+      const currentUserGroups: IGroup[] =
+        getProp(this.context, "currentUser.groups") || [];
+      const defaultShareWithGroups = [
+        editorContext.contentGroupId,
         editorContext.collaborationGroupId,
-        editor._groups
-      );
+      ].reduce((acc, groupId) => {
+        const group = currentUserGroups.find((g: IGroup) => g.id === groupId);
+        const canShareToGroup =
+          !!group &&
+          (!group.isViewOnly ||
+            (group.isViewOnly &&
+              ["owner", "admin"].includes(group.memberType)));
+
+        canShareToGroup && acc.push(groupId);
+        return acc;
+      }, []);
+      editor._groups = [...editor._groups, ...defaultShareWithGroups];
     }
 
     return editor;


### PR DESCRIPTION
[7937](https://devtopia.esri.com/dc/hub/issues/7937)

1. Description:
currently we _always_ pre-populate the "Share with..." field on project creation with the site's content and collaboration group IDs. If the current user isn't a member of these groups/doesn't have the ability to share with these groups, this results in a console error because we still try sharing the project with these groups. This PR adds additional checks to avoid this issue.

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.