### PR TITLE
Fix month calculation in relativeDateToDateRange

### DIFF
--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -159,6 +159,7 @@ export function relativeDateToDateRange(
       // NOTE: when the previous month has fewer days than this month
       // setMonth() will return a date w/in the current month
       // example: 3/30 -> 3/2 b/c there is no 2/28
+      now.setDate(1)
       now.setMonth(now.getMonth() - relative.num);
       result.from = now.getTime();
       break;


### PR DESCRIPTION
Fixes Issue #761

This PR addresses the issue where the relativeDateToDateRange function was incorrectly calculating the date for the previous month when the current date was later than the last day of the previous month.

Changes:
- Modified the relativeDateToDateRange function to set the day to the first day of the month before subtracting months. This ensures that the function always lands in the correct month, regardless of the number of days in the current month.

This fix should resolve the intermittent test failures we were seeing for 'month' with days < current month days.

Please review and let me know if there are any concerns.