### PR TITLE
[WIP] fix: context.refreshUser updated cached object

### DIFF
--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -226,7 +226,7 @@ export interface IArcGISContext {
   /**
    * Refresh the current user, including their groups
    */
-  refreshUser(win?: any): Promise<void>;
+  refreshUser(): Promise<void>;
 }
 
 /**
@@ -767,7 +767,7 @@ export class ArcGISContext implements IArcGISContext {
    * update the user in the serialized context manager.
    * @returns
    */
-  public refreshUser(win: any = window): Promise<void> {
+  public refreshUser(): Promise<void> {
     const opts: IGetUserOptions = {
       authentication: this.session,
       portal: this.sharingApiUrl,
@@ -780,15 +780,17 @@ export class ArcGISContext implements IArcGISContext {
       // extract it, add the user to it, and then
       // re-serialize it and store it back in localStorage
       /* istanbul ignore else */
-      if (win && win.localStorage) {
-        const encoded = win.localStorage.getItem(STORAGE_KEYS.contextManager);
+      if (typeof window !== "undefined") {
+        const encoded = window.localStorage.getItem(
+          STORAGE_KEYS.contextManager
+        );
         if (encoded) {
           const serializedContext = base64ToUnicode(encoded);
           const context = JSON.parse(serializedContext);
           // update the user
           context.currentUser = user;
           // re-serialize and store
-          win.localStorage.setItem(
+          window.localStorage.setItem(
             STORAGE_KEYS.contextManager,
             unicodeToBase64(JSON.stringify(context))
           );

--- a/packages/common/src/localStorageKeys.ts
+++ b/packages/common/src/localStorageKeys.ts
@@ -1,0 +1,9 @@
+/**
+ * Centralized list of keys used for localStorage
+ */
+export const STORAGE_KEYS = {
+  contextManager: "ESRI_HUB_CONTEXT_MANAGER",
+  domainCache: "ESRI_HUB_DOMAIN_CACHE",
+  privacySettings: "ESRI_HUB_PRIVACY_SETTINGS",
+  notices: "ESRI_HUB_NOTICES",
+};

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -19,6 +19,7 @@ import { MOCK_AUTH, MOCK_ENTERPRISE_AUTH } from "./mocks/mock-auth";
 import { IPortal } from "@esri/arcgis-rest-portal";
 import ExceptionFactory from "./mocks/ExceptionFactory";
 import { TOMORROW } from "./test-helpers/tomorrow";
+import { STORAGE_KEYS } from "../src/localStorageKeys";
 
 const onlineUserResponse = {
   username: "jvader",
@@ -1024,7 +1025,7 @@ describe("ArcGISContext:", () => {
         mgr.context.featureFlags["hub:feature:workspace"]
       ).not.toBeDefined();
     });
-    it("can refresh user", async () => {
+    it("refreshUser updates user", async () => {
       const selfSpy = spyOn(portalModule, "getSelf").and.callFake(() => {
         return Promise.resolve(cloneObject(onlinePortalSelfResponse));
       });
@@ -1044,11 +1045,40 @@ describe("ArcGISContext:", () => {
       spyOn(requestModule, "request").and.callFake(() => {
         return Promise.resolve(cloneObject(onlinePartneredOrgResponse));
       });
+      // Create a fake localStorage
+      const fakeWindow = {
+        localStorage: {
+          cache: {} as { [key: string]: any },
+          getItem(key: string) {
+            return this.cache[key];
+          },
+          setItem(key: string, value: string) {
+            this.cache[key] = value;
+          },
+        },
+      };
+
       const serialized = unicodeToBase64(
         JSON.stringify(validSerializedContext)
       );
 
       const mgr = await ArcGISContextManager.deserialize(serialized!);
+      // Add the context to the fake local storage
+      fakeWindow.localStorage.setItem(
+        STORAGE_KEYS.contextManager,
+        serialized as string
+      );
+
+      // setup spies
+      const getItemSpy = spyOn(
+        fakeWindow.localStorage,
+        "getItem"
+      ).and.callThrough();
+      const setItemSpy = spyOn(
+        fakeWindow.localStorage,
+        "setItem"
+      ).and.callThrough();
+
       expect(selfSpy.calls.count()).toBe(0);
       expect(userSpy.calls.count()).toBe(0);
       expect(mgr.context.portalUrl).toBe(
@@ -1059,13 +1089,140 @@ describe("ArcGISContext:", () => {
         validSerializedContext.currentUser
       );
       expect(mgr.context.currentUser.groups?.length).toEqual(1);
-      // call refresh user
-      await mgr.context.refreshUser();
+      // call refresh user with fake window
+      await mgr.context.refreshUser(fakeWindow);
       expect(userSpy.calls.count()).toBe(1);
       expect(mgr.context.currentUser.groups?.length).toEqual(2);
       expect(mgr.context.currentUser).toEqual(
         updatedUserResponse as portalModule.IUser
       );
+      // verify that the context was updated in local storage
+      expect(getItemSpy).toHaveBeenCalled();
+      expect(setItemSpy).toHaveBeenCalled();
+      const updatedSerializedContext = fakeWindow.localStorage.getItem(
+        STORAGE_KEYS.contextManager
+      );
+      expect(updatedSerializedContext).toBeDefined();
+      const decoded = JSON.parse(base64ToUnicode(updatedSerializedContext));
+      expect(decoded.currentUser.groups?.length).toEqual(2);
+    });
+    it("refreshUser does not fail if no localStorage entry", async () => {
+      const selfSpy = spyOn(portalModule, "getSelf").and.callFake(() => {
+        return Promise.resolve(cloneObject(onlinePortalSelfResponse));
+      });
+      const updatedUserResponse = cloneObject(onlineUserResponse);
+      updatedUserResponse.groups.push({
+        id: "ff0",
+        title: "Fake Group 2",
+        userMembership: {
+          username: "jvader",
+          memberType: "admin",
+          applications: 0,
+        },
+      } as portalModule.IGroup);
+      const userSpy = spyOn(portalModule, "getUser").and.callFake(() => {
+        return Promise.resolve(cloneObject(updatedUserResponse));
+      });
+      spyOn(requestModule, "request").and.callFake(() => {
+        return Promise.resolve(cloneObject(onlinePartneredOrgResponse));
+      });
+      // Create a fake localStorage
+      const fakeWindow = {
+        localStorage: {
+          cache: {} as { [key: string]: any },
+          getItem(key: string) {
+            return this.cache[key];
+          },
+          setItem(key: string, value: string) {
+            this.cache[key] = value;
+          },
+        },
+      };
+
+      const serialized = unicodeToBase64(
+        JSON.stringify(validSerializedContext)
+      );
+
+      const mgr = await ArcGISContextManager.deserialize(serialized!);
+
+      // setup spies
+      const getItemSpy = spyOn(
+        fakeWindow.localStorage,
+        "getItem"
+      ).and.callThrough();
+      const setItemSpy = spyOn(
+        fakeWindow.localStorage,
+        "setItem"
+      ).and.callThrough();
+
+      expect(selfSpy.calls.count()).toBe(0);
+      expect(userSpy.calls.count()).toBe(0);
+      expect(mgr.context.portalUrl).toBe(
+        MOCK_AUTH.portal.replace(`/sharing/rest`, "")
+      );
+      expect(mgr.context.isAuthenticated).toBeTruthy();
+      expect(mgr.context.currentUser).toEqual(
+        validSerializedContext.currentUser
+      );
+      expect(mgr.context.currentUser.groups?.length).toEqual(1);
+      // call refresh user with fake window
+      await mgr.context.refreshUser(fakeWindow);
+      expect(userSpy.calls.count()).toBe(1);
+      expect(mgr.context.currentUser.groups?.length).toEqual(2);
+      expect(mgr.context.currentUser).toEqual(
+        updatedUserResponse as portalModule.IUser
+      );
+      // verify that the context was updated in local storage
+      expect(getItemSpy).toHaveBeenCalled();
+      expect(setItemSpy).not.toHaveBeenCalled();
+    });
+    it("refreshUser does not fail if localStorage is not defined", async () => {
+      const selfSpy = spyOn(portalModule, "getSelf").and.callFake(() => {
+        return Promise.resolve(cloneObject(onlinePortalSelfResponse));
+      });
+      const updatedUserResponse = cloneObject(onlineUserResponse);
+      updatedUserResponse.groups.push({
+        id: "ff0",
+        title: "Fake Group 2",
+        userMembership: {
+          username: "jvader",
+          memberType: "admin",
+          applications: 0,
+        },
+      } as portalModule.IGroup);
+      const userSpy = spyOn(portalModule, "getUser").and.callFake(() => {
+        return Promise.resolve(cloneObject(updatedUserResponse));
+      });
+      spyOn(requestModule, "request").and.callFake(() => {
+        return Promise.resolve(cloneObject(onlinePartneredOrgResponse));
+      });
+
+      const serialized = unicodeToBase64(
+        JSON.stringify(validSerializedContext)
+      );
+
+      const mgr = await ArcGISContextManager.deserialize(serialized!);
+
+      expect(selfSpy.calls.count()).toBe(0);
+      expect(userSpy.calls.count()).toBe(0);
+      expect(mgr.context.portalUrl).toBe(
+        MOCK_AUTH.portal.replace(`/sharing/rest`, "")
+      );
+      expect(mgr.context.isAuthenticated).toBeTruthy();
+      expect(mgr.context.currentUser).toEqual(
+        validSerializedContext.currentUser
+      );
+      expect(mgr.context.currentUser.groups?.length).toEqual(1);
+      // call refresh user with window as undefined (like node)
+      await mgr.context.refreshUser(undefined);
+      expect(userSpy.calls.count()).toBe(1);
+      expect(mgr.context.currentUser.groups?.length).toEqual(2);
+      expect(mgr.context.currentUser).toEqual(
+        updatedUserResponse as portalModule.IUser
+      );
+      // call with no args, should default to window
+      await mgr.context.refreshUser();
+      expect(userSpy.calls.count()).toBe(2);
     });
   });
 


### PR DESCRIPTION
1. Description:

`context.refreshUser()` will also update the cached context manage in localStorage

Also adds `STORAGE_KEYS` hash of localStorage keys.

There will be a follow-up PR to -ui to start using the `STORAGE_KEYS` in components and utils

1. Instructions for testing:

1. Closes Issues: [8694](https://devtopia.esri.com/dc/hub/issues/8694)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [ x PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
