### PR TITLE
feat(hub-common): allow boolean predicates for OGC searches, openData flag for OGC aggs requests

### DIFF
--- a/packages/common/src/search/_internal/commonHelpers/isNilOrEmptyString.ts
+++ b/packages/common/src/search/_internal/commonHelpers/isNilOrEmptyString.ts
@@ -1,0 +1,9 @@
+/**
+ * Determines whether a value is null, undefined, or an empty string.
+ * This is particularly useful when 0 and false are considered meaningful values
+ * @param value value to check
+ * @returns whether the value is null, undefined, or an empty string
+ */
+export function isNilOrEmptyString(value: any) {
+  return value == null || value === "";
+}

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcAggregationQueryParams.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcAggregationQueryParams.ts
@@ -1,15 +1,21 @@
 import { getProp } from "../../../objects/get-prop";
 import { IQuery } from "../../types/IHubCatalog";
 import { IHubSearchOptions } from "../../types/IHubSearchOptions";
+import { getOpenDataQueryParam } from "./getOpenDataQueryParam";
 
 export function getOgcAggregationQueryParams(
-  _query: IQuery,
+  query: IQuery,
   options: IHubSearchOptions
 ) {
   // TODO: use options.aggLimit once the OGC API supports it
   const aggregations = `terms(fields=(${options.aggFields.join()}))`;
-  // TODO: Use `query` to filter aggregations once the OGC API supports it
+  // TODO: Use the rest of `query` to filter aggregations once the OGC API supports it
+  const openData = getOpenDataQueryParam(query);
   const token = getProp(options, "requestOptions.authentication.token");
 
-  return { aggregations, token };
+  return {
+    aggregations,
+    openData,
+    token,
+  };
 }

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getOpenDataQueryParam.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getOpenDataQueryParam.ts
@@ -1,0 +1,16 @@
+import { IQuery } from "../../types/IHubCatalog";
+import { getTopLevelPredicate } from "../commonHelpers/getTopLevelPredicate";
+
+/**
+ * @private
+ * Extracts the openData flag that the search should be filtered by.
+ * Also validates that the openData predicate is not combined in some
+ * invalid way with other predicates.
+ *
+ * @param query query to extract the opendata predicate from
+ * @returns the openData value to filter by
+ */
+export function getOpenDataQueryParam(query: IQuery): string {
+  const openDataPredicate = getTopLevelPredicate("openData", query.filters);
+  return openDataPredicate?.openData;
+}

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getQueryString.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getQueryString.ts
@@ -1,6 +1,8 @@
+import { isNilOrEmptyString } from "../commonHelpers/isNilOrEmptyString";
+
 export function getQueryString(queryParams: Record<string, any>) {
   const result = Object.entries(queryParams)
-    .filter(([_key, value]) => !!value)
+    .filter(([_key, value]) => !isNilOrEmptyString(value))
     .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
     .join("&");
 

--- a/packages/common/test/search/_internal/getTopLevelPredicate.test.ts
+++ b/packages/common/test/search/_internal/getTopLevelPredicate.test.ts
@@ -6,6 +6,18 @@ describe("getTopLevelPredicate |", () => {
     const result = getTopLevelPredicate("bbox", []);
     expect(result).toBeNull();
   });
+  it("returns null when passed when predicate has nil value", () => {
+    const result = getTopLevelPredicate("bbox", [
+      { predicates: [{ bbox: undefined }] },
+    ]);
+    expect(result).toBeNull();
+  });
+  it("returns null when passed when predicate has empty string value", () => {
+    const result = getTopLevelPredicate("bbox", [
+      { predicates: [{ bbox: "" }] },
+    ]);
+    expect(result).toBeNull();
+  });
   it("throws an error when more than 1 filter with target field predicates are passed in", () => {
     const filters: IFilter[] = [
       { predicates: [{ bbox: "1,2,3,4" }] },
@@ -69,7 +81,7 @@ describe("getTopLevelPredicate |", () => {
       expect(true).toBe(false);
     } catch (err) {
       expect(err.message).toEqual(
-        "'bbox' predicate must have a string value, string[] and IMatchOptions are not allowed."
+        "'bbox' predicate must be a string or boolean primitive. string[] and IMatchOptions are not allowed."
       );
     }
   });
@@ -92,7 +104,7 @@ describe("getTopLevelPredicate |", () => {
       expect(true).toBe(false);
     } catch (err) {
       expect(err.message).toEqual(
-        "'bbox' predicate must have a string value, string[] and IMatchOptions are not allowed."
+        "'bbox' predicate must be a string or boolean primitive. string[] and IMatchOptions are not allowed."
       );
     }
   });

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -97,6 +97,14 @@ describe("hubSearchItems Module |", () => {
         expect(result).toEqual("(type=typeA)");
       });
 
+      it("handles a boolean predicate", () => {
+        const predicate = {
+          openData: false,
+        };
+        const result = formatPredicate(predicate);
+        expect(result).toEqual("(openData=false)");
+      });
+
       it("handles a simple multi-predicate", () => {
         const predicate = {
           type: "typeA",
@@ -519,7 +527,7 @@ describe("hubSearchItems Module |", () => {
     });
 
     describe("getOgcAggregationsQueryString |", () => {
-      const query: IQuery = {
+      const baseQuery: IQuery = {
         targetEntity: "item",
         filters: [
           {
@@ -533,7 +541,7 @@ describe("hubSearchItems Module |", () => {
         const options: IHubSearchOptions = {
           aggFields: ["type", "tags", "categories"],
         };
-        const result = getOgcAggregationQueryParams(query, options);
+        const result = getOgcAggregationQueryParams(baseQuery, options);
         const queryString = getQueryString(result);
         expect(queryString).toEqual(
           `?aggregations=${encodeURIComponent(
@@ -542,7 +550,23 @@ describe("hubSearchItems Module |", () => {
         );
       });
 
-      it("handles aggregations and token", () => {
+      it("handles aggregations and openData flag", () => {
+        const options: IHubSearchOptions = {
+          aggFields: ["type", "tags", "categories"],
+        };
+        const opendataQuery = cloneObject(baseQuery);
+        opendataQuery.filters.push({ predicates: [{ openData: true }] });
+
+        const result = getOgcAggregationQueryParams(opendataQuery, options);
+        const queryString = getQueryString(result);
+        expect(queryString).toEqual(
+          `?aggregations=${encodeURIComponent(
+            "terms(fields=(type,tags,categories))"
+          )}&openData=true`
+        );
+      });
+
+      it("handles aggregations, openData flag and token", () => {
         const options: IHubSearchOptions = {
           aggFields: ["type", "tags", "categories"],
           requestOptions: {
@@ -551,12 +575,15 @@ describe("hubSearchItems Module |", () => {
             } as UserSession,
           },
         };
-        const result = getOgcAggregationQueryParams(query, options);
+        const opendataQuery = cloneObject(baseQuery);
+        opendataQuery.filters.push({ predicates: [{ openData: true }] });
+
+        const result = getOgcAggregationQueryParams(opendataQuery, options);
         const queryString = getQueryString(result);
         expect(queryString).toEqual(
           `?aggregations=${encodeURIComponent(
             "terms(fields=(type,tags,categories))"
-          )}&token=abc`
+          )}&openData=true&token=abc`
         );
       });
     });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Part of https://devtopia.esri.com/dc/hub/issues/5706

This PR facilitates using the new search logic on umbrella search pages, which makes use of the boolean `openData` queryable on the OGC API

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
