### PR TITLE
fix(hub-common): fix reharvest site catalog response interface

### DIFF
--- a/packages/common/src/sites/reharvestSiteCatalog.ts
+++ b/packages/common/src/sites/reharvestSiteCatalog.ts
@@ -15,10 +15,14 @@ interface IGroupReharvestInfo {
   status: number;
 }
 
+interface IReharvestError {
+  message: string;
+  cause: string;
+}
+
 interface IReharvestInfo {
   groups?: IGroupReharvestInfo[];
-  message?: string;
-  cause?: string;
+  error?: IReharvestError;
 }
 
 /**
@@ -43,5 +47,17 @@ export async function reharvestSiteCatalog(
       authorization: context.hubRequestOptions.authentication.token,
     },
   };
-  return fetch(url, options).then((result) => result.json());
+
+  return fetch(url, options)
+    .then((result) => result.json())
+    .then((rawResult) => {
+      const result: IReharvestInfo = {};
+      if (rawResult.groups) {
+        result.groups = rawResult.groups;
+      }
+      if (rawResult.message) {
+        result.error = rawResult;
+      }
+      return result;
+    });
 }

--- a/packages/common/src/sites/reharvestSiteCatalog.ts
+++ b/packages/common/src/sites/reharvestSiteCatalog.ts
@@ -15,6 +15,12 @@ interface IGroupReharvestInfo {
   status: number;
 }
 
+interface IReharvestInfo {
+  groups?: IGroupReharvestInfo[];
+  message?: string;
+  cause?: string;
+}
+
 /**
  * Trigger a manual update to reharvest each public item within a site's catalog.
  * This should only be used when search metadata has gotten out of sync despite
@@ -27,7 +33,7 @@ interface IGroupReharvestInfo {
 export async function reharvestSiteCatalog(
   siteId: string,
   context: IArcGISContext
-): Promise<IGroupReharvestInfo[]> {
+): Promise<IReharvestInfo> {
   const apiHost = context.hubUrl;
   const url = `${apiHost}/api/v3/jobs/site/${siteId}/harvest`;
   const options = {

--- a/packages/common/test/sites/reharvestSiteCatalog.test.ts
+++ b/packages/common/test/sites/reharvestSiteCatalog.test.ts
@@ -5,13 +5,15 @@ import { reharvestSiteCatalog } from "../../src/sites/reharvestSiteCatalog";
 describe("reharvestSiteCatalog", () => {
   it("correctly calls the reharvest endpoint", async () => {
     const url = `${MOCK_CONTEXT.hubUrl}/api/v3/jobs/site/some-site-id/harvest`;
-    const expectedResults = [
-      {
-        groupId: "some-group-id",
-        jobId: "some-job-id",
-        status: 202,
-      },
-    ];
+    const expectedResults = {
+      groups: [
+        {
+          groupId: "some-group-id",
+          jobId: "some-job-id",
+          status: 202,
+        },
+      ],
+    };
     fetchMock.once(url, expectedResults);
     const actualResults = await reharvestSiteCatalog(
       "some-site-id",

--- a/packages/common/test/sites/reharvestSiteCatalog.test.ts
+++ b/packages/common/test/sites/reharvestSiteCatalog.test.ts
@@ -3,6 +3,8 @@ import { MOCK_CONTEXT } from "../mocks/mock-auth";
 import { reharvestSiteCatalog } from "../../src/sites/reharvestSiteCatalog";
 
 describe("reharvestSiteCatalog", () => {
+  afterEach(fetchMock.restore);
+
   it("correctly calls the reharvest endpoint", async () => {
     const url = `${MOCK_CONTEXT.hubUrl}/api/v3/jobs/site/some-site-id/harvest`;
     const expectedResults = {
@@ -20,5 +22,21 @@ describe("reharvestSiteCatalog", () => {
       MOCK_CONTEXT
     );
     expect(actualResults).toEqual(expectedResults);
+  });
+  it("correctly returns error from the reharvest endpoint", async () => {
+    const url = `${MOCK_CONTEXT.hubUrl}/api/v3/jobs/site/some-site-id/harvest`;
+    const erroResponse = {
+      message: "site has been harvested too recently",
+      cause: "TIME_LOCK",
+    };
+    const expectedResponse = {
+      error: erroResponse,
+    };
+    fetchMock.once(url, erroResponse);
+    const actualResults = await reharvestSiteCatalog(
+      "some-site-id",
+      MOCK_CONTEXT
+    );
+    expect(actualResults).toEqual(expectedResponse);
   });
 });

--- a/packages/common/test/sites/reharvestSiteCatalog.test.ts
+++ b/packages/common/test/sites/reharvestSiteCatalog.test.ts
@@ -25,14 +25,14 @@ describe("reharvestSiteCatalog", () => {
   });
   it("correctly returns error from the reharvest endpoint", async () => {
     const url = `${MOCK_CONTEXT.hubUrl}/api/v3/jobs/site/some-site-id/harvest`;
-    const erroResponse = {
+    const errorResponse = {
       message: "site has been harvested too recently",
       cause: "TIME_LOCK",
     };
     const expectedResponse = {
-      error: erroResponse,
+      error: errorResponse,
     };
-    fetchMock.once(url, erroResponse);
+    fetchMock.once(url, errorResponse);
     const actualResults = await reharvestSiteCatalog(
       "some-site-id",
       MOCK_CONTEXT


### PR DESCRIPTION
1. Description: This PR fixes interface of the response returned by catalog re-harvest function `reharvestSiteCatalog()`. 
 
Indexer's harvest endpoint `/harvest` sample response on successfuly initiating re-harvest job: 
```
{
   groups: [
      {
         "groupId":"430bd4970f4a4d9d886f966e1aa6eaa9",
         "status":202,
         "jobId":"c30af92d-661f-4ba4-9b77-93b69d57066a"
      },
      ...
   ]
}
```
Response when continuously re-attempting to re-harvest in short period of time.

```
{
    "message": "site has been harvested too recently",
    "cause": "TIME_LOCK"
}
```

After updating the interface response, `cause` property of the response,  can be used to notify user know that re-harvest is already in progress on opendata-ui.

1. Instructions for testing:

1. Closes Issues: [#8185](https://devtopia.esri.com/dc/hub/issues/8185)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
