### PR TITLE
feat(): allow metrics visibility

### DIFF
--- a/packages/common/src/core/types/Metrics.ts
+++ b/packages/common/src/core/types/Metrics.ts
@@ -216,13 +216,13 @@ export enum ExpressionRelationships {
 }
 
 /**
- * Configuration for how to show a metric in the ui
+ * Configuration for how to show a metric in the ui. These are just values that are important to how to
+ * display the metric; values that are configured in the editor should be added to IMetricEditorValues instead.
  */
 export interface IMetricDisplayConfig extends IMetricEditorValues {
   metricId: string;
   displayType: string;
   visibility?: MetricVisibility;
-  [key: string]: any;
 }
 
 /**
@@ -236,13 +236,17 @@ export enum MetricVisibility {
 }
 
 /**
- * Editor values expected when editing a metric
+ * Editor values expected when editing a metric. These are options that are set in the metric editor that
+ * help build the IMetricDisplayConfig.
  */
 export interface IMetricEditorValues {
   /** the main value of the metric  */
   value?: string | number;
   /** all values related to constructing a service-query metric */
   dynamicMetric?: IDynamicMetricValues;
+
+  // TODO: enumerate all editor values here
+  [key: string]: any;
 }
 
 /**

--- a/packages/common/src/core/types/Metrics.ts
+++ b/packages/common/src/core/types/Metrics.ts
@@ -225,7 +225,15 @@ export interface IMetricDisplayConfig {
   [key: string]: any;
 }
 
-export type MetricVisibility = "visible" | "hidden" | "featured";
+/**
+ * Types of states of visibility a metric can be in
+ * featured, visible, or hidden
+ */
+export enum MetricVisibility {
+  visible = "visible",
+  hidden = "hidden",
+  featured = "featured",
+}
 
 /**
  * Editor values expected when editing a metric

--- a/packages/common/src/core/types/Metrics.ts
+++ b/packages/common/src/core/types/Metrics.ts
@@ -218,7 +218,7 @@ export enum ExpressionRelationships {
 /**
  * Configuration for how to show a metric in the ui
  */
-export interface IMetricDisplayConfig {
+export interface IMetricDisplayConfig extends IMetricEditorValues {
   metricId: string;
   displayType: string;
   visibility?: MetricVisibility;
@@ -238,7 +238,7 @@ export enum MetricVisibility {
 /**
  * Editor values expected when editing a metric
  */
-export interface IMetricEditorValues extends IMetricDisplayConfig {
+export interface IMetricEditorValues {
   /** the main value of the metric  */
   value?: string | number;
   /** all values related to constructing a service-query metric */

--- a/packages/common/src/core/types/Metrics.ts
+++ b/packages/common/src/core/types/Metrics.ts
@@ -221,8 +221,11 @@ export enum ExpressionRelationships {
 export interface IMetricDisplayConfig {
   metricId: string;
   displayType: string;
+  visibility?: MetricVisibility;
   [key: string]: any;
 }
+
+export type MetricVisibility = "visible" | "hidden" | "featured";
 
 /**
  * Editor values expected when editing a metric

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -32,6 +32,7 @@ export const ProjectPermissions = [
   "hub:project:workspace:collaborators",
   "hub:project:workspace:content",
   "hub:project:workspace:metrics",
+  "hub:project:workspace:metrics-coming-soon",
   "hub:project:manage",
 ] as const;
 
@@ -116,7 +117,12 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:project:workspace", "hub:project:edit"],
   },
   {
+    permission: "hub:project:workspace:metrics-coming-soon",
+    dependencies: ["hub:project:workspace", "hub:project:edit"],
+  },
+  {
     permission: "hub:project:workspace:metrics",
+    availability: ["alpha"], // gate to alpha for just now
     dependencies: ["hub:project:workspace", "hub:project:edit"],
   },
   {


### PR DESCRIPTION
1. Description:
Adds the optional `visibility` prop to IMetricDisplayConfig.
1. Instructions for testing:


1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
