### PR TITLE
feat: add new deepFilter util

### DIFF
--- a/packages/common/src/objects/deepFilter.ts
+++ b/packages/common/src/objects/deepFilter.ts
@@ -72,9 +72,9 @@ export function deepFilter(
       if (predicate(object[entry])) {
         if (isFindable(object[entry])) {
           const filteredEntry = deepFilter(object[entry], predicate);
-          setProp(entry, filteredEntry, acc);
+          (acc as any)[entry] = filteredEntry;
         } else {
-          setProp(entry, object[entry], acc);
+          (acc as any)[entry] = object[entry];
         }
       }
       return acc;

--- a/packages/common/src/objects/deepFilter.ts
+++ b/packages/common/src/objects/deepFilter.ts
@@ -5,6 +5,9 @@ import { setProp } from "./set-prop";
  * Traverse a graph filtering out entries that do
  * not pass the predicate
  *
+ * Note: this util uses cloning behind the scenes
+ * so will only work for POJOs and not class instances
+ *
  * example:
  * const predicate = (link: any) => link.key !== "00a"
  * const obj = [

--- a/packages/common/src/objects/deepFilter.ts
+++ b/packages/common/src/objects/deepFilter.ts
@@ -1,0 +1,39 @@
+import { isFindable } from "./internal/isFindable";
+import { setProp } from "./set-prop";
+
+/**
+ * Traverse a graph filtering out entities that do
+ * not passes the predicate
+ * @param object
+ * @param predicate
+ */
+export function deepFilter(
+  object: any,
+  predicate: (object: any) => boolean
+): any {
+  if (Array.isArray(object)) {
+    return object.reduce((acc, entry) => {
+      if (predicate(entry)) {
+        if (isFindable(entry)) {
+          const filteredEntry = deepFilter(entry, predicate);
+          acc = [...acc, filteredEntry];
+        } else {
+          acc = [...acc, entry];
+        }
+      }
+      return acc;
+    }, []);
+  } else if (isFindable(object)) {
+    return Object.keys(object).reduce((acc, entry) => {
+      if (isFindable(object[entry])) {
+        const filteredEntry = deepFilter(object[entry], predicate);
+        setProp(entry, filteredEntry, acc);
+      } else {
+        setProp(entry, object[entry], acc);
+      }
+      return acc;
+    }, {});
+  } else {
+    return undefined;
+  }
+}

--- a/packages/common/src/objects/deepFilter.ts
+++ b/packages/common/src/objects/deepFilter.ts
@@ -2,8 +2,8 @@ import { isFindable } from "./internal/isFindable";
 import { setProp } from "./set-prop";
 
 /**
- * Traverse a graph filtering out entities that do
- * not passes the predicate
+ * Traverse a graph filtering out entries that do
+ * not pass the predicate
  * @param object
  * @param predicate
  */

--- a/packages/common/src/objects/deepFilter.ts
+++ b/packages/common/src/objects/deepFilter.ts
@@ -4,6 +4,47 @@ import { setProp } from "./set-prop";
 /**
  * Traverse a graph filtering out entries that do
  * not pass the predicate
+ *
+ * example:
+ * const predicate = (link: any) => link.key !== "00a"
+ * const obj = [
+ *   {
+ *     key: "001",
+ *     label: "Stop the Spotted Lanternfly",
+ *   },
+ *   {
+ *     key: "002",
+ *     label: "Create a Map",
+ *     children: [
+ *       {
+ *         key: "00a",
+ *         label: "ArcGIS Map Viewer",
+ *       },
+ *       {
+ *         key: "00b",
+ *         label: "ArcGIS Map Viewer Classic",
+ *       },
+ *     ],
+ *   },
+ * ];
+ * const res = deepFilter(obj, predicate)
+ * res = [
+ *   {
+ *     key: "001",
+ *     label: "Stop the Spotted Lanternfly",
+ *   },
+ *   {
+ *     key: "002",
+ *     label: "Create a Map",
+ *     children: [
+ *       {
+ *         key: "00b",
+ *         label: "ArcGIS Map Viewer Classic",
+ *       },
+ *     ],
+ *   },
+ * ];
+ *
  * @param object
  * @param predicate
  */
@@ -25,11 +66,13 @@ export function deepFilter(
     }, []);
   } else if (isFindable(object)) {
     return Object.keys(object).reduce((acc, entry) => {
-      if (isFindable(object[entry])) {
-        const filteredEntry = deepFilter(object[entry], predicate);
-        setProp(entry, filteredEntry, acc);
-      } else {
-        setProp(entry, object[entry], acc);
+      if (predicate(object[entry])) {
+        if (isFindable(object[entry])) {
+          const filteredEntry = deepFilter(object[entry], predicate);
+          setProp(entry, filteredEntry, acc);
+        } else {
+          setProp(entry, object[entry], acc);
+        }
       }
       return acc;
     }, {});

--- a/packages/common/src/objects/deepFind.ts
+++ b/packages/common/src/objects/deepFind.ts
@@ -1,10 +1,4 @@
-import {
-  _isString,
-  _isDate,
-  _isFunction,
-  _isObject,
-  _isRegExp,
-} from "./_deep-map-values";
+import { isFindable } from "./internal/isFindable";
 
 /**
  * Traverse a graph, locating the first entry with an `id` property that
@@ -87,18 +81,4 @@ export function deepFind(
   } else {
     return undefined;
   }
-}
-
-function isFindable(object: any): boolean {
-  let result = false;
-  if (
-    object &&
-    _isObject(object) &&
-    !_isDate(object) &&
-    !_isRegExp(object) &&
-    !_isFunction(object)
-  ) {
-    result = true;
-  }
-  return result;
 }

--- a/packages/common/src/objects/index.ts
+++ b/packages/common/src/objects/index.ts
@@ -9,6 +9,7 @@ export * from "./remove-empty-props";
 export * from "./deep-string-replace";
 export * from "./merge-objects";
 export * from "./set-prop";
+export * from "./deepFilter";
 export * from "./deepFind";
 export * from "./resolveReferences";
 export * from "./pickProps";

--- a/packages/common/src/objects/internal/isFindable.ts
+++ b/packages/common/src/objects/internal/isFindable.ts
@@ -1,0 +1,21 @@
+import {
+  _isString,
+  _isDate,
+  _isFunction,
+  _isObject,
+  _isRegExp,
+} from "../_deep-map-values";
+
+export function isFindable(object: any): boolean {
+  let result = false;
+  if (
+    object &&
+    _isObject(object) &&
+    !_isDate(object) &&
+    !_isRegExp(object) &&
+    !_isFunction(object)
+  ) {
+    result = true;
+  }
+  return result;
+}

--- a/packages/common/test/objects/deepFilter.test.ts
+++ b/packages/common/test/objects/deepFilter.test.ts
@@ -1,0 +1,113 @@
+import { deepFilter } from "../../src/objects/deepFilter";
+
+describe("deepFilter:", () => {
+  describe("predicate:", () => {
+    it("filters entries in an array", () => {
+      const test = ["a", "b", "c"];
+      const predicate = (obj: any) => obj !== "b";
+      const chk = deepFilter(test, predicate);
+
+      expect(chk.length).toBe(2);
+      expect(chk).toEqual(["a", "c"]);
+    });
+    it("filters object entries in array", () => {
+      const test = [{ notid: "a" }, { id: "b" }, { id: "c" }];
+      const predicate = (obj: any) => obj?.id !== "b";
+      const chk = deepFilter(test, predicate);
+
+      expect(chk.length).toBe(2);
+      expect(chk).toEqual([{ notid: "a" }, { id: "c" }]);
+    });
+    it("filters simple objects", () => {
+      const test = { id: "b" };
+      const predicate = (obj: any) => obj?.id !== "b";
+      const chk = deepFilter(test, predicate);
+
+      expect(chk).toEqual({ id: "b" });
+    });
+    it("filters deeply nested entries in an array", () => {
+      const predicate = (link: any) => link.key !== "00a";
+      const object = [
+        {
+          key: "001",
+          label: "Stop the Spotted Lanternfly",
+        },
+        {
+          key: "002",
+          label: "Create a Map",
+          children: [
+            {
+              key: "00a",
+              label: "ArcGIS Map Viewer",
+            },
+            {
+              key: "00b",
+              label: "ArcGIS Map Viewer Classic",
+            },
+          ],
+        },
+      ];
+
+      const chk = deepFilter(object, predicate);
+
+      expect(chk.length).toBe(2);
+      expect(chk[0].key).toBe("001");
+      expect(chk[1].key).toBe("002");
+      expect(chk[1].children.length).toBe(1);
+      expect(chk[1].children[0].key).toBe("00b");
+    });
+    it("filters deeply nested entries in an object", () => {
+      const predicate = (link: any) => link.status !== "not started";
+      const object = {
+        key: "001",
+        status: "in progress",
+        children: [
+          {
+            key: "00a",
+            status: "not started",
+          },
+          {
+            key: "00b",
+            status: "in progress",
+            children: [
+              {
+                key: "00c",
+                status: "not started",
+              },
+              {
+                key: "00d",
+                status: "complete",
+              },
+            ],
+          },
+        ],
+      };
+
+      const chk = deepFilter(object, predicate);
+
+      expect(chk.status).toBe("in progress");
+      expect(chk.children.length).toBe(1);
+      expect(chk.children[0].children.length).toBe(1);
+    });
+    it("skips dates", () => {
+      const test = new Date();
+      const predicate = (obj: any) => obj.id === "b";
+      const chk = deepFilter(test, predicate);
+
+      expect(chk).toBeUndefined();
+    });
+    it("skips fns", () => {
+      const test = () => 2;
+      test.id = "b";
+      const predicate = (obj: any) => obj.id === "b";
+      const chk = deepFilter(test, predicate);
+      expect(chk).toBeUndefined();
+    });
+    it("skips regex", () => {
+      const test = new RegExp("b");
+      const predicate = (obj: any) => obj.id === "b";
+      const chk = deepFilter(test, predicate);
+      expect(chk).toBeUndefined();
+    });
+  });
+});

--- a/packages/common/test/objects/deepFilter.test.ts
+++ b/packages/common/test/objects/deepFilter.test.ts
@@ -19,15 +19,15 @@ describe("deepFilter:", () => {
       expect(chk).toEqual([{ notid: "a" }, { id: "c" }]);
     });
     it("filters simple objects", () => {
-      const test = { id: "b" };
-      const predicate = (obj: any) => obj?.id !== "b";
+      const test = { id: "a", someProp: { id: "b" } };
+      const predicate = (obj: any) => obj.id !== "b";
       const chk = deepFilter(test, predicate);
 
-      expect(chk).toEqual({ id: "b" });
+      expect(chk).toEqual({ id: "a" });
     });
     it("filters deeply nested entries in an array", () => {
       const predicate = (link: any) => link.key !== "00a";
-      const object = [
+      const test = [
         {
           key: "001",
           label: "Stop the Spotted Lanternfly",
@@ -48,7 +48,7 @@ describe("deepFilter:", () => {
         },
       ];
 
-      const chk = deepFilter(object, predicate);
+      const chk = deepFilter(test, predicate);
 
       expect(chk.length).toBe(2);
       expect(chk[0].key).toBe("001");
@@ -56,23 +56,23 @@ describe("deepFilter:", () => {
       expect(chk[1].children.length).toBe(1);
       expect(chk[1].children[0].key).toBe("00b");
     });
-    it("filters deeply nested entries in an object", () => {
-      const predicate = (link: any) => link.status !== "not started";
-      const object = {
+    it("filters deeply nested arrays in an object", () => {
+      const predicate = (link: any) => link.status !== "not-started";
+      const test = {
         key: "001",
-        status: "in progress",
+        status: "in-progress",
         children: [
           {
             key: "00a",
-            status: "not started",
+            status: "not-started",
           },
           {
             key: "00b",
-            status: "in progress",
+            status: "in-progress",
             children: [
               {
                 key: "00c",
-                status: "not started",
+                status: "not-started",
               },
               {
                 key: "00d",
@@ -83,11 +83,35 @@ describe("deepFilter:", () => {
         ],
       };
 
-      const chk = deepFilter(object, predicate);
+      const chk = deepFilter(test, predicate);
 
-      expect(chk.status).toBe("in progress");
+      expect(chk.status).toBe("in-progress");
       expect(chk.children.length).toBe(1);
       expect(chk.children[0].children.length).toBe(1);
+    });
+    it("filters deeply nested objects in an object", () => {
+      const predicate = (link: any) => link.status !== "complete";
+      const test = {
+        status: "in-progress",
+        level1: {
+          status: "in-progress",
+          level2: {
+            status: "in-progress",
+            level3a: {
+              status: "complete",
+            },
+            level3b: {
+              status: "not-started",
+            },
+          },
+        },
+      };
+
+      const chk = deepFilter(test, predicate);
+
+      expect(chk.status).toBe("in-progress");
+      expect(chk.level1.level2.level3a).toBeUndefined();
+      expect(chk.level1.level2.level3b.status).toBe("not-started");
     });
     it("skips dates", () => {
       const test = new Date();


### PR DESCRIPTION
[4980](https://devtopia.esri.com/dc/hub/issues/4980)

Adds a new `deepFilter` util that traverses a graph and filters out entries that do not pass a provided predicate. This is needed for work being done in the UI involving nested action links, but is generally a helpful and reusable util. 

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.