### PR TITLE
feat: add enrichement to refetch item with additional props

### DIFF
--- a/packages/common/src/core/types/IItemEnrichments.ts
+++ b/packages/common/src/core/types/IItemEnrichments.ts
@@ -1,7 +1,11 @@
-import { IUser, IPortal } from "@esri/arcgis-rest-portal";
+import { IUser, IPortal, IItem } from "@esri/arcgis-rest-portal";
 import { IEnrichmentErrorInfo } from "../../types";
 
 export interface IItemEnrichments {
+  /**
+   * Enable the item to be re-fetched so we get more props
+   */
+  item?: IItem;
   /** The portal item's data (if any) */
   data?: {
     [propName: string]: any;

--- a/packages/common/src/items/_enrichments.ts
+++ b/packages/common/src/items/_enrichments.ts
@@ -1,5 +1,6 @@
 import {
   IItem,
+  getItem,
   getItemData,
   getItemGroups,
   getUser,
@@ -183,6 +184,25 @@ const enrichData = (
     .catch((error) => handleEnrichmentError(error, input, opId));
 };
 
+/**
+ * Enriches an item by fetching the item directly as this returns additional
+ * information not included in a search result.
+ * @param input - The input object containing the item and enrichments.
+ * @returns A promise that resolves to the updated input object.
+ */
+const enrichItem = (
+  input: IPipeable<IItemAndEnrichments>
+): Promise<IPipeable<IItemAndEnrichments>> => {
+  const { data, stack, requestOptions } = input;
+  const opId = stack.start("enrichData");
+  return getItem(data.item.id, requestOptions)
+    .then((itemJson) => {
+      stack.finish(opId);
+      return { data: { ...data, item: itemJson }, stack, requestOptions };
+    })
+    .catch((error) => handleEnrichmentError(error, input, opId));
+};
+
 const enrichServer = (
   input: IPipeable<IItemAndEnrichments>
 ): Promise<IPipeable<IItemAndEnrichments>> => {
@@ -277,6 +297,7 @@ const enrichmentOperations: IEnrichmentOperations = {
   data: enrichData,
   server: enrichServer,
   layers: enrichLayers,
+  item: enrichItem,
 };
 
 /**

--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -173,7 +173,7 @@ async function searchPortalAsHubSearchResult(
   const fn = (item: IItem) => {
     return itemToSearchResult(
       item,
-      searchOptions.includes,
+      searchOptions.include,
       searchOptions.requestOptions
     );
   };

--- a/packages/common/test/items/_enrichments.test.ts
+++ b/packages/common/test/items/_enrichments.test.ts
@@ -16,7 +16,7 @@ describe("_enrichments", () => {
     } as IEnrichmentErrorInfo;
     let item: IItem;
     beforeEach(() => {
-      item = cloneObject(featureServiceItem);
+      item = cloneObject(featureServiceItem) as unknown as IItem;
     });
     describe("groupIds", () => {
       it("fetches groupIds", async () => {
@@ -126,6 +126,23 @@ describe("_enrichments", () => {
       it("handles errors", async () => {
         fetchMock.once("*", 404);
         const result = await fetchItemEnrichments(item, ["data"]);
+        expect(result.data).toBeUndefined();
+        expect(result.errors).toEqual([expectedError]);
+      });
+    });
+    describe("enrichItem", () => {
+      it("fetches item", async () => {
+        const itemJson = {
+          id: item.id,
+          itemControl: "admin",
+        } as unknown as IItem;
+        fetchMock.once("*", itemJson);
+        const result = await fetchItemEnrichments(item, ["item"]);
+        expect(result.item.itemControl).toEqual("admin");
+      });
+      it("handles errors", async () => {
+        fetchMock.once("*", 404);
+        const result = await fetchItemEnrichments(item, ["item"]);
         expect(result.data).toBeUndefined();
         expect(result.errors).toEqual([expectedError]);
       });


### PR DESCRIPTION
1. Description:

Add support of `include: ["item.itemControl"]` which requires re-fetching of the item to get this additional property that's not present on an item search result.

Also fixes a typo which was preventing includes from working.

1. Instructions for testing:

1. Closes Issues: n/a - side effect of 8462 (gallery callback)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
