### PR TITLE
refactor: rows with new calcite text area for details summary

### DIFF
--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -52,6 +52,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-input",
               type: "textarea",
+              rows: 4,
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.hint`,
               },

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -66,6 +66,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-input",
               type: "textarea",
+              rows: 4,
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -42,6 +42,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-input",
               type: "textarea",
+              rows: 4,
             },
           },
           {

--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
@@ -72,6 +72,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-input",
               type: "textarea",
+              rows: 4,
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
@@ -57,6 +57,7 @@ export const buildUiSchema = async (
                     options: {
                       control: "hub-field-input-input",
                       type: "textarea",
+                      rows: 4,
                       helperText: {
                         labelKey: `${i18nScope}.fields.summary.helperText`,
                       },

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -48,6 +48,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-input",
               type: "textarea",
+              rows: 4,
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },

--- a/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
+++ b/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
@@ -47,6 +47,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-input",
               type: "textarea",
+              rows: 4,
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },

--- a/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
@@ -54,6 +54,7 @@ export const buildUiSchema = async (
                     options: {
                       control: "hub-field-input-input",
                       type: "textarea",
+                      rows: 4,
                       helperText: {
                         labelKey: `${i18nScope}.fields.summary.helperText`,
                       },

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -49,6 +49,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-input",
               type: "textarea",
+              rows: 4,
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },

--- a/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
@@ -57,6 +57,7 @@ export const buildUiSchema = async (
                     options: {
                       control: "hub-field-input-input",
                       type: "textarea",
+                      rows: 4,
                       helperText: {
                         labelKey: `${i18nScope}.fields.summary.helperText`,
                       },

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -47,6 +47,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-input",
               type: "textarea",
+              rows: 4,
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },

--- a/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
+++ b/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
@@ -71,6 +71,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-input",
               type: "textarea",
+              rows: 4,
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },

--- a/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
@@ -60,6 +60,7 @@ describe("buildUiSchema: content edit", () => {
               options: {
                 control: "hub-field-input-input",
                 type: "textarea",
+                rows: 4,
                 helperText: {
                   labelKey: "some.scope.fields.summary.hint",
                 },

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -79,6 +79,7 @@ describe("buildUiSchema: discussion edit", () => {
               options: {
                 control: "hub-field-input-input",
                 type: "textarea",
+                rows: 4,
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },

--- a/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
@@ -37,6 +37,7 @@ describe("buildUiSchema: group edit", () => {
               options: {
                 control: "hub-field-input-input",
                 type: "textarea",
+                rows: 4,
               },
             },
             {

--- a/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
@@ -69,6 +69,7 @@ describe("buildUiSchema: initiative template edit", () => {
               options: {
                 control: "hub-field-input-input",
                 type: "textarea",
+                rows: 4,
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
@@ -58,6 +58,7 @@ describe("buildUiSchema: initiative create", () => {
                       options: {
                         control: "hub-field-input-input",
                         type: "textarea",
+                        rows: 4,
                         helperText: {
                           labelKey: "some.scope.fields.summary.helperText",
                         },

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -62,6 +62,7 @@ describe("buildUiSchema: initiative edit", () => {
               options: {
                 control: "hub-field-input-input",
                 type: "textarea",
+                rows: 4,
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },

--- a/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
+++ b/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
@@ -57,6 +57,7 @@ describe("buildUiSchema: page edit", () => {
               options: {
                 control: "hub-field-input-input",
                 type: "textarea",
+                rows: 4,
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },

--- a/packages/common/test/projects/_internal/ProjectUiSchemaCreate.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaCreate.test.ts
@@ -58,6 +58,7 @@ describe("buildUiSchema: project create", () => {
                       options: {
                         control: "hub-field-input-input",
                         type: "textarea",
+                        rows: 4,
                         helperText: {
                           labelKey: "some.scope.fields.summary.helperText",
                         },

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -66,6 +66,7 @@ describe("buildUiSchema: project edit", () => {
               options: {
                 control: "hub-field-input-input",
                 type: "textarea",
+                rows: 4,
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },

--- a/packages/common/test/sites/_internal/SiteUiSchemaCreate.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaCreate.test.ts
@@ -58,6 +58,7 @@ describe("buildUiSchema: site create", () => {
                       options: {
                         control: "hub-field-input-input",
                         type: "textarea",
+                        rows: 4,
                         helperText: {
                           labelKey: "some.scope.fields.summary.helperText",
                         },

--- a/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
@@ -57,6 +57,7 @@ describe("buildUiSchema: site edit", () => {
               options: {
                 control: "hub-field-input-input",
                 type: "textarea",
+                rows: 4,
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },

--- a/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
@@ -63,6 +63,7 @@ describe("buildUiSchema: template edit", () => {
               options: {
                 control: "hub-field-input-input",
                 type: "textarea",
+                rows: 4,
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },


### PR DESCRIPTION
1. Description: OD-UI PR: https://github.com/ArcGIS/opendata-ui/pull/12664
- calcite input --> calcite text area
- rows can now be used for textarea types
- vertical + none now used for textarea types

1. Instructions for testing: Confirm each workspace details pane has a summary textarea input with 4 rows

1. Closes Issues: [#8125](https://devtopia.esri.com/dc/hub/issues/8125)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
