### PR TITLE
fix: template workspace strings

### DIFF
--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
@@ -48,6 +48,12 @@ export const buildUiSchema = async (
           messages: [
             {
               type: "ERROR",
+              keyword: "format",
+              icon: true,
+              labelKey: `${i18nScope}.fields.previewUrl.formatError`,
+            },
+            {
+              type: "ERROR",
               keyword: "if",
               hidden: true,
             },
@@ -61,6 +67,9 @@ export const buildUiSchema = async (
         options: {
           control: "hub-field-input-input",
           type: "textarea",
+          helperText: {
+            labelKey: `${i18nScope}.fields.summary.helperText`,
+          },
         },
       },
       {
@@ -70,6 +79,9 @@ export const buildUiSchema = async (
         options: {
           control: "hub-field-input-input",
           type: "textarea",
+          helperText: {
+            labelKey: `${i18nScope}.fields.description.helperText`,
+          },
         },
       },
       getThumbnailUiSchemaElement(i18nScope, entity),

--- a/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
+++ b/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
@@ -52,6 +52,12 @@ export const buildUiSchema = async (
               messages: [
                 {
                   type: "ERROR",
+                  keyword: "format",
+                  icon: true,
+                  labelKey: `${i18nScope}.fields.previewUrl.formatError`,
+                },
+                {
+                  type: "ERROR",
                   keyword: "if",
                   hidden: true,
                 },

--- a/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
@@ -41,6 +41,12 @@ describe("buildUiSchema: initiative template edit", () => {
             messages: [
               {
                 type: "ERROR",
+                keyword: "format",
+                icon: true,
+                labelKey: "some.scope.fields.previewUrl.formatError",
+              },
+              {
+                type: "ERROR",
                 keyword: "if",
                 hidden: true,
               },
@@ -54,6 +60,9 @@ describe("buildUiSchema: initiative template edit", () => {
           options: {
             control: "hub-field-input-input",
             type: "textarea",
+            helperText: {
+              labelKey: "some.scope.fields.summary.helperText",
+            },
           },
         },
         {
@@ -63,6 +72,9 @@ describe("buildUiSchema: initiative template edit", () => {
           options: {
             control: "hub-field-input-input",
             type: "textarea",
+            helperText: {
+              labelKey: "some.scope.fields.description.helperText",
+            },
           },
         },
         {

--- a/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
@@ -44,6 +44,12 @@ describe("buildUiSchema: template edit", () => {
                 messages: [
                   {
                     type: "ERROR",
+                    keyword: "format",
+                    icon: true,
+                    labelKey: "some.scope.fields.previewUrl.formatError",
+                  },
+                  {
+                    type: "ERROR",
                     keyword: "if",
                     hidden: true,
                   },


### PR DESCRIPTION
[7732](https://devtopia.esri.com/dc/hub/issues/7732)
### Description
update the `uiSchema` for templates and initiative templates for string purposes

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.