### PR TITLE
fix(): remove scope from uiSchema for stat card

### DIFF
--- a/packages/common/src/core/schemas/internal/getCardEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getCardEditorSchemas.ts
@@ -43,7 +43,11 @@ export async function getCardEditorSchemas(
         ([schemaModuleResolved, statModuleResolved]) => {
           const { MetricSchema } = schemaModuleResolved;
           schema = cloneObject(MetricSchema);
-          uiSchema = statModuleResolved.buildUiSchema(options, context);
+          uiSchema = statModuleResolved.buildUiSchema(
+            i18nScope,
+            options,
+            context
+          );
         }
       );
       break;

--- a/packages/common/src/core/schemas/internal/getCardEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getCardEditorSchemas.ts
@@ -43,11 +43,7 @@ export async function getCardEditorSchemas(
         ([schemaModuleResolved, statModuleResolved]) => {
           const { MetricSchema } = schemaModuleResolved;
           schema = cloneObject(MetricSchema);
-          uiSchema = statModuleResolved.buildUiSchema(
-            i18nScope,
-            options,
-            context
-          );
+          uiSchema = statModuleResolved.buildUiSchema(options, context);
         }
       );
       break;

--- a/packages/common/src/core/schemas/internal/metrics/StatCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/metrics/StatCardUiSchema.ts
@@ -8,6 +8,7 @@ import { UiSchemaRuleEffects, IUiSchema } from "../../types";
  * @returns
  */
 export const buildUiSchema = (
+  i18nScope: string,
   config: IStatCardEditorOptions,
   context: IArcGISContext
 ): IUiSchema => {

--- a/packages/common/src/core/schemas/internal/metrics/StatCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/metrics/StatCardUiSchema.ts
@@ -8,7 +8,6 @@ import { UiSchemaRuleEffects, IUiSchema } from "../../types";
  * @returns
  */
 export const buildUiSchema = (
-  i18nScope: string,
   config: IStatCardEditorOptions,
   context: IArcGISContext
 ): IUiSchema => {
@@ -18,7 +17,7 @@ export const buildUiSchema = (
     elements: [
       {
         type: "Section",
-        labelKey: `${i18nScope}.statistic.sectionTitle`,
+        labelKey: `statistic.sectionTitle`,
         options: {
           section: "block",
           open: true,
@@ -27,16 +26,16 @@ export const buildUiSchema = (
           {
             type: "Control",
             scope: "/properties/type",
-            labelKey: `${i18nScope}.statistic.type.label`,
+            labelKey: `statistic.type.label`,
             options: {
               control: "hub-field-input-tile-select",
               enum: {
-                i18nScope: `${i18nScope}.statistic.type.enum`,
+                i18nScope: `statistic.type.enum`,
               },
             },
           },
           {
-            labelKey: `${i18nScope}.statistic.displayValue`,
+            labelKey: `statistic.displayValue`,
             scope: "/properties/value",
             type: "Control",
             rule: SHOW_FOR_STATIC_RULE,
@@ -44,7 +43,7 @@ export const buildUiSchema = (
           {
             scope: "/properties/dynamicMetric",
             type: "Control",
-            labelKey: `${i18nScope}.statistic.dataSource`,
+            labelKey: `statistic.dataSource`,
             rule: SHOW_FOR_DYNAMIC_RULE,
             options: {
               control: "hub-composite-input-service-query-metric",
@@ -52,7 +51,7 @@ export const buildUiSchema = (
           },
           {
             type: "Section",
-            labelKey: `${i18nScope}.formatting.sectionTitle`,
+            labelKey: `formatting.sectionTitle`,
             scope: "/properties/allowUnitFormatting",
             options: {
               section: "subblock",
@@ -61,26 +60,26 @@ export const buildUiSchema = (
             },
             elements: [
               {
-                labelKey: `${i18nScope}.formatting.unit.label`,
+                labelKey: `formatting.unit.label`,
                 scope: "/properties/unit",
                 type: "Control",
                 rule: SHOW_FOR_UNITS_SECTION_ENABLED,
                 options: {
                   helperText: {
-                    labelKey: `${i18nScope}.formatting.unit.helperText`,
+                    labelKey: `formatting.unit.helperText`,
                     placement: "bottom",
                   },
                 },
               },
               {
-                labelKey: `${i18nScope}.formatting.unitPosition.label`,
+                labelKey: `formatting.unitPosition.label`,
                 scope: "/properties/unitPosition",
                 type: "Control",
                 rule: SHOW_FOR_UNITS_SECTION_ENABLED,
                 options: {
                   control: "hub-field-input-select",
                   enum: {
-                    i18nScope: `${i18nScope}.formatting.unitPosition.enum`,
+                    i18nScope: `formatting.unitPosition.enum`,
                   },
                 },
               },
@@ -88,7 +87,7 @@ export const buildUiSchema = (
           },
           {
             type: "Section",
-            labelKey: `${i18nScope}.advancedConfig.label`,
+            labelKey: `advancedConfig.label`,
             options: {
               section: "subblock",
             },
@@ -96,33 +95,33 @@ export const buildUiSchema = (
             elements: [
               {
                 scope: "/properties/serverTimeout",
-                labelKey: `${i18nScope}.advancedConfig.serverTimeout.label`,
+                labelKey: `advancedConfig.serverTimeout.label`,
                 type: "Control",
                 rule: SHOW_FOR_DYNAMIC_RULE,
                 options: {
                   control: "hub-field-input-input",
                   type: "number",
                   helperText: {
-                    labelKey: `${i18nScope}.advancedConfig.serverTimeout.helperText`,
+                    labelKey: `advancedConfig.serverTimeout.helperText`,
                     placement: "bottom",
                   },
                   messages: [
                     {
                       type: "ERROR",
                       keyword: "type",
-                      labelKey: `${i18nScope}.advancedConfig.serverTimeout.errors.type`,
+                      labelKey: `advancedConfig.serverTimeout.errors.type`,
                       icon: true,
                     },
                     {
                       type: "ERROR",
                       keyword: "minimum",
-                      labelKey: `${i18nScope}.advancedConfig.serverTimeout.errors.minimum`,
+                      labelKey: `advancedConfig.serverTimeout.errors.minimum`,
                       icon: true,
                     },
                     {
                       type: "ERROR",
                       keyword: "maximum",
-                      labelKey: `${i18nScope}.advancedConfig.serverTimeout.errors.maximum`,
+                      labelKey: `advancedConfig.serverTimeout.errors.maximum`,
                       icon: true,
                     },
                   ],
@@ -134,29 +133,29 @@ export const buildUiSchema = (
       },
       {
         type: "Section",
-        labelKey: `${i18nScope}.details.sectionTitle`,
+        labelKey: `details.sectionTitle`,
         options: {
           section: "block",
         },
         elements: [
           {
-            labelKey: `${i18nScope}.details.title`,
+            labelKey: `details.title`,
             scope: "/properties/cardTitle",
             type: "Control",
           },
           {
-            labelKey: `${i18nScope}.details.subtitle`,
+            labelKey: `details.subtitle`,
             scope: "/properties/subtitle",
             type: "Control",
           },
           {
-            labelKey: `${i18nScope}.details.trailingText`,
+            labelKey: `details.trailingText`,
             scope: "/properties/trailingText",
             type: "Control",
           },
           {
             type: "Section",
-            labelKey: `${i18nScope}.details.link.sectionTitle`,
+            labelKey: `details.link.sectionTitle`,
             scope: "/properties/allowLink",
             options: {
               section: "subblock",
@@ -165,7 +164,7 @@ export const buildUiSchema = (
             rule: SHOW_FOR_STATIC_RULE,
             elements: [
               {
-                labelKey: `${i18nScope}.details.link.sourceLink`,
+                labelKey: `details.link.sourceLink`,
                 scope: "/properties/sourceLink",
                 type: "Control",
                 rule: SHOW_FOR_LINK_SECTION_ENABLED_AND_STATIC,
@@ -176,14 +175,14 @@ export const buildUiSchema = (
                       type: "ERROR",
                       keyword: "required",
                       icon: true,
-                      labelKey: `${i18nScope}.errors.sourceLink.required`,
+                      labelKey: `errors.sourceLink.required`,
                       allowShowBeforeInteract: true,
                     },
                   ],
                 },
               },
               {
-                labelKey: `${i18nScope}.details.link.sourceTitle`,
+                labelKey: `details.link.sourceTitle`,
                 scope: "/properties/sourceTitle",
                 type: "Control",
                 rule: SHOW_FOR_LINK_SECTION_ENABLED_AND_STATIC,
@@ -193,7 +192,7 @@ export const buildUiSchema = (
           {
             type: "Control",
             scope: "/properties/allowDynamicLink",
-            labelKey: `${i18nScope}.details.allowDynamicLink`,
+            labelKey: `details.allowDynamicLink`,
             rule: SHOW_FOR_DYNAMIC_RULE,
             options: {
               layout: "inline-space-between",
@@ -204,23 +203,23 @@ export const buildUiSchema = (
       },
       {
         type: "Section",
-        labelKey: `${i18nScope}.appearance.sectionTitle`,
+        labelKey: `appearance.sectionTitle`,
         options: { section: "block" },
         elements: [
           {
-            labelKey: `${i18nScope}.appearance.layout.label`,
+            labelKey: `appearance.layout.label`,
             scope: "/properties/layout",
             type: "Control",
             rule: HIDE_FOR_ALL, // Temporary while no layouts
             options: {
               control: "hub-field-input-select",
               enum: {
-                i18nScope: `${i18nScope}.layout.enum`,
+                i18nScope: `layout.enum`,
               },
             },
           },
           {
-            labelKey: `${i18nScope}.appearance.textAlign`,
+            labelKey: `appearance.textAlign`,
             scope: "/properties/textAlign",
             type: "Control",
             rule: HIDE_FOR_DATA_VIZ_RULE,
@@ -229,7 +228,7 @@ export const buildUiSchema = (
             },
           },
           {
-            labelKey: `${i18nScope}.appearance.valueColor`,
+            labelKey: `appearance.valueColor`,
             scope: "/properties/valueColor",
             type: "Control",
             options: {
@@ -238,38 +237,38 @@ export const buildUiSchema = (
             },
           },
           {
-            labelKey: `${i18nScope}.appearance.dropShadow.label`,
+            labelKey: `appearance.dropShadow.label`,
             scope: "/properties/dropShadow",
             type: "Control",
             rule: HIDE_FOR_ALL,
             options: {
               control: "hub-field-input-select",
               enum: {
-                i18nScope: `${i18nScope}.appearance.dropShadow.enum`,
+                i18nScope: `appearance.dropShadow.enum`,
               },
             },
           },
 
           {
-            labelKey: `${i18nScope}.appearance.visualInterest.label`,
+            labelKey: `appearance.visualInterest.label`,
             scope: "/properties/visualInterest",
             type: "Control",
             rule: HIDE_FOR_ALL,
             options: {
               control: "hub-field-input-select",
               enum: {
-                i18nScope: `${i18nScope}.appearance.visualInterest.enum`,
+                i18nScope: `appearance.visualInterest.enum`,
               },
             },
           },
           {
-            labelKey: `${i18nScope}.appearance.popoverTitle`,
+            labelKey: `appearance.popoverTitle`,
             scope: "/properties/popoverTitle",
             type: "Control",
             rule: SHOW_FOR_MORE_INFO_RULE,
           },
           {
-            labelKey: `${i18nScope}.appearance.popoverDescription`,
+            labelKey: `appearance.popoverDescription`,
             scope: "/properties/popoverDescription",
             type: "Control",
             rule: SHOW_FOR_MORE_INFO_RULE,
@@ -278,38 +277,38 @@ export const buildUiSchema = (
       },
       {
         type: "Section",
-        labelKey: `${i18nScope}.sharing.sectionTitle`,
+        labelKey: `sharing.sectionTitle`,
         options: {
           section: "block",
         },
         elements: [
           {
-            labelKey: `${i18nScope}.sharing.showShareIcon`,
+            labelKey: `sharing.showShareIcon`,
             scope: "/properties/shareable",
             type: "Control",
             options: {
               helperText: {
-                labelKey: `${i18nScope}.sharing.showShareIconHelperText`,
+                labelKey: `sharing.showShareIconHelperText`,
               },
               control: "hub-field-input-switch",
               layout: "inline-space-between",
             },
           },
           {
-            labelKey: `${i18nScope}.sharing.shareableByValue`,
+            labelKey: `sharing.shareableByValue`,
             scope: "/properties/shareableByValue",
             type: "Control",
             rule: HIDE_FOR_ALL,
           },
           {
-            labelKey: `${i18nScope}.sharing.shareableOnHover.label`,
+            labelKey: `sharing.shareableOnHover.label`,
             scope: "/properties/shareableOnHover",
             type: "Control",
             rule: SHOW_FOR_SHARING_RULE,
             options: {
               control: "hub-field-input-switch",
               helperText: {
-                labelKey: `${i18nScope}.sharing.shareableOnHover.helperText.label`,
+                labelKey: `sharing.shareableOnHover.helperText.label`,
               },
               layout: "inline-space-between",
             },

--- a/packages/common/test/core/schemas/internal/metrics/StatCardUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/StatCardUiSchema.test.ts
@@ -4,7 +4,11 @@ import { MOCK_CONTEXT } from "../../../../mocks/mock-auth";
 
 describe("buildUiSchema: stat", () => {
   it("returns the full stat card uiSchema", async () => {
-    const uiSchema = buildUiSchema({ themeColors: ["#ffffff"] }, MOCK_CONTEXT);
+    const uiSchema = buildUiSchema(
+      "",
+      { themeColors: ["#ffffff"] },
+      MOCK_CONTEXT
+    );
 
     expect(uiSchema).toEqual({
       type: "Layout",

--- a/packages/common/test/core/schemas/internal/metrics/StatCardUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/StatCardUiSchema.test.ts
@@ -4,18 +4,14 @@ import { MOCK_CONTEXT } from "../../../../mocks/mock-auth";
 
 describe("buildUiSchema: stat", () => {
   it("returns the full stat card uiSchema", async () => {
-    const uiSchema = buildUiSchema(
-      "some.scope",
-      { themeColors: ["#ffffff"] },
-      MOCK_CONTEXT
-    );
+    const uiSchema = buildUiSchema({ themeColors: ["#ffffff"] }, MOCK_CONTEXT);
 
     expect(uiSchema).toEqual({
       type: "Layout",
       elements: [
         {
           type: "Section",
-          labelKey: `some.scope.statistic.sectionTitle`,
+          labelKey: `statistic.sectionTitle`,
           options: {
             section: "block",
             open: true,
@@ -24,16 +20,16 @@ describe("buildUiSchema: stat", () => {
             {
               type: "Control",
               scope: "/properties/type",
-              labelKey: `some.scope.statistic.type.label`,
+              labelKey: `statistic.type.label`,
               options: {
                 control: "hub-field-input-tile-select",
                 enum: {
-                  i18nScope: `some.scope.statistic.type.enum`,
+                  i18nScope: `statistic.type.enum`,
                 },
               },
             },
             {
-              labelKey: `some.scope.statistic.displayValue`,
+              labelKey: `statistic.displayValue`,
               scope: "/properties/value",
               type: "Control",
               rule: {
@@ -47,7 +43,7 @@ describe("buildUiSchema: stat", () => {
             {
               scope: "/properties/dynamicMetric",
               type: "Control",
-              labelKey: `some.scope.statistic.dataSource`,
+              labelKey: `statistic.dataSource`,
               rule: {
                 condition: {
                   scope: "/properties/type",
@@ -61,7 +57,7 @@ describe("buildUiSchema: stat", () => {
             },
             {
               type: "Section",
-              labelKey: `some.scope.formatting.sectionTitle`,
+              labelKey: `formatting.sectionTitle`,
               scope: "/properties/allowUnitFormatting",
               options: {
                 section: "subblock",
@@ -70,7 +66,7 @@ describe("buildUiSchema: stat", () => {
               },
               elements: [
                 {
-                  labelKey: `some.scope.formatting.unit.label`,
+                  labelKey: `formatting.unit.label`,
                   scope: "/properties/unit",
                   type: "Control",
                   rule: {
@@ -82,13 +78,13 @@ describe("buildUiSchema: stat", () => {
                   },
                   options: {
                     helperText: {
-                      labelKey: `some.scope.formatting.unit.helperText`,
+                      labelKey: `formatting.unit.helperText`,
                       placement: "bottom",
                     },
                   },
                 },
                 {
-                  labelKey: `some.scope.formatting.unitPosition.label`,
+                  labelKey: `formatting.unitPosition.label`,
                   scope: "/properties/unitPosition",
                   type: "Control",
                   rule: {
@@ -101,7 +97,7 @@ describe("buildUiSchema: stat", () => {
                   options: {
                     control: "hub-field-input-select",
                     enum: {
-                      i18nScope: `some.scope.formatting.unitPosition.enum`,
+                      i18nScope: `formatting.unitPosition.enum`,
                     },
                   },
                 },
@@ -109,7 +105,7 @@ describe("buildUiSchema: stat", () => {
             },
             {
               type: "Section",
-              labelKey: `some.scope.advancedConfig.label`,
+              labelKey: `advancedConfig.label`,
               options: {
                 section: "subblock",
               },
@@ -123,7 +119,7 @@ describe("buildUiSchema: stat", () => {
               elements: [
                 {
                   scope: "/properties/serverTimeout",
-                  labelKey: `some.scope.advancedConfig.serverTimeout.label`,
+                  labelKey: `advancedConfig.serverTimeout.label`,
                   type: "Control",
                   rule: {
                     condition: {
@@ -136,26 +132,26 @@ describe("buildUiSchema: stat", () => {
                     control: "hub-field-input-input",
                     type: "number",
                     helperText: {
-                      labelKey: `some.scope.advancedConfig.serverTimeout.helperText`,
+                      labelKey: `advancedConfig.serverTimeout.helperText`,
                       placement: "bottom",
                     },
                     messages: [
                       {
                         type: "ERROR",
                         keyword: "type",
-                        labelKey: `some.scope.advancedConfig.serverTimeout.errors.type`,
+                        labelKey: `advancedConfig.serverTimeout.errors.type`,
                         icon: true,
                       },
                       {
                         type: "ERROR",
                         keyword: "minimum",
-                        labelKey: `some.scope.advancedConfig.serverTimeout.errors.minimum`,
+                        labelKey: `advancedConfig.serverTimeout.errors.minimum`,
                         icon: true,
                       },
                       {
                         type: "ERROR",
                         keyword: "maximum",
-                        labelKey: `some.scope.advancedConfig.serverTimeout.errors.maximum`,
+                        labelKey: `advancedConfig.serverTimeout.errors.maximum`,
                         icon: true,
                       },
                     ],
@@ -167,29 +163,29 @@ describe("buildUiSchema: stat", () => {
         },
         {
           type: "Section",
-          labelKey: `some.scope.details.sectionTitle`,
+          labelKey: `details.sectionTitle`,
           options: {
             section: "block",
           },
           elements: [
             {
-              labelKey: `some.scope.details.title`,
+              labelKey: `details.title`,
               scope: "/properties/cardTitle",
               type: "Control",
             },
             {
-              labelKey: `some.scope.details.subtitle`,
+              labelKey: `details.subtitle`,
               scope: "/properties/subtitle",
               type: "Control",
             },
             {
-              labelKey: `some.scope.details.trailingText`,
+              labelKey: `details.trailingText`,
               scope: "/properties/trailingText",
               type: "Control",
             },
             {
               type: "Section",
-              labelKey: `some.scope.details.link.sectionTitle`,
+              labelKey: `details.link.sectionTitle`,
               scope: "/properties/allowLink",
               options: {
                 section: "subblock",
@@ -204,7 +200,7 @@ describe("buildUiSchema: stat", () => {
               },
               elements: [
                 {
-                  labelKey: `some.scope.details.link.sourceLink`,
+                  labelKey: `details.link.sourceLink`,
                   scope: "/properties/sourceLink",
                   type: "Control",
                   rule: {
@@ -225,14 +221,14 @@ describe("buildUiSchema: stat", () => {
                         type: "ERROR",
                         keyword: "required",
                         icon: true,
-                        labelKey: `some.scope.errors.sourceLink.required`,
+                        labelKey: `errors.sourceLink.required`,
                         allowShowBeforeInteract: true,
                       },
                     ],
                   },
                 },
                 {
-                  labelKey: `some.scope.details.link.sourceTitle`,
+                  labelKey: `details.link.sourceTitle`,
                   scope: "/properties/sourceTitle",
                   type: "Control",
                   rule: {
@@ -252,7 +248,7 @@ describe("buildUiSchema: stat", () => {
             {
               type: "Control",
               scope: "/properties/allowDynamicLink",
-              labelKey: `some.scope.details.allowDynamicLink`,
+              labelKey: `details.allowDynamicLink`,
               rule: {
                 condition: {
                   scope: "/properties/type",
@@ -269,11 +265,11 @@ describe("buildUiSchema: stat", () => {
         },
         {
           type: "Section",
-          labelKey: `some.scope.appearance.sectionTitle`,
+          labelKey: `appearance.sectionTitle`,
           options: { section: "block" },
           elements: [
             {
-              labelKey: `some.scope.appearance.layout.label`,
+              labelKey: `appearance.layout.label`,
               scope: "/properties/layout",
               type: "Control",
               rule: {
@@ -286,12 +282,12 @@ describe("buildUiSchema: stat", () => {
               options: {
                 control: "hub-field-input-select",
                 enum: {
-                  i18nScope: `some.scope.layout.enum`,
+                  i18nScope: `layout.enum`,
                 },
               },
             },
             {
-              labelKey: `some.scope.appearance.textAlign`,
+              labelKey: `appearance.textAlign`,
               scope: "/properties/textAlign",
               type: "Control",
               rule: {
@@ -306,7 +302,7 @@ describe("buildUiSchema: stat", () => {
               },
             },
             {
-              labelKey: `some.scope.appearance.valueColor`,
+              labelKey: `appearance.valueColor`,
               scope: "/properties/valueColor",
               type: "Control",
               options: {
@@ -315,7 +311,7 @@ describe("buildUiSchema: stat", () => {
               },
             },
             {
-              labelKey: `some.scope.appearance.dropShadow.label`,
+              labelKey: `appearance.dropShadow.label`,
               scope: "/properties/dropShadow",
               type: "Control",
               rule: {
@@ -328,13 +324,13 @@ describe("buildUiSchema: stat", () => {
               options: {
                 control: "hub-field-input-select",
                 enum: {
-                  i18nScope: `some.scope.appearance.dropShadow.enum`,
+                  i18nScope: `appearance.dropShadow.enum`,
                 },
               },
             },
 
             {
-              labelKey: `some.scope.appearance.visualInterest.label`,
+              labelKey: `appearance.visualInterest.label`,
               scope: "/properties/visualInterest",
               type: "Control",
               rule: {
@@ -347,7 +343,7 @@ describe("buildUiSchema: stat", () => {
               options: {
                 control: "hub-field-input-select",
                 enum: {
-                  i18nScope: `some.scope.appearance.visualInterest.enum`,
+                  i18nScope: `appearance.visualInterest.enum`,
                 },
               },
             },
@@ -364,7 +360,7 @@ describe("buildUiSchema: stat", () => {
             //   }
             // },
             {
-              labelKey: `some.scope.appearance.popoverTitle`,
+              labelKey: `appearance.popoverTitle`,
               scope: "/properties/popoverTitle",
               type: "Control",
               rule: {
@@ -376,7 +372,7 @@ describe("buildUiSchema: stat", () => {
               },
             },
             {
-              labelKey: `some.scope.appearance.popoverDescription`,
+              labelKey: `appearance.popoverDescription`,
               scope: "/properties/popoverDescription",
               type: "Control",
               rule: {
@@ -391,25 +387,25 @@ describe("buildUiSchema: stat", () => {
         },
         {
           type: "Section",
-          labelKey: `some.scope.sharing.sectionTitle`,
+          labelKey: `sharing.sectionTitle`,
           options: {
             section: "block",
           },
           elements: [
             {
-              labelKey: `some.scope.sharing.showShareIcon`,
+              labelKey: `sharing.showShareIcon`,
               scope: "/properties/shareable",
               type: "Control",
               options: {
                 helperText: {
-                  labelKey: `some.scope.sharing.showShareIconHelperText`,
+                  labelKey: `sharing.showShareIconHelperText`,
                 },
                 control: "hub-field-input-switch",
                 layout: "inline-space-between",
               },
             },
             {
-              labelKey: `some.scope.sharing.shareableByValue`,
+              labelKey: `sharing.shareableByValue`,
               scope: "/properties/shareableByValue",
               type: "Control",
               rule: {
@@ -421,7 +417,7 @@ describe("buildUiSchema: stat", () => {
               },
             },
             {
-              labelKey: `some.scope.sharing.shareableOnHover.label`,
+              labelKey: `sharing.shareableOnHover.label`,
               scope: "/properties/shareableOnHover",
               type: "Control",
               rule: {
@@ -434,7 +430,7 @@ describe("buildUiSchema: stat", () => {
               options: {
                 control: "hub-field-input-switch",
                 helperText: {
-                  labelKey: `some.scope.sharing.shareableOnHover.helperText.label`,
+                  labelKey: `sharing.shareableOnHover.helperText.label`,
                 },
                 layout: "inline-space-between",
               },


### PR DESCRIPTION
1. Description:
Removes the i18nscope from the stat card uiSchema to allow for no scope to be passed in.
1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
