### PR TITLE
feat: implement hub user settings and integrate with context

### DIFF
--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -11,6 +11,7 @@ import { HubEnvironment, HubLicense, IFeatureFlags } from "./permissions/types";
 import { IHubRequestOptions, IHubTrustedOrgsResponse } from "./types";
 import { getEnvironmentFromPortalUrl } from "./utils/getEnvironmentFromPortalUrl";
 import { IUserResourceToken, UserResourceApp } from "./ArcGISContextManager";
+import { IUserHubSettings } from "./utils";
 
 /**
  * Hash of Hub API end points so updates
@@ -280,6 +281,12 @@ export interface IArcGISContextOptions {
    * with user-app-resources
    */
   userResourceTokens?: IUserResourceToken[];
+
+  /**
+   * Hash of user hub settings. These are stored as
+   * user-app-resources, associated with the `hubforarcgis` clientId
+   */
+  userHubSettings?: IUserHubSettings;
 }
 
 /**
@@ -325,6 +332,8 @@ export class ArcGISContext implements IArcGISContext {
 
   private _userResourceTokens: IUserResourceToken[] = [];
 
+  private _userHubSettings: IUserHubSettings;
+
   /**
    * Create a new instance of `ArcGISContext`.
    *
@@ -360,6 +369,7 @@ export class ArcGISContext implements IArcGISContext {
 
     this._featureFlags = opts.featureFlags || {};
     this._userResourceTokens = opts.userResourceTokens || [];
+    this._userHubSettings = opts.userHubSettings || null;
   }
 
   /**
@@ -708,5 +718,13 @@ export class ArcGISContext implements IArcGISContext {
     if (entry) {
       return entry.token;
     }
+  }
+
+  /**
+   * Return the user hub settings.
+   * Updates must be done via `contextManager.updateUserHubSettings`
+   */
+  public get userHubSettings(): IUserHubSettings {
+    return this._userHubSettings;
   }
 }

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -205,6 +205,12 @@ export interface IArcGISContext {
   userResourceTokens?: IUserResourceToken[];
 
   /**
+   * Hash of user hub settings. These are stored as
+   * user-app-resources, associated with the `hubforarcgis` clientId
+   */
+  userHubSettings?: IUserHubSettings;
+
+  /**
    * Return the token for a given app, if defined
    * @param app
    */
@@ -237,12 +243,13 @@ export interface IArcGISContextOptions {
    */
   authentication?: UserSession;
   /**
-   * If the user is authenticated, the portal should be passed in
+   * DEPRECATED: If the user is authenticated, the portal should be passed in
    * so various getters can work as expected.
    *
    * ArcGISContextManager handles this internally
    */
   portalSelf?: IPortal;
+
   /**
    * If the user is authenticated, the user should be passed in
    * so various getters can work as expected.
@@ -709,6 +716,14 @@ export class ArcGISContext implements IArcGISContext {
   }
 
   /**
+   * Return the user hub settings.
+   * Updates must be done via `contextManager.updateUserHubSettings`
+   */
+  public get userHubSettings(): IUserHubSettings {
+    return this._userHubSettings;
+  }
+
+  /**
    * Return a token for a specific app
    * @param app
    * @returns
@@ -718,13 +733,5 @@ export class ArcGISContext implements IArcGISContext {
     if (entry) {
       return entry.token;
     }
-  }
-
-  /**
-   * Return the user hub settings.
-   * Updates must be done via `contextManager.updateUserHubSettings`
-   */
-  public get userHubSettings(): IUserHubSettings {
-    return this._userHubSettings;
   }
 }

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -243,7 +243,7 @@ export interface IArcGISContextOptions {
    */
   authentication?: UserSession;
   /**
-   * DEPRECATED: If the user is authenticated, the portal should be passed in
+   * If the user is authenticated, the portal should be passed in
    * so various getters can work as expected.
    *
    * ArcGISContextManager handles this internally

--- a/packages/common/src/permissions/checkPermission.ts
+++ b/packages/common/src/permissions/checkPermission.ts
@@ -113,7 +113,14 @@ export function checkPermission(
       access: false,
       response: respValue,
       code: getPolicyResponseCode(respValue),
-      checks: [],
+      // checks are needed so the aggregations in checkParents function works
+      checks: [
+        {
+          response: respValue,
+          code: getPolicyResponseCode(respValue),
+          name: `Feature Flag: ${permission}`,
+        },
+      ],
     } as IPermissionAccessResponse;
     logResponse(disabledByFlagResponse, label);
     return disabledByFlagResponse;

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -100,7 +100,6 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:site:workspace",
     dependencies: ["hub:feature:workspace"],
-    environments: ["devext", "qaext"],
   },
   {
     permission: "hub:site:workspace:overview",
@@ -130,6 +129,10 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:site:workspace:metrics",
     dependencies: ["hub:site:workspace", "hub:site:edit"],
+    // Setting environments ensures this is not accessible to users who
+    // opt into workspaces via feature flag for hub:feature:workspace
+    // Stated another way, accessing this in PROD would require passing
+    // ?pe=hub:site:workspace:metrics
     environments: ["devext", "qaext"],
   },
   {

--- a/packages/common/src/utils/hubUserAppResources.ts
+++ b/packages/common/src/utils/hubUserAppResources.ts
@@ -51,6 +51,7 @@ export interface IUserHubSettings {
  * @param replace
  * @returns
  */
+/* istanbul ignore next */
 export async function setUserSiteSettings(
   settings: IUserSiteSettings,
   context: IArcGISContext,
@@ -66,9 +67,11 @@ export async function setUserSiteSettings(
  * @param context
  * @returns
  */
+/* istanbul ignore next */
 export async function getUserSiteSettings(
   context: IArcGISContext
 ): Promise<IUserSiteSettings> {
+  /* istanbul ignore next */
   return fetchUserSiteSettings(context);
 }
 
@@ -81,11 +84,13 @@ export async function getUserSiteSettings(
  * @param replace
  * @returns
  */
+/* istanbul ignore next */
 export async function setUserHubSettings(
   settings: IUserHubSettings,
   context: IArcGISContext,
   replace: boolean = false
 ): Promise<void> {
+  /* istanbul ignore next */
   return updateUserHubSettings(settings, context, replace);
 }
 
@@ -96,9 +101,11 @@ export async function setUserHubSettings(
  * @param context
  * @returns
  */
+/* istanbul ignore next */
 export async function getUserHubSettings(
   context: IArcGISContext
 ): Promise<IUserHubSettings> {
+  /* istanbul ignore next */
   return fetchUserHubSettings(context);
 }
 

--- a/packages/common/src/utils/hubUserAppResources.ts
+++ b/packages/common/src/utils/hubUserAppResources.ts
@@ -7,15 +7,13 @@ import {
   USER_HUB_SETTINGS_APP,
   USER_HUB_SETTINGS_KEY,
 } from "./internal/clearUserHubSettings";
-import {
-  applyHubSettingsMigrations,
-  applySiteSettingsMigrations,
-} from "./internal/siteSettingsMigrations";
+import { applySiteSettingsMigrations } from "./internal/siteSettingsMigrations";
 import {
   IAddUserResource,
   getUserResource,
   setUserResource,
 } from "./internal/userAppResources";
+import { fetchAndMigrateUserHubSettings } from "./internal/fetchAndMigrateUserHubSettings";
 
 /**
  * Site Level Settings
@@ -33,6 +31,75 @@ export interface IUserHubSettings {
   schemaVersion: number;
   username?: string;
   updated?: number;
+  /**
+   * Features that are enabled for the user in preview mode
+   */
+  preview?: {
+    /**
+     *
+     */
+    workspace: boolean;
+  };
+}
+
+/**
+ * @private
+ * DEPRECATED: Use `updateUserSiteSettings` instead
+ * Store User settings in the Site App's cache
+ * @param settings
+ * @param context
+ * @param replace
+ * @returns
+ */
+export async function setUserSiteSettings(
+  settings: IUserSiteSettings,
+  context: IArcGISContext,
+  replace: boolean = false
+): Promise<void> {
+  return updateUserSiteSettings(settings, context, replace);
+}
+
+/**
+ * @private
+ * DEPRECATED: Use `fetchUserSiteSettings`
+ * Get the current user's settings for the current Site
+ * @param context
+ * @returns
+ */
+export async function getUserSiteSettings(
+  context: IArcGISContext
+): Promise<IUserSiteSettings> {
+  return fetchUserSiteSettings(context);
+}
+
+/**
+ * @private
+ * DEPRECATED: use `updateUserHubSettings` instead
+ * Store the current user's Hub settings
+ * @param settings
+ * @param context
+ * @param replace
+ * @returns
+ */
+export async function setUserHubSettings(
+  settings: IUserHubSettings,
+  context: IArcGISContext,
+  replace: boolean = false
+): Promise<void> {
+  return updateUserHubSettings(settings, context, replace);
+}
+
+/**
+ * @private
+ * DEPRECATED: Use `fetchUserHubSettings`
+ * Get the current user's settings for ArcGIS Hub
+ * @param context
+ * @returns
+ */
+export async function getUserHubSettings(
+  context: IArcGISContext
+): Promise<IUserHubSettings> {
+  return fetchUserHubSettings(context);
 }
 
 /**
@@ -42,7 +109,7 @@ export interface IUserHubSettings {
  * @param replace
  * @returns
  */
-export async function setUserSiteSettings(
+export async function updateUserSiteSettings(
   settings: IUserSiteSettings,
   context: IArcGISContext,
   replace: boolean = false
@@ -74,11 +141,11 @@ export async function setUserSiteSettings(
 }
 
 /**
- * Get the current user's settings for the current Site
+ * Fetch the user's settings for the current Site
  * @param context
  * @returns
  */
-export async function getUserSiteSettings(
+export async function fetchUserSiteSettings(
   context: IArcGISContext
 ): Promise<IUserSiteSettings> {
   const token = context.tokenFor(USER_SITE_SETTINGS_APP);
@@ -98,13 +165,13 @@ export async function getUserSiteSettings(
 }
 
 /**
- * Store the current user's Hub settings
+ * Store the current user's Hub settings as a User App Resource
  * @param settings
  * @param context
  * @param replace
  * @returns
  */
-export async function setUserHubSettings(
+export async function updateUserHubSettings(
   settings: IUserHubSettings,
   context: IArcGISContext,
   replace: boolean = false
@@ -135,23 +202,21 @@ export async function setUserHubSettings(
 }
 
 /**
- * Get the current user's settings for ArcGIS Hub
+ * Fetch the current user's settings for ArcGIS Hub
+ * Will return null if the hubforarcgis token is not available
  * @param context
  * @returns
  */
-export async function getUserHubSettings(
+export async function fetchUserHubSettings(
   context: IArcGISContext
 ): Promise<IUserHubSettings> {
   const token = context.tokenFor(USER_HUB_SETTINGS_APP);
-
   if (token) {
-    const settings = await getUserResource(
+    return await fetchAndMigrateUserHubSettings(
       context.currentUser.username,
-      USER_HUB_SETTINGS_KEY,
       context.portalUrl,
       token
     );
-    return applyHubSettingsMigrations(settings);
   } else {
     return Promise.resolve(null);
   }

--- a/packages/common/src/utils/hubUserAppResources.ts
+++ b/packages/common/src/utils/hubUserAppResources.ts
@@ -57,6 +57,7 @@ export async function setUserSiteSettings(
   context: IArcGISContext,
   replace: boolean = false
 ): Promise<void> {
+  /* istanbul ignore next */
   return updateUserSiteSettings(settings, context, replace);
 }
 

--- a/packages/common/src/utils/internal/fetchAndMigrateUserHubSettings.ts
+++ b/packages/common/src/utils/internal/fetchAndMigrateUserHubSettings.ts
@@ -1,0 +1,53 @@
+import { failSafe } from "../fail-safe";
+import { IUserHubSettings } from "../hubUserAppResources";
+import { USER_HUB_SETTINGS_KEY } from "./clearUserHubSettings";
+import { applyHubSettingsMigrations } from "./siteSettingsMigrations";
+import { getUserResource } from "./userAppResources";
+
+/**
+ * @private
+ * Fetch the User Hub Settings and apply migrations
+ * Caller is responsible for ensuring the passed token
+ * is assoicated with the `hubforarcgis` client id
+ * @param username
+ * @param portalUrl
+ * @param token
+ * @returns
+ */
+export async function fetchAndMigrateUserHubSettings(
+  username: string,
+  portalUrl: string,
+  token: string
+): Promise<IUserHubSettings> {
+  // create failsafe function that returns a default Hub Settings object
+  const fsGetResource = failSafe(
+    getUserResource,
+    getDefaultUserHubSettings(username)
+  );
+  // fetch the user's Hub Settings
+  const settings = await fsGetResource(
+    username,
+    USER_HUB_SETTINGS_KEY,
+    portalUrl,
+    token
+  );
+  // apply any migrations and return the result
+  return applyHubSettingsMigrations(settings);
+}
+
+/**
+ * Get a default Hub Settings object for a user
+ * This will be run through migrations, so it's ok if it's not the latest version
+ * @param username
+ * @returns
+ */
+function getDefaultUserHubSettings(username: string): IUserHubSettings {
+  return {
+    schemaVersion: 1,
+    username,
+    updated: new Date().getTime(),
+    preview: {
+      workspace: false,
+    },
+  };
+}

--- a/packages/common/test/content/HubContent.test.ts
+++ b/packages/common/test/content/HubContent.test.ts
@@ -10,6 +10,11 @@ import * as EnrichEntityModule from "../../src/core/enrichEntity";
 
 describe("HubContent class", () => {
   let authdCtxMgr: ArcGISContextManager;
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {});
+  });
   // let unauthdCtxMgr: ArcGISContextManager;
   beforeEach(async () => {
     // unauthdCtxMgr = await ArcGISContextManager.create();

--- a/packages/common/test/content/_fetch.test.ts
+++ b/packages/common/test/content/_fetch.test.ts
@@ -10,6 +10,11 @@ import * as documentItem from "../mocks/items/document.json";
 import * as featureServiceItem from "../mocks/items/feature-service-item.json";
 
 describe("_fetch", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {});
+  });
   describe("getContentEnrichments", () => {
     it("should return defaults for items that are not maps, services, or templates, etc", () => {
       const result = getContentEnrichments(documentItem);

--- a/packages/common/test/content/_internal/internalContentUtils.test.ts
+++ b/packages/common/test/content/_internal/internalContentUtils.test.ts
@@ -6,6 +6,11 @@ import { MOCK_HUB_REQOPTS } from "../../mocks/mock-auth";
 
 describe("getContentEditUrl", () => {
   let requestOptions: IHubRequestOptions;
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {});
+  });
   beforeEach(async () => {
     requestOptions = cloneObject(MOCK_HUB_REQOPTS);
   });

--- a/packages/common/test/content/compose.test.ts
+++ b/packages/common/test/content/compose.test.ts
@@ -29,6 +29,11 @@ const featureServiceItem = {
 } as IItem;
 
 describe("composeContent", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {});
+  });
   let item: IItem;
   // most of compose content is currently covered by
   // tests of higher level functions like datasetToContent()

--- a/packages/common/test/content/computeProps.test.ts
+++ b/packages/common/test/content/computeProps.test.ts
@@ -11,6 +11,11 @@ import { MOCK_HUB_REQOPTS } from "../mocks/mock-auth";
 
 describe("content computeProps", () => {
   let requestOptions: IHubRequestOptions;
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {});
+  });
   beforeEach(async () => {
     requestOptions = cloneObject(MOCK_HUB_REQOPTS);
   });

--- a/packages/common/test/content/content.test.ts
+++ b/packages/common/test/content/content.test.ts
@@ -47,1361 +47,1371 @@ import * as documentItem from "../mocks/items/document.json";
 import * as documentsJson from "../mocks/datasets/document.json";
 import * as featureLayerJson from "../mocks/datasets/feature-layer.json";
 
-describe("getTypes", () => {
-  it("can abort", () => {
-    expect(getTypes()).toBe(undefined);
-  });
-  it("can get a list of types for a category", () => {
-    expect(getTypes("site")).toEqual([
-      "Hub Site Application",
-      "Site Application",
-    ]);
-  });
-});
-
-describe("normalizeItemType", () => {
-  it("can get type from item.type if typeKeywords is not defined", () => {
-    expect(normalizeItemType({ type: "type from item" })).toEqual(
-      "type from item"
-    );
-  });
-  it("can get type from item.type without typeKeywords", () => {
-    expect(normalizeItemType({ type: "Web Mapping Application" })).toEqual(
-      "Web Mapping Application"
-    );
-  });
-  it("normalizes sites", () => {
-    expect(
-      normalizeItemType({
-        type: "Web Mapping Application",
-        typeKeywords: ["hubSite"],
-      })
-    ).toEqual("Hub Site Application");
-    expect(
-      normalizeItemType({ type: "Site Application", typeKeywords: [] })
-    ).toEqual("Hub Site Application");
-  });
-  it("normalizes pages", () => {
-    expect(
-      normalizeItemType({
-        type: "Web Mapping Application",
-        typeKeywords: ["hubPage"],
-      })
-    ).toEqual("Hub Page");
-    expect(
-      normalizeItemType({ type: "Site Page", typeKeywords: ["hubPage"] })
-    ).toEqual("Hub Page");
-  });
-  it("normalizes initiative templates", () => {
-    expect(
-      normalizeItemType({
-        type: "Hub Initiative",
-        typeKeywords: ["hubInitiativeTemplate"],
-      })
-    ).toEqual("Hub Initiative Template");
-  });
-  it("normalizes solution templates", () => {
-    expect(
-      normalizeItemType({
-        type: "Web Mapping Application",
-        typeKeywords: ["hubSolutionTemplate"],
-      })
-    ).toEqual("Solution");
-  });
-  it("can work with blank inputs", () => {
-    expect(normalizeItemType()).toBe(undefined);
-  });
-});
-
-describe("isFeatureService", () => {
-  it("returns true when the type is Feature Service", () => {
-    expect(isFeatureService("Feature Service")).toBe(true);
-    expect(isFeatureService("feature service")).toBe(true);
-  });
-  it("returns false when the type is not Feature Service", () => {
-    expect(isFeatureService("Map Service")).toBe(false);
-  });
-});
-
-describe("getLayerIdFromUrl", () => {
-  it("returns layerId when present", () => {
-    expect(
-      getLayerIdFromUrl(
-        "https://services9.arcgis.com/BH6j7VrWdIXhhNYw/arcgis/rest/services/Befolkning_efter_k%C3%B6n/FeatureServer/0"
-      )
-    ).toBe("0");
-  });
-  it("returns undefined when not present", () => {
-    expect(
-      getLayerIdFromUrl(
-        "https://services9.arcgis.com/BH6j7VrWdIXhhNYw/arcgis/rest/services/Befolkning_efter_k%C3%B6n/FeatureServer"
-      )
-    ).toBe(null);
-  });
-});
-
-describe("getLayerIdFromItem", () => {
-  it("returns '0' when typeKeywords includes 'Singlelayer'", () => {
-    const item: any = {
-      type: "Feature Service",
-      url: "https://services9.arcgis.com/BH6j7VrWdIXhhNYw/arcgis/rest/services/Befolkning_efter_k%C3%B6n/FeatureServer",
-      typeKeywords: [
-        "ArcGIS Server",
-        "Data",
-        "Feature Access",
-        "Feature Service",
-        "Metadata",
-        "Service",
-        "Singlelayer",
-        "Hosted Service",
-      ],
-    };
-    expect(getItemLayerId(item)).toBe("0");
-  });
-});
-
-describe("getItemHubId", () => {
-  let layerItem: any;
-  beforeEach(() => {
-    layerItem = {
-      id: "4ef",
-      access: "shared",
-      type: "Feature Service",
-      url: "https://services9.arcgis.com/BH6j7VrWdIXhhNYw/arcgis/rest/services/Befolkning_efter_k%C3%B6n/FeatureServer/42",
-    };
-  });
-  it("returns undefined when not public", () => {
-    expect(getItemHubId(layerItem)).toBeFalsy();
-  });
-  it("returns itemId_layerId when public layer", () => {
-    layerItem.access = "public";
-    expect(getItemHubId(layerItem)).toBe("4ef_42");
-  });
-  it("returns item id when public non-layer", () => {
-    const item: any = {
-      id: "3ec",
-      access: "public",
-    };
-    expect(getItemHubId(item)).toBe("3ec");
-  });
-});
-
-describe("getContentIdentifier", () => {
-  it("returns content id when content family is 'template'", () => {
-    const template = {
-      id: "template_id",
-      family: "template",
-    } as IHubContent;
-
-    const result = getContentIdentifier(template);
-    expect(result).toBe("template_id");
-  });
-  it("returns content id when content family is 'feedback'", () => {
-    const survey = {
-      id: "survey_id",
-      family: "feedback",
-    } as IHubContent;
-
-    const result = getContentIdentifier(survey);
-    expect(result).toBe("survey_id");
-  });
-  it("returns content id when content type is 'Hub Page' and no site is provided", () => {
-    const page = {
-      id: "page_id",
-      type: "Hub Page",
-    } as IHubContent;
-
-    const result = getContentIdentifier(page);
-    expect(result).toBe("page_id");
-  });
-  it("returns content id when content type is 'Site Page' and no site is provided", () => {
-    const page = {
-      id: "page_id",
-      type: "Site Page",
-    } as IHubContent;
-
-    const result = getContentIdentifier(page);
-    expect(result).toBe("page_id");
-  });
-  it("returns content id when content is a page but the site has no pages", () => {
-    const page = {
-      id: "page_id",
-      type: "Site Page",
-    } as IHubContent;
-    const site: any = { data: { values: {} } };
-
-    const result = getContentIdentifier(page, site);
-    expect(result).toBe("page_id");
-  });
-  it("returns content id when content is a page but is not one of the site's pages", () => {
-    const page = {
-      id: "page_id",
-      type: "Site Page",
-    } as IHubContent;
-    const site: any = {
-      data: {
-        values: {
-          pages: [
-            {
-              id: "another_page_id",
-            },
-          ],
-        },
-      },
-    };
-
-    const result = getContentIdentifier(page, site);
-    expect(result).toBe("page_id");
+describe("content: ", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {});
   });
 
-  it("returns the site's page slug when content is one of the site's pages", () => {
-    const page = {
-      id: "page_id",
-      type: "Site Page",
-    } as IHubContent;
-    const site: any = {
-      data: {
-        values: {
-          pages: [
-            {
-              id: "page_id",
-              slug: "page_slug",
-            },
-          ],
-        },
-      },
-    };
-
-    const result = getContentIdentifier(page, site);
-    expect(result).toBe("page_slug");
-  });
-
-  it("returns the full slug of other types of content when no site is passed in", () => {
-    const collection = {
-      id: "collection_id",
-      type: "Csv Collection",
-      slug: "full::slug",
-    } as IHubContent;
-
-    const result = getContentIdentifier(collection);
-    expect(result).toBe("full::slug");
-  });
-
-  it("returns the full slug of other types of content when umbrella site is passed in", () => {
-    const collection = {
-      id: "collection_id",
-      type: "Csv Collection",
-      slug: "full::slug",
-    } as IHubContent;
-    const site: any = {
-      data: {
-        values: {
-          isUmbrella: true,
-        },
-      },
-    };
-
-    const result = getContentIdentifier(collection, site);
-    expect(result).toBe("full::slug");
-  });
-
-  it("returns the full slug of other types of content when site orgKey is different from the content's slug's prefix", () => {
-    const collection = {
-      id: "collection_id",
-      type: "Csv Collection",
-      slug: "full::slug",
-    } as IHubContent;
-    const site: any = {
-      data: { values: {} },
-      domainInfo: {
-        orgKey: "other",
-      },
-    };
-
-    const result = getContentIdentifier(collection, site);
-    expect(result).toBe("full::slug");
-  });
-
-  it("returns the shortened slug of other types of content when site orgKey is the same as the content's slug's prefix", () => {
-    const collection = {
-      id: "collection_id",
-      type: "Csv Collection",
-      slug: "full::slug",
-    } as IHubContent;
-    const site: any = {
-      data: { values: {} },
-      domainInfo: {
-        orgKey: "full",
-      },
-    };
-
-    const result = getContentIdentifier(collection, site);
-    expect(result).toBe("slug");
-  });
-
-  it("returns the hubId of other types of content when the content has no slug", () => {
-    const collection = {
-      id: "collection_id",
-      type: "Csv Collection",
-      hubId: "collection_hub_id",
-    } as IHubContent;
-
-    const result = getContentIdentifier(collection);
-    expect(result).toBe("collection_hub_id");
-  });
-
-  it("returns the id of other types of content when the content has no slug and no hubId", () => {
-    const webMap = {
-      id: "web_map_id",
-      type: "Web Map",
-    } as IHubContent;
-
-    const result = getContentIdentifier(webMap);
-    expect(result).toBe("web_map_id");
-  });
-});
-
-describe("Slug Helpers", () => {
-  const title = "foo-bar";
-  const orgKey = "org-key";
-  const slugWithContext = `${orgKey}::${title}`;
-  describe("isSlug", function () {
-    it("returns false when identifier is undefined", () => {
-      const result = isSlug(undefined);
-      expect(result).toBe(false);
+  describe("getTypes", () => {
+    it("can abort", () => {
+      expect(getTypes()).toBe(undefined);
     });
-    it("returns false when identifier is an item id", () => {
-      const result = isSlug("7a153563b0c74f7eb2b3eae8a66f2fbb");
-      expect(result).toBe(false);
-    });
-    it("returns true when identifier is a slug w/o orgKey", () => {
-      const result = isSlug("foo-bar");
-      expect(result).toBe(true);
-    });
-    it("returns true when identifier is a slug w/ orgKey", () => {
-      const result = isSlug("org-key::foo-bar");
-      expect(result).toBe(true);
+    it("can get a list of types for a category", () => {
+      expect(getTypes("site")).toEqual([
+        "Hub Site Application",
+        "Site Application",
+      ]);
     });
   });
-  describe("addContextToSlug", () => {
-    it("appends the context to slug without context", () => {
-      const slug = addContextToSlug(title, orgKey);
-      expect(slug).toBe(slugWithContext);
-    });
-    it("returns the slug as is when it already has context", () => {
-      const slug = addContextToSlug(slugWithContext, orgKey);
-      expect(slug).toBe(slugWithContext);
-    });
-    it("returns the slug as is when no context is passed", () => {
-      const slug = addContextToSlug(slugWithContext, undefined);
-      expect(slug).toBe(slugWithContext);
-    });
-    it("returns the slug as is when it has a different context", () => {
-      const slug = addContextToSlug(slugWithContext, "other-org");
-      expect(slug).toBe(slugWithContext);
-    });
-  });
-  describe("removeContextFromSlug", () => {
-    it("removes context when present", () => {
-      const slug = removeContextFromSlug(slugWithContext, orgKey);
-      expect(slug).toBe(title);
-    });
-    it("doesn't remove context when not present", () => {
-      const slug = removeContextFromSlug(slugWithContext, "other-org");
-      expect(slug).toBe(slugWithContext);
-    });
-    it("correctly matches on full context", () => {
-      const slugOne = removeContextFromSlug(slugWithContext, orgKey);
-      expect(slugOne).toBe(title);
-      const slugTwo = removeContextFromSlug(
-        slugWithContext,
-        `another-${orgKey}`
+
+  describe("normalizeItemType", () => {
+    it("can get type from item.type if typeKeywords is not defined", () => {
+      expect(normalizeItemType({ type: "type from item" })).toEqual(
+        "type from item"
       );
-      expect(slugTwo).toBe(slugWithContext);
+    });
+    it("can get type from item.type without typeKeywords", () => {
+      expect(normalizeItemType({ type: "Web Mapping Application" })).toEqual(
+        "Web Mapping Application"
+      );
+    });
+    it("normalizes sites", () => {
+      expect(
+        normalizeItemType({
+          type: "Web Mapping Application",
+          typeKeywords: ["hubSite"],
+        })
+      ).toEqual("Hub Site Application");
+      expect(
+        normalizeItemType({ type: "Site Application", typeKeywords: [] })
+      ).toEqual("Hub Site Application");
+    });
+    it("normalizes pages", () => {
+      expect(
+        normalizeItemType({
+          type: "Web Mapping Application",
+          typeKeywords: ["hubPage"],
+        })
+      ).toEqual("Hub Page");
+      expect(
+        normalizeItemType({ type: "Site Page", typeKeywords: ["hubPage"] })
+      ).toEqual("Hub Page");
+    });
+    it("normalizes initiative templates", () => {
+      expect(
+        normalizeItemType({
+          type: "Hub Initiative",
+          typeKeywords: ["hubInitiativeTemplate"],
+        })
+      ).toEqual("Hub Initiative Template");
+    });
+    it("normalizes solution templates", () => {
+      expect(
+        normalizeItemType({
+          type: "Web Mapping Application",
+          typeKeywords: ["hubSolutionTemplate"],
+        })
+      ).toEqual("Solution");
+    });
+    it("can work with blank inputs", () => {
+      expect(normalizeItemType()).toBe(undefined);
     });
   });
-});
 
-describe("get item family", () => {
-  it("returns dataset for image service", () => {
-    expect(getFamily("Image Service")).toBe("dataset");
+  describe("isFeatureService", () => {
+    it("returns true when the type is Feature Service", () => {
+      expect(isFeatureService("Feature Service")).toBe(true);
+      expect(isFeatureService("feature service")).toBe(true);
+    });
+    it("returns false when the type is not Feature Service", () => {
+      expect(isFeatureService("Map Service")).toBe(false);
+    });
   });
-  it("returns map for feature service and raster layer", () => {
-    expect(getFamily("Feature Service")).toBe("map");
-    expect(getFamily("Raster Layer")).toBe("map");
-  });
-  it("returns document for excel", () => {
-    expect(getFamily("Microsoft Excel")).toBe("document");
-  });
-  it("returns template for solution", () => {
-    expect(getFamily("Solution")).toBe("template");
-  });
-  it("returns project for hub project", () => {
-    expect(getFamily("Hub Project")).toBe("project");
-  });
-  it("returns project for discussion board", () => {
-    expect(getFamily("Discussion")).toBe("discussion");
-  });
-  it("returns content for other specific types", () => {
-    expect(getFamily("CAD Drawing")).toBe("content");
-    expect(getFamily("Feature Collection Template")).toBe("content");
-    expect(getFamily("Report Template")).toBe("content");
-  });
-  it("returns content for collection other", () => {
-    expect(getFamily("360 VR Experience")).toBe("content");
-  });
-});
 
-describe("parse item categories", () => {
-  it("parses the categories", () => {
-    const categories = [
-      "/Categories/Boundaries",
-      "/Categories/Planning and cadastre/Property records",
-      "/Categories/Structure",
-    ];
-    expect(parseItemCategories(categories)).toEqual([
-      "Boundaries",
-      "Planning and cadastre",
-      "Property records",
-      "Structure",
-    ]);
+  describe("getLayerIdFromUrl", () => {
+    it("returns layerId when present", () => {
+      expect(
+        getLayerIdFromUrl(
+          "https://services9.arcgis.com/BH6j7VrWdIXhhNYw/arcgis/rest/services/Befolkning_efter_k%C3%B6n/FeatureServer/0"
+        )
+      ).toBe("0");
+    });
+    it("returns undefined when not present", () => {
+      expect(
+        getLayerIdFromUrl(
+          "https://services9.arcgis.com/BH6j7VrWdIXhhNYw/arcgis/rest/services/Befolkning_efter_k%C3%B6n/FeatureServer"
+        )
+      ).toBe(null);
+    });
   });
-  it("doesn't blow up with undefined", () => {
-    expect(() => parseItemCategories(undefined)).not.toThrow();
-  });
-});
 
-describe("item to content", () => {
-  let item: IItem;
-  beforeEach(() => {
-    item = cloneObject(documentItem) as IItem;
-  });
-  it("gets summary from description when no snippet", () => {
-    item.snippet = null;
-    const content = itemToContent(item);
-    expect(content.summary).toBe(item.description);
-  });
-  it("gets permissions.control from itemControl when it exists", () => {
-    item.itemControl = "update";
-    const content = itemToContent(item);
-    expect(content.permissions.control).toBe(item.itemControl);
-  });
-  describe("when item has properties", () => {
-    it("should set actionLinks to links", () => {
-      item.properties = {
-        links: [{ url: "https://foo.com" }],
+  describe("getLayerIdFromItem", () => {
+    it("returns '0' when typeKeywords includes 'Singlelayer'", () => {
+      const item: any = {
+        type: "Feature Service",
+        url: "https://services9.arcgis.com/BH6j7VrWdIXhhNYw/arcgis/rest/services/Befolkning_efter_k%C3%B6n/FeatureServer",
+        typeKeywords: [
+          "ArcGIS Server",
+          "Data",
+          "Feature Access",
+          "Feature Service",
+          "Metadata",
+          "Service",
+          "Singlelayer",
+          "Hosted Service",
+        ],
       };
-      const content = itemToContent(item);
-      expect(content.actionLinks).toEqual(item.properties.links);
+      expect(getItemLayerId(item)).toBe("0");
     });
   });
-  it("has a reference to the item", () => {
-    const content = itemToContent(item);
-    expect(content.item).toEqual(item);
-  });
-  it("gets relative url from type and family", () => {
-    const content = itemToContent(item);
-    expect(content.urls.relative).toBe(`/documents/${content.id}`);
-  });
-  // NOTE: other use cases (including when a portal is passed)
-  // are covered by getContentFromPortal() tests
-});
-describe("parseDatasetId", function () {
-  it("returns undefined", () => {
-    const result = parseDatasetId(undefined);
-    expect(result).toEqual({ itemId: undefined, layerId: undefined });
-  });
-  it("parse item id", () => {
-    const result = parseDatasetId("7a153563b0c74f7eb2b3eae8a66f2fbb");
-    expect(result).toEqual({
-      itemId: "7a153563b0c74f7eb2b3eae8a66f2fbb",
-      layerId: undefined,
+
+  describe("getItemHubId", () => {
+    let layerItem: any;
+    beforeEach(() => {
+      layerItem = {
+        id: "4ef",
+        access: "shared",
+        type: "Feature Service",
+        url: "https://services9.arcgis.com/BH6j7VrWdIXhhNYw/arcgis/rest/services/Befolkning_efter_k%C3%B6n/FeatureServer/42",
+      };
+    });
+    it("returns undefined when not public", () => {
+      expect(getItemHubId(layerItem)).toBeFalsy();
+    });
+    it("returns itemId_layerId when public layer", () => {
+      layerItem.access = "public";
+      expect(getItemHubId(layerItem)).toBe("4ef_42");
+    });
+    it("returns item id when public non-layer", () => {
+      const item: any = {
+        id: "3ec",
+        access: "public",
+      };
+      expect(getItemHubId(item)).toBe("3ec");
     });
   });
-  it("parse item id and layer id", () => {
-    const result = parseDatasetId("7a153563b0c74f7eb2b3eae8a66f2fbb_0");
-    expect(result).toEqual({
-      itemId: "7a153563b0c74f7eb2b3eae8a66f2fbb",
-      layerId: "0",
+
+  describe("getContentIdentifier", () => {
+    it("returns content id when content family is 'template'", () => {
+      const template = {
+        id: "template_id",
+        family: "template",
+      } as IHubContent;
+
+      const result = getContentIdentifier(template);
+      expect(result).toBe("template_id");
+    });
+    it("returns content id when content family is 'feedback'", () => {
+      const survey = {
+        id: "survey_id",
+        family: "feedback",
+      } as IHubContent;
+
+      const result = getContentIdentifier(survey);
+      expect(result).toBe("survey_id");
+    });
+    it("returns content id when content type is 'Hub Page' and no site is provided", () => {
+      const page = {
+        id: "page_id",
+        type: "Hub Page",
+      } as IHubContent;
+
+      const result = getContentIdentifier(page);
+      expect(result).toBe("page_id");
+    });
+    it("returns content id when content type is 'Site Page' and no site is provided", () => {
+      const page = {
+        id: "page_id",
+        type: "Site Page",
+      } as IHubContent;
+
+      const result = getContentIdentifier(page);
+      expect(result).toBe("page_id");
+    });
+    it("returns content id when content is a page but the site has no pages", () => {
+      const page = {
+        id: "page_id",
+        type: "Site Page",
+      } as IHubContent;
+      const site: any = { data: { values: {} } };
+
+      const result = getContentIdentifier(page, site);
+      expect(result).toBe("page_id");
+    });
+    it("returns content id when content is a page but is not one of the site's pages", () => {
+      const page = {
+        id: "page_id",
+        type: "Site Page",
+      } as IHubContent;
+      const site: any = {
+        data: {
+          values: {
+            pages: [
+              {
+                id: "another_page_id",
+              },
+            ],
+          },
+        },
+      };
+
+      const result = getContentIdentifier(page, site);
+      expect(result).toBe("page_id");
+    });
+
+    it("returns the site's page slug when content is one of the site's pages", () => {
+      const page = {
+        id: "page_id",
+        type: "Site Page",
+      } as IHubContent;
+      const site: any = {
+        data: {
+          values: {
+            pages: [
+              {
+                id: "page_id",
+                slug: "page_slug",
+              },
+            ],
+          },
+        },
+      };
+
+      const result = getContentIdentifier(page, site);
+      expect(result).toBe("page_slug");
+    });
+
+    it("returns the full slug of other types of content when no site is passed in", () => {
+      const collection = {
+        id: "collection_id",
+        type: "Csv Collection",
+        slug: "full::slug",
+      } as IHubContent;
+
+      const result = getContentIdentifier(collection);
+      expect(result).toBe("full::slug");
+    });
+
+    it("returns the full slug of other types of content when umbrella site is passed in", () => {
+      const collection = {
+        id: "collection_id",
+        type: "Csv Collection",
+        slug: "full::slug",
+      } as IHubContent;
+      const site: any = {
+        data: {
+          values: {
+            isUmbrella: true,
+          },
+        },
+      };
+
+      const result = getContentIdentifier(collection, site);
+      expect(result).toBe("full::slug");
+    });
+
+    it("returns the full slug of other types of content when site orgKey is different from the content's slug's prefix", () => {
+      const collection = {
+        id: "collection_id",
+        type: "Csv Collection",
+        slug: "full::slug",
+      } as IHubContent;
+      const site: any = {
+        data: { values: {} },
+        domainInfo: {
+          orgKey: "other",
+        },
+      };
+
+      const result = getContentIdentifier(collection, site);
+      expect(result).toBe("full::slug");
+    });
+
+    it("returns the shortened slug of other types of content when site orgKey is the same as the content's slug's prefix", () => {
+      const collection = {
+        id: "collection_id",
+        type: "Csv Collection",
+        slug: "full::slug",
+      } as IHubContent;
+      const site: any = {
+        data: { values: {} },
+        domainInfo: {
+          orgKey: "full",
+        },
+      };
+
+      const result = getContentIdentifier(collection, site);
+      expect(result).toBe("slug");
+    });
+
+    it("returns the hubId of other types of content when the content has no slug", () => {
+      const collection = {
+        id: "collection_id",
+        type: "Csv Collection",
+        hubId: "collection_hub_id",
+      } as IHubContent;
+
+      const result = getContentIdentifier(collection);
+      expect(result).toBe("collection_hub_id");
+    });
+
+    it("returns the id of other types of content when the content has no slug and no hubId", () => {
+      const webMap = {
+        id: "web_map_id",
+        type: "Web Map",
+      } as IHubContent;
+
+      const result = getContentIdentifier(webMap);
+      expect(result).toBe("web_map_id");
     });
   });
-});
-describe("dataset to item", () => {
-  it("handles no dataset", () => {
-    expect(datasetToItem(null)).toBeUndefined();
-  });
-  it("handles no dataset attributes", () => {
-    expect(datasetToItem({ id: "foo", type: "dataset" })).toBeUndefined();
-  });
-  it("returns snippet when no searchDescription", () => {
-    const dataset = cloneObject(documentsJson.data) as DatasetResource;
-    delete dataset.attributes.searchDescription;
-    const item = datasetToItem(dataset);
-    expect(item.snippet).toBe(dataset.attributes.snippet);
-  });
-  it("handles when no itemModified", () => {
-    // NOTE: I expect that the API always returns itemModified
-    // so I don't know if this ever happens
-    const dataset = cloneObject(featureLayerJson.data) as DatasetResource;
-    const attributes = dataset.attributes;
-    attributes.modified = 1623232000295;
-    delete attributes.itemModified;
-    let item = datasetToItem(dataset);
-    expect(item.modified).toBe(
-      attributes.modified,
-      "returns modified when provenance is item"
-    );
-    attributes.modifiedProvenance = "layer.editingInfo.lastEditDate";
-    item = datasetToItem(dataset);
-    expect(item.modified).toBeFalsy(
-      "is undefined when provenance is layer.editingInfo"
-    );
-  });
-  // NOTE: other use cases are covered by getContent() tests
-});
-describe("dataset to content", () => {
-  it("has a reference to the item", () => {
-    const dataset = cloneObject(documentsJson.data) as DatasetResource;
-    const content = datasetToContent(dataset);
-    expect(content.item).toEqual(datasetToItem(dataset));
-  });
-  it("has enriched updatedDate", () => {
-    const dataset = cloneObject(featureLayerJson.data) as DatasetResource;
-    const attributes = dataset.attributes;
-    // simulate API returning date the layer was last modified
-    // instead of the date the item was last modified
-    const lastEditDate = 1623232000295;
-    const editingInfo = { lastEditDate };
-    attributes.modified = lastEditDate;
-    attributes.modifiedProvenance = "layer.editingInfo.lastEditDate";
-    attributes.layer.editingInfo = editingInfo;
-    // NOTE: the above 3 lines help emulate what the Hub API would return
-    // but only the following line is needed
-    attributes.layers[0].editingInfo = editingInfo;
-    const content = datasetToContent(dataset);
-    expect(content.modified).toBe(attributes.modified);
-    expect(content.updatedDate).toEqual(new Date(attributes.modified));
-    expect(content.updatedDateSource).toBe(attributes.modifiedProvenance);
-  });
-  it("has org", () => {
-    const dataset = cloneObject(featureLayerJson.data) as DatasetResource;
-    const {
-      orgId: id,
-      orgExtent: extent,
-      orgName: name,
-      organization,
-    } = dataset.attributes;
-    let content = datasetToContent(dataset);
-    expect(content.org).toEqual({ id, extent, name });
-    delete dataset.attributes.orgName;
-    content = datasetToContent(dataset);
-    expect(content.org).toEqual(
-      { id, extent, name: organization },
-      "name falls back to organization"
-    );
-  });
-  it("only uses enrichment attributes when they exist", () => {
-    const dataset = cloneObject(documentsJson.data) as DatasetResource;
-    // NOTE: I don't necessarily expect the API to return w/o these
-    // but our code depends on them, this test is mostly here for coverage
-    delete dataset.attributes.searchDescription;
-    delete dataset.attributes.errors;
-    const content = datasetToContent(dataset);
-    expect(content.summary).toBe(dataset.attributes.snippet);
-    expect(content.extent).toBeUndefined();
-    // NOTE: the document JSON does not have org attributes
-    expect(content.org).toBeUndefined();
-  });
-  it("has extent returned from hub API", () => {
-    const dataset = cloneObject(featureLayerJson.data) as DatasetResource;
-    const content = datasetToContent(dataset);
-    expect(content.extent).toEqual(dataset.attributes.extent.coordinates);
-  });
-  // NOTE: other use cases are covered by getContent() tests
-});
-describe("setContentType", () => {
-  // NOTE: this test is meant to verify that normalizedType
-  // is passed into getFamily(), not the raw type.
-  it("Sets the family based on the normalizedType", () => {
-    const oldInitiativeTemplate = {
-      identifier: "9001",
-      item: {
-        type: "Hub Initiative",
-        typeKeywords: ["hubInitiativeTemplate"],
-      },
-    } as unknown as IHubContent;
 
-    const updated = setContentType(oldInitiativeTemplate, "Hub Initiative");
-    expect(updated.family).toBe("template");
-  });
-  describe("getContentTypeIcon", () => {
-    it("sets content type icons", () => {
-      expect(getContentTypeIcon("Application")).toEqual("web");
-      expect(getContentTypeIcon("Feature Service")).toEqual("collection");
-      expect(getContentTypeIcon("Mobile Application")).toEqual("mobile");
-      expect(getContentTypeIcon("Web Map")).toEqual("map");
-      expect(getContentTypeIcon("Hub Project")).toEqual("projects");
+  describe("Slug Helpers", () => {
+    const title = "foo-bar";
+    const orgKey = "org-key";
+    const slugWithContext = `${orgKey}::${title}`;
+    describe("isSlug", function () {
+      it("returns false when identifier is undefined", () => {
+        const result = isSlug(undefined);
+        expect(result).toBe(false);
+      });
+      it("returns false when identifier is an item id", () => {
+        const result = isSlug("7a153563b0c74f7eb2b3eae8a66f2fbb");
+        expect(result).toBe(false);
+      });
+      it("returns true when identifier is a slug w/o orgKey", () => {
+        const result = isSlug("foo-bar");
+        expect(result).toBe(true);
+      });
+      it("returns true when identifier is a slug w/ orgKey", () => {
+        const result = isSlug("org-key::foo-bar");
+        expect(result).toBe(true);
+      });
     });
-    it("sets non-existing type icon to file", () => {
-      expect(getContentTypeIcon("fooBar")).toEqual("file");
+    describe("addContextToSlug", () => {
+      it("appends the context to slug without context", () => {
+        const slug = addContextToSlug(title, orgKey);
+        expect(slug).toBe(slugWithContext);
+      });
+      it("returns the slug as is when it already has context", () => {
+        const slug = addContextToSlug(slugWithContext, orgKey);
+        expect(slug).toBe(slugWithContext);
+      });
+      it("returns the slug as is when no context is passed", () => {
+        const slug = addContextToSlug(slugWithContext, undefined);
+        expect(slug).toBe(slugWithContext);
+      });
+      it("returns the slug as is when it has a different context", () => {
+        const slug = addContextToSlug(slugWithContext, "other-org");
+        expect(slug).toBe(slugWithContext);
+      });
     });
-  });
-  describe("getContentTypeLabel", () => {
-    it("sets content type label to the normalized type if is not proxied", () => {
-      expect(getContentTypeLabel("Application", false)).toEqual("application");
-    });
-    it("sets content type label to CSV if is proxied", () => {
-      expect(getContentTypeLabel("PDF", true)).toEqual("CSV");
-    });
-    it("returns an empty string if no args???", () => {
-      // I'm just here for the coverage
-      expect(getContentTypeLabel(undefined, false)).toEqual("");
-    });
-  });
-});
-
-describe("getProxyUrl", () => {
-  it("returns undefined when item cannot be a proxied csv", () => {
-    const item = {
-      access: "private",
-      type: "CSV",
-      size: 500000,
-    } as unknown as IItem;
-
-    const requestOptions: IHubRequestOptions = {
-      isPortal: false,
-      hubApiUrl: "https://opendata.arcgis.com",
-    };
-
-    const url = getProxyUrl(item, requestOptions);
-    expect(url).toBeUndefined();
-  });
-
-  it("returns url when item is a proxied csv", () => {
-    const item = {
-      access: "public",
-      type: "CSV",
-      size: 500000,
-      id: 0,
-    } as unknown as IItem;
-
-    const requestOptions: IHubRequestOptions = {
-      isPortal: false,
-      hubApiUrl: "https://opendata.arcgis.com",
-    };
-
-    const url = getProxyUrl(item, requestOptions);
-    expect(url).toBe(
-      "https://opendata.arcgis.com/datasets/0_0/FeatureServer/0"
-    );
-  });
-});
-
-// the tests below of internal functions are
-// usually only added to get to 100% coverage
-describe("internal", () => {
-  describe("setContentBoundary", () => {
-    it("sets boundary to none", () => {
-      const content = setContentBoundary(itemToContent(documentItem), "none");
-      expect(content.boundary).toEqual({
-        provenance: "none",
-        geometry: null,
+    describe("removeContextFromSlug", () => {
+      it("removes context when present", () => {
+        const slug = removeContextFromSlug(slugWithContext, orgKey);
+        expect(slug).toBe(title);
+      });
+      it("doesn't remove context when not present", () => {
+        const slug = removeContextFromSlug(slugWithContext, "other-org");
+        expect(slug).toBe(slugWithContext);
+      });
+      it("correctly matches on full context", () => {
+        const slugOne = removeContextFromSlug(slugWithContext, orgKey);
+        expect(slugOne).toBe(title);
+        const slugTwo = removeContextFromSlug(
+          slugWithContext,
+          `another-${orgKey}`
+        );
+        expect(slugTwo).toBe(slugWithContext);
       });
     });
   });
 
-  describe("isProxiedCSV", () => {
-    it("returns false when in a portal environment", () => {
-      const item = {
-        access: "public",
-        type: "CSV",
-        size: 9001,
-      } as unknown as IItem;
-
-      const requestOptions: IHubRequestOptions = {
-        isPortal: true,
-      };
-
-      expect(isProxiedCSV(item, requestOptions)).toBeFalsy();
+  describe("get item family", () => {
+    it("returns dataset for image service", () => {
+      expect(getFamily("Image Service")).toBe("dataset");
     });
+    it("returns map for feature service and raster layer", () => {
+      expect(getFamily("Feature Service")).toBe("map");
+      expect(getFamily("Raster Layer")).toBe("map");
+    });
+    it("returns document for excel", () => {
+      expect(getFamily("Microsoft Excel")).toBe("document");
+    });
+    it("returns template for solution", () => {
+      expect(getFamily("Solution")).toBe("template");
+    });
+    it("returns project for hub project", () => {
+      expect(getFamily("Hub Project")).toBe("project");
+    });
+    it("returns project for discussion board", () => {
+      expect(getFamily("Discussion")).toBe("discussion");
+    });
+    it("returns content for other specific types", () => {
+      expect(getFamily("CAD Drawing")).toBe("content");
+      expect(getFamily("Feature Collection Template")).toBe("content");
+      expect(getFamily("Report Template")).toBe("content");
+    });
+    it("returns content for collection other", () => {
+      expect(getFamily("360 VR Experience")).toBe("content");
+    });
+  });
 
-    it("returns false when access is not public", () => {
+  describe("parse item categories", () => {
+    it("parses the categories", () => {
+      const categories = [
+        "/Categories/Boundaries",
+        "/Categories/Planning and cadastre/Property records",
+        "/Categories/Structure",
+      ];
+      expect(parseItemCategories(categories)).toEqual([
+        "Boundaries",
+        "Planning and cadastre",
+        "Property records",
+        "Structure",
+      ]);
+    });
+    it("doesn't blow up with undefined", () => {
+      expect(() => parseItemCategories(undefined)).not.toThrow();
+    });
+  });
+
+  describe("item to content", () => {
+    let item: IItem;
+    beforeEach(() => {
+      item = cloneObject(documentItem) as IItem;
+    });
+    it("gets summary from description when no snippet", () => {
+      item.snippet = null;
+      const content = itemToContent(item);
+      expect(content.summary).toBe(item.description);
+    });
+    it("gets permissions.control from itemControl when it exists", () => {
+      item.itemControl = "update";
+      const content = itemToContent(item);
+      expect(content.permissions.control).toBe(item.itemControl);
+    });
+    describe("when item has properties", () => {
+      it("should set actionLinks to links", () => {
+        item.properties = {
+          links: [{ url: "https://foo.com" }],
+        };
+        const content = itemToContent(item);
+        expect(content.actionLinks).toEqual(item.properties.links);
+      });
+    });
+    it("has a reference to the item", () => {
+      const content = itemToContent(item);
+      expect(content.item).toEqual(item);
+    });
+    it("gets relative url from type and family", () => {
+      const content = itemToContent(item);
+      expect(content.urls.relative).toBe(`/documents/${content.id}`);
+    });
+    // NOTE: other use cases (including when a portal is passed)
+    // are covered by getContentFromPortal() tests
+  });
+  describe("parseDatasetId", function () {
+    it("returns undefined", () => {
+      const result = parseDatasetId(undefined);
+      expect(result).toEqual({ itemId: undefined, layerId: undefined });
+    });
+    it("parse item id", () => {
+      const result = parseDatasetId("7a153563b0c74f7eb2b3eae8a66f2fbb");
+      expect(result).toEqual({
+        itemId: "7a153563b0c74f7eb2b3eae8a66f2fbb",
+        layerId: undefined,
+      });
+    });
+    it("parse item id and layer id", () => {
+      const result = parseDatasetId("7a153563b0c74f7eb2b3eae8a66f2fbb_0");
+      expect(result).toEqual({
+        itemId: "7a153563b0c74f7eb2b3eae8a66f2fbb",
+        layerId: "0",
+      });
+    });
+  });
+  describe("dataset to item", () => {
+    it("handles no dataset", () => {
+      expect(datasetToItem(null)).toBeUndefined();
+    });
+    it("handles no dataset attributes", () => {
+      expect(datasetToItem({ id: "foo", type: "dataset" })).toBeUndefined();
+    });
+    it("returns snippet when no searchDescription", () => {
+      const dataset = cloneObject(documentsJson.data) as DatasetResource;
+      delete dataset.attributes.searchDescription;
+      const item = datasetToItem(dataset);
+      expect(item.snippet).toBe(dataset.attributes.snippet);
+    });
+    it("handles when no itemModified", () => {
+      // NOTE: I expect that the API always returns itemModified
+      // so I don't know if this ever happens
+      const dataset = cloneObject(featureLayerJson.data) as DatasetResource;
+      const attributes = dataset.attributes;
+      attributes.modified = 1623232000295;
+      delete attributes.itemModified;
+      let item = datasetToItem(dataset);
+      expect(item.modified).toBe(
+        attributes.modified,
+        "returns modified when provenance is item"
+      );
+      attributes.modifiedProvenance = "layer.editingInfo.lastEditDate";
+      item = datasetToItem(dataset);
+      expect(item.modified).toBeFalsy(
+        "is undefined when provenance is layer.editingInfo"
+      );
+    });
+    // NOTE: other use cases are covered by getContent() tests
+  });
+  describe("dataset to content", () => {
+    it("has a reference to the item", () => {
+      const dataset = cloneObject(documentsJson.data) as DatasetResource;
+      const content = datasetToContent(dataset);
+      expect(content.item).toEqual(datasetToItem(dataset));
+    });
+    it("has enriched updatedDate", () => {
+      const dataset = cloneObject(featureLayerJson.data) as DatasetResource;
+      const attributes = dataset.attributes;
+      // simulate API returning date the layer was last modified
+      // instead of the date the item was last modified
+      const lastEditDate = 1623232000295;
+      const editingInfo = { lastEditDate };
+      attributes.modified = lastEditDate;
+      attributes.modifiedProvenance = "layer.editingInfo.lastEditDate";
+      attributes.layer.editingInfo = editingInfo;
+      // NOTE: the above 3 lines help emulate what the Hub API would return
+      // but only the following line is needed
+      attributes.layers[0].editingInfo = editingInfo;
+      const content = datasetToContent(dataset);
+      expect(content.modified).toBe(attributes.modified);
+      expect(content.updatedDate).toEqual(new Date(attributes.modified));
+      expect(content.updatedDateSource).toBe(attributes.modifiedProvenance);
+    });
+    it("has org", () => {
+      const dataset = cloneObject(featureLayerJson.data) as DatasetResource;
+      const {
+        orgId: id,
+        orgExtent: extent,
+        orgName: name,
+        organization,
+      } = dataset.attributes;
+      let content = datasetToContent(dataset);
+      expect(content.org).toEqual({ id, extent, name });
+      delete dataset.attributes.orgName;
+      content = datasetToContent(dataset);
+      expect(content.org).toEqual(
+        { id, extent, name: organization },
+        "name falls back to organization"
+      );
+    });
+    it("only uses enrichment attributes when they exist", () => {
+      const dataset = cloneObject(documentsJson.data) as DatasetResource;
+      // NOTE: I don't necessarily expect the API to return w/o these
+      // but our code depends on them, this test is mostly here for coverage
+      delete dataset.attributes.searchDescription;
+      delete dataset.attributes.errors;
+      const content = datasetToContent(dataset);
+      expect(content.summary).toBe(dataset.attributes.snippet);
+      expect(content.extent).toBeUndefined();
+      // NOTE: the document JSON does not have org attributes
+      expect(content.org).toBeUndefined();
+    });
+    it("has extent returned from hub API", () => {
+      const dataset = cloneObject(featureLayerJson.data) as DatasetResource;
+      const content = datasetToContent(dataset);
+      expect(content.extent).toEqual(dataset.attributes.extent.coordinates);
+    });
+    // NOTE: other use cases are covered by getContent() tests
+  });
+  describe("setContentType", () => {
+    // NOTE: this test is meant to verify that normalizedType
+    // is passed into getFamily(), not the raw type.
+    it("Sets the family based on the normalizedType", () => {
+      const oldInitiativeTemplate = {
+        identifier: "9001",
+        item: {
+          type: "Hub Initiative",
+          typeKeywords: ["hubInitiativeTemplate"],
+        },
+      } as unknown as IHubContent;
+
+      const updated = setContentType(oldInitiativeTemplate, "Hub Initiative");
+      expect(updated.family).toBe("template");
+    });
+    describe("getContentTypeIcon", () => {
+      it("sets content type icons", () => {
+        expect(getContentTypeIcon("Application")).toEqual("web");
+        expect(getContentTypeIcon("Feature Service")).toEqual("collection");
+        expect(getContentTypeIcon("Mobile Application")).toEqual("mobile");
+        expect(getContentTypeIcon("Web Map")).toEqual("map");
+        expect(getContentTypeIcon("Hub Project")).toEqual("projects");
+      });
+      it("sets non-existing type icon to file", () => {
+        expect(getContentTypeIcon("fooBar")).toEqual("file");
+      });
+    });
+    describe("getContentTypeLabel", () => {
+      it("sets content type label to the normalized type if is not proxied", () => {
+        expect(getContentTypeLabel("Application", false)).toEqual(
+          "application"
+        );
+      });
+      it("sets content type label to CSV if is proxied", () => {
+        expect(getContentTypeLabel("PDF", true)).toEqual("CSV");
+      });
+      it("returns an empty string if no args???", () => {
+        // I'm just here for the coverage
+        expect(getContentTypeLabel(undefined, false)).toEqual("");
+      });
+    });
+  });
+
+  describe("getProxyUrl", () => {
+    it("returns undefined when item cannot be a proxied csv", () => {
       const item = {
         access: "private",
-        type: "CSV",
-        size: 9001,
-      } as unknown as IItem;
-
-      const requestOptions: IHubRequestOptions = {
-        isPortal: false,
-      };
-
-      expect(isProxiedCSV(item, requestOptions)).toBeFalsy();
-    });
-
-    it("returns false when type is not CSV", () => {
-      const item = {
-        access: "public",
-        type: "Feature Service",
-      } as unknown as IItem;
-
-      const requestOptions: IHubRequestOptions = {
-        isPortal: false,
-      };
-
-      expect(isProxiedCSV(item, requestOptions)).toBeFalsy();
-    });
-
-    it("returns false when size is greater than the max allowed", () => {
-      const item = {
-        access: "public",
-        type: "CSV",
-        size: 5000001,
-      } as unknown as IItem;
-
-      const requestOptions: IHubRequestOptions = {
-        isPortal: false,
-      };
-
-      expect(isProxiedCSV(item, requestOptions)).toBeFalsy();
-    });
-
-    it("returns true when the item is a proxied csv", () => {
-      const item = {
-        access: "public",
         type: "CSV",
         size: 500000,
       } as unknown as IItem;
 
       const requestOptions: IHubRequestOptions = {
         isPortal: false,
+        hubApiUrl: "https://opendata.arcgis.com",
       };
 
-      expect(isProxiedCSV(item, requestOptions)).toBeTruthy();
+      const url = getProxyUrl(item, requestOptions);
+      expect(url).toBeUndefined();
+    });
+
+    it("returns url when item is a proxied csv", () => {
+      const item = {
+        access: "public",
+        type: "CSV",
+        size: 500000,
+        id: 0,
+      } as unknown as IItem;
+
+      const requestOptions: IHubRequestOptions = {
+        isPortal: false,
+        hubApiUrl: "https://opendata.arcgis.com",
+      };
+
+      const url = getProxyUrl(item, requestOptions);
+      expect(url).toBe(
+        "https://opendata.arcgis.com/datasets/0_0/FeatureServer/0"
+      );
     });
   });
 
-  describe("parseISODateString", () => {
-    it("should parse various date strings properly", () => {
-      const expectations = [
-        {
-          dateString: "2018",
-          result: { date: new Date(2018, 0, 1), precision: "year" },
-        },
-        {
-          dateString: "2018-02",
-          result: { date: new Date(2018, 1, 1), precision: "month" },
-        },
-        {
-          dateString: "2018-02-07",
-          result: { date: new Date(2018, 1, 7), precision: "day" },
-        },
-        {
-          dateString: "2018-02-07T16:30",
-          result: { date: new Date("2018-02-07T16:30"), precision: "time" },
-        },
-        {
-          dateString: "02/07/1970",
-          result: { date: new Date("02/07/1970"), precision: "day" },
-        },
-      ];
-      expectations.forEach((expectation) => {
-        const result = parseISODateString(expectation.dateString);
-        expect(result.date).toEqual(expectation.result.date);
-        expect(result.precision).toEqual(expectation.result.precision);
+  // the tests below of internal functions are
+  // usually only added to get to 100% coverage
+  describe("internal", () => {
+    describe("setContentBoundary", () => {
+      it("sets boundary to none", () => {
+        const content = setContentBoundary(itemToContent(documentItem), "none");
+        expect(content.boundary).toEqual({
+          provenance: "none",
+          geometry: null,
+        });
       });
     });
 
-    it("should return undefined when provided an unsupported date format", () => {
-      const result = parseISODateString("2018-02-07T16");
-      expect(result).toBe(undefined);
+    describe("isProxiedCSV", () => {
+      it("returns false when in a portal environment", () => {
+        const item = {
+          access: "public",
+          type: "CSV",
+          size: 9001,
+        } as unknown as IItem;
+
+        const requestOptions: IHubRequestOptions = {
+          isPortal: true,
+        };
+
+        expect(isProxiedCSV(item, requestOptions)).toBeFalsy();
+      });
+
+      it("returns false when access is not public", () => {
+        const item = {
+          access: "private",
+          type: "CSV",
+          size: 9001,
+        } as unknown as IItem;
+
+        const requestOptions: IHubRequestOptions = {
+          isPortal: false,
+        };
+
+        expect(isProxiedCSV(item, requestOptions)).toBeFalsy();
+      });
+
+      it("returns false when type is not CSV", () => {
+        const item = {
+          access: "public",
+          type: "Feature Service",
+        } as unknown as IItem;
+
+        const requestOptions: IHubRequestOptions = {
+          isPortal: false,
+        };
+
+        expect(isProxiedCSV(item, requestOptions)).toBeFalsy();
+      });
+
+      it("returns false when size is greater than the max allowed", () => {
+        const item = {
+          access: "public",
+          type: "CSV",
+          size: 5000001,
+        } as unknown as IItem;
+
+        const requestOptions: IHubRequestOptions = {
+          isPortal: false,
+        };
+
+        expect(isProxiedCSV(item, requestOptions)).toBeFalsy();
+      });
+
+      it("returns true when the item is a proxied csv", () => {
+        const item = {
+          access: "public",
+          type: "CSV",
+          size: 500000,
+        } as unknown as IItem;
+
+        const requestOptions: IHubRequestOptions = {
+          isPortal: false,
+        };
+
+        expect(isProxiedCSV(item, requestOptions)).toBeTruthy();
+      });
+    });
+
+    describe("parseISODateString", () => {
+      it("should parse various date strings properly", () => {
+        const expectations = [
+          {
+            dateString: "2018",
+            result: { date: new Date(2018, 0, 1), precision: "year" },
+          },
+          {
+            dateString: "2018-02",
+            result: { date: new Date(2018, 1, 1), precision: "month" },
+          },
+          {
+            dateString: "2018-02-07",
+            result: { date: new Date(2018, 1, 7), precision: "day" },
+          },
+          {
+            dateString: "2018-02-07T16:30",
+            result: { date: new Date("2018-02-07T16:30"), precision: "time" },
+          },
+          {
+            dateString: "02/07/1970",
+            result: { date: new Date("02/07/1970"), precision: "day" },
+          },
+        ];
+        expectations.forEach((expectation) => {
+          const result = parseISODateString(expectation.dateString);
+          expect(result.date).toEqual(expectation.result.date);
+          expect(result.precision).toEqual(expectation.result.precision);
+        });
+      });
+
+      it("should return undefined when provided an unsupported date format", () => {
+        const result = parseISODateString("2018-02-07T16");
+        expect(result).toBe(undefined);
+      });
+    });
+
+    describe("getItemSpatialReference", () => {
+      it("should handle wkt name", () => {
+        const spatialReference =
+          "NAD_1983_HARN_StatePlane_Hawaii_3_FIPS_5103_Feet";
+        const item = { spatialReference } as unknown as IItem;
+        const result = getItemSpatialReference(item);
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("getHubRelativeUrl", () => {
+      const identifier = "a-slug";
+      it("should handle a family that does not have a puralized route", () => {
+        // 'report template' should be in the 'content' family
+        const result = getHubRelativeUrl("report template", identifier);
+        expect(result).toBe(`/content/${identifier}`);
+      });
+      it("should handle initiative templates", () => {
+        let result = getHubRelativeUrl("Hub Initiative", identifier, [
+          "hubInitiativeTemplate",
+        ]);
+        expect(result).toBe(`/initiatives/templates/${identifier}/about`);
+        result = getHubRelativeUrl("Hub Initiative Template", identifier);
+        expect(result).toBe(`/initiatives/templates/${identifier}/about`);
+      });
+      it("should handle initiative items", () => {
+        const result = getHubRelativeUrl("Hub Initiative", identifier);
+        expect(result).toBe(`/content/${identifier}`);
+      });
+      it("should handle solution templates", () => {
+        let result = getHubRelativeUrl("Web Mapping Application", identifier, [
+          "hubSolutionTemplate",
+        ]);
+        expect(result).toBe(`/templates/${identifier}/about`);
+        result = getHubRelativeUrl("Web Mapping Application", identifier);
+        expect(result).toBe(`/apps/${identifier}`);
+        result = getHubRelativeUrl("Solution", identifier);
+        expect(result).toBe(`/templates/${identifier}/about`);
+        result = getHubRelativeUrl("Solution", identifier, ["Deployed"]);
+        expect(result).toBe(`/content/${identifier}/about`);
+      });
+      it("should handle feedback", () => {
+        const result = getHubRelativeUrl("Form", identifier);
+        expect(result).toBe(`/feedback/surveys/${identifier}`);
+      });
+      it("should handle discussion", () => {
+        const result = getHubRelativeUrl("Discussion", identifier);
+        expect(result).toBe(`/discussions/${identifier}`);
+      });
+    });
+    describe("isSiteType", () => {
+      it("Should return false for web mapping application with no type keywords", () => {
+        expect(isSiteType("Web Mapping Application")).toBeFalsy();
+      });
+      it("Should return true for a Hub Site Application", () => {
+        expect(isSiteType("Hub Site Application")).toBeTruthy();
+      });
     });
   });
 
-  describe("getItemSpatialReference", () => {
-    it("should handle wkt name", () => {
-      const spatialReference =
-        "NAD_1983_HARN_StatePlane_Hawaii_3_FIPS_5103_Feet";
-      const item = { spatialReference } as unknown as IItem;
-      const result = getItemSpatialReference(item);
+  // Gets branches not covered in compose.test.ts
+  describe("getAdditionalResources", () => {
+    const item: any = {
+      type: "Feature Service",
+      url: "https://services9.arcgis.com/BH6j7VrWdIXhhNYw/arcgis/rest/services/Befolkning_efter_k%C3%B6n/FeatureServer",
+    };
+
+    // Partially covers extractRawResources
+    it("returns null when no metadata is passed in", () => {
+      const result = getAdditionalResources(item);
       expect(result).toBeNull();
     });
   });
 
-  describe("getHubRelativeUrl", () => {
-    const identifier = "a-slug";
-    it("should handle a family that does not have a puralized route", () => {
-      // 'report template' should be in the 'content' family
-      const result = getHubRelativeUrl("report template", identifier);
-      expect(result).toBe(`/content/${identifier}`);
-    });
-    it("should handle initiative templates", () => {
-      let result = getHubRelativeUrl("Hub Initiative", identifier, [
-        "hubInitiativeTemplate",
-      ]);
-      expect(result).toBe(`/initiatives/templates/${identifier}/about`);
-      result = getHubRelativeUrl("Hub Initiative Template", identifier);
-      expect(result).toBe(`/initiatives/templates/${identifier}/about`);
-    });
-    it("should handle initiative items", () => {
-      const result = getHubRelativeUrl("Hub Initiative", identifier);
-      expect(result).toBe(`/content/${identifier}`);
-    });
-    it("should handle solution templates", () => {
-      let result = getHubRelativeUrl("Web Mapping Application", identifier, [
-        "hubSolutionTemplate",
-      ]);
-      expect(result).toBe(`/templates/${identifier}/about`);
-      result = getHubRelativeUrl("Web Mapping Application", identifier);
-      expect(result).toBe(`/apps/${identifier}`);
-      result = getHubRelativeUrl("Solution", identifier);
-      expect(result).toBe(`/templates/${identifier}/about`);
-      result = getHubRelativeUrl("Solution", identifier, ["Deployed"]);
-      expect(result).toBe(`/content/${identifier}/about`);
-    });
-    it("should handle feedback", () => {
-      const result = getHubRelativeUrl("Form", identifier);
-      expect(result).toBe(`/feedback/surveys/${identifier}`);
-    });
-    it("should handle discussion", () => {
-      const result = getHubRelativeUrl("Discussion", identifier);
-      expect(result).toBe(`/discussions/${identifier}`);
-    });
-  });
-  describe("isSiteType", () => {
-    it("Should return false for web mapping application with no type keywords", () => {
-      expect(isSiteType("Web Mapping Application")).toBeFalsy();
-    });
-    it("Should return true for a Hub Site Application", () => {
-      expect(isSiteType("Hub Site Application")).toBeTruthy();
-    });
-  });
-});
-
-// Gets branches not covered in compose.test.ts
-describe("getAdditionalResources", () => {
-  const item: any = {
-    type: "Feature Service",
-    url: "https://services9.arcgis.com/BH6j7VrWdIXhhNYw/arcgis/rest/services/Befolkning_efter_k%C3%B6n/FeatureServer",
-  };
-
-  // Partially covers extractRawResources
-  it("returns null when no metadata is passed in", () => {
-    const result = getAdditionalResources(item);
-    expect(result).toBeNull();
-  });
-});
-
-// Gets branches not covered in compose.test.ts
-describe("extractRawResources", () => {
-  it("handles when onLineSrc is undefined", () => {
-    const metadata = {
-      metadata: {
-        distInfo: {
-          distTranOps: {},
-        },
-      },
-    };
-    const result = extractRawResources(metadata);
-    expect(result).toBeNull();
-  });
-
-  it("handles when onLineSrc is an object", () => {
-    const metadata = {
-      metadata: {
-        distInfo: {
-          distTranOps: {
-            onLineSrc: {
-              orName: "Resource Name",
-              linkage: "resource-url",
-            },
+  // Gets branches not covered in compose.test.ts
+  describe("extractRawResources", () => {
+    it("handles when onLineSrc is undefined", () => {
+      const metadata = {
+        metadata: {
+          distInfo: {
+            distTranOps: {},
           },
         },
-      },
-    };
-    const result = extractRawResources(metadata);
-    expect(result).toEqual([
-      {
-        orName: "Resource Name",
-        linkage: "resource-url",
-      },
-    ]);
-  });
+      };
+      const result = extractRawResources(metadata);
+      expect(result).toBeNull();
+    });
 
-  it("handles when onLineSrc is a multi-element array", () => {
-    const metadata = {
-      metadata: {
-        distInfo: {
-          distTranOps: {
-            onLineSrc: [
-              {
+    it("handles when onLineSrc is an object", () => {
+      const metadata = {
+        metadata: {
+          distInfo: {
+            distTranOps: {
+              onLineSrc: {
                 orName: "Resource Name",
                 linkage: "resource-url",
               },
+            },
+          },
+        },
+      };
+      const result = extractRawResources(metadata);
+      expect(result).toEqual([
+        {
+          orName: "Resource Name",
+          linkage: "resource-url",
+        },
+      ]);
+    });
+
+    it("handles when onLineSrc is a multi-element array", () => {
+      const metadata = {
+        metadata: {
+          distInfo: {
+            distTranOps: {
+              onLineSrc: [
+                {
+                  orName: "Resource Name",
+                  linkage: "resource-url",
+                },
+                {
+                  orName: "Other Resource Name",
+                  linkage: "other-resource-url",
+                },
+              ],
+            },
+          },
+        },
+      };
+      const result = extractRawResources(metadata);
+      expect(result).toEqual([
+        {
+          orName: "Resource Name",
+          linkage: "resource-url",
+        },
+        {
+          orName: "Other Resource Name",
+          linkage: "other-resource-url",
+        },
+      ]);
+    });
+
+    it("handles when distTranOps is undefined", () => {
+      const metadata = {
+        metadata: {
+          distInfo: {},
+        },
+      };
+      const result = extractRawResources(metadata);
+      expect(result).toBeNull();
+    });
+
+    it("handles when distTranOps is a single item array", () => {
+      const metadata = {
+        metadata: {
+          distInfo: {
+            distTranOps: [
               {
-                orName: "Other Resource Name",
-                linkage: "other-resource-url",
+                onLineSrc: {
+                  orName: "Resource Name",
+                  linkage: "resource-url",
+                },
               },
             ],
           },
         },
-      },
-    };
-    const result = extractRawResources(metadata);
-    expect(result).toEqual([
-      {
-        orName: "Resource Name",
-        linkage: "resource-url",
-      },
-      {
-        orName: "Other Resource Name",
-        linkage: "other-resource-url",
-      },
-    ]);
-  });
+      };
+      const result = extractRawResources(metadata);
+      expect(result).toEqual([
+        {
+          orName: "Resource Name",
+          linkage: "resource-url",
+        },
+      ]);
+    });
 
-  it("handles when distTranOps is undefined", () => {
-    const metadata = {
-      metadata: {
-        distInfo: {},
-      },
-    };
-    const result = extractRawResources(metadata);
-    expect(result).toBeNull();
-  });
+    it("handles when distTranOps is a multi item array", () => {
+      const metadata = {
+        metadata: {
+          distInfo: {
+            distTranOps: [
+              {
+                onLineSrc: {
+                  orName: "Resource Name",
+                  linkage: "resource-url",
+                },
+              },
+              {
+                onLineSrc: {
+                  orName: "Other Resource Name",
+                  linkage: "other-resource-url",
+                },
+              },
+            ],
+          },
+        },
+      };
+      const result = extractRawResources(metadata);
+      expect(result).toEqual([
+        {
+          orName: "Resource Name",
+          linkage: "resource-url",
+        },
+        {
+          orName: "Other Resource Name",
+          linkage: "other-resource-url",
+        },
+      ]);
+    });
 
-  it("handles when distTranOps is a single item array", () => {
-    const metadata = {
-      metadata: {
-        distInfo: {
-          distTranOps: [
+    it("handles when distInfo is a single item array", () => {
+      const metadata = {
+        metadata: {
+          distInfo: [
             {
-              onLineSrc: {
-                orName: "Resource Name",
-                linkage: "resource-url",
+              distTranOps: {
+                onLineSrc: {
+                  orName: "Resource Name",
+                  linkage: "resource-url",
+                },
               },
             },
           ],
         },
-      },
-    };
-    const result = extractRawResources(metadata);
-    expect(result).toEqual([
-      {
-        orName: "Resource Name",
-        linkage: "resource-url",
-      },
-    ]);
-  });
+      };
+      const result = extractRawResources(metadata);
+      expect(result).toEqual([
+        {
+          orName: "Resource Name",
+          linkage: "resource-url",
+        },
+      ]);
+    });
 
-  it("handles when distTranOps is a multi item array", () => {
-    const metadata = {
-      metadata: {
-        distInfo: {
-          distTranOps: [
+    it("handles when distInfo is a multi item array", () => {
+      const metadata = {
+        metadata: {
+          distInfo: [
             {
-              onLineSrc: {
-                orName: "Resource Name",
-                linkage: "resource-url",
+              distTranOps: {
+                onLineSrc: {
+                  orName: "Resource Name",
+                  linkage: "resource-url",
+                },
               },
             },
             {
-              onLineSrc: {
-                orName: "Other Resource Name",
-                linkage: "other-resource-url",
+              distTranOps: {
+                onLineSrc: {
+                  orName: "Other Resource Name",
+                  linkage: "other-resource-url",
+                },
               },
             },
           ],
         },
-      },
-    };
-    const result = extractRawResources(metadata);
-    expect(result).toEqual([
-      {
-        orName: "Resource Name",
-        linkage: "resource-url",
-      },
-      {
-        orName: "Other Resource Name",
-        linkage: "other-resource-url",
-      },
-    ]);
-  });
-
-  it("handles when distInfo is a single item array", () => {
-    const metadata = {
-      metadata: {
-        distInfo: [
-          {
-            distTranOps: {
-              onLineSrc: {
-                orName: "Resource Name",
-                linkage: "resource-url",
-              },
-            },
-          },
-        ],
-      },
-    };
-    const result = extractRawResources(metadata);
-    expect(result).toEqual([
-      {
-        orName: "Resource Name",
-        linkage: "resource-url",
-      },
-    ]);
-  });
-
-  it("handles when distInfo is a multi item array", () => {
-    const metadata = {
-      metadata: {
-        distInfo: [
-          {
-            distTranOps: {
-              onLineSrc: {
-                orName: "Resource Name",
-                linkage: "resource-url",
-              },
-            },
-          },
-          {
-            distTranOps: {
-              onLineSrc: {
-                orName: "Other Resource Name",
-                linkage: "other-resource-url",
-              },
-            },
-          },
-        ],
-      },
-    };
-    const result = extractRawResources(metadata);
-    expect(result).toEqual([
-      {
-        orName: "Resource Name",
-        linkage: "resource-url",
-      },
-      {
-        orName: "Other Resource Name",
-        linkage: "other-resource-url",
-      },
-    ]);
-  });
-});
-
-// Gets branches not covered in compose.test.ts
-// Partially covers isDataSourceOfItem
-describe("getAdditionalResourceUrl", () => {
-  const serviceUrl =
-    "https://services9.arcgis.com/BH6j7VrWdIXhhNYw/arcgis/rest/services/Befolkning_efter_k%C3%B6n/FeatureServer";
-  const item = {
-    type: "Feature Service",
-    url: serviceUrl,
-  } as unknown as IItem;
-  it("appends token onto preexisting query string when resource points to the item's data source", () => {
-    const resourceUrl = `${serviceUrl}/0?my-flag=true`;
-    const resource = { linkage: resourceUrl };
-    const requestOptions = {
-      authentication: {
-        token: "my-token",
-      },
-    } as unknown as IHubRequestOptions;
-
-    const result = getAdditionalResourceUrl(resource, item, requestOptions);
-    expect(result).toEqual(`${resourceUrl}&token=my-token`);
-  });
-  it("appends token onto new query string when resource points to the item's data source", () => {
-    const resourceUrl = `${serviceUrl}/0`;
-    const resource = { linkage: resourceUrl };
-    const requestOptions = {
-      authentication: {
-        token: "my-token",
-      },
-    } as unknown as IHubRequestOptions;
-
-    const result = getAdditionalResourceUrl(resource, item, requestOptions);
-    expect(result).toEqual(`${resourceUrl}?token=my-token`);
-  });
-  it("does not append token when resource isn't the item's data source", () => {
-    const resourceUrl = "https://google.com";
-    const resource = { linkage: resourceUrl };
-    const requestOptions = {
-      authentication: {
-        token: "my-token",
-      },
-    } as unknown as IHubRequestOptions;
-
-    const result = getAdditionalResourceUrl(resource, item, requestOptions);
-    expect(result).toEqual(resourceUrl);
-  });
-});
-
-// Gets branches not covered in compose.test.ts
-describe("isDataSourceOfItem", () => {
-  it("returns false when the item has no url", () => {
-    const item = { type: "csv" } as unknown as IItem;
-    const resource = { linkage: "my-link" };
-    expect(isDataSourceOfItem(resource, item)).toBeFalsy();
-  });
-});
-
-// Gets branches not covered in compose.test.ts
-describe("determineExtent", () => {
-  it("returns item extent when valid bbox", () => {
-    const item = {
-      extent: [
-        [0, 1],
-        [1, 0],
-      ],
-    } as unknown as IItem;
-    const result = determineExtent(item);
-    expect(result).toEqual(item.extent);
-  });
-  it("returns extent enrichment coordinates if is valid bbox and item extent isn't a valid bbox", () => {
-    const item = {
-      extent: [],
-    } as unknown as IItem;
-    const extentEnrichment = {
-      coordinates: [
-        [0, 1],
-        [1, 0],
-      ],
-      type: "envelope",
-    };
-    const result = determineExtent(item, extentEnrichment);
-    expect(result).toEqual(extentEnrichment.coordinates);
-  });
-  it("returns layer extent as bbox when spatial ref is 4326 and both item extent and extent enrichment aren't valid", () => {
-    const item = {
-      extent: [],
-    } as unknown as IItem;
-    const extentEnrichment = {};
-    const layer = {
-      extent: {
-        spatialReference: {
-          wkid: 4326,
+      };
+      const result = extractRawResources(metadata);
+      expect(result).toEqual([
+        {
+          orName: "Resource Name",
+          linkage: "resource-url",
         },
-        xmin: 1,
-        xmax: 2,
-        ymin: 3,
-        ymax: 4,
-      },
-    } as unknown as ILayerDefinition;
-    const result = determineExtent(item, extentEnrichment, layer);
-    expect(result).toEqual([
-      [1, 3],
-      [2, 4],
-    ]);
-  });
-});
-
-// Gets branches not covered in compose.test.ts
-describe("extractFirstContact", () => {
-  it("handles when the path points to a contact array", () => {
-    const contact1 = {
-      rpIndName: "contact1",
-      rpOrgName: "org1",
-    };
-    const contact2 = {
-      rpIndName: "contact2",
-      rpOrgName: "org2",
-    };
-    const metadata = {
-      metadata: {
-        path: [contact1, contact2],
-      },
-    };
-    expect(extractFirstContact(metadata, "metadata.path")).toEqual({
-      individualName: contact1.rpIndName,
-      organizationName: contact1.rpOrgName,
-    });
-  });
-});
-
-// Gets branches not covered in compose.test.ts
-describe("getPublisherInfo", () => {
-  it("correctly reports when no info is available", () => {
-    const item = { id: "abc", access: "public" } as unknown as IItem;
-    const result = getPublisherInfo(item, null, null, null);
-    expect(result).toEqual({
-      nameSource: PublisherSource.None,
-      organizationSource: PublisherSource.None,
-      isExternal: false,
-    });
-  });
-
-  it("correctly reports when no info is available and the item is external", () => {
-    const item = { id: "abc", access: "private" } as unknown as IItem;
-    const result = getPublisherInfo(item, null, null, null);
-    expect(result).toEqual({
-      nameSource: PublisherSource.None,
-      organizationSource: PublisherSource.None,
-      isExternal: true,
-    });
-  });
-
-  it("correctly reports citation contact info", () => {
-    const item = { id: "abc" } as unknown as IItem;
-    const metadata = {
-      metadata: {
-        // Metadata Info
-        mdContact: {
-          rpIndName: "Metadata Name",
-          rpOrgName: "Metadata Org",
+        {
+          orName: "Other Resource Name",
+          linkage: "other-resource-url",
         },
-        dataIdInfo: {
-          // Citation Info
-          idCitation: {
-            citRespParty: {
-              rpIndName: "Citation Name",
-              rpOrgName: "Citation Org",
+      ]);
+    });
+  });
+
+  // Gets branches not covered in compose.test.ts
+  // Partially covers isDataSourceOfItem
+  describe("getAdditionalResourceUrl", () => {
+    const serviceUrl =
+      "https://services9.arcgis.com/BH6j7VrWdIXhhNYw/arcgis/rest/services/Befolkning_efter_k%C3%B6n/FeatureServer";
+    const item = {
+      type: "Feature Service",
+      url: serviceUrl,
+    } as unknown as IItem;
+    it("appends token onto preexisting query string when resource points to the item's data source", () => {
+      const resourceUrl = `${serviceUrl}/0?my-flag=true`;
+      const resource = { linkage: resourceUrl };
+      const requestOptions = {
+        authentication: {
+          token: "my-token",
+        },
+      } as unknown as IHubRequestOptions;
+
+      const result = getAdditionalResourceUrl(resource, item, requestOptions);
+      expect(result).toEqual(`${resourceUrl}&token=my-token`);
+    });
+    it("appends token onto new query string when resource points to the item's data source", () => {
+      const resourceUrl = `${serviceUrl}/0`;
+      const resource = { linkage: resourceUrl };
+      const requestOptions = {
+        authentication: {
+          token: "my-token",
+        },
+      } as unknown as IHubRequestOptions;
+
+      const result = getAdditionalResourceUrl(resource, item, requestOptions);
+      expect(result).toEqual(`${resourceUrl}?token=my-token`);
+    });
+    it("does not append token when resource isn't the item's data source", () => {
+      const resourceUrl = "https://google.com";
+      const resource = { linkage: resourceUrl };
+      const requestOptions = {
+        authentication: {
+          token: "my-token",
+        },
+      } as unknown as IHubRequestOptions;
+
+      const result = getAdditionalResourceUrl(resource, item, requestOptions);
+      expect(result).toEqual(resourceUrl);
+    });
+  });
+
+  // Gets branches not covered in compose.test.ts
+  describe("isDataSourceOfItem", () => {
+    it("returns false when the item has no url", () => {
+      const item = { type: "csv" } as unknown as IItem;
+      const resource = { linkage: "my-link" };
+      expect(isDataSourceOfItem(resource, item)).toBeFalsy();
+    });
+  });
+
+  // Gets branches not covered in compose.test.ts
+  describe("determineExtent", () => {
+    it("returns item extent when valid bbox", () => {
+      const item = {
+        extent: [
+          [0, 1],
+          [1, 0],
+        ],
+      } as unknown as IItem;
+      const result = determineExtent(item);
+      expect(result).toEqual(item.extent);
+    });
+    it("returns extent enrichment coordinates if is valid bbox and item extent isn't a valid bbox", () => {
+      const item = {
+        extent: [],
+      } as unknown as IItem;
+      const extentEnrichment = {
+        coordinates: [
+          [0, 1],
+          [1, 0],
+        ],
+        type: "envelope",
+      };
+      const result = determineExtent(item, extentEnrichment);
+      expect(result).toEqual(extentEnrichment.coordinates);
+    });
+    it("returns layer extent as bbox when spatial ref is 4326 and both item extent and extent enrichment aren't valid", () => {
+      const item = {
+        extent: [],
+      } as unknown as IItem;
+      const extentEnrichment = {};
+      const layer = {
+        extent: {
+          spatialReference: {
+            wkid: 4326,
+          },
+          xmin: 1,
+          xmax: 2,
+          ymin: 3,
+          ymax: 4,
+        },
+      } as unknown as ILayerDefinition;
+      const result = determineExtent(item, extentEnrichment, layer);
+      expect(result).toEqual([
+        [1, 3],
+        [2, 4],
+      ]);
+    });
+  });
+
+  // Gets branches not covered in compose.test.ts
+  describe("extractFirstContact", () => {
+    it("handles when the path points to a contact array", () => {
+      const contact1 = {
+        rpIndName: "contact1",
+        rpOrgName: "org1",
+      };
+      const contact2 = {
+        rpIndName: "contact2",
+        rpOrgName: "org2",
+      };
+      const metadata = {
+        metadata: {
+          path: [contact1, contact2],
+        },
+      };
+      expect(extractFirstContact(metadata, "metadata.path")).toEqual({
+        individualName: contact1.rpIndName,
+        organizationName: contact1.rpOrgName,
+      });
+    });
+  });
+
+  // Gets branches not covered in compose.test.ts
+  describe("getPublisherInfo", () => {
+    it("correctly reports when no info is available", () => {
+      const item = { id: "abc", access: "public" } as unknown as IItem;
+      const result = getPublisherInfo(item, null, null, null);
+      expect(result).toEqual({
+        nameSource: PublisherSource.None,
+        organizationSource: PublisherSource.None,
+        isExternal: false,
+      });
+    });
+
+    it("correctly reports when no info is available and the item is external", () => {
+      const item = { id: "abc", access: "private" } as unknown as IItem;
+      const result = getPublisherInfo(item, null, null, null);
+      expect(result).toEqual({
+        nameSource: PublisherSource.None,
+        organizationSource: PublisherSource.None,
+        isExternal: true,
+      });
+    });
+
+    it("correctly reports citation contact info", () => {
+      const item = { id: "abc" } as unknown as IItem;
+      const metadata = {
+        metadata: {
+          // Metadata Info
+          mdContact: {
+            rpIndName: "Metadata Name",
+            rpOrgName: "Metadata Org",
+          },
+          dataIdInfo: {
+            // Citation Info
+            idCitation: {
+              citRespParty: {
+                rpIndName: "Citation Name",
+                rpOrgName: "Citation Org",
+              },
+            },
+            // Resource Info
+            idPoC: {
+              rpIndName: "Resource Name",
+              rpOrgName: "Resource Org",
             },
           },
-          // Resource Info
-          idPoC: {
+        },
+      };
+      const ownerUser = {
+        fullName: "Owner User",
+        username: "username",
+        orgId: "org_id",
+      };
+      const org = {
+        id: "org_id",
+        name: "Org Name",
+      };
+      const result = getPublisherInfo(item, metadata, org, ownerUser);
+      expect(result).toEqual({
+        name: "Citation Name",
+        nameSource: PublisherSource.CitationContact,
+        organization: "Citation Org",
+        organizationSource: PublisherSource.CitationContact,
+        isExternal: false,
+      });
+    });
+
+    it("correctly reports resource contact info", () => {
+      const item = { id: "abc" } as unknown as IItem;
+      const metadata = {
+        metadata: {
+          // Metadata Info
+          mdContact: {
             rpIndName: "Resource Name",
             rpOrgName: "Resource Org",
           },
-        },
-      },
-    };
-    const ownerUser = {
-      fullName: "Owner User",
-      username: "username",
-      orgId: "org_id",
-    };
-    const org = {
-      id: "org_id",
-      name: "Org Name",
-    };
-    const result = getPublisherInfo(item, metadata, org, ownerUser);
-    expect(result).toEqual({
-      name: "Citation Name",
-      nameSource: PublisherSource.CitationContact,
-      organization: "Citation Org",
-      organizationSource: PublisherSource.CitationContact,
-      isExternal: false,
-    });
-  });
-
-  it("correctly reports resource contact info", () => {
-    const item = { id: "abc" } as unknown as IItem;
-    const metadata = {
-      metadata: {
-        // Metadata Info
-        mdContact: {
-          rpIndName: "Resource Name",
-          rpOrgName: "Resource Org",
-        },
-        dataIdInfo: {
-          // Resource Info
-          idPoC: {
-            rpIndName: "Resource Name",
-            rpOrgName: "Resource Org",
+          dataIdInfo: {
+            // Resource Info
+            idPoC: {
+              rpIndName: "Resource Name",
+              rpOrgName: "Resource Org",
+            },
           },
         },
-      },
-    };
-    const ownerUser = {
-      fullName: "Owner User",
-      username: "username",
-      orgId: "org_id",
-    };
-    const org = {
-      id: "org_id",
-      name: "Org Name",
-    };
-    const result = getPublisherInfo(item, metadata, org, ownerUser);
-    expect(result).toEqual({
-      name: "Resource Name",
-      nameSource: PublisherSource.ResourceContact,
-      organization: "Resource Org",
-      organizationSource: PublisherSource.ResourceContact,
-      isExternal: false,
+      };
+      const ownerUser = {
+        fullName: "Owner User",
+        username: "username",
+        orgId: "org_id",
+      };
+      const org = {
+        id: "org_id",
+        name: "Org Name",
+      };
+      const result = getPublisherInfo(item, metadata, org, ownerUser);
+      expect(result).toEqual({
+        name: "Resource Name",
+        nameSource: PublisherSource.ResourceContact,
+        organization: "Resource Org",
+        organizationSource: PublisherSource.ResourceContact,
+        isExternal: false,
+      });
     });
-  });
 
-  it("correctly reports metadata contact info", () => {
-    const item = { id: "abc" } as unknown as IItem;
-    const metadata = {
-      metadata: {
-        // Metadata Info
-        mdContact: {
-          rpIndName: "Metadata Name",
-          rpOrgName: "Metadata Org",
+    it("correctly reports metadata contact info", () => {
+      const item = { id: "abc" } as unknown as IItem;
+      const metadata = {
+        metadata: {
+          // Metadata Info
+          mdContact: {
+            rpIndName: "Metadata Name",
+            rpOrgName: "Metadata Org",
+          },
         },
-      },
-    };
-    const ownerUser = {
-      fullName: "Owner User",
-      username: "username",
-      orgId: "org_id",
-    };
-    const org = {
-      id: "org_id",
-      name: "Org Name",
-    };
-    const result = getPublisherInfo(item, metadata, org, ownerUser);
-    expect(result).toEqual({
-      name: "Metadata Name",
-      nameSource: PublisherSource.MetadataContact,
-      organization: "Metadata Org",
-      organizationSource: PublisherSource.MetadataContact,
-      isExternal: false,
+      };
+      const ownerUser = {
+        fullName: "Owner User",
+        username: "username",
+        orgId: "org_id",
+      };
+      const org = {
+        id: "org_id",
+        name: "Org Name",
+      };
+      const result = getPublisherInfo(item, metadata, org, ownerUser);
+      expect(result).toEqual({
+        name: "Metadata Name",
+        nameSource: PublisherSource.MetadataContact,
+        organization: "Metadata Org",
+        organizationSource: PublisherSource.MetadataContact,
+        isExternal: false,
+      });
     });
-  });
 
-  it("correctly reports item owner / org info", () => {
-    const item = { id: "abc" } as unknown as IItem;
-    const ownerUser = {
-      fullName: "Owner User",
-      username: "username",
-      orgId: "org_id",
-    };
-    const org = {
-      id: "org_id",
-      name: "Item Org Name",
-    };
-    const result = getPublisherInfo(item, null, org, ownerUser);
-    expect(result).toEqual({
-      name: "Owner User",
-      username: "username",
-      nameSource: PublisherSource.ItemOwner,
-      organization: "Item Org Name",
-      orgId: "org_id",
-      organizationSource: PublisherSource.ItemOwner,
-      isExternal: false,
+    it("correctly reports item owner / org info", () => {
+      const item = { id: "abc" } as unknown as IItem;
+      const ownerUser = {
+        fullName: "Owner User",
+        username: "username",
+        orgId: "org_id",
+      };
+      const org = {
+        id: "org_id",
+        name: "Item Org Name",
+      };
+      const result = getPublisherInfo(item, null, org, ownerUser);
+      expect(result).toEqual({
+        name: "Owner User",
+        username: "username",
+        nameSource: PublisherSource.ItemOwner,
+        organization: "Item Org Name",
+        orgId: "org_id",
+        organizationSource: PublisherSource.ItemOwner,
+        isExternal: false,
+      });
     });
-  });
 
-  it("correctly reports mixed name and org info", () => {
-    const item = { id: "abc" } as unknown as IItem;
-    const metadata = {
-      metadata: {
-        // Metadata Info
-        mdContact: {
-          rpIndName: "Metadata Name",
-          // note that metadata org name is omitted
+    it("correctly reports mixed name and org info", () => {
+      const item = { id: "abc" } as unknown as IItem;
+      const metadata = {
+        metadata: {
+          // Metadata Info
+          mdContact: {
+            rpIndName: "Metadata Name",
+            // note that metadata org name is omitted
+          },
         },
-      },
-    };
-    const ownerUser = {
-      fullName: "Owner User",
-      username: "username",
-      orgId: "org_id",
-    };
-    const org = {
-      id: "org_id",
-      name: "Org Name",
-    };
-    const result = getPublisherInfo(item, metadata, org, ownerUser);
-    expect(result).toEqual({
-      name: "Metadata Name",
-      nameSource: PublisherSource.MetadataContact,
-      organization: "Org Name",
-      orgId: "org_id",
-      organizationSource: PublisherSource.ItemOwner,
-      isExternal: false,
+      };
+      const ownerUser = {
+        fullName: "Owner User",
+        username: "username",
+        orgId: "org_id",
+      };
+      const org = {
+        id: "org_id",
+        name: "Org Name",
+      };
+      const result = getPublisherInfo(item, metadata, org, ownerUser);
+      expect(result).toEqual({
+        name: "Metadata Name",
+        nameSource: PublisherSource.MetadataContact,
+        organization: "Org Name",
+        orgId: "org_id",
+        organizationSource: PublisherSource.ItemOwner,
+        isExternal: false,
+      });
     });
   });
 });

--- a/packages/common/test/content/edit.test.ts
+++ b/packages/common/test/content/edit.test.ts
@@ -15,6 +15,11 @@ import { cloneObject } from "../../src/util";
 const GUID = "9b77674e43cf4bbd9ecad5189b3f1fdc";
 
 describe("content editing:", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {});
+  });
   describe("create content:", () => {
     it("converts to a model and creates the item", async () => {
       const createSpy = spyOn(modelUtils, "createModel").and.callFake(

--- a/packages/common/test/content/fetch.test.ts
+++ b/packages/common/test/content/fetch.test.ts
@@ -54,6 +54,11 @@ const getMultiLayerItemEnrichments = () => {
 };
 
 describe("fetchContent", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {});
+  });
   let portal: string;
   let hubApiUrl: string;
   let itemId: string;

--- a/packages/common/test/content/get-family.test.ts
+++ b/packages/common/test/content/get-family.test.ts
@@ -1,6 +1,11 @@
 import { getFamilyTypes } from "../../src";
 
 describe("getFamily", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {});
+  });
   describe("getFamilyTypes", () => {
     it("can get 'content' types", () => {
       const types = getFamilyTypes("content");

--- a/packages/common/test/content/getShortenedCategories.test.ts
+++ b/packages/common/test/content/getShortenedCategories.test.ts
@@ -1,6 +1,11 @@
 import { getShortenedCategories } from "../../src/content/_internal/internalContentUtils";
 
 describe("getShortenedCategories", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {});
+  });
   it("returns an empty array when no categories are provided", () => {
     const result = getShortenedCategories([]);
     expect(result).toEqual([]);

--- a/packages/common/test/content/hostedServiceUtils.test.ts
+++ b/packages/common/test/content/hostedServiceUtils.test.ts
@@ -10,6 +10,11 @@ import {
 } from "../../src/content/hostedServiceUtils";
 
 describe("isHostedFeatureServiceItem", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {});
+  });
   it("returns true for hosted feature service items", () => {
     const item = {
       type: "Feature Service",

--- a/packages/common/test/content/index.test.ts
+++ b/packages/common/test/content/index.test.ts
@@ -61,6 +61,11 @@ const FEATURE_SERVICE_ITEM: IItem = {
 };
 
 describe("content module:", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {});
+  });
   describe("enrichments:", () => {
     let enrichmentSpy: jasmine.Spy;
     let hubRo: IHubRequestOptions;

--- a/packages/common/test/permissions/checkPermission.test.ts
+++ b/packages/common/test/permissions/checkPermission.test.ts
@@ -4,6 +4,7 @@ import { checkPermission, IHubItemEntity, Permission } from "../../src";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import { IPermissionPolicy } from "../../dist/types/permissions/types/IPermissionPolicy";
 import * as GetPolicyModule from "../../src/permissions/HubPermissionPolicies";
+import * as IsPermissionModule from "../../src/permissions/types/Permission";
 // In order to have stable tests over time, we define some policies just
 // for the purposes of testing. We then spy on getPermissionPolicy
 // and use these test-only structures instead of current businessrules
@@ -12,6 +13,11 @@ import * as GetPolicyModule from "../../src/permissions/HubPermissionPolicies";
 
 // THIS USES PROJECT PERMISSIONS BUT THE POLICIES ARE JUST FOR TESTING
 const TestPermissionPolicies: IPermissionPolicy[] = [
+  {
+    permission: "hub:feature:workspace",
+    availability: ["alpha"],
+    environments: ["devext", "qaext"],
+  },
   {
     permission: "hub:project",
     services: ["portal"],
@@ -45,6 +51,10 @@ const TestPermissionPolicies: IPermissionPolicy[] = [
     entityConfigurable: true,
   },
   {
+    permission: "hub:project:workspace",
+    dependencies: ["hub:feature:workspace"],
+  },
+  {
     permission: "hub:project:workspace:dashboard",
     dependencies: ["hub:project:view"],
     availability: ["alpha"],
@@ -54,6 +64,15 @@ const TestPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:project:workspace:details",
     dependencies: ["hub:project:edit"],
     entityConfigurable: true,
+  },
+  {
+    permission: "hub:project:workspace:hierarchy",
+    dependencies: ["hub:project:workspace"],
+    environments: ["devext"],
+  },
+  {
+    permission: "hub:project:workspace:hierarchy2",
+    dependencies: ["hub:project:workspace"],
   },
   // More permissions that can be used to create more test scenarios
   // {
@@ -86,6 +105,13 @@ function getPermissionPolicy(permission: Permission): IPermissionPolicy {
   ) as unknown as IPermissionPolicy;
 }
 
+function isPermission(permission: Permission): boolean {
+  const permissions = TestPermissionPolicies.map((p) => p.permission);
+  // Add one to flex a missing policy condition
+  permissions.push("hub:missing:policy");
+  return permissions.includes(permission);
+}
+
 describe("checkPermission:", () => {
   let basicCtxMgr: ArcGISContextManager;
   let premiumCtxMgr: ArcGISContextManager;
@@ -97,6 +123,7 @@ describe("checkPermission:", () => {
     spyOn(GetPolicyModule, "getPermissionPolicy").and.callFake(
       getPermissionPolicy
     );
+    spyOn(IsPermissionModule, "isPermission").and.callFake(isPermission);
     // unauthdCtxMgr = await ArcGISContextManager.create();
     // When we pass in all this information, the context
     // manager will not try to fetch anything, so no need
@@ -147,6 +174,8 @@ describe("checkPermission:", () => {
         "hub:project:workspace:details": false,
         // force content to be enabled, even if entity turned it off
         "hub:project:content": true,
+        // enable hub:project:workspace:hiearchy by enabling hub:feature:workspace
+        "hub:feature:workspace": true,
       },
     });
   });
@@ -168,7 +197,7 @@ describe("checkPermission:", () => {
     );
   });
   it("fails for missing policy", () => {
-    const chk = checkPermission("hub:project:owner", basicCtxMgr.context);
+    const chk = checkPermission("hub:missing:policy", basicCtxMgr.context);
     expect(chk.access).toBe(false);
     expect(chk.response).toBe("no-policy-exists");
     expect(chk.checks.length).toBe(0);
@@ -273,7 +302,7 @@ describe("checkPermission:", () => {
       );
       expect(chk.access).toBe(false);
       expect(chk.response).toBe("disabled-by-entity-flag");
-      expect(chk.checks.length).toBe(0);
+      expect(chk.checks.length).toBe(1);
     });
     it("enabled entity flag runs all checks", () => {
       const entity = {
@@ -326,6 +355,22 @@ describe("checkPermission:", () => {
     it("disabled feature flag denies access", () => {
       const chk = checkPermission(
         "hub:project:workspace:details",
+        premiumCtxMgr.context
+      );
+
+      expect(chk.access).toBe(false);
+    });
+    it("permission dependencies respect flags", () => {
+      const chk = checkPermission(
+        "hub:project:workspace:hierarchy2",
+        premiumCtxMgr.context
+      );
+
+      expect(chk.access).toBe(true);
+    });
+    it("flags for dependencies do not override child conditions", () => {
+      const chk = checkPermission(
+        "hub:project:workspace:hierarchy",
         premiumCtxMgr.context
       );
 

--- a/packages/common/test/permissions/checkPermission.test.ts
+++ b/packages/common/test/permissions/checkPermission.test.ts
@@ -118,8 +118,10 @@ describe("checkPermission:", () => {
   let consoleInfoSpy: jasmine.Spy;
   let consoleDirSpy: jasmine.Spy;
   beforeEach(async () => {
-    consoleInfoSpy = spyOn(console, "info").and.callThrough();
-    consoleDirSpy = spyOn(console, "dir").and.callThrough();
+    // tslint:disable-next-line: no-empty
+    consoleInfoSpy = spyOn(console, "info").and.callFake(() => {}); // suppress console output
+    // tslint:disable-next-line: no-empty
+    consoleDirSpy = spyOn(console, "dir").and.callFake(() => {}); // suppress console output
     spyOn(GetPolicyModule, "getPermissionPolicy").and.callFake(
       getPermissionPolicy
     );

--- a/packages/common/test/utils/hubUserAppResources.test.ts
+++ b/packages/common/test/utils/hubUserAppResources.test.ts
@@ -1,12 +1,12 @@
 import { IUser } from "@esri/arcgis-rest-types";
 import {
-  setUserSiteSettings,
-  getUserSiteSettings,
-  setUserHubSettings,
-  getUserHubSettings,
   IUserSiteSettings,
   ArcGISContext,
   IUserHubSettings,
+  updateUserSiteSettings,
+  updateUserHubSettings,
+  fetchUserHubSettings,
+  fetchUserSiteSettings,
 } from "../../src";
 
 import * as resourceModule from "../../src/utils/internal/userAppResources";
@@ -14,7 +14,7 @@ import { USER_SITE_SETTINGS_KEY } from "../../src/utils/internal/clearUserSiteSe
 import { USER_HUB_SETTINGS_KEY } from "../../src/utils/internal/clearUserHubSettings";
 
 describe("hubUserAppResources:", () => {
-  describe("setUserSiteSettings:", () => {
+  describe("updateUserSiteSettings:", () => {
     let spy: jasmine.Spy;
     let ctx: ArcGISContext;
     beforeEach(() => {
@@ -42,7 +42,7 @@ describe("hubUserAppResources:", () => {
           },
         ],
       });
-      await setUserSiteSettings(settings, ctx);
+      await updateUserSiteSettings(settings, ctx);
       expect(spy).toHaveBeenCalled();
       // inspect the arts
       const [resource, username, url, token, replace] = spy.calls.argsFor(0);
@@ -53,6 +53,8 @@ describe("hubUserAppResources:", () => {
       expect(username).toBe("jsmith");
       expect(url).toBe(ctx.portalUrl);
       expect(token).toBe("FAKESITETOKEN");
+      await updateUserSiteSettings(settings, ctx, true);
+      expect(spy.calls.argsFor(1)[4]).toEqual(true);
     });
     it("throws if token not found for ", async () => {
       const settings: IUserSiteSettings = {
@@ -75,7 +77,7 @@ describe("hubUserAppResources:", () => {
         ],
       });
       try {
-        await setUserSiteSettings(settings, ctx);
+        await updateUserSiteSettings(settings, ctx);
       } catch (ex) {
         expect((ex as any).message).toContain(
           "user-app-resource token available"
@@ -83,7 +85,7 @@ describe("hubUserAppResources:", () => {
       }
     });
   });
-  describe("getUserSiteSettings:", () => {
+  describe("fetchUserSiteSettings:", () => {
     let spy: jasmine.Spy;
     let ctx: ArcGISContext;
     beforeEach(() => {
@@ -106,7 +108,7 @@ describe("hubUserAppResources:", () => {
           },
         ],
       });
-      const settings = await getUserSiteSettings(ctx);
+      const settings = await fetchUserSiteSettings(ctx);
       expect(settings).toEqual({
         fake: "settings",
       } as unknown as IUserSiteSettings);
@@ -133,11 +135,11 @@ describe("hubUserAppResources:", () => {
         ],
       });
 
-      const settings = await getUserSiteSettings(ctx);
+      const settings = await fetchUserSiteSettings(ctx);
       expect(settings).toBeNull();
     });
   });
-  describe("setUserHubSettings:", () => {
+  describe("updateUserHubSettings:", () => {
     let spy: jasmine.Spy;
     let ctx: ArcGISContext;
     beforeEach(() => {
@@ -165,10 +167,11 @@ describe("hubUserAppResources:", () => {
           },
         ],
       });
-      await setUserHubSettings(settings, ctx);
+      await updateUserHubSettings(settings, ctx);
       expect(spy).toHaveBeenCalled();
       // inspect the arts
       const [resource, username, url, token, replace] = spy.calls.argsFor(0);
+      expect(replace).toBe(false);
       expect(resource.key).toBe(USER_HUB_SETTINGS_KEY);
       expect(resource.data.username).toBe("jsmith");
       expect(resource.data.updated).toBeGreaterThan(0);
@@ -176,6 +179,8 @@ describe("hubUserAppResources:", () => {
       expect(username).toBe("jsmith");
       expect(url).toBe(ctx.portalUrl);
       expect(token).toBe("FAKEHUBTOKEN");
+      await updateUserHubSettings(settings, ctx, true);
+      expect(spy.calls.argsFor(1)[4]).toEqual(true);
     });
     it("throws if token not found for ", async () => {
       const settings: IUserSiteSettings = {
@@ -198,7 +203,7 @@ describe("hubUserAppResources:", () => {
         ],
       });
       try {
-        await setUserHubSettings(settings, ctx);
+        await updateUserHubSettings(settings, ctx);
       } catch (ex) {
         expect((ex as any).message).toContain(
           "user-app-resource token available"
@@ -206,7 +211,7 @@ describe("hubUserAppResources:", () => {
       }
     });
   });
-  describe("getUserHubSettings:", () => {
+  describe("fetchUserHubSettings:", () => {
     let spy: jasmine.Spy;
     let ctx: ArcGISContext;
     beforeEach(() => {
@@ -229,7 +234,7 @@ describe("hubUserAppResources:", () => {
           },
         ],
       });
-      const settings = await getUserHubSettings(ctx);
+      const settings = await fetchUserHubSettings(ctx);
       expect(settings).toEqual({
         fake: "settings",
       } as unknown as IUserHubSettings);
@@ -256,7 +261,7 @@ describe("hubUserAppResources:", () => {
         ],
       });
 
-      const settings = await getUserHubSettings(ctx);
+      const settings = await fetchUserHubSettings(ctx);
       expect(settings).toBeNull();
     });
   });

--- a/packages/search/test/ago/compute-items-facets.test.ts
+++ b/packages/search/test/ago/compute-items-facets.test.ts
@@ -11,7 +11,7 @@ const item: IItem = {
   numViews: 1,
   size: 1,
   title: "title",
-  type: "CSV"
+  type: "CSV",
 };
 
 const aggregations = {
@@ -21,28 +21,33 @@ const aggregations = {
       fieldValues: [
         {
           value: "feature service",
-          count: 12
+          count: 12,
         },
         {
           value: "map service",
-          count: 10
-        }
-      ]
+          count: 10,
+        },
+      ],
     },
     {
       fieldName: "access",
       fieldValues: [
         {
           value: "private",
-          count: 3
-        }
-      ]
-    }
-  ]
+          count: 3,
+        },
+      ],
+    },
+  ],
 };
 
 describe("computeItemsFacets test", () => {
-  it("it should call ago searchItems if custom aggs are requested", async done => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
+  it("it should call ago searchItems if custom aggs are requested", async (done) => {
     const getItemsSpy = spyOn(GetItems, "getItems").and.callFake(() => {
       const response: ISearchResult<IItem> = {
         results: [item],
@@ -50,7 +55,7 @@ describe("computeItemsFacets test", () => {
         start: 1,
         num: 0,
         nextStart: -1,
-        total: 0
+        total: 0,
       };
       return Promise.resolve(response);
     });
@@ -62,15 +67,15 @@ describe("computeItemsFacets test", () => {
     const expected = {
       downloadable: [
         { key: "true", docCount: 1 },
-        { key: "false", docCount: 0 }
-      ]
+        { key: "false", docCount: 0 },
+      ],
     };
     expect(facets).toEqual(expected);
     expect(getItemsSpy.calls.count()).toEqual(1);
     done();
   });
 
-  it("it should compute facets from custom and ago-provided aggs correctly", async done => {
+  it("it should compute facets from custom and ago-provided aggs correctly", async (done) => {
     const getItemsSpy = spyOn(GetItems, "getItems").and.callFake(() => {
       const response: ISearchResult<IItem> = {
         results: [item],
@@ -78,13 +83,13 @@ describe("computeItemsFacets test", () => {
         start: 1,
         num: 0,
         nextStart: -1,
-        total: 0
+        total: 0,
       };
       return Promise.resolve(response);
     });
     const params = {
       q: "blah",
-      agg: { fields: "downloadable,type,access,hasApi" }
+      agg: { fields: "downloadable,type,access,hasApi" },
     };
     const token = "secret";
     const portal = "https://qaext.arcgis.com/sharing/rest";
@@ -97,26 +102,29 @@ describe("computeItemsFacets test", () => {
     const expected = {
       downloadable: [
         { key: "true", docCount: 1 },
-        { key: "false", docCount: 0 }
+        { key: "false", docCount: 0 },
       ],
       type: [
         { key: "feature service", docCount: 12 },
-        { key: "map service", docCount: 10 }
+        { key: "map service", docCount: 10 },
       ],
       access: [{ key: "private", docCount: 3 }],
-      hasApi: [{ key: "true", docCount: 22 }, { key: "false", docCount: 0 }]
+      hasApi: [
+        { key: "true", docCount: 22 },
+        { key: "false", docCount: 0 },
+      ],
     };
     expect(facets).toEqual(expected);
     expect(getItemsSpy.calls.count()).toEqual(1);
     done();
   });
 
-  it("it should handle undefined agoAggregations and undefined agg params correctly", async done => {
+  it("it should handle undefined agoAggregations and undefined agg params correctly", async (done) => {
     const getItemsSpy = spyOn(GetItems, "getItems").and.callFake(() => {
       return Promise.resolve({});
     });
     const params = {
-      q: "blah"
+      q: "blah",
     };
     const token = "secret";
     const portal = "https://qaext.arcgis.com/sharing/rest";
@@ -126,7 +134,7 @@ describe("computeItemsFacets test", () => {
     done();
   });
 
-  it("it should flatten categories facet if present", async done => {
+  it("it should flatten categories facet if present", async (done) => {
     spyOn(GetItems, "getItems").and.callFake(() => {
       return Promise.resolve({});
     });
@@ -137,10 +145,10 @@ describe("computeItemsFacets test", () => {
           fieldValues: [
             { value: "/categories", count: 5 },
             { value: "/categories/economy", count: 5 },
-            { value: "/categories/economy/business", count: 5 }
-          ]
-        }
-      ]
+            { value: "/categories/economy/business", count: 5 },
+          ],
+        },
+      ],
     };
     const params = { q: "blah", agg: { fields: "categories" } };
     const token = "secret";
@@ -149,8 +157,8 @@ describe("computeItemsFacets test", () => {
     const expected = {
       categories: [
         { key: "economy", docCount: 10 },
-        { key: "business", docCount: 5 }
-      ]
+        { key: "business", docCount: 5 },
+      ],
     };
     expect(facets).toEqual(expected);
     done();

--- a/packages/search/test/ago/encode-ago-query.test.ts
+++ b/packages/search/test/ago/encode-ago-query.test.ts
@@ -1,6 +1,11 @@
 import { encodeAgoQuery } from "../../src/ago/encode-ago-query";
 
 describe("encodeAgoQuery test", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
   it("encodes ago query for all fields defined in params", () => {
     const params: any = {
       q: "crime",

--- a/packages/search/test/ago/format-item-collection.test.ts
+++ b/packages/search/test/ago/format-item-collection.test.ts
@@ -2,13 +2,18 @@ import { agoFormatItemCollection } from "../../src/ago/format-item-collection";
 import { searchResults } from "./mocks/ago-response";
 
 describe("agoFormatItemCollection test", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
   it("it format item collection correctly", () => {
     const params = {
       q: "blah",
       tags: "all(a,b)",
       agg: { fields: "tags,collection" },
       start: 1,
-      num: 10
+      num: 10,
     };
     const facets = { a: 1 };
     const formatted = agoFormatItemCollection(searchResults, facets, params);
@@ -28,7 +33,7 @@ describe("agoFormatItemCollection test", () => {
       tags: "all(a,b)",
       agg: { fields: "tags,collection" },
       start: 1,
-      num: 10
+      num: 10,
     };
     const formatted = agoFormatItemCollection(searchResults, undefined, params);
     expect(formatted.data.length).toBe(10);

--- a/packages/search/test/ago/get-items.test.ts
+++ b/packages/search/test/ago/get-items.test.ts
@@ -4,6 +4,11 @@ import { ISearchParams } from "../../src/ago/params";
 import * as EncodeAgoQuery from "../../src/ago/encode-ago-query";
 
 describe("getItems test", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
   it("gets items when there are no count fields i.e. aggs", async (done) => {
     const rawAgoResults = {
       results: [],

--- a/packages/search/test/ago/helpers/aggs/categories.test.ts
+++ b/packages/search/test/ago/helpers/aggs/categories.test.ts
@@ -1,6 +1,12 @@
 import { flattenCategories } from "../../../../src/ago/helpers/aggs/categories";
 
 describe("categories aggs test", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
+
   it("works on undefined categories", () => {
     expect(flattenCategories()).toEqual([]);
   });
@@ -10,11 +16,11 @@ describe("categories aggs test", () => {
       { key: "", docCount: 2 },
       { key: "/categories", docCount: 2 },
       { key: "/categories/economy", docCount: 2 },
-      { key: "/categories/economy/business", docCount: 2 }
+      { key: "/categories/economy/business", docCount: 2 },
     ];
     const expected = [
       { key: "economy", docCount: 4 },
-      { key: "business", docCount: 2 }
+      { key: "business", docCount: 2 },
     ];
     expect(flattenCategories(categoriesAggs)).toEqual(expected);
   });

--- a/packages/search/test/ago/helpers/aggs/collection.test.ts
+++ b/packages/search/test/ago/helpers/aggs/collection.test.ts
@@ -1,6 +1,11 @@
 import { collectionAgg } from "../../../../src/ago/helpers/aggs/collection";
 
 describe("collection aggs test", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
   it("calculates collection raw aggs correctly", () => {
     const agoAggs = {
       counts: [
@@ -9,19 +14,19 @@ describe("collection aggs test", () => {
           fieldValues: [
             {
               value: "Feature Layer",
-              count: 12
+              count: 12,
             },
             {
               value: "PDF",
-              count: 10
+              count: 10,
             },
             {
               value: "unknown type",
-              count: 10
-            }
-          ]
-        }
-      ]
+              count: 10,
+            },
+          ],
+        },
+      ],
     };
     const actual = collectionAgg(agoAggs);
     const expected = { collection: { Dataset: 12, Document: 10, Other: 10 } };

--- a/packages/search/test/ago/helpers/aggs/create-aggs.test.ts
+++ b/packages/search/test/ago/helpers/aggs/create-aggs.test.ts
@@ -1,6 +1,11 @@
 import { createAggs } from "../../../../src/ago/helpers/aggs/create-aggs";
 
 describe("createAggs test", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
   it("returns an object of countFields and countSize", () => {
     const facets = "tags,collection,hasApi,downloadable,access";
     const actual = createAggs(facets);

--- a/packages/search/test/ago/helpers/format/format-item.test.ts
+++ b/packages/search/test/ago/helpers/format/format-item.test.ts
@@ -12,10 +12,18 @@ const itemProps = {
   type: "feature layer",
   numViews: 1000,
   size: 1,
-  extent: [[1, 2], [3, 4]]
+  extent: [
+    [1, 2],
+    [3, 4],
+  ],
 };
 
 describe("highlights test", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
   it("formats item into v3 style dataset", () => {
     const item: IItem = { ...itemProps };
     const query = "fake";
@@ -30,18 +38,20 @@ describe("highlights test", () => {
         hubType: "dataset",
         collection: ["Dataset"],
         extent: {
-          coordinates: [[1, 2], [3, 4]],
-          type: "envelope"
-        }
+          coordinates: [
+            [1, 2],
+            [3, 4],
+          ],
+          type: "envelope",
+        },
       },
       meta: {
         highlights: {
-          name:
-            '<mark class="hub-search-highlight name-highlight">fake</mark> item',
+          name: '<mark class="hub-search-highlight name-highlight">fake</mark> item',
           searchDescription:
-            '<mark class="hub-search-highlight description-highlight">fake</mark> description'
-        }
-      }
+            '<mark class="hub-search-highlight description-highlight">fake</mark> description',
+        },
+      },
     };
     expect(actual).toEqual(expected);
   });
@@ -60,10 +70,13 @@ describe("highlights test", () => {
         hubType: "dataset",
         collection: ["Dataset"],
         extent: {
-          coordinates: [[1, 2], [3, 4]],
-          type: "envelope"
-        }
-      }
+          coordinates: [
+            [1, 2],
+            [3, 4],
+          ],
+          type: "envelope",
+        },
+      },
     };
     expect(actual).toEqual(expected);
   });
@@ -83,10 +96,13 @@ describe("highlights test", () => {
         hubType: "Other",
         collection: ["Other"],
         extent: {
-          coordinates: [[1, 2], [3, 4]],
-          type: "envelope"
-        }
-      }
+          coordinates: [
+            [1, 2],
+            [3, 4],
+          ],
+          type: "envelope",
+        },
+      },
     };
     expect(actual).toEqual(expected);
   });

--- a/packages/search/test/ago/helpers/format/highlights.test.ts
+++ b/packages/search/test/ago/helpers/format/highlights.test.ts
@@ -1,6 +1,11 @@
 import { calcHighlights } from "../../../../src/ago/helpers/format/highlights";
 
 describe("highlights test", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
   it("highlights the search term for multiple occurrences", () => {
     const input = "Capital bike share... blah blah capital.... CAPITAL CAPITAL";
     const query = "capital";

--- a/packages/search/test/ago/search.test.ts
+++ b/packages/search/test/ago/search.test.ts
@@ -5,11 +5,16 @@ import * as FormatItemCollection from "../../src/ago/format-item-collection";
 import { ISearchParams } from "../../src/ago/params";
 
 describe("agoSearch test", () => {
-  it("uses the right functions", async done => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
+  it("uses the right functions", async (done) => {
     const rawAgoResults = {
       results: [],
       total: 0,
-      aggregations: { counts: {} }
+      aggregations: { counts: {} },
     } as any;
     const facets = { facet1: [{ key: "a", docCount: 5 }] };
     const formatted = { data: [], meta: { stats: {} } } as any;
@@ -34,7 +39,7 @@ describe("agoSearch test", () => {
       groupIds: "1ef",
       agg: { fields: "tags,collection,owner,source,hasApi,downloadable" },
       start: 1,
-      num: 10
+      num: 10,
     };
     const token = "token";
     const portal = "https://test.com";
@@ -51,7 +56,7 @@ describe("agoSearch test", () => {
       aggsForComputeFacets,
       paramsForComputeFacets,
       tokenForComputeFacets,
-      portalForComputeFacets
+      portalForComputeFacets,
     ] = computeItemsFacetsSpy.calls.argsFor(0);
     expect(aggsForComputeFacets).toEqual({ counts: {} });
     expect(paramsForComputeFacets).toEqual(params);
@@ -60,11 +65,8 @@ describe("agoSearch test", () => {
 
     // step 4: ago format item collection
     expect(agoFormatCollectionSpy.calls.count()).toBe(1);
-    const [
-      resultsForFormat,
-      facetsForFormat,
-      paramsForFormat
-    ] = agoFormatCollectionSpy.calls.argsFor(0);
+    const [resultsForFormat, facetsForFormat, paramsForFormat] =
+      agoFormatCollectionSpy.calls.argsFor(0);
     expect(resultsForFormat).toEqual(rawAgoResults);
     expect(facetsForFormat).toEqual(facets);
     expect(paramsForFormat).toEqual(params);

--- a/packages/search/test/ago/serialize.test.ts
+++ b/packages/search/test/ago/serialize.test.ts
@@ -2,6 +2,11 @@ import { serialize } from "../../src/ago/serialize";
 import { ISearchParams } from "../../src/ago/params";
 
 describe("serialize test", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
   it("serializes q, tags, aggs, sort, groupIds, orgId, initiativeId correctly", () => {
     const input: ISearchParams = {
       q: "crime",
@@ -13,18 +18,18 @@ describe("serialize test", () => {
       agg: {
         fields: "tags,collection,owner,source,hasApi,downloadable",
         size: 10,
-        mode: "uniqueCount"
+        mode: "uniqueCount",
       },
       page: {
         hub: {
           start: 1,
-          size: 10
+          size: 10,
         },
         ago: {
           start: 1,
-          size: 10
-        }
-      }
+          size: 10,
+        },
+      },
     };
     const actual = serialize(input);
     const expected =
@@ -37,7 +42,7 @@ describe("serialize test", () => {
       q: "crime",
       sort: "name",
       groupIds: "1ef,2ab",
-      id: "1qw"
+      id: "1qw",
     };
     const actual = serialize(input);
     const expected =
@@ -49,7 +54,7 @@ describe("serialize test", () => {
 
   it("serializes without nonFilters and filters", () => {
     const input: ISearchParams = {
-      q: ""
+      q: "",
     };
     const actual = serialize(input);
     const expected = "";

--- a/packages/search/test/util/aggregations/merge-aggregations.test.ts
+++ b/packages/search/test/util/aggregations/merge-aggregations.test.ts
@@ -1,9 +1,14 @@
 import {
   IAggregationResult,
-  mergeAggregations
+  mergeAggregations,
 } from "../../../src/util/aggregations/merge-aggregations";
 
 describe("Merge Aggregation Function", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
   it("can properly merge several lists of aggregations with a default merge function", () => {
     // Setup
     const aggregationsOne: IAggregationResult[] = [
@@ -12,31 +17,31 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "public",
-            value: 5
+            value: 5,
           },
           {
             label: "private",
-            value: 3
+            value: 3,
           },
           {
             label: "0",
-            value: 2
-          }
-        ]
+            value: 2,
+          },
+        ],
       },
       {
         fieldName: "category",
         aggregations: [
           {
             label: "1",
-            value: 23
+            value: 23,
           },
           {
             label: "a_category",
-            value: 10
-          }
-        ]
-      }
+            value: 10,
+          },
+        ],
+      },
     ];
 
     const aggregationsTwo: IAggregationResult[] = [
@@ -45,31 +50,31 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "public",
-            value: 17
+            value: 17,
           },
           {
             label: "shared",
-            value: 5
+            value: 5,
           },
           {
             label: "1",
-            value: 4
-          }
-        ]
+            value: 4,
+          },
+        ],
       },
       {
         fieldName: "type",
         aggregations: [
           {
             label: "1",
-            value: 12
+            value: 12,
           },
           {
             label: "feature layer",
-            value: 7
-          }
-        ]
-      }
+            value: 7,
+          },
+        ],
+      },
     ];
 
     const aggregationsThree: IAggregationResult[] = [
@@ -78,27 +83,27 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "a_category",
-            value: 12
+            value: 12,
           },
           {
             label: "0",
-            value: 9
-          }
-        ]
+            value: 9,
+          },
+        ],
       },
       {
         fieldName: "type",
         aggregations: [
           {
             label: "0",
-            value: 6
+            value: 6,
           },
           {
             label: "feature layer",
-            value: 2
-          }
-        ]
-      }
+            value: 2,
+          },
+        ],
+      },
     ];
 
     const expectedMergedAggregations: IAggregationResult[] = [
@@ -107,67 +112,67 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "0",
-            value: 2
+            value: 2,
           },
           {
             label: "1",
-            value: 4
+            value: 4,
           },
           {
             label: "public",
-            value: 22
+            value: 22,
           },
           {
             label: "private",
-            value: 3
+            value: 3,
           },
           {
             label: "shared",
-            value: 5
-          }
-        ]
+            value: 5,
+          },
+        ],
       },
       {
         fieldName: "category",
         aggregations: [
           {
             label: "0",
-            value: 9
+            value: 9,
           },
           {
             label: "1",
-            value: 23
+            value: 23,
           },
           {
             label: "a_category",
-            value: 22
-          }
-        ]
+            value: 22,
+          },
+        ],
       },
       {
         fieldName: "type",
         aggregations: [
           {
             label: "0",
-            value: 6
+            value: 6,
           },
           {
             label: "1",
-            value: 12
+            value: 12,
           },
           {
             label: "feature layer",
-            value: 9
-          }
-        ]
-      }
+            value: 9,
+          },
+        ],
+      },
     ];
 
     // Test
     const actualMergedAggregations: IAggregationResult[] = mergeAggregations([
       aggregationsOne,
       aggregationsTwo,
-      aggregationsThree
+      aggregationsThree,
     ]);
 
     // Assert
@@ -182,31 +187,31 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "public",
-            value: 5
+            value: 5,
           },
           {
             label: "private",
-            value: 3
+            value: 3,
           },
           {
             label: "0",
-            value: 2
-          }
-        ]
+            value: 2,
+          },
+        ],
       },
       {
         fieldName: "category",
         aggregations: [
           {
             label: "1",
-            value: 23
+            value: 23,
           },
           {
             label: "a_category",
-            value: 10
-          }
-        ]
-      }
+            value: 10,
+          },
+        ],
+      },
     ];
 
     const aggregationsTwo: IAggregationResult[] = [
@@ -215,31 +220,31 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "public",
-            value: 17
+            value: 17,
           },
           {
             label: "shared",
-            value: 5
+            value: 5,
           },
           {
             label: "1",
-            value: 4
-          }
-        ]
+            value: 4,
+          },
+        ],
       },
       {
         fieldName: "type",
         aggregations: [
           {
             label: "1",
-            value: 12
+            value: 12,
           },
           {
             label: "feature layer",
-            value: 7
-          }
-        ]
-      }
+            value: 7,
+          },
+        ],
+      },
     ];
 
     const aggregationsThree: IAggregationResult[] = [
@@ -248,27 +253,27 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "a_category",
-            value: 12
+            value: 12,
           },
           {
             label: "0",
-            value: 9
-          }
-        ]
+            value: 9,
+          },
+        ],
       },
       {
         fieldName: "type",
         aggregations: [
           {
             label: "0",
-            value: 6
+            value: 6,
           },
           {
             label: "feature layer",
-            value: 2
-          }
-        ]
-      }
+            value: 2,
+          },
+        ],
+      },
     ];
 
     const mergeFunc: any = (one: number, two: number) => Math.max(one, two);
@@ -279,60 +284,60 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "0",
-            value: 2
+            value: 2,
           },
           {
             label: "1",
-            value: 4
+            value: 4,
           },
           {
             label: "public",
-            value: 17
+            value: 17,
           },
           {
             label: "private",
-            value: 3
+            value: 3,
           },
           {
             label: "shared",
-            value: 5
-          }
-        ]
+            value: 5,
+          },
+        ],
       },
       {
         fieldName: "category",
         aggregations: [
           {
             label: "0",
-            value: 9
+            value: 9,
           },
           {
             label: "1",
-            value: 23
+            value: 23,
           },
           {
             label: "a_category",
-            value: 12
-          }
-        ]
+            value: 12,
+          },
+        ],
       },
       {
         fieldName: "type",
         aggregations: [
           {
             label: "0",
-            value: 6
+            value: 6,
           },
           {
             label: "1",
-            value: 12
+            value: 12,
           },
           {
             label: "feature layer",
-            value: 7
-          }
-        ]
-      }
+            value: 7,
+          },
+        ],
+      },
     ];
 
     // Test
@@ -353,31 +358,31 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "public",
-            value: null
+            value: null,
           },
           {
             label: "private",
-            value: 3
+            value: 3,
           },
           {
             label: "0",
-            value: 2
-          }
-        ]
+            value: 2,
+          },
+        ],
       },
       {
         fieldName: "category",
         aggregations: [
           {
             label: "1",
-            value: 23
+            value: 23,
           },
           {
             label: "a_category",
-            value: 4
-          }
-        ]
-      }
+            value: 4,
+          },
+        ],
+      },
     ];
 
     const aggregationsTwo: IAggregationResult[] = [
@@ -386,18 +391,18 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "public",
-            value: 17
+            value: 17,
           },
           {
             label: "shared",
-            value: 5
+            value: 5,
           },
           {
             label: "1",
-            value: 4
-          }
-        ]
-      }
+            value: 4,
+          },
+        ],
+      },
     ];
 
     const aggregationsThree: IAggregationResult[] = [
@@ -406,14 +411,14 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "a_category",
-            value: undefined
+            value: undefined,
           },
           {
             label: "0",
-            value: 9
-          }
-        ]
-      }
+            value: 9,
+          },
+        ],
+      },
     ];
 
     const expectedMergedAggregations: IAggregationResult[] = [
@@ -422,50 +427,50 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "0",
-            value: 2
+            value: 2,
           },
           {
             label: "1",
-            value: 4
+            value: 4,
           },
           {
             label: "private",
-            value: 3
+            value: 3,
           },
           {
             label: "public",
-            value: 17
+            value: 17,
           },
           {
             label: "shared",
-            value: 5
-          }
-        ]
+            value: 5,
+          },
+        ],
       },
       {
         fieldName: "category",
         aggregations: [
           {
             label: "0",
-            value: 9
+            value: 9,
           },
           {
             label: "1",
-            value: 23
+            value: 23,
           },
           {
             label: "a_category",
-            value: 4
-          }
-        ]
-      }
+            value: 4,
+          },
+        ],
+      },
     ];
 
     // Test
     const actualMergedAggregations: IAggregationResult[] = mergeAggregations([
       aggregationsOne,
       aggregationsTwo,
-      aggregationsThree
+      aggregationsThree,
     ]);
 
     // Assert
@@ -480,31 +485,31 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "public",
-            value: null
+            value: null,
           },
           {
             label: "private",
-            value: 3
+            value: 3,
           },
           {
             label: "0",
-            value: 2
-          }
-        ]
+            value: 2,
+          },
+        ],
       },
       {
         fieldName: "category",
         aggregations: [
           {
             label: "1",
-            value: 23
+            value: 23,
           },
           {
             label: "a_category",
-            value: undefined
-          }
-        ]
-      }
+            value: undefined,
+          },
+        ],
+      },
     ];
 
     const aggregationsTwo: IAggregationResult[] = [
@@ -513,18 +518,18 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "public",
-            value: undefined
+            value: undefined,
           },
           {
             label: "shared",
-            value: 5
+            value: 5,
           },
           {
             label: "1",
-            value: 4
-          }
-        ]
-      }
+            value: 4,
+          },
+        ],
+      },
     ];
 
     const aggregationsThree: IAggregationResult[] = [
@@ -533,14 +538,14 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "a_category",
-            value: null
+            value: null,
           },
           {
             label: "0",
-            value: 9
-          }
-        ]
-      }
+            value: 9,
+          },
+        ],
+      },
     ];
 
     const expectedMergedAggregations: IAggregationResult[] = [
@@ -549,42 +554,42 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "0",
-            value: 2
+            value: 2,
           },
           {
             label: "1",
-            value: 4
+            value: 4,
           },
           {
             label: "private",
-            value: 3
+            value: 3,
           },
           {
             label: "shared",
-            value: 5
-          }
-        ]
+            value: 5,
+          },
+        ],
       },
       {
         fieldName: "category",
         aggregations: [
           {
             label: "0",
-            value: 9
+            value: 9,
           },
           {
             label: "1",
-            value: 23
-          }
-        ]
-      }
+            value: 23,
+          },
+        ],
+      },
     ];
 
     // Test
     const actualMergedAggregations: IAggregationResult[] = mergeAggregations([
       aggregationsOne,
       aggregationsTwo,
-      aggregationsThree
+      aggregationsThree,
     ]);
 
     // Assert
@@ -599,26 +604,26 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "public",
-            value: 5
+            value: 5,
           },
           {
             label: "private",
-            value: 3
+            value: 3,
           },
           {
             label: "0",
-            value: 2
-          }
-        ]
+            value: 2,
+          },
+        ],
       },
       {
         fieldName: "category",
-        aggregations: []
+        aggregations: [],
       },
       {
         fieldName: "type",
-        aggregations: undefined
-      }
+        aggregations: undefined,
+      },
     ];
 
     const aggregationsTwo: IAggregationResult[] = [
@@ -627,22 +632,22 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "public",
-            value: undefined
+            value: undefined,
           },
           {
             label: "shared",
-            value: 5
+            value: 5,
           },
           {
             label: "1",
-            value: 4
-          }
-        ]
+            value: 4,
+          },
+        ],
       },
       {
         fieldName: "type",
-        aggregations: null
-      }
+        aggregations: null,
+      },
     ];
 
     const aggregationsThree: IAggregationResult[] = [
@@ -651,14 +656,14 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "a_category",
-            value: 20
+            value: 20,
           },
           {
             label: "0",
-            value: 9
-          }
-        ]
-      }
+            value: 9,
+          },
+        ],
+      },
     ];
 
     const expectedMergedAggregations: IAggregationResult[] = [
@@ -667,46 +672,46 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "0",
-            value: 2
+            value: 2,
           },
           {
             label: "1",
-            value: 4
+            value: 4,
           },
           {
             label: "public",
-            value: 5
+            value: 5,
           },
           {
             label: "private",
-            value: 3
+            value: 3,
           },
           {
             label: "shared",
-            value: 5
-          }
-        ]
+            value: 5,
+          },
+        ],
       },
       {
         fieldName: "category",
         aggregations: [
           {
             label: "0",
-            value: 9
+            value: 9,
           },
           {
             label: "a_category",
-            value: 20
-          }
-        ]
-      }
+            value: 20,
+          },
+        ],
+      },
     ];
 
     // Test
     const actualMergedAggregations: IAggregationResult[] = mergeAggregations([
       aggregationsOne,
       aggregationsTwo,
-      aggregationsThree
+      aggregationsThree,
     ]);
 
     // Assert
@@ -721,31 +726,31 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "PUBLIC",
-            value: 5
+            value: 5,
           },
           {
             label: "private",
-            value: 3
+            value: 3,
           },
           {
             label: "0",
-            value: 2
-          }
-        ]
+            value: 2,
+          },
+        ],
       },
       {
         fieldName: "CATEGORY",
         aggregations: [
           {
             label: "1",
-            value: 23
+            value: 23,
           },
           {
             label: "a_Category",
-            value: 10
-          }
-        ]
-      }
+            value: 10,
+          },
+        ],
+      },
     ];
 
     const aggregationsTwo: IAggregationResult[] = [
@@ -754,31 +759,31 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "public",
-            value: 17
+            value: 17,
           },
           {
             label: "shared",
-            value: 5
+            value: 5,
           },
           {
             label: "1",
-            value: 4
-          }
-        ]
+            value: 4,
+          },
+        ],
       },
       {
         fieldName: "type",
         aggregations: [
           {
             label: "1",
-            value: 12
+            value: 12,
           },
           {
             label: "FeaTure laYer",
-            value: 7
-          }
-        ]
-      }
+            value: 7,
+          },
+        ],
+      },
     ];
 
     const aggregationsThree: IAggregationResult[] = [
@@ -787,27 +792,27 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "a_category",
-            value: 12
+            value: 12,
           },
           {
             label: "0",
-            value: 9
-          }
-        ]
+            value: 9,
+          },
+        ],
       },
       {
         fieldName: "TYPE",
         aggregations: [
           {
             label: "0",
-            value: 6
+            value: 6,
           },
           {
             label: "FeaturE LayeR",
-            value: 2
-          }
-        ]
-      }
+            value: 2,
+          },
+        ],
+      },
     ];
 
     const expectedMergedAggregations: IAggregationResult[] = [
@@ -816,67 +821,67 @@ describe("Merge Aggregation Function", () => {
         aggregations: [
           {
             label: "0",
-            value: 2
+            value: 2,
           },
           {
             label: "1",
-            value: 4
+            value: 4,
           },
           {
             label: "public",
-            value: 22
+            value: 22,
           },
           {
             label: "private",
-            value: 3
+            value: 3,
           },
           {
             label: "shared",
-            value: 5
-          }
-        ]
+            value: 5,
+          },
+        ],
       },
       {
         fieldName: "category",
         aggregations: [
           {
             label: "0",
-            value: 9
+            value: 9,
           },
           {
             label: "1",
-            value: 23
+            value: 23,
           },
           {
             label: "a_category",
-            value: 22
-          }
-        ]
+            value: 22,
+          },
+        ],
       },
       {
         fieldName: "type",
         aggregations: [
           {
             label: "0",
-            value: 6
+            value: 6,
           },
           {
             label: "1",
-            value: 12
+            value: 12,
           },
           {
             label: "feature layer",
-            value: 9
-          }
-        ]
-      }
+            value: 9,
+          },
+        ],
+      },
     ];
 
     // Test
     const actualMergedAggregations: IAggregationResult[] = mergeAggregations([
       aggregationsOne,
       aggregationsTwo,
-      aggregationsThree
+      aggregationsThree,
     ]);
 
     // Assert

--- a/packages/search/test/util/merge-pagination/merge.test.ts
+++ b/packages/search/test/util/merge-pagination/merge.test.ts
@@ -1,20 +1,25 @@
 import { mergePages } from "../../../src/util/merge-pagination/merge";
 
 describe("Merge Paginations Function", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
   it("can properly merge pages from different sources, handling cases when nextStart is not specified", () => {
     // Setup
     const pages: any[] = [
       {
         label: "hub",
-        nextPageStart: 13
+        nextPageStart: 13,
       },
       {
         label: "ago",
-        nextPageStart: 4
+        nextPageStart: 4,
       },
       {
-        label: "event"
-      }
+        label: "event",
+      },
     ];
 
     const expectedResult: string = "eyJodWIiOjEzLCJhZ28iOjQsImV2ZW50IjoxfQ==";

--- a/packages/search/test/util/merge-sort/merge.test.ts
+++ b/packages/search/test/util/merge-sort/merge.test.ts
@@ -2,6 +2,11 @@ import { lorem, date, datatype } from "faker";
 import { BinaryHeap, kMerge } from "../../../src/util/merge-sort/merge";
 
 describe("Binary Heap", () => {
+  beforeAll(() => {
+    // suppress deprecation warnings
+    // tslint:disable-next-line: no-empty
+    spyOn(console, "warn").and.callFake(() => {}); // suppress console output
+  });
   it("should successfully initialize if falsey nodes are explicitly provided", () => {
     // Setup
     const comparator = (one: number[], two: number[]): number => {


### PR DESCRIPTION
1. Description:

This has a lot of files b/c I got sick of all the deprecation warnings in the test output, so I carpet bombed spies that no-op console.warn into a ton of test files... on to the meat of the deal...

Implement internals around `IHubUserSettings`, connect into `ArcGISContextManager` so it's fetched during the boot cycle, reads the `preview.*` properties and maps them into `hub:feature:*` feature flags.

Also exposes `.updateUserHubSettings(settings):Promise<void>` on `ArcGISContextManager`, which will be exposed into the app via `appSettings.updateUserHubSettings(settings):Promise<void>`

Verified by integrating into opendata-ui locally.

1. Instructions for testing: run tests

1. Closes Issues: #8200

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
