### PR TITLE
feat(hub-common): add "reharvestSiteCatalog" util

### DIFF
--- a/packages/common/src/sites/index.ts
+++ b/packages/common/src/sites/index.ts
@@ -12,6 +12,7 @@ export * from "./site-schema-version";
 export * from "./themes";
 export * from "./upgrade-site-schema";
 export * from "./feed-configuration";
+export * from "./reharvestSiteCatalog";
 // No longer exported b/c site app registration is now handled
 // by the domain service due to requirement to send signed HMAC request
 // export * from "./registerSiteAsApplication";

--- a/packages/common/src/sites/reharvestSiteCatalog.ts
+++ b/packages/common/src/sites/reharvestSiteCatalog.ts
@@ -1,0 +1,41 @@
+import { IArcGISContext } from "../ArcGISContext";
+
+interface IGroupReharvestInfo {
+  /**
+   * Catalog group being harvested
+   */
+  groupId: string;
+  /**
+   * Internal job id
+   */
+  jobId: string;
+  /**
+   * HTTP status code of the job
+   */
+  status: number;
+}
+
+/**
+ * Trigger a manual update to reharvest each public item within a site's catalog.
+ * This should only be used when search metadata has gotten out of sync despite
+ * the nightly reharvest.
+ *
+ * @param siteId site's catalog to reharvest
+ * @param context
+ * @returns Job info for each group whose content is being harvested
+ */
+export async function reharvestSiteCatalog(
+  siteId: string,
+  context: IArcGISContext
+): Promise<IGroupReharvestInfo[]> {
+  const apiHost = context.hubUrl;
+  const url = `${apiHost}/api/v3/jobs/site/${siteId}/harvest`;
+  const options = {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: context.hubRequestOptions.authentication.token,
+    },
+  };
+  return fetch(url, options).then((result) => result.json());
+}

--- a/packages/common/test/sites/reharvestSiteCatalog.test.ts
+++ b/packages/common/test/sites/reharvestSiteCatalog.test.ts
@@ -1,0 +1,22 @@
+import * as fetchMock from "fetch-mock";
+import { MOCK_CONTEXT } from "../mocks/mock-auth";
+import { reharvestSiteCatalog } from "../../src/sites/reharvestSiteCatalog";
+
+describe("reharvestSiteCatalog", () => {
+  it("correctly calls the reharvest endpoint", async () => {
+    const url = `${MOCK_CONTEXT.hubUrl}/api/v3/jobs/site/some-site-id/harvest`;
+    const expectedResults = [
+      {
+        groupId: "some-group-id",
+        jobId: "some-job-id",
+        status: 202,
+      },
+    ];
+    fetchMock.once(url, expectedResults);
+    const actualResults = await reharvestSiteCatalog(
+      "some-site-id",
+      MOCK_CONTEXT
+    );
+    expect(actualResults).toEqual(expectedResults);
+  });
+});


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
