### PR TITLE
feat: add notices to IUserHubSettings

### DIFF
--- a/packages/common/src/utils/hubUserAppResources.ts
+++ b/packages/common/src/utils/hubUserAppResources.ts
@@ -32,11 +32,21 @@ export interface IUserHubSettings {
   username?: string;
   updated?: number;
   /**
+   * Track notices the user has dismissed
+   * stored as an object so we can add more types in the future
+   */
+  notices?: {
+    /**
+     * Ids of notices the user has dismissed
+     */
+    dismissed?: string[];
+  };
+  /**
    * Features that are enabled for the user in preview mode
    */
   preview?: {
     /**
-     *
+     * Enable the workspace feature
      */
     workspace: boolean;
   };


### PR DESCRIPTION
1. Description:

Add `.notices.dismissed: string[]` to `IUserHubSettings`

1. Instructions for testing: n/a - just a type change

1. Part of Issues: #8605

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
