### PR TITLE
fix: initiative UI schema enhancement

### DIFF
--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
@@ -91,7 +91,7 @@ export const buildUiSchema = async (
                       ],
                       descriptions: [
                         `{{${i18nScope}.fields.hero.map.description:translate}}`,
-                        `{{${i18nScope}.fields.hero.map.description:translate}}`,
+                        `{{${i18nScope}.fields.hero.image.description:translate}}`,
                       ],
                       icons: ["map-pin", "image"],
                     },
@@ -148,9 +148,8 @@ export const buildUiSchema = async (
                 ],
               },
               {
+                type: "Section",
                 labelKey: `${i18nScope}.fields.featuredImage.label`,
-                scope: "/properties/view/properties/featuredImage",
-                type: "Control",
                 rule: {
                   effect: UiSchemaRuleEffects.HIDE,
                   condition: {
@@ -158,39 +157,35 @@ export const buildUiSchema = async (
                     schema: { const: "map" },
                   },
                 },
-                options: {
-                  control: "hub-field-input-image-picker",
-                  imgSrc: getAuthedImageUrl(
-                    options.view?.featuredImageUrl,
-                    context.requestOptions
-                  ),
-                  maxWidth: 727,
-                  maxHeight: 484,
-                  aspectRatio: 1.5,
-                  helperText: {
-                    labelKey: `${i18nScope}.fields.featuredImage.helperText`,
+                elements: [
+                  {
+                    scope: "/properties/view/properties/featuredImage",
+                    type: "Control",
+                    options: {
+                      control: "hub-field-input-image-picker",
+                      imgSrc: getAuthedImageUrl(
+                        options.view?.featuredImageUrl,
+                        context.requestOptions
+                      ),
+                      maxWidth: 727,
+                      maxHeight: 484,
+                      aspectRatio: 1.5,
+                      sizeDescription: {
+                        labelKey: `${i18nScope}.fields.featuredImage.sizeDescription`,
+                      },
+                    },
                   },
-                  sizeDescription: {
-                    labelKey: `${i18nScope}.fields.featuredImage.sizeDescription`,
+                  {
+                    labelKey: `${i18nScope}.fields.featuredImage.altText.label`,
+                    scope: "/properties/view/properties/featuredImageAltText",
+                    type: "Control",
+                    options: {
+                      helperText: {
+                        labelKey: `${i18nScope}.fields.featuredImage.altText.helperText`,
+                      },
+                    },
                   },
-                },
-              },
-              {
-                labelKey: `${i18nScope}.fields.featuredImage.altText.label`,
-                scope: "/properties/view/properties/featuredImageAltText",
-                type: "Control",
-                rule: {
-                  effect: UiSchemaRuleEffects.HIDE,
-                  condition: {
-                    scope: "/properties/view/properties/hero",
-                    schema: { const: "map" },
-                  },
-                },
-                options: {
-                  helperText: {
-                    labelKey: `${i18nScope}.fields.featuredImage.altText.helperText`,
-                  },
-                },
+                ],
               },
             ],
           },

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -122,9 +122,6 @@ export const buildUiSchema = async (
               maxWidth: 727,
               maxHeight: 484,
               aspectRatio: 1.5,
-              helperText: {
-                labelKey: `${i18nScope}.fields.featuredImage.helperText`,
-              },
               sizeDescription: {
                 labelKey: `${i18nScope}.fields.featuredImage.sizeDescription`,
               },

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
@@ -98,7 +98,7 @@ describe("buildUiSchema: initiative create", () => {
                         ],
                         descriptions: [
                           "{{some.scope.fields.hero.map.description:translate}}",
-                          "{{some.scope.fields.hero.map.description:translate}}",
+                          "{{some.scope.fields.hero.image.description:translate}}",
                         ],
                         icons: ["map-pin", "image"],
                       },
@@ -146,9 +146,8 @@ describe("buildUiSchema: initiative create", () => {
                   ],
                 },
                 {
+                  type: "Section",
                   labelKey: "some.scope.fields.featuredImage.label",
-                  scope: "/properties/view/properties/featuredImage",
-                  type: "Control",
                   rule: {
                     effect: UiSchemaRuleEffects.HIDE,
                     condition: {
@@ -156,38 +155,34 @@ describe("buildUiSchema: initiative create", () => {
                       schema: { const: "map" },
                     },
                   },
-                  options: {
-                    control: "hub-field-input-image-picker",
-                    imgSrc: "https://some-image-url.com",
-                    maxWidth: 727,
-                    maxHeight: 484,
-                    aspectRatio: 1.5,
-                    helperText: {
-                      labelKey: "some.scope.fields.featuredImage.helperText",
+                  elements: [
+                    {
+                      scope: "/properties/view/properties/featuredImage",
+                      type: "Control",
+                      options: {
+                        control: "hub-field-input-image-picker",
+                        imgSrc: "https://some-image-url.com",
+                        maxWidth: 727,
+                        maxHeight: 484,
+                        aspectRatio: 1.5,
+                        sizeDescription: {
+                          labelKey:
+                            "some.scope.fields.featuredImage.sizeDescription",
+                        },
+                      },
                     },
-                    sizeDescription: {
-                      labelKey:
-                        "some.scope.fields.featuredImage.sizeDescription",
+                    {
+                      labelKey: "some.scope.fields.featuredImage.altText.label",
+                      scope: "/properties/view/properties/featuredImageAltText",
+                      type: "Control",
+                      options: {
+                        helperText: {
+                          labelKey:
+                            "some.scope.fields.featuredImage.altText.helperText",
+                        },
+                      },
                     },
-                  },
-                },
-                {
-                  labelKey: "some.scope.fields.featuredImage.altText.label",
-                  scope: "/properties/view/properties/featuredImageAltText",
-                  type: "Control",
-                  rule: {
-                    effect: UiSchemaRuleEffects.HIDE,
-                    condition: {
-                      scope: "/properties/view/properties/hero",
-                      schema: { const: "map" },
-                    },
-                  },
-                  options: {
-                    helperText: {
-                      labelKey:
-                        "some.scope.fields.featuredImage.altText.helperText",
-                    },
-                  },
+                  ],
                 },
               ],
             },
@@ -328,7 +323,7 @@ describe("buildUiSchema: initiative create", () => {
                         ],
                         descriptions: [
                           "{{some.scope.fields.hero.map.description:translate}}",
-                          "{{some.scope.fields.hero.map.description:translate}}",
+                          "{{some.scope.fields.hero.image.description:translate}}",
                         ],
                         icons: ["map-pin", "image"],
                       },
@@ -376,9 +371,8 @@ describe("buildUiSchema: initiative create", () => {
                   ],
                 },
                 {
+                  type: "Section",
                   labelKey: "some.scope.fields.featuredImage.label",
-                  scope: "/properties/view/properties/featuredImage",
-                  type: "Control",
                   rule: {
                     effect: UiSchemaRuleEffects.HIDE,
                     condition: {
@@ -386,38 +380,34 @@ describe("buildUiSchema: initiative create", () => {
                       schema: { const: "map" },
                     },
                   },
-                  options: {
-                    control: "hub-field-input-image-picker",
-                    imgSrc: "https://some-image-url.com",
-                    maxWidth: 727,
-                    maxHeight: 484,
-                    aspectRatio: 1.5,
-                    helperText: {
-                      labelKey: "some.scope.fields.featuredImage.helperText",
+                  elements: [
+                    {
+                      scope: "/properties/view/properties/featuredImage",
+                      type: "Control",
+                      options: {
+                        control: "hub-field-input-image-picker",
+                        imgSrc: "https://some-image-url.com",
+                        maxWidth: 727,
+                        maxHeight: 484,
+                        aspectRatio: 1.5,
+                        sizeDescription: {
+                          labelKey:
+                            "some.scope.fields.featuredImage.sizeDescription",
+                        },
+                      },
                     },
-                    sizeDescription: {
-                      labelKey:
-                        "some.scope.fields.featuredImage.sizeDescription",
+                    {
+                      labelKey: "some.scope.fields.featuredImage.altText.label",
+                      scope: "/properties/view/properties/featuredImageAltText",
+                      type: "Control",
+                      options: {
+                        helperText: {
+                          labelKey:
+                            "some.scope.fields.featuredImage.altText.helperText",
+                        },
+                      },
                     },
-                  },
-                },
-                {
-                  labelKey: "some.scope.fields.featuredImage.altText.label",
-                  scope: "/properties/view/properties/featuredImageAltText",
-                  type: "Control",
-                  rule: {
-                    effect: UiSchemaRuleEffects.HIDE,
-                    condition: {
-                      scope: "/properties/view/properties/hero",
-                      schema: { const: "map" },
-                    },
-                  },
-                  options: {
-                    helperText: {
-                      labelKey:
-                        "some.scope.fields.featuredImage.altText.helperText",
-                    },
-                  },
+                  ],
                 },
               ],
             },

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -137,9 +137,6 @@ describe("buildUiSchema: initiative edit", () => {
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,
-                helperText: {
-                  labelKey: `some.scope.fields.featuredImage.helperText`,
-                },
                 sizeDescription: {
                   labelKey: `some.scope.fields.featuredImage.sizeDescription`,
                 },
@@ -423,9 +420,6 @@ describe("buildUiSchema: initiative edit", () => {
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,
-                helperText: {
-                  labelKey: `some.scope.fields.featuredImage.helperText`,
-                },
                 sizeDescription: {
                   labelKey: `some.scope.fields.featuredImage.sizeDescription`,
                 },


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
- Rename featured image to image on both initiative creation and edit
- Remove featured image helper text
- Reorder initiative UI schema create so image becomes the section on the 2nd step, and featuredImage and alt text are the control
1. Instructions for testing:
See opendata PR here

1. Closes Issues: [8182](https://zentopia.esri.com/workspaces/collaboration-sprint-board-614f9bfc0946c40011ef574e/issues/gh/dc/hub/8182)


1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
