### PR TITLE
feat(hub-common): sets discussion board isDiscussable true by default

### DIFF
--- a/packages/common/src/discussions/defaults.ts
+++ b/packages/common/src/discussions/defaults.ts
@@ -12,6 +12,7 @@ export const DEFAULT_DISCUSSION: Partial<IHubDiscussion> = {
   typeKeywords: ["Hub Discussion"],
   permissions: [],
   schemaVersion: 1,
+  isDiscussable: true,
 };
 
 /**


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 8285

1. Description: Sets discussion board isDiscussable true by default

1. Instructions for testing:

1. Closes Issues: #8285

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
