### PR TITLE
fix: add guards around excape predicate to avoid exceptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.52.0",
+			"version": "14.54.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/core/schemas/internal/metrics/editorToMetric.ts
+++ b/packages/common/src/core/schemas/internal/metrics/editorToMetric.ts
@@ -137,21 +137,24 @@ export function buildWhereClause(expressionSet: IExpression[] = []): string {
 
           case "esriFieldTypeDate":
             // just the second bounding value
-            if (!isNil(values[0])) {
+            if (typeof values[0] === "string") {
               clause = `${field.name} >= timestamp '${escape(
                 values[0] as string
               )} 00:00:00'`;
             }
 
             // just the first bounding value
-            if (!isNil(values[1])) {
+            if (typeof values[1] === "string") {
               clause = `${field.name} <= timestamp '${escape(
                 values[1] as string
               )} 23:59:59'`;
             }
 
             // if we have both, rewrite clause
-            if (!isNil(values[0]) && !isNil(values[1])) {
+            if (
+              typeof values[0] === "string" &&
+              typeof values[1] === "string"
+            ) {
               clause = `${field.name} >= timestamp '${escape(
                 values[0] as string
               )} 00:00:00' AND ${field.name} <= timestamp '${escape(

--- a/packages/common/src/core/schemas/internal/metrics/editorToMetric.ts
+++ b/packages/common/src/core/schemas/internal/metrics/editorToMetric.ts
@@ -110,7 +110,12 @@ export function buildWhereClause(expressionSet: IExpression[] = []): string {
       .map((expression) => {
         const { field, values, relationship } = expression;
 
-        const escape = (value: string) => value.replace(/(['])/g, "$1$1"); // currently only handles single quotes
+        const escape = (value: string) => {
+          // Ensure that the value has a .replace method
+          // We encountered a case where the value was an empty object (unclear how this happened)
+          // and it caused the site to go into an infinite loop and crash. This is a safeguard.
+          return value.replace && value.replace(/(['])/g, "$1$1"); // currently only handles single quotes
+        };
 
         // if we don't have values or field, or if it is an "incomplete" expression, do not include
         if (!values || !values.length || !field || !field.name) {

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -18,6 +18,10 @@ export function cloneObject<T>(obj: T): T {
   if (Array.isArray(obj)) {
     clone = obj.map(cloneObject);
   } else if (typeof obj === "object") {
+    // allow nulls to carry through
+    if (obj === null) {
+      return obj;
+    }
     for (const i in obj) {
       if (obj.hasOwnProperty(i)) {
         const value = obj[i];

--- a/packages/common/test/core/schemas/internal/metrics/editorToMetric.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/editorToMetric.test.ts
@@ -92,7 +92,7 @@ describe("editorToMetric", () => {
         "(category IN ('value1')) AND (amount) >= 0 AND (amount) <= 2 AND (amount) <= 4 AND (amount) >= 1 AND date <= timestamp '2023-01-04 23:59:59' AND date >= timestamp '2023-01-02 00:00:00' AND date >= timestamp '2023-01-01 00:00:00' AND date <= timestamp '2023-01-03 23:59:59' AND (guid) >= 1234 AND (guid) <= 5234 AND category like '%val%' AND (category IN ('val', 'e'))"
       );
     });
-    // NOTE THESE NEXT THREE TESTS COVER CASES WHICH SHOULD NEVER OCCUR
+    // NOTE THESE NEXT FIVE TESTS COVER CASES WHICH SHOULD NEVER OCCUR
     // BUT WHICH HAVE BEEN SEEN IN THE WILD. THE GOAL IS TO JUST ENSURE
     // AN EXCEPTION IS NOT THROWN. THE WHERE CLAUSE WILL BE INVALID, BUT
     // THE SITE WILL NOT CRASH
@@ -137,6 +137,30 @@ describe("editorToMetric", () => {
       expect(whereClause).toEqual(
         "date >= timestamp 'WAT 00:00:00' AND date <= timestamp 'BLARG 23:59:59'"
       );
+    });
+    it("handles single entry in values with between", () => {
+      const expressionSet: IExpression[] = [
+        {
+          field: MOCK_DATE_FIELD,
+          key: "expression-7890",
+          values: ["2022-01-01"],
+          relationship: ExpressionRelationships.BETWEEN,
+        },
+      ];
+      const whereClause = EditorToMetric.buildWhereClause(expressionSet);
+      expect(whereClause).toEqual("date >= timestamp '2022-01-01 00:00:00'");
+    });
+    it("handles null in values with between", () => {
+      const expressionSet: IExpression[] = [
+        {
+          field: MOCK_DATE_FIELD,
+          key: "expression-7890",
+          values: [null as unknown as string, "2022-01-01"],
+          relationship: ExpressionRelationships.BETWEEN,
+        },
+      ];
+      const whereClause = EditorToMetric.buildWhereClause(expressionSet);
+      expect(whereClause).toEqual("date <= timestamp '2022-01-01 23:59:59'");
     });
     // END
     it("handles an undefined expression set", () => {

--- a/packages/common/test/core/schemas/internal/metrics/editorToMetric.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/editorToMetric.test.ts
@@ -106,9 +106,7 @@ describe("editorToMetric", () => {
         },
       ];
       const whereClause = EditorToMetric.buildWhereClause(expressionSet);
-      expect(whereClause).toEqual(
-        "date >= timestamp 'undefined 00:00:00' AND date <= timestamp '2023-01-03 23:59:59'"
-      );
+      expect(whereClause).toEqual("date <= timestamp '2023-01-03 23:59:59'");
     });
     it("handles objects in values with between", () => {
       const expressionSet: IExpression[] = [
@@ -120,9 +118,7 @@ describe("editorToMetric", () => {
         },
       ];
       const whereClause = EditorToMetric.buildWhereClause(expressionSet);
-      expect(whereClause).toEqual(
-        "date >= timestamp 'undefined 00:00:00' AND date <= timestamp 'undefined 23:59:59'"
-      );
+      expect(whereClause).toEqual("1=1");
     });
     it("handles bad strings in values with between", () => {
       const expressionSet: IExpression[] = [

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -81,6 +81,17 @@ describe("util functions", () => {
     });
   });
 
+  it("handles nulls in arrays", () => {
+    const obj: any[] = [null, null, null];
+    const chk = cloneObject(obj);
+    expect(chk).toEqual(obj);
+  });
+  it("handles nulls in arrays nested in objects", () => {
+    const obj: { values: any[] } = { values: [null, null, null] };
+    const chk = cloneObject(obj);
+    expect(chk).toEqual(obj);
+  });
+
   if (typeof Blob !== "undefined") {
     it("can clone a Blob", () => {
       const obj = {


### PR DESCRIPTION
1. Description:

This addresses some issues we ran into helping support debug issues with a DC site in PROD. We are unclear how they got the site into a state where the values array in the Expression for a Stat card had an entry that was an `{}`, but they did, and it caused an exception, which was uncaught, and ember went into a death spiral.

This PR simply adds a guard to make sure `.replace` method exists on the object passed into the `escape` predicate. The tests flex invalid-but-somehow-occured configurations.

1. Instructions for testing: run tests

1. Closes Issues: n/a

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
