### PR TITLE
feat: add permission for privacy; refactor workspace permissions

### DIFF
--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -18,6 +18,7 @@ export const ContentPermissions = [
   // "hub:content:delete",
   "hub:content:edit",
   "hub:content:view",
+  "hub:content:workspace",
   "hub:content:workspace:overview",
   "hub:content:workspace:dashboard",
   "hub:content:workspace:details",
@@ -58,29 +59,33 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
   //   licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
   // },
   {
+    permission: "hub:content:workspace",
+    dependencies: ["hub:feature:workspace"],
+  },
+  {
     permission: "hub:content:workspace:overview",
-    dependencies: ["hub:content:view"],
+    dependencies: ["hub:content:workspace", "hub:content:view"],
   },
   {
     permission: "hub:content:workspace:dashboard",
-    dependencies: ["hub:content:view"],
+    dependencies: ["hub:content:workspace", "hub:content:view"],
   },
   {
     permission: "hub:content:workspace:details",
-    dependencies: ["hub:content:edit"],
+    dependencies: ["hub:content:workspace", "hub:content:edit"],
   },
   {
     permission: "hub:content:workspace:discussion",
-    dependencies: ["hub:content:edit"],
+    dependencies: ["hub:content:workspace", "hub:content:edit"],
   },
   {
     permission: "hub:content:workspace:settings",
-    dependencies: ["hub:content:edit"],
+    dependencies: ["hub:content:workspace", "hub:content:edit"],
     entityOwner: true,
   },
   {
     permission: "hub:content:workspace:collaborators",
-    dependencies: ["hub:content:edit"],
+    dependencies: ["hub:content:workspace", "hub:content:edit"],
   },
   {
     permission: "hub:content:manage",

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -12,6 +12,7 @@ export const GroupPermissions = [
   "hub:group:edit",
   "hub:group:view",
   "hub:group:owner",
+  "hub:group:workspace",
   "hub:group:workspace:overview",
   "hub:group:workspace:dashboard",
   "hub:group:workspace:details",
@@ -62,24 +63,28 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
     entityOwner: true,
   },
   {
+    permission: "hub:group:workspace",
+    dependencies: ["hub:feature:workspace"],
+  },
+  {
     permission: "hub:group:workspace:details",
-    dependencies: ["hub:group:edit"],
+    dependencies: ["hub:group:workspace", "hub:group:edit"],
   },
   {
     permission: "hub:group:workspace:discussion",
-    dependencies: ["hub:group:edit"],
+    dependencies: ["hub:group:workspace", "hub:group:edit"],
   },
   {
     permission: "hub:group:workspace:settings",
-    dependencies: ["hub:group:edit"],
+    dependencies: ["hub:group:workspace", "hub:group:edit"],
   },
   {
     permission: "hub:group:workspace:content",
-    dependencies: ["hub:group:view"],
+    dependencies: ["hub:group:workspace", "hub:group:view"],
   },
   {
     permission: "hub:group:workspace:members",
-    dependencies: ["hub:group:view"],
+    dependencies: ["hub:group:workspace", "hub:group:view"],
   },
   {
     permission: "hub:group:shareContent",

--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateBusinessRules.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateBusinessRules.ts
@@ -18,6 +18,7 @@ export const InitiativeTemplatePermissions = [
   "hub:initiativeTemplate:delete",
   "hub:initiativeTemplate:edit",
   "hub:initiativeTemplate:view",
+  "hub:initiativeTemplate:workspace",
   "hub:initiativeTemplate:workspace:overview",
   "hub:initiativeTemplate:workspace:dashboard",
   "hub:initiativeTemplate:workspace:details",
@@ -59,24 +60,43 @@ export const InitiativeTemplatePermissionPolicies: IPermissionPolicy[] = [
     entityOwner: true,
   },
   {
+    permission: "hub:initiativeTemplate:workspace",
+    dependencies: ["hub:feature:workspace"],
+  },
+  {
     permission: "hub:initiativeTemplate:workspace:overview",
-    dependencies: ["hub:initiativeTemplate:view"],
+    dependencies: [
+      "hub:initiativeTemplate:workspace",
+      "hub:initiativeTemplate:view",
+    ],
   },
   {
     permission: "hub:initiativeTemplate:workspace:dashboard",
-    dependencies: ["hub:initiativeTemplate:edit"],
+    dependencies: [
+      "hub:initiativeTemplate:workspace",
+      "hub:initiativeTemplate:edit",
+    ],
   },
   {
     permission: "hub:initiativeTemplate:workspace:details",
-    dependencies: ["hub:initiativeTemplate:edit"],
+    dependencies: [
+      "hub:initiativeTemplate:workspace",
+      "hub:initiativeTemplate:edit",
+    ],
   },
   {
     permission: "hub:initiativeTemplate:workspace:collaborators",
-    dependencies: ["hub:initiativeTemplate:edit"],
+    dependencies: [
+      "hub:initiativeTemplate:workspace",
+      "hub:initiativeTemplate:edit",
+    ],
   },
   {
     permission: "hub:initiativeTemplate:workspace:settings",
-    dependencies: ["hub:initiativeTemplate:edit"],
+    dependencies: [
+      "hub:initiativeTemplate:workspace",
+      "hub:initiativeTemplate:edit",
+    ],
     entityOwner: true,
   },
   {

--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -23,6 +23,7 @@ export const InitiativePermissions = [
   "hub:initiative:events",
   "hub:initiative:content",
   "hub:initiative:discussions",
+  "hub:initiative:workspace",
   "hub:initiative:workspace:overview",
   "hub:initiative:workspace:dashboard",
   "hub:initiative:workspace:details",
@@ -81,33 +82,38 @@ export const InitiativePermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:initiative:view"],
   },
   {
+    permission: "hub:initiative:workspace",
+    dependencies: ["hub:feature:workspace"],
+    environments: ["devext", "qaext"],
+  },
+  {
     permission: "hub:initiative:workspace:overview",
-    dependencies: ["hub:initiative:view"],
+    dependencies: ["hub:initiative:workspace", "hub:initiative:view"],
   },
   {
     permission: "hub:initiative:workspace:dashboard",
-    dependencies: ["hub:initiative:view"],
+    dependencies: ["hub:initiative:workspace", "hub:initiative:view"],
   },
   {
     permission: "hub:initiative:workspace:details",
-    dependencies: ["hub:initiative:edit"],
+    dependencies: ["hub:initiative:workspace", "hub:initiative:edit"],
   },
   {
     permission: "hub:initiative:workspace:settings",
-    dependencies: ["hub:initiative:edit"],
+    dependencies: ["hub:initiative:workspace", "hub:initiative:edit"],
     entityOwner: true,
   },
   {
     permission: "hub:initiative:workspace:collaborators",
-    dependencies: ["hub:initiative:edit"],
+    dependencies: ["hub:initiative:workspace", "hub:initiative:edit"],
   },
   {
     permission: "hub:initiative:workspace:content",
-    dependencies: ["hub:initiative:edit"],
+    dependencies: ["hub:initiative:workspace", "hub:initiative:edit"],
   },
   {
     permission: "hub:initiative:workspace:metrics",
-    dependencies: ["hub:initiative:edit"],
+    dependencies: ["hub:initiative:workspace", "hub:initiative:edit"],
   },
   {
     permission: "hub:initiative:manage",

--- a/packages/common/src/pages/_internal/PageBusinessRules.ts
+++ b/packages/common/src/pages/_internal/PageBusinessRules.ts
@@ -18,6 +18,7 @@ export const PagePermissions = [
   "hub:page:delete",
   "hub:page:edit",
   "hub:page:view",
+  "hub:page:workspace",
   "hub:page:workspace:overview",
   "hub:page:workspace:dashboard",
   "hub:page:workspace:details",
@@ -58,24 +59,28 @@ export const PagePermissionPolicies: IPermissionPolicy[] = [
     entityOwner: true,
   },
   {
+    permission: "hub:page:workspace",
+    dependencies: ["hub:feature:workspace"],
+  },
+  {
     permission: "hub:page:workspace:overview",
-    dependencies: ["hub:page:view"],
+    dependencies: ["hub:page:workspace", "hub:page:view"],
   },
   {
     permission: "hub:page:workspace:dashboard",
-    dependencies: ["hub:page:view"],
+    dependencies: ["hub:page:workspace", "hub:page:view"],
   },
   {
     permission: "hub:page:workspace:details",
-    dependencies: ["hub:page:edit"],
+    dependencies: ["hub:page:workspace", "hub:page:edit"],
   },
   {
     permission: "hub:page:workspace:collaborators",
-    dependencies: ["hub:page:edit"],
+    dependencies: ["hub:page:workspace", "hub:page:edit"],
   },
   {
     permission: "hub:page:workspace:settings",
-    dependencies: ["hub:page:edit"],
+    dependencies: ["hub:page:workspace", "hub:page:edit"],
     entityOwner: true,
   },
   {

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -64,10 +64,29 @@ import { TemplatePermissionPolicies } from "../templates/_internal/TemplateBusin
 //   },
 // ];
 
+// DEPRECATED!
+// NO LONGER USED IN OPENDATA-UI DO NOT ADD MORE TO THIS LIST
 const TempPermissionPolicies: IPermissionPolicy[] = [
   {
-    // alpha orgs not on prod
-    permission: "temp:workspace:released",
+    permission: "temp:workspace:released", // replace with hub:features:workspace
+    availability: ["alpha"],
+    environments: ["devext", "qaext"],
+  },
+];
+
+/**
+ * Highlevel Permission definitions for the Hub System as a whole
+ * Typically other permissions depend on these so a whole set of features
+ * can be enabled / disabled by changing a single permission
+ */
+const SystemPermissionPolicies: IPermissionPolicy[] = [
+  {
+    permission: "hub:feature:privacy",
+    availability: ["alpha"],
+    environments: ["qaext"],
+  },
+  {
+    permission: "hub:feature:workspace",
     availability: ["alpha"],
     environments: ["devext", "qaext"],
   },
@@ -88,6 +107,7 @@ export const HubPermissionsPolicies: IPermissionPolicy[] = [
   ...PlatformPermissionPolicies,
   ...TempPermissionPolicies,
   ...InitiativeTemplatePermissionPolicies,
+  ...SystemPermissionPolicies,
 ];
 
 /**

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -17,6 +17,8 @@ import { TemplatePermissions } from "../../templates/_internal/TemplateBusinessR
 // to be used until we release workspaces or it can be replaced with our new access control (permission/feature/capability) system
 const TempPermissions = ["temp:workspace:released"];
 
+const SystemPermissions = ["hub:feature:privacy", "hub:feature:workspace"];
+
 const validPermissions = [
   ...SitePermissions,
   ...ProjectPermissions,
@@ -29,6 +31,7 @@ const validPermissions = [
   ...DiscussionPermissions,
   ...InitiativeTemplatePermissions,
   ...TemplatePermissions,
+  ...SystemPermissions,
 ] as const;
 
 /**
@@ -45,7 +48,8 @@ export type Permission =
   | (typeof TempPermissions)[number]
   | (typeof DiscussionPermissions)[number]
   | (typeof InitiativeTemplatePermissions)[number]
-  | (typeof TemplatePermissions)[number];
+  | (typeof TemplatePermissions)[number]
+  | (typeof SystemPermissions)[number];
 
 /**
  * Validate a Permission

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -24,6 +24,7 @@ export const ProjectPermissions = [
   "hub:project:events",
   "hub:project:content",
   "hub:project:discussions",
+  "hub:project:workspace",
   "hub:project:workspace:overview",
   "hub:project:workspace:dashboard",
   "hub:project:workspace:details",
@@ -87,33 +88,36 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:project:view"],
   },
   {
+    permission: "hub:project:workspace",
+  },
+  {
     permission: "hub:project:workspace:overview",
-    dependencies: ["hub:project:view"],
+    dependencies: ["hub:project:workspace", "hub:project:view"],
   },
   {
     permission: "hub:project:workspace:dashboard",
-    dependencies: ["hub:project:view"],
+    dependencies: ["hub:project:workspace", "hub:project:view"],
   },
   {
     permission: "hub:project:workspace:details",
-    dependencies: ["hub:project:edit"],
+    dependencies: ["hub:project:workspace", "hub:project:edit"],
   },
   {
     permission: "hub:project:workspace:settings",
-    dependencies: ["hub:project:edit"],
+    dependencies: ["hub:project:workspace", "hub:project:edit"],
     entityOwner: true,
   },
   {
     permission: "hub:project:workspace:collaborators",
-    dependencies: ["hub:project:edit"],
+    dependencies: ["hub:project:workspace", "hub:project:edit"],
   },
   {
     permission: "hub:project:workspace:content",
-    dependencies: ["hub:project:edit"],
+    dependencies: ["hub:project:workspace", "hub:project:edit"],
   },
   {
     permission: "hub:project:workspace:metrics",
-    dependencies: ["hub:project:edit"],
+    dependencies: ["hub:project:workspace", "hub:project:edit"],
   },
   {
     permission: "hub:project:manage",

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -27,6 +27,7 @@ export const SitePermissions = [
   "hub:site:discussions",
   "hub:site:feature:follow",
   "hub:site:feature:discussions",
+  "hub:site:workspace",
   "hub:site:workspace:overview",
   "hub:site:workspace:dashboard",
   "hub:site:workspace:details",
@@ -97,38 +98,43 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
     entityConfigurable: true,
   },
   {
+    permission: "hub:site:workspace",
+    dependencies: ["hub:feature:workspace"],
+    environments: ["devext", "qaext"],
+  },
+  {
     permission: "hub:site:workspace:overview",
-    dependencies: ["hub:site:view"],
+    dependencies: ["hub:site:workspace", "hub:site:view"],
   },
   {
     permission: "hub:site:workspace:dashboard",
-    dependencies: ["hub:site:view"],
+    dependencies: ["hub:site:workspace", "hub:site:view"],
   },
   {
     permission: "hub:site:workspace:details",
-    dependencies: ["hub:site:edit"],
+    dependencies: ["hub:site:workspace", "hub:site:edit"],
   },
   {
     permission: "hub:site:workspace:settings",
-    dependencies: ["hub:site:edit"],
+    dependencies: ["hub:site:workspace", "hub:site:edit"],
     entityOwner: true,
   },
   {
     permission: "hub:site:workspace:collaborators",
-    dependencies: ["hub:site:edit"],
+    dependencies: ["hub:site:workspace", "hub:site:edit"],
   },
   {
     permission: "hub:site:workspace:content",
-    dependencies: ["hub:site:edit"],
+    dependencies: ["hub:site:workspace", "hub:site:edit"],
   },
   {
     permission: "hub:site:workspace:metrics",
-    dependencies: ["hub:site:edit"],
+    dependencies: ["hub:site:workspace", "hub:site:edit"],
     environments: ["devext", "qaext"],
   },
   {
     permission: "hub:site:workspace:followers",
-    dependencies: ["hub:site:edit"],
+    dependencies: ["hub:site:workspace", "hub:site:edit"],
   },
   {
     permission: "hub:site:workspace:followers:member",
@@ -154,7 +160,7 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:site:workspace:discussion",
-    dependencies: ["hub:site:edit"],
+    dependencies: ["hub:site:workspace", "hub:site:edit"],
   },
   {
     permission: "hub:site:manage",

--- a/packages/common/src/templates/_internal/TemplateBusinessRules.ts
+++ b/packages/common/src/templates/_internal/TemplateBusinessRules.ts
@@ -18,6 +18,7 @@ export const TemplatePermissions = [
   "hub:template:edit",
   "hub:template:manage",
   "hub:template:view",
+  "hub:template:workspace",
   "hub:template:workspace:overview",
   "hub:template:workspace:details",
   "hub:template:workspace:dashboard",
@@ -62,24 +63,28 @@ export const TemplatePermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:template:edit"],
   },
   {
+    permission: "hub:template:workspace",
+    dependencies: ["hub:feature:workspace"],
+  },
+  {
     permission: "hub:template:workspace:overview",
-    dependencies: ["hub:template:view"],
+    dependencies: ["hub:template:workspace", "hub:template:view"],
   },
   {
     permission: "hub:template:workspace:details",
-    dependencies: ["hub:template:manage"],
+    dependencies: ["hub:template:workspace", "hub:template:manage"],
   },
   {
     permission: "hub:template:workspace:dashboard",
-    dependencies: ["hub:template:manage"],
+    dependencies: ["hub:template:workspace", "hub:template:manage"],
   },
   {
     permission: "hub:template:workspace:collaborators",
-    dependencies: ["hub:template:manage"],
+    dependencies: ["hub:template:workspace", "hub:template:manage"],
   },
   {
     permission: "hub:template:workspace:settings",
-    dependencies: ["hub:template:manage"],
+    dependencies: ["hub:template:workspace", "hub:template:manage"],
     entityOwner: true,
   },
 ];


### PR DESCRIPTION
1. Description:

This PR makes changes to the permissions to address two issues:
- Control the "Privacy Mode" (Tracking Consent - how it works today, vs Privacy Consent - new UX)
- Setup Permissions to enable customers to opt into "Workspace Preview" 

To address this, I added 

```
const SystemPermissionPolicies: IPermissionPolicy[] = [
  {
    permission: "hub:feature:privacy", 
    availability: ["alpha"],
    environments: ["qaext"],
  },
  {
    permission: "hub:feature:workspace",  // also replaces temp:workspace:released
    availability: ["alpha"],
    environments: ["devext", "qaext"],
  },
];
```

In addition, for all Entities (other than Projects), I created a new permission `hub:<entity>:workspace`, which depends on `hub:feature:workspace`, centralizing access to all un-released workspaces behind a single permission. I also updates all the other `hub:<entity>:workspace:<pane>` entries to depend on it's associated `hub:<entity>:workspace` permission, in addition to any existing dependencies.

### PLEASE REVIEW THE CHANGES FOR YOUR ENTITY
I'm pretty sure this will not have any actual impact, and have done a bunch of testing locally, but more sets of eyes is better.

1. Instructions for testing:
- run tests

1. Closes Issues: 
- [#8199](https://devtopia.esri.com/dc/hub/issues/8199) - privacy permission
- [#8200](https://devtopia.esri.com/dc/hub/issues/8200) - workspace preview

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
