### PR TITLE
fix(hub-discussions): use the platform isOrgAdmin function in discuss…

### DIFF
--- a/packages/discussions/src/utils/channel-permission.ts
+++ b/packages/discussions/src/utils/channel-permission.ts
@@ -158,7 +158,7 @@ export class ChannelPermission {
       }
 
       return (
-        doesPermissionAllowOrgRole(permission, user.role) &&
+        doesPermissionAllowOrgRole(permission, user) &&
         channelActionLookup(action).includes(permission.role)
       );
     });
@@ -275,12 +275,12 @@ function doesPermissionAllowGroupMemberType(
 
 function doesPermissionAllowOrgRole(
   permission: IChannelAclPermission,
-  orgRole: string
+  user: IDiscussionsUser
 ): boolean {
   return (
     permission.category === AclCategory.ORG &&
     (permission.subCategory === AclSubCategory.MEMBER ||
-      (permission.subCategory === "admin" && orgRole === "org_admin"))
+      (permission.subCategory === AclSubCategory.ADMIN && isOrgAdmin(user)))
   );
 }
 


### PR DESCRIPTION
…ions access check

affects: @esri/hub-discussions

1. Description: Use the platform function `isOrgAdmin` in the channel permissions checks related to orgs.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
