### PR TITLE
feat: add advancedEditRelative to template links hash

### DIFF
--- a/packages/common/src/templates/_internal/computeLinks.ts
+++ b/packages/common/src/templates/_internal/computeLinks.ts
@@ -29,16 +29,18 @@ export function computeLinks(
   // managing it in the workspace, so we kick users to AGO
   const isDeployed = item.typeKeywords?.includes("Deployed");
   const itemHomeUrl = getItemHomeUrl(item.id, requestOptions);
+  const siteRelativeUrl = getHubRelativeUrl(
+    item.type,
+    getItemIdentifier(item),
+    item.typeKeywords
+  );
   return {
     self: itemHomeUrl,
-    siteRelative: getHubRelativeUrl(
-      item.type,
-      getItemIdentifier(item),
-      item.typeKeywords
-    ),
+    siteRelative: siteRelativeUrl,
     workspaceRelative: isDeployed
       ? itemHomeUrl
       : getRelativeWorkspaceUrl(item.type, getItemIdentifier(item)),
+    advancedEditRelative: `${siteRelativeUrl}/edit/advanced`,
     thumbnail: getItemThumbnailUrl(item, requestOptions, token),
   };
 }

--- a/packages/common/src/templates/_internal/computeLinks.ts
+++ b/packages/common/src/templates/_internal/computeLinks.ts
@@ -40,7 +40,10 @@ export function computeLinks(
     workspaceRelative: isDeployed
       ? itemHomeUrl
       : getRelativeWorkspaceUrl(item.type, getItemIdentifier(item)),
-    advancedEditRelative: `${siteRelativeUrl}/edit/advanced`,
+    advancedEditRelative: `${siteRelativeUrl
+      .split("/")
+      .slice(0, -1)
+      .join("/")}/edit/advanced`,
     thumbnail: getItemThumbnailUrl(item, requestOptions, token),
   };
 }

--- a/packages/common/test/templates/_internal/computeLinks.test.ts
+++ b/packages/common/test/templates/_internal/computeLinks.test.ts
@@ -38,9 +38,7 @@ describe("templates: computeLinks", () => {
     expect(chk.self).toBe("/some-item-home-url");
     expect(chk.siteRelative).toBe("/templates/mock-slug/about");
     expect(chk.workspaceRelative).toBe("/workspace/templates/mock-slug");
-    expect(chk.advancedEditRelative).toBe(
-      "/templates/mock-slug/about/edit/advanced"
-    );
+    expect(chk.advancedEditRelative).toBe("/templates/mock-slug/edit/advanced");
     expect(chk.thumbnail).toBe("/some-thumbnail-url");
   });
   it("generates a links hash using the templates's id when no slug is available", () => {
@@ -49,7 +47,7 @@ describe("templates: computeLinks", () => {
     expect(chk.self).toBe("/some-item-home-url");
     expect(chk.siteRelative).toBe("/templates/00c/about");
     expect(chk.workspaceRelative).toBe("/workspace/templates/00c");
-    expect(chk.advancedEditRelative).toBe("/templates/00c/about/edit/advanced");
+    expect(chk.advancedEditRelative).toBe("/templates/00c/edit/advanced");
     expect(chk.thumbnail).toBe("/some-thumbnail-url");
   });
   describe("Deployed templates", () => {

--- a/packages/common/test/templates/_internal/computeLinks.test.ts
+++ b/packages/common/test/templates/_internal/computeLinks.test.ts
@@ -38,6 +38,9 @@ describe("templates: computeLinks", () => {
     expect(chk.self).toBe("/some-item-home-url");
     expect(chk.siteRelative).toBe("/templates/mock-slug/about");
     expect(chk.workspaceRelative).toBe("/workspace/templates/mock-slug");
+    expect(chk.advancedEditRelative).toBe(
+      "/templates/mock-slug/about/edit/advanced"
+    );
     expect(chk.thumbnail).toBe("/some-thumbnail-url");
   });
   it("generates a links hash using the templates's id when no slug is available", () => {
@@ -46,6 +49,7 @@ describe("templates: computeLinks", () => {
     expect(chk.self).toBe("/some-item-home-url");
     expect(chk.siteRelative).toBe("/templates/00c/about");
     expect(chk.workspaceRelative).toBe("/workspace/templates/00c");
+    expect(chk.advancedEditRelative).toBe("/templates/00c/about/edit/advanced");
     expect(chk.thumbnail).toBe("/some-thumbnail-url");
   });
   describe("Deployed templates", () => {


### PR DESCRIPTION
[7735](https://devtopia.esri.com/dc/hub/issues/7735)

### Description:
- add `advancedEditRelative` url to template links hash
- update relevant tests

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.