### PR TITLE
chore: allow for maintenance releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
       - beta
       # - alpha disabled to allow push to alpha then merge to master w/o incurring a release
       - next
+      - '[0-9]+.[0-9]+.x'
     # Dont run if it's just markdown or doc files
     paths-ignore:
       - "**.md"

--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
 	},
 	"release": {
 		"branches": [
+			"+([1-9])?(.{+([1-9]),x}).x",
 			"master",
 			{
 				"name": "next",


### PR DESCRIPTION
_May_ allow for maintenance releases on old channels under some circumstances. This did not work for my specific scenario but may work for others.

My scenario would not work because I wanted to release hub-common 13.17.4 based on @esri/hub-common@13.17.3 but the git history of that tag contains discussions releases in the 25.x range.