### PR TITLE
fix(): update max size of metrics on an entity to 24

### DIFF
--- a/packages/common/src/core/schemas/internal/metrics/setMetricAndDisplay.ts
+++ b/packages/common/src/core/schemas/internal/metrics/setMetricAndDisplay.ts
@@ -20,9 +20,12 @@ export function setMetricAndDisplay(
 ): IHubProject {
   const entityCopy = cloneObject(entity);
   const metricId = metric.id;
-  const mIndex = entityCopy.metrics.findIndex((m) => m.id === metricId);
 
-  // get array in case of undefined
+  // get with default in case we have an undefined metrics array
+  const metrics = getWithDefault(entityCopy, "metrics", []);
+  const mIndex = metrics.findIndex((m: IMetric) => m.id === metricId);
+
+  // get array in case of undefined displays array
   const displays = getWithDefault(entityCopy, "view.metricDisplays", []);
   const dIndex = displays.findIndex(
     (d: IMetricDisplayConfig) => d.metricId === metricId
@@ -30,9 +33,9 @@ export function setMetricAndDisplay(
 
   // existing vs new metric
   if (mIndex > -1) {
-    entityCopy.metrics[mIndex] = metric;
+    metrics[mIndex] = metric;
   } else {
-    entityCopy.metrics.push(metric);
+    metrics.push(metric);
   }
 
   // existing vs new display
@@ -42,8 +45,9 @@ export function setMetricAndDisplay(
     displays.push(displayConfig);
   }
 
-  // reset the displays array
+  // reset the arrays
   entityCopy.view.metricDisplays = displays;
+  entityCopy.metrics = metrics;
 
   return entityCopy;
 }

--- a/packages/common/src/core/types/Metrics.ts
+++ b/packages/common/src/core/types/Metrics.ts
@@ -282,4 +282,4 @@ export interface IDynamicMetricValues {
 }
 
 /** Maxmium number of metrics allowed on any given entity. */
-export const MAX_ENTITY_METRICS_ALLOWED = 12;
+export const MAX_ENTITY_METRICS_ALLOWED = 24;


### PR DESCRIPTION
1. Description:
Changes the maximum amount of metrics allowed on an entity to 24. 
1. Instructions for testing:

1. Closes Issues: #6633<number> (if appropriate)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
