### PR TITLE
feat(hub-common): updates DiscussionUiSchemaEdit schema layout and de…

### DIFF
--- a/packages/common/src/discussions/_internal/DiscussionSchema.ts
+++ b/packages/common/src/discussions/_internal/DiscussionSchema.ts
@@ -13,11 +13,12 @@ export const DiscussionEditorTypes = [
  */
 export const DiscussionSchema: IConfigurationSchema = {
   ...HubItemEntitySchema,
+  required: ["name", "prompt"],
   properties: {
     ...HubItemEntitySchema.properties,
     prompt: {
       type: "string",
-      default: "We want to hear from you!",
+      default: "",
     },
   },
 } as IConfigurationSchema;

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaCreate.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaCreate.ts
@@ -36,6 +36,24 @@ export const buildUiSchema = async (
           ],
         },
       },
+      {
+        labelKey: `${i18nScope}.fields.prompt.label`,
+        scope: "/properties/prompt",
+        type: "Control",
+        options: {
+          helperText: {
+            labelKey: `${i18nScope}.fields.prompt.helperText`,
+          },
+          messages: [
+            {
+              type: "ERROR",
+              keyword: "required",
+              icon: true,
+              labelKey: `${i18nScope}.fields.prompt.requiredError`,
+            },
+          ],
+        },
+      },
     ],
   };
 };

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -65,77 +65,47 @@ export const buildUiSchema = async (
               ],
             },
           },
-          {
-            labelKey: `${i18nScope}.fields.summary.label`,
-            scope: "/properties/summary",
-            type: "Control",
-            options: {
-              control: "hub-field-input-input",
-              type: "textarea",
-              rows: 4,
-              helperText: {
-                labelKey: `${i18nScope}.fields.summary.helperText`,
-              },
-              messages: [
-                {
-                  type: "ERROR",
-                  keyword: "maxLength",
-                  icon: true,
-                  labelKey: `shared.fields.purpose.maxLengthError`,
-                },
-              ],
-            },
-          },
-          {
-            labelKey: `${i18nScope}.fields.description.label`,
-            scope: "/properties/description",
-            type: "Control",
-            options: {
-              control: "hub-field-input-input",
-              type: "textarea",
-              helperText: {
-                labelKey: `${i18nScope}.fields.description.helperText`,
-              },
-            },
-          },
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
             options.thumbnailUrl
           ),
+        ],
+      },
+      {
+        type: "Section",
+        labelKey: `${i18nScope}.sections.location.label`,
+        options: {
+          helperText: {
+            labelKey: `${i18nScope}.sections.location.helperText`,
+          },
+        },
+        elements: [
           {
-            labelKey: `${i18nScope}.fields.featuredImage.label`,
-            scope: "/properties/view/properties/featuredImage",
+            scope: "/properties/location",
             type: "Control",
             options: {
-              control: "hub-field-input-image-picker",
-              imgSrc: getAuthedImageUrl(
-                options.view?.featuredImageUrl,
-                context
+              control: "hub-field-input-location-picker",
+              extent: await getLocationExtent(
+                options.location,
+                context.hubRequestOptions
               ),
-              maxWidth: 727,
-              maxHeight: 484,
-              aspectRatio: 1.5,
-              sizeDescription: {
-                labelKey: `${i18nScope}.fields.featuredImage.sizeDescription`,
-              },
+              options: await getLocationOptions(
+                options.id,
+                options.type,
+                options.location,
+                context.portal.name,
+                context.hubRequestOptions
+              ),
+              mapTools: ["polygon", "rectangle"],
             },
           },
-          {
-            labelKey: `${i18nScope}.fields.featuredImage.altText.label`,
-            scope: "/properties/view/properties/featuredImageAltText",
-            type: "Control",
-            options: {
-              helperText: {
-                labelKey: `${i18nScope}.fields.featuredImage.altText.helperText`,
-              },
-            },
-          },
-          {
-            labelKey: `${i18nScope}.fields.featuredImage.name.label`,
-            scope: "/properties/view/properties/featuredImageName",
-            type: "Control",
-          },
+        ],
+      },
+      {
+        type: "Section",
+        labelKey: `${i18nScope}.sections.searchDiscoverability.label`,
+        elements: [
           {
             labelKey: `${i18nScope}.fields.tags.label`,
             scope: "/properties/tags",
@@ -167,34 +137,37 @@ export const buildUiSchema = async (
               placeholderIcon: "select-category",
             },
           },
-        ],
-      },
-      {
-        type: "Section",
-        labelKey: `${i18nScope}.sections.location.label`,
-        options: {
-          helperText: {
-            labelKey: `${i18nScope}.sections.location.helperText`,
-          },
-        },
-        elements: [
           {
-            scope: "/properties/location",
+            labelKey: `${i18nScope}.fields.summary.label`,
+            scope: "/properties/summary",
             type: "Control",
             options: {
-              control: "hub-field-input-location-picker",
-              extent: await getLocationExtent(
-                options.location,
-                context.hubRequestOptions
-              ),
-              options: await getLocationOptions(
-                options.id,
-                options.type,
-                options.location,
-                context.portal.name,
-                context.hubRequestOptions
-              ),
-              mapTools: ["polygon", "rectangle"],
+              control: "hub-field-input-input",
+              type: "textarea",
+              rows: 4,
+              helperText: {
+                labelKey: `${i18nScope}.fields.summary.helperText`,
+              },
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `shared.fields.purpose.maxLengthError`,
+                },
+              ],
+            },
+          },
+          {
+            labelKey: `${i18nScope}.fields.description.label`,
+            scope: "/properties/description",
+            type: "Control",
+            options: {
+              control: "hub-field-input-input",
+              type: "textarea",
+              helperText: {
+                labelKey: `${i18nScope}.fields.description.helperText`,
+              },
             },
           },
         ],

--- a/packages/common/src/discussions/defaults.ts
+++ b/packages/common/src/discussions/defaults.ts
@@ -7,7 +7,7 @@ export const HUB_DISCUSSION_ITEM_TYPE = "Discussion";
  * Default values of a IHubDiscussion
  */
 export const DEFAULT_DISCUSSION: Partial<IHubDiscussion> = {
-  name: "No title provided",
+  name: "",
   tags: [],
   typeKeywords: ["Hub Discussion"],
   permissions: [],
@@ -21,8 +21,8 @@ export const DEFAULT_DISCUSSION: Partial<IHubDiscussion> = {
 export const DEFAULT_DISCUSSION_MODEL: IModel = {
   item: {
     type: HUB_DISCUSSION_ITEM_TYPE,
-    title: "No Title Provided",
-    description: "No Description Provided",
+    title: "",
+    description: "",
     snippet: "",
     tags: [],
     typeKeywords: ["Hub Discussion"],
@@ -32,6 +32,6 @@ export const DEFAULT_DISCUSSION_MODEL: IModel = {
     },
   },
   data: {
-    prompt: "We want to hear from you!",
+    prompt: "",
   },
 } as unknown as IModel;

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaCreate.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaCreate.test.ts
@@ -28,6 +28,24 @@ describe("buildUiSchema: discussion create", () => {
             ],
           },
         },
+        {
+          labelKey: "some.scope.fields.prompt.label",
+          scope: "/properties/prompt",
+          type: "Control",
+          options: {
+            helperText: {
+              labelKey: "some.scope.fields.prompt.helperText",
+            },
+            messages: [
+              {
+                type: "ERROR",
+                keyword: "required",
+                icon: true,
+                labelKey: "some.scope.fields.prompt.requiredError",
+              },
+            ],
+          },
+        },
       ],
     });
   });

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -55,7 +55,7 @@ describe("buildUiSchema: discussion edit", () => {
                     type: "ERROR",
                     keyword: "maxLength",
                     icon: true,
-                    labelKey: `shared.fields.title.maxLengthError`,
+                    labelKey: "shared.fields.title.maxLengthError",
                   },
                 ],
               },
@@ -79,39 +79,6 @@ describe("buildUiSchema: discussion edit", () => {
               },
             },
             {
-              labelKey: "some.scope.fields.summary.label",
-              scope: "/properties/summary",
-              type: "Control",
-              options: {
-                control: "hub-field-input-input",
-                type: "textarea",
-                rows: 4,
-                helperText: {
-                  labelKey: "some.scope.fields.summary.helperText",
-                },
-                messages: [
-                  {
-                    type: "ERROR",
-                    keyword: "maxLength",
-                    icon: true,
-                    labelKey: `shared.fields.purpose.maxLengthError`,
-                  },
-                ],
-              },
-            },
-            {
-              labelKey: "some.scope.fields.description.label",
-              scope: "/properties/description",
-              type: "Control",
-              options: {
-                control: "hub-field-input-input",
-                type: "textarea",
-                helperText: {
-                  labelKey: "some.scope.fields.description.helperText",
-                },
-              },
-            },
-            {
               labelKey: "shared.fields._thumbnail.label",
               scope: "/properties/_thumbnail",
               type: "Control",
@@ -130,37 +97,33 @@ describe("buildUiSchema: discussion edit", () => {
                 messages: [],
               },
             },
+          ],
+        },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.location.label",
+          options: {
+            helperText: {
+              labelKey: "some.scope.sections.location.helperText",
+            },
+          },
+          elements: [
             {
-              labelKey: "some.scope.fields.featuredImage.label",
-              scope: "/properties/view/properties/featuredImage",
+              scope: "/properties/location",
               type: "Control",
               options: {
-                control: "hub-field-input-image-picker",
-                imgSrc: "https://some-image-url.com",
-                maxWidth: 727,
-                maxHeight: 484,
-                aspectRatio: 1.5,
-                sizeDescription: {
-                  labelKey: "some.scope.fields.featuredImage.sizeDescription",
-                },
+                control: "hub-field-input-location-picker",
+                extent: [],
+                options: [],
+                mapTools: ["polygon", "rectangle"],
               },
             },
-            {
-              labelKey: "some.scope.fields.featuredImage.altText.label",
-              scope: "/properties/view/properties/featuredImageAltText",
-              type: "Control",
-              options: {
-                helperText: {
-                  labelKey:
-                    "some.scope.fields.featuredImage.altText.helperText",
-                },
-              },
-            },
-            {
-              labelKey: "some.scope.fields.featuredImage.name.label",
-              scope: "/properties/view/properties/featuredImageName",
-              type: "Control",
-            },
+          ],
+        },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.searchDiscoverability.label",
+          elements: [
             {
               labelKey: "some.scope.fields.tags.label",
               scope: "/properties/tags",
@@ -185,25 +148,37 @@ describe("buildUiSchema: discussion edit", () => {
                 placeholderIcon: "select-category",
               },
             },
-          ],
-        },
-        {
-          type: "Section",
-          labelKey: "some.scope.sections.location.label",
-          options: {
-            helperText: {
-              labelKey: "some.scope.sections.location.helperText",
-            },
-          },
-          elements: [
             {
-              scope: "/properties/location",
+              labelKey: "some.scope.fields.summary.label",
+              scope: "/properties/summary",
               type: "Control",
               options: {
-                control: "hub-field-input-location-picker",
-                extent: [],
-                options: [],
-                mapTools: ["polygon", "rectangle"],
+                control: "hub-field-input-input",
+                type: "textarea",
+                rows: 4,
+                helperText: {
+                  labelKey: "some.scope.fields.summary.helperText",
+                },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: "shared.fields.purpose.maxLengthError",
+                  },
+                ],
+              },
+            },
+            {
+              labelKey: "some.scope.fields.description.label",
+              scope: "/properties/description",
+              type: "Control",
+              options: {
+                control: "hub-field-input-input",
+                type: "textarea",
+                helperText: {
+                  labelKey: "some.scope.fields.description.helperText",
+                },
               },
             },
           ],
@@ -262,7 +237,7 @@ describe("buildUiSchema: discussion edit", () => {
                     type: "ERROR",
                     keyword: "maxLength",
                     icon: true,
-                    labelKey: `shared.fields.title.maxLengthError`,
+                    labelKey: "shared.fields.title.maxLengthError",
                   },
                 ],
               },
@@ -286,39 +261,6 @@ describe("buildUiSchema: discussion edit", () => {
               },
             },
             {
-              labelKey: "some.scope.fields.summary.label",
-              scope: "/properties/summary",
-              type: "Control",
-              options: {
-                control: "hub-field-input-input",
-                type: "textarea",
-                rows: 4,
-                helperText: {
-                  labelKey: "some.scope.fields.summary.helperText",
-                },
-                messages: [
-                  {
-                    type: "ERROR",
-                    keyword: "maxLength",
-                    icon: true,
-                    labelKey: `shared.fields.purpose.maxLengthError`,
-                  },
-                ],
-              },
-            },
-            {
-              labelKey: "some.scope.fields.description.label",
-              scope: "/properties/description",
-              type: "Control",
-              options: {
-                control: "hub-field-input-input",
-                type: "textarea",
-                helperText: {
-                  labelKey: "some.scope.fields.description.helperText",
-                },
-              },
-            },
-            {
               labelKey: "shared.fields._thumbnail.label",
               scope: "/properties/_thumbnail",
               type: "Control",
@@ -337,37 +279,33 @@ describe("buildUiSchema: discussion edit", () => {
                 messages: [],
               },
             },
+          ],
+        },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.location.label",
+          options: {
+            helperText: {
+              labelKey: "some.scope.sections.location.helperText",
+            },
+          },
+          elements: [
             {
-              labelKey: "some.scope.fields.featuredImage.label",
-              scope: "/properties/view/properties/featuredImage",
+              scope: "/properties/location",
               type: "Control",
               options: {
-                control: "hub-field-input-image-picker",
-                imgSrc: "https://some-image-url.com",
-                maxWidth: 727,
-                maxHeight: 484,
-                aspectRatio: 1.5,
-                sizeDescription: {
-                  labelKey: "some.scope.fields.featuredImage.sizeDescription",
-                },
+                control: "hub-field-input-location-picker",
+                extent: [],
+                options: [],
+                mapTools: ["polygon", "rectangle"],
               },
             },
-            {
-              labelKey: "some.scope.fields.featuredImage.altText.label",
-              scope: "/properties/view/properties/featuredImageAltText",
-              type: "Control",
-              options: {
-                helperText: {
-                  labelKey:
-                    "some.scope.fields.featuredImage.altText.helperText",
-                },
-              },
-            },
-            {
-              labelKey: "some.scope.fields.featuredImage.name.label",
-              scope: "/properties/view/properties/featuredImageName",
-              type: "Control",
-            },
+          ],
+        },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.searchDiscoverability.label",
+          elements: [
             {
               labelKey: "some.scope.fields.tags.label",
               scope: "/properties/tags",
@@ -392,25 +330,37 @@ describe("buildUiSchema: discussion edit", () => {
                 placeholderIcon: "select-category",
               },
             },
-          ],
-        },
-        {
-          type: "Section",
-          labelKey: "some.scope.sections.location.label",
-          options: {
-            helperText: {
-              labelKey: "some.scope.sections.location.helperText",
-            },
-          },
-          elements: [
             {
-              scope: "/properties/location",
+              labelKey: "some.scope.fields.summary.label",
+              scope: "/properties/summary",
               type: "Control",
               options: {
-                control: "hub-field-input-location-picker",
-                extent: [],
-                options: [],
-                mapTools: ["polygon", "rectangle"],
+                control: "hub-field-input-input",
+                type: "textarea",
+                rows: 4,
+                helperText: {
+                  labelKey: "some.scope.fields.summary.helperText",
+                },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: "shared.fields.purpose.maxLengthError",
+                  },
+                ],
+              },
+            },
+            {
+              labelKey: "some.scope.fields.description.label",
+              scope: "/properties/description",
+              type: "Control",
+              options: {
+                control: "hub-field-input-input",
+                type: "textarea",
+                helperText: {
+                  labelKey: "some.scope.fields.description.helperText",
+                },
               },
             },
           ],


### PR DESCRIPTION
…faults

affects: @esri/hub-common

1. Description: Removes unneeded fields from Discussions UI Schema, adds new Search & Discoverability section, and removes any default values when creating a Discussion Board.

1. Instructions for testing:

1. Issues: #7082. #8383, #8384

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.

<img width="779" alt="Screenshot 2023-11-13 at 9 06 10 AM" src="https://github.com/Esri/hub.js/assets/3883995/91d497bc-7752-48ea-8a19-275ac68f84b0">

<img width="500" alt="Screenshot 2023-11-11 at 8 17 40 PM" src="https://github.com/Esri/hub.js/assets/3883995/2a386d59-04f6-404b-b257-a43e5b649161">

 
