### PR TITLE
feat(hub-common): upgradeCatalogSchema handles "orgId" field in legacy catalogs

### DIFF
--- a/packages/common/test/search/upgradeCatalogSchema.test.ts
+++ b/packages/common/test/search/upgradeCatalogSchema.test.ts
@@ -41,6 +41,17 @@ describe("upgradeCatalogSchema", () => {
     ]);
   });
 
+  it("handles org-level home site legacy catalogs", () => {
+    const chk = upgradeCatalogSchema({ orgId: "a3g" });
+    expect(chk.title).toBe("Default Catalog");
+    expect(chk.scopes).toBeDefined();
+    expect(chk.scopes?.item?.filters.length).toBe(1);
+    expect(chk.scopes?.item?.filters[0].predicates[0].orgid).toEqual(["a3g"]);
+    expect(chk.scopes?.item?.filters[0].predicates[1].type).toEqual({
+      not: ["Code Attachment"],
+    });
+  });
+
   it("skips upgrade if on the same version", () => {
     const cat = { schemaVersion: 1.0 };
     const chk = upgradeCatalogSchema(cat);


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Part of https://devtopia.esri.com/dc/hub/issues/7187

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
