### PR TITLE
fix: add data.telemetry to site draft include list; redo telemetry config migration

### DIFF
--- a/packages/common/src/sites/_internal/_migrate-telemetry-config.ts
+++ b/packages/common/src/sites/_internal/_migrate-telemetry-config.ts
@@ -11,7 +11,8 @@ import { cloneObject } from "../../util";
 export function _migrateTelemetryConfig<T extends IModel | IDraft>(
   model: T
 ): T {
-  const newSchemaVersion = 1.7;
+  // NOTE: this migration was initially 1.6 => 1.7 but i (jupe) did not get the ui in sync so we will just do it again and i will get it right this time
+  const newSchemaVersion = 1.8;
   // do nothing if migration already applied
   if (getProp(model, "item.properties.schemaVersion") >= newSchemaVersion) {
     return model;

--- a/packages/common/src/sites/site-schema-version.ts
+++ b/packages/common/src/sites/site-schema-version.ts
@@ -1,1 +1,1 @@
-export const SITE_SCHEMA_VERSION = 1.7;
+export const SITE_SCHEMA_VERSION = 1.8;

--- a/packages/common/test/sites/_internal/_migrate-telemetry-config.test.ts
+++ b/packages/common/test/sites/_internal/_migrate-telemetry-config.test.ts
@@ -2,23 +2,23 @@ import { IModel } from "../../../src";
 import { _migrateTelemetryConfig } from "../../../src/sites/_internal/_migrate-telemetry-config";
 
 describe("_migrateTelemetryConfig", () => {
-  it("Bumps the item.properties.schemaVersion if schemaVersion is < 1.7", () => {
+  it("Bumps the item.properties.schemaVersion if schemaVersion is < 1.8", () => {
     const siteModel = {
-      item: { properties: { schemaVersion: 1.6 } },
+      item: { properties: { schemaVersion: 1.7 } },
       data: { values: {} },
     } as unknown as IModel;
     const result = _migrateTelemetryConfig(siteModel);
     expect(result.item.properties.schemaVersion).toEqual(
-      1.7,
-      "site.item.properties.schemaVersion should be 1.7"
+      1.8,
+      "site.item.properties.schemaVersion should be 1.8"
     );
   });
 
-  it("Does not run the migration if schemaVersion is >= 1.7", () => {
+  it("Does not run the migration if schemaVersion is >= 1.8", () => {
     const siteModel = {
       item: {
         properties: {
-          schemaVersion: 1.7,
+          schemaVersion: 1.8,
         },
       },
     } as unknown as IModel;
@@ -29,7 +29,7 @@ describe("_migrateTelemetryConfig", () => {
 
   it("should apply migration if schemaVersion < newSchemaVersion", () => {
     const model = {
-      item: { properties: { schemaVersion: 1.6 } },
+      item: { properties: { schemaVersion: 1.7 } },
       data: {
         values: {
           capabilities: ["consentNotice"],
@@ -38,7 +38,7 @@ describe("_migrateTelemetryConfig", () => {
       },
     };
     const result = _migrateTelemetryConfig(model);
-    expect(result.item.properties.schemaVersion).toEqual(1.7);
+    expect(result.item.properties.schemaVersion).toEqual(1.8);
     expect(
       (result.data as any).telemetry.consentNotice.allowPrivacyConfig
     ).toEqual(true);

--- a/packages/sites/src/drafts/site-draft-include-list.ts
+++ b/packages/sites/src/drafts/site-draft-include-list.ts
@@ -19,4 +19,5 @@ export const SITE_DRAFT_INCLUDE_LIST = [
   "data.values.capabilities",
   "data.values.contentViews",
   "data.values.headContent",
+  "data.telemetry",
 ];


### PR DESCRIPTION
affects: @esri/hub-common, @esri/hub-sites

1. Description: Adds data.telemetry to site draft include list; redo telemetry migration because I failed to get the ui in sync with the migration last release.

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
