### PR TITLE
fix(hub-common): for Channel group enrichment, account for null groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.60.1",
+			"version": "14.64.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/search/_internal/hubSearchChannels.ts
+++ b/packages/common/src/search/_internal/hubSearchChannels.ts
@@ -142,24 +142,25 @@ export const toHubSearchResult = async (
       },
       includes: {
         // when 'include' requests 'groups' enrichment, get group details
-        groups: options.include?.includes("groups")
-          ? await Promise.all(
-              channel.groups.map(async (groupId) => {
-                let group;
-                try {
-                  group = await getGroup(groupId, options.requestOptions);
-                } catch (e) {
-                  group = null;
-                  /* tslint:disable-next-line: no-console */
-                  console.warn(
-                    `Cannot fetch group enhancement for id = ${groupId}`,
-                    e
-                  );
-                }
-                return group;
-              })
-            )
-          : [],
+        groups:
+          options.include?.includes("groups") && channel.groups
+            ? await Promise.all(
+                channel.groups.map(async (groupId) => {
+                  let group;
+                  try {
+                    group = await getGroup(groupId, options.requestOptions);
+                  } catch (e) {
+                    group = null;
+                    /* tslint:disable-next-line: no-console */
+                    console.warn(
+                      `Cannot fetch group enhancement for id = ${groupId}`,
+                      e
+                    );
+                  }
+                  return group;
+                })
+              )
+            : [],
       },
       rawResult: channel,
     };


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Handles Error encountered when searching for group enriched channels and `groups: null`.

<img width="772" alt="Screenshot 2023-11-21 at 9 13 02 AM" src="https://github.com/Esri/hub.js/assets/3883995/926ee536-c5a6-43b7-b654-d0ceb8ba66cc">

1. Instructions for testing:

1. Relating to issue 8595

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
