### PR TITLE
fix(): add metrics-coming-soon permission

### DIFF
--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -32,6 +32,7 @@ export const ProjectPermissions = [
   "hub:project:workspace:collaborators",
   "hub:project:workspace:content",
   "hub:project:workspace:metrics",
+  "hub:project:workspace:metrics-coming-soon",
   "hub:project:manage",
 ] as const;
 
@@ -116,7 +117,12 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:project:workspace", "hub:project:edit"],
   },
   {
+    permission: "hub:project:workspace:metrics-coming-soon",
+    dependencies: ["hub:project:workspace", "hub:project:edit"],
+  },
+  {
     permission: "hub:project:workspace:metrics",
+    availability: ["alpha"], // gate to alpha for just now
     dependencies: ["hub:project:workspace", "hub:project:edit"],
   },
   {


### PR DESCRIPTION
1. Description:
Adds a metrics-coming-soon permission to project business rules to allow for a metrics pane to be developed without interrupting the coming-soon metrics pane.

1. Instructions for testing:

1. Closes Issues: [#6661](https://zentopia.esri.com/workspaces/collaboration-sprint-board-614f9bfc0946c40011ef574e/issues/dc/hub/6661)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
