### PR TITLE
feat(): add featured metrics limit

### DIFF
--- a/packages/common/src/core/types/Metrics.ts
+++ b/packages/common/src/core/types/Metrics.ts
@@ -283,3 +283,6 @@ export interface IDynamicMetricValues {
 
 /** Maxmium number of metrics allowed on any given entity. */
 export const MAX_ENTITY_METRICS_ALLOWED = 24;
+
+/** Maximum number of featured metrics allowed on any given entity. */
+export const MAX_FEATURED_METRICS_ALLOWED = 4;


### PR DESCRIPTION
1. Description:
Adds a constant for the limit of the number of featured metrics allowed on an entity. 
1. Instructions for testing:

1. Closes Issues: #8181 (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
