### PR TITLE
fix(hub-common): properly compute workspace route for content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22659,9 +22659,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22676,21 +22677,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22704,9 +22708,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22724,9 +22729,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64981,7 +64987,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.21.1",
+			"version": "14.22.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -83401,7 +83407,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83416,17 +83423,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83440,7 +83450,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83457,7 +83468,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/core/getRelativeWorkspaceUrl.ts
+++ b/packages/common/src/core/getRelativeWorkspaceUrl.ts
@@ -22,7 +22,11 @@ export const getRelativeWorkspaceUrl = (
    * 2. handle entity variation
    */
   if (isValidEntityType(entityType)) {
-    url = `/workspace/${entityType}s/${identifier}`;
+    let typeSegment = entityType as string;
+    if (typeSegment !== "content") {
+      typeSegment = `${typeSegment}s`;
+    }
+    url = `/workspace/${typeSegment}/${identifier}`;
   }
 
   return url;

--- a/packages/common/test/core/getRelativeWorkspaceUrl.test.ts
+++ b/packages/common/test/core/getRelativeWorkspaceUrl.test.ts
@@ -21,6 +21,22 @@ describe("getRelativeWorkspaceUrl", () => {
     expect(isValidEntityTypeSpy).toHaveBeenCalledTimes(1);
     expect(result).toBe("/workspace/projects/123");
   });
+  it("returns the relative workspace url if provided entity type content", () => {
+    const getTypeFromEntitySpy = spyOn(
+      getTypeFromEntityModule,
+      "getTypeFromEntity"
+    ).and.returnValue("content");
+    const isValidEntityTypeSpy = spyOn(
+      isValidEntityTypeModule,
+      "isValidEntityType"
+    ).and.returnValue(true);
+
+    result = getRelativeWorkspaceUrl("Web Mapping Application", "123");
+
+    expect(getTypeFromEntitySpy).toHaveBeenCalledTimes(1);
+    expect(isValidEntityTypeSpy).toHaveBeenCalledTimes(1);
+    expect(result).toBe("/workspace/content/123");
+  });
   it('returns "/" if provided an invalid entity type', () => {
     const getTypeFromEntitySpy = spyOn(
       getTypeFromEntityModule,


### PR DESCRIPTION
1. Description: workspace route for content is /workspace/content/:id not /workspace/contents/:id

1. Related: [7992](https://devtopia.esri.com/dc/hub/issues/7992)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
