### PR TITLE
feat(): update projects schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.64.0",
+			"version": "14.69.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65039,7 +65039,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "26.2.0",
+			"version": "27.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
+++ b/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
@@ -58,6 +58,7 @@ export const HubItemEntitySchema: IConfigurationSchema = {
           default: HubEntityHero.map,
           enum: Object.keys(HubEntityHero),
         },
+        heroActions: { type: "array" },
       },
     },
   },

--- a/packages/common/src/core/traits/IWithViewSettings.ts
+++ b/packages/common/src/core/traits/IWithViewSettings.ts
@@ -1,5 +1,5 @@
 import { HubEntityHero } from "../../types";
-import { IHubTimeline, IMetricDisplayConfig } from "../types";
+import { IHubTimeline, IMetricDisplayConfig, HubActionLink } from "../types";
 
 /**
  * Properties to be exclusively displayed on an entity's
@@ -44,4 +44,9 @@ export interface IWithViewSettings {
    * what to show in the hero field, map/image
    */
   hero?: HubEntityHero;
+
+  /**
+   * array of actions for action links
+   */
+  heroActions?: HubActionLink[];
 }

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -259,6 +259,45 @@ export const buildUiSchema = async (
           },
         ],
       },
+      {
+        type: "Section",
+        labelKey: `${i18nScope}.sections.callToAction.label`,
+        options: {
+          helperText: {
+            labelKey: `${i18nScope}.sections.callToAction.helperText`,
+          },
+        },
+        elements: [
+          {
+            scope: "/properties/view/properties/heroActions",
+            type: "Control",
+            options: {
+              control: "hub-composite-input-action-links",
+              type: "button",
+              catalogs: getFeaturedContentCatalogs(context.currentUser), // for now we'll just re-use this util to get the catalogs
+              facets: [
+                {
+                  label: `{{${i18nScope}.fields.callToAction.facets.type:translate}}`,
+                  key: "type",
+                  display: "multi-select",
+                  field: "type",
+                  options: [],
+                  operation: "OR",
+                  aggLimit: 100,
+                },
+                {
+                  label: `{{${i18nScope}.fields.callToAction.facets.sharing:translate}}`,
+                  key: "access",
+                  display: "multi-select",
+                  field: "access",
+                  options: [],
+                  operation: "OR",
+                },
+              ],
+            },
+          },
+        ],
+      },
     ],
   };
 };

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -274,6 +274,45 @@ describe("buildUiSchema: project edit", () => {
             },
           ],
         },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.callToAction.label",
+          options: {
+            helperText: {
+              labelKey: "some.scope.sections.callToAction.helperText",
+            },
+          },
+          elements: [
+            {
+              scope: "/properties/view/properties/heroActions",
+              type: "Control",
+              options: {
+                control: "hub-composite-input-action-links",
+                type: "button",
+                catalogs: {},
+                facets: [
+                  {
+                    label: `{{some.scope.fields.callToAction.facets.type:translate}}`,
+                    key: "type",
+                    display: "multi-select",
+                    field: "type",
+                    options: [],
+                    operation: "OR",
+                    aggLimit: 100,
+                  },
+                  {
+                    label: `{{some.scope.fields.callToAction.facets.sharing:translate}}`,
+                    key: "access",
+                    display: "multi-select",
+                    field: "access",
+                    options: [],
+                    operation: "OR",
+                  },
+                ],
+              },
+            },
+          ],
+        },
       ],
     });
   });
@@ -535,6 +574,45 @@ describe("buildUiSchema: project edit", () => {
                   {
                     label:
                       "{{some.scope.fields.featuredContent.facets.sharing:translate}}",
+                    key: "access",
+                    display: "multi-select",
+                    field: "access",
+                    options: [],
+                    operation: "OR",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.callToAction.label",
+          options: {
+            helperText: {
+              labelKey: "some.scope.sections.callToAction.helperText",
+            },
+          },
+          elements: [
+            {
+              scope: "/properties/view/properties/heroActions",
+              type: "Control",
+              options: {
+                control: "hub-composite-input-action-links",
+                type: "button",
+                catalogs: {},
+                facets: [
+                  {
+                    label: `{{some.scope.fields.callToAction.facets.type:translate}}`,
+                    key: "type",
+                    display: "multi-select",
+                    field: "type",
+                    options: [],
+                    operation: "OR",
+                    aggLimit: 100,
+                  },
+                  {
+                    label: `{{some.scope.fields.callToAction.facets.sharing:translate}}`,
                     key: "access",
                     display: "multi-select",
                     field: "access",


### PR DESCRIPTION
1. Description:
    - updates project ui schema to support action links

1. Instructions for testing:
    - will be included in opendata-ui pr

1. Closes Issues: #<number> (if appropriate)
    - [3630](https://devtopia.esri.com/dc/hub/issues/3630)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
