### PR TITLE
fix: properly deserialize trustedOrgs from context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64981,7 +64981,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.23.0",
+			"version": "14.26.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/src/ArcGISContextManager.ts
+++ b/packages/common/src/ArcGISContextManager.ts
@@ -245,6 +245,12 @@ export class ArcGISContextManager {
         if (state.properties) {
           opts.properties = state.properties;
         }
+        if (state.trustedOrgIds) {
+          opts.trustedOrgIds = state.trustedOrgIds;
+        }
+        if (state.trustedOrgs) {
+          opts.trustedOrgs = state.trustedOrgs;
+        }
       }
     } else {
       // if the session is expired, we can still carry forward the portalUrl

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -219,6 +219,8 @@ const serializedContext = {
   properties: {
     foo: "bar",
   },
+  trustedOrgIds: ["FAKEID", "FOTHERID"],
+  trustedOrgs: onlinePartneredOrgResponse.trustedOrgs,
 };
 
 const validSerializedContext = cloneObject(serializedContext);
@@ -597,6 +599,13 @@ describe("ArcGISContext:", () => {
         validSerializedContext.currentUser
       );
       expect(mgr.context.session.token).toEqual(validSession.token);
+      // trusted orgs/ids
+      expect(mgr.context.trustedOrgIds).toEqual(
+        validSerializedContext.trustedOrgIds
+      );
+      expect(mgr.context.trustedOrgs).toEqual(
+        validSerializedContext.trustedOrgs
+      );
     });
     it("can deserialize sparse, valid context", async () => {
       const selfSpy = spyOn(portalModule, "getSelf").and.callFake(() => {
@@ -612,6 +621,8 @@ describe("ArcGISContext:", () => {
       delete sparseValidContext.currentUser;
       delete sparseValidContext.portal;
       delete sparseValidContext.properties;
+      delete sparseValidContext.trustedOrgIds;
+      delete sparseValidContext.trustedOrgs;
 
       const serialized = unicodeToBase64(JSON.stringify(sparseValidContext));
       const mgr = await ArcGISContextManager.deserialize(serialized!);


### PR DESCRIPTION
1. Description: We weren't properly deserializing trustedOrgs/trustedOrgIds from the context so issues were occurring in the app like "refreshing the page wasn't properly fleshing out the context so there were issues in some components" 

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
