### PR TITLE
fix: hub:feature:privacy is gated to devext

### DIFF
--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -82,8 +82,13 @@ const TempPermissionPolicies: IPermissionPolicy[] = [
 const SystemPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:feature:privacy",
-    availability: ["alpha"],
-    environments: ["qaext"],
+    // alpha does not do what we want here, it says "grant if the _logged in user_ is in an alpha org"
+    // but what we really want is "grant if the _current site_ is in an alpha org" which we can't do
+    // availability: ["alpha"],
+    // so the fallback is to deny this permission in all cases except when the feature flag is passed (?pe=hub:feature:privacy)
+    // but we can't do that either
+    // so we will just enable it only in devext since we don't use that env
+    environments: ["devext"],
   },
   {
     permission: "hub:feature:workspace",


### PR DESCRIPTION
affects: @esri/hub-common

We noticed that the gating of hub:feature:privacy does not really work the way we intended and that it can't really work the way we intended. So we now gate that feature to devext. Which means it is off in qaext and prod unless you provide `?pe=hub:feature:privacy`

