### PR TITLE
feat(hub-common): add filter in site catalog to ignore Code Attachments in search results

### DIFF
--- a/packages/common/src/search/upgradeCatalogSchema.ts
+++ b/packages/common/src/search/upgradeCatalogSchema.ts
@@ -63,19 +63,22 @@ function applyCatalogSchema(original: any): IHubCatalog {
     const orgId = getProp(original, "orgId");
     if (orgId) {
       catalog.scopes.item.filters.push({
-        operation: "AND",
         predicates: [
           // Portal uses `orgid` instead of `orgId`, so we comply.
           // While `orgid` is valid field for search, it does not count
           // towards Portal's requirement of needing at least one filter.
           { orgid: [orgId] },
-          // Hack to force Portal to think that at least one filter has
-          // been provided. 'Code Attachment' is an old AGO type that has
-          // been defunct for some time, so the results won't be affected.
-          { type: { not: ["Code Attachment"] } },
         ],
       });
     }
+
+    // 'Code Attachment' is an old AGO type that has
+    // been defunct for some time, so add this predicate
+    // to all catalog filter to omit 'Code Attachment' items
+    // from search results
+    catalog.scopes.item.filters.push({
+      predicates: [{ type: { not: ["Code Attachment"] } }],
+    });
 
     return catalog;
   }

--- a/packages/common/test/search/fetchCatalog.test.ts
+++ b/packages/common/test/search/fetchCatalog.test.ts
@@ -37,7 +37,7 @@ describe("fetchCatalog:", () => {
     // verify response
     expect(chk.schemaVersion).toBe(1);
     expect(chk.scopes?.item).toBeDefined();
-    expect(chk.scopes?.item?.filters.length).toBe(1);
+    expect(chk.scopes?.item?.filters.length).toBe(2);
     // verify calls
     expect(lookupDomainSpy.calls.count()).toBe(1);
     const [url, hroParam] = lookupDomainSpy.calls.argsFor(0);
@@ -71,7 +71,7 @@ describe("fetchCatalog:", () => {
     // verify response
     expect(chk.schemaVersion).toBe(1);
     expect(chk.scopes?.item).toBeDefined();
-    expect(chk.scopes?.item?.filters.length).toBe(0);
+    expect(chk.scopes?.item?.filters.length).toBe(1);
     // verify calls
     expect(lookupDomainSpy.calls.count()).toBe(1);
     const [url, hroParam] = lookupDomainSpy.calls.argsFor(0);
@@ -96,7 +96,7 @@ describe("fetchCatalog:", () => {
     // verify response
     expect(chk.schemaVersion).toBe(1);
     expect(chk.scopes?.item).toBeDefined();
-    expect(chk.scopes?.item?.filters.length).toBe(1);
+    expect(chk.scopes?.item?.filters.length).toBe(2);
     // verify calls
     expect(getItemDataSpy.calls.count()).toBe(1);
     const [id, opts] = getItemDataSpy.calls.argsFor(0);
@@ -116,7 +116,7 @@ describe("fetchCatalog:", () => {
     // verify response
     expect(chk.schemaVersion).toBe(1);
     expect(chk.scopes?.item).toBeDefined();
-    expect(chk.scopes?.item?.filters.length).toBe(0);
+    expect(chk.scopes?.item?.filters.length).toBe(1);
     // verify calls
     expect(getItemDataSpy.calls.count()).toBe(1);
     const [id, opts] = getItemDataSpy.calls.argsFor(0);

--- a/packages/common/test/search/upgradeCatalogSchema.test.ts
+++ b/packages/common/test/search/upgradeCatalogSchema.test.ts
@@ -5,50 +5,64 @@ describe("upgradeCatalogSchema", () => {
     const chk = upgradeCatalogSchema(null);
     expect(chk.title).toBe("Default Catalog");
     expect(chk.scopes).toBeDefined();
-    expect(chk.scopes?.item?.filters.length).toBe(0);
+    expect(chk.scopes?.item?.filters.length).toBe(1);
+    expect(chk.scopes?.item?.filters[0].predicates[0].type).toEqual({
+      not: ["Code Attachment"],
+    });
   });
 
   it("returns default catalog if passed empty object", () => {
     const chk = upgradeCatalogSchema({});
     expect(chk.title).toBe("Default Catalog");
     expect(chk.scopes).toBeDefined();
-    expect(chk.scopes?.item?.filters.length).toBe(0);
+    expect(chk.scopes?.item?.filters.length).toBe(1);
+    expect(chk.scopes?.item?.filters[0].predicates[0].type).toEqual({
+      not: ["Code Attachment"],
+    });
   });
 
   it("does not return groups if passed empty array", () => {
     const chk = upgradeCatalogSchema({ groups: [] });
     expect(chk.title).toBe("Default Catalog");
     expect(chk.scopes).toBeDefined();
-    expect(chk.scopes?.item?.filters.length).toBe(0);
+    expect(chk.scopes?.item?.filters.length).toBe(1);
+    expect(chk.scopes?.item?.filters[0].predicates[0].type).toEqual({
+      not: ["Code Attachment"],
+    });
   });
 
   it("returns groups if passed a string", () => {
     const chk = upgradeCatalogSchema({ groups: "3ef" });
     expect(chk.title).toBe("Default Catalog");
     expect(chk.scopes).toBeDefined();
-    expect(chk.scopes?.item?.filters.length).toBe(1);
+    expect(chk.scopes?.item?.filters.length).toBe(2);
     expect(chk.scopes?.item?.filters[0].predicates[0].group).toEqual(["3ef"]);
+    expect(chk.scopes?.item?.filters[1].predicates[0].type).toEqual({
+      not: ["Code Attachment"],
+    });
   });
 
   it("returns groups if passed an array", () => {
     const chk = upgradeCatalogSchema({ groups: ["3ef", "bc4"] });
     expect(chk.title).toBe("Default Catalog");
     expect(chk.scopes).toBeDefined();
-    expect(chk.scopes?.item?.filters.length).toBe(1);
+    expect(chk.scopes?.item?.filters.length).toBe(2);
     expect(chk.scopes?.item?.filters[0].predicates[0].group).toEqual([
       "3ef",
       "bc4",
     ]);
+    expect(chk.scopes?.item?.filters[1].predicates[0].type).toEqual({
+      not: ["Code Attachment"],
+    });
   });
 
   it("handles org-level home site legacy catalogs", () => {
     const chk = upgradeCatalogSchema({ orgId: "a3g" });
     expect(chk.title).toBe("Default Catalog");
     expect(chk.scopes).toBeDefined();
-    expect(chk.scopes?.item?.filters.length).toBe(1);
-    expect(chk.scopes?.item?.filters[0].operation).toEqual("AND");
+    expect(chk.scopes?.item?.filters.length).toBe(2);
     expect(chk.scopes?.item?.filters[0].predicates[0].orgid).toEqual(["a3g"]);
-    expect(chk.scopes?.item?.filters[0].predicates[1].type).toEqual({
+    expect(chk.scopes?.item?.filters[1].predicates[0].type).toEqual({
       not: ["Code Attachment"],
     });
   });


### PR DESCRIPTION

1. Description: This PR adds a default filter in site's catalog to not include 'Code Attachment' item types in search results as those items are not needed in results. 

1. Instructions for testing:

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/8144

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
