### PR TITLE
feat: polishing details pane for site workspace

### DIFF
--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -57,7 +57,7 @@ export const buildUiSchema = async (
             scope: "/properties/description",
             type: "Control",
             options: {
-              control: "hub-field-input-input",
+              control: "hub-field-input-rich-text",
               type: "textarea",
               helperText: {
                 labelKey: `${i18nScope}.fields.description.helperText`,

--- a/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
@@ -67,7 +67,7 @@ describe("buildUiSchema: site edit", () => {
               scope: "/properties/description",
               type: "Control",
               options: {
-                control: "hub-field-input-input",
+                control: "hub-field-input-rich-text",
                 type: "textarea",
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",


### PR DESCRIPTION
OD-UI: https://github.com/ArcGIS/opendata-ui/pull/12633

**Note**: A tech ticket for the other portions of #7730 is slated to be done soon. This is what we can accomplish with what is currently available.

1. Description: Polishing the details pane for site workspace. More coming post-tech ticket.

1. Instructions for testing: 
- Open the site workspace
- Visit my fake site: 8e67c41951804ef9965e290b3d83c182
- Open the details pane
- Confirm "Basic Info" is now "Basic Information"
- Confirm Description section now uses CK5 editor and saves different HTML properly

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/7730

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
