### PR TITLE
fix(hub-common): delete the discussion entity settings before the dis…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.69.1",
+			"version": "14.70.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/discussions/edit.ts
+++ b/packages/common/src/discussions/edit.ts
@@ -185,11 +185,11 @@ export async function deleteDiscussion(
   requestOptions: IHubRequestOptions
 ): Promise<void> {
   const ro = { ...requestOptions, ...{ id } } as IUserItemOptions;
-  await removeItem(ro);
   try {
     await removeSetting({ id, ...requestOptions });
   } catch (e) {
     // suppress error
   }
+  await removeItem(ro);
   return;
 }

--- a/packages/common/test/discussions/edit.test.ts
+++ b/packages/common/test/discussions/edit.test.ts
@@ -50,17 +50,28 @@ const DEFAULT_SETTINGS =
 describe("discussions edit:", () => {
   describe("deleteDiscussion:", () => {
     it("deletes the item", async () => {
-      const removeSpy = spyOn(portalModule, "removeItem").and.returnValue(
+      const removeItemSpy = spyOn(portalModule, "removeItem").and.returnValue(
         Promise.resolve({ success: true })
       );
+      const removeSettingSpy = spyOn(
+        settingUtils,
+        "removeSetting"
+      ).and.returnValue(Promise.resolve({ success: true }));
 
       const result = await deleteDiscussion("3ef", {
         authentication: MOCK_AUTH,
       });
       expect(result).toBeUndefined();
-      expect(removeSpy.calls.count()).toBe(1);
-      expect(removeSpy.calls.argsFor(0)[0].authentication).toBe(MOCK_AUTH);
-      expect(removeSpy.calls.argsFor(0)[0].id).toBe("3ef");
+      expect(removeSettingSpy.calls.count()).toBe(1);
+      expect(removeSettingSpy.calls.argsFor(0)[0].authentication).toBe(
+        MOCK_AUTH
+      );
+      expect(removeItemSpy.calls.count()).toBe(1);
+      expect(removeItemSpy.calls.argsFor(0)[0]).toEqual({
+        id: "3ef",
+        authentication: MOCK_AUTH,
+      });
+      expect(removeItemSpy.calls.argsFor(0)[0].id).toBe("3ef");
     });
   });
 


### PR DESCRIPTION
…cussion entity

affects: @esri/hub-common

ISSUES CLOSED: 8835

1. Description:

- Deletes the discussion entity settings before the discussion entity

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
