### PR TITLE
fix(hub-common): prompt no longer required

### DIFF
--- a/packages/common/src/discussions/_internal/DiscussionSchema.ts
+++ b/packages/common/src/discussions/_internal/DiscussionSchema.ts
@@ -13,7 +13,7 @@ export const DiscussionEditorTypes = [
  */
 export const DiscussionSchema: IConfigurationSchema = {
   ...HubItemEntitySchema,
-  required: ["name", "prompt"],
+  required: ["name"],
   properties: {
     ...HubItemEntitySchema.properties,
     prompt: {

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaCreate.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaCreate.ts
@@ -44,14 +44,6 @@ export const buildUiSchema = async (
           helperText: {
             labelKey: `${i18nScope}.fields.prompt.helperText`,
           },
-          messages: [
-            {
-              type: "ERROR",
-              keyword: "required",
-              icon: true,
-              labelKey: `${i18nScope}.fields.prompt.requiredError`,
-            },
-          ],
         },
       },
     ],

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -55,14 +55,6 @@ export const buildUiSchema = async (
               helperText: {
                 labelKey: `${i18nScope}.fields.prompt.helperText`,
               },
-              messages: [
-                {
-                  type: "ERROR",
-                  keyword: "required",
-                  icon: true,
-                  labelKey: `${i18nScope}.fields.prompt.requiredError`,
-                },
-              ],
             },
           },
           getThumbnailUiSchemaElement(

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaCreate.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaCreate.test.ts
@@ -36,14 +36,6 @@ describe("buildUiSchema: discussion create", () => {
             helperText: {
               labelKey: "some.scope.fields.prompt.helperText",
             },
-            messages: [
-              {
-                type: "ERROR",
-                keyword: "required",
-                icon: true,
-                labelKey: "some.scope.fields.prompt.requiredError",
-              },
-            ],
           },
         },
       ],

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -68,14 +68,6 @@ describe("buildUiSchema: discussion edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.prompt.helperText",
                 },
-                messages: [
-                  {
-                    type: "ERROR",
-                    keyword: "required",
-                    icon: true,
-                    labelKey: "some.scope.fields.prompt.requiredError",
-                  },
-                ],
               },
             },
             {
@@ -250,14 +242,6 @@ describe("buildUiSchema: discussion edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.prompt.helperText",
                 },
-                messages: [
-                  {
-                    type: "ERROR",
-                    keyword: "required",
-                    icon: true,
-                    labelKey: "some.scope.fields.prompt.requiredError",
-                  },
-                ],
               },
             },
             {


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 8534

1. Description: Removes prompt requirement.

1. Instructions for testing:

1. Closes Issues: #8534

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
