### PR TITLE
feat(hub-common): add metric display config to hub.js

### DIFF
--- a/packages/common/src/core/traits/IWithViewSettings.ts
+++ b/packages/common/src/core/traits/IWithViewSettings.ts
@@ -1,4 +1,4 @@
-import { IHubTimeline } from "../types";
+import { IHubTimeline, IMetricDisplayConfig } from "../types";
 
 /**
  * Properties to be exclusively displayed on an entity's
@@ -33,4 +33,9 @@ export interface IWithViewSettings {
    * timeline associated with an entity
    */
   timeline?: IHubTimeline;
+
+  /**
+   * configurations for how to display metrics in the ui
+   */
+  metricDisplays?: IMetricDisplayConfig[];
 }

--- a/packages/common/src/core/types/Metrics.ts
+++ b/packages/common/src/core/types/Metrics.ts
@@ -197,3 +197,12 @@ export interface IExpression {
    */
   key?: string;
 }
+
+/**
+ * Configuration for how to show a metric in the ui
+ */
+export interface IMetricDisplayConfig {
+  metricId: string;
+  displayType: string;
+  [key: string]: any;
+}

--- a/packages/common/src/projects/defaults.ts
+++ b/packages/common/src/projects/defaults.ts
@@ -19,6 +19,7 @@ export const DEFAULT_PROJECT: Partial<IHubProject> = {
     contacts: [],
     featuredContentIds: [],
     showMap: true,
+    metricDisplays: [],
   },
   features: InitiativeDefaultFeatures,
 };
@@ -47,6 +48,7 @@ export const DEFAULT_PROJECT_MODEL: IModel = {
       contacts: [],
       featuredContentIds: [],
       showMap: true,
+      metricDisplays: [],
     },
   },
 } as unknown as IModel;


### PR DESCRIPTION
1. Description:
Adds the metric display configuration interface to hub.js. Called `IMetricDisplayConfig`. 
1. Instructions for testing:

1. Closes Issues: [#6614](https://zentopia.esri.com/workspaces/collaboration-sprint-board-614f9bfc0946c40011ef574e/issues/dc/hub/6614)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
