### PR TITLE
feat(hub-discussions): post parentId required

### DIFF
--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -467,7 +467,7 @@ export interface IPost
   postType: PostType;
   channelId?: string;
   channel?: IChannel;
-  parentId?: string;
+  parentId: string | null;
   parent?: IPost | null;
   replies?: IPost[] | IPagedResponse<IPost>;
   replyCount?: number;


### PR DESCRIPTION
1. Description: Updated `ICreatePost` param `parentId` to be string or null instead of optional

1. Instructions for testing:

1. Closes Issues: [7408](https://zentopia.esri.com/workspaces/engagement-workspace-61508ae50946c40014ef574f/issues/dc/hub/7408)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
