### PR TITLE
fix(hub-common): content location should be of type extent, not polygon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64981,7 +64981,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.20.0",
+			"version": "14.21.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -65025,7 +65025,7 @@
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "14.0.0",
+			"version": "14.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",

--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -25,13 +25,9 @@ export const getExtentObject = (itemExtent: number[][]): IExtent => {
 
 export function deriveLocationFromItemExtent(itemExtent?: number[][]) {
   const location: IHubLocation = { type: "custom" };
-  const geometry: any = getExtentObject(itemExtent); // TODO: this needs to be fixed -tom
+  const geometry: any = getExtentObject(itemExtent);
   if (geometry) {
-    const convertedExtent = {
-      ...extentToPolygon(geometry),
-      type: "polygon",
-    } as unknown as Geometry;
-    location.geometries = [convertedExtent];
+    location.geometries = [geometry];
     location.spatialReference = geometry.spatialReference;
     location.extent = itemExtent;
   }

--- a/packages/common/src/core/types/IHubLocation.ts
+++ b/packages/common/src/core/types/IHubLocation.ts
@@ -17,8 +17,14 @@ export interface IHubLocation {
   // the extent of the location
   extent?: number[][];
 
-  // An esri geometry: __esri.Geometry
-  geometries?: __esri.Geometry[];
+  // array of geometries representing the location
+  // NOTE: we use partial here b/c __esri.Geometry
+  // is the type for instances and includes methods, etc
+  // but we want to be able to pass around POJOs as well as instances
+  // instead, we might want to use __esri.GeometryProperties or
+  // a discriminated union of the point, line, polygon, and extent _property_ types
+  // but for now it is a non-breaking change to relax __esri.Geometry w/ a partial
+  geometries?: Array<Partial<__esri.Geometry>>;
 
   // DEPRECATED: the following will be removed at next breaking version
   provenance?: "none" | "custom" | "existing";


### PR DESCRIPTION
affects: @esri/hub-common

also relax IHubLocation.geometries to accept POJOs

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
