### PR TITLE
feat(hub-common): adds temporary gated permissions for creating new d…

### DIFF
--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -19,6 +19,7 @@ export const DiscussionPermissions = [
   "hub:discussion:workspace:discussion",
   "hub:discussion:workspace:metrics",
   "hub:discussion:manage",
+  "temp:hub:discussion:create",
 ] as const;
 
 /**

--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -91,4 +91,11 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:discussion:manage",
     dependencies: ["hub:discussion:edit"],
   },
+  // Temporary gated creation of new discussion boards
+  {
+    permission: "temp:hub:discussion:create",
+    dependencies: ["hub:discussion:create"],
+    availability: ["alpha"],
+    environments: ["devext", "qaext"],
+  },
 ];


### PR DESCRIPTION
…iscussion boards

affects: @esri/hub-common

1. Description: This PR adds a new permission for the temporary gating of creating new Discussion Boards.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
