### PR TITLE
fix(hub-common): handle undefined context.portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
       - beta
       # - alpha disabled to allow push to alpha then merge to master w/o incurring a release
       - next
+      - +([0-9])?(.{+([0-9]),x}).x
     # Dont run if it's just markdown or doc files
     paths-ignore:
       - "**.md"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       - beta
       # - alpha disabled to allow push to alpha then merge to master w/o incurring a release
       - next
-      - +([0-9])?(.{+([0-9]),x}).x
+      - '[0-9]+.[0-9]+.x'
     # Dont run if it's just markdown or doc files
     paths-ignore:
       - "**.md"

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
 				"@esri/arcgis-rest-portal": "^3.5.0",
 				"@esri/arcgis-rest-request": "^3.1.1",
 				"@esri/arcgis-rest-types": "^3.1.1",
-				"@semantic-release/changelog": "^6.0.1",
+				"@semantic-release/changelog": "^6.0.3",
 				"@semantic-release/git": "^10.0.1",
 				"@types/arcgis-js-api": "~4.26.0",
 				"@types/es6-promise": "0.0.32",
@@ -64972,7 +64972,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "13.16.0",
+			"version": "13.17.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
 	},
 	"release": {
 		"branches": [
+			"+([1-9])?(.{+([1-9]),x}).x",
 			"master",
 			{
 				"name": "next",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@esri/arcgis-rest-portal": "^3.5.0",
     "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/arcgis-rest-types": "^3.1.1",
-		"@semantic-release/changelog": "^6.0.1",
+		"@semantic-release/changelog": "^6.0.3",
 		"@semantic-release/git": "^10.0.1",
 		"@types/arcgis-js-api": "~4.26.0",
 		"@types/es6-promise": "0.0.32",
@@ -150,7 +150,7 @@
 		"y:push": "lerna run y:push",
 		"release:dry": "multi-semantic-release --dry-run --deps.prefix=^ --deps.bump=satisfy --deps.release=inherit --ignore-private-packages --debug",
 		"prerelease": "npm config set workspaces-update false",
-		"release": "multi-semantic-release --deps.prefix=^ --deps.bump=satisfy --deps.release=inherit --ignore-private-packages"
+		"release": "multi-semantic-release --deps.prefix=^ --deps.bump=satisfy --deps.release=inherit --ignore-packages=packages/discussions --ignore-private-packages"
 	},
 	"husky": {
 		"hooks": {

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -142,7 +142,7 @@ export class HubSite
   ): IHubSite {
     // ensure we have the orgUrlKey
     if (!partialSite.orgUrlKey) {
-      partialSite.orgUrlKey = context.portal.urlKey;
+      partialSite.orgUrlKey = context.portal?.urlKey;
     }
     // extend the partial over the defaults
     const pojo = { ...DEFAULT_SITE, ...partialSite } as IHubSite;

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -52,7 +52,10 @@ describe("HubSite Class:", () => {
   describe("static methods:", () => {
     it("loads from minimal json", () => {
       const createSpy = spyOn(HubSitesModule, "createSite");
-      const chk = HubSite.fromJson({ name: "Test Site" }, authdCtxMgr.context);
+      const chk = HubSite.fromJson(
+        { name: "Test Site" },
+        unauthdCtxMgr.context
+      );
 
       expect(createSpy).not.toHaveBeenCalled();
       expect(chk.toJson().name).toEqual("Test Site");


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
