### PR TITLE
feat: add context.OGCApiUrl

### DIFF
--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -21,7 +21,7 @@ const hubApiEndpoints = {
   domains: "/api/v3/domains",
   search: "/api/v3/datasets",
   discussions: "/api/discussions/v1",
-  ogcapi: "/api/search/v1",
+  ogcRecords: "/api/search/v1",
 };
 
 /**
@@ -95,7 +95,7 @@ export interface IArcGISContext {
   /**
    * Url for the Hub OGC API
    */
-  OGCApiUrl: string;
+  ogcApiUrl: string;
   /**
    * Returns the current user's hub-home url. If not authenticated,
    * returns the Hub Url. If portal, returns undefined
@@ -609,13 +609,13 @@ export class ArcGISContext implements IArcGISContext {
   /**
    * Returns Hub OGCAPI Service URL
    */
-  public get OGCApiUrl(): string {
+  public get ogcApiUrl(): string {
     if (this._hubUrl) {
       // NOTE: In the future, we will be able to use _hubUrl directly
       // but for now, we swap "hub" to "opendata" in _hubUrl so we end
       // up with urls like https://opendataqa.arcgis.com/api/search/v1
       const opendataUrl = this._hubUrl.replace("hub", "opendata");
-      return `${opendataUrl}${hubApiEndpoints.ogcapi}`;
+      return `${opendataUrl}${hubApiEndpoints.ogcRecords}`;
     }
   }
 

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -21,6 +21,7 @@ const hubApiEndpoints = {
   domains: "/api/v3/domains",
   search: "/api/v3/datasets",
   discussions: "/api/discussions/v1",
+  ogcapi: "/api/search/v1",
 };
 
 /**
@@ -91,6 +92,10 @@ export interface IArcGISContext {
    * For ArcGIS Enterprise this will return `undefined`
    */
   hubUrl: string;
+  /**
+   * Url for the Hub OGC API
+   */
+  OGCApiUrl: string;
   /**
    * Returns the current user's hub-home url. If not authenticated,
    * returns the Hub Url. If portal, returns undefined
@@ -598,6 +603,19 @@ export class ArcGISContext implements IArcGISContext {
   public get domainServiceUrl(): string {
     if (this._hubUrl) {
       return `${this._hubUrl}${hubApiEndpoints.domains}`;
+    }
+  }
+
+  /**
+   * Returns Hub OGCAPI Service URL
+   */
+  public get OGCApiUrl(): string {
+    if (this._hubUrl) {
+      // NOTE: In the future, we will be able to use _hubUrl directly
+      // but for now, we swap "hub" to "opendata" in _hubUrl so we end
+      // up with urls like https://opendataqa.arcgis.com/api/search/v1
+      const opendataUrl = this._hubUrl.replace("hub", "opendata");
+      return `${opendataUrl}${hubApiEndpoints.ogcapi}`;
     }
   }
 

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -251,7 +251,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.portalUrl).toBe("https://www.arcgis.com");
       expect(mgr.context.isPortal).toBe(false);
       expect(mgr.context.hubUrl).toBe("https://hub.arcgis.com");
-      expect(mgr.context.OGCApiUrl).toBe(
+      expect(mgr.context.ogcApiUrl).toBe(
         "https://opendata.arcgis.com/api/search/v1"
       );
       expect(mgr.context.hubHomeUrl).toBe("https://hub.arcgis.com");
@@ -335,7 +335,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.environment).toBe("enterprise");
       expect(mgr.context.properties.site).toEqual(site);
       expect(mgr.context.userResourceTokens).toEqual([]);
-      expect(mgr.context.OGCApiUrl).toBeUndefined();
+      expect(mgr.context.ogcApiUrl).toBeUndefined();
     });
     it("verify when passed featureFlags", async () => {
       const t = new Date().getTime();
@@ -1040,7 +1040,7 @@ describe("ArcGISContext:", () => {
       );
       expect(mgr.context.isPortal).toBe(true);
       expect(mgr.context.hubUrl).toBeUndefined();
-      expect(mgr.context.OGCApiUrl).toBeUndefined();
+      expect(mgr.context.ogcApiUrl).toBeUndefined();
       expect(mgr.context.hubHomeUrl).toBeUndefined();
       expect(mgr.context.discussionsServiceUrl).toBeUndefined();
       expect(mgr.context.hubSearchServiceUrl).toBeUndefined();

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -251,6 +251,9 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.portalUrl).toBe("https://www.arcgis.com");
       expect(mgr.context.isPortal).toBe(false);
       expect(mgr.context.hubUrl).toBe("https://hub.arcgis.com");
+      expect(mgr.context.OGCApiUrl).toBe(
+        "https://opendata.arcgis.com/api/search/v1"
+      );
       expect(mgr.context.hubHomeUrl).toBe("https://hub.arcgis.com");
       expect(mgr.context.requestOptions).toEqual({
         portal: mgr.context.sharingApiUrl,
@@ -332,6 +335,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.environment).toBe("enterprise");
       expect(mgr.context.properties.site).toEqual(site);
       expect(mgr.context.userResourceTokens).toEqual([]);
+      expect(mgr.context.OGCApiUrl).toBeUndefined();
     });
     it("verify when passed featureFlags", async () => {
       const t = new Date().getTime();
@@ -1036,6 +1040,7 @@ describe("ArcGISContext:", () => {
       );
       expect(mgr.context.isPortal).toBe(true);
       expect(mgr.context.hubUrl).toBeUndefined();
+      expect(mgr.context.OGCApiUrl).toBeUndefined();
       expect(mgr.context.hubHomeUrl).toBeUndefined();
       expect(mgr.context.discussionsServiceUrl).toBeUndefined();
       expect(mgr.context.hubSearchServiceUrl).toBeUndefined();


### PR DESCRIPTION
1. Description:

adds `context.OGCApiUrl` for use in `hubSearch` or other parts of the app. 

1. Instructions for testing: run tests

1. Closes Issues: #[8461](https://devtopia.esri.com/dc/hub/issues/8461)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [ x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
