### PR TITLE
feat(hub-common): allow workspaces to route to specific panes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.59.0",
+			"version": "14.60.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/core/getEntityDefaultWorkspacePane.ts
+++ b/packages/common/src/core/getEntityDefaultWorkspacePane.ts
@@ -1,0 +1,6 @@
+export const getEntityDefaultWorkspacePane = (entityType: string): string => {
+  const DEFAULT_PANES: Record<string, string> = {
+    discussion: "details",
+  };
+  return DEFAULT_PANES[entityType];
+};

--- a/packages/common/src/core/getRelativeWorkspaceUrl.ts
+++ b/packages/common/src/core/getRelativeWorkspaceUrl.ts
@@ -11,7 +11,8 @@ import { HubEntity } from "./types";
  */
 export const getRelativeWorkspaceUrl = (
   type: string,
-  identifier: string
+  identifier: string,
+  pane?: string
 ): string => {
   let url = "/";
   const entityType = getTypeFromEntity({ type } as HubEntity);
@@ -27,6 +28,9 @@ export const getRelativeWorkspaceUrl = (
       typeSegment = `${typeSegment}s`;
     }
     url = `/workspace/${typeSegment}/${identifier}`;
+    if (pane) {
+      url += `/${pane}`;
+    }
   }
 
   return url;

--- a/packages/common/src/core/index.ts
+++ b/packages/common/src/core/index.ts
@@ -3,6 +3,7 @@ export * from "./types";
 export * from "./behaviors";
 export * from "./schemas";
 export * from "./fetchHubEntity";
+export * from "./getEntityDefaultWorkspacePane";
 export * from "./getTypeFromEntity";
 export * from "./getRelativeWorkspaceUrl";
 export * from "./isValidEntityType";

--- a/packages/common/test/core/getEntityDefaultWorkspacePane.test.ts
+++ b/packages/common/test/core/getEntityDefaultWorkspacePane.test.ts
@@ -1,0 +1,12 @@
+import { getEntityDefaultWorkspacePane } from "../../src/core/getEntityDefaultWorkspacePane";
+
+describe("getRelativeWorkspaceUrl", () => {
+  it("returns default for entity type", () => {
+    const result = getEntityDefaultWorkspacePane("discussion");
+    expect(result).toEqual("details");
+  });
+  it("returns undefined if no default set", () => {
+    const result = getEntityDefaultWorkspacePane("fake");
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/common/test/core/getRelativeWorkspaceUrl.test.ts
+++ b/packages/common/test/core/getRelativeWorkspaceUrl.test.ts
@@ -53,4 +53,20 @@ describe("getRelativeWorkspaceUrl", () => {
     expect(isValidEntityTypeSpy).toHaveBeenCalledTimes(1);
     expect(result).toBe("/");
   });
+  it("returns url with workspace pane when provided", () => {
+    const getTypeFromEntitySpy = spyOn(
+      getTypeFromEntityModule,
+      "getTypeFromEntity"
+    ).and.returnValue("project");
+    const isValidEntityTypeSpy = spyOn(
+      isValidEntityTypeModule,
+      "isValidEntityType"
+    ).and.returnValue(true);
+
+    result = getRelativeWorkspaceUrl("Hub Project", "123", "details");
+
+    expect(getTypeFromEntitySpy).toHaveBeenCalledTimes(1);
+    expect(isValidEntityTypeSpy).toHaveBeenCalledTimes(1);
+    expect(result).toBe("/workspace/projects/123/details");
+  });
 });


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 8529, 8527

1. Description: Allows workspaces to route to specific panes.

1. Instructions for testing:

1. Closes Issues: #8529, #8527

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
