### PR TITLE
feat(hub-discussions): true isOrgAdmin check if org_admin via platfor…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.60.1",
+			"version": "14.64.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/discussions/src/utils/channel-permission.ts
+++ b/packages/discussions/src/utils/channel-permission.ts
@@ -153,7 +153,6 @@ export class ChannelPermission {
     const orgPermissions = this.permissionsByCategory[AclCategory.ORG] ?? [];
 
     return orgPermissions.some((permission) => {
-      const { key } = permission;
       if (permission.key !== user.orgId) {
         return false;
       }

--- a/packages/discussions/src/utils/platform.ts
+++ b/packages/discussions/src/utils/platform.ts
@@ -31,5 +31,5 @@ export function reduceByGroupMembership(
 // which first resolves `user` from `IUserRequestOptions` to make this determination
 // https://github.com/Esri/arcgis-rest-js/blob/7ab072184f89dcb35367518101ee4abeb5a9d112/packages/arcgis-rest-portal/src/sharing/helpers.ts#L45
 export function isOrgAdmin(user: IUser): boolean {
-  return user.role === "org_admin" && !user.roleId;
+  return user.role === "org_admin";
 }

--- a/packages/discussions/src/utils/platform.ts
+++ b/packages/discussions/src/utils/platform.ts
@@ -21,7 +21,7 @@ export function reduceByGroupMembership(
 }
 
 /**
- * Utility that checks if a user is a portal org admin (default role)
+ * Utility that checks if a user is a portal org admin, or an org_admin by a platform role
  *
  * @export
  * @param {IUser} user

--- a/packages/discussions/test/utils/platform.test.ts
+++ b/packages/discussions/test/utils/platform.test.ts
@@ -14,18 +14,18 @@ describe("Util: reduceByGroupMembership", () => {
 });
 
 describe("Util: isOrgAdmin", () => {
-  it("returns true if org_admin and no roleId", async () => {
-    const user = { role: "org_admin", roleId: null } as unknown as IUser;
+  it("returns true if org_admin", async () => {
+    const user = { role: "org_admin" } as unknown as IUser;
     expect(isOrgAdmin(user)).toBeTruthy();
   });
 
-  it("returns false if org_admin via platform role", async () => {
+  it("returns true if org_admin via platform role", async () => {
     const user = { role: "org_admin", roleId: "3ef" } as IUser;
-    expect(isOrgAdmin(user)).toBeFalsy();
+    expect(isOrgAdmin(user)).toBeTruthy();
   });
 
   it("returns false if not org_admin", async () => {
-    const user = { role: "org_user", roleId: null } as unknown as IUser;
+    const user = { role: "org_user" } as unknown as IUser;
     expect(isOrgAdmin(user)).toBeFalsy();
   });
 });


### PR DESCRIPTION
…m role

affects: @esri/hub-discussions

BREAKING CHANGE:
function isOrgAdmin returns true if the user is an org_admin by an assigned roleId

1. Description: Update the discussions service `isOrgAdmin` to return true for org_admins by an assigned platform role, as well as true org_admins.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
