### PR TITLE
fix(hub-common): page schema missing _thumbnail; caused details pane to crash

### DIFF
--- a/packages/common/src/pages/_internal/PageSchema.ts
+++ b/packages/common/src/pages/_internal/PageSchema.ts
@@ -1,10 +1,5 @@
 import { IConfigurationSchema } from "../../core";
-import {
-  ENTITY_ACCESS_SCHEMA,
-  ENTITY_CATEGORIES_SCHEMA,
-  ENTITY_NAME_SCHEMA,
-  ENTITY_TAGS_SCHEMA,
-} from "../../core/schemas/shared";
+import { HubItemEntitySchema } from "../../core/schemas/shared/HubItemEntitySchema";
 
 export const PageEditorTypes = ["hub:page:edit"] as const;
 export type PageEditorType = (typeof PageEditorTypes)[number];
@@ -13,27 +8,8 @@ export type PageEditorType = (typeof PageEditorTypes)[number];
  * defines the JSON schema for a Hub Site's editable fields
  */
 export const PageSchema: IConfigurationSchema = {
-  required: ["name"],
-  type: "object",
+  ...HubItemEntitySchema,
   properties: {
-    name: ENTITY_NAME_SCHEMA,
-    summary: {
-      type: "string",
-    },
-    description: {
-      type: "string",
-    },
-    access: ENTITY_ACCESS_SCHEMA,
-    groups: {
-      type: "array",
-      items: {
-        type: "string",
-      },
-    },
-    location: {
-      type: "object",
-    },
-    tags: ENTITY_TAGS_SCHEMA,
-    categories: ENTITY_CATEGORIES_SCHEMA,
+    ...HubItemEntitySchema.properties,
   },
 } as unknown as IConfigurationSchema;


### PR DESCRIPTION
1. Description: Changed PageSchema to include _thumbnail like the other Schemas!

1. Instructions for testing: 
- Go to Page workspace
- open details pane
- confirm all inputs are there and console is clear of errors

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/8123

Before:
![Screenshot 2023-10-20 at 12 17 45 PM](https://github.com/Esri/hub.js/assets/60486980/0d101cbf-290a-482f-b77a-a205044ebd2b)

After:
![Screenshot 2023-10-20 at 12 19 06 PM](https://github.com/Esri/hub.js/assets/60486980/ec08b3d5-f6b6-4c07-b7b3-032c29d44855)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
