### PR TITLE
fix: checkPermission uses userHubSettings.preview flags

### DIFF
--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -95,6 +95,15 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     availability: ["alpha"],
     environments: ["devext", "qaext"],
   },
+  {
+    // Enables access to the user preferences section of the user profile
+    // This will likely be removed when we swap the user profile to use workspace
+    permission: "hub:feature:user:preferences",
+    // gated to alpha and qa/dev for now, but will be accessible on PROD when
+    // we pass `?pe=hub:feature:user:preferences` in the URL
+    availability: ["alpha"],
+    environments: ["devext", "qaext"],
+  },
 ];
 
 /**

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -17,7 +17,11 @@ import { TemplatePermissions } from "../../templates/_internal/TemplateBusinessR
 // to be used until we release workspaces or it can be replaced with our new access control (permission/feature/capability) system
 const TempPermissions = ["temp:workspace:released"];
 
-const SystemPermissions = ["hub:feature:privacy", "hub:feature:workspace"];
+const SystemPermissions = [
+  "hub:feature:privacy",
+  "hub:feature:workspace",
+  "hub:feature:user:preferences",
+];
 
 const validPermissions = [
   ...SitePermissions,

--- a/packages/common/test/permissions/checkPermission.test.ts
+++ b/packages/common/test/permissions/checkPermission.test.ts
@@ -2,8 +2,10 @@ import { IPortal, IUser } from "@esri/arcgis-rest-portal";
 import { ArcGISContextManager } from "../../src/ArcGISContextManager";
 import {
   checkPermission,
+  cloneObject,
   IHubItemEntity,
   IPermissionPolicy,
+  IUserHubSettings,
   Permission,
 } from "../../src";
 import { MOCK_AUTH } from "../mocks/mock-auth";
@@ -400,6 +402,21 @@ describe("checkPermission:", () => {
         expect(chk.response).toBe("granted");
         expect(chk.checks.length).toBe(4);
       });
+    });
+  });
+  describe("user preferences", () => {
+    it("enabled user feature flag overrides availability and env", () => {
+      const localCtx = cloneObject(premiumCtxMgr.context);
+      localCtx.userHubSettings = {
+        schemaVersion: 1,
+        preview: {
+          workspace: true,
+          otherProp: true,
+        } as unknown as IUserHubSettings["preview"],
+      };
+      const chk = checkPermission("hub:feature:workspace", localCtx);
+
+      expect(chk.access).toBe(true);
     });
   });
 });


### PR DESCRIPTION
1. Description:

`checkPermission` integrates preview flags from `context.userHubSettings.preview`

1. Instructions for testing: run tests

1. Closes Issues: associated with #8495

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
