### PR TITLE
feat: initiative/project description fields are rich text

### DIFF
--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -74,11 +74,13 @@ export const buildUiSchema = async (
             scope: "/properties/description",
             type: "Control",
             options: {
-              control: "hub-field-input-input",
+              control: "hub-field-input-rich-text",
               type: "textarea",
               helperText: {
                 labelKey: `${i18nScope}.fields.description.helperText`,
               },
+              toolbar:
+                "heading,|,bold,italic,blockQuote,removeFormat,link,|,bulletedList,numberedList,alignment,outdent,indent,|,undo,redo",
             },
           },
           {

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -74,11 +74,13 @@ export const buildUiSchema = async (
             scope: "/properties/description",
             type: "Control",
             options: {
-              control: "hub-field-input-input",
+              control: "hub-field-input-rich-text",
               type: "textarea",
               helperText: {
                 labelKey: `${i18nScope}.fields.description.helperText`,
               },
+              toolbar:
+                "heading,|,bold,italic,blockQuote,removeFormat,link,|,bulletedList,numberedList,alignment,outdent,indent,|,undo,redo",
             },
           },
           {

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -92,11 +92,13 @@ describe("buildUiSchema: initiative edit", () => {
               scope: "/properties/description",
               type: "Control",
               options: {
-                control: "hub-field-input-input",
+                control: "hub-field-input-rich-text",
                 type: "textarea",
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",
                 },
+                toolbar:
+                  "heading,|,bold,italic,blockQuote,removeFormat,link,|,bulletedList,numberedList,alignment,outdent,indent,|,undo,redo",
               },
             },
             {
@@ -378,11 +380,13 @@ describe("buildUiSchema: initiative edit", () => {
               scope: "/properties/description",
               type: "Control",
               options: {
-                control: "hub-field-input-input",
+                control: "hub-field-input-rich-text",
                 type: "textarea",
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",
                 },
+                toolbar:
+                  "heading,|,bold,italic,blockQuote,removeFormat,link,|,bulletedList,numberedList,alignment,outdent,indent,|,undo,redo",
               },
             },
             {

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -91,11 +91,13 @@ describe("buildUiSchema: project edit", () => {
               scope: "/properties/description",
               type: "Control",
               options: {
-                control: "hub-field-input-input",
+                control: "hub-field-input-rich-text",
                 type: "textarea",
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",
                 },
+                toolbar:
+                  "heading,|,bold,italic,blockQuote,removeFormat,link,|,bulletedList,numberedList,alignment,outdent,indent,|,undo,redo",
               },
             },
             {
@@ -363,11 +365,13 @@ describe("buildUiSchema: project edit", () => {
               scope: "/properties/description",
               type: "Control",
               options: {
-                control: "hub-field-input-input",
+                control: "hub-field-input-rich-text",
                 type: "textarea",
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",
                 },
+                toolbar:
+                  "heading,|,bold,italic,blockQuote,removeFormat,link,|,bulletedList,numberedList,alignment,outdent,indent,|,undo,redo",
               },
             },
             {


### PR DESCRIPTION
1. Description: Changes project/initiative ui edit schemas to use rich text with provided toolbar.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
