### PR TITLE
feat: add generic action link interfaces/types

### DIFF
--- a/packages/common/src/core/types/ActionLinks.ts
+++ b/packages/common/src/core/types/ActionLinks.ts
@@ -1,3 +1,9 @@
+/**
+ * Type to represent an action link. This is a discriminated
+ * union between actions that link to "external" sources,
+ * actions that link to existing "content", "well-known"
+ * actions, and action link "sections"
+ */
 export type HubActionLink =
   | IHubActionLinkSection
   | IHubExternalActionLink

--- a/packages/common/src/core/types/ActionLinks.ts
+++ b/packages/common/src/core/types/ActionLinks.ts
@@ -1,4 +1,4 @@
-export type IHubActionLink =
+export type HubActionLink =
   | IHubActionLinkSection
   | IHubExternalActionLink
   | IHubContentActionLink
@@ -31,7 +31,7 @@ interface IHubBaseActionLink {
 export interface IHubActionLinkSection extends IHubBaseActionLink {
   kind: "section";
   /** section links */
-  children: IHubActionLink[];
+  children: HubActionLink[];
 }
 
 /**

--- a/packages/common/src/core/types/ActionLinks.ts
+++ b/packages/common/src/core/types/ActionLinks.ts
@@ -4,29 +4,64 @@ export type IHubActionLink =
   | IHubContentActionLink
   | IHubWellKnownActionLink;
 
+/**
+ * base action link properties that all action
+ * link interfaces extend
+ */
 interface IHubBaseActionLink {
+  /**
+   * translated action label - used for the visible label
+   * and/or the underlyiing a11y label
+   */
   label: string;
+  /**
+   * whether the label should be shown in the UI or just be
+   * used for the underlying a11y label
+   */
+  showLabel?: string;
+  /** translated action description */
   description?: string;
+  /** action icon */
   icon?: string;
 }
 
+/**
+ * action link interface for sections
+ */
 export interface IHubActionLinkSection extends IHubBaseActionLink {
   kind: "section";
+  /** section links */
   children: IHubActionLink[];
 }
 
+/**
+ * action link interface for linking to an external source
+ */
 export interface IHubExternalActionLink extends IHubBaseActionLink {
   kind: "external";
+  /**
+   * specifies the URL of the linked resource, which can be
+   * set as an absolute or relative path.
+   */
   href: string;
+  /** specifies where to open the link */
   target?: "_blank";
 }
 
+/**
+ * action link interface for linking to existing content
+ */
 export interface IHubContentActionLink extends IHubBaseActionLink {
   kind: "content";
+  /** content id to link to */
   contentId: string;
 }
 
+/**
+ * action link interface for well-known hub actions
+ */
 export interface IHubWellKnownActionLink extends IHubBaseActionLink {
   kind: "well-known";
+  /** unique action identifier */
   action: string;
 }

--- a/packages/common/src/core/types/ActionLinks.ts
+++ b/packages/common/src/core/types/ActionLinks.ts
@@ -1,0 +1,32 @@
+export type IHubActionLink =
+  | IHubActionLinkSection
+  | IHubExternalActionLink
+  | IHubContentActionLink
+  | IHubWellKnownActionLink;
+
+interface IHubBaseActionLink {
+  label: string;
+  description?: string;
+  icon?: string;
+}
+
+export interface IHubActionLinkSection extends IHubBaseActionLink {
+  kind: "section";
+  children: IHubActionLink[];
+}
+
+export interface IHubExternalActionLink extends IHubBaseActionLink {
+  kind: "external";
+  href: string;
+  target?: "_blank";
+}
+
+export interface IHubContentActionLink extends IHubBaseActionLink {
+  kind: "content";
+  contentId: string;
+}
+
+export interface IHubWellKnownActionLink extends IHubBaseActionLink {
+  kind: "well-known";
+  action: string;
+}

--- a/packages/common/src/core/types/index.ts
+++ b/packages/common/src/core/types/index.ts
@@ -1,3 +1,4 @@
+export * from "./ActionLinks";
 export * from "./DynamicValues";
 export * from "./HubEntity";
 export * from "./HubEntityEditor";


### PR DESCRIPTION
[8466](https://devtopia.esri.com/dc/hub/issues/8466)
###  Description:
introduce a new `HubActionLink` type that is a discriminated union of action link interfaces (external, content, well-known, section)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.