### PR TITLE
fix(hub-common): use only capabilities key to update extract capability service definition

### DIFF
--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -21,7 +21,11 @@ import { IModel } from "../types";
 import { getProp } from "../objects/get-prop";
 import { setDiscussableKeyword } from "../discussions";
 import { modelToHubEditableContent } from "./fetch";
-import { getService, parseServiceUrl } from "@esri/arcgis-rest-feature-layer";
+import {
+  getService,
+  IFeatureServiceDefinition,
+  parseServiceUrl,
+} from "@esri/arcgis-rest-feature-layer";
 import { updateServiceDefinition } from "@esri/arcgis-rest-service-admin";
 import {
   hasServiceCapability,
@@ -151,9 +155,12 @@ export async function updateContent(
         ServiceCapabilities.EXTRACT,
         currentDefinition
       );
+      const updatedServiceCapabilities: Partial<IFeatureServiceDefinition> = {
+        capabilities: updatedDefinition.capabilities,
+      };
       await updateServiceDefinition(parseServiceUrl(content.url), {
         authentication: requestOptions.authentication,
-        updateDefinition: updatedDefinition,
+        updateDefinition: updatedServiceCapabilities,
       });
       enrichments.server = updatedDefinition;
     } else {

--- a/packages/common/test/content/edit.test.ts
+++ b/packages/common/test/content/edit.test.ts
@@ -189,7 +189,7 @@ describe("content editing:", () => {
     });
     it("updates the hosted service if configurations have changed", async () => {
       const currentDefinition: Partial<featureLayerModule.IFeatureServiceDefinition> =
-        { capabilities: "Query" };
+        { currentVersion: 11.2, capabilities: "Query" };
       getServiceSpy.and.returnValue(Promise.resolve(currentDefinition));
 
       const content: IHubEditableContent = {
@@ -227,13 +227,6 @@ describe("content editing:", () => {
       expect(updateModelSpy.calls.count()).toBe(1);
       expect(getServiceSpy).toHaveBeenCalledTimes(1);
       expect(updateServiceSpy).toHaveBeenCalledTimes(1);
-      expect(updateServiceSpy).toHaveBeenCalledWith(
-        "https://services.arcgis.com/:orgId/arcgis/rest/services/:serviceName/FeatureServer",
-        {
-          authentication: MOCK_AUTH,
-          updateDefinition: { capabilities: "Query,Extract" },
-        }
-      );
       const [url, { updateDefinition }] = updateServiceSpy.calls.argsFor(0);
       expect(url).toEqual(
         "https://services.arcgis.com/:orgId/arcgis/rest/services/:serviceName/FeatureServer"

--- a/packages/common/test/content/edit.test.ts
+++ b/packages/common/test/content/edit.test.ts
@@ -227,6 +227,13 @@ describe("content editing:", () => {
       expect(updateModelSpy.calls.count()).toBe(1);
       expect(getServiceSpy).toHaveBeenCalledTimes(1);
       expect(updateServiceSpy).toHaveBeenCalledTimes(1);
+      expect(updateServiceSpy).toHaveBeenCalledWith(
+        "https://services.arcgis.com/:orgId/arcgis/rest/services/:serviceName/FeatureServer",
+        {
+          authentication: MOCK_AUTH,
+          updateDefinition: { capabilities: "Query,Extract" },
+        }
+      );
       const [url, { updateDefinition }] = updateServiceSpy.calls.argsFor(0);
       expect(url).toEqual(
         "https://services.arcgis.com/:orgId/arcgis/rest/services/:serviceName/FeatureServer"


### PR DESCRIPTION
…ty service definition

1. Description: This PR fixes `updateServiceDefinition` payload when saving extract capability option to include only `capabilities` key as required instead of passing the whole service definition. This will prevent errors like [#7010](https://devtopia.esri.com/dc/hub/issues/7010)

1. Instructions for testing:

1. Closes Issues: [#7010](https://devtopia.esri.com/dc/hub/issues/7010)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
