### PR TITLE
feat: add new processActionLinks utils

### DIFF
--- a/packages/common/src/core/index.ts
+++ b/packages/common/src/core/index.ts
@@ -6,6 +6,7 @@ export * from "./fetchHubEntity";
 export * from "./getTypeFromEntity";
 export * from "./getRelativeWorkspaceUrl";
 export * from "./isValidEntityType";
+export * from "./processActionLinks";
 
 // For sme reason, if updateHubEntity is exported here,
 // it is not actually exported in the final package.

--- a/packages/common/src/core/processActionLinks.ts
+++ b/packages/common/src/core/processActionLinks.ts
@@ -1,0 +1,82 @@
+import { IQuery, hubSearch } from "../search";
+import { IHubRequestOptions } from "../types";
+import {
+  HubActionLink,
+  IHubContentActionLink,
+  IHubExternalActionLink,
+} from "./types";
+
+/**
+ * Given an array of IHubActionLinks, the following util will
+ * "pre-process" the action links. This includes:
+ *
+ * 1. For kind = "content": Fetching the content item, grabbing
+ * its site relative href, and transforming the link into an
+ * external action link that can be consumed in the UI
+ *
+ * Note: we can add other pre-processing as necessary
+ *
+ * @param links hub action links
+ * @param requestOptions hub request options
+ */
+export async function processActionLinks(
+  links: HubActionLink[],
+  requestOptions: IHubRequestOptions
+): Promise<Array<Exclude<HubActionLink, IHubContentActionLink>>> {
+  const processedActionLinks = await Promise.all(
+    links.map(async (link: HubActionLink) => {
+      return processActionLink(link, requestOptions);
+    })
+  );
+
+  return processedActionLinks;
+}
+
+/**
+ * Given a single IHubActionLink, the following util will
+ * "pre-process" the action link. This includes:
+ *
+ * 1. For kind = "content": Fetching the content item, grabbing
+ * its site relative href, and transforming the link into an
+ * external action link that can be consumed in the UI
+ *
+ * Note: we can add other pre-processing as necessary
+ *
+ * @param link hub action link
+ * @param requestOptions hub request options
+ */
+export async function processActionLink(
+  link: HubActionLink,
+  requestOptions: IHubRequestOptions
+): Promise<Exclude<HubActionLink, IHubContentActionLink>> {
+  // recursively process nested links
+  if (link.kind === "section") {
+    link.children = await processActionLinks(link.children, requestOptions);
+  }
+  if (link.kind === "content") {
+    try {
+      // 1. query for the content item so we can grab its
+      // siteRelative href
+      const query: IQuery = {
+        targetEntity: "item",
+        filters: [{ predicates: [{ id: link.contentId }] }],
+      };
+      const { results } = await hubSearch(query, { requestOptions });
+
+      // 2. construct a new "external" action link
+      // with the content item's site relative href
+      delete link.contentId;
+      const processedLink: IHubExternalActionLink = {
+        ...link,
+        kind: "external",
+        href: results[0].links.siteRelative,
+      };
+
+      return processedLink;
+    } catch (error) {
+      throw new Error(`Unable to fetch entity: ${link.contentId}`);
+    }
+  } else {
+    return link;
+  }
+}

--- a/packages/common/test/core/processActionLinks.test.ts
+++ b/packages/common/test/core/processActionLinks.test.ts
@@ -1,0 +1,123 @@
+import { getProp } from "../../src/objects";
+import { processActionLink } from "../../src/core/processActionLinks";
+import {
+  HubActionLink,
+  IHubActionLinkSection,
+  IHubContentActionLink,
+  IHubExternalActionLink,
+  IHubWellKnownActionLink,
+} from "../../src/core/types/ActionLinks";
+import * as searchModule from "../../src/search";
+
+describe("processActionLink", () => {
+  let hubSearchSpy: jasmine.Spy;
+
+  it('processes action links of kind "content": fetches the content item and returns an external action link', async () => {
+    hubSearchSpy = spyOn(searchModule, "hubSearch").and.returnValue(
+      Promise.resolve({
+        results: [{ id: "00c", links: { siteRelative: "/mock-site-url" } }],
+      })
+    );
+    const mockLink: IHubContentActionLink = {
+      kind: "content",
+      contentId: "00c",
+      label: "content action link",
+    };
+
+    const res = await processActionLink(mockLink, {});
+    expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+    expect(res).toEqual({
+      kind: "external",
+      href: "/mock-site-url",
+      label: "content action link",
+    });
+  });
+
+  it('does nothing to action links of kind "external"', async () => {
+    const mockLink: IHubExternalActionLink = {
+      kind: "external",
+      href: "https://some-url.com",
+      label: "external action link",
+    };
+
+    const res = await processActionLink(mockLink, {});
+    expect(res).toEqual(mockLink);
+  });
+
+  it('does nothing to action links of kind "well-known"', async () => {
+    const mockLink: IHubWellKnownActionLink = {
+      kind: "well-known",
+      action: "follow",
+      label: "well-known action link",
+    };
+
+    const res = await processActionLink(mockLink, {});
+    expect(res).toEqual(mockLink);
+  });
+
+  it('does nothing to action links of kind "section"', async () => {
+    const mockLink: IHubActionLinkSection = {
+      kind: "section",
+      children: [],
+      label: "action link section",
+    };
+
+    const res = await processActionLink(mockLink, {});
+    expect(res).toEqual(mockLink);
+  });
+
+  it("handles nested links", async () => {
+    hubSearchSpy = spyOn(searchModule, "hubSearch").and.returnValue(
+      Promise.resolve({
+        results: [{ id: "00c", links: { siteRelative: "/mock-site-url" } }],
+      })
+    );
+    const mockLink: HubActionLink = {
+      kind: "section",
+      label: "action link section",
+      children: [
+        {
+          kind: "content",
+          contentId: "00b",
+          label: "nested conent action link",
+        },
+        {
+          kind: "section",
+          label: "action link nested section",
+          children: [
+            {
+              kind: "content",
+              contentId: "00c",
+              label: "doubly nested conent action link",
+            },
+          ],
+        },
+      ],
+    };
+
+    const res = await processActionLink(mockLink, {});
+    expect(getProp(res, "children[0].kind")).toBe("external");
+    expect(getProp(res, "children[0].href")).toBe("/mock-site-url");
+    expect(getProp(res, "children[1].children[0].kind")).toBe("external");
+    expect(getProp(res, "children[1].children[0].href")).toBe("/mock-site-url");
+  });
+
+  it("handles errors", async () => {
+    hubSearchSpy = spyOn(searchModule, "hubSearch").and.returnValue(
+      Promise.reject(new Error("error"))
+    );
+
+    const mockLink: IHubContentActionLink = {
+      kind: "content",
+      contentId: "00c",
+      label: "content action link",
+    };
+
+    try {
+      await processActionLink(mockLink, {});
+    } catch (ex) {
+      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+      expect((ex as any).message).toBe("Unable to fetch entity: 00c");
+    }
+  });
+});


### PR DESCRIPTION
[8466](https://devtopia.esri.com/dc/hub/issues/8466)

### Description 
adds new `processActionLink` and `processActionLinks` utils to "pre-process" a single `HubActionLink` or an array of `HubActionLinks`. For now, this involves transforming action links of `kind = "content"` into action links with an `href` that can be easily consumed in the UI. We can theoretically add additional "pre-processing" transforms to this util as they become necessary.

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.