### PR TITLE
fix: enable featured image alt text on hub initiative

### DIFF
--- a/packages/common/src/initiatives/_internal/computeProps.ts
+++ b/packages/common/src/initiatives/_internal/computeProps.ts
@@ -43,6 +43,7 @@ export function computeProps(
       model.data.view.featuredImageUrl,
       requestOptions
     ),
+    featuredImageAltText: model.data.view.featuredImageAltText,
     hero: model.data.view.hero,
   };
 


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Enable featured image alt text on hub initiative

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)
[8182](https://zentopia.esri.com/workspaces/collaboration-sprint-board-614f9bfc0946c40011ef574e/issues/dc/hub/8182)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
