### PR TITLE
F/8125 max length error messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64987,7 +64987,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.39.0",
+			"version": "14.42.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",

--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -41,6 +41,12 @@ export const buildUiSchema = async (
                   icon: true,
                   labelKey: `${i18nScope}.fields.title.requiredError`,
                 },
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.name.maxLengthError`,
+                },
               ],
             },
           },
@@ -56,6 +62,14 @@ export const buildUiSchema = async (
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.hint`,
               },
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.summary.maxLengthError`,
+                },
+              ],
             },
           },
           // description

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaCreate.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaCreate.ts
@@ -27,6 +27,12 @@ export const buildUiSchema = async (
               icon: true,
               labelKey: `${i18nScope}.fields.name.requiredError`,
             },
+            {
+              type: "ERROR",
+              keyword: "maxLength",
+              icon: true,
+              labelKey: `shared.fields.name.maxLengthError`,
+            },
           ],
         },
       },

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -38,6 +38,12 @@ export const buildUiSchema = async (
                   icon: true,
                   labelKey: `${i18nScope}.fields.name.requiredError`,
                 },
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.name.maxLengthError`,
+                },
               ],
             },
           },
@@ -70,6 +76,14 @@ export const buildUiSchema = async (
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.summary.maxLengthError`,
+                },
+              ],
             },
           },
           {

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -32,6 +32,12 @@ export const buildUiSchema = async (
                   icon: true,
                   labelKey: `${i18nScope}.fields.name.requiredError`,
                 },
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.name.maxLengthError`,
+                },
               ],
             },
           },
@@ -43,6 +49,14 @@ export const buildUiSchema = async (
               control: "hub-field-input-input",
               type: "textarea",
               rows: 4,
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.summary.maxLengthError`,
+                },
+              ],
             },
           },
           {

--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
@@ -39,6 +39,12 @@ export const buildUiSchema = async (
                   icon: true,
                   labelKey: `${i18nScope}.fields.name.requiredError`,
                 },
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.name.maxLengthError`,
+                },
               ],
             },
           },
@@ -76,6 +82,14 @@ export const buildUiSchema = async (
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.summary.maxLengthError`,
+                },
+              ],
             },
           },
           {

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
@@ -47,6 +47,12 @@ export const buildUiSchema = async (
                           icon: true,
                           labelKey: `${i18nScope}.fields.name.requiredError`,
                         },
+                        {
+                          type: "ERROR",
+                          keyword: "maxLength",
+                          icon: true,
+                          labelKey: `shared.fields.name.maxLengthError`,
+                        },
                       ],
                     },
                   },
@@ -61,6 +67,14 @@ export const buildUiSchema = async (
                       helperText: {
                         labelKey: `${i18nScope}.fields.summary.helperText`,
                       },
+                      messages: [
+                        {
+                          type: "ERROR",
+                          keyword: "maxLength",
+                          icon: true,
+                          labelKey: `shared.fields.summary.maxLengthError`,
+                        },
+                      ],
                     },
                   },
                 ],

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -38,6 +38,12 @@ export const buildUiSchema = async (
                   icon: true,
                   labelKey: `${i18nScope}.fields.name.requiredError`,
                 },
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.name.maxLengthError`,
+                },
               ],
             },
           },
@@ -52,6 +58,14 @@ export const buildUiSchema = async (
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.summary.maxLengthError`,
+                },
+              ],
             },
           },
           {

--- a/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
+++ b/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
@@ -37,6 +37,12 @@ export const buildUiSchema = async (
                   icon: true,
                   labelKey: `${i18nScope}.fields.name.requiredError`,
                 },
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.name.maxLengthError`,
+                },
               ],
             },
           },
@@ -51,6 +57,14 @@ export const buildUiSchema = async (
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.summary.maxLengthError`,
+                },
+              ],
             },
           },
           {

--- a/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
@@ -44,6 +44,12 @@ export const buildUiSchema = async (
                           icon: true,
                           labelKey: `${i18nScope}.fields.name.requiredError`,
                         },
+                        {
+                          type: "ERROR",
+                          keyword: "maxLength",
+                          icon: true,
+                          labelKey: `shared.fields.name.maxLengthError`,
+                        },
                       ],
                     },
                   },
@@ -58,6 +64,14 @@ export const buildUiSchema = async (
                       helperText: {
                         labelKey: `${i18nScope}.fields.summary.helperText`,
                       },
+                      messages: [
+                        {
+                          type: "ERROR",
+                          keyword: "maxLength",
+                          icon: true,
+                          labelKey: `shared.fields.summary.maxLengthError`,
+                        },
+                      ],
                     },
                   },
                   {

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -39,6 +39,12 @@ export const buildUiSchema = async (
                   icon: true,
                   labelKey: `${i18nScope}.fields.name.requiredError`,
                 },
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.name.maxLengthError`,
+                },
               ],
             },
           },
@@ -53,6 +59,14 @@ export const buildUiSchema = async (
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.summary.maxLengthError`,
+                },
+              ],
             },
           },
           {

--- a/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
@@ -47,6 +47,12 @@ export const buildUiSchema = async (
                           icon: true,
                           labelKey: `${i18nScope}.fields.name.requiredError`,
                         },
+                        {
+                          type: "ERROR",
+                          keyword: "maxLength",
+                          icon: true,
+                          labelKey: `shared.fields.name.maxLengthError`,
+                        },
                       ],
                     },
                   },
@@ -61,6 +67,14 @@ export const buildUiSchema = async (
                       helperText: {
                         labelKey: `${i18nScope}.fields.summary.helperText`,
                       },
+                      messages: [
+                        {
+                          type: "ERROR",
+                          keyword: "maxLength",
+                          icon: true,
+                          labelKey: `shared.fields.summary.maxLengthError`,
+                        },
+                      ],
                     },
                   },
                 ],

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -37,6 +37,12 @@ export const buildUiSchema = async (
                   icon: true,
                   labelKey: `${i18nScope}.fields.name.requiredError`,
                 },
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.name.maxLengthError`,
+                },
               ],
             },
           },
@@ -51,6 +57,14 @@ export const buildUiSchema = async (
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.summary.maxLengthError`,
+                },
+              ],
             },
           },
           {

--- a/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
+++ b/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
@@ -38,6 +38,12 @@ export const buildUiSchema = async (
                   icon: true,
                   labelKey: `${i18nScope}.fields.name.requiredError`,
                 },
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.name.maxLengthError`,
+                },
               ],
             },
           },
@@ -75,6 +81,14 @@ export const buildUiSchema = async (
               helperText: {
                 labelKey: `${i18nScope}.fields.summary.helperText`,
               },
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.summary.maxLengthError`,
+                },
+              ],
             },
           },
           {

--- a/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
@@ -50,6 +50,12 @@ describe("buildUiSchema: content edit", () => {
                     icon: true,
                     labelKey: "some.scope.fields.title.requiredError",
                   },
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.name.maxLengthError`,
+                  },
                 ],
               },
             },
@@ -64,6 +70,14 @@ describe("buildUiSchema: content edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.summary.hint",
                 },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.summary.maxLengthError`,
+                  },
+                ],
               },
             },
             {

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaCreate.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaCreate.test.ts
@@ -19,6 +19,12 @@ describe("buildUiSchema: discussion create", () => {
                 icon: true,
                 labelKey: "some.scope.fields.name.requiredError",
               },
+              {
+                type: "ERROR",
+                keyword: "maxLength",
+                icon: true,
+                labelKey: `shared.fields.name.maxLengthError`,
+              },
             ],
           },
         },

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -51,6 +51,12 @@ describe("buildUiSchema: discussion edit", () => {
                     icon: true,
                     labelKey: "some.scope.fields.name.requiredError",
                   },
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.name.maxLengthError`,
+                  },
                 ],
               },
             },
@@ -83,6 +89,14 @@ describe("buildUiSchema: discussion edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.summary.maxLengthError`,
+                  },
+                ],
               },
             },
             {

--- a/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
@@ -27,6 +27,12 @@ describe("buildUiSchema: group edit", () => {
                     icon: true,
                     labelKey: "some.scope.fields.name.requiredError",
                   },
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.name.maxLengthError`,
+                  },
                 ],
               },
             },
@@ -38,6 +44,14 @@ describe("buildUiSchema: group edit", () => {
                 control: "hub-field-input-input",
                 type: "textarea",
                 rows: 4,
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.summary.maxLengthError`,
+                  },
+                ],
               },
             },
             {

--- a/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
@@ -36,6 +36,12 @@ describe("buildUiSchema: initiative template edit", () => {
                     icon: true,
                     labelKey: `some.scope.fields.name.requiredError`,
                   },
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.name.maxLengthError`,
+                  },
                 ],
               },
             },
@@ -73,6 +79,14 @@ describe("buildUiSchema: initiative template edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.summary.maxLengthError`,
+                  },
+                ],
               },
             },
             {

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
@@ -48,6 +48,12 @@ describe("buildUiSchema: initiative create", () => {
                             icon: true,
                             labelKey: "some.scope.fields.name.requiredError",
                           },
+                          {
+                            type: "ERROR",
+                            keyword: "maxLength",
+                            icon: true,
+                            labelKey: `shared.fields.name.maxLengthError`,
+                          },
                         ],
                       },
                     },
@@ -62,6 +68,14 @@ describe("buildUiSchema: initiative create", () => {
                         helperText: {
                           labelKey: "some.scope.fields.summary.helperText",
                         },
+                        messages: [
+                          {
+                            type: "ERROR",
+                            keyword: "maxLength",
+                            icon: true,
+                            labelKey: `shared.fields.summary.maxLengthError`,
+                          },
+                        ],
                       },
                     },
                   ],

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -52,6 +52,12 @@ describe("buildUiSchema: initiative edit", () => {
                     icon: true,
                     labelKey: "some.scope.fields.name.requiredError",
                   },
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.name.maxLengthError`,
+                  },
                 ],
               },
             },
@@ -66,6 +72,14 @@ describe("buildUiSchema: initiative edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.summary.maxLengthError`,
+                  },
+                ],
               },
             },
             {

--- a/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
+++ b/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
@@ -47,6 +47,12 @@ describe("buildUiSchema: page edit", () => {
                     icon: true,
                     labelKey: "some.scope.fields.name.requiredError",
                   },
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.name.maxLengthError`,
+                  },
                 ],
               },
             },
@@ -61,6 +67,14 @@ describe("buildUiSchema: page edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.summary.maxLengthError`,
+                  },
+                ],
               },
             },
             {

--- a/packages/common/test/projects/_internal/ProjectUiSchemaCreate.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaCreate.test.ts
@@ -48,6 +48,12 @@ describe("buildUiSchema: project create", () => {
                             icon: true,
                             labelKey: "some.scope.fields.name.requiredError",
                           },
+                          {
+                            type: "ERROR",
+                            keyword: "maxLength",
+                            icon: true,
+                            labelKey: `shared.fields.name.maxLengthError`,
+                          },
                         ],
                       },
                     },
@@ -62,6 +68,14 @@ describe("buildUiSchema: project create", () => {
                         helperText: {
                           labelKey: "some.scope.fields.summary.helperText",
                         },
+                        messages: [
+                          {
+                            type: "ERROR",
+                            keyword: "maxLength",
+                            icon: true,
+                            labelKey: `shared.fields.summary.maxLengthError`,
+                          },
+                        ],
                       },
                     },
                     {

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -56,6 +56,12 @@ describe("buildUiSchema: project edit", () => {
                     icon: true,
                     labelKey: "some.scope.fields.name.requiredError",
                   },
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.name.maxLengthError`,
+                  },
                 ],
               },
             },
@@ -70,6 +76,14 @@ describe("buildUiSchema: project edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.summary.maxLengthError`,
+                  },
+                ],
               },
             },
             {

--- a/packages/common/test/sites/_internal/SiteUiSchemaCreate.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaCreate.test.ts
@@ -48,6 +48,12 @@ describe("buildUiSchema: site create", () => {
                             icon: true,
                             labelKey: "some.scope.fields.name.requiredError",
                           },
+                          {
+                            type: "ERROR",
+                            keyword: "maxLength",
+                            icon: true,
+                            labelKey: `shared.fields.name.maxLengthError`,
+                          },
                         ],
                       },
                     },
@@ -62,6 +68,14 @@ describe("buildUiSchema: site create", () => {
                         helperText: {
                           labelKey: "some.scope.fields.summary.helperText",
                         },
+                        messages: [
+                          {
+                            type: "ERROR",
+                            keyword: "maxLength",
+                            icon: true,
+                            labelKey: `shared.fields.summary.maxLengthError`,
+                          },
+                        ],
                       },
                     },
                   ],

--- a/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
@@ -47,6 +47,12 @@ describe("buildUiSchema: site edit", () => {
                     icon: true,
                     labelKey: "some.scope.fields.name.requiredError",
                   },
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.name.maxLengthError`,
+                  },
                 ],
               },
             },
@@ -61,6 +67,14 @@ describe("buildUiSchema: site edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.summary.maxLengthError`,
+                  },
+                ],
               },
             },
             {

--- a/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
@@ -30,6 +30,12 @@ describe("buildUiSchema: template edit", () => {
                     icon: true,
                     labelKey: "some.scope.fields.name.requiredError",
                   },
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.name.maxLengthError`,
+                  },
                 ],
               },
             },
@@ -67,6 +73,14 @@ describe("buildUiSchema: template edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.summary.helperText",
                 },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.summary.maxLengthError`,
+                  },
+                ],
               },
             },
             {


### PR DESCRIPTION
1. Description: added error message for max length in name and summary inputs in all workspaces
OD-UI: https://github.com/ArcGIS/opendata-ui/pull/12685

1. Instructions for testing: Add text past the limit in name and summary inputs to see new errors

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/8125

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
