### PR TITLE
feat: add logic/schema to allow follower group creation

### DIFF
--- a/packages/common/src/core/schemas/internal/getEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getEditorSchemas.ts
@@ -201,6 +201,8 @@ export async function getEditorSchemas(
       schema = cloneObject(GroupSchema);
 
       const groupModule = await {
+        "hub:group:create:followers": () =>
+          import("../../../groups/_internal/GroupUiSchemaCreateFollowers"),
         "hub:group:edit": () =>
           import("../../../groups/_internal/GroupUiSchemaEdit"),
         "hub:group:settings": () =>

--- a/packages/common/src/groups/HubGroup.ts
+++ b/packages/common/src/groups/HubGroup.ts
@@ -287,8 +287,6 @@ export class HubGroup
    * @returns
    */
   async fromEditor(editor: IHubGroupEditor): Promise<IHubGroup> {
-    const isCreate = !editor.id;
-
     // Setting the thumbnailCache will ensure that
     // the thumbnail is updated on next save
     if (editor._thumbnail) {
@@ -339,14 +337,9 @@ export class HubGroup
     // of the toEditor method
     const entity = cloneObject(editor) as IHubGroup;
 
-    // create it if it does not yet exist...
-    if (isCreate) {
-      throw new Error("Cannot create group using the Editor.");
-    } else {
-      // ...otherwise, update the in-memory entity and save it
-      this.entity = entity;
-      await this.save();
-    }
+    // save or create group
+    this.entity = entity;
+    await this.save();
 
     return this.entity;
   }

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -20,6 +20,7 @@ import { convertGroupToHubGroup } from "./_internal/convertGroupToHubGroup";
 import { setDiscussableKeyword } from "../discussions";
 import { IHubSearchResult } from "../search/types/IHubSearchResult";
 import { computeLinks } from "./_internal/computeLinks";
+import { getUniqueGroupTitle } from "./_internal/getUniqueGroupTitle";
 
 /**
  * Enrich a generic search result
@@ -102,6 +103,11 @@ export async function createHubGroup(
 ): Promise<IHubGroup> {
   // merge the incoming and default groups
   const hubGroup = { ...DEFAULT_GROUP, ...partialGroup } as IHubGroup;
+
+  // ensure the group has a unique title
+  const uniqueTitle = await getUniqueGroupTitle(hubGroup.name, requestOptions);
+  hubGroup.name = uniqueTitle;
+
   hubGroup.typeKeywords = setDiscussableKeyword(
     hubGroup.typeKeywords,
     hubGroup.isDiscussable

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -39,6 +39,15 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:group"],
     authenticated: true,
     privileges: ["portal:user:createGroup"],
+    assertions: [
+      {
+        property: "context:currentUser.groups",
+        type: "length-lt",
+        // TODO: 512 is the default, but there are exceptions
+        // this should be based on the org's specified limit
+        value: 512,
+      },
+    ],
   },
   {
     permission: "hub:group:view",

--- a/packages/common/src/groups/_internal/GroupSchema.ts
+++ b/packages/common/src/groups/_internal/GroupSchema.ts
@@ -11,6 +11,7 @@ export const GroupEditorTypes = [
   "hub:group:edit",
   "hub:group:settings",
   "hub:group:discussions",
+  // editor to create a followers group
   "hub:group:create:followers",
 ] as const;
 

--- a/packages/common/src/groups/_internal/GroupSchema.ts
+++ b/packages/common/src/groups/_internal/GroupSchema.ts
@@ -8,10 +8,10 @@ import {
 
 export type GroupEditorType = (typeof GroupEditorTypes)[number];
 export const GroupEditorTypes = [
-  "hub:group:create:followers",
   "hub:group:edit",
   "hub:group:settings",
   "hub:group:discussions",
+  "hub:group:create:followers",
 ] as const;
 
 /**

--- a/packages/common/src/groups/_internal/GroupSchema.ts
+++ b/packages/common/src/groups/_internal/GroupSchema.ts
@@ -8,6 +8,7 @@ import {
 
 export type GroupEditorType = (typeof GroupEditorTypes)[number];
 export const GroupEditorTypes = [
+  "hub:group:create:followers",
   "hub:group:edit",
   "hub:group:settings",
   "hub:group:discussions",

--- a/packages/common/src/groups/_internal/GroupUiSchemaCreateFollowers.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaCreateFollowers.ts
@@ -1,0 +1,111 @@
+import { IUiSchema, UiSchemaRuleEffects } from "../../core/schemas/types";
+import { IArcGISContext } from "../../ArcGISContext";
+import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
+
+/**
+ * @private
+ * constructs the complete create uiSchema for Hub follower
+ * groups. This defines how the schema properties should be
+ * rendered in the follower group creation experience
+ */
+export const buildUiSchema = async (
+  i18nScope: string,
+  options: EntityEditorOptions,
+  context: IArcGISContext
+): Promise<IUiSchema> => {
+  return {
+    type: "Layout",
+    elements: [
+      {
+        type: "Section",
+        options: { section: "stepper", scale: "l" },
+        elements: [
+          {
+            type: "Step",
+            labelKey: `${i18nScope}.sections.details.label`,
+            elements: [
+              {
+                labelKey: `${i18nScope}.fields.name.label`,
+                scope: "/properties/name",
+                type: "Control",
+                options: {
+                  messages: [
+                    {
+                      type: "ERROR",
+                      keyword: "required",
+                      icon: true,
+                      labelKey: `${i18nScope}.fields.name.requiredError`,
+                    },
+                    {
+                      type: "ERROR",
+                      keyword: "maxLength",
+                      icon: true,
+                      labelKey: `${i18nScope}.fields.name.maxLengthError`,
+                    },
+                  ],
+                },
+              },
+              {
+                labelKey: `${i18nScope}.fields.summary.label`,
+                scope: "/properties/summary",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-input",
+                  type: "textarea",
+                  rows: 4,
+                  messages: [
+                    {
+                      type: "ERROR",
+                      keyword: "maxLength",
+                      icon: true,
+                      labelKey: `${i18nScope}.fields.summary.maxLengthError`,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            type: "Step",
+            labelKey: `${i18nScope}.sections.membershipAccess.label`,
+            rule: {
+              effect: UiSchemaRuleEffects.DISABLE,
+              condition: {
+                scope: "/properties/name",
+                schema: { const: "" },
+              },
+            },
+            elements: [
+              {
+                labelKey: `${i18nScope}.fields.membershipAccess.label`,
+                scope: "/properties/membershipAccess",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-radio",
+                  labels: [
+                    `{{${i18nScope}.fields.membershipAccess.org:translate}}`,
+                    `{{${i18nScope}.fields.membershipAccess.collab:translate}}`,
+                    `{{${i18nScope}.fields.membershipAccess.any:translate}}`,
+                  ],
+                  disabled: [false, false, options.isSharedUpdate],
+                },
+              },
+              {
+                labelKey: `${i18nScope}.fields.contributeContent.label`,
+                scope: "/properties/isViewOnly",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-radio",
+                  labels: [
+                    `{{${i18nScope}.fields.contributeContent.all:translate}}`,
+                    `{{${i18nScope}.fields.contributeContent.admins:translate}}`,
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+};

--- a/packages/common/src/groups/_internal/GroupUiSchemaCreateFollowers.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaCreateFollowers.ts
@@ -4,8 +4,8 @@ import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
 
 /**
  * @private
- * constructs the complete create uiSchema for Hub follower
- * groups. This defines how the schema properties should be
+ * constructs the complete uiSchema for creating a followers
+ * group. This defines how the schema properties should be
  * rendered in the follower group creation experience
  */
 export const buildUiSchema = async (

--- a/packages/common/src/groups/_internal/getUniqueGroupTitle.ts
+++ b/packages/common/src/groups/_internal/getUniqueGroupTitle.ts
@@ -3,6 +3,7 @@ import { hubSearch } from "../../search/hubSearch";
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 /**
+ * @private
  * Given a title, construct a group title that is unique
  * in the user's org.
  *
@@ -10,11 +11,12 @@ import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
  * title exists this fn will add a number on the end, and
  * increment until an available group title is found - i.e.
  * "Medical Team 3"
+ *
  * @param {String} title Group Title to ensure if unique
  * @param {IUserRequestOptions} requestOptions
  * @param {Number} step Number to increment. Defaults to 0
  */
-export function getUniqueGroupTitle(
+export async function getUniqueGroupTitle(
   title: string,
   requestOptions: IUserRequestOptions,
   step = 0
@@ -40,7 +42,7 @@ export function getUniqueGroupTitle(
 }
 
 /**
- * checks whether the group with the specified title
+ * checks whether a group with the specified title
  * exists in the user's org
  *
  * @param {String} title Group Title

--- a/packages/common/src/groups/_internal/getUniqueGroupTitle.ts
+++ b/packages/common/src/groups/_internal/getUniqueGroupTitle.ts
@@ -8,11 +8,11 @@ import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
  * in the user's org.
  *
  * Ex: Given a title of "Medical Team", if a group with that
- * title exists this fn will add a number on the end, and
+ * title exists, this fn will add a number on the end, and
  * increment until an available group title is found - i.e.
  * "Medical Team 3"
  *
- * @param {String} title Group Title to ensure if unique
+ * @param {String} title Group Title to ensure is unique
  * @param {IUserRequestOptions} requestOptions
  * @param {Number} step Number to increment. Defaults to 0
  */

--- a/packages/common/src/groups/_internal/getUniqueGroupTitle.ts
+++ b/packages/common/src/groups/_internal/getUniqueGroupTitle.ts
@@ -1,0 +1,63 @@
+import { IQuery } from "../../search/types";
+import { hubSearch } from "../../search/hubSearch";
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+
+/**
+ * Given a title, construct a group title that is unique
+ * in the user's org.
+ *
+ * Ex: Given a title of "Medical Team", if a group with that
+ * title exists this fn will add a number on the end, and
+ * increment until an available group title is found - i.e.
+ * "Medical Team 3"
+ * @param {String} title Group Title to ensure if unique
+ * @param {IUserRequestOptions} requestOptions
+ * @param {Number} step Number to increment. Defaults to 0
+ */
+export function getUniqueGroupTitle(
+  title: string,
+  requestOptions: IUserRequestOptions,
+  step = 0
+): Promise<string> {
+  let combinedName = title;
+
+  if (step) {
+    combinedName = `${title} ${step}`;
+  }
+
+  return doesGroupExist(combinedName, requestOptions)
+    .then((result) => {
+      if (result) {
+        step++;
+        return getUniqueGroupTitle(title, requestOptions, step);
+      } else {
+        return combinedName;
+      }
+    })
+    .catch((err) => {
+      throw Error(`Error in getUniqueGroupTitle: ${err}`);
+    });
+}
+
+/**
+ * checks whether the group with the specified title
+ * exists in the user's org
+ *
+ * @param {String} title Group Title
+ * @param {IUserRequestOptions} requestOptions
+ */
+async function doesGroupExist(
+  title: string,
+  requestOptions: IUserRequestOptions
+) {
+  const query: IQuery = {
+    targetEntity: "group",
+    filters: [{ predicates: [{ title }] }],
+  };
+  try {
+    const { results } = await hubSearch(query, { requestOptions });
+    return results.length > 0;
+  } catch (error) {
+    throw Error(`Error in getUniqueGroupTitle > doesGroupExist: ${error}`);
+  }
+}

--- a/packages/common/src/permissions/_internal/checkAssertion.ts
+++ b/packages/common/src/permissions/_internal/checkAssertion.ts
@@ -65,6 +65,10 @@ export function checkAssertion(
       case "lt":
         response = rangeAssertions(assertion, propValue, val);
         break;
+      case "length-gt":
+      case "length-lt":
+        response = lengthAssertions(assertion, propValue, val);
+        break;
       case "is-group-admin":
       case "is-group-member":
       case "is-group-owner":
@@ -225,6 +229,33 @@ function rangeAssertions(
     response = "assertion-failed";
   } else if (assertion.type === "lt" && propValue > val) {
     response = "assertion-failed";
+  }
+  return response;
+}
+
+/**
+ * Is the propValue length "gt" or "lt" to the val?
+ * @param assertion
+ * @param propValue
+ * @param val
+ * @returns
+ */
+function lengthAssertions(
+  assertion: IPolicyAssertion,
+  propValue: any,
+  val: any
+): PolicyResponse {
+  let response: PolicyResponse = "granted";
+  if (typeof propValue !== "string" && !Array.isArray(propValue)) {
+    response = "property-has-no-length";
+  } else if (typeof val !== "number") {
+    response = "assertion-requires-numeric-values";
+  } else {
+    if (assertion.type === "length-gt" && propValue.length < val) {
+      response = "assertion-failed";
+    } else if (assertion.type === "length-lt" && propValue.length > val) {
+      response = "assertion-failed";
+    }
   }
   return response;
 }

--- a/packages/common/src/permissions/types/IPermissionPolicy.ts
+++ b/packages/common/src/permissions/types/IPermissionPolicy.ts
@@ -129,6 +129,8 @@ export type AssertionType =
   | "neq"
   | "gt"
   | "lt"
+  | "length-gt"
+  | "length-lt"
   | "contains"
   | "contains-all"
   | "without"

--- a/packages/common/src/permissions/types/PolicyResponse.ts
+++ b/packages/common/src/permissions/types/PolicyResponse.ts
@@ -31,6 +31,7 @@ export type PolicyResponse =
   | "not-beta-org" // user is not in a beta org
   | "property-missing" // assertion requires property but is missing from entity
   | "property-not-array" // assertion requires array property
+  | "property-has-no-length" // assertion requires string or array property
   | "array-contains-invalid-value" // assertion specifies a value not be included
   | "array-missing-required-value" // assertion specifies a value not be included
   | "property-mismatch"

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -137,6 +137,7 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:site:workspace:followers",
+    licenses: ["hub-premium"],
     dependencies: ["hub:site:workspace", "hub:site:edit"],
   },
   {

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -38,6 +38,7 @@ export const SitePermissions = [
   "hub:site:workspace:followers",
   "hub:site:workspace:followers:member",
   "hub:site:workspace:followers:manager",
+  "hub:site:workspace:followers:create",
   "hub:site:workspace:discussion",
   "hub:site:manage",
 ] as const;
@@ -137,6 +138,8 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:site:workspace:followers",
+    // TODO: refactor once we have an "upsell" UI to try to
+    // get basic users to switch to premium for this feature
     licenses: ["hub-premium"],
     dependencies: ["hub:site:workspace", "hub:site:edit"],
   },
@@ -161,6 +164,12 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
         value: "entity:followersGroupId",
       },
     ],
+  },
+  // permission to create a followers group
+  {
+    permission: "hub:site:workspace:followers:create",
+    dependencies: ["hub:site:workspace:followers", "hub:group:create"],
+    privileges: ["portal:user:addExternalMembersToGroup"],
   },
   {
     permission: "hub:site:workspace:discussion",

--- a/packages/common/test/core/schemas/internal/getEditorSchemas.test.ts
+++ b/packages/common/test/core/schemas/internal/getEditorSchemas.test.ts
@@ -37,6 +37,7 @@ import { GroupEditorTypes } from "../../../../src/groups/_internal/GroupSchema";
 import * as GroupBuildEditUiSchema from "../../../../src/groups/_internal/GroupUiSchemaEdit";
 import * as GroupBuildSettingsUiSchema from "../../../../src/groups/_internal/GroupUiSchemaSettings";
 import * as GroupBuildDiscussionsUiSchema from "../../../../src/groups/_internal/GroupUiSchemaDiscussions";
+import * as GroupBuildCreateFollowersUiSchema from "../../../../src/groups/_internal/GroupUiSchemaCreateFollowers";
 
 import { InitiativeTemplateEditorTypes } from "../../../../src/initiative-templates/_internal/InitiativeTemplateSchema";
 import * as InitiativeTemplateBuildEditUiSchema from "../../../../src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit";
@@ -73,11 +74,12 @@ describe("getEditorSchemas: ", () => {
     { type: TemplateEditorTypes[0], buildFn: TemplateBuildEditUiSchema },
     { type: GroupEditorTypes[0], buildFn: GroupBuildEditUiSchema },
     { type: GroupEditorTypes[1], buildFn: GroupBuildSettingsUiSchema },
+    { type: GroupEditorTypes[2], buildFn: GroupBuildDiscussionsUiSchema },
+    { type: GroupEditorTypes[3], buildFn: GroupBuildCreateFollowersUiSchema },
     {
       type: InitiativeTemplateEditorTypes[0],
       buildFn: InitiativeTemplateBuildEditUiSchema,
     },
-    { type: GroupEditorTypes[2], buildFn: GroupBuildDiscussionsUiSchema },
     { type: validCardEditorTypes[0], buildFn: statUiSchemaModule },
   ].forEach(async ({ type, buildFn }) => {
     it("returns a schema & uiSchema for a given entity and editor type", async () => {

--- a/packages/common/test/groups/HubGroup.test.ts
+++ b/packages/common/test/groups/HubGroup.test.ts
@@ -383,29 +383,6 @@ describe("HubGroup class:", () => {
         expect(result.name).toEqual("new name");
       });
 
-      it("throws when is create", async () => {
-        const chk = HubGroup.fromJson(
-          {
-            name: "Test Entity",
-            thumbnailUrl: "https://myserver.com/thumbnail.png",
-          },
-          authdCtxMgr.context
-        );
-        // spy on the instance .save method and retrn void
-        const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
-        // make changes to the editor
-        const editor = await chk.toEditor();
-        // get the group loaded from the editor
-        try {
-          await await chk.fromEditor(editor);
-        } catch (e) {
-          expect(getProp(e, "message")).toBe(
-            "Cannot create group using the Editor."
-          );
-        }
-        expect(saveSpy).toHaveBeenCalledTimes(0);
-      });
-
       it("handles thumbnail change", async () => {
         const chk = HubGroup.fromJson(
           {

--- a/packages/common/test/groups/HubGroups.test.ts
+++ b/packages/common/test/groups/HubGroups.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../src";
 import * as HubGroupsModule from "../../src/groups/HubGroups";
 import * as FetchEnrichments from "../../src/groups/_internal/enrichments";
+import * as GetUniqueGroupTitleModule from "../../src/groups/_internal/getUniqueGroupTitle";
 import { IHubGroup } from "../../src/core/types/IHubGroup";
 
 const GUID = "9b77674e43cf4bbd9ecad5189b3f1fdc";
@@ -151,6 +152,10 @@ describe("HubGroups Module:", () => {
 
   describe("createHubGroup", () => {
     it("creates a HubGroup from an IGroup", async () => {
+      const getUniqueGroupTitleSpy = spyOn(
+        GetUniqueGroupTitleModule,
+        "getUniqueGroupTitle"
+      ).and.returnValue(Promise.resolve(TEST_GROUP.title));
       const portalCreateGroupSpy = spyOn(
         PortalModule,
         "createGroup"
@@ -167,6 +172,7 @@ describe("HubGroups Module:", () => {
         { authentication: MOCK_AUTH }
       );
       expect(chk.name).toBe("dev followers Content");
+      expect(getUniqueGroupTitleSpy).toHaveBeenCalledTimes(1);
       expect(portalCreateGroupSpy).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/common/test/groups/_internal/GroupUiSchemaCreateFollowers.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaCreateFollowers.test.ts
@@ -1,0 +1,108 @@
+import { IHubGroup, UiSchemaRuleEffects } from "../../../src";
+import { buildUiSchema } from "../../../src/groups/_internal/GroupUiSchemaCreateFollowers";
+import { MOCK_CONTEXT } from "../../mocks/mock-auth";
+
+describe("buildUiSchema: create followers group", () => {
+  it("returns the uiSchema to create a followers group", async () => {
+    const uiSchema = await buildUiSchema(
+      "some.scope",
+      { isSharedUpdate: true } as IHubGroup,
+      MOCK_CONTEXT
+    );
+    expect(uiSchema).toEqual({
+      type: "Layout",
+      elements: [
+        {
+          type: "Section",
+          options: { section: "stepper", scale: "l" },
+          elements: [
+            {
+              type: "Step",
+              labelKey: "some.scope.sections.details.label",
+              elements: [
+                {
+                  labelKey: "some.scope.fields.name.label",
+                  scope: "/properties/name",
+                  type: "Control",
+                  options: {
+                    messages: [
+                      {
+                        type: "ERROR",
+                        keyword: "required",
+                        icon: true,
+                        labelKey: "some.scope.fields.name.requiredError",
+                      },
+                      {
+                        type: "ERROR",
+                        keyword: "maxLength",
+                        icon: true,
+                        labelKey: "some.scope.fields.name.maxLengthError",
+                      },
+                    ],
+                  },
+                },
+                {
+                  labelKey: "some.scope.fields.summary.label",
+                  scope: "/properties/summary",
+                  type: "Control",
+                  options: {
+                    control: "hub-field-input-input",
+                    type: "textarea",
+                    rows: 4,
+                    messages: [
+                      {
+                        type: "ERROR",
+                        keyword: "maxLength",
+                        icon: true,
+                        labelKey: "some.scope.fields.summary.maxLengthError",
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            {
+              type: "Step",
+              labelKey: "some.scope.sections.membershipAccess.label",
+              rule: {
+                effect: UiSchemaRuleEffects.DISABLE,
+                condition: {
+                  scope: "/properties/name",
+                  schema: { const: "" },
+                },
+              },
+              elements: [
+                {
+                  labelKey: "some.scope.fields.membershipAccess.label",
+                  scope: "/properties/membershipAccess",
+                  type: "Control",
+                  options: {
+                    control: "hub-field-input-radio",
+                    labels: [
+                      "{{some.scope.fields.membershipAccess.org:translate}}",
+                      "{{some.scope.fields.membershipAccess.collab:translate}}",
+                      "{{some.scope.fields.membershipAccess.any:translate}}",
+                    ],
+                    disabled: [false, false, true],
+                  },
+                },
+                {
+                  labelKey: "some.scope.fields.contributeContent.label",
+                  scope: "/properties/isViewOnly",
+                  type: "Control",
+                  options: {
+                    control: "hub-field-input-radio",
+                    labels: [
+                      "{{some.scope.fields.contributeContent.all:translate}}",
+                      "{{some.scope.fields.contributeContent.admins:translate}}",
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/common/test/groups/_internal/getUniqueGroupTitle.test.ts
+++ b/packages/common/test/groups/_internal/getUniqueGroupTitle.test.ts
@@ -1,0 +1,51 @@
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import { getUniqueGroupTitle } from "../../../src/groups/_internal/getUniqueGroupTitle";
+import * as SearchModule from "../../../src/search/hubSearch";
+
+describe("getUniqueGroupTitle", () => {
+  let hubSearchSpy: jasmine.Spy;
+
+  it("returns an unmodified title when a group with the provided title does NOT exist", async () => {
+    hubSearchSpy = spyOn(SearchModule, "hubSearch").and.returnValue(
+      Promise.resolve({ results: [] })
+    );
+
+    const res = await getUniqueGroupTitle(
+      "Mock Title",
+      {} as IUserRequestOptions
+    );
+
+    expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+    expect(res).toBe("Mock Title");
+  });
+
+  it("returns a unique title when a group with the provided title already exists", async () => {
+    hubSearchSpy = spyOn(SearchModule, "hubSearch").and.returnValues(
+      Promise.resolve({ results: [{ id: "00c" }] }),
+      Promise.resolve({ results: [] })
+    );
+
+    const res = await getUniqueGroupTitle(
+      "Mock Title",
+      {} as IUserRequestOptions
+    );
+
+    expect(hubSearchSpy).toHaveBeenCalledTimes(2);
+    expect(res).toBe("Mock Title 1");
+  });
+
+  it("handles errors", async () => {
+    hubSearchSpy = spyOn(SearchModule, "hubSearch").and.returnValue(
+      Promise.reject(new Error("error"))
+    );
+
+    try {
+      await getUniqueGroupTitle("Mock Title", {} as IUserRequestOptions);
+    } catch (error) {
+      expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+      expect((error as any).message).toContain(
+        "Error in getUniqueGroupTitle: "
+      );
+    }
+  });
+});

--- a/packages/common/test/permissions/_internal/checkAssertion.test.ts
+++ b/packages/common/test/permissions/_internal/checkAssertion.test.ts
@@ -458,6 +458,100 @@ describe("checkAssertion:", () => {
       expect(chk.response).toBe("assertion-requires-numeric-values");
     });
   });
+  describe("length checks:", () => {
+    it("prop length gt val", () => {
+      const assertion: IPolicyAssertion = {
+        property: "groups",
+        type: "length-gt",
+        value: 2,
+      };
+      const ctx = {
+        isAuthenticated: true,
+      } as unknown as IArcGISContext;
+
+      const chk = checkAssertion(
+        assertion,
+        {
+          groups: ["group-1", "group-2", "group-3"],
+        },
+        ctx
+      );
+      expect(chk.response).toBe("granted");
+      const fail = checkAssertion(
+        assertion,
+        {
+          groups: ["group-1"],
+        },
+        ctx
+      );
+      expect(fail.response).toBe("assertion-failed");
+    });
+    it("prop length lt val", () => {
+      const assertion: IPolicyAssertion = {
+        property: "title",
+        type: "length-lt",
+        value: 10,
+      };
+      const ctx = {
+        isAuthenticated: true,
+      } as unknown as IArcGISContext;
+
+      const chk = checkAssertion(
+        assertion,
+        {
+          title: "mock title",
+        },
+        ctx
+      );
+      expect(chk.response).toBe("granted");
+      const fail = checkAssertion(
+        assertion,
+        {
+          title: "some really long mock title",
+        },
+        ctx
+      );
+      expect(fail.response).toBe("assertion-failed");
+    });
+    it("prop values without a length error", () => {
+      const assertion: IPolicyAssertion = {
+        property: "count",
+        type: "length-gt",
+        value: 12,
+      };
+      const ctx = {
+        isAuthenticated: true,
+      } as unknown as IArcGISContext;
+
+      const chk = checkAssertion(
+        assertion,
+        {
+          count: 10,
+        },
+        ctx
+      );
+      expect(chk.response).toBe("property-has-no-length");
+    });
+    it("non-numeric value error", () => {
+      const assertion: IPolicyAssertion = {
+        property: "groups",
+        type: "length-gt",
+        value: "12",
+      };
+      const ctx = {
+        isAuthenticated: true,
+      } as unknown as IArcGISContext;
+
+      const chk = checkAssertion(
+        assertion,
+        {
+          groups: ["group-1"],
+        },
+        ctx
+      );
+      expect(chk.response).toBe("assertion-requires-numeric-values");
+    });
+  });
   describe("includes checks:", () => {
     it("entity prop included-in val", () => {
       const assertion: IPolicyAssertion = {


### PR DESCRIPTION
[8257](https://devtopia.esri.com/dc/hub/issues/8257)

### Description
- add a new `uiSchema` to create followers groups
- hoist `getUniqueGroupTitle` util from `hub-teams` into `hub-common/groups` and leverage in group creation workflow
- gate followers pane on sites to premium licenses
- add permission for creating followers group
  - add two new assertion types (`lenght-gt` and `length-lt`)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.