### PR TITLE
fix: adds label to site telemetry ui schema section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.70.2",
+			"version": "14.71.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/sites/_internal/SiteUiSchemaSettings.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaSettings.ts
@@ -18,6 +18,7 @@ export const buildUiSchema = async (
     elements: [
       {
         type: "Section",
+        labelKey: `${i18nScope}.sections.privacy.label`,
         elements: [
           {
             scope: "/properties/telemetry/properties/consentNotice",

--- a/packages/common/test/sites/_internal/SiteuUiSchemaTelemetry.test.ts
+++ b/packages/common/test/sites/_internal/SiteuUiSchemaTelemetry.test.ts
@@ -9,6 +9,7 @@ describe("buildUiSchema: site telemetry", () => {
       elements: [
         {
           type: "Section",
+          labelKey: `some.scope.sections.privacy.label`,
           elements: [
             {
               scope: "/properties/telemetry/properties/consentNotice",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: adds label to site telemetry ui schema section

1. Instructions for testing: 

1. Related Issues: [8676](https://devtopia.esri.com/dc/hub/issues/8676)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
