### PR TITLE
fix(): update check for metricDisplays to have default

### DIFF
--- a/packages/common/src/core/schemas/internal/metrics/setMetricAndDisplay.ts
+++ b/packages/common/src/core/schemas/internal/metrics/setMetricAndDisplay.ts
@@ -1,3 +1,4 @@
+import { getWithDefault } from "../../../../objects";
 import { cloneObject } from "../../../../util";
 import { IHubProject } from "../../../types/IHubProject";
 import { IMetric, IMetricDisplayConfig } from "../../../types/Metrics";
@@ -20,20 +21,29 @@ export function setMetricAndDisplay(
   const entityCopy = cloneObject(entity);
   const metricId = metric.id;
   const mIndex = entityCopy.metrics.findIndex((m) => m.id === metricId);
-  const dIndex = entityCopy.view.metricDisplays.findIndex(
-    (d) => d.metricId === metricId
+
+  // get array in case of undefined
+  const displays = getWithDefault(entityCopy, "view.metricDisplays", []);
+  const dIndex = displays.findIndex(
+    (d: IMetricDisplayConfig) => d.metricId === metricId
   );
 
-  // existing metric and display
-  if (mIndex > -1 && dIndex > -1) {
+  // existing vs new metric
+  if (mIndex > -1) {
     entityCopy.metrics[mIndex] = metric;
-    entityCopy.view.metricDisplays[dIndex] = displayConfig;
-  }
-  // new metric and display
-  else {
+  } else {
     entityCopy.metrics.push(metric);
-    entityCopy.view.metricDisplays.push(displayConfig);
   }
+
+  // existing vs new display
+  if (dIndex > -1) {
+    displays[dIndex] = displayConfig;
+  } else {
+    displays.push(displayConfig);
+  }
+
+  // reset the displays array
+  entityCopy.view.metricDisplays = displays;
 
   return entityCopy;
 }

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -34,11 +34,12 @@ import { camelize, cloneObject, createId } from "../util";
 import { createProject, editorToProject, updateProject } from "./edit";
 import { ProjectEditorType } from "./_internal/ProjectSchema";
 import { enrichEntity } from "../core/enrichEntity";
-import { getProp } from "../objects";
+import { getProp, getWithDefault } from "../objects";
 import { IGroup } from "@esri/arcgis-rest-types";
 import { metricToEditor } from "../core/schemas/internal/metrics/metricToEditor";
 import { editorToMetric } from "../core/schemas/internal/metrics/editorToMetric";
 import { setMetricAndDisplay } from "../core/schemas/internal/metrics/setMetricAndDisplay";
+import { IMetricDisplayConfig } from "../core/types/Metrics";
 
 /**
  * Hub Project Class
@@ -234,9 +235,12 @@ export class HubProject
     // handle metrics
     const metrics = getEntityMetrics(this.entity);
     const metric = metrics.find((m) => m.id === editorContext.metricId);
-    const displayConfig = this.entity.view.metricDisplays.find(
-      (display) => display.metricId === editorContext.metricId
-    );
+    const displays = getWithDefault(this.entity, "view.metricDisplays", []);
+    const displayConfig =
+      displays.find(
+        (display: IMetricDisplayConfig) =>
+          display.metricId === editorContext.metricId
+      ) || {};
     editor._metric = metricToEditor(metric, displayConfig);
 
     return editor;

--- a/packages/common/test/projects/HubProject.test.ts
+++ b/packages/common/test/projects/HubProject.test.ts
@@ -826,6 +826,65 @@ describe("HubProject Class:", () => {
           },
         ]);
       });
+      it("handles setting metrics when metricDisplays is undefined", async () => {
+        const chk = HubProject.fromJson(
+          {
+            id: "bc3",
+            name: "Test Entity",
+            metrics: [
+              {
+                id: "metric1",
+                source: {
+                  type: "static-value",
+                  value: "123",
+                },
+              },
+            ],
+            view: {},
+          },
+          authdCtxMgr.context
+        );
+
+        const editor = await chk.toEditor();
+        editor._metric = {
+          trailingText: "...",
+          type: "static",
+          value: "123",
+          cardTitle: "metric1",
+          metricId: "metric1",
+          displayType: "stat-card",
+        };
+        const result = await chk.fromEditor(editor, { metricId: "metric1" });
+        expect(getProp(result, "metrics")).toEqual([
+          {
+            id: "metric1",
+            source: {
+              type: "static-value",
+              value: "123",
+            },
+            name: "metric1",
+            entityInfo: {
+              id: undefined,
+              name: undefined,
+              type: undefined,
+            },
+          },
+        ]);
+        expect(getProp(result, "view.metricDisplays")).toEqual([
+          {
+            cardTitle: "metric1",
+            trailingText: "...",
+            fieldType: undefined,
+            statistic: undefined,
+            sourceLink: undefined,
+            sourceTitle: undefined,
+            allowLink: undefined,
+            type: "static",
+            displayType: "stat-card",
+            metricId: "metric1",
+          },
+        ]);
+      });
     });
   });
 });


### PR DESCRIPTION
1. Description:
Fixes an issue where if metricDisplays was undefined, the operation would not complete correctly. 

1. Instructions for testing:
Fixes hub-components failed test from entit-editor in testing suite with preview version: 
![Screenshot 2023-10-31 at 6 05 32 PM](https://github.com/Esri/hub.js/assets/64275596/6de5e81f-ce07-4e20-8323-aa28c3fbb1d8)


1. Closes Issues: No issue -- discovered as a blocker to hub-components. 

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
