### PR TITLE
fix: update groups link from teams to groups

### DIFF
--- a/packages/common/src/groups/_internal/computeLinks.ts
+++ b/packages/common/src/groups/_internal/computeLinks.ts
@@ -25,7 +25,7 @@ export function computeLinks(
 
   return {
     self: getGroupHomeUrl(group.id, requestOptions),
-    siteRelative: `/teams/${group.id}`,
+    siteRelative: `/groups/${group.id}`,
     workspaceRelative: getRelativeWorkspaceUrl("Group", group.id),
     thumbnail: getGroupThumbnailUrl(requestOptions.portal, group, token),
   };

--- a/packages/common/test/groups/HubGroups.test.ts
+++ b/packages/common/test/groups/HubGroups.test.ts
@@ -106,7 +106,7 @@ describe("HubGroups Module:", () => {
       expect(chk.links?.self).toEqual(
         `https://some-server.com/gis/home/group.html?id=${GRP.id}`
       );
-      expect(chk.links?.siteRelative).toEqual(`/teams/${GRP.id}`);
+      expect(chk.links?.siteRelative).toEqual(`/groups/${GRP.id}`);
       expect(chk.links?.thumbnail).toEqual(
         `${hubRo.portal}/community/groups/${GRP.id}/info/${GRP.thumbnail}`
       );

--- a/packages/common/test/groups/_internal/computeLinks.test.ts
+++ b/packages/common/test/groups/_internal/computeLinks.test.ts
@@ -30,7 +30,7 @@ describe("computeLinks", () => {
   it("generates a links hash", () => {
     const chk = computeLinks(group, authdCtxMgr.context.requestOptions);
 
-    expect(chk.siteRelative).toBe("/teams/00c");
+    expect(chk.siteRelative).toBe("/groups/00c");
     expect(chk.workspaceRelative).toBe("/workspace/groups/00c");
   });
 });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Update groups link from teams/:id to groups/:id

1. Instructions for testing:

1. Closes Issues: #<8043> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
