### PR TITLE
fix: add Project to wellKnownCatalogs

### DIFF
--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -351,6 +351,24 @@ function getAllCollectionsMap(i18nScope: string, entityType: EntityType): any {
         ],
       },
     } as IHubCollection,
+    project: {
+      key: "project",
+      label: `{{${i18nScope}collection.projects:translate}}`,
+      targetEntity: entityType,
+      include: [],
+      scope: {
+        targetEntity: entityType,
+        filters: [
+          {
+            predicates: [
+              {
+                type: getFamilyTypes("project"),
+              },
+            ],
+          },
+        ],
+      },
+    } as IHubCollection,
   };
 }
 
@@ -359,7 +377,7 @@ function getAllCollectionsMap(i18nScope: string, entityType: EntityType): any {
  * @returns a list of WellKnownCollection definition strings
  */
 function getDefaultCollectionNames(): WellKnownCollection[] {
-  return ["appAndMap", "dataset", "document", "feedback", "site"];
+  return ["appAndMap", "dataset", "document", "feedback", "site", "project"];
 }
 
 /**

--- a/packages/common/test/search/wellKnownCatalog.test.ts
+++ b/packages/common/test/search/wellKnownCatalog.test.ts
@@ -35,6 +35,7 @@ describe("WellKnownCatalog", () => {
         "document",
         "feedback",
         "site",
+        "project",
       ]);
       chk = getWellKnownCatalog("mockI18nScope", "favorites", "item", options);
       expect(chk.scopes).toBeDefined();
@@ -47,6 +48,7 @@ describe("WellKnownCatalog", () => {
         "document",
         "feedback",
         "site",
+        "project",
       ]);
     });
     it("returns the expected catalog for groups", () => {
@@ -178,6 +180,7 @@ describe("WellKnownCatalog", () => {
         "document",
         "feedback",
         "site",
+        "project",
       ]);
       expect(chk[1].scope.filters[0].predicates[0].type).toEqual([
         "CSV Collection",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

 Add Project to wellKnownCatalogs and add Projects to default collections in wellKnownColletions. Issue [8052](https://zentopia.esri.com/workspaces/collaboration-sprint-board-614f9bfc0946c40011ef574e/issues/dc/hub/8052)


![image](https://github.com/Esri/hub.js/assets/16672774/8dbab885-0714-4538-866c-dc44818a7cd9)


1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
