### PR TITLE
chore: add deprecated notice to config editor interface

### DIFF
--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -107,6 +107,9 @@ export interface IChangeEventDetail {
  * to hub.js and should live in opendata-ui. It is now
  * duplicated there, and this interface should be removed
  * during the next breaking change
+ *
+ * Note: once removed, we should also be able to remove
+ * ajv as a dependency in this repo
  */
 export interface IValidationResult {
   valid: boolean;

--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -102,6 +102,12 @@ export interface IChangeEventDetail {
   };
 }
 
+/**
+ * **DEPRECATED:** this should not have been hoisted
+ * to hub.js and should live in opendata-ui. It is now
+ * duplicated there, and this interface should be removed
+ * during the next breaking change
+ */
 export interface IValidationResult {
   valid: boolean;
   errors?: Ajv.ErrorObject[];


### PR DESCRIPTION
[8280](https://devtopia.esri.com/dc/hub/issues/8280)

### Description
adds a "Deprecated" notice to the `IValidationResult` interface that shouldn't have been hoisted to `hub.js`. It is now duplicated in `opendata-ui` and should be used from there. We should remove this and `ajv` during the next breaking change

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.