### PR TITLE
fix(hub-common): change allowedLocations type from geometry array to …

### DIFF
--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -3,7 +3,7 @@ import {
   IPagedResponse as IRestPagedResponse,
   IUser,
 } from "@esri/arcgis-rest-types";
-import { Geometry } from "geojson";
+import { Geometry, Polygon } from "geojson";
 import { IHubRequestOptions } from "../../types";
 
 /**
@@ -1062,7 +1062,7 @@ export interface IEntitySettings {
  */
 export interface IDiscussionsSettings {
   allowedChannelIds?: string[] | null;
-  allowedLocations?: Geometry[] | null;
+  allowedLocations?: Polygon[] | null;
 }
 
 /**


### PR DESCRIPTION
…polygon array

affects: @esri/hub-common

1. Description: Restrict entity settings `allowedLocations` to an array of geojson Polygons

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
