### PR TITLE
fix(hub-common): handle undefined context.portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
       - beta
       # - alpha disabled to allow push to alpha then merge to master w/o incurring a release
       - next
+      - +([0-9])?(.{+([0-9]),x}).x
     # Dont run if it's just markdown or doc files
     paths-ignore:
       - "**.md"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       - beta
       # - alpha disabled to allow push to alpha then merge to master w/o incurring a release
       - next
-      - +([0-9])?(.{+([0-9]),x}).x
+      - '[0-9]+.[0-9]+.x'
     # Dont run if it's just markdown or doc files
     paths-ignore:
       - "**.md"

--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
 	},
 	"release": {
 		"branches": [
+			"+([1-9])?(.{+([1-9]),x}).x",
 			"master",
 			{
 				"name": "next",

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -142,7 +142,7 @@ export class HubSite
   ): IHubSite {
     // ensure we have the orgUrlKey
     if (!partialSite.orgUrlKey) {
-      partialSite.orgUrlKey = context.portal.urlKey;
+      partialSite.orgUrlKey = context.portal?.urlKey;
     }
     // extend the partial over the defaults
     const pojo = { ...DEFAULT_SITE, ...partialSite } as IHubSite;

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -52,7 +52,10 @@ describe("HubSite Class:", () => {
   describe("static methods:", () => {
     it("loads from minimal json", () => {
       const createSpy = spyOn(HubSitesModule, "createSite");
-      const chk = HubSite.fromJson({ name: "Test Site" }, authdCtxMgr.context);
+      const chk = HubSite.fromJson(
+        { name: "Test Site" },
+        unauthdCtxMgr.context
+      );
 
       expect(createSpy).not.toHaveBeenCalled();
       expect(chk.toJson().name).toEqual("Test Site");


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
