### PR TITLE
fix(hub-common): change search result view models to exclude usernames in source values

### DIFF
--- a/packages/common/src/initiative-templates/view.ts
+++ b/packages/common/src/initiative-templates/view.ts
@@ -121,12 +121,17 @@ const getSharedInitiativeTemplateCardModel = (
     },
   ];
 
+  let source: string = null;
+  if (entityOrSearchResult.source !== entityOrSearchResult.owner) {
+    source = entityOrSearchResult.source;
+  }
+
   return {
     access: entityOrSearchResult.access,
     badges: [],
     id: entityOrSearchResult.id,
     family: getFamily(entityOrSearchResult.type),
-    source: entityOrSearchResult.owner,
+    source,
     summary: entityOrSearchResult.summary,
     title: entityOrSearchResult.name,
     type: entityOrSearchResult.type,

--- a/packages/common/src/initiatives/view.ts
+++ b/packages/common/src/initiatives/view.ts
@@ -122,12 +122,17 @@ const getSharedInitiativeCardModel = (
     },
   ];
 
+  let source: string = null;
+  if (entityOrSearchResult.source !== entityOrSearchResult.owner) {
+    source = entityOrSearchResult.source;
+  }
+
   return {
     access: entityOrSearchResult.access,
     badges: [],
     id: entityOrSearchResult.id,
     family: getFamily(entityOrSearchResult.type),
-    source: entityOrSearchResult.owner,
+    source,
     summary: entityOrSearchResult.summary,
     title: entityOrSearchResult.name,
     type: entityOrSearchResult.type,

--- a/packages/common/src/projects/view.ts
+++ b/packages/common/src/projects/view.ts
@@ -118,12 +118,17 @@ const getSharedProjectCardModel = (
     },
   ];
 
+  let source: string = null;
+  if (entityOrSearchResult.source !== entityOrSearchResult.owner) {
+    source = entityOrSearchResult.source;
+  }
+
   return {
     access: entityOrSearchResult.access,
     badges: [],
     id: entityOrSearchResult.id,
     family: getFamily(entityOrSearchResult.type),
-    source: entityOrSearchResult.owner,
+    source,
     summary: entityOrSearchResult.summary,
     title: entityOrSearchResult.name,
     type: entityOrSearchResult.type,

--- a/packages/common/src/templates/view.ts
+++ b/packages/common/src/templates/view.ts
@@ -124,12 +124,17 @@ const getSharedTemplateCardModel = (
     },
   ];
 
+  let source: string = null;
+  if (entityOrSearchResult.source !== entityOrSearchResult.owner) {
+    source = entityOrSearchResult.source;
+  }
+
   return {
     access: entityOrSearchResult.access,
     badges: [],
     id: entityOrSearchResult.id,
     family: getFamily(entityOrSearchResult.type),
-    source: entityOrSearchResult.owner,
+    source,
     summary: entityOrSearchResult.summary,
     title: entityOrSearchResult.name,
     type: entityOrSearchResult.type,


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

DNM for PR Preview Only

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
