### PR TITLE
fix: switch null to empty string for membershipAccess

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64981,7 +64981,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.44.0",
+			"version": "14.51.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -65007,7 +65007,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "26.1.2",
+			"version": "26.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65084,7 +65084,7 @@
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "14.1.0",
+			"version": "14.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65106,7 +65106,7 @@
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "14.2.0",
+			"version": "14.2.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/src/groups/_internal/convertHubGroupToGroup.ts
+++ b/packages/common/src/groups/_internal/convertHubGroupToGroup.ts
@@ -27,7 +27,7 @@ export function convertHubGroupToGroup(hubGroup: IHubGroup): IGroup {
   // since we are setting null to a prop, we need to
   // send clearEmptyFields: true to the updateGroup call
   if (group.membershipAccess === "anyone") {
-    group.membershipAccess = null;
+    group.membershipAccess = "";
     group._clearEmptyFields = true;
   }
   return group;

--- a/packages/common/test/groups/HubGroups.test.ts
+++ b/packages/common/test/groups/HubGroups.test.ts
@@ -210,7 +210,7 @@ describe("HubGroups Module:", () => {
       // to the updateGroup call
       expect(
         portalUpdateGroupSpy.calls.argsFor(0)[0].group.membershipAccess
-      ).toBe(null);
+      ).toBe("");
       expect(
         portalUpdateGroupSpy.calls.argsFor(0)[0].params.clearEmptyFields
       ).toBeTruthy();


### PR DESCRIPTION
1. Description: request, from arcgis-rest-request, does not allow one to use null/undefined's as empty vals. An empty string needs to be sent. ( https://github.com/Esri/arcgis-rest-js/blob/main/packages/arcgis-rest-request/src/utils/process-params.ts#L72-L75 ).

In this particular case membershipAccess was being stripped from the update call altogether when set to 'anyone'

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
