### PR TITLE
fix(hub-common): fix catalog filter query

### DIFF
--- a/packages/common/src/search/upgradeCatalogSchema.ts
+++ b/packages/common/src/search/upgradeCatalogSchema.ts
@@ -63,6 +63,7 @@ function applyCatalogSchema(original: any): IHubCatalog {
     const orgId = getProp(original, "orgId");
     if (orgId) {
       catalog.scopes.item.filters.push({
+        operation: "AND",
         predicates: [
           // Portal uses `orgid` instead of `orgId`, so we comply.
           // While `orgid` is valid field for search, it does not count

--- a/packages/common/test/search/upgradeCatalogSchema.test.ts
+++ b/packages/common/test/search/upgradeCatalogSchema.test.ts
@@ -46,6 +46,7 @@ describe("upgradeCatalogSchema", () => {
     expect(chk.title).toBe("Default Catalog");
     expect(chk.scopes).toBeDefined();
     expect(chk.scopes?.item?.filters.length).toBe(1);
+    expect(chk.scopes?.item?.filters[0].operation).toEqual("AND");
     expect(chk.scopes?.item?.filters[0].predicates[0].orgid).toEqual(["a3g"]);
     expect(chk.scopes?.item?.filters[0].predicates[1].type).toEqual({
       not: ["Code Attachment"],


### PR DESCRIPTION
1. Description: This PR fixes catalog query filter.

1. Instructions for testing:

1. Closes Issues: #[8262](https://devtopia.esri.com/dc/hub/issues/8262#)(if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
