### PR TITLE
fix(hub-discussions): add author and editor to isearchchannels

### DIFF
--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -890,12 +890,16 @@ export interface IFetchChannel {
  * @extends {Partial<IWithSorting<ChannelSort>>}
  * @extends {Partial<IWithTimeQueries>}
  * @extends {Partial<IWithFiltering<ChannelFilter>>}
+ * @extends {Partial<IWithAuthor>}
+ * @extends {Partial<IWithEditor>}
  */
 export interface ISearchChannels
   extends Partial<IPagingParams>,
     Partial<IWithSorting<ChannelSort>>,
     Partial<IWithTimeQueries>,
-    Partial<IWithFiltering<ChannelFilter>> {
+    Partial<IWithFiltering<ChannelFilter>>,
+    Partial<IWithAuthor>,
+    Partial<IWithEditor> {
   groups?: string[];
   access?: SharingAccess[];
   relations?: ChannelRelation[];


### PR DESCRIPTION
1. Description: Added `author` and `editor` params to `ISearchChannels` interface

2. Related Issues: #<9781> ([if appropriate](https://zentopia.esri.com/workspaces/engagement-workspace-61508ae50946c40014ef574f/issues/dc/hub/7981))

3. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

4. [X] used semantic commit messages
  
5. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

6. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
