### PR TITLE
feat: collaborator pane for content workspace

### DIFF
--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -23,6 +23,7 @@ export const ContentPermissions = [
   "hub:content:workspace:details",
   "hub:content:workspace:discussion",
   "hub:content:workspace:settings",
+  "hub:content:workspace:collaborators",
   "hub:content:manage",
 ] as const;
 
@@ -76,6 +77,10 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:content:workspace:settings",
     dependencies: ["hub:content:edit"],
     entityOwner: true,
+  },
+  {
+    permission: "hub:content:workspace:collaborators",
+    dependencies: ["hub:content:edit"],
   },
   {
     permission: "hub:content:manage",


### PR DESCRIPTION
OD-UI: https://github.com/ArcGIS/opendata-ui/pull/12617

1. Description: Added a collaborators pane to the content workspace. Has the same features as the collaborators pane in the site workspace.

1. Instructions for testing:
- Open the content workspace for a content item
- View the collaborators tab
- Make changes to the `Groups that can edit` and `Groups that can view`
- Feel free to test with my content item: `88b077a232224e52b684eacd2ecdda5f`

1. Closes Issues: [7942](https://devtopia.esri.com/dc/hub/issues/7942)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
