### PR TITLE
feat: search result has rawResult prop

### DIFF
--- a/packages/common/src/content/search.ts
+++ b/packages/common/src/content/search.ts
@@ -44,6 +44,7 @@ export async function enrichContentSearchResult(
       siteRelative: "not-implemented",
       thumbnail: "not-implemented",
     },
+    rawResult: item,
   };
 
   // default includes

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -51,6 +51,7 @@ export async function enrichGroupSearchResult(
       siteRelative: "not-implemented",
       thumbnail: "not-implemented",
     },
+    rawResult: group,
   };
 
   // Informal Enrichments - basically adding type-specific props

--- a/packages/common/src/initiative-templates/fetch.ts
+++ b/packages/common/src/initiative-templates/fetch.ts
@@ -82,6 +82,7 @@ export async function enrichInitiativeTemplateSearchResult(
       thumbnail: "not-implemented",
       workspaceRelative: "not-implemented",
     },
+    rawResult: item,
   };
 
   // TODO: reimplement enrichment fetching when we know what enrichments we're looking for

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -245,6 +245,7 @@ export async function enrichInitiativeSearchResult(
       thumbnail: "not-implemented",
       workspaceRelative: "not-implemented",
     },
+    rawResult: item,
   };
 
   // default includes

--- a/packages/common/src/pages/HubPages.ts
+++ b/packages/common/src/pages/HubPages.ts
@@ -214,6 +214,7 @@ export async function enrichPageSearchResult(
       siteRelative: "not-implemented",
       thumbnail: "not-implemented",
     },
+    rawResult: item,
   };
 
   // default includes

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -100,6 +100,7 @@ export async function enrichProjectSearchResult(
       thumbnail: "not-implemented",
       workspaceRelative: "not-implemented",
     },
+    rawResult: item,
   };
 
   // default includes

--- a/packages/common/src/search/_internal/hubSearchChannels.ts
+++ b/packages/common/src/search/_internal/hubSearchChannels.ts
@@ -161,6 +161,7 @@ export const toHubSearchResult = async (
             )
           : [],
       },
+      rawResult: channel,
     };
   };
   return {

--- a/packages/common/src/search/types/IHubSearchResult.ts
+++ b/packages/common/src/search/types/IHubSearchResult.ts
@@ -1,6 +1,6 @@
 import { IGroup, IItem, IUser } from "@esri/arcgis-rest-portal";
 import { AccessLevel, IHubEntityBase } from "../../core";
-import { HubFamily, IHubGeography, ISearchResponse } from "../../types";
+import { HubFamily, IHubGeography } from "../../types";
 import { IOgcItem } from "../_internal/hubSearchItemsHelpers/interfaces";
 import { IChannel } from "../../discussions/api/types";
 

--- a/packages/common/src/search/types/IHubSearchResult.ts
+++ b/packages/common/src/search/types/IHubSearchResult.ts
@@ -55,7 +55,7 @@ export interface IHubSearchResult extends IHubEntityBase {
    * Note: We will need to cast to the approproate type
    * in order to access the properties
    */
-  rawResult: IItem | IGroup | IUser | IOgcItem | IChannel;
+  rawResult?: IItem | IGroup | IUser | IOgcItem | IChannel;
 
   /** Allow any additional properties to be added */
   [key: string]: any;

--- a/packages/common/src/search/types/IHubSearchResult.ts
+++ b/packages/common/src/search/types/IHubSearchResult.ts
@@ -1,5 +1,9 @@
+import { IGroup, IItem, IUser } from "@esri/arcgis-rest-portal";
 import { AccessLevel, IHubEntityBase } from "../../core";
-import { HubFamily, IHubGeography } from "../../types";
+import { HubFamily, IHubGeography, ISearchResponse } from "../../types";
+import { IOgcItem } from "../_internal/hubSearchItemsHelpers/interfaces";
+import { ISearch } from "@esri/arcgis-rest-types";
+import { IChannel } from "../../discussions/api/types";
 
 /**
  * Standardized light-weight search result structure, applicable to all
@@ -43,6 +47,16 @@ export interface IHubSearchResult extends IHubEntityBase {
    * or the extent of a layer
    */
   geometry?: IHubGeography;
+
+  /**
+   * Raw result object returned from the search.
+   * This allows downstream processing to access
+   * additional properties that may not be
+   * explicitly defined in this interface
+   * Note: We will need to cast to the approproate type
+   * in order to access the properties
+   */
+  rawResult: IItem | IGroup | IUser | IOgcItem | IChannel;
 
   /** Allow any additional properties to be added */
   [key: string]: any;

--- a/packages/common/src/search/types/IHubSearchResult.ts
+++ b/packages/common/src/search/types/IHubSearchResult.ts
@@ -2,7 +2,6 @@ import { IGroup, IItem, IUser } from "@esri/arcgis-rest-portal";
 import { AccessLevel, IHubEntityBase } from "../../core";
 import { HubFamily, IHubGeography, ISearchResponse } from "../../types";
 import { IOgcItem } from "../_internal/hubSearchItemsHelpers/interfaces";
-import { ISearch } from "@esri/arcgis-rest-types";
 import { IChannel } from "../../discussions/api/types";
 
 /**

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -491,6 +491,7 @@ export async function enrichSiteSearchResult(
       siteRelative: "not-implemented",
       thumbnail: "not-implemented",
     },
+    rawResult: item,
   };
 
   // default includes

--- a/packages/common/src/templates/fetch.ts
+++ b/packages/common/src/templates/fetch.ts
@@ -98,6 +98,7 @@ export async function enrichTemplateSearchResult(
       thumbnail: "not-implemented",
       workspaceRelative: "not-implemented",
     },
+    rawResult: item,
   };
 
   // 1. optionally enrich the template item with

--- a/packages/common/src/users/HubUsers.ts
+++ b/packages/common/src/users/HubUsers.ts
@@ -49,6 +49,7 @@ export async function enrichUserSearchResult(
       siteRelative: "not-implemented",
       thumbnail: null,
     },
+    rawResult: user,
   };
   // Group Memberships need these additional properties
   if (user.memberType) {

--- a/packages/common/test/initiative-templates/fixtures.ts
+++ b/packages/common/test/initiative-templates/fixtures.ts
@@ -105,6 +105,7 @@ export const INITIATIVE_TEMPLATE_HUB_SEARCH_RESULT: IHubSearchResult = {
     thumbnail: "https://thumbnail/mock-thumbnail.png",
     workspaceRelative: "/mock-relative-workspace-url",
   },
+  rawResult: INITIATIVE_TEMPLATE_ITEM,
 };
 
 export const INITIATIVE_TEMPLATE_DATA = {

--- a/packages/common/test/initiatives/fixtures.ts
+++ b/packages/common/test/initiatives/fixtures.ts
@@ -150,6 +150,7 @@ export const INITIATIVE_HUB_SEARCH_RESULT: IHubSearchResult = {
     thumbnail: "https://thumbnail/mock-thumbnail.png",
     workspaceRelative: "/mock-relative-workspace-url",
   },
+  rawResult: INITIATIVE_ITEM,
 };
 
 export const INITIATIVE_DATA = {

--- a/packages/common/test/projects/fixtures.ts
+++ b/packages/common/test/projects/fixtures.ts
@@ -150,6 +150,7 @@ export const PROJECT_HUB_SEARCH_RESULT: IHubSearchResult = {
     thumbnail: "https://thumbnail/mock-thumbnail.png",
     workspaceRelative: "/mock-relative-workspace-url",
   },
+  rawResult: PROJECT_ITEM,
 };
 
 export const PROJECT_DATA = {

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -671,6 +671,8 @@ describe("hubSearchItems Module |", () => {
         thumbnail:
           "https://www.arcgis.com/sharing/rest/content/items/f4bcc/info/thumbnail/hub_thumbnail_1658341016537.png",
       },
+      // TODO: fill this and add some verification
+      rawResult: ogcItemsResponse.features[0].properties as IOgcItem,
     },
   ];
 

--- a/packages/common/test/templates/fixtures.ts
+++ b/packages/common/test/templates/fixtures.ts
@@ -111,6 +111,7 @@ export const TEMPLATE_HUB_SEARCH_RESULT: IHubSearchResult = {
     thumbnail: "https://thumbnail/mock-thumbnail.png",
     workspaceRelative: "/mock-relative-workspace-url",
   },
+  rawResult: TEMPLATE_ITEM,
 };
 
 export const TEMPLATE_DATA = {};

--- a/packages/common/test/users/fixtures.ts
+++ b/packages/common/test/users/fixtures.ts
@@ -55,4 +55,5 @@ export const USER_HUB_SEARCH_RESULT: IHubSearchResult = {
   index: 2,
   typeKeywords: ["User"],
   tags: ["tag1", "tag2"],
+  rawResult: USER,
 };


### PR DESCRIPTION
1. Description:

Add `rawResult:  IItem | IGroup | IUser | IOgcItem | IChannel;` to `IHubSearchResult` and ensured it's set in all the places where a result is constructed, or used in a fixture. This sets things up for the next block of work where we have type specific functions that convert `IHubSearchResult` -> `IHubCardViewModel`, and a callback from gallery which would allow for custom logic for a specific gallery instance.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
