### PR TITLE
feat: add links hash for project, initiative, and group entities

### DIFF
--- a/packages/common/src/core/types/IHubEntityBase.ts
+++ b/packages/common/src/core/types/IHubEntityBase.ts
@@ -13,6 +13,39 @@ export interface ILink {
 }
 
 /**
+ * Interface for entity links
+ */
+export interface IHubEntityLinks {
+  /**
+   * Url to Thumbnail. May not include a token
+   * TODO: Why should we not include the token?
+   */
+  thumbnail?: string;
+  /**
+   * Url to the entities canonical "self"
+   * For Items/Groups/Users, this will be the Home App url
+   * For other entities, it will be the canonical url
+   */
+  self: string;
+  /**
+   * Relative url of the entity, within a site
+   */
+  siteRelative?: string;
+  /**
+   * Relative workspace url of the entity, within a site
+   */
+  workspaceRelative?: string;
+  /**
+   * Relative url to the entity's layout editing experience
+   */
+  layoutRelative?: string;
+  /**
+   * Additional urls
+   */
+  [key: string]: string | ILink;
+}
+
+/**
  * Base properties for Hub Entities
  * This includes a subset of `IItem`, that can apply to
  * models that are not backed by items. It also includes
@@ -68,33 +101,5 @@ export interface IHubEntityBase {
   /**
    * Links to related things
    */
-  links?: {
-    /**
-     * Url to Thumbnail. May not include a token
-     * TODO: Why should we not include the token?
-     */
-    thumbnail?: string;
-    /**
-     * Url to the entities canonical "self"
-     * For Items/Groups/Users, this will be the Home App url
-     * For other entities, it will be the canonical url
-     */
-    self: string;
-    /**
-     * Relative url of the entity, within a site
-     */
-    siteRelative?: string;
-    /**
-     * Relative workspace url of the entity, within a site
-     */
-    workspaceRelative?: string;
-    /**
-     * Relative url to the entity's layout editing experience
-     */
-    layoutRelative?: string;
-    /**
-     * Additional urls
-     */
-    [key: string]: string | ILink;
-  };
+  links?: IHubEntityLinks;
 }

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -81,7 +81,7 @@ export async function enrichGroupSearchResult(
   });
 
   // Handle links
-  result.links = { ...computeLinks(group, requestOptions) };
+  result.links = computeLinks(group, requestOptions);
 
   return result;
 }

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -1,10 +1,8 @@
 import { IGroup } from "@esri/arcgis-rest-types";
 import { fetchGroupEnrichments } from "./_internal/enrichments";
 import { getProp, setProp } from "../objects";
-import { getGroupThumbnailUrl } from "../search/utils";
 import { parseInclude } from "../search/_internal/parseInclude";
 import { IHubRequestOptions } from "../types";
-import { getGroupHomeUrl } from "../urls";
 import { unique } from "../util";
 import { mapBy } from "../utils";
 import {
@@ -19,8 +17,8 @@ import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { DEFAULT_GROUP } from "./defaults";
 import { convertHubGroupToGroup } from "./_internal/convertHubGroupToGroup";
 import { convertGroupToHubGroup } from "./_internal/convertGroupToHubGroup";
-import { getRelativeWorkspaceUrl } from "../core/getRelativeWorkspaceUrl";
 import { IHubSearchResult } from "../search/types/IHubSearchResult";
+import { computeLinks } from "./_internal/computeLinks";
 
 /**
  * Enrich a generic search result
@@ -82,11 +80,9 @@ export async function enrichGroupSearchResult(
     result[spec.prop] = getProp(enriched, spec.path);
   });
 
-  // Handle links
-  result.links.thumbnail = getGroupThumbnailUrl(requestOptions.portal, group);
-  result.links.self = getGroupHomeUrl(result.id, requestOptions);
-  result.links.siteRelative = `/teams/${result.id}`;
-  result.links.workspaceRelative = getRelativeWorkspaceUrl("Group", result.id);
+  // Add links to search result
+  // TODO: Link handling should be an enrichment
+  result.links = { ...computeLinks(group, requestOptions) };
 
   return result;
 }

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -80,8 +80,7 @@ export async function enrichGroupSearchResult(
     result[spec.prop] = getProp(enriched, spec.path);
   });
 
-  // Add links to search result
-  // TODO: Link handling should be an enrichment
+  // Handle links
   result.links = { ...computeLinks(group, requestOptions) };
 
   return result;

--- a/packages/common/src/groups/_internal/computeLinks.ts
+++ b/packages/common/src/groups/_internal/computeLinks.ts
@@ -1,0 +1,32 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { IHubEntityLinks } from "../../core/types";
+import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
+import { getGroupHomeUrl } from "../../urls/getGroupHomeUrl";
+import { getGroupThumbnailUrl } from "../../search/utils";
+
+/**
+ * Compute the links that get appended to a Hub Group
+ * search result and entity
+ *
+ * @param group
+ * @param requestOptions
+ */
+export function computeLinks(
+  group: IGroup,
+  requestOptions: IRequestOptions
+): IHubEntityLinks {
+  let token: string;
+  if (requestOptions.authentication) {
+    const session: UserSession = requestOptions.authentication as UserSession;
+    token = session.token;
+  }
+
+  return {
+    self: getGroupHomeUrl(group.id, requestOptions),
+    siteRelative: `/teams/${group.id}`,
+    workspaceRelative: getRelativeWorkspaceUrl("Group", group.id),
+    thumbnail: getGroupThumbnailUrl(requestOptions.portal, group, token),
+  };
+}

--- a/packages/common/src/groups/_internal/computeProps.ts
+++ b/packages/common/src/groups/_internal/computeProps.ts
@@ -27,8 +27,7 @@ export function computeProps(
     const session: UserSession = requestOptions.authentication as UserSession;
     token = session.token;
   }
-
-  // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead
+  // thumbnail url
   hubGroup.thumbnailUrl = getGroupThumbnailUrl(
     requestOptions.portal,
     group,

--- a/packages/common/src/groups/_internal/computeProps.ts
+++ b/packages/common/src/groups/_internal/computeProps.ts
@@ -27,11 +27,12 @@ export function computeProps(
     token = session.token;
   }
   // thumbnail url
-  hubGroup.thumbnailUrl = getGroupThumbnailUrl(
+  const thumbnailUrl = getGroupThumbnailUrl(
     requestOptions.portal,
     group,
     token
   );
+  hubGroup.thumbnailUrl = thumbnailUrl;
 
   // Handle Dates
   hubGroup.createdDate = new Date(group.created);
@@ -68,7 +69,7 @@ export function computeProps(
     self: getGroupHomeUrl(group.id, requestOptions),
     siteRelative: `/teams/${group.id}`,
     workspaceRelative: getRelativeWorkspaceUrl("Group", group.id),
-    thumbnail: getGroupThumbnailUrl(requestOptions.portal, group),
+    thumbnail: thumbnailUrl,
   };
   // cast b/c this takes a partial but returns a full group
   return hubGroup as IHubGroup;

--- a/packages/common/src/groups/_internal/computeProps.ts
+++ b/packages/common/src/groups/_internal/computeProps.ts
@@ -7,6 +7,7 @@ import { isDiscussable } from "../../discussions";
 import { getGroupThumbnailUrl } from "../../search/utils";
 import { getRelativeWorkspaceUrl } from "../../core";
 import { getGroupHomeUrl } from "../../urls";
+import { computeLinks } from "./computeLinks";
 
 /**
  * Given a model and a group, set various computed properties that can't be directly mapped
@@ -26,14 +27,13 @@ export function computeProps(
     const session: UserSession = requestOptions.authentication as UserSession;
     token = session.token;
   }
-  // thumbnail url
-  const thumbnailUrl = getGroupThumbnailUrl(
+
+  // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead
+  hubGroup.thumbnailUrl = getGroupThumbnailUrl(
     requestOptions.portal,
     group,
     token
   );
-  // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead
-  hubGroup.thumbnailUrl = thumbnailUrl;
 
   // Handle Dates
   hubGroup.createdDate = new Date(group.created);
@@ -66,12 +66,8 @@ export function computeProps(
     group.userMembership?.memberType === "admin";
   hubGroup.canDelete = hubGroup.canEdit;
 
-  hubGroup.links = {
-    self: getGroupHomeUrl(group.id, requestOptions),
-    siteRelative: `/teams/${group.id}`,
-    workspaceRelative: getRelativeWorkspaceUrl("Group", group.id),
-    thumbnail: thumbnailUrl,
-  };
+  hubGroup.links = computeLinks(group, requestOptions);
+
   // cast b/c this takes a partial but returns a full group
   return hubGroup as IHubGroup;
 }

--- a/packages/common/src/groups/_internal/computeProps.ts
+++ b/packages/common/src/groups/_internal/computeProps.ts
@@ -5,8 +5,6 @@ import { IHubGroup } from "../../core/types/IHubGroup";
 import { IGroup } from "@esri/arcgis-rest-types";
 import { isDiscussable } from "../../discussions";
 import { getGroupThumbnailUrl } from "../../search/utils";
-import { getRelativeWorkspaceUrl } from "../../core";
-import { getGroupHomeUrl } from "../../urls";
 import { computeLinks } from "./computeLinks";
 
 /**

--- a/packages/common/src/groups/_internal/computeProps.ts
+++ b/packages/common/src/groups/_internal/computeProps.ts
@@ -32,6 +32,7 @@ export function computeProps(
     group,
     token
   );
+  // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead
   hubGroup.thumbnailUrl = thumbnailUrl;
 
   // Handle Dates

--- a/packages/common/src/groups/_internal/computeProps.ts
+++ b/packages/common/src/groups/_internal/computeProps.ts
@@ -5,6 +5,8 @@ import { IHubGroup } from "../../core/types/IHubGroup";
 import { IGroup } from "@esri/arcgis-rest-types";
 import { isDiscussable } from "../../discussions";
 import { getGroupThumbnailUrl } from "../../search/utils";
+import { getRelativeWorkspaceUrl } from "../../core";
+import { getGroupHomeUrl } from "../../urls";
 
 /**
  * Given a model and a group, set various computed properties that can't be directly mapped
@@ -62,6 +64,12 @@ export function computeProps(
     group.userMembership?.memberType === "admin";
   hubGroup.canDelete = hubGroup.canEdit;
 
+  hubGroup.links = {
+    self: getGroupHomeUrl(group.id, requestOptions),
+    siteRelative: `/teams/${group.id}`,
+    workspaceRelative: getRelativeWorkspaceUrl("Group", group.id),
+    thumbnail: getGroupThumbnailUrl(requestOptions.portal, group),
+  };
   // cast b/c this takes a partial but returns a full group
   return hubGroup as IHubGroup;
 }

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -261,7 +261,7 @@ export async function enrichInitiativeSearchResult(
   // TODO: remove once sites are separated from initiatives and
   // the initiatives view route is released
   result.links.siteRelative = getHubRelativeUrl(result.type, result.id);
-  // result.links.siteRelative = ;
+
   return result;
 }
 

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -17,13 +17,11 @@ import {
 import {
   isGuid,
   cloneObject,
-  getItemThumbnailUrl,
   unique,
   mapBy,
   getProp,
   getFamily,
   IHubRequestOptions,
-  getItemHomeUrl,
   setDiscussableKeyword,
   IModel,
 } from "../index";
@@ -41,17 +39,16 @@ import { IEntityInfo, IHubInitiative } from "../core/types";
 import { IHubSearchResult } from "../search";
 import { parseInclude } from "../search/_internal/parseInclude";
 import { fetchItemEnrichments } from "../items/_enrichments";
-import { getHubRelativeUrl } from "../content/_internal/internalContentUtils";
 import { DEFAULT_INITIATIVE, DEFAULT_INITIATIVE_MODEL } from "./defaults";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 import { computeProps } from "./_internal/computeProps";
 import { applyInitiativeMigrations } from "./_internal/applyInitiativeMigrations";
-import { getRelativeWorkspaceUrl } from "../core/getRelativeWorkspaceUrl";
 import { combineQueries } from "../search/_internal/combineQueries";
 import { portalSearchItemsAsItems } from "../search/_internal/portalSearchItems";
 import { getTypeWithKeywordQuery } from "../associations/internal/getTypeWithKeywordQuery";
-import { getTypeWithoutKeywordQuery } from "../associations/internal/getTypeWithoutKeywordQuery";
 import { negateGroupPredicates } from "../search/_internal/negateGroupPredicates";
+import { computeLinks } from "./_internal/computeLinks";
+import { getHubRelativeUrl } from "../content/_internal/internalContentUtils";
 
 /**
  * @private
@@ -258,26 +255,17 @@ export async function enrichInitiativeSearchResult(
     result[spec.prop] = getProp(enriched, spec.path);
   });
 
-  // Handle links
+  // Add links to search result
   // TODO: Link handling should be an enrichment
-  result.links.thumbnail = getItemThumbnailUrl(item, requestOptions);
-  result.links.self = getItemHomeUrl(result.id, requestOptions);
-  const identifier = item.id;
-  // Until the new initiatives route is in place we need to
-  // route using the id. Once the route is in place we can
-  // un-comment this
-  // const identifier = getItemIdentifier(item);
-
+  result.links = { ...computeLinks(item, requestOptions) };
+  // TODO: remove once sites are separated from initiatives and
+  // the initiatives view route is released
   result.links.siteRelative = getHubRelativeUrl(
     result.type,
-    identifier,
+    result.id,
     item.typeKeywords
   );
-  result.links.workspaceRelative = getRelativeWorkspaceUrl(
-    result.type,
-    identifier
-  );
-
+  // result.links.siteRelative = ;
   return result;
 }
 

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -255,7 +255,7 @@ export async function enrichInitiativeSearchResult(
     result[spec.prop] = getProp(enriched, spec.path);
   });
 
-  // Add links to search result
+  // Handle links
   // TODO: Link handling should be an enrichment
   result.links = { ...computeLinks(item, requestOptions) };
   // TODO: remove once sites are separated from initiatives and

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -257,10 +257,12 @@ export async function enrichInitiativeSearchResult(
 
   // Handle links
   // TODO: Link handling should be an enrichment
-  result.links = { ...computeLinks(item, requestOptions) };
-  // TODO: remove once sites are separated from initiatives and
-  // the initiatives view route is released
-  result.links.siteRelative = getHubRelativeUrl(result.type, result.id);
+  result.links = {
+    ...computeLinks(item, requestOptions),
+    // TODO: remove once sites are separated from initiatives and
+    // the initiatives view route is released
+    siteRelative: getHubRelativeUrl(result.type, result.id),
+  };
 
   return result;
 }

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -260,11 +260,7 @@ export async function enrichInitiativeSearchResult(
   result.links = { ...computeLinks(item, requestOptions) };
   // TODO: remove once sites are separated from initiatives and
   // the initiatives view route is released
-  result.links.siteRelative = getHubRelativeUrl(
-    result.type,
-    result.id,
-    item.typeKeywords
-  );
+  result.links.siteRelative = getHubRelativeUrl(result.type, result.id);
   // result.links.siteRelative = ;
   return result;
 }

--- a/packages/common/src/initiatives/_internal/computeLinks.ts
+++ b/packages/common/src/initiatives/_internal/computeLinks.ts
@@ -4,12 +4,11 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemHomeUrl } from "../../urls";
 import { IHubEntityLinks } from "../../core/types";
 import { getItemIdentifier } from "../../items";
-import { getHubRelativeUrl } from "../../content/_internal/internalContentUtils";
 import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
 import { getItemThumbnailUrl } from "../../resources/get-item-thumbnail-url";
 
 /**
- * Compute the links that get appended to a Hub Project
+ * Compute the links that get appended to a Hub Initiative
  * search result and entity
  *
  * @param item
@@ -27,7 +26,10 @@ export function computeLinks(
 
   return {
     self: getItemHomeUrl(item.id, requestOptions),
-    siteRelative: getHubRelativeUrl(item.type, getItemIdentifier(item)),
+    // TODO: once the initiative view is moved to initiatives/:id,
+    // update and leverage the getHubRelativeUrl util to construct
+    // this url. For now, we hard-code to the initiatives2/:id route
+    siteRelative: `/initiatives2/${getItemIdentifier(item)}`,
     workspaceRelative: getRelativeWorkspaceUrl(
       item.type,
       getItemIdentifier(item)

--- a/packages/common/src/initiatives/_internal/computeProps.ts
+++ b/packages/common/src/initiatives/_internal/computeProps.ts
@@ -28,8 +28,7 @@ export function computeProps(
     const session: UserSession = requestOptions.authentication as UserSession;
     token = session.token;
   }
-
-  // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead
+  // thumbnail url
   initiative.thumbnailUrl = getItemThumbnailUrl(
     model.item,
     requestOptions,

--- a/packages/common/src/initiatives/_internal/computeProps.ts
+++ b/packages/common/src/initiatives/_internal/computeProps.ts
@@ -31,6 +31,7 @@ export function computeProps(
   }
   // thumbnail url
   const thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
+  // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead
   initiative.thumbnailUrl = thumbnailUrl;
 
   // Handle Dates

--- a/packages/common/src/initiatives/_internal/computeProps.ts
+++ b/packages/common/src/initiatives/_internal/computeProps.ts
@@ -4,10 +4,12 @@ import { getItemThumbnailUrl } from "../../resources";
 
 import { IModel } from "../../types";
 
-import { IHubInitiative } from "../../core";
+import { IHubInitiative, getRelativeWorkspaceUrl } from "../../core";
 import { isDiscussable } from "../../discussions";
 import { processEntityFeatures } from "../../permissions/_internal/processEntityFeatures";
 import { InitiativeDefaultFeatures } from "./InitiativeBusinessRules";
+import { getItemHomeUrl } from "../../urls";
+import { getHubRelativeUrl } from "../../content/_internal/internalContentUtils";
 
 /**
  * Given a model and an Initiative, set various computed properties that can't be directly mapped
@@ -28,11 +30,8 @@ export function computeProps(
     token = session.token;
   }
   // thumbnail url
-  initiative.thumbnailUrl = getItemThumbnailUrl(
-    model.item,
-    requestOptions,
-    token
-  );
+  const thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
+  initiative.thumbnailUrl = thumbnailUrl;
 
   // Handle Dates
   initiative.createdDate = new Date(model.item.created);
@@ -48,6 +47,19 @@ export function computeProps(
     model.data.settings?.features || {},
     InitiativeDefaultFeatures
   );
+
+  initiative.links = {
+    self: getItemHomeUrl(initiative.id, requestOptions),
+    // TODO: once the initiative view is moved to initiatives/:id,
+    // leverage the getHubRelativeUrl util to construct this url.
+    // For now, we hard-code to the initiatives2/:id route
+    siteRelative: `/initiatives2/${initiative.slug || initiative.id}`,
+    workspaceRelative: getRelativeWorkspaceUrl(
+      initiative.type,
+      initiative.slug || initiative.id
+    ),
+    thumbnail: thumbnailUrl,
+  };
 
   // cast b/c this takes a partial but returns a full object
   return initiative as IHubInitiative;

--- a/packages/common/src/projects/_internal/computeLinks.ts
+++ b/packages/common/src/projects/_internal/computeLinks.ts
@@ -1,0 +1,37 @@
+import { IItem } from "@esri/arcgis-rest-types";
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { getItemHomeUrl } from "../../urls";
+import { IHubEntityLinks } from "../../core/types";
+import { getItemIdentifier } from "../../items";
+import { getHubRelativeUrl } from "../../content/_internal/internalContentUtils";
+import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
+import { getItemThumbnailUrl } from "../../resources/get-item-thumbnail-url";
+
+/**
+ * compute the links that get appended to a Hub project
+ * search result and project entity
+ *
+ * @param item
+ * @param requestOptions
+ */
+export function computeLinks(
+  item: IItem,
+  requestOptions: IRequestOptions
+): IHubEntityLinks {
+  let token: string;
+  if (requestOptions.authentication) {
+    const session: UserSession = requestOptions.authentication as UserSession;
+    token = session.token;
+  }
+
+  return {
+    self: getItemHomeUrl(item.id, requestOptions),
+    siteRelative: getHubRelativeUrl(item.type, getItemIdentifier(item)),
+    workspaceRelative: getRelativeWorkspaceUrl(
+      item.type,
+      getItemIdentifier(item)
+    ),
+    thumbnail: getItemThumbnailUrl(item, requestOptions, token),
+  };
+}

--- a/packages/common/src/projects/_internal/computeProps.ts
+++ b/packages/common/src/projects/_internal/computeProps.ts
@@ -1,12 +1,14 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
-import { IHubProject } from "../../core";
+import { IHubProject, getRelativeWorkspaceUrl } from "../../core";
 import { IModel } from "../../types";
 
 import { isDiscussable } from "../../discussions";
 import { processEntityFeatures } from "../../permissions/_internal/processEntityFeatures";
 import { ProjectDefaultFeatures } from "./ProjectBusinessRules";
+import { getItemHomeUrl } from "../../urls";
+import { getHubRelativeUrl } from "../../content/_internal/internalContentUtils";
 
 /**
  * Given a model and a project, set various computed properties that can't be directly mapped
@@ -27,7 +29,9 @@ export function computeProps(
     token = session.token;
   }
   // thumbnail url
-  project.thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
+  const thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
+  // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead
+  project.thumbnailUrl = thumbnailUrl;
 
   // Handle Dates
   project.createdDate = new Date(model.item.created);
@@ -43,6 +47,16 @@ export function computeProps(
     model.data.settings?.features || {},
     ProjectDefaultFeatures
   );
+
+  project.links = {
+    self: getItemHomeUrl(project.id, requestOptions),
+    siteRelative: getHubRelativeUrl(project.type, project.slug || project.id),
+    workspaceRelative: getRelativeWorkspaceUrl(
+      project.type,
+      project.slug || project.id
+    ),
+    thumbnail: thumbnailUrl,
+  };
 
   // cast b/c this takes a partial but returns a full project
   return project as IHubProject;

--- a/packages/common/src/projects/_internal/computeProps.ts
+++ b/packages/common/src/projects/_internal/computeProps.ts
@@ -26,7 +26,7 @@ export function computeProps(
     const session: UserSession = requestOptions.authentication as UserSession;
     token = session.token;
   }
-  // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead
+  // thumbnail url
   project.thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
 
   // Handle Dates

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -123,7 +123,7 @@ export async function enrichProjectSearchResult(
 
   // Handle links
   // TODO: Link handling should be an enrichment
-  result.links = { ...computeLinks(item, requestOptions) };
+  result.links = computeLinks(item, requestOptions);
 
   return result;
 }

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -121,7 +121,7 @@ export async function enrichProjectSearchResult(
     result[spec.prop] = getProp(enriched, spec.path);
   });
 
-  // Add links to search result
+  // Handle links
   // TODO: Link handling should be an enrichment
   result.links = { ...computeLinks(item, requestOptions) };
 

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -2,7 +2,6 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { getItem, IItem } from "@esri/arcgis-rest-portal";
 
 import { getFamily } from "../content/get-family";
-import { getHubRelativeUrl } from "../content/_internal/internalContentUtils";
 import { IHubProject } from "../core/types";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
 import { getItemBySlug } from "../items/slugs";

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -18,12 +18,9 @@ import { computeProps } from "./_internal/computeProps";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 import { unique } from "../util";
 import { getProp } from "../objects/get-prop";
-import { getItemThumbnailUrl } from "../resources/get-item-thumbnail-url";
-import { getItemHomeUrl } from "../urls/get-item-home-url";
-import { getItemIdentifier } from "../items";
-import { getRelativeWorkspaceUrl } from "../core/getRelativeWorkspaceUrl";
 import { listAssociations } from "../associations";
 import { getTypeByIdsQuery } from "../associations/internal/getTypeByIdsQuery";
+import { computeLinks } from "./_internal/computeLinks";
 
 /**
  * @private
@@ -125,20 +122,9 @@ export async function enrichProjectSearchResult(
     result[spec.prop] = getProp(enriched, spec.path);
   });
 
-  // Handle links
+  // Add links to search result
   // TODO: Link handling should be an enrichment
-  result.links.thumbnail = getItemThumbnailUrl(item, requestOptions);
-  result.links.self = getItemHomeUrl(result.id, requestOptions);
-  const identifier = getItemIdentifier(item);
-  result.links.siteRelative = getHubRelativeUrl(
-    result.type,
-    identifier,
-    item.typeKeywords
-  );
-  result.links.workspaceRelative = getRelativeWorkspaceUrl(
-    result.type,
-    identifier
-  );
+  result.links = { ...computeLinks(item, requestOptions) };
 
   return result;
 }

--- a/packages/common/test/groups/_internal/computeLinks.test.ts
+++ b/packages/common/test/groups/_internal/computeLinks.test.ts
@@ -1,0 +1,36 @@
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
+import { computeLinks } from "../../../src/groups/_internal/computeLinks";
+import { ArcGISContextManager } from "../../../src";
+import { MOCK_AUTH } from "../../mocks/mock-auth";
+import { IPortal } from "@esri/arcgis-rest-portal";
+
+describe("computeLinks", () => {
+  let authdCtxMgr: ArcGISContextManager;
+  let group: IGroup;
+
+  beforeEach(async () => {
+    group = {
+      id: "00c",
+    } as IGroup;
+    authdCtxMgr = await ArcGISContextManager.create({
+      authentication: MOCK_AUTH,
+      currentUser: {} as IUser,
+      portal: {
+        name: "DC R&D Center",
+        id: "BRXFAKE",
+        urlKey: "fake-org",
+        properties: {
+          hub: { enabled: true },
+        },
+      } as unknown as IPortal,
+      portalUrl: "https://org.maps.arcgis.com",
+    });
+  });
+
+  it("generates a links hash", () => {
+    const chk = computeLinks(group, authdCtxMgr.context.requestOptions);
+
+    expect(chk.siteRelative).toBe("/teams/00c");
+    expect(chk.workspaceRelative).toBe("/workspace/groups/00c");
+  });
+});

--- a/packages/common/test/groups/_internal/computeProps.test.ts
+++ b/packages/common/test/groups/_internal/computeProps.test.ts
@@ -3,6 +3,7 @@ import { MOCK_AUTH } from "../../mocks/mock-auth";
 import { ArcGISContextManager } from "../../../src/ArcGISContextManager";
 import { computeProps } from "../../../src/groups/_internal/computeProps";
 import { IHubGroup } from "../../../src/core/types/IHubGroup";
+import * as computeLinksModule from "../../../src/groups/_internal/computeLinks";
 
 describe("groups: computeProps:", () => {
   let group: IGroup;
@@ -86,15 +87,18 @@ describe("groups: computeProps:", () => {
           "https://org.maps.arcgis.com/sharing/rest/community/groups/3ef/info/group.jpg"
         );
       });
-      it("computes a links hash for the group", () => {
+      it("generates a links hash", () => {
+        const computeLinksSpy = spyOn(
+          computeLinksModule,
+          "computeLinks"
+        ).and.returnValue({ self: "some-link" });
         const chk = computeProps(
           group,
           hubGroup,
           authdCtxMgr.context.requestOptions
         );
-
-        expect(chk.links?.siteRelative).toBe("/teams/3ef");
-        expect(chk.links?.workspaceRelative).toBe("/workspace/groups/3ef");
+        expect(computeLinksSpy).toHaveBeenCalledTimes(1);
+        expect(chk.links).toEqual({ self: "some-link" });
       });
       it("computes the correct props when no userMembership", () => {
         group = {

--- a/packages/common/test/groups/_internal/computeProps.test.ts
+++ b/packages/common/test/groups/_internal/computeProps.test.ts
@@ -86,6 +86,16 @@ describe("groups: computeProps:", () => {
           "https://org.maps.arcgis.com/sharing/rest/community/groups/3ef/info/group.jpg"
         );
       });
+      it("computes a links hash for the group", () => {
+        const chk = computeProps(
+          group,
+          hubGroup,
+          authdCtxMgr.context.requestOptions
+        );
+
+        expect(chk.links?.siteRelative).toBe("/teams/3ef");
+        expect(chk.links?.workspaceRelative).toBe("/workspace/groups/3ef");
+      });
       it("computes the correct props when no userMembership", () => {
         group = {
           id: "3ef",

--- a/packages/common/test/initiatives/_internal/computeLinks.test.ts
+++ b/packages/common/test/initiatives/_internal/computeLinks.test.ts
@@ -1,0 +1,44 @@
+import { IItem, IUser } from "@esri/arcgis-rest-types";
+import { computeLinks } from "../../../src/initiatives/_internal/computeLinks";
+import { ArcGISContextManager, setProp } from "../../../src";
+import { MOCK_AUTH } from "../../mocks/mock-auth";
+import { IPortal } from "@esri/arcgis-rest-portal";
+
+describe("computeLinks", () => {
+  let authdCtxMgr: ArcGISContextManager;
+  let item: IItem;
+
+  beforeEach(async () => {
+    item = {
+      type: "Hub Initiative",
+      id: "00c",
+    } as IItem;
+    authdCtxMgr = await ArcGISContextManager.create({
+      authentication: MOCK_AUTH,
+      currentUser: {} as IUser,
+      portal: {
+        name: "DC R&D Center",
+        id: "BRXFAKE",
+        urlKey: "fake-org",
+        properties: {
+          hub: { enabled: true },
+        },
+      } as unknown as IPortal,
+      portalUrl: "https://org.maps.arcgis.com",
+    });
+  });
+
+  it("generates a links hash using the initiative's slug", () => {
+    setProp("properties.slug", "mock-slug", item);
+    const chk = computeLinks(item, authdCtxMgr.context.requestOptions);
+
+    expect(chk.siteRelative).toBe("/initiatives2/mock-slug");
+    expect(chk.workspaceRelative).toBe("/workspace/initiatives/mock-slug");
+  });
+  it("generates a links hash using the initiative's id when no slug is available", () => {
+    const chk = computeLinks(item, authdCtxMgr.context.requestOptions);
+
+    expect(chk.siteRelative).toBe("/initiatives2/00c");
+    expect(chk.workspaceRelative).toBe("/workspace/initiatives/00c");
+  });
+});

--- a/packages/common/test/initiatives/_internal/computeProps.test.ts
+++ b/packages/common/test/initiatives/_internal/computeProps.test.ts
@@ -5,6 +5,7 @@ import { computeProps } from "../../../src/initiatives/_internal/computeProps";
 import { IHubInitiative, IModel } from "../../../src";
 import * as processEntitiesModule from "../../../src/permissions/_internal/processEntityFeatures";
 import { InitiativeDefaultFeatures } from "../../../src/initiatives/_internal/InitiativeBusinessRules";
+import * as computeLinksModule from "../../../src/initiatives/_internal/computeLinks";
 
 describe("initiatives: computeProps:", () => {
   let authdCtxMgr: ArcGISContextManager;
@@ -97,30 +98,18 @@ describe("initiatives: computeProps:", () => {
       expect(chk.features?.settings).toBeFalsy();
       expect(spy.calls.argsFor(0)[0]).toEqual({ details: true });
     });
-    describe("links hash", () => {
-      it("generates a links hash using the initiative's slug", () => {
-        const chk = computeProps(
-          model,
-          initiative,
-          authdCtxMgr.context.requestOptions
-        );
-
-        expect(chk.links?.siteRelative).toBe("/initiatives2/mock-slug");
-        expect(chk.links?.workspaceRelative).toBe(
-          "/workspace/initiatives/mock-slug"
-        );
-      });
-      it("generates a links hash using the initiative's id when no slug is available", () => {
-        initiative.slug = undefined;
-        const chk = computeProps(
-          model,
-          initiative,
-          authdCtxMgr.context.requestOptions
-        );
-
-        expect(chk.links?.siteRelative).toBe("/initiatives2/00c");
-        expect(chk.links?.workspaceRelative).toBe("/workspace/initiatives/00c");
-      });
+    it("generates a links hash", () => {
+      const computeLinksSpy = spyOn(
+        computeLinksModule,
+        "computeLinks"
+      ).and.returnValue({ self: "some-link" });
+      const chk = computeProps(
+        model,
+        initiative,
+        authdCtxMgr.context.requestOptions
+      );
+      expect(computeLinksSpy).toHaveBeenCalledTimes(1);
+      expect(chk.links).toEqual({ self: "some-link" });
     });
   });
 });

--- a/packages/common/test/projects/_internal/computeLinks.test.ts
+++ b/packages/common/test/projects/_internal/computeLinks.test.ts
@@ -1,0 +1,44 @@
+import { IItem, IUser } from "@esri/arcgis-rest-types";
+import { computeLinks } from "../../../src/projects/_internal/computeLinks";
+import { ArcGISContextManager, setProp } from "../../../src";
+import { MOCK_AUTH } from "../../mocks/mock-auth";
+import { IPortal } from "@esri/arcgis-rest-portal";
+
+describe("computeLinks", () => {
+  let authdCtxMgr: ArcGISContextManager;
+  let item: IItem;
+
+  beforeEach(async () => {
+    item = {
+      type: "Hub Project",
+      id: "00c",
+    } as IItem;
+    authdCtxMgr = await ArcGISContextManager.create({
+      authentication: MOCK_AUTH,
+      currentUser: {} as IUser,
+      portal: {
+        name: "DC R&D Center",
+        id: "BRXFAKE",
+        urlKey: "fake-org",
+        properties: {
+          hub: { enabled: true },
+        },
+      } as unknown as IPortal,
+      portalUrl: "https://org.maps.arcgis.com",
+    });
+  });
+
+  it("generates a links hash using the project's slug", () => {
+    setProp("properties.slug", "mock-slug", item);
+    const chk = computeLinks(item, authdCtxMgr.context.requestOptions);
+
+    expect(chk.siteRelative).toBe("/projects/mock-slug");
+    expect(chk.workspaceRelative).toBe("/workspace/projects/mock-slug");
+  });
+  it("generates a links hash using the project's id when no slug is available", () => {
+    const chk = computeLinks(item, authdCtxMgr.context.requestOptions);
+
+    expect(chk.siteRelative).toBe("/projects/00c");
+    expect(chk.workspaceRelative).toBe("/workspace/projects/00c");
+  });
+});

--- a/packages/common/test/projects/_internal/computeProps.test.ts
+++ b/packages/common/test/projects/_internal/computeProps.test.ts
@@ -5,6 +5,8 @@ import { computeProps } from "../../../src/projects/_internal/computeProps";
 import { IHubProject, IModel } from "../../../src";
 import * as processEntitiesModule from "../../../src/permissions/_internal/processEntityFeatures";
 import { ProjectDefaultFeatures } from "../../../src/projects/_internal/ProjectBusinessRules";
+import * as computeLinksModule from "../../../src/projects/_internal/computeLinks";
+
 describe("projects: computeProps:", () => {
   let authdCtxMgr: ArcGISContextManager;
   let model: IModel;
@@ -96,30 +98,18 @@ describe("projects: computeProps:", () => {
       expect(chk.features?.settings).toBeFalsy();
       expect(spy.calls.argsFor(0)[0]).toEqual({ details: true });
     });
-    describe("links hash", () => {
-      it("generates a links hash using the project's slug", () => {
-        const chk = computeProps(
-          model,
-          project,
-          authdCtxMgr.context.requestOptions
-        );
-
-        expect(chk.links?.siteRelative).toBe("/projects/mock-slug");
-        expect(chk.links?.workspaceRelative).toBe(
-          "/workspace/projects/mock-slug"
-        );
-      });
-      it("generates a links hash using the project's id when no slug is available", () => {
-        project.slug = undefined;
-        const chk = computeProps(
-          model,
-          project,
-          authdCtxMgr.context.requestOptions
-        );
-
-        expect(chk.links?.siteRelative).toBe("/projects/00c");
-        expect(chk.links?.workspaceRelative).toBe("/workspace/projects/00c");
-      });
+    it("generates a links hash", () => {
+      const computeLinksSpy = spyOn(
+        computeLinksModule,
+        "computeLinks"
+      ).and.returnValue({ self: "some-link" });
+      const chk = computeProps(
+        model,
+        project,
+        authdCtxMgr.context.requestOptions
+      );
+      expect(computeLinksSpy).toHaveBeenCalledTimes(1);
+      expect(chk.links).toEqual({ self: "some-link" });
     });
   });
 });


### PR DESCRIPTION
### Description:
- centralize link logic for project, initiative, and group entities by adding an internal `computeLinks` util for each
- call `computeLinks` form `computeProps` and `enrich<Entity>SearchResult` to generate a links hash for project, initiative and group entities/search results

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.