### PR TITLE
feat(hub-common): add section heading for template ui schemas

### DIFF
--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
@@ -2,7 +2,6 @@ import { IArcGISContext } from "../..";
 import { IHubInitiativeTemplate } from "../../core";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
 import { IUiSchema, UiSchemaMessageTypes } from "../../core/schemas/types";
-import { getRecommendedTemplatesCatalog } from "./getRecommendedTemplatesCatalog";
 
 /**
  * @private
@@ -24,91 +23,61 @@ export const buildUiSchema = async (
     type: "Layout",
     elements: [
       {
-        type: "Control",
-        scope: "/properties/name",
-        labelKey: `${i18nScope}.fields.name.label`,
-        options: {
-          messages: [
-            {
-              type: UiSchemaMessageTypes.error,
-              keyword: "required",
-              icon: true,
-              labelKey: `${i18nScope}.fields.name.requiredError`,
+        type: "Section",
+        labelKey: `${i18nScope}.sections.basicInfo.label`,
+        elements: [
+          {
+            type: "Control",
+            scope: "/properties/name",
+            labelKey: `${i18nScope}.fields.name.label`,
+            options: {
+              messages: [
+                {
+                  type: UiSchemaMessageTypes.error,
+                  keyword: "required",
+                  icon: true,
+                  labelKey: `${i18nScope}.fields.name.requiredError`,
+                },
+              ],
             },
-          ],
-        },
-      },
-      {
-        type: "Control",
-        scope: "/properties/previewUrl",
-        labelKey: `${i18nScope}.fields.previewUrl.label`,
-        options: {
-          helperText: {
-            labelKey: `${i18nScope}.fields.previewUrl.helperText`,
           },
-          messages: [
-            {
-              type: "ERROR",
-              keyword: "format",
-              icon: true,
-              labelKey: `${i18nScope}.fields.previewUrl.formatError`,
+          {
+            type: "Control",
+            scope: "/properties/previewUrl",
+            labelKey: `${i18nScope}.fields.previewUrl.label`,
+            options: {
+              helperText: {
+                labelKey: `${i18nScope}.fields.previewUrl.helperText`,
+              },
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "if",
+                  hidden: true,
+                },
+              ],
             },
-            {
-              type: "ERROR",
-              keyword: "if",
-              hidden: true,
-            },
-          ],
-        },
-      },
-      {
-        type: "Control",
-        scope: "/properties/summary",
-        labelKey: `${i18nScope}.fields.summary.label`,
-        options: {
-          control: "hub-field-input-input",
-          type: "textarea",
-          helperText: {
-            labelKey: `${i18nScope}.fields.summary.helperText`,
           },
-        },
-      },
-      {
-        type: "Control",
-        scope: "/properties/description",
-        labelKey: `${i18nScope}.fields.description.label`,
-        options: {
-          control: "hub-field-input-input",
-          type: "textarea",
-          helperText: {
-            labelKey: `${i18nScope}.fields.description.helperText`,
-          },
-        },
-      },
-      getThumbnailUiSchemaElement(i18nScope, entity),
-      {
-        type: "Control",
-        scope: "/properties/recommendedTemplates",
-        labelKey: `${i18nScope}.fields.recommendedTemplates.label`,
-        options: {
-          control: "hub-field-input-gallery-picker",
-          targetEntity: "item",
-          catalogs: getRecommendedTemplatesCatalog(
-            context.currentUser,
-            i18nScope
-          ),
-          facets: [
-            {
-              label: `{{${i18nScope}.fields.recommendedTemplates.facets.sharing:translate}}`,
-              key: "access",
-              field: "access",
-              display: "multi-select",
-              operation: "OR",
+          {
+            type: "Control",
+            scope: "/properties/summary",
+            labelKey: `${i18nScope}.fields.summary.label`,
+            options: {
+              control: "hub-field-input-input",
+              type: "textarea",
             },
-          ],
-          canReorder: false,
-          linkTarget: "workspaceRelative",
-        },
+          },
+          {
+            type: "Control",
+            scope: "/properties/description",
+            labelKey: `${i18nScope}.fields.description.label`,
+            options: {
+              control: "hub-field-input-input",
+              type: "textarea",
+            },
+          },
+          getThumbnailUiSchemaElement(i18nScope, entity),
+        ],
       },
     ],
   };

--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
@@ -2,6 +2,7 @@ import { IArcGISContext } from "../..";
 import { IHubInitiativeTemplate } from "../../core";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
 import { IUiSchema, UiSchemaMessageTypes } from "../../core/schemas/types";
+import { getRecommendedTemplatesCatalog } from "./getRecommendedTemplatesCatalog";
 
 /**
  * @private
@@ -52,6 +53,12 @@ export const buildUiSchema = async (
               messages: [
                 {
                   type: "ERROR",
+                  keyword: "format",
+                  icon: true,
+                  labelKey: `${i18nScope}.fields.previewUrl.formatError`,
+                },
+                {
+                  type: "ERROR",
                   keyword: "if",
                   hidden: true,
                 },
@@ -65,6 +72,9 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-input",
               type: "textarea",
+              helperText: {
+                labelKey: `${i18nScope}.fields.summary.helperText`,
+              },
             },
           },
           {
@@ -74,9 +84,36 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-input",
               type: "textarea",
+              helperText: {
+                labelKey: `${i18nScope}.fields.description.helperText`,
+              },
             },
           },
           getThumbnailUiSchemaElement(i18nScope, entity),
+          {
+            type: "Control",
+            scope: "/properties/recommendedTemplates",
+            labelKey: `${i18nScope}.fields.recommendedTemplates.label`,
+            options: {
+              control: "hub-field-input-gallery-picker",
+              targetEntity: "item",
+              catalogs: getRecommendedTemplatesCatalog(
+                context.currentUser,
+                i18nScope
+              ),
+              facets: [
+                {
+                  label: `{{${i18nScope}.fields.recommendedTemplates.facets.sharing:translate}}`,
+                  key: "access",
+                  field: "access",
+                  display: "multi-select",
+                  operation: "OR",
+                },
+              ],
+              canReorder: false,
+              linkTarget: "workspaceRelative",
+            },
+          },
         ],
       },
     ],

--- a/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
@@ -21,106 +21,112 @@ describe("buildUiSchema: initiative template edit", () => {
       type: "Layout",
       elements: [
         {
-          type: "Control",
-          scope: "/properties/name",
-          labelKey: `some.scope.fields.name.label`,
-          options: {
-            messages: [
-              {
-                type: UiSchemaMessageTypes.error,
-                keyword: "required",
-                icon: true,
-                labelKey: `some.scope.fields.name.requiredError`,
+          type: "Section",
+          labelKey: `some.scope.sections.basicInfo.label`,
+          elements: [
+            {
+              type: "Control",
+              scope: "/properties/name",
+              labelKey: `some.scope.fields.name.label`,
+              options: {
+                messages: [
+                  {
+                    type: UiSchemaMessageTypes.error,
+                    keyword: "required",
+                    icon: true,
+                    labelKey: `some.scope.fields.name.requiredError`,
+                  },
+                ],
               },
-            ],
-          },
-        },
-        {
-          type: "Control",
-          scope: "/properties/previewUrl",
-          labelKey: `some.scope.fields.previewUrl.label`,
-          options: {
-            helperText: {
-              labelKey: "some.scope.fields.previewUrl.helperText",
             },
-            messages: [
-              {
-                type: "ERROR",
-                keyword: "format",
-                icon: true,
-                labelKey: "some.scope.fields.previewUrl.formatError",
+            {
+              type: "Control",
+              scope: "/properties/previewUrl",
+              labelKey: `some.scope.fields.previewUrl.label`,
+              options: {
+                helperText: {
+                  labelKey: "some.scope.fields.previewUrl.helperText",
+                },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "format",
+                    icon: true,
+                    labelKey: "some.scope.fields.previewUrl.formatError",
+                  },
+                  {
+                    type: "ERROR",
+                    keyword: "if",
+                    hidden: true,
+                  },
+                ],
               },
-              {
-                type: "ERROR",
-                keyword: "if",
-                hidden: true,
+            },
+            {
+              type: "Control",
+              scope: "/properties/summary",
+              labelKey: `some.scope.fields.summary.label`,
+              options: {
+                control: "hub-field-input-input",
+                type: "textarea",
+                helperText: {
+                  labelKey: "some.scope.fields.summary.helperText",
+                },
               },
-            ],
-          },
-        },
-        {
-          type: "Control",
-          scope: "/properties/summary",
-          labelKey: `some.scope.fields.summary.label`,
-          options: {
-            control: "hub-field-input-input",
-            type: "textarea",
-            helperText: {
-              labelKey: "some.scope.fields.summary.helperText",
             },
-          },
-        },
-        {
-          type: "Control",
-          scope: "/properties/description",
-          labelKey: `some.scope.fields.description.label`,
-          options: {
-            control: "hub-field-input-input",
-            type: "textarea",
-            helperText: {
-              labelKey: "some.scope.fields.description.helperText",
-            },
-          },
-        },
-        {
-          type: "Control",
-          scope: "/properties/_thumbnail",
-          labelKey: `shared.fields._thumbnail.label`,
-          options: {
-            control: "hub-field-input-image-picker",
-            imgSrc: "https://some-thumbnail-url.com",
-            maxWidth: 727,
-            maxHeight: 484,
-            aspectRatio: 1.5,
-            helperText: {
-              labelKey: "some.scope.fields._thumbnail.helperText",
-            },
-            sizeDescription: {
-              labelKey: "shared.fields._thumbnail.sizeDescription",
-            },
-            messages: [],
-          },
-        },
-        {
-          type: "Control",
-          scope: "/properties/recommendedTemplates",
-          labelKey: `some.scope.fields.recommendedTemplates.label`,
-          options: {
-            control: "hub-field-input-gallery-picker",
-            targetEntity: "item",
-            catalogs: [],
-            facets: [
-              {
-                label: `{{some.scope.fields.recommendedTemplates.facets.sharing:translate}}`,
-                key: "access",
-                field: "access",
-                display: "multi-select",
-                operation: "OR",
+            {
+              type: "Control",
+              scope: "/properties/description",
+              labelKey: `some.scope.fields.description.label`,
+              options: {
+                control: "hub-field-input-input",
+                type: "textarea",
+                helperText: {
+                  labelKey: "some.scope.fields.description.helperText",
+                },
               },
-            ],
-            canReorder: false,
-            linkTarget: "workspaceRelative",
-          },
+            },
+            {
+              type: "Control",
+              scope: "/properties/_thumbnail",
+              labelKey: `shared.fields._thumbnail.label`,
+              options: {
+                control: "hub-field-input-image-picker",
+                imgSrc: "https://some-thumbnail-url.com",
+                maxWidth: 727,
+                maxHeight: 484,
+                aspectRatio: 1.5,
+                helperText: {
+                  labelKey: "some.scope.fields._thumbnail.helperText",
+                },
+                sizeDescription: {
+                  labelKey: "shared.fields._thumbnail.sizeDescription",
+                },
+                messages: [],
+              },
+            },
+            {
+              type: "Control",
+              scope: "/properties/recommendedTemplates",
+              labelKey: `some.scope.fields.recommendedTemplates.label`,
+              options: {
+                control: "hub-field-input-gallery-picker",
+                targetEntity: "item",
+                catalogs: [],
+                facets: [
+                  {
+                    label: `{{some.scope.fields.recommendedTemplates.facets.sharing:translate}}`,
+                    key: "access",
+                    field: "access",
+                    display: "multi-select",
+                    operation: "OR",
+                  },
+                ],
+                canReorder: false,
+                linkTarget: "workspaceRelative",
+              },
+            },
+          ],
         },
       ],
     });


### PR DESCRIPTION
1. Description: Follow up to previous PR to ensure consistency across all details panes

1. Instructions for testing: Converted initiative template details pane to use a "Section" and added label on OD-UI

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/7730

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
