### PR TITLE
feat: add new polling util

### DIFF
--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -22,3 +22,4 @@ export * from "./dasherize";
 export * from "./titleize";
 export * from "./memoize";
 export * from "./getEnvironmentFromPortalUrl";
+export * from "./poll";

--- a/packages/common/src/utils/poll.ts
+++ b/packages/common/src/utils/poll.ts
@@ -13,12 +13,18 @@ export const poll = async (
     timeBetweenRequests?: number;
   }
 ): Promise<any> => {
-  const { timeout = 30000, timeBetweenRequests = 3000 } = opts || {};
+  const options =
+    opts || /* istanbul ignore next - must pass in overrides for tests */ {};
+  const timeout = options.timeout || 30000;
+  const timeBetweenRequests =
+    options.timeBetweenRequests ||
+    /* istanbul ignore next - cannot delay by this much in tests */ 3000;
+
   let resp: any;
   let requestCount = 0;
 
   do {
-    // on subsequent requests, check if the configured
+    // On subsequent requests, check if the configured
     // timeout has been reached
     // If YES: throw an error
     // If NO: delay before the next request

--- a/packages/common/src/utils/poll.ts
+++ b/packages/common/src/utils/poll.ts
@@ -24,8 +24,7 @@ export const poll = async (
   let requestCount = 0;
 
   do {
-    // On subsequent requests, check if the configured
-    // timeout has been reached
+    // On subsequent requests, check if the timeout has been reached
     // If YES: throw an error
     // If NO: delay before the next request
     if (requestCount > 0) {

--- a/packages/common/src/utils/poll.ts
+++ b/packages/common/src/utils/poll.ts
@@ -1,0 +1,41 @@
+/**
+ * Function to poll a provided request until a validation
+ * state or timeout is reached
+ * @param requestFn
+ * @param validationFn
+ * @param opts
+ */
+export const poll = async (
+  requestFn: () => any,
+  validationFn: (resp: any) => boolean,
+  opts?: {
+    timeout?: number;
+    timeBetweenRequests?: number;
+  }
+): Promise<any> => {
+  const { timeout = 30000, timeBetweenRequests = 3000 } = opts || {};
+  let resp: any;
+  let requestCount = 0;
+
+  do {
+    // on subsequent requests, check if the configured
+    // timeout has been reached
+    // If YES: throw an error
+    // If NO: delay before the next request
+    if (requestCount > 0) {
+      if (requestCount * timeBetweenRequests >= timeout) {
+        throw new Error("Polling timeout");
+      }
+      await delay(timeBetweenRequests);
+    }
+
+    resp = await requestFn();
+    requestCount++;
+  } while (!validationFn(resp));
+
+  return resp;
+};
+
+const delay = (milliseconds: number) => {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+};

--- a/packages/common/test/utils/poll.test.ts
+++ b/packages/common/test/utils/poll.test.ts
@@ -1,0 +1,37 @@
+import { poll } from "../../src/utils/poll";
+
+describe("poll", () => {
+  it("polls the request function until the validation function succeeds", async () => {
+    const validationFn = (resp) => resp && resp.id;
+    const requestFnSpy = jasmine
+      .createSpy()
+      .and.returnValues(Promise.resolve({}), Promise.resolve({ id: "00c" }));
+
+    const chk = await poll(
+      requestFnSpy,
+      validationFn,
+      // set delay to 0 for testing purposes
+      { timeBetweenRequests: 0 }
+    );
+    expect(requestFnSpy).toHaveBeenCalledTimes(2);
+    expect(chk.id).toBe("00c");
+  });
+  it("throws an error when the timeout is reached", async () => {
+    const validationFn = (resp) => resp && resp.id;
+    const requestFnSpy = jasmine
+      .createSpy()
+      .and.returnValue(Promise.resolve({}));
+
+    let errorMessage = "Polling timeout";
+    try {
+      await poll(requestFnSpy, validationFn, {
+        timeBetweenRequests: 100,
+        timeout: 200,
+      });
+    } catch (error) {
+      errorMessage = error.message;
+    }
+    expect(requestFnSpy).toHaveBeenCalledTimes(2);
+    expect(errorMessage).toBe("Polling timeout");
+  });
+});

--- a/packages/common/test/utils/poll.test.ts
+++ b/packages/common/test/utils/poll.test.ts
@@ -2,7 +2,7 @@ import { poll } from "../../src/utils/poll";
 
 describe("poll", () => {
   it("polls the request function until the validation function succeeds", async () => {
-    const validationFn = (resp) => resp && resp.id;
+    const validationFn = (resp: any) => resp && resp.id;
     const requestFnSpy = jasmine
       .createSpy()
       .and.returnValues(Promise.resolve({}), Promise.resolve({ id: "00c" }));
@@ -17,21 +17,19 @@ describe("poll", () => {
     expect(chk.id).toBe("00c");
   });
   it("throws an error when the timeout is reached", async () => {
-    const validationFn = (resp) => resp && resp.id;
+    const validationFn = (resp: any) => resp && resp.id;
     const requestFnSpy = jasmine
       .createSpy()
       .and.returnValue(Promise.resolve({}));
 
-    let errorMessage = "Polling timeout";
     try {
       await poll(requestFnSpy, validationFn, {
         timeBetweenRequests: 100,
         timeout: 200,
       });
     } catch (error) {
-      errorMessage = error.message;
+      expect(requestFnSpy).toHaveBeenCalledTimes(2);
+      expect((error as Error).message).toBe("Polling timeout");
     }
-    expect(requestFnSpy).toHaveBeenCalledTimes(2);
-    expect(errorMessage).toBe("Polling timeout");
   });
 });


### PR DESCRIPTION
[8012](https://devtopia.esri.com/dc/hub/issues/8012)

### Description:
There have been a couple of instances lately where we've observed a slight delay between creating, sharing, etc. using the rest API and the information registering on a subsequent fetch of the item. Rather than setting a random timeout, the better approach is to poll the API. 

This PR adds a new `poll` util which accepts a generic request and validation function and will execute the request until the validation condition(s) have been met or a timeout is reached.  

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.