### PR TITLE
feat: add refreshUser method to context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.54.0",
+			"version": "14.59.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -3,7 +3,7 @@ import {
   IUserRequestOptions,
   UserSession,
 } from "@esri/arcgis-rest-auth";
-import { IPortal } from "@esri/arcgis-rest-portal";
+import { IGetUserOptions, IPortal, getUser } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { HubServiceStatus } from "./core";
 import { getProp, getWithDefault } from "./objects";
@@ -220,6 +220,11 @@ export interface IArcGISContext {
    * @param app
    */
   tokenFor(app: UserResourceApp): string;
+
+  /**
+   * Refresh the current user, including their groups
+   */
+  refreshUser(): Promise<void>;
 }
 
 /**
@@ -751,5 +756,21 @@ export class ArcGISContext implements IArcGISContext {
     if (entry) {
       return entry.token;
     }
+  }
+
+  /**
+   * Re-fetch the current user, including their groups
+   * @returns
+   */
+  public refreshUser(): Promise<void> {
+    const opts: IGetUserOptions = {
+      authentication: this.session,
+      portal: this.sharingApiUrl,
+      username: this.session.username,
+    };
+
+    return getUser(opts).then((user) => {
+      this._currentUser = user;
+    });
   }
 }


### PR DESCRIPTION
1. Description:

Adds `context.refreshUser():Promise<void>` which can be used to force context to update it's cached version of the user, and their groups. This should be called by apps when the current user creates or removes groups, or when they join/leave groups.

1. Instructions for testing: run tests

1. Closes Issues: #8455

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
