### PR TITLE
tech(): refactor buildUiSchema Utils to not take EntityEditorOptions

### DIFF
--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -85,7 +85,11 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(i18nScope, options),
+          getThumbnailUiSchemaElement(
+            i18nScope,
+            options.thumbnail,
+            options.thumbnailUrl
+          ),
           // tags
           {
             labelKey: `${i18nScope}.fields.tags.label`,

--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -157,7 +157,9 @@ export const buildUiSchema = async (
                 context.hubRequestOptions
               ),
               options: await getLocationOptions(
-                options,
+                options.id,
+                options.type,
+                options.location,
                 context.portal.name,
                 context.hubRequestOptions
               ),

--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -94,7 +94,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-combobox",
               items: await getTagItems(
-                options,
+                options.tags,
                 context.portal.id,
                 context.hubRequestOptions
               ),
@@ -153,7 +153,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-location-picker",
               extent: await getLocationExtent(
-                options,
+                options.location,
                 context.hubRequestOptions
               ),
               options: await getLocationOptions(

--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -5,7 +5,7 @@ import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { IUiSchema } from "../../core/schemas/types";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
-import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
+import { IHubEditableContent } from "../../core/types";
 
 /**
  * @private
@@ -15,7 +15,7 @@ import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
  */
 export const buildUiSchema = async (
   i18nScope: string,
-  options: EntityEditorOptions,
+  options: Partial<IHubEditableContent>,
   context: IArcGISContext
 ): Promise<IUiSchema> => {
   return {

--- a/packages/common/src/core/schemas/internal/EditorOptions.ts
+++ b/packages/common/src/core/schemas/internal/EditorOptions.ts
@@ -10,7 +10,7 @@ export type EditorOptions = EntityEditorOptions | CardEditorOptions;
  *
  * However, it must always have "type" on the options, even if not the entire entity.
  */
-export type EntityEditorOptions = Partial<HubEntity>;
+export type EntityEditorOptions = HubEntity;
 
 /**
  * Options to use when constructing a schema and uiSchema for

--- a/packages/common/src/core/schemas/internal/EditorOptions.ts
+++ b/packages/common/src/core/schemas/internal/EditorOptions.ts
@@ -10,7 +10,7 @@ export type EditorOptions = EntityEditorOptions | CardEditorOptions;
  *
  * However, it must always have "type" on the options, even if not the entire entity.
  */
-export type EntityEditorOptions = HubEntity & Record<string, any>;
+export type EntityEditorOptions = HubEntity;
 
 /**
  * Options to use when constructing a schema and uiSchema for

--- a/packages/common/src/core/schemas/internal/EditorOptions.ts
+++ b/packages/common/src/core/schemas/internal/EditorOptions.ts
@@ -10,7 +10,7 @@ export type EditorOptions = EntityEditorOptions | CardEditorOptions;
  *
  * However, it must always have "type" on the options, even if not the entire entity.
  */
-export type EntityEditorOptions = HubEntity;
+export type EntityEditorOptions = Partial<HubEntity>;
 
 /**
  * Options to use when constructing a schema and uiSchema for

--- a/packages/common/src/core/schemas/internal/getAuthedImageUrl.ts
+++ b/packages/common/src/core/schemas/internal/getAuthedImageUrl.ts
@@ -1,17 +1,10 @@
-import { IWithViewSettings } from "../../../core/traits/IWithViewSettings";
 import { IArcGISContext } from "../../../ArcGISContext";
 import { cacheBustUrl } from "../../../urls/cacheBustUrl";
 
-export function getFeaturedImageUrl(
-  view: IWithViewSettings,
-  context: IArcGISContext
-) {
+export function getAuthedImageUrl(url: string, context: IArcGISContext) {
   const queryParams = context.isAuthenticated
     ? `?token=${context.session.token}`
     : "";
   // TODO: Decide if the url should be passed in or plucked out of this deep path here
-  return (
-    view?.featuredImageUrl &&
-    cacheBustUrl(`${view.featuredImageUrl}${queryParams}`)
-  );
+  return url && cacheBustUrl(`${url}${queryParams}`);
 }

--- a/packages/common/src/core/schemas/internal/getFeaturedImageUrl.ts
+++ b/packages/common/src/core/schemas/internal/getFeaturedImageUrl.ts
@@ -1,9 +1,9 @@
+import { IWithViewSettings } from "../../../core/traits/IWithViewSettings";
 import { IArcGISContext } from "../../../ArcGISContext";
 import { cacheBustUrl } from "../../../urls/cacheBustUrl";
-import { EntityEditorOptions } from "./EditorOptions";
 
 export function getFeaturedImageUrl(
-  options: EntityEditorOptions,
+  view: IWithViewSettings,
   context: IArcGISContext
 ) {
   const queryParams = context.isAuthenticated
@@ -11,7 +11,7 @@ export function getFeaturedImageUrl(
     : "";
   // TODO: Decide if the url should be passed in or plucked out of this deep path here
   return (
-    options.view?.featuredImageUrl &&
-    cacheBustUrl(`${options.view.featuredImageUrl}${queryParams}`)
+    view?.featuredImageUrl &&
+    cacheBustUrl(`${view.featuredImageUrl}${queryParams}`)
   );
 }

--- a/packages/common/src/core/schemas/internal/getLocationExtent.ts
+++ b/packages/common/src/core/schemas/internal/getLocationExtent.ts
@@ -1,15 +1,16 @@
 import { bBoxToExtent, orgExtent } from "../../../extent";
 import { IHubRequestOptions } from "../../../types";
-import { EntityEditorOptions } from "./EditorOptions";
+import { IHubLocation } from "../../types";
+
 /**
  * Get the extent from the entity's location, if it has one.
  * Otherwise, fall back to using the org extent.
  */
 export async function getLocationExtent(
-  options: EntityEditorOptions,
+  location: IHubLocation,
   hubRequestOptions: IHubRequestOptions
 ) {
-  return options.location?.extent?.length
-    ? bBoxToExtent(options.location.extent)
+  return location?.extent?.length
+    ? bBoxToExtent(location.extent)
     : await orgExtent(hubRequestOptions);
 }

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -1,7 +1,6 @@
 import { extentToBBox, orgExtent as orgExtent } from "../../../extent";
 import { IHubRequestOptions } from "../../../types";
 import { getTypeFromEntity } from "../../getTypeFromEntity";
-import { EntityEditorOptions } from "./EditorOptions";
 import { IHubLocation, IHubLocationOption } from "../../types/IHubLocation";
 import { IExtent } from "@esri/arcgis-rest-types";
 
@@ -18,12 +17,13 @@ import { IExtent } from "@esri/arcgis-rest-types";
  * location
  */
 export async function getLocationOptions(
-  options: EntityEditorOptions,
+  id: string,
+  type: string,
+  location: IHubLocation,
   portalName: string,
   hubRequestOptions: IHubRequestOptions
 ): Promise<IHubLocationOption[]> {
   const defaultExtent: IExtent = await orgExtent(hubRequestOptions);
-  const location: IHubLocation = options.location;
 
   // Base options
   const optionsArray = [
@@ -43,7 +43,7 @@ export async function getLocationOptions(
     {
       label: "{{shared.fields.location.custom:translate}}",
       description: "{{shared.fields.location.customDescription:translate}}",
-      entityType: getTypeFromEntity(options),
+      entityType: getTypeFromEntity({ type }),
       location: {
         type: "custom",
         spatialReference: defaultExtent.spatialReference,
@@ -60,9 +60,9 @@ export async function getLocationOptions(
 
   return optionsArray.map((option) => {
     // If this is a new entity, select the custom option by default
-    if (!options.id && option.location.type === "custom") {
+    if (!id && option.location.type === "custom") {
       option.selected = true;
-    } else if (options.id && !location && option.location.type === "none") {
+    } else if (id && !location && option.location.type === "none") {
       option.selected = true;
     } else if (location?.type === option.location.type) {
       option.location = location;

--- a/packages/common/src/core/schemas/internal/getTagItems.ts
+++ b/packages/common/src/core/schemas/internal/getTagItems.ts
@@ -15,7 +15,7 @@ import { EntityEditorOptions } from "./EditorOptions";
  * be hoisted to hub.js
  */
 export async function getTagItems(
-  options: EntityEditorOptions,
+  tags: string[],
   orgId: string,
   hubRequestOptions: IHubRequestOptions
 ): Promise<IUiSchemaComboboxItem[]> {
@@ -60,7 +60,7 @@ export async function getTagItems(
      * and the tags fetched from the orgs, then remove duplicates, filter out
      * any empty values and convert them to the IUiSchemaComboboxItem format
      */
-    const entityTags = options.tags || [];
+    const entityTags = tags || [];
     return [...new Set([...tagsAgg.values.map((t) => t.value), ...entityTags])]
       .filter((t) => t)
       .map((t) => ({ value: t }));

--- a/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
@@ -3,7 +3,6 @@ import {
   IUiSchemaMessage,
   UiSchemaMessageTypes,
 } from "../types";
-import { EntityEditorOptions } from "./EditorOptions";
 
 /**
  * Returns the UI schema element needed to render
@@ -15,14 +14,12 @@ import { EntityEditorOptions } from "./EditorOptions";
  */
 export function getThumbnailUiSchemaElement(
   i18nScope: string,
-  options: EntityEditorOptions
+  thumbnail: string,
+  thumbnailUrl: string
 ): IUiSchemaElement {
   const messages: IUiSchemaMessage[] = [];
   // Advise the user if the entity's thumbnail is either of the default values
-  if (
-    !options.thumbnail ||
-    options.thumbnail === "thumbnail/ago_downloaded.png"
-  ) {
+  if (!thumbnail || thumbnail === "thumbnail/ago_downloaded.png") {
     messages.push({
       type: UiSchemaMessageTypes.custom,
       display: "notice",
@@ -38,7 +35,7 @@ export function getThumbnailUiSchemaElement(
     type: "Control",
     options: {
       control: "hub-field-input-image-picker",
-      imgSrc: options.thumbnailUrl,
+      imgSrc: thumbnailUrl,
       maxWidth: 727,
       maxHeight: 484,
       aspectRatio: 1.5,

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -98,7 +98,11 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(i18nScope, options),
+          getThumbnailUiSchemaElement(
+            i18nScope,
+            options.thumbnail,
+            options.thumbnailUrl
+          ),
           {
             labelKey: `${i18nScope}.fields.featuredImage.label`,
             scope: "/properties/view/properties/featuredImage",

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -136,7 +136,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-combobox",
               items: await getTagItems(
-                options,
+                options.tags,
                 context.portal.id,
                 context.hubRequestOptions
               ),
@@ -172,7 +172,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-location-picker",
               extent: await getLocationExtent(
-                options,
+                options.location,
                 context.hubRequestOptions
               ),
               options: await getLocationOptions(

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -105,7 +105,7 @@ export const buildUiSchema = async (
             type: "Control",
             options: {
               control: "hub-field-input-image-picker",
-              imgSrc: getFeaturedImageUrl(options, context),
+              imgSrc: getFeaturedImageUrl(options.view, context),
               maxWidth: 727,
               maxHeight: 484,
               aspectRatio: 1.5,

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -6,7 +6,7 @@ import { getCategoryItems } from "../../core/schemas/internal/getCategoryItems";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
-import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
+import { IHubDiscussion } from "../../core/types";
 
 /**
  * @private
@@ -16,7 +16,7 @@ import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
  */
 export const buildUiSchema = async (
   i18nScope: string,
-  options: EntityEditorOptions,
+  options: Partial<IHubDiscussion>,
   context: IArcGISContext
 ): Promise<IUiSchema> => {
   return {

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -1,6 +1,6 @@
 import { IUiSchema } from "../../core/schemas/types";
 import { IArcGISContext } from "../../ArcGISContext";
-import { getFeaturedImageUrl } from "../../core/schemas/internal/getFeaturedImageUrl";
+import { getAuthedImageUrl } from "../../core/schemas/internal/getAuthedImageUrl";
 import { getTagItems } from "../../core/schemas/internal/getTagItems";
 import { getCategoryItems } from "../../core/schemas/internal/getCategoryItems";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
@@ -109,7 +109,10 @@ export const buildUiSchema = async (
             type: "Control",
             options: {
               control: "hub-field-input-image-picker",
-              imgSrc: getFeaturedImageUrl(options.view, context),
+              imgSrc: getAuthedImageUrl(
+                options.view?.featuredImageUrl,
+                context
+              ),
               maxWidth: 727,
               maxHeight: 484,
               aspectRatio: 1.5,

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -176,7 +176,9 @@ export const buildUiSchema = async (
                 context.hubRequestOptions
               ),
               options: await getLocationOptions(
-                options,
+                options.id,
+                options.type,
+                options.location,
                 context.portal.name,
                 context.hubRequestOptions
               ),

--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
@@ -104,7 +104,11 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(i18nScope, options),
+          getThumbnailUiSchemaElement(
+            i18nScope,
+            options.thumbnail,
+            options.thumbnailUrl
+          ),
         ],
       },
       {

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
@@ -111,7 +111,9 @@ export const buildUiSchema = async (
                         context.hubRequestOptions
                       ),
                       options: await getLocationOptions(
-                        options,
+                        options.id,
+                        options.type,
+                        options.location,
                         context.portal.name,
                         context.hubRequestOptions
                       ),

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
@@ -107,7 +107,7 @@ export const buildUiSchema = async (
                     options: {
                       control: "hub-field-input-location-picker",
                       extent: await getLocationExtent(
-                        options,
+                        options.location,
                         context.hubRequestOptions
                       ),
                       options: await getLocationOptions(

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
@@ -4,7 +4,7 @@ import { IUiSchema, UiSchemaRuleEffects } from "../../core/schemas/types";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { getSharableGroupsComboBoxItems } from "../../core/schemas/internal/getSharableGroupsComboBoxItems";
-import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
+import { IHubInitiative } from "../../core/types";
 
 /**
  * @private
@@ -17,7 +17,7 @@ import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
  */
 export const buildUiSchema = async (
   i18nScope: string,
-  options: EntityEditorOptions,
+  options: Partial<IHubInitiative>,
   context: IArcGISContext
 ): Promise<IUiSchema> => {
   return {

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -80,7 +80,11 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(i18nScope, options),
+          getThumbnailUiSchemaElement(
+            i18nScope,
+            options.thumbnail,
+            options.thumbnailUrl
+          ),
           {
             labelKey: `${i18nScope}.fields.tags.label`,
             scope: "/properties/tags",

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -88,7 +88,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-combobox",
               items: await getTagItems(
-                options,
+                options.tags,
                 context.portal.id,
                 context.hubRequestOptions
               ),
@@ -133,7 +133,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-location-picker",
               extent: await getLocationExtent(
-                options,
+                options.location,
                 context.hubRequestOptions
               ),
               options: await getLocationOptions(

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -137,7 +137,9 @@ export const buildUiSchema = async (
                 context.hubRequestOptions
               ),
               options: await getLocationOptions(
-                options,
+                options.id,
+                options.type,
+                options.location,
                 context.portal.name,
                 context.hubRequestOptions
               ),

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -6,7 +6,7 @@ import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { getFeaturedContentCatalogs } from "../../core/schemas/internal/getFeaturedContentCatalogs";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
-import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
+import { IHubInitiative } from "../../core";
 
 /**
  * @private
@@ -16,7 +16,7 @@ import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
  */
 export const buildUiSchema = async (
   i18nScope: string,
-  options: EntityEditorOptions,
+  options: Partial<IHubInitiative>,
   context: IArcGISContext
 ): Promise<IUiSchema> => {
   return {

--- a/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
+++ b/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
@@ -136,7 +136,9 @@ export const buildUiSchema = async (
                 context.hubRequestOptions
               ),
               options: await getLocationOptions(
-                options,
+                options.id,
+                options.type,
+                options.location,
                 context.portal.name,
                 context.hubRequestOptions
               ),

--- a/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
+++ b/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
@@ -5,7 +5,7 @@ import { getCategoryItems } from "../../core/schemas/internal/getCategoryItems";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
-import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
+import { IHubPage } from "../../core/types";
 
 /**
  * @private
@@ -15,7 +15,7 @@ import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
  */
 export const buildUiSchema = async (
   i18nScope: string,
-  options: EntityEditorOptions,
+  options: Partial<IHubPage>,
   context: IArcGISContext
 ): Promise<IUiSchema> => {
   return {

--- a/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
+++ b/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
@@ -87,7 +87,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-combobox",
               items: await getTagItems(
-                options,
+                options.tags,
                 context.portal.id,
                 context.hubRequestOptions
               ),
@@ -132,7 +132,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-location-picker",
               extent: await getLocationExtent(
-                options,
+                options.location,
                 context.hubRequestOptions
               ),
               options: await getLocationOptions(

--- a/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
+++ b/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
@@ -79,7 +79,11 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(i18nScope, options),
+          getThumbnailUiSchemaElement(
+            i18nScope,
+            options.thumbnail,
+            options.thumbnailUrl
+          ),
           {
             labelKey: `${i18nScope}.fields.tags.label`,
             scope: "/properties/tags",

--- a/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
@@ -115,7 +115,7 @@ export const buildUiSchema = async (
                     options: {
                       control: "hub-field-input-location-picker",
                       extent: await getLocationExtent(
-                        options,
+                        options.location,
                         context.hubRequestOptions
                       ),
                       options: await getLocationOptions(

--- a/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
@@ -4,7 +4,7 @@ import { IUiSchema, UiSchemaRuleEffects } from "../../core/schemas/types";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { getSharableGroupsComboBoxItems } from "../../core/schemas/internal/getSharableGroupsComboBoxItems";
-import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
+import { IHubProject } from "../../core/types";
 
 /**
  * @private
@@ -14,7 +14,7 @@ import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
  */
 export const buildUiSchema = async (
   i18nScope: string,
-  options: EntityEditorOptions,
+  options: Partial<IHubProject>,
   context: IArcGISContext
 ): Promise<IUiSchema> => {
   return {

--- a/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
@@ -119,7 +119,9 @@ export const buildUiSchema = async (
                         context.hubRequestOptions
                       ),
                       options: await getLocationOptions(
-                        options,
+                        options.id,
+                        options.type,
+                        options.location,
                         context.portal.name,
                         context.hubRequestOptions
                       ),

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -179,7 +179,11 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(i18nScope, options),
+          getThumbnailUiSchemaElement(
+            i18nScope,
+            options.thumbnail,
+            options.thumbnailUrl
+          ),
         ],
       },
       {

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -130,7 +130,9 @@ export const buildUiSchema = async (
                 context.hubRequestOptions
               ),
               options: await getLocationOptions(
-                options,
+                options.id,
+                options.type,
+                options.location,
                 context.portal.name,
                 context.hubRequestOptions
               ),

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -87,7 +87,7 @@ export const buildUiSchema = async (
             type: "Control",
             options: {
               control: "hub-field-input-image-picker",
-              imgSrc: getFeaturedImageUrl(options, context),
+              imgSrc: getFeaturedImageUrl(options.view, context),
               maxWidth: 727,
               maxHeight: 484,
               aspectRatio: 1.5,

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -126,7 +126,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-location-picker",
               extent: await getLocationExtent(
-                options,
+                options.location,
                 context.hubRequestOptions
               ),
               options: await getLocationOptions(
@@ -151,7 +151,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-combobox",
               items: await getTagItems(
-                options,
+                options.tags,
                 context.portal.id,
                 context.hubRequestOptions
               ),

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -2,7 +2,7 @@ import { IArcGISContext } from "../../ArcGISContext";
 import { IUiSchema } from "../../core/schemas/types";
 import { getCategoryItems } from "../../core/schemas/internal/getCategoryItems";
 import { getFeaturedContentCatalogs } from "../../core/schemas/internal/getFeaturedContentCatalogs";
-import { getFeaturedImageUrl } from "../../core/schemas/internal/getFeaturedImageUrl";
+import { getAuthedImageUrl } from "../../core/schemas/internal/getAuthedImageUrl";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { getTagItems } from "../../core/schemas/internal/getTagItems";
@@ -87,7 +87,10 @@ export const buildUiSchema = async (
             type: "Control",
             options: {
               control: "hub-field-input-image-picker",
-              imgSrc: getFeaturedImageUrl(options.view, context),
+              imgSrc: getAuthedImageUrl(
+                options.view?.featuredImageUrl,
+                context
+              ),
               maxWidth: 727,
               maxHeight: 484,
               aspectRatio: 1.5,

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -7,7 +7,7 @@ import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { getTagItems } from "../../core/schemas/internal/getTagItems";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
-import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
+import { IHubProject } from "../../core/types";
 
 /**
  * @private
@@ -17,7 +17,7 @@ import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
  */
 export const buildUiSchema = async (
   i18nScope: string,
-  options: EntityEditorOptions,
+  options: Partial<IHubProject>,
   context: IArcGISContext
 ): Promise<IUiSchema> => {
   return {

--- a/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
@@ -111,7 +111,9 @@ export const buildUiSchema = async (
                         context.hubRequestOptions
                       ),
                       options: await getLocationOptions(
-                        options,
+                        options.id,
+                        options.type,
+                        options.location,
                         context.portal.name,
                         context.hubRequestOptions
                       ),

--- a/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
@@ -107,7 +107,7 @@ export const buildUiSchema = async (
                     options: {
                       control: "hub-field-input-location-picker",
                       extent: await getLocationExtent(
-                        options,
+                        options.location,
                         context.hubRequestOptions
                       ),
                       options: await getLocationOptions(

--- a/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
@@ -4,7 +4,7 @@ import { IUiSchema, UiSchemaRuleEffects } from "../../core/schemas/types";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { getSharableGroupsComboBoxItems } from "../../core/schemas/internal/getSharableGroupsComboBoxItems";
-import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
+import { IHubSite } from "../../core/types";
 
 /**
  * @private
@@ -17,7 +17,7 @@ import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
  */
 export const buildUiSchema = async (
   i18nScope: string,
-  options: EntityEditorOptions,
+  options: Partial<IHubSite>,
   context: IArcGISContext
 ): Promise<IUiSchema> => {
   return {

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -136,7 +136,9 @@ export const buildUiSchema = async (
                 context.hubRequestOptions
               ),
               options: await getLocationOptions(
-                options,
+                options.id,
+                options.type,
+                options.location,
                 context.portal.name,
                 context.hubRequestOptions
               ),

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -5,7 +5,7 @@ import { getLocationOptions } from "../../core/schemas/internal/getLocationOptio
 import { getTagItems } from "../../core/schemas/internal/getTagItems";
 import { IUiSchema } from "../../core/schemas/types";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
-import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
+import { IHubSite } from "../../core/types";
 
 /**
  * @private
@@ -15,7 +15,7 @@ import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
  */
 export const buildUiSchema = async (
   i18nScope: string,
-  options: EntityEditorOptions,
+  options: Partial<IHubSite>,
   context: IArcGISContext
 ): Promise<IUiSchema> => {
   return {

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -87,7 +87,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-combobox",
               items: await getTagItems(
-                options,
+                options.tags,
                 context.portal.id,
                 context.hubRequestOptions
               ),
@@ -132,7 +132,7 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-location-picker",
               extent: await getLocationExtent(
-                options,
+                options.location,
                 context.hubRequestOptions
               ),
               options: await getLocationOptions(

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -79,7 +79,11 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(i18nScope, options),
+          getThumbnailUiSchemaElement(
+            i18nScope,
+            options.thumbnail,
+            options.thumbnailUrl
+          ),
           {
             labelKey: `${i18nScope}.fields.tags.label`,
             scope: "/properties/tags",

--- a/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
+++ b/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
@@ -103,7 +103,11 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(i18nScope, options),
+          getThumbnailUiSchemaElement(
+            i18nScope,
+            options.thumbnail,
+            options.thumbnailUrl
+          ),
         ],
       },
     ],

--- a/packages/common/test/core/schemas/internal/getAuthedImageUrl.test.ts
+++ b/packages/common/test/core/schemas/internal/getAuthedImageUrl.test.ts
@@ -4,11 +4,10 @@ import {
   IArcGISContext,
   IHubProject,
 } from "../../../../src";
-import { IWithViewSettings } from "../../../../src/core/traits/IWithViewSettings";
 import { MOCK_AUTH } from "../../../mocks/mock-auth";
-import { getFeaturedImageUrl } from "../../../../src/core/schemas/internal/getFeaturedImageUrl";
+import { getAuthedImageUrl } from "../../../../src/core/schemas/internal/getAuthedImageUrl";
 
-describe("getFeaturedImageUrl:", () => {
+describe("getAuthedImageUrl:", () => {
   let authdCtxMgr: ArcGISContextManager;
   beforeEach(async () => {
     // When we pass in all this information, the context
@@ -40,8 +39,8 @@ describe("getFeaturedImageUrl:", () => {
       },
     } as unknown as IHubProject;
 
-    const url = getFeaturedImageUrl(
-      entity.view as IWithViewSettings,
+    const url = getAuthedImageUrl(
+      entity.view?.featuredImageUrl as string,
       authdCtxMgr.context
     );
     expect(url?.includes("token=fake-token")).toBeTruthy();
@@ -55,8 +54,8 @@ describe("getFeaturedImageUrl:", () => {
       },
     } as unknown as IHubProject;
 
-    const url = getFeaturedImageUrl(
-      entity.view as IWithViewSettings,
+    const url = getAuthedImageUrl(
+      entity.view?.featuredImageUrl as string,
       {
         isAuthenticated: false,
       } as unknown as IArcGISContext
@@ -66,8 +65,8 @@ describe("getFeaturedImageUrl:", () => {
   });
   it("returns undefined if a featured image url is not defined on the entity", () => {
     const entity = {} as IHubProject;
-    const url = getFeaturedImageUrl(
-      entity.view as IWithViewSettings,
+    const url = getAuthedImageUrl(
+      entity.view?.featuredImageUrl as string,
       {
         isAuthenticated: false,
       } as IArcGISContext

--- a/packages/common/test/core/schemas/internal/getFeaturedImageUrl.test.ts
+++ b/packages/common/test/core/schemas/internal/getFeaturedImageUrl.test.ts
@@ -4,6 +4,7 @@ import {
   IArcGISContext,
   IHubProject,
 } from "../../../../src";
+import { IWithViewSettings } from "../../../../src/core/traits/IWithViewSettings";
 import { MOCK_AUTH } from "../../../mocks/mock-auth";
 import { getFeaturedImageUrl } from "../../../../src/core/schemas/internal/getFeaturedImageUrl";
 
@@ -39,9 +40,12 @@ describe("getFeaturedImageUrl:", () => {
       },
     } as unknown as IHubProject;
 
-    const url = getFeaturedImageUrl(entity, authdCtxMgr.context);
-    expect(url.includes("token=fake-token")).toBeTruthy();
-    expect(url.includes("v=")).toBeTruthy();
+    const url = getFeaturedImageUrl(
+      entity.view as IWithViewSettings,
+      authdCtxMgr.context
+    );
+    expect(url?.includes("token=fake-token")).toBeTruthy();
+    expect(url?.includes("v=")).toBeTruthy();
   });
   it("skips token if not authd", () => {
     const entity = {
@@ -51,17 +55,23 @@ describe("getFeaturedImageUrl:", () => {
       },
     } as unknown as IHubProject;
 
-    const url = getFeaturedImageUrl(entity, {
-      isAuthenticated: false,
-    } as unknown as IArcGISContext);
-    expect(url.includes("token=fake-token")).toBeFalsy();
-    expect(url.includes("v=")).toBeTruthy();
+    const url = getFeaturedImageUrl(
+      entity.view as IWithViewSettings,
+      {
+        isAuthenticated: false,
+      } as unknown as IArcGISContext
+    );
+    expect(url?.includes("token=fake-token")).toBeFalsy();
+    expect(url?.includes("v=")).toBeTruthy();
   });
   it("returns undefined if a featured image url is not defined on the entity", () => {
     const entity = {} as IHubProject;
-    const url = getFeaturedImageUrl(entity, {
-      isAuthenticated: false,
-    } as IArcGISContext);
+    const url = getFeaturedImageUrl(
+      entity.view as IWithViewSettings,
+      {
+        isAuthenticated: false,
+      } as IArcGISContext
+    );
 
     expect(url).toBeUndefined();
   });

--- a/packages/common/test/core/schemas/internal/getLocationExtent.test.ts
+++ b/packages/common/test/core/schemas/internal/getLocationExtent.test.ts
@@ -1,4 +1,5 @@
 import { IHubProject, IHubRequestOptions } from "../../../../src";
+import { IHubLocation } from "../../../../src/core/types";
 import { getLocationExtent } from "../../../../src/core/schemas/internal/getLocationExtent";
 import * as ExtentModule from "../../../../src/extent";
 
@@ -26,7 +27,10 @@ describe("getLocationExtent", () => {
         ],
       },
     } as unknown as IHubProject;
-    const chk = await getLocationExtent(entity, {} as IHubRequestOptions);
+    const chk = await getLocationExtent(
+      entity.location as IHubLocation,
+      {} as IHubRequestOptions
+    );
     expect(chk).toEqual({
       xmin: -170,
       ymin: -80,
@@ -41,7 +45,10 @@ describe("getLocationExtent", () => {
     const entity: IHubProject = {
       location: {},
     } as unknown as IHubProject;
-    const chk = await getLocationExtent(entity, {} as IHubRequestOptions);
+    const chk = await getLocationExtent(
+      entity.location as IHubLocation,
+      {} as IHubRequestOptions
+    );
     expect(chk).toEqual({
       xmin: -180,
       ymin: -90,
@@ -54,7 +61,10 @@ describe("getLocationExtent", () => {
   });
   it("return org extent if location undefined", async () => {
     const entity: IHubProject = {} as unknown as IHubProject;
-    const chk = await getLocationExtent(entity, {} as IHubRequestOptions);
+    const chk = await getLocationExtent(
+      entity.location as IHubLocation,
+      {} as IHubRequestOptions
+    );
     expect(chk).toEqual({
       xmin: -180,
       ymin: -90,

--- a/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
+++ b/packages/common/test/core/schemas/internal/getLocationOptions.test.ts
@@ -1,4 +1,5 @@
 import { IHubProject, IHubRequestOptions } from "../../../../src";
+import { IHubLocation } from "../../../../src/core/types";
 import { getLocationOptions } from "../../../../src/core/schemas/internal/getLocationOptions";
 import * as ExtentModule from "../../../../src/extent";
 
@@ -18,16 +19,18 @@ describe("getLocationOptions:", () => {
     );
   });
   it("custom is selected", async () => {
-    const entity: IHubProject = {
+    const entity = {
       id: "00c",
       type: "Hub Project",
       location: {
         type: "custom",
-      },
-    } as IHubProject;
+      } as IHubLocation,
+    };
 
     const chk = await getLocationOptions(
-      entity,
+      entity.id,
+      entity.type,
+      entity.location,
       "portalName",
       {} as IHubRequestOptions
     );
@@ -42,7 +45,9 @@ describe("getLocationOptions:", () => {
     } as IHubProject;
 
     const chk = await getLocationOptions(
-      entity,
+      entity.id,
+      entity.type,
+      entity.location as unknown as IHubLocation,
       "portalName",
       {} as IHubRequestOptions
     );
@@ -51,16 +56,18 @@ describe("getLocationOptions:", () => {
     expect(chk[0].selected).toBe(true);
   });
   it("org is selected", async () => {
-    const entity: IHubProject = {
+    const entity = {
       id: "00c",
       type: "Hub Project",
       location: {
         type: "org",
-      },
-    } as IHubProject;
+      } as IHubLocation,
+    };
 
     const chk = await getLocationOptions(
-      entity,
+      entity.id,
+      entity.type,
+      entity.location,
       "portalName",
       {} as IHubRequestOptions
     );
@@ -69,15 +76,17 @@ describe("getLocationOptions:", () => {
     expect(chk[1].selected).toBe(true);
   });
   it("custom is selected if entity does not have an id", async () => {
-    const entity: IHubProject = {
+    const entity = {
       type: "Hub Project",
       location: {
         type: "org",
-      },
-    } as IHubProject;
+      } as IHubLocation,
+    };
 
     const chk = await getLocationOptions(
-      entity,
+      undefined as unknown as any,
+      entity.type,
+      entity.location,
       "portalName",
       {} as IHubRequestOptions
     );

--- a/packages/common/test/core/schemas/internal/getTagItems.test.ts
+++ b/packages/common/test/core/schemas/internal/getTagItems.test.ts
@@ -14,7 +14,7 @@ describe("getTagItems:", () => {
     } as IHubProject;
     const orgId = "some-org-id";
     const ro = {} as IHubRequestOptions;
-    const chk = await getTagItems(entity, orgId, ro);
+    const chk = await getTagItems(entity.tags, orgId, ro);
     expect(searchSpy).toHaveBeenCalled();
     // include tags from the item
     expect(chk.find((e) => e.value === "a")).toBeTruthy();
@@ -30,7 +30,7 @@ describe("getTagItems:", () => {
     const entity = {} as IHubProject;
     const orgId = "some-org-id";
     const ro = {} as IHubRequestOptions;
-    const chk = await getTagItems(entity, orgId, ro);
+    const chk = await getTagItems(entity.tags, orgId, ro);
     expect(searchSpy).toHaveBeenCalled();
     // include tags from the item
     expect(chk.find((e) => e.value === "a")).toBeFalsy();
@@ -45,7 +45,7 @@ describe("getTagItems:", () => {
     const orgId = "some-org-id";
     const ro = {} as IHubRequestOptions;
 
-    const chk = await getTagItems(entity, orgId, ro);
+    const chk = await getTagItems(entity.tags, orgId, ro);
     expect(chk).toEqual([]);
   });
 });

--- a/packages/common/test/core/schemas/internal/getThumbnailUiSchemaElement.test.ts
+++ b/packages/common/test/core/schemas/internal/getThumbnailUiSchemaElement.test.ts
@@ -1,5 +1,4 @@
 import { IHubItemEntity } from "../../../../src";
-import { EntityEditorOptions } from "../../../../src/core/schemas/internal/EditorOptions";
 import { getThumbnailUiSchemaElement } from "../../../../src/core/schemas/internal/getThumbnailUiSchemaElement";
 
 describe("getThumbnailUiSchemaElement:", () => {
@@ -22,7 +21,8 @@ describe("getThumbnailUiSchemaElement:", () => {
     };
     const uiSchema = getThumbnailUiSchemaElement(
       "scope",
-      entity as EntityEditorOptions
+      entity.thumbnail as unknown as string,
+      entity.thumbnailUrl as unknown as string
     );
     expect(uiSchema.options?.messages.length).toBe(0);
   });
@@ -45,7 +45,8 @@ describe("getThumbnailUiSchemaElement:", () => {
     };
     const uiSchema = getThumbnailUiSchemaElement(
       "scope",
-      entity as EntityEditorOptions
+      entity.thumbnail as unknown as string,
+      entity.thumbnailUrl as unknown as string
     );
     expect(uiSchema.options?.messages.length).toBe(1);
   });
@@ -69,7 +70,8 @@ describe("getThumbnailUiSchemaElement:", () => {
     };
     const uiSchema = getThumbnailUiSchemaElement(
       "scope",
-      entity as EntityEditorOptions
+      entity.thumbnail as string,
+      entity.thumbnailUrl as unknown as string
     );
     expect(uiSchema.options?.messages.length).toBe(1);
   });

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -1,7 +1,7 @@
 import { buildUiSchema } from "../../../src/discussions/_internal/DiscussionUiSchemaEdit";
 import { MOCK_CONTEXT } from "../../mocks/mock-auth";
 import * as getCategoryItemsModule from "../../../src/core/schemas/internal/getCategoryItems";
-import * as getFeaturedImageUrlModule from "../../../src/core/schemas/internal/getFeaturedImageUrl";
+import * as getAuthedImageUrlModule from "../../../src/core/schemas/internal/getAuthedImageUrl";
 import * as getLocationExtentModule from "../../../src/core/schemas/internal/getLocationExtent";
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
@@ -11,7 +11,7 @@ describe("buildUiSchema: discussion edit", () => {
     spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
       Promise.resolve([])
     );
-    spyOn(getFeaturedImageUrlModule, "getFeaturedImageUrl").and.returnValue(
+    spyOn(getAuthedImageUrlModule, "getAuthedImageUrl").and.returnValue(
       "https://some-image-url.com"
     );
     spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
@@ -29,6 +29,207 @@ describe("buildUiSchema: discussion edit", () => {
       {
         thumbnail: "thumbnail/custom.png",
         thumbnailUrl: "https://some-thumbnail-url.com",
+      } as any,
+      MOCK_CONTEXT
+    );
+    expect(uiSchema).toEqual({
+      type: "Layout",
+      elements: [
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.basicInfo.label",
+          elements: [
+            {
+              labelKey: "some.scope.fields.name.label",
+              scope: "/properties/name",
+              type: "Control",
+              options: {
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "required",
+                    icon: true,
+                    labelKey: "some.scope.fields.name.requiredError",
+                  },
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.title.maxLengthError`,
+                  },
+                ],
+              },
+            },
+            {
+              labelKey: "some.scope.fields.prompt.label",
+              scope: "/properties/prompt",
+              type: "Control",
+              options: {
+                helperText: {
+                  labelKey: "some.scope.fields.prompt.helperText",
+                },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "required",
+                    icon: true,
+                    labelKey: "some.scope.fields.prompt.requiredError",
+                  },
+                ],
+              },
+            },
+            {
+              labelKey: "some.scope.fields.summary.label",
+              scope: "/properties/summary",
+              type: "Control",
+              options: {
+                control: "hub-field-input-input",
+                type: "textarea",
+                rows: 4,
+                helperText: {
+                  labelKey: "some.scope.fields.summary.helperText",
+                },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.purpose.maxLengthError`,
+                  },
+                ],
+              },
+            },
+            {
+              labelKey: "some.scope.fields.description.label",
+              scope: "/properties/description",
+              type: "Control",
+              options: {
+                control: "hub-field-input-input",
+                type: "textarea",
+                helperText: {
+                  labelKey: "some.scope.fields.description.helperText",
+                },
+              },
+            },
+            {
+              labelKey: "shared.fields._thumbnail.label",
+              scope: "/properties/_thumbnail",
+              type: "Control",
+              options: {
+                control: "hub-field-input-image-picker",
+                imgSrc: "https://some-thumbnail-url.com",
+                maxWidth: 727,
+                maxHeight: 484,
+                aspectRatio: 1.5,
+                helperText: {
+                  labelKey: "some.scope.fields._thumbnail.helperText",
+                },
+                sizeDescription: {
+                  labelKey: "shared.fields._thumbnail.sizeDescription",
+                },
+                messages: [],
+              },
+            },
+            {
+              labelKey: "some.scope.fields.featuredImage.label",
+              scope: "/properties/view/properties/featuredImage",
+              type: "Control",
+              options: {
+                control: "hub-field-input-image-picker",
+                imgSrc: "https://some-image-url.com",
+                maxWidth: 727,
+                maxHeight: 484,
+                aspectRatio: 1.5,
+                sizeDescription: {
+                  labelKey: "some.scope.fields.featuredImage.sizeDescription",
+                },
+              },
+            },
+            {
+              labelKey: "some.scope.fields.featuredImage.altText.label",
+              scope: "/properties/view/properties/featuredImageAltText",
+              type: "Control",
+              options: {
+                helperText: {
+                  labelKey:
+                    "some.scope.fields.featuredImage.altText.helperText",
+                },
+              },
+            },
+            {
+              labelKey: "some.scope.fields.featuredImage.name.label",
+              scope: "/properties/view/properties/featuredImageName",
+              type: "Control",
+            },
+            {
+              labelKey: "some.scope.fields.tags.label",
+              scope: "/properties/tags",
+              type: "Control",
+              options: {
+                control: "hub-field-input-combobox",
+                items: [],
+                allowCustomValues: true,
+                selectionMode: "multiple",
+                placeholderIcon: "label",
+              },
+            },
+            {
+              labelKey: "some.scope.fields.categories.label",
+              scope: "/properties/categories",
+              type: "Control",
+              options: {
+                control: "hub-field-input-combobox",
+                items: [],
+                allowCustomValues: false,
+                selectionMode: "multiple",
+                placeholderIcon: "select-category",
+              },
+            },
+          ],
+        },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.location.label",
+          elements: [
+            {
+              scope: "/properties/location",
+              type: "Control",
+              options: {
+                control: "hub-field-input-location-picker",
+                extent: [],
+                options: [],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+  it("returns the full discussion edit uiSchema when entity does have a view", async () => {
+    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+      Promise.resolve([])
+    );
+    spyOn(getAuthedImageUrlModule, "getAuthedImageUrl").and.returnValue(
+      "https://some-image-url.com"
+    );
+    spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
+      Promise.resolve([])
+    );
+    spyOn(getLocationOptionsModule, "getLocationOptions").and.returnValue(
+      Promise.resolve([])
+    );
+    spyOn(getTagItemsModule, "getTagItems").and.returnValue(
+      Promise.resolve([])
+    );
+
+    const uiSchema = await buildUiSchema(
+      "some.scope",
+      {
+        thumbnail: "thumbnail/custom.png",
+        thumbnailUrl: "https://some-thumbnail-url.com",
+        view: {
+          featuredImageUrl: "https://some-image-url.com",
+        },
       } as any,
       MOCK_CONTEXT
     );

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -2,7 +2,7 @@ import { buildUiSchema } from "../../../src/projects/_internal/ProjectUiSchemaEd
 import { MOCK_CONTEXT } from "../../mocks/mock-auth";
 import * as getCategoryItemsModule from "../../../src/core/schemas/internal/getCategoryItems";
 import * as getFeaturedContentCatalogsModule from "../../../src/core/schemas/internal/getFeaturedContentCatalogs";
-import * as getFeaturedImageUrlModule from "../../../src/core/schemas/internal/getFeaturedImageUrl";
+import * as getAuthedImageUrlModule from "../../../src/core/schemas/internal/getAuthedImageUrl";
 import * as getLocationExtentModule from "../../../src/core/schemas/internal/getLocationExtent";
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
@@ -16,7 +16,7 @@ describe("buildUiSchema: project edit", () => {
       getFeaturedContentCatalogsModule,
       "getFeaturedContentCatalogs"
     ).and.returnValue({});
-    spyOn(getFeaturedImageUrlModule, "getFeaturedImageUrl").and.returnValue(
+    spyOn(getAuthedImageUrlModule, "getAuthedImageUrl").and.returnValue(
       "https://some-image-url.com"
     );
     spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
@@ -34,6 +34,278 @@ describe("buildUiSchema: project edit", () => {
       {
         thumbnail: "thumbnail/custom.png",
         thumbnailUrl: "https://some-thumbnail-url.com",
+      } as any,
+      MOCK_CONTEXT
+    );
+    expect(uiSchema).toEqual({
+      type: "Layout",
+      elements: [
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.basicInfo.label",
+          elements: [
+            {
+              labelKey: "some.scope.fields.name.label",
+              scope: "/properties/name",
+              type: "Control",
+              options: {
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "required",
+                    icon: true,
+                    labelKey: "some.scope.fields.name.requiredError",
+                  },
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `some.scope.fields.name.maxLengthError`,
+                  },
+                ],
+              },
+            },
+            {
+              labelKey: "some.scope.fields.summary.label",
+              scope: "/properties/summary",
+              type: "Control",
+              options: {
+                control: "hub-field-input-input",
+                type: "textarea",
+                rows: 4,
+                helperText: {
+                  labelKey: "some.scope.fields.summary.helperText",
+                },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `shared.fields.purpose.maxLengthError`,
+                  },
+                ],
+              },
+            },
+            {
+              labelKey: "some.scope.fields.description.label",
+              scope: "/properties/description",
+              type: "Control",
+              options: {
+                control: "hub-field-input-input",
+                type: "textarea",
+                helperText: {
+                  labelKey: "some.scope.fields.description.helperText",
+                },
+              },
+            },
+            {
+              labelKey: "some.scope.fields.featuredImage.label",
+              scope: "/properties/view/properties/featuredImage",
+              type: "Control",
+              options: {
+                control: "hub-field-input-image-picker",
+                imgSrc: "https://some-image-url.com",
+                maxWidth: 727,
+                maxHeight: 484,
+                aspectRatio: 1.5,
+                helperText: {
+                  labelKey: "some.scope.fields.featuredImage.helperText",
+                },
+                sizeDescription: {
+                  labelKey: "some.scope.fields.featuredImage.sizeDescription",
+                },
+              },
+            },
+            {
+              labelKey: "some.scope.fields.featuredImage.altText.label",
+              scope: "/properties/view/properties/featuredImageAltText",
+              type: "Control",
+              options: {
+                helperText: {
+                  labelKey:
+                    "some.scope.fields.featuredImage.altText.helperText",
+                },
+              },
+            },
+          ],
+        },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.location.label",
+          options: {
+            helperText: {
+              labelKey: "some.scope.sections.location.helperText",
+            },
+          },
+          elements: [
+            {
+              scope: "/properties/location",
+              type: "Control",
+              options: {
+                control: "hub-field-input-location-picker",
+                extent: [],
+                options: [],
+              },
+            },
+          ],
+        },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.searchDiscoverability.label",
+          elements: [
+            {
+              labelKey: "some.scope.fields.tags.label",
+              scope: "/properties/tags",
+              type: "Control",
+              options: {
+                control: "hub-field-input-combobox",
+                items: [],
+                allowCustomValues: true,
+                selectionMode: "multiple",
+                placeholderIcon: "label",
+                helperText: { labelKey: "some.scope.fields.tags.helperText" },
+              },
+            },
+            {
+              labelKey: "some.scope.fields.categories.label",
+              scope: "/properties/categories",
+              type: "Control",
+              options: {
+                control: "hub-field-input-combobox",
+                items: [],
+                allowCustomValues: false,
+                selectionMode: "multiple",
+                placeholderIcon: "select-category",
+                helperText: {
+                  labelKey: "some.scope.fields.categories.helperText",
+                },
+              },
+            },
+            {
+              labelKey: "shared.fields._thumbnail.label",
+              scope: "/properties/_thumbnail",
+              type: "Control",
+              options: {
+                control: "hub-field-input-image-picker",
+                imgSrc: "https://some-thumbnail-url.com",
+                maxWidth: 727,
+                maxHeight: 484,
+                aspectRatio: 1.5,
+                helperText: {
+                  labelKey: "some.scope.fields._thumbnail.helperText",
+                },
+                sizeDescription: {
+                  labelKey: "shared.fields._thumbnail.sizeDescription",
+                },
+                messages: [],
+              },
+            },
+          ],
+        },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.status.label",
+          elements: [
+            {
+              scope: "/properties/status",
+              type: "Control",
+              labelKey: "some.scope.fields.status.label",
+              options: {
+                control: "hub-field-input-select",
+                enum: {
+                  i18nScope: "some.scope.fields.status.enum",
+                },
+              },
+            },
+          ],
+        },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.timeline.label",
+          elements: [
+            {
+              scope: "/properties/view/properties/timeline",
+              type: "Control",
+              options: {
+                control: "arcgis-hub-timeline-editor",
+                showTitleAndDescription: false,
+              },
+            },
+          ],
+        },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.featuredContent.label",
+          options: {
+            helperText: {
+              labelKey: "some.scope.sections.featuredContent.helperText",
+            },
+          },
+          elements: [
+            {
+              scope: "/properties/view/properties/featuredContentIds",
+              type: "Control",
+              options: {
+                control: "hub-field-input-gallery-picker",
+                targetEntity: "item",
+                catalogs: {},
+                facets: [
+                  {
+                    label:
+                      "{{some.scope.fields.featuredContent.facets.type:translate}}",
+                    key: "type",
+                    display: "multi-select",
+                    field: "type",
+                    options: [],
+                    operation: "OR",
+                    aggLimit: 100,
+                  },
+                  {
+                    label:
+                      "{{some.scope.fields.featuredContent.facets.sharing:translate}}",
+                    key: "access",
+                    display: "multi-select",
+                    field: "access",
+                    options: [],
+                    operation: "OR",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+  it("returns the full project edit uiSchema with a defined view", async () => {
+    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+      Promise.resolve([])
+    );
+    spyOn(
+      getFeaturedContentCatalogsModule,
+      "getFeaturedContentCatalogs"
+    ).and.returnValue({});
+    spyOn(getAuthedImageUrlModule, "getAuthedImageUrl").and.returnValue(
+      "https://some-image-url.com"
+    );
+    spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
+      Promise.resolve([])
+    );
+    spyOn(getLocationOptionsModule, "getLocationOptions").and.returnValue(
+      Promise.resolve([])
+    );
+    spyOn(getTagItemsModule, "getTagItems").and.returnValue(
+      Promise.resolve([])
+    );
+
+    const uiSchema = await buildUiSchema(
+      "some.scope",
+      {
+        thumbnail: "thumbnail/custom.png",
+        thumbnailUrl: "https://some-thumbnail-url.com",
+        view: {
+          featuredImageUrl: "https://some-image-url.com",
+        },
       } as any,
       MOCK_CONTEXT
     );


### PR DESCRIPTION
1. Description:
Refactors the utils in buildUiSchema to take specific props rather than the entire entity, allowing EntityEditorOptions to be strongly typed. 
1. Instructions for testing:

1. Closes Issues: [8221](https://zentopia.esri.com/workspaces/collaboration-sprint-board-614f9bfc0946c40011ef574e/issues/dc/hub/8221)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
