### PR TITLE
feat: support for Site and Hub user app resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64981,7 +64981,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.29.0",
+			"version": "14.30.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -65007,7 +65007,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "26.0.1",
+			"version": "26.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65025,7 +65025,7 @@
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "14.1.0",
+			"version": "14.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -65084,7 +65084,7 @@
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "14.0.0",
+			"version": "14.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65106,7 +65106,7 @@
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "14.0.1",
+			"version": "14.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65128,7 +65128,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "14.0.0",
+			"version": "14.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65148,7 +65148,7 @@
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "14.0.0",
+			"version": "14.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/e2e/associations.e2e.ts
+++ b/packages/common/e2e/associations.e2e.ts
@@ -49,7 +49,7 @@ const TEST_ITEMS = {
   ],
 };
 
-fdescribe("associations development harness:", () => {
+describe("associations development harness:", () => {
   let factory: Artifactory;
   const orgName = "hubPremiumAlpha";
   beforeAll(() => {

--- a/packages/common/e2e/context-manager.e2e.ts
+++ b/packages/common/e2e/context-manager.e2e.ts
@@ -13,7 +13,7 @@ describe("context-manager:", () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
     factory = new Artifactory(config);
   });
-  it("can set thumbnail on a project", async () => {
+  it("can serialize and deserialize", async () => {
     // create context
     const ctxMgr = await factory.getContextManager("hubBasic", "admin");
     // serialize

--- a/packages/common/e2e/hub-user-search.e2e.ts
+++ b/packages/common/e2e/hub-user-search.e2e.ts
@@ -33,6 +33,35 @@ describe("Hub User search", () => {
       expect(response.results.length).toBe(1);
       expect(response.results[0].owner).toBe("dave_pub_qa_pre");
     });
+    it("can search for users not in current users org", async () => {
+      const ctxMgr = await factory.getContextManager("hubPremium", "admin");
+      const ctx = ctxMgr.context;
+      const qry: IQuery = {
+        targetEntity: "communityUser",
+        filters: [
+          {
+            predicates: [
+              {
+                orgid: {
+                  not: [ctx.currentUser.orgId],
+                },
+              },
+              {
+                orgid: { type: "range", from: "0", to: "\\{" },
+              },
+            ],
+          },
+        ],
+      };
+
+      const response = await hubSearch(qry, {
+        requestOptions: ctx.hubRequestOptions,
+      });
+
+      expect(response.results).toBeDefined();
+      expect(response.results.length).toBe(1);
+      expect(response.results[0].owner).toBe("dave_pub_qa_pre");
+    });
   });
 
   describe("Search for Group Users", () => {

--- a/packages/common/e2e/user-app-resources.e2e.ts
+++ b/packages/common/e2e/user-app-resources.e2e.ts
@@ -1,21 +1,40 @@
 import { UserSession } from "@esri/arcgis-rest-auth";
-import { ArcGISContextManager } from "../src";
+import {
+  ArcGISContextManager,
+  IUserHubSettings,
+  IUserSiteSettings,
+  UserResourceApp,
+  getUserHubSettings,
+  getUserSiteSettings,
+  setUserHubSettings,
+  setUserSiteSettings,
+} from "../src";
+import {
+  IAddUserResource,
+  getUserResource,
+  listUserResources,
+  removeUserResource,
+  setUserResource,
+} from "../src/utils/internal/userAppResources";
 import Artifactory from "./helpers/Artifactory";
 import config from "./helpers/config";
 import { getUser } from "@esri/arcgis-rest-portal";
+import { clearUserSiteSettings } from "../src/utils/internal/clearUserSiteSettings";
+import { clearUserHubSettings } from "../src/utils/internal/clearUserHubSettings";
 
 // NOTE: User App Resources is coupled with oAuth
 // so we can't simply create a session via username / pwd
 // because the resultant token is NOT tied to a clientId
 //
 // Auth into uar-harness-qa-pre-a-hub.hubqa.arcgis.com as paige_pa
-// ** BE SURE TO AUTH INTO THIS SITE** don't just transition from
-// another site!
+// ** BE SURE TO AUTH INTO THIS SITE** don't just transition from another site!
 // go into network tab and get the token
 const SITE_TOKEN =
-  "5jBAbdC6em0-T0BPBeYnoyIYn-9tBYpPOWsdY8ieSxU9bcw4XCvRMGUXTr5bkvZm3RyqynXHz7aLPFPOPbC4nx-HTtgIEZB6QnABW55Z5sRNHi9mOWWsfxjVtXjyiQk-OAC7g0F-X9bAKVE_ombXhlaBxiGkSh_TOK4I0_jFhol2TG5mwHd8-JAU0UgSe7Q-kbY97VLP_RDByOvrQb5xC7KQmFPRQqRkUFUqX7MYTE.";
+  "yK55bPcOmtP3tWOVxqO8CroEfutCJjZEcf_9CZiDEZjJL8CoSWbm6eaVjnIcrXg9-jgUam2s204haNHoi1JGd1YBLBtk6W5AQrEZVK77y8b-sX2LOVuc_pb0jhIJLYE_pLeqKa9AY46mVMU2pTWDrR_moQu73ih9P9lVi_1MV43l6tfK_9BLgDx7dcf8DsnM_TKTxsw8sdDFMPgIfGGOse-BKTMie31g_9Riyn1ir1I.";
+// site  "yK55bPcOmtP3tWOVxqO8CroEfutCJjZEcf_9CZiDEZjJL8CoSWbm6eaVjnIcrXg9-jgUam2s204haNHoi1JGd1YBLBtk6W5AQrEZVK77y8b-sX2LOVuc_pb0jhIJLYE_pLeqKa9AY46mVMU2pTWDrR_moQu73ih9P9lVi_1MV43l6tfK_9BLgDx7dcf8DsnM_TKTxsw8sdDFMPgIfGGOse-BKTMie31g_9Riyn1ir1I.";
+// AGO "gMJyciD9aSJvVI78OU1L7zVAFJYDxWMMK9VJfXGzc2S2nK5hyHSp6qnIO9B3vaN4MXQg3VjOptRS4moWWtlAgvZLsBDDvsC4rOehHPXkWFkvTu_zrEBYIRDIPTtdfr5pkxmfLQZwJ73But5eaiiKWey63XrOnQXknOBcn-0Nd3t7QO3kvobvYtjLXj87SQf5wlIS0sFjMnZZ6FNPPjj9Djz7iJ9cAXX4uuEVo7LMy0Q."
 
-fdescribe("user-app-resources harness", () => {
+fdescribe("user-app-resources harness: ", () => {
   let factory: Artifactory;
   const orgName = "hubPremiumAlpha";
   let contextMgr: ArcGISContextManager;
@@ -29,13 +48,24 @@ fdescribe("user-app-resources harness", () => {
       userId: "paige_pa",
       server: factory.getPortalUrl(orgName),
       token: SITE_TOKEN,
-      expires: 30000,
+      expires: new Date().getTime() + 3600 * 24,
       ssl: true,
     });
+
     try {
       contextMgr = await ArcGISContextManager.create({
         portalUrl: factory.getPortalUrl(orgName),
         authentication: session,
+        resourceConfigs: [
+          {
+            app: "arcgisonline",
+            clientId: "arcgisonline",
+          },
+          {
+            app: "hubforarcgis",
+            clientId: "hubforarcgis",
+          },
+        ],
       });
     } catch (ex) {
       /* tslint:disable no-console */
@@ -44,9 +74,229 @@ fdescribe("user-app-resources harness", () => {
       console.error(`Ensure SITE_TOKEN is valid in user-app-resources.e2e.ts`);
     }
   });
-  it("fetch user via request options", async () => {
+  it("validate by fetching user", async () => {
     const u = await getUser(contextMgr.context.userRequestOptions);
     expect(u.username).toEqual("paige_pa");
-    // debugger;
+  });
+
+  xdescribe("low-level: ", () => {
+    // Should be connected to https://uar-harness-qa-pre-a-hub.hubqa.arcgis.com/
+    // clientId: 5cPqtyH2yLMndSx8
+    // unf we can't really "tell" that from a token :(
+
+    xit("purge hub resources", async () => {
+      // clean up janky hub resources
+      const siteToken = contextMgr.context.tokenFor("self");
+      const username = contextMgr.context.currentUser.username as string;
+      const portalUrl = contextMgr.context.portalUrl;
+      const list = await listUserResources(
+        username,
+        portalUrl,
+        siteToken,
+        true
+      );
+
+      // iterate the list, looking for specific entries to remove
+      const removeList = [
+        "hub-site-settings.json",
+        "hub-site-settings2.json",
+        "site-settings.json",
+        "hub-settings.json",
+      ];
+      for (const entry of list.userResources) {
+        console.info(`Resource ${entry.key} for clientId: ${entry.clientId}`);
+        if (removeList.includes(entry.key)) {
+          // DON'T DO THIS IN REAL APPS!
+          // Usually an app will have an entry for the clientId of the "self" app
+          const token =
+            contextMgr.context.tokenFor(entry.clientId as UserResourceApp) ||
+            contextMgr.context.tokenFor("self");
+          await removeUserResource(username, entry.key, portalUrl, token);
+        }
+      }
+      // re-fetch the list
+      const chk = await listUserResources(username, portalUrl, siteToken, true);
+      chk.userResources.forEach((entry) => {
+        console.info(`Resource ${entry.key} for clientId: ${entry.clientId}`);
+      });
+    });
+
+    it("store & fetch site setting", async () => {
+      const key = "hub-site-settings.json";
+      const data = {
+        test: {
+          simple: "data",
+          other: "data with 👍🏻 emojii",
+          updated: new Date().toDateString(),
+        },
+      };
+
+      const payload: IAddUserResource = {
+        access: "userappprivate",
+        data,
+        key,
+      };
+
+      const siteToken = contextMgr.context.tokenFor("self");
+      const portalUrl = contextMgr.context.portalUrl;
+      const username = contextMgr.context.currentUser.username as string;
+
+      const list = await listUserResources(
+        username,
+        portalUrl,
+        siteToken,
+        true
+      );
+
+      await setUserResource(payload, username, portalUrl, siteToken);
+
+      // now fetch it back again
+      const chk = await getUserResource(
+        username,
+        key,
+        contextMgr.context.portalUrl,
+        siteToken
+      );
+
+      expect(chk.test).toEqual(data.test);
+      // clean up
+      await removeUserResource(
+        username,
+        key,
+        contextMgr.context.portalUrl,
+        siteToken
+      );
+    });
+    it("store & fetch hub setting", async () => {
+      const key = "hub-settings.json";
+      const data = {
+        test: {
+          simple: "data",
+          other: "data with 👍🏻 emojii",
+          updated: new Date().toDateString(),
+        },
+      };
+
+      const payload: IAddUserResource = {
+        access: "userappprivate",
+        data,
+        key,
+      };
+
+      const hubToken = contextMgr.context.tokenFor("hubforarcgis");
+      const portalUrl = contextMgr.context.portalUrl;
+      const username = contextMgr.context.currentUser.username as string;
+      await setUserResource(
+        payload,
+        username,
+        contextMgr.context.portalUrl,
+        hubToken
+      );
+
+      const list = await listUserResources(username, portalUrl, hubToken, true);
+
+      // now fetch it back again
+      const chk = await getUserResource(
+        username,
+        key,
+        contextMgr.context.portalUrl,
+        hubToken
+      );
+
+      expect(chk.test).toEqual(data.test);
+      // clean up
+      await removeUserResource(
+        username,
+        key,
+        contextMgr.context.portalUrl,
+        hubToken
+      );
+    });
+    it("store & fetch AGO setting", async () => {
+      const key = "privacy-settings.json";
+      const data = {
+        test: {
+          simple: "data",
+          other: "data with 👍🏻 emojii",
+          updated: new Date().toDateString(),
+        },
+      };
+
+      const payload: IAddUserResource = {
+        access: "userappprivate",
+        data,
+        key,
+      };
+
+      const token = contextMgr.context.tokenFor("arcgisonline");
+      const username = contextMgr.context.currentUser.username as string;
+      await setUserResource(
+        payload,
+        username,
+        contextMgr.context.portalUrl,
+        token
+      );
+      // now fetch it back again
+      const chk = await getUserResource(
+        username,
+        key,
+        contextMgr.context.portalUrl,
+        token
+      );
+
+      expect(chk.test).toEqual(data.test);
+      // clean up
+      await removeUserResource(
+        username,
+        key,
+        contextMgr.context.portalUrl,
+        token
+      );
+    });
+  });
+
+  fdescribe("hub abstractions: ", () => {
+    it("stores site level settings", async () => {
+      const ts = new Date().getTime();
+      const settings: IUserSiteSettings = {
+        schemaVersion: 1,
+        username: "verify-overwrite",
+      };
+      const token = contextMgr.context.tokenFor("self");
+      const username = contextMgr.context.currentUser.username as string;
+      const portalUrl = contextMgr.context.portalUrl;
+      const list = await listUserResources(username, portalUrl, token, true);
+      await setUserSiteSettings(settings, contextMgr.context);
+      // now get it back
+      const chk = await getUserSiteSettings(contextMgr.context);
+      expect(chk.username).toBe("paige_pa");
+      expect(chk.updated).toBeGreaterThanOrEqual(ts);
+      await clearUserSiteSettings(contextMgr.context);
+    });
+    it("stores hub level settings", async () => {
+      const ts = new Date().getTime();
+      const settings: IUserHubSettings = {
+        schemaVersion: 1,
+        username: "verify-overwrite",
+      };
+      const token = contextMgr.context.tokenFor("hubforarcgis");
+      const username = contextMgr.context.currentUser.username as string;
+      const portalUrl = contextMgr.context.portalUrl;
+      const list = await listUserResources(username, portalUrl, token, true);
+      await setUserHubSettings(settings, contextMgr.context);
+      // now get it back
+      const chk = await getUserHubSettings(contextMgr.context);
+      expect(chk.username).toBe("paige_pa");
+      expect(chk.updated).toBeGreaterThanOrEqual(ts);
+      // now update it
+      settings.schemaVersion = 2;
+      await setUserHubSettings(settings, contextMgr.context, true);
+      const chk2 = await getUserHubSettings(contextMgr.context);
+      expect(chk2.username).toBe("paige_pa");
+      expect(chk2.updated).toBeGreaterThanOrEqual(ts);
+      expect(chk2.schemaVersion).toEqual(2);
+      // now kill it
+      await clearUserHubSettings(contextMgr.context);
+    });
   });
 });

--- a/packages/common/e2e/user-app-resources.e2e.ts
+++ b/packages/common/e2e/user-app-resources.e2e.ts
@@ -1,0 +1,52 @@
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { ArcGISContextManager } from "../src";
+import Artifactory from "./helpers/Artifactory";
+import config from "./helpers/config";
+import { getUser } from "@esri/arcgis-rest-portal";
+
+// NOTE: User App Resources is coupled with oAuth
+// so we can't simply create a session via username / pwd
+// because the resultant token is NOT tied to a clientId
+//
+// Auth into uar-harness-qa-pre-a-hub.hubqa.arcgis.com as paige_pa
+// ** BE SURE TO AUTH INTO THIS SITE** don't just transition from
+// another site!
+// go into network tab and get the token
+const SITE_TOKEN =
+  "5jBAbdC6em0-T0BPBeYnoyIYn-9tBYpPOWsdY8ieSxU9bcw4XCvRMGUXTr5bkvZm3RyqynXHz7aLPFPOPbC4nx-HTtgIEZB6QnABW55Z5sRNHi9mOWWsfxjVtXjyiQk-OAC7g0F-X9bAKVE_ombXhlaBxiGkSh_TOK4I0_jFhol2TG5mwHd8-JAU0UgSe7Q-kbY97VLP_RDByOvrQb5xC7KQmFPRQqRkUFUqX7MYTE.";
+
+fdescribe("user-app-resources harness", () => {
+  let factory: Artifactory;
+  const orgName = "hubPremiumAlpha";
+  let contextMgr: ArcGISContextManager;
+  let session: UserSession;
+
+  beforeAll(async () => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
+    factory = new Artifactory(config);
+    // create a session
+    session = UserSession.fromCredential({
+      userId: "paige_pa",
+      server: factory.getPortalUrl(orgName),
+      token: SITE_TOKEN,
+      expires: 30000,
+      ssl: true,
+    });
+    try {
+      contextMgr = await ArcGISContextManager.create({
+        portalUrl: factory.getPortalUrl(orgName),
+        authentication: session,
+      });
+    } catch (ex) {
+      /* tslint:disable no-console */
+      console.error(ex);
+      /* tslint:disable no-console */
+      console.error(`Ensure SITE_TOKEN is valid in user-app-resources.e2e.ts`);
+    }
+  });
+  it("fetch user via request options", async () => {
+    const u = await getUser(contextMgr.context.userRequestOptions);
+    expect(u.username).toEqual("paige_pa");
+    // debugger;
+  });
+});

--- a/packages/common/e2e/user-app-resources.e2e.ts
+++ b/packages/common/e2e/user-app-resources.e2e.ts
@@ -29,10 +29,8 @@ import { clearUserHubSettings } from "../src/utils/internal/clearUserHubSettings
 // Auth into uar-harness-qa-pre-a-hub.hubqa.arcgis.com as paige_pa
 // ** BE SURE TO AUTH INTO THIS SITE** don't just transition from another site!
 // go into network tab and get the token
-const SITE_TOKEN =
-  "yK55bPcOmtP3tWOVxqO8CroEfutCJjZEcf_9CZiDEZjJL8CoSWbm6eaVjnIcrXg9-jgUam2s204haNHoi1JGd1YBLBtk6W5AQrEZVK77y8b-sX2LOVuc_pb0jhIJLYE_pLeqKa9AY46mVMU2pTWDrR_moQu73ih9P9lVi_1MV43l6tfK_9BLgDx7dcf8DsnM_TKTxsw8sdDFMPgIfGGOse-BKTMie31g_9Riyn1ir1I.";
-// site  "yK55bPcOmtP3tWOVxqO8CroEfutCJjZEcf_9CZiDEZjJL8CoSWbm6eaVjnIcrXg9-jgUam2s204haNHoi1JGd1YBLBtk6W5AQrEZVK77y8b-sX2LOVuc_pb0jhIJLYE_pLeqKa9AY46mVMU2pTWDrR_moQu73ih9P9lVi_1MV43l6tfK_9BLgDx7dcf8DsnM_TKTxsw8sdDFMPgIfGGOse-BKTMie31g_9Riyn1ir1I.";
-// AGO "gMJyciD9aSJvVI78OU1L7zVAFJYDxWMMK9VJfXGzc2S2nK5hyHSp6qnIO9B3vaN4MXQg3VjOptRS4moWWtlAgvZLsBDDvsC4rOehHPXkWFkvTu_zrEBYIRDIPTtdfr5pkxmfLQZwJ73But5eaiiKWey63XrOnQXknOBcn-0Nd3t7QO3kvobvYtjLXj87SQf5wlIS0sFjMnZZ6FNPPjj9Djz7iJ9cAXX4uuEVo7LMy0Q."
+const SITE_TOKEN = "paste a token copied from a browser as per details above";
+// AGO "you may also need a token from the home app"
 
 fdescribe("user-app-resources harness: ", () => {
   let factory: Artifactory;

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -10,6 +10,7 @@ import { getProp, getWithDefault } from "./objects";
 import { HubEnvironment, HubLicense, IFeatureFlags } from "./permissions/types";
 import { IHubRequestOptions, IHubTrustedOrgsResponse } from "./types";
 import { getEnvironmentFromPortalUrl } from "./utils/getEnvironmentFromPortalUrl";
+import { IUserResourceToken, UserResourceApp } from "./ArcGISContextManager";
 
 /**
  * Hash of Hub API end points so updates
@@ -196,6 +197,17 @@ export interface IArcGISContext {
    * Trusted orgs xhr response
    */
   trustedOrgs: IHubTrustedOrgsResponse[];
+  /**
+   * Array of exchanged tokens for use
+   * with user-app-resources
+   */
+  userResourceTokens?: IUserResourceToken[];
+
+  /**
+   * Return the token for a given app, if defined
+   * @param app
+   */
+  tokenFor(app: UserResourceApp): string;
 }
 
 /**
@@ -262,6 +274,12 @@ export interface IArcGISContextOptions {
    * Trusted orgs xhr response
    */
   trustedOrgs?: IHubTrustedOrgsResponse[];
+
+  /**
+   * Array of exchanged tokens for use
+   * with user-app-resources
+   */
+  userResourceTokens?: IUserResourceToken[];
 }
 
 /**
@@ -305,6 +323,8 @@ export class ArcGISContext implements IArcGISContext {
 
   private _trustedOrgs: IHubTrustedOrgsResponse[];
 
+  private _userResourceTokens: IUserResourceToken[] = [];
+
   /**
    * Create a new instance of `ArcGISContext`.
    *
@@ -339,6 +359,7 @@ export class ArcGISContext implements IArcGISContext {
     }
 
     this._featureFlags = opts.featureFlags || {};
+    this._userResourceTokens = opts.userResourceTokens || [];
   }
 
   /**
@@ -668,5 +689,24 @@ export class ArcGISContext implements IArcGISContext {
    */
   public get trustedOrgs(): IHubTrustedOrgsResponse[] {
     return this._trustedOrgs;
+  }
+
+  /**
+   * Return the whole array of user resource tokens
+   */
+  public get userResourceTokens(): IUserResourceToken[] {
+    return this._userResourceTokens;
+  }
+
+  /**
+   * Return a token for a specific app
+   * @param app
+   * @returns
+   */
+  public tokenFor(app: UserResourceApp): string {
+    const entry = this._userResourceTokens.find((e) => e.app === app);
+    if (entry) {
+      return entry.token;
+    }
   }
 }

--- a/packages/common/src/ArcGISContextManager.ts
+++ b/packages/common/src/ArcGISContextManager.ts
@@ -1,5 +1,5 @@
 import { getSelf, getUser, IPortal } from "@esri/arcgis-rest-portal";
-import { IUser, UserSession } from "@esri/arcgis-rest-auth";
+import { exchangeToken, IUser, UserSession } from "@esri/arcgis-rest-auth";
 import {
   ArcGISContext,
   IArcGISContext,
@@ -16,6 +16,20 @@ import { IFeatureFlags } from "./permissions";
 import { IHubTrustedOrgsResponse } from "./types";
 import { request } from "@esri/arcgis-rest-request";
 import { failSafe } from "./utils/fail-safe";
+
+export type UserResourceApp = "self" | "hubforarcgis" | "arcgisonline";
+// Passed into ContextManager, specifying what exchangeToken calls
+// should be made
+export interface IUserResourceConfig {
+  app: UserResourceApp;
+  clientId: string;
+}
+
+// After exchangeToken call is successful, this is the structure
+// stored in the context.userResourceTokens prop
+export interface IUserResourceToken extends IUserResourceConfig {
+  token: string;
+}
 
 /**
  * Options that can be passed into `ArcGISContextManager.create`
@@ -86,6 +100,12 @@ export interface IArcGISContextManagerOptions {
    * Trusted orgs xhr response
    */
   trustedOrgs?: IHubTrustedOrgsResponse[];
+
+  /**
+   * Hash of clientId's that Context Manager should
+   * exchange tokens for
+   */
+  resourceConfigs?: IUserResourceConfig[];
 }
 
 /**
@@ -116,7 +136,7 @@ export class ArcGISContextManager {
 
   private _portalUrl: string = "https://www.arcgis.com";
 
-  private _properties: Record<string, any>;
+  private _properties: Record<string, any> = {};
 
   private _hubUrl: string;
 
@@ -134,6 +154,10 @@ export class ArcGISContextManager {
 
   private _trustedOrgs: IHubTrustedOrgsResponse[];
 
+  private _resourceConfigs: IUserResourceConfig[] = [];
+
+  private _resourceTokens: IUserResourceToken[] = [];
+
   /**
    * Private constructor. Use `ArcGISContextManager.create(...)` to
    * instantiate an instance
@@ -150,6 +174,11 @@ export class ArcGISContextManager {
 
     if (opts.properties) {
       this._properties = opts.properties;
+    }
+    // Default to the Alpha orgs defined in Hub.js unless
+    // other values are passed in
+    if (!this._properties.alphaOrgs) {
+      this._properties.alphaOrgs = [...ALPHA_ORGS];
     }
 
     if (opts.authentication) {
@@ -188,6 +217,10 @@ export class ArcGISContextManager {
 
     if (opts.trustedOrgs) {
       this._trustedOrgs = cloneObject(opts.trustedOrgs);
+    }
+
+    if (opts.resourceConfigs) {
+      this._resourceConfigs = opts.resourceConfigs;
     }
   }
 
@@ -262,6 +295,8 @@ export class ArcGISContextManager {
     opts.serviceStatus = state.serviceStatus;
     opts.featureFlags = state.featureFlags;
 
+    opts.resourceConfigs = state.resourceConfigs;
+
     return ArcGISContextManager.create(opts);
   }
 
@@ -297,10 +332,12 @@ export class ArcGISContextManager {
     if (!this._context.isPortal) {
       this._portalUrl = getPortalBaseFromOrgUrl(this._portalUrl);
     }
-    // Clear the auth, portalSelf and currentUser props
+    // Clear the auth related props
     this._authentication = null;
     this._portalSelf = null;
     this._currentUser = null;
+    this._resourceTokens = [];
+    // re-create the context
     this._context = new ArcGISContext(this.contextOpts);
   }
 
@@ -348,6 +385,10 @@ export class ArcGISContextManager {
       state.trustedOrgs = this._trustedOrgs;
     }
 
+    if (this._resourceConfigs) {
+      state.resourceConfigs = this._resourceConfigs;
+    }
+
     return unicodeToBase64(JSON.stringify(state));
   }
 
@@ -360,24 +401,52 @@ export class ArcGISContextManager {
     if (this._authentication && (!this._portalSelf || !this._currentUser)) {
       Logger.debug(`ArcGISContextManager-${this.id}: Initializing`);
       const username = this._authentication.username;
+      const token = await this._authentication.getToken(
+        this._authentication.portal
+      );
       const requests: [
         Promise<IPortal>,
         Promise<IUser>,
-        Promise<IHubTrustedOrgsResponse[]>
+        Promise<IHubTrustedOrgsResponse[]>,
+        Promise<IUserResourceToken[]>
       ] = [
         getSelf({ authentication: this._authentication }),
         getUser({ username, authentication: this._authentication }),
         getTrustedOrgs(this._portalUrl, this._authentication),
+        getUserResourceTokens(
+          this._resourceConfigs,
+          token,
+          this._portalUrl + "/sharing/rest"
+        ),
       ];
       try {
-        const [portal, user, trustedOrgs] = await Promise.all(requests);
+        const [portal, user, trustedOrgs, resourceTokens] = await Promise.all(
+          requests
+        );
         this._portalSelf = portal;
         this._currentUser = user;
         this._trustedOrgs = trustedOrgs;
         this._trustedOrgIds = getTrustedOrgIds(trustedOrgs);
+        this._resourceTokens = resourceTokens;
         Logger.debug(
           `ArcGISContextManager-${this.id}: received portalSelf and currentUser`
         );
+        // add the "self" entry for resourceTokens as it should always be available
+        this._resourceTokens.push({
+          app: "self",
+          token,
+          clientId: this._authentication.clientId || "self",
+        });
+        // Under normal circumstances, this will be defined
+        // but in node, where the context was created via a UserSession
+        // that was not returned from an oAuth flow, it will not be set
+        if (this._authentication.clientId) {
+          this._resourceTokens.push({
+            app: this._authentication.clientId as UserResourceApp,
+            token,
+            clientId: this._authentication.clientId,
+          });
+        }
       } catch (ex) {
         const msg = `ArcGISContextManager could not fetch portal & user for "${this._authentication.username}" using ${this._authentication.portal}.`;
         Logger.error(msg);
@@ -423,6 +492,8 @@ export class ArcGISContextManager {
       contextOpts.trustedOrgs = this._trustedOrgs;
     }
 
+    contextOpts.userResourceTokens = this._resourceTokens;
+
     return contextOpts;
   }
 }
@@ -466,6 +537,25 @@ function getTrustedOrgIds(trustedOrgs: IHubTrustedOrgsResponse[]): string[] {
   return trustedOrgs.map((org) => org.to.orgId);
 }
 
+async function getUserResourceTokens(
+  configs: IUserResourceConfig[],
+  currentToken: string,
+  portalUrl: string
+): Promise<IUserResourceToken[]> {
+  // failSafe exchangeToken so we don't have to catch
+  const failSafeExchange = failSafe(exchangeToken, null);
+  const promises = configs.map((cfg) => {
+    return failSafeExchange(currentToken, cfg.clientId, portalUrl).then(
+      (token) => {
+        if (token) {
+          return { ...cfg, token } as IUserResourceToken;
+        }
+      }
+    );
+  });
+  return Promise.all(promises);
+}
+
 const HUB_SERVICE_STATUS: HubServiceStatus = {
   portal: "online",
   discussions: "online",
@@ -485,3 +575,27 @@ const ENTERPRISE_SITES_SERVICE_STATUS: HubServiceStatus = {
   "hub-search": "not-available",
   domains: "not-available",
 };
+
+const DEV_ALPHA_ORGS = [
+  "LjjARY1mkhxulWPq",
+  "q2ikdtW0bkt5EgtQ",
+  "yHYVvboBBOdmcKci",
+];
+const QA_ALPHA_ORGS = [
+  "97KLIFOSt5CxbiRI",
+  "MiFBHFxEZWumnKCx",
+  "8HRYeOqprj872mxP",
+  "Xj56SBi2udA78cC9",
+];
+const PROD_ALPHA_ORGS = [
+  "gGHDlz6USftL5Pau",
+  "CrA5hYOKgL3Vwan8",
+  "zj227gjeSqEyG4HF",
+  "bkrWlSKcjUDFDtgw",
+];
+
+export const ALPHA_ORGS = [
+  ...PROD_ALPHA_ORGS,
+  ...QA_ALPHA_ORGS,
+  ...DEV_ALPHA_ORGS,
+];

--- a/packages/common/src/utils/getObjectSize.ts
+++ b/packages/common/src/utils/getObjectSize.ts
@@ -1,0 +1,17 @@
+export interface IObjectSize {
+  bytes: number;
+  kilobytes: number;
+  megabytes: number;
+}
+// Helper used to verify object size before storing resource
+export function getObjectSize(object: Record<string, any>): IObjectSize {
+  // javascript stores strings in unicode, so 2 bytes per char
+  const bytes = JSON.stringify(object).length * 2;
+  const kilobytes = bytes / 1024;
+  const megabytes = kilobytes / 1024;
+  return {
+    bytes,
+    kilobytes,
+    megabytes,
+  };
+}

--- a/packages/common/src/utils/hubUserAppResources.ts
+++ b/packages/common/src/utils/hubUserAppResources.ts
@@ -1,5 +1,4 @@
-import { IArcGISContext } from "..";
-import { UserResourceApp } from "../ArcGISContextManager";
+import { IArcGISContext } from "../ArcGISContext";
 import {
   USER_SITE_SETTINGS_APP,
   USER_SITE_SETTINGS_KEY,

--- a/packages/common/src/utils/hubUserAppResources.ts
+++ b/packages/common/src/utils/hubUserAppResources.ts
@@ -1,0 +1,159 @@
+import { IArcGISContext } from "..";
+import { UserResourceApp } from "../ArcGISContextManager";
+import {
+  USER_SITE_SETTINGS_APP,
+  USER_SITE_SETTINGS_KEY,
+} from "./internal/clearUserSiteSettings";
+import {
+  USER_HUB_SETTINGS_APP,
+  USER_HUB_SETTINGS_KEY,
+} from "./internal/clearUserHubSettings";
+import {
+  applyHubSettingsMigrations,
+  applySiteSettingsMigrations,
+} from "./internal/siteSettingsMigrations";
+import {
+  IAddUserResource,
+  getUserResource,
+  setUserResource,
+} from "./internal/userAppResources";
+
+/**
+ * Site Level Settings
+ */
+export interface IUserSiteSettings {
+  schemaVersion: number;
+  username?: string;
+  updated?: number;
+}
+
+/**
+ * Hub Level Settings
+ */
+export interface IUserHubSettings {
+  schemaVersion: number;
+  username?: string;
+  updated?: number;
+}
+
+/**
+ * Store User settings in the Site App's cache
+ * @param settings
+ * @param context
+ * @param replace
+ * @returns
+ */
+export async function setUserSiteSettings(
+  settings: IUserSiteSettings,
+  context: IArcGISContext,
+  replace: boolean = false
+): Promise<void> {
+  const token = context.tokenFor(USER_SITE_SETTINGS_APP);
+
+  if (token) {
+    // always stamp in the updated and username properties
+    settings.updated = new Date().getTime();
+    settings.username = context.currentUser.username;
+
+    const resource: IAddUserResource = {
+      key: USER_SITE_SETTINGS_KEY,
+      data: settings,
+      access: "userappprivate",
+    };
+    return setUserResource(
+      resource,
+      context.currentUser.username,
+      context.portalUrl,
+      token,
+      replace
+    );
+  } else {
+    throw new Error(
+      `No user-app-resource token available to store Site Settings`
+    );
+  }
+}
+
+/**
+ * Get the current user's settings for the current Site
+ * @param context
+ * @returns
+ */
+export async function getUserSiteSettings(
+  context: IArcGISContext
+): Promise<IUserSiteSettings> {
+  const token = context.tokenFor(USER_SITE_SETTINGS_APP);
+
+  if (token) {
+    const settings = (await getUserResource(
+      context.currentUser.username,
+      USER_SITE_SETTINGS_KEY,
+      context.portalUrl,
+      token
+    )) as Promise<IUserSiteSettings>;
+    // run though schema upgrades
+    return applySiteSettingsMigrations(settings);
+  } else {
+    return Promise.resolve(null);
+  }
+}
+
+/**
+ * Store the current user's Hub settings
+ * @param settings
+ * @param context
+ * @param replace
+ * @returns
+ */
+export async function setUserHubSettings(
+  settings: IUserHubSettings,
+  context: IArcGISContext,
+  replace: boolean = false
+): Promise<void> {
+  const token = context.tokenFor(USER_HUB_SETTINGS_APP);
+
+  if (token) {
+    // always stamp in the updated and username properties
+    settings.updated = new Date().getTime();
+    settings.username = context.currentUser.username;
+    const resource: IAddUserResource = {
+      key: USER_HUB_SETTINGS_KEY,
+      data: settings,
+      access: "userappprivate",
+    };
+    return setUserResource(
+      resource,
+      context.currentUser.username,
+      context.portalUrl,
+      token,
+      replace
+    );
+  } else {
+    throw new Error(
+      `No user-app-resource token available to store Site Settings`
+    );
+  }
+}
+
+/**
+ * Get the current user's settings for ArcGIS Hub
+ * @param context
+ * @returns
+ */
+export async function getUserHubSettings(
+  context: IArcGISContext
+): Promise<IUserHubSettings> {
+  const token = context.tokenFor(USER_HUB_SETTINGS_APP);
+
+  if (token) {
+    const settings = await getUserResource(
+      context.currentUser.username,
+      USER_HUB_SETTINGS_KEY,
+      context.portalUrl,
+      token
+    );
+    return applyHubSettingsMigrations(settings);
+  } else {
+    return Promise.resolve(null);
+  }
+}

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -23,3 +23,4 @@ export * from "./titleize";
 export * from "./memoize";
 export * from "./getEnvironmentFromPortalUrl";
 export * from "./poll";
+export * from "./hubUserAppResources";

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -24,3 +24,4 @@ export * from "./memoize";
 export * from "./getEnvironmentFromPortalUrl";
 export * from "./poll";
 export * from "./hubUserAppResources";
+export * from "./getObjectSize";

--- a/packages/common/src/utils/internal/clearUserHubSettings.ts
+++ b/packages/common/src/utils/internal/clearUserHubSettings.ts
@@ -1,0 +1,25 @@
+import { IArcGISContext } from "../../ArcGISContext";
+import { UserResourceApp } from "../../ArcGISContextManager";
+import { removeUserResource } from "./userAppResources";
+
+export const USER_HUB_SETTINGS_APP: UserResourceApp = "hubforarcgis";
+export const USER_HUB_SETTINGS_KEY = "hub-settings.json";
+/**
+ * @private
+ * Internal use only; Clear User Hub Settings
+ * @param context
+ * @returns
+ */
+
+export function clearUserHubSettings(
+  context: IArcGISContext
+): Promise<Record<string, any>> {
+  const token = context.tokenFor(USER_HUB_SETTINGS_APP);
+  const key = USER_HUB_SETTINGS_KEY;
+  return removeUserResource(
+    context.currentUser.username,
+    key,
+    context.portalUrl,
+    token
+  );
+}

--- a/packages/common/src/utils/internal/clearUserSiteSettings.ts
+++ b/packages/common/src/utils/internal/clearUserSiteSettings.ts
@@ -1,0 +1,25 @@
+import { IArcGISContext } from "../../ArcGISContext";
+import { UserResourceApp } from "../../ArcGISContextManager";
+import { removeUserResource } from "./userAppResources";
+
+export const USER_SITE_SETTINGS_APP: UserResourceApp = "self";
+export const USER_SITE_SETTINGS_KEY = "hub-site-settings.json";
+
+/**
+ * @private
+ * Internal use only; Clear User Site Settings
+ * @param context
+ * @returns
+ */
+export function clearUserSiteSettings(
+  context: IArcGISContext
+): Promise<Record<string, any>> {
+  const token = context.tokenFor(USER_SITE_SETTINGS_APP);
+  const key = USER_SITE_SETTINGS_KEY;
+  return removeUserResource(
+    context.currentUser.username,
+    key,
+    context.portalUrl,
+    token
+  );
+}

--- a/packages/common/src/utils/internal/siteSettingsMigrations.ts
+++ b/packages/common/src/utils/internal/siteSettingsMigrations.ts
@@ -1,0 +1,28 @@
+import { cloneObject } from "../../util";
+import { IUserHubSettings, IUserSiteSettings } from "../hubUserAppResources";
+
+/**
+ * Apply migrations for Site Settings
+ * @param settings
+ * @returns
+ */
+export function applySiteSettingsMigrations(
+  settings: Record<string, any>
+): IUserSiteSettings {
+  // const currentSchema = 1;
+
+  return cloneObject(settings) as IUserSiteSettings;
+}
+
+/**
+ * Apply migrations for Hub Settings
+ * @param settings
+ * @returns
+ */
+export function applyHubSettingsMigrations(
+  settings: Record<string, any>
+): IUserHubSettings {
+  // const currentSchema = 1;
+
+  return cloneObject(settings) as IUserHubSettings;
+}

--- a/packages/common/src/utils/internal/userAppResources.ts
+++ b/packages/common/src/utils/internal/userAppResources.ts
@@ -9,10 +9,18 @@ import { IRequestOptions, request } from "@esri/arcgis-rest-request";
 import { failSafe } from "../fail-safe";
 import { getObjectSize } from "../getObjectSize";
 
-// Defines the access for the resource
-// see the API details listed at the url in the comment above
+/**
+ * @private
+ * Defines the access for the resource. The access level can be one of the following:
+ * - `userappprivate` Resource is available only to the user through the app from which resource was uploaded.
+ * - `userprivateallapps`  Resource is available only to the user that uploaded the resource through any app.
+ * - `allorgusersprivateapp` Resource is available to all members of the org as that of the resource owner and through the app that uploaded. We allow adding resource with level only if the user's access is either public or org.
+ * - `public`  Resource is available to anyone (including anonymous access) through any app. We allow adding a resource at public level only if the user's access is public and the canSharePublic flag of the org is set to true.
+ */
 export type UserResourceAccess =
-  // Resource is available only to the user through the app from which resource was uploaded.
+  /**
+   * Resource is available only to the user through the app from which resource was uploaded.
+   */
   | "userappprivate"
   // Resource is available only to the user that uploaded the resource through any app
   | "userprivateallapps"
@@ -24,32 +32,80 @@ export type UserResourceAccess =
   | "public";
 
 /**
+ * @private
  * Add an User-App Resource
  */
 export interface IAddUserResource {
-  key: string; // aka filename
-  data: Record<string, any>; // json object to store; will be stringified
-  access: UserResourceAccess; // access level
-}
-
-// Returned when we get a list of resources for a user
-export interface IUserResourceInfo {
+  /**
+   * The filename of the resource
+   */
   key: string;
-  clientId: string;
-  created: string;
-  size: number;
+  /**
+   * The json object to store; will be stringified
+   */
+  data: Record<string, any>;
+  /**
+   * The access level for the resource
+   */
   access: UserResourceAccess;
 }
 
+/**
+ * @private
+ * Information about a user app resource
+ */
+export interface IUserResourceInfo {
+  /**
+   * The filename of the resource
+   */
+  key: string;
+  /**
+   * The clientId of the app that created the resource
+   */
+  clientId: string;
+  /**
+   * The date the resource was created
+   */
+  created: string;
+  /**
+   * The size of the resource in bytes
+   */
+  size: number;
+  /**
+   * The access level for the resource
+   */
+  access: UserResourceAccess;
+}
+
+/**
+ * @private
+ * Returned when we get a list of resources for a user
+ */
 export interface IUserResourceListResponse {
+  /**
+   * The total number of resources
+   */
   total: number;
+  /**
+   * The index of the first resource in the list
+   */
   start: number;
+  /**
+   * The number of resources returned
+   */
   num: number;
+  /**
+   * The next index to use to get the next set of resources
+   */
   nextStart: number;
+  /**
+   * The list of resources
+   */
   userResources: IUserResourceInfo[];
 }
 
 /**
+ * @private
  * Set a User-App-Resource
  * By default this will fetch and merge with an existing resource.
  * Passing `true` as the last parameter,
@@ -104,7 +160,8 @@ export async function setUserResource(
 }
 
 /**
- * Gets a user resource.
+ * @private
+ * Gets a user app resource
  * If the resource does not exist, this will throw. This can be wrapped in `failSafe`
  * configured to return an empty object.
  * @param username
@@ -129,6 +186,7 @@ export function getUserResource(
 }
 
 /**
+ * @private
  * Remove a resource
  * Used primarily in tests, but can be useful if you need to clean up
  * settings that are no longer used
@@ -159,7 +217,9 @@ export function removeUserResource(
 }
 
 /**
- * List user resources associated with
+ * @private
+ * List user resources associated with the user/token.
+ * Defaults to listing only resources associated with the app the token is associated with
  * @param username
  * @param portalUrl
  * @param token

--- a/packages/common/src/utils/internal/userAppResources.ts
+++ b/packages/common/src/utils/internal/userAppResources.ts
@@ -10,11 +10,18 @@ import { failSafe } from "../fail-safe";
 import { getObjectSize } from "../getObjectSize";
 
 // Defines the access for the resource
+// see the API details listed at the url in the comment above
 export type UserResourceAccess =
-  | "userappprivate" // default
-  | "userprivateallapps" // readable by any platform app, private to user
-  | "allorgusersprivateapp" // only if user is public or org
-  | "public"; // only if user is public or org
+  // Resource is available only to the user through the app from which resource was uploaded.
+  | "userappprivate"
+  // Resource is available only to the user that uploaded the resource through any app
+  | "userprivateallapps"
+  // resource is available to all members of the org as that of the resource owner and through
+  // the app that uploaded. We allow adding resource with level only if the user's access is either public or org
+  | "allorgusersprivateapp"
+  // Resource is available to anyone (including anonymous access) through any app. We allow adding a
+  // resource at public level only if the user's access is public and the canSharePublic flag of the org is set to true
+  | "public";
 
 /**
  * Add an User-App Resource

--- a/packages/common/src/utils/userAppResources.ts
+++ b/packages/common/src/utils/userAppResources.ts
@@ -1,0 +1,144 @@
+// These Types and Functions can land in rest-js
+// a friendly name for the scope of the resource
+// the API deals with clientIds, which are
+// listed here https://confluencewikidev.esri.com/pages/viewpage.action?pageId=50561461
+// Generally speaking, the UserResourceScope is a downcased version of the
+// clientId. Hub is unique b/c Sites have their own clientId,
+
+import { IRequestOptions, request } from "@esri/arcgis-rest-request";
+import { failSafe } from "./fail-safe";
+import { getObjectSize } from "./getObjectSize";
+
+// AND (unlike other apps) we can exchange that for other Esri App clientIds.
+export type UserResourceApp = "self" | "hubforarcgis" | "arcgisonline";
+
+// Defines the access for the resource
+export type UserResourceAccess =
+  | "userappprivate" // default
+  | "userprivateallapps" // readable by any platform app, private to user
+  | "allorgusersprivateapp" // only if user is public or org
+  | "public"; // only if user is public or org
+
+/**
+ * Add an User-App Resource
+ */
+export interface IAddUserResource {
+  key: string; // aka filename
+  data: Record<string, any>; // json object to store; will be stringified
+  access: UserResourceAccess; // access level
+}
+
+// Returned when we get a list of resources for a user
+export interface IUserResourceInfo {
+  key: string;
+  clientId: string;
+  created: string;
+  size: number;
+  access: UserResourceAccess;
+}
+
+export interface IUserResourceListResponse {
+  total: number;
+  start: number;
+  num: number;
+  nextStart: number;
+  userResources: IUserResourceInfo[];
+}
+
+/**
+ * Set a User-App-Resource
+ * By default this will fetch and merge with an existing resource.
+ * Passing `true` as the last parameter,
+ * @param resource
+ * @param username
+ * @param portal
+ * @param token
+ * @param replace
+ * @returns
+ */
+export async function setUserResource(
+  resource: IAddUserResource,
+  username: string,
+  portal: string,
+  token: string,
+  replace: false
+): Promise<void> {
+  // Ensure we are below 5MB max size
+  if (getObjectSize(resource.data).megabytes > 4.95) {
+    throw new Error(
+      `User Resource is too large to store. Please ensure it is less than 5MB in size`
+    );
+  }
+
+  let payload = resource.data;
+  if (!replace) {
+    const fsGetResource = failSafe(getUserResource, {});
+    const currentResource = await fsGetResource(
+      username,
+      resource.key,
+      portal,
+      token
+    );
+    // extend current object witn updated object
+    payload = { ...currentResource, ...resource.data };
+  }
+  const ro: IRequestOptions = {
+    portal,
+    httpMethod: "POST",
+    params: {
+      text: JSON.stringify(payload),
+      access: resource.access,
+      key: resource.key,
+      token,
+    },
+  };
+  // TODO Experiment w/ how we can make this call w/o creating a UserSession with the token
+  return request(`${portal}/community/users/${username}/addResource`, ro);
+}
+
+/**
+ * Gets a user resource.
+ * If the resource does not exist, this will throw. This can be wrapped in `failSafe`
+ * configured to return an empty object.
+ * @param username
+ * @param key
+ * @param portal
+ * @param token
+ * @returns
+ */
+export function getUserResource(
+  username: string,
+  key: string,
+  portal: string,
+  token: string
+): Promise<Record<string, any>> {
+  const ro: IRequestOptions = {
+    portal,
+  };
+  return request(
+    `${portal}/community/users/${username}/resources/${key}?token=${token}`,
+    ro
+  );
+}
+
+/**
+ * List user resources associated with
+ * @param username
+ * @param portal
+ * @param token
+ * @returns
+ */
+export function listUserResources(
+  username: string,
+  portal: string,
+  token: string,
+  returnAllApps?: false
+): Promise<IUserResourceListResponse> {
+  const ro: IRequestOptions = {
+    portal,
+  };
+  return request(
+    `${portal}/community/users/${username}/resources?token=${token}&returnAllApps=${returnAllApps}`,
+    ro
+  ) as Promise<IUserResourceListResponse>;
+}

--- a/packages/common/test/utils/getObjectSize.test.ts
+++ b/packages/common/test/utils/getObjectSize.test.ts
@@ -1,0 +1,17 @@
+import { getObjectSize } from "../../src";
+
+fdescribe("getObjectSize:", () => {
+  it("returns size in b, kb, mb", () => {
+    const chk = getObjectSize({ test: "object" });
+    expect(chk.bytes).toBe(34);
+    expect(chk.kilobytes).toBeCloseTo(0.0332, 4);
+    expect(chk.megabytes).toBeCloseTo(0.000032, 5);
+  });
+  it("verify large object", () => {
+    const data = {
+      fake: new Array(200000).fill({ key: "value" }),
+    };
+    const chk = getObjectSize(data);
+    expect(chk.megabytes).toBeGreaterThan(6);
+  });
+});

--- a/packages/common/test/utils/getObjectSize.test.ts
+++ b/packages/common/test/utils/getObjectSize.test.ts
@@ -1,6 +1,6 @@
 import { getObjectSize } from "../../src";
 
-fdescribe("getObjectSize:", () => {
+describe("getObjectSize:", () => {
   it("returns size in b, kb, mb", () => {
     const chk = getObjectSize({ test: "object" });
     expect(chk.bytes).toBe(34);

--- a/packages/common/test/utils/hubUserAppResources.test.ts
+++ b/packages/common/test/utils/hubUserAppResources.test.ts
@@ -1,0 +1,263 @@
+import { IUser } from "@esri/arcgis-rest-types";
+import {
+  setUserSiteSettings,
+  getUserSiteSettings,
+  setUserHubSettings,
+  getUserHubSettings,
+  IUserSiteSettings,
+  ArcGISContext,
+  IUserHubSettings,
+} from "../../src";
+
+import * as resourceModule from "../../src/utils/internal/userAppResources";
+import { USER_SITE_SETTINGS_KEY } from "../../src/utils/internal/clearUserSiteSettings";
+import { USER_HUB_SETTINGS_KEY } from "../../src/utils/internal/clearUserHubSettings";
+
+describe("hubUserAppResources:", () => {
+  describe("setUserSiteSettings:", () => {
+    let spy: jasmine.Spy;
+    let ctx: ArcGISContext;
+    beforeEach(() => {
+      spy = spyOn(resourceModule, "setUserResource").and.callFake(() => {
+        return Promise.resolve();
+      });
+    });
+    it("sends resource", async () => {
+      const settings: IUserSiteSettings = {
+        username: "should change",
+        updated: 0,
+        schemaVersion: 1,
+      };
+      ctx = new ArcGISContext({
+        id: 1,
+        portalUrl: "https://www.arcgis.com",
+        currentUser: {
+          username: "jsmith",
+        } as unknown as IUser,
+        userResourceTokens: [
+          {
+            app: "self",
+            token: "FAKESITETOKEN",
+            clientId: "FAKECLIENTID",
+          },
+        ],
+      });
+      await setUserSiteSettings(settings, ctx);
+      expect(spy).toHaveBeenCalled();
+      // inspect the arts
+      const [resource, username, url, token, replace] = spy.calls.argsFor(0);
+      expect(resource.key).toBe(USER_SITE_SETTINGS_KEY);
+      expect(resource.data.username).toBe("jsmith");
+      expect(resource.data.updated).toBeGreaterThan(0);
+      expect(resource.data.schemaVersion).toBe(1);
+      expect(username).toBe("jsmith");
+      expect(url).toBe(ctx.portalUrl);
+      expect(token).toBe("FAKESITETOKEN");
+    });
+    it("throws if token not found for ", async () => {
+      const settings: IUserSiteSettings = {
+        username: "should change",
+        updated: 0,
+        schemaVersion: 1,
+      };
+      ctx = new ArcGISContext({
+        id: 1,
+        portalUrl: "https://www.arcgis.com",
+        currentUser: {
+          username: "jsmith",
+        } as unknown as IUser,
+        userResourceTokens: [
+          {
+            app: "arcgisonline",
+            token: "FAKESITETOKEN",
+            clientId: "FAKECLIENTID",
+          },
+        ],
+      });
+      try {
+        await setUserSiteSettings(settings, ctx);
+      } catch (ex) {
+        expect((ex as any).message).toContain(
+          "user-app-resource token available"
+        );
+      }
+    });
+  });
+  describe("getUserSiteSettings:", () => {
+    let spy: jasmine.Spy;
+    let ctx: ArcGISContext;
+    beforeEach(() => {
+      spy = spyOn(resourceModule, "getUserResource").and.callFake(() => {
+        return Promise.resolve({ fake: "settings" });
+      });
+    });
+    it("get resource", async () => {
+      ctx = new ArcGISContext({
+        id: 1,
+        portalUrl: "https://www.arcgis.com",
+        currentUser: {
+          username: "jsmith",
+        } as unknown as IUser,
+        userResourceTokens: [
+          {
+            app: "self",
+            token: "FAKESITETOKEN",
+            clientId: "FAKECLIENTID",
+          },
+        ],
+      });
+      const settings = await getUserSiteSettings(ctx);
+      expect(settings).toEqual({
+        fake: "settings",
+      } as unknown as IUserSiteSettings);
+      expect(spy).toHaveBeenCalled();
+      const [username, key, url, token] = spy.calls.argsFor(0);
+      expect(key).toEqual(USER_SITE_SETTINGS_KEY);
+      expect(username).toBe("jsmith");
+      expect(url).toBe(ctx.portalUrl);
+      expect(token).toBe("FAKESITETOKEN");
+    });
+    it("returns null if no token", async () => {
+      ctx = new ArcGISContext({
+        id: 1,
+        portalUrl: "https://www.arcgis.com",
+        currentUser: {
+          username: "jsmith",
+        } as unknown as IUser,
+        userResourceTokens: [
+          {
+            app: "arcgisonline",
+            token: "FAKESITETOKEN",
+            clientId: "FAKECLIENTID",
+          },
+        ],
+      });
+
+      const settings = await getUserSiteSettings(ctx);
+      expect(settings).toBeNull();
+    });
+  });
+  describe("setUserHubSettings:", () => {
+    let spy: jasmine.Spy;
+    let ctx: ArcGISContext;
+    beforeEach(() => {
+      spy = spyOn(resourceModule, "setUserResource").and.callFake(() => {
+        return Promise.resolve();
+      });
+    });
+    it("sends resource", async () => {
+      const settings: IUserHubSettings = {
+        username: "should change",
+        updated: 0,
+        schemaVersion: 1,
+      };
+      ctx = new ArcGISContext({
+        id: 1,
+        portalUrl: "https://www.arcgis.com",
+        currentUser: {
+          username: "jsmith",
+        } as unknown as IUser,
+        userResourceTokens: [
+          {
+            app: "hubforarcgis",
+            token: "FAKEHUBTOKEN",
+            clientId: "FAKECLIENTID",
+          },
+        ],
+      });
+      await setUserHubSettings(settings, ctx);
+      expect(spy).toHaveBeenCalled();
+      // inspect the arts
+      const [resource, username, url, token, replace] = spy.calls.argsFor(0);
+      expect(resource.key).toBe(USER_HUB_SETTINGS_KEY);
+      expect(resource.data.username).toBe("jsmith");
+      expect(resource.data.updated).toBeGreaterThan(0);
+      expect(resource.data.schemaVersion).toBe(1);
+      expect(username).toBe("jsmith");
+      expect(url).toBe(ctx.portalUrl);
+      expect(token).toBe("FAKEHUBTOKEN");
+    });
+    it("throws if token not found for ", async () => {
+      const settings: IUserSiteSettings = {
+        username: "should change",
+        updated: 0,
+        schemaVersion: 1,
+      };
+      ctx = new ArcGISContext({
+        id: 1,
+        portalUrl: "https://www.arcgis.com",
+        currentUser: {
+          username: "jsmith",
+        } as unknown as IUser,
+        userResourceTokens: [
+          {
+            app: "arcgisonline",
+            token: "FAKEAGOTOKEN",
+            clientId: "arcgisonline",
+          },
+        ],
+      });
+      try {
+        await setUserHubSettings(settings, ctx);
+      } catch (ex) {
+        expect((ex as any).message).toContain(
+          "user-app-resource token available"
+        );
+      }
+    });
+  });
+  describe("getUserHubSettings:", () => {
+    let spy: jasmine.Spy;
+    let ctx: ArcGISContext;
+    beforeEach(() => {
+      spy = spyOn(resourceModule, "getUserResource").and.callFake(() => {
+        return Promise.resolve({ fake: "settings" });
+      });
+    });
+    it("get resource", async () => {
+      ctx = new ArcGISContext({
+        id: 1,
+        portalUrl: "https://www.arcgis.com",
+        currentUser: {
+          username: "jsmith",
+        } as unknown as IUser,
+        userResourceTokens: [
+          {
+            app: "hubforarcgis",
+            token: "FAKEHUBTOKEN",
+            clientId: "FAKECLIENTID",
+          },
+        ],
+      });
+      const settings = await getUserHubSettings(ctx);
+      expect(settings).toEqual({
+        fake: "settings",
+      } as unknown as IUserHubSettings);
+      expect(spy).toHaveBeenCalled();
+      const [username, key, url, token] = spy.calls.argsFor(0);
+      expect(key).toEqual(USER_HUB_SETTINGS_KEY);
+      expect(username).toBe("jsmith");
+      expect(url).toBe(ctx.portalUrl);
+      expect(token).toBe("FAKEHUBTOKEN");
+    });
+    it("returns null if no token", async () => {
+      ctx = new ArcGISContext({
+        id: 1,
+        portalUrl: "https://www.arcgis.com",
+        currentUser: {
+          username: "jsmith",
+        } as unknown as IUser,
+        userResourceTokens: [
+          {
+            app: "arcgisonline",
+            token: "FAKESITETOKEN",
+            clientId: "FAKECLIENTID",
+          },
+        ],
+      });
+
+      const settings = await getUserHubSettings(ctx);
+      expect(settings).toBeNull();
+    });
+  });
+});

--- a/packages/common/test/utils/internal/clearUserHubSettings.test.ts
+++ b/packages/common/test/utils/internal/clearUserHubSettings.test.ts
@@ -1,0 +1,38 @@
+import { IUser } from "@esri/arcgis-rest-portal";
+import { ArcGISContext } from "../../../src";
+import {
+  USER_HUB_SETTINGS_KEY,
+  clearUserHubSettings,
+} from "../../../src/utils/internal/clearUserHubSettings";
+import * as resourceModule from "../../../src/utils/internal/userAppResources";
+
+describe("clearUserHubSettings:", () => {
+  it("delegates to removeUserResource", async () => {
+    const spy = spyOn(resourceModule, "removeUserResource").and.callFake(() => {
+      return Promise.resolve({ success: true });
+    });
+    const ctx = new ArcGISContext({
+      id: 1,
+      portalUrl: "https://www.arcgis.com",
+      currentUser: {
+        username: "jsmith",
+      } as unknown as IUser,
+      userResourceTokens: [
+        {
+          app: "hubforarcgis",
+          token: "FAKEHUBTOKEN",
+          clientId: "FAKECLIENTID",
+        },
+      ],
+    });
+    const chk = await clearUserHubSettings(ctx);
+    expect(chk).toEqual({ success: true });
+    expect(spy).toHaveBeenCalled();
+    // verify args
+    const [username, key, url, token] = spy.calls.argsFor(0);
+    expect(key).toBe(USER_HUB_SETTINGS_KEY);
+    expect(username).toBe("jsmith");
+    expect(url).toBe(ctx.portalUrl);
+    expect(token).toBe("FAKEHUBTOKEN");
+  });
+});

--- a/packages/common/test/utils/internal/clearUserSiteSettings.test.ts
+++ b/packages/common/test/utils/internal/clearUserSiteSettings.test.ts
@@ -1,0 +1,39 @@
+import { IUser } from "@esri/arcgis-rest-portal";
+import { ArcGISContext } from "../../../src";
+
+import * as resourceModule from "../../../src/utils/internal/userAppResources";
+import {
+  USER_SITE_SETTINGS_KEY,
+  clearUserSiteSettings,
+} from "../../../src/utils/internal/clearUserSiteSettings";
+
+describe("clearUserSiteSettings:", () => {
+  it("delegates to removeUserResource", async () => {
+    const spy = spyOn(resourceModule, "removeUserResource").and.callFake(() => {
+      return Promise.resolve({ success: true });
+    });
+    const ctx = new ArcGISContext({
+      id: 1,
+      portalUrl: "https://www.arcgis.com",
+      currentUser: {
+        username: "jsmith",
+      } as unknown as IUser,
+      userResourceTokens: [
+        {
+          app: "self",
+          token: "FAKESITETOKEN",
+          clientId: "FAKECLIENTID",
+        },
+      ],
+    });
+    const chk = await clearUserSiteSettings(ctx);
+    expect(chk).toEqual({ success: true });
+    expect(spy).toHaveBeenCalled();
+    // verify args
+    const [username, key, url, token] = spy.calls.argsFor(0);
+    expect(key).toBe(USER_SITE_SETTINGS_KEY);
+    expect(username).toBe("jsmith");
+    expect(url).toBe(ctx.portalUrl);
+    expect(token).toBe("FAKESITETOKEN");
+  });
+});

--- a/packages/common/test/utils/internal/userAppResources.test.ts
+++ b/packages/common/test/utils/internal/userAppResources.test.ts
@@ -35,7 +35,7 @@ const LISTRESPONSE = {
 const PORTALURL = "https://www.arcgis.com";
 const TOKEN = "THEFAKETOKEN";
 
-fdescribe("userAppResources:", () => {
+describe("userAppResources:", () => {
   let requestSpy: jasmine.Spy;
 
   describe("setUserResource:", () => {
@@ -61,7 +61,7 @@ fdescribe("userAppResources:", () => {
         };
         await setUserResource(resourceOpts, "jsmith", PORTALURL, TOKEN);
       } catch (ex) {
-        expect(ex.message).toContain("too large to store");
+        expect((ex as any).message).toContain("too large to store");
       }
     });
     it("can replace", async () => {

--- a/packages/common/test/utils/internal/userAppResources.test.ts
+++ b/packages/common/test/utils/internal/userAppResources.test.ts
@@ -1,0 +1,169 @@
+import * as ResquestModule from "@esri/arcgis-rest-request";
+import {
+  setUserResource,
+  getUserResource,
+  removeUserResource,
+  listUserResources,
+  IAddUserResource,
+} from "../../../src/utils/internal/userAppResources";
+
+const RESOURCE = { prop: "value" };
+
+const LISTRESPONSE = {
+  total: 2,
+  start: 1,
+  num: 10,
+  nextStart: -1,
+  userResources: [
+    {
+      key: "insights-settings.json",
+      clientId: "arcgisInsights",
+      created: "Tue Aug 18 20:54:41 UTC 2020",
+      size: 131,
+      access: "userappprivate",
+    },
+    {
+      key: "hub-user-settings.json",
+      clientId: "arcgisonline",
+      created: "Tue Apr 27 21:36:26 UTC 2021",
+      size: 85,
+      access: "userprivateallapps",
+    },
+  ],
+};
+
+const PORTALURL = "https://www.arcgis.com";
+const TOKEN = "THEFAKETOKEN";
+
+fdescribe("userAppResources:", () => {
+  let requestSpy: jasmine.Spy;
+
+  describe("setUserResource:", () => {
+    beforeEach(() => {
+      requestSpy = spyOn(ResquestModule, "request").and.callFake(
+        (url: string) => {
+          if (url.includes("/some-resource.json")) {
+            return Promise.resolve({ other: "values" });
+          } else {
+            return Promise.resolve({ success: true });
+          }
+        }
+      );
+    });
+    it("throws if data is too large", async () => {
+      try {
+        const resourceOpts: IAddUserResource = {
+          data: {
+            fake: new Array(200000).fill({ key: "value" }),
+          },
+          key: "some-resource.json",
+          access: "userappprivate",
+        };
+        await setUserResource(resourceOpts, "jsmith", PORTALURL, TOKEN);
+      } catch (ex) {
+        expect(ex.message).toContain("too large to store");
+      }
+    });
+    it("can replace", async () => {
+      const resourceOpts: IAddUserResource = {
+        data: RESOURCE,
+        key: "some-resource.json",
+        access: "userappprivate",
+      };
+      await setUserResource(resourceOpts, "jsmith", PORTALURL, TOKEN, true);
+      expect(requestSpy.calls.count()).toBe(1);
+      const url = requestSpy.calls.argsFor(0)[0];
+      const opts = requestSpy.calls.argsFor(0)[1];
+      expect(url).toContain("users/jsmith/addResource");
+      expect(opts.params.text).toEqual(JSON.stringify(RESOURCE));
+      expect(opts.params.key).toEqual("some-resource.json");
+      expect(opts.params.access).toEqual("userappprivate");
+      expect(opts.params.token).toEqual(TOKEN);
+    });
+    it("auto-merges", async () => {
+      const resourceOpts: IAddUserResource = {
+        data: RESOURCE,
+        key: "some-resource.json",
+        access: "userappprivate",
+      };
+      await setUserResource(resourceOpts, "jsmith", PORTALURL, TOKEN);
+      expect(requestSpy.calls.count()).toBe(2);
+      const url1 = requestSpy.calls.argsFor(0)[0];
+      const url2 = requestSpy.calls.argsFor(1)[0];
+      const opts = requestSpy.calls.argsFor(1)[1];
+      expect(url1).toContain("jsmith/resources/some-resource.json");
+      expect(url2).toContain("users/jsmith/addResource");
+      expect(opts.params.text).toEqual(
+        JSON.stringify({ ...{ other: "values" }, ...RESOURCE })
+      );
+
+      expect(opts.params.key).toEqual("some-resource.json");
+      expect(opts.params.access).toEqual("userappprivate");
+      expect(opts.params.token).toEqual(TOKEN);
+    });
+  });
+
+  describe("getUserResource:", () => {
+    beforeEach(() => {
+      requestSpy = spyOn(ResquestModule, "request").and.callFake(() => {
+        return Promise.resolve(RESOURCE);
+      });
+    });
+    it("construct url", async () => {
+      const chk = await getUserResource(
+        "jsmith",
+        "some-resource.json",
+        PORTALURL,
+        TOKEN
+      );
+      const url1 = requestSpy.calls.argsFor(0)[0];
+      expect(url1).toContain("jsmith/resources/some-resource.json");
+      expect(url1).toContain(`token=${TOKEN}`);
+      expect(chk).toEqual(RESOURCE);
+    });
+  });
+
+  describe("removeUserResource:", () => {
+    beforeEach(() => {
+      requestSpy = spyOn(ResquestModule, "request").and.callFake(() => {
+        return Promise.resolve({ success: true });
+      });
+    });
+    it("construct url", async () => {
+      await removeUserResource(
+        "jsmith",
+        "some-resource.json",
+        PORTALURL,
+        TOKEN
+      );
+      const url = requestSpy.calls.argsFor(0)[0];
+      expect(url).toContain("jsmith/removeResource");
+      const opts = requestSpy.calls.argsFor(0)[1];
+      expect(opts.params.key).toEqual("some-resource.json");
+      expect(opts.params.token).toEqual(TOKEN);
+    });
+  });
+
+  describe("listUserResources:", () => {
+    beforeEach(() => {
+      requestSpy = spyOn(ResquestModule, "request").and.callFake(() => {
+        return Promise.resolve(LISTRESPONSE);
+      });
+    });
+
+    it("construct url", async () => {
+      await listUserResources("jsmith", PORTALURL, TOKEN);
+      const url = requestSpy.calls.argsFor(0)[0];
+      expect(url).toContain("jsmith/resources");
+      expect(url).toContain(`token=${TOKEN}`);
+      expect(url).toContain(`returnAllApps=false`);
+    });
+    it("can return all apps", async () => {
+      await listUserResources("jsmith", PORTALURL, TOKEN, true);
+      const url = requestSpy.calls.argsFor(0)[0];
+      expect(url).toContain("jsmith/resources");
+      expect(url).toContain(`token=${TOKEN}`);
+      expect(url).toContain(`returnAllApps=true`);
+    });
+  });
+});


### PR DESCRIPTION
1. Description:
- Adds low-level functions for user app resources 
```
export function setUserResource(
  resource: IAddUserResource,
  username: string,
  portalUrl: string,
  token: string,
  replace: boolean = false
): Promise<void> {...}

export function getUserResource(
  username: string,
  key: string,
  portalUrl: string,
  token: string
): Promise<Record<string, any>> {...}

export function removeUserResource(
  username: string,
  key: string,
  portalUrl: string,
  token: string
): Promise<Record<string, any>> {...}

export function listUserResources(
  username: string,
  portalUrl: string,
  token: string,
  returnAllApps: boolean = false
): Promise<IUserResourceListResponse> {...}
```

- Adds abstraction functions for Site level settings
```
export function setUserSiteSettings(
  settings: IUserSiteSettings,
  context: IArcGISContext,
  replace: boolean = false
): Promise<void> {...}


export async function getUserSiteSettings(
  context: IArcGISContext
): Promise<IUserSiteSettings> {...}

```

- Adds abstraction functions for Hub level settings
```
export async function setUserHubSettings(
  settings: IUserHubSettings,
  context: IArcGISContext,
  replace: boolean = false
): Promise<void> {...}

export async function getUserHubSettings(
  context: IArcGISContext
): Promise<IUserHubSettings>
```

- Updated ArcGISContextManager to accept array of `IUserResourceConfig` objects, which it parses and gets tokens for the specified app ids (generally, this is `hubforarcgis` for "Hub", and `arcgisonline` for "Portal" - the current site is always added as "self"
- re-works how ArcGISContextManager.initialize works so it only fetches things which are not passed in. Old code was over-fetching in some scenarios.

- Adds a development harness e2e, which requires a live token, created via oAuth on a Hub Site item

1. Instructions for testing: run tests

1. Closes Issues: #7778

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
