### PR TITLE
fix: deployed solution templates should redirect to AGO

### DIFF
--- a/packages/common/src/core/getRelativeWorkspaceUrl.ts
+++ b/packages/common/src/core/getRelativeWorkspaceUrl.ts
@@ -1,3 +1,5 @@
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { getItemHomeUrl } from "../urls";
 import { getTypeFromEntity } from "./getTypeFromEntity";
 import { isValidEntityType } from "./isValidEntityType";
 import { HubEntity } from "./types";
@@ -11,7 +13,9 @@ import { HubEntity } from "./types";
  */
 export const getRelativeWorkspaceUrl = (
   type: string,
-  identifier: string
+  identifier: string,
+  typeKeywords?: string[],
+  requestOptions?: IRequestOptions
 ): string => {
   let url = "/";
   const entityType = getTypeFromEntity({ type } as HubEntity);
@@ -27,6 +31,12 @@ export const getRelativeWorkspaceUrl = (
       typeSegment = `${typeSegment}s`;
     }
     url = `/workspace/${typeSegment}/${identifier}`;
+
+    // If a solution template is deployed, we don't support
+    // managing it in the workspace, so we kick users to AGO
+    if (entityType === "template" && typeKeywords?.includes("Deployed")) {
+      url = getItemHomeUrl(identifier, requestOptions);
+    }
   }
 
   return url;

--- a/packages/common/src/templates/_internal/computeLinks.ts
+++ b/packages/common/src/templates/_internal/computeLinks.ts
@@ -36,7 +36,12 @@ export function computeLinks(
       item.typeKeywords
     ),
     workspaceRelative: isDeployed
-      ? getRelativeWorkspaceUrl(item.type, item.id, item.typeKeywords)
+      ? getRelativeWorkspaceUrl(
+          item.type,
+          item.id,
+          item.typeKeywords,
+          requestOptions
+        )
       : getRelativeWorkspaceUrl(item.type, getItemIdentifier(item)),
     thumbnail: getItemThumbnailUrl(item, requestOptions, token),
   };

--- a/packages/common/src/templates/_internal/computeLinks.ts
+++ b/packages/common/src/templates/_internal/computeLinks.ts
@@ -25,6 +25,9 @@ export function computeLinks(
     token = session.token;
   }
 
+  // If a solution template is deployed, we don't support
+  // managing it in the workspace, so we kick users to AGO
+  const isDeployed = item.typeKeywords?.includes("Deployed");
   return {
     self: getItemHomeUrl(item.id, requestOptions),
     siteRelative: getHubRelativeUrl(
@@ -32,10 +35,9 @@ export function computeLinks(
       getItemIdentifier(item),
       item.typeKeywords
     ),
-    workspaceRelative: getRelativeWorkspaceUrl(
-      item.type,
-      getItemIdentifier(item)
-    ),
+    workspaceRelative: isDeployed
+      ? getRelativeWorkspaceUrl(item.type, item.id, item.typeKeywords)
+      : getRelativeWorkspaceUrl(item.type, getItemIdentifier(item)),
     thumbnail: getItemThumbnailUrl(item, requestOptions, token),
   };
 }

--- a/packages/common/test/core/getRelativeWorkspaceUrl.test.ts
+++ b/packages/common/test/core/getRelativeWorkspaceUrl.test.ts
@@ -1,41 +1,79 @@
 import { getRelativeWorkspaceUrl } from "../../src/core/getRelativeWorkspaceUrl";
 import * as getTypeFromEntityModule from "../../src/core/getTypeFromEntity";
 import * as isValidEntityTypeModule from "../../src/core/isValidEntityType";
+import * as urlsModule from "../../src/urls";
 
 describe("getRelativeWorkspaceUrl", () => {
   let result;
 
-  it("returns the relative workspace url if provided a valid entity type", () => {
-    const getTypeFromEntitySpy = spyOn(
-      getTypeFromEntityModule,
-      "getTypeFromEntity"
-    ).and.returnValue("project");
-    const isValidEntityTypeSpy = spyOn(
-      isValidEntityTypeModule,
-      "isValidEntityType"
-    ).and.returnValue(true);
+  describe("valid entity types", () => {
+    it("returns the relative workspace url if provided a valid entity type", () => {
+      const getTypeFromEntitySpy = spyOn(
+        getTypeFromEntityModule,
+        "getTypeFromEntity"
+      ).and.returnValue("project");
+      const isValidEntityTypeSpy = spyOn(
+        isValidEntityTypeModule,
+        "isValidEntityType"
+      ).and.returnValue(true);
 
-    result = getRelativeWorkspaceUrl("Hub Project", "123");
+      result = getRelativeWorkspaceUrl("Hub Project", "123");
 
-    expect(getTypeFromEntitySpy).toHaveBeenCalledTimes(1);
-    expect(isValidEntityTypeSpy).toHaveBeenCalledTimes(1);
-    expect(result).toBe("/workspace/projects/123");
-  });
-  it("returns the relative workspace url if provided entity type content", () => {
-    const getTypeFromEntitySpy = spyOn(
-      getTypeFromEntityModule,
-      "getTypeFromEntity"
-    ).and.returnValue("content");
-    const isValidEntityTypeSpy = spyOn(
-      isValidEntityTypeModule,
-      "isValidEntityType"
-    ).and.returnValue(true);
+      expect(getTypeFromEntitySpy).toHaveBeenCalledTimes(1);
+      expect(isValidEntityTypeSpy).toHaveBeenCalledTimes(1);
+      expect(result).toBe("/workspace/projects/123");
+    });
+    it("returns the relative workspace url if provided entity type content", () => {
+      const getTypeFromEntitySpy = spyOn(
+        getTypeFromEntityModule,
+        "getTypeFromEntity"
+      ).and.returnValue("content");
+      const isValidEntityTypeSpy = spyOn(
+        isValidEntityTypeModule,
+        "isValidEntityType"
+      ).and.returnValue(true);
 
-    result = getRelativeWorkspaceUrl("Web Mapping Application", "123");
+      result = getRelativeWorkspaceUrl("Web Mapping Application", "123");
 
-    expect(getTypeFromEntitySpy).toHaveBeenCalledTimes(1);
-    expect(isValidEntityTypeSpy).toHaveBeenCalledTimes(1);
-    expect(result).toBe("/workspace/content/123");
+      expect(getTypeFromEntitySpy).toHaveBeenCalledTimes(1);
+      expect(isValidEntityTypeSpy).toHaveBeenCalledTimes(1);
+      expect(result).toBe("/workspace/content/123");
+    });
+    describe("templates", () => {
+      let getTypeFromEntitySpy: jasmine.Spy;
+      let isValidEntityTypeSpy: jasmine.Spy;
+      beforeEach(() => {
+        getTypeFromEntitySpy = spyOn(
+          getTypeFromEntityModule,
+          "getTypeFromEntity"
+        ).and.returnValue("template");
+        isValidEntityTypeSpy = spyOn(
+          isValidEntityTypeModule,
+          "isValidEntityType"
+        ).and.returnValue(true);
+      });
+
+      it("returns the relative workspace url for a solution template", () => {
+        result = getRelativeWorkspaceUrl("template", "123");
+
+        expect(getTypeFromEntitySpy).toHaveBeenCalledTimes(1);
+        expect(isValidEntityTypeSpy).toHaveBeenCalledTimes(1);
+        expect(result).toBe("/workspace/templates/123");
+      });
+      it("returns the AGO item home url for a deployed solution template", () => {
+        const getItemHomeUrlSpy = spyOn(
+          urlsModule,
+          "getItemHomeUrl"
+        ).and.returnValue("/some-item-home-url");
+
+        result = getRelativeWorkspaceUrl("template", "123", ["Deployed"], {});
+
+        expect(getTypeFromEntitySpy).toHaveBeenCalledTimes(1);
+        expect(isValidEntityTypeSpy).toHaveBeenCalledTimes(1);
+        expect(getItemHomeUrlSpy).toHaveBeenCalledTimes(1);
+        expect(result).toBe("/some-item-home-url");
+      });
+    });
   });
   it('returns "/" if provided an invalid entity type', () => {
     const getTypeFromEntitySpy = spyOn(

--- a/packages/common/test/templates/_internal/computeLinks.test.ts
+++ b/packages/common/test/templates/_internal/computeLinks.test.ts
@@ -1,13 +1,16 @@
 import { IItem } from "@esri/arcgis-rest-types";
 import { computeLinks } from "../../../src/templates/_internal/computeLinks";
-import { ArcGISContextManager, setProp } from "../../../src";
+import { ArcGISContextManager, IHubEntityLinks, setProp } from "../../../src";
 import { initContextManager } from "../fixtures";
 import * as getItemThumbnailUrlModule from "../../../src/resources/get-item-thumbnail-url";
+import * as urlsModule from "../../../src/urls";
 
 describe("templates: computeLinks", () => {
   let authdCtxMgr: ArcGISContextManager;
   let unauthdCtxMgr: ArcGISContextManager;
   let item: IItem;
+  let getItemHomeUrlSpy: jasmine.Spy;
+  let getItemThumbnailUrlSpy: jasmine.Spy;
 
   beforeEach(async () => {
     item = {
@@ -16,25 +19,44 @@ describe("templates: computeLinks", () => {
     } as IItem;
     authdCtxMgr = await initContextManager();
     unauthdCtxMgr = await ArcGISContextManager.create();
+
+    getItemHomeUrlSpy = spyOn(urlsModule, "getItemHomeUrl").and.returnValue(
+      "/some-item-home-url"
+    );
+    getItemThumbnailUrlSpy = spyOn(
+      getItemThumbnailUrlModule,
+      "getItemThumbnailUrl"
+    ).and.returnValue("/some-thumbnail-url");
   });
 
   it("generates a links hash using the template's slug", () => {
     setProp("properties.slug", "mock-slug", item);
     const chk = computeLinks(item, authdCtxMgr.context.requestOptions);
 
+    expect(chk.self).toBe("/some-item-home-url");
     expect(chk.siteRelative).toBe("/templates/mock-slug/about");
     expect(chk.workspaceRelative).toBe("/workspace/templates/mock-slug");
+    expect(chk.thumbnail).toBe("/some-thumbnail-url");
   });
   it("generates a links hash using the templates's id when no slug is available", () => {
     const chk = computeLinks(item, authdCtxMgr.context.requestOptions);
 
+    expect(chk.self).toBe("/some-item-home-url");
     expect(chk.siteRelative).toBe("/templates/00c/about");
     expect(chk.workspaceRelative).toBe("/workspace/templates/00c");
+    expect(chk.thumbnail).toBe("/some-thumbnail-url");
   });
-  it("Deployed templates are redirected to the generic content route", () => {
-    setProp("typeKeywords", ["Deployed"], item);
-    const chk = computeLinks(item, unauthdCtxMgr.context.requestOptions);
-
-    expect(chk.siteRelative).toBe("/content/00c/about");
+  describe("Deployed templates", () => {
+    let chk: IHubEntityLinks;
+    beforeEach(() => {
+      setProp("typeKeywords", ["Deployed"], item);
+      chk = computeLinks(item, unauthdCtxMgr.context.requestOptions);
+    });
+    it("the siteRelative url redirects users to the generic content route", () => {
+      expect(chk.siteRelative).toBe("/content/00c/about");
+    });
+    it("the workspace relative url redirects users to the item home in AGO", () => {
+      expect(chk.workspaceRelative).toBe("/some-item-home-url");
+    });
   });
 });


### PR DESCRIPTION
[7399](https://devtopia.esri.com/dc/hub/issues/7399)

### Description
if a Solution Template has the `typeKeyword` "Deployed", we won't support managing it in the workspace, and instead, we should kick users to the item's home in AGO. This PR updates the `getRelativeWorkspaceUrl` to accommodate this entity-specific criteria. 

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.