### PR TITLE
fix: reorder fields in initiative editor, hide featured content for MVP

### DIFF
--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -146,46 +146,6 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(
-            i18nScope,
-            options.thumbnail,
-            options.thumbnailUrl
-          ),
-          {
-            labelKey: `${i18nScope}.fields.tags.label`,
-            scope: "/properties/tags",
-            type: "Control",
-            options: {
-              control: "hub-field-input-combobox",
-              items: await getTagItems(
-                options.tags,
-                context.portal.id,
-                context.hubRequestOptions
-              ),
-              allowCustomValues: true,
-              selectionMode: "multiple",
-              placeholderIcon: "label",
-              helperText: { labelKey: `${i18nScope}.fields.tags.helperText` },
-            },
-          },
-          {
-            labelKey: `${i18nScope}.fields.categories.label`,
-            scope: "/properties/categories",
-            type: "Control",
-            options: {
-              control: "hub-field-input-combobox",
-              items: await getCategoryItems(
-                context.portal.id,
-                context.hubRequestOptions
-              ),
-              allowCustomValues: false,
-              selectionMode: "multiple",
-              placeholderIcon: "select-category",
-              helperText: {
-                labelKey: `${i18nScope}.fields.categories.helperText`,
-              },
-            },
-          },
         ],
       },
       {
@@ -219,6 +179,52 @@ export const buildUiSchema = async (
       },
       {
         type: "Section",
+        labelKey: `${i18nScope}.sections.searchDiscoverability.label`,
+        elements: [
+          {
+            labelKey: `${i18nScope}.fields.categories.label`,
+            scope: "/properties/categories",
+            type: "Control",
+            options: {
+              control: "hub-field-input-combobox",
+              items: await getCategoryItems(
+                context.portal.id,
+                context.hubRequestOptions
+              ),
+              allowCustomValues: false,
+              selectionMode: "multiple",
+              placeholderIcon: "select-category",
+              helperText: {
+                labelKey: `${i18nScope}.fields.categories.helperText`,
+              },
+            },
+          },
+          {
+            labelKey: `${i18nScope}.fields.tags.label`,
+            scope: "/properties/tags",
+            type: "Control",
+            options: {
+              control: "hub-field-input-combobox",
+              items: await getTagItems(
+                options.tags,
+                context.portal.id,
+                context.hubRequestOptions
+              ),
+              allowCustomValues: true,
+              selectionMode: "multiple",
+              placeholderIcon: "label",
+              helperText: { labelKey: `${i18nScope}.fields.tags.helperText` },
+            },
+          },
+          getThumbnailUiSchemaElement(
+            i18nScope,
+            options.thumbnail,
+            options.thumbnailUrl
+          ),
+        ],
+      },
+      {
+        type: "Section",
         labelKey: `${i18nScope}.sections.status.label`,
         elements: [
           {
@@ -234,45 +240,46 @@ export const buildUiSchema = async (
           },
         ],
       },
-      {
-        type: "Section",
-        labelKey: `${i18nScope}.sections.featuredContent.label`,
-        options: {
-          helperText: {
-            labelKey: `${i18nScope}.sections.featuredContent.helperText`,
-          },
-        },
-        elements: [
-          {
-            scope: "/properties/view/properties/featuredContentIds",
-            type: "Control",
-            options: {
-              control: "hub-field-input-gallery-picker",
-              targetEntity: "item",
-              catalogs: getFeaturedContentCatalogs(context.currentUser),
-              facets: [
-                {
-                  label: `{{${i18nScope}.fields.featuredContent.facets.type:translate}}`,
-                  key: "type",
-                  display: "multi-select",
-                  field: "type",
-                  options: [],
-                  operation: "OR",
-                  aggLimit: 100,
-                },
-                {
-                  label: `{{${i18nScope}.fields.featuredContent.facets.sharing:translate}}`,
-                  key: "access",
-                  display: "multi-select",
-                  field: "access",
-                  options: [],
-                  operation: "OR",
-                },
-              ],
-            },
-          },
-        ],
-      },
+      // Feature Content - Hidden for MVP
+      // {
+      //   type: "Section",
+      //   labelKey: `${i18nScope}.sections.featuredContent.label`,
+      //   options: {
+      //     helperText: {
+      //       labelKey: `${i18nScope}.sections.featuredContent.helperText`,
+      //     },
+      //   },
+      //   elements: [
+      //     {
+      //       scope: "/properties/view/properties/featuredContentIds",
+      //       type: "Control",
+      //       options: {
+      //         control: "hub-field-input-gallery-picker",
+      //         targetEntity: "item",
+      //         catalogs: getFeaturedContentCatalogs(context.currentUser),
+      //         facets: [
+      //           {
+      //             label: `{{${i18nScope}.fields.featuredContent.facets.type:translate}}`,
+      //             key: "type",
+      //             display: "multi-select",
+      //             field: "type",
+      //             options: [],
+      //             operation: "OR",
+      //             aggLimit: 100,
+      //           },
+      //           {
+      //             label: `{{${i18nScope}.fields.featuredContent.facets.sharing:translate}}`,
+      //             key: "access",
+      //             display: "multi-select",
+      //             field: "access",
+      //             options: [],
+      //             operation: "OR",
+      //           },
+      //         ],
+      //       },
+      //     },
+      //   ],
+      // },
     ],
   };
 };

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -240,7 +240,7 @@ export const buildUiSchema = async (
           },
         ],
       },
-      // Feature Content - Hidden for MVP
+      // Feature Content - hiding for MVP
       // {
       //   type: "Section",
       //   labelKey: `${i18nScope}.sections.featuredContent.label`,

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -161,53 +161,6 @@ describe("buildUiSchema: initiative edit", () => {
                 },
               },
             },
-            {
-              labelKey: "shared.fields._thumbnail.label",
-              scope: "/properties/_thumbnail",
-              type: "Control",
-              options: {
-                control: "hub-field-input-image-picker",
-                imgSrc: "https://some-thumbnail-url.com",
-                maxWidth: 727,
-                maxHeight: 484,
-                aspectRatio: 1.5,
-                helperText: {
-                  labelKey: "some.scope.fields._thumbnail.helperText",
-                },
-                sizeDescription: {
-                  labelKey: "shared.fields._thumbnail.sizeDescription",
-                },
-                messages: [],
-              },
-            },
-            {
-              labelKey: "some.scope.fields.tags.label",
-              scope: "/properties/tags",
-              type: "Control",
-              options: {
-                control: "hub-field-input-combobox",
-                items: [],
-                allowCustomValues: true,
-                selectionMode: "multiple",
-                placeholderIcon: "label",
-                helperText: { labelKey: "some.scope.fields.tags.helperText" },
-              },
-            },
-            {
-              labelKey: "some.scope.fields.categories.label",
-              scope: "/properties/categories",
-              type: "Control",
-              options: {
-                control: "hub-field-input-combobox",
-                items: [],
-                allowCustomValues: false,
-                selectionMode: "multiple",
-                placeholderIcon: "select-category",
-                helperText: {
-                  labelKey: "some.scope.fields.categories.helperText",
-                },
-              },
-            },
           ],
         },
         {
@@ -232,6 +185,59 @@ describe("buildUiSchema: initiative edit", () => {
         },
         {
           type: "Section",
+          labelKey: "some.scope.sections.searchDiscoverability.label",
+          elements: [
+            {
+              labelKey: "some.scope.fields.categories.label",
+              scope: "/properties/categories",
+              type: "Control",
+              options: {
+                control: "hub-field-input-combobox",
+                items: [],
+                allowCustomValues: false,
+                selectionMode: "multiple",
+                placeholderIcon: "select-category",
+                helperText: {
+                  labelKey: "some.scope.fields.categories.helperText",
+                },
+              },
+            },
+            {
+              labelKey: "some.scope.fields.tags.label",
+              scope: "/properties/tags",
+              type: "Control",
+              options: {
+                control: "hub-field-input-combobox",
+                items: [],
+                allowCustomValues: true,
+                selectionMode: "multiple",
+                placeholderIcon: "label",
+                helperText: { labelKey: "some.scope.fields.tags.helperText" },
+              },
+            },
+            {
+              labelKey: "shared.fields._thumbnail.label",
+              scope: "/properties/_thumbnail",
+              type: "Control",
+              options: {
+                control: "hub-field-input-image-picker",
+                imgSrc: "https://some-thumbnail-url.com",
+                maxWidth: 727,
+                maxHeight: 484,
+                aspectRatio: 1.5,
+                helperText: {
+                  labelKey: "some.scope.fields._thumbnail.helperText",
+                },
+                sizeDescription: {
+                  labelKey: "shared.fields._thumbnail.sizeDescription",
+                },
+                messages: [],
+              },
+            },
+          ],
+        },
+        {
+          type: "Section",
           labelKey: "some.scope.sections.status.label",
           elements: [
             {
@@ -247,47 +253,48 @@ describe("buildUiSchema: initiative edit", () => {
             },
           ],
         },
-        {
-          type: "Section",
-          labelKey: "some.scope.sections.featuredContent.label",
-          options: {
-            helperText: {
-              labelKey: "some.scope.sections.featuredContent.helperText",
-            },
-          },
-          elements: [
-            {
-              scope: "/properties/view/properties/featuredContentIds",
-              type: "Control",
-              options: {
-                control: "hub-field-input-gallery-picker",
-                targetEntity: "item",
-                catalogs: {},
-                facets: [
-                  {
-                    label:
-                      "{{some.scope.fields.featuredContent.facets.type:translate}}",
-                    key: "type",
-                    display: "multi-select",
-                    field: "type",
-                    options: [],
-                    operation: "OR",
-                    aggLimit: 100,
-                  },
-                  {
-                    label:
-                      "{{some.scope.fields.featuredContent.facets.sharing:translate}}",
-                    key: "access",
-                    display: "multi-select",
-                    field: "access",
-                    options: [],
-                    operation: "OR",
-                  },
-                ],
-              },
-            },
-          ],
-        },
+        // Feature Content - hiding for MVP
+        // {
+        //   type: "Section",
+        //   labelKey: "some.scope.sections.featuredContent.label",
+        //   options: {
+        //     helperText: {
+        //       labelKey: "some.scope.sections.featuredContent.helperText",
+        //     },
+        //   },
+        //   elements: [
+        //     {
+        //       scope: "/properties/view/properties/featuredContentIds",
+        //       type: "Control",
+        //       options: {
+        //         control: "hub-field-input-gallery-picker",
+        //         targetEntity: "item",
+        //         catalogs: {},
+        //         facets: [
+        //           {
+        //             label:
+        //               "{{some.scope.fields.featuredContent.facets.type:translate}}",
+        //             key: "type",
+        //             display: "multi-select",
+        //             field: "type",
+        //             options: [],
+        //             operation: "OR",
+        //             aggLimit: 100,
+        //           },
+        //           {
+        //             label:
+        //               "{{some.scope.fields.featuredContent.facets.sharing:translate}}",
+        //             key: "access",
+        //             display: "multi-select",
+        //             field: "access",
+        //             options: [],
+        //             operation: "OR",
+        //           },
+        //         ],
+        //       },
+        //     },
+        //   ],
+        // },
       ],
     });
   });
@@ -446,53 +453,6 @@ describe("buildUiSchema: initiative edit", () => {
                 },
               },
             },
-            {
-              labelKey: "shared.fields._thumbnail.label",
-              scope: "/properties/_thumbnail",
-              type: "Control",
-              options: {
-                control: "hub-field-input-image-picker",
-                imgSrc: "https://some-thumbnail-url.com",
-                maxWidth: 727,
-                maxHeight: 484,
-                aspectRatio: 1.5,
-                helperText: {
-                  labelKey: "some.scope.fields._thumbnail.helperText",
-                },
-                sizeDescription: {
-                  labelKey: "shared.fields._thumbnail.sizeDescription",
-                },
-                messages: [],
-              },
-            },
-            {
-              labelKey: "some.scope.fields.tags.label",
-              scope: "/properties/tags",
-              type: "Control",
-              options: {
-                control: "hub-field-input-combobox",
-                items: [],
-                allowCustomValues: true,
-                selectionMode: "multiple",
-                placeholderIcon: "label",
-                helperText: { labelKey: "some.scope.fields.tags.helperText" },
-              },
-            },
-            {
-              labelKey: "some.scope.fields.categories.label",
-              scope: "/properties/categories",
-              type: "Control",
-              options: {
-                control: "hub-field-input-combobox",
-                items: [],
-                allowCustomValues: false,
-                selectionMode: "multiple",
-                placeholderIcon: "select-category",
-                helperText: {
-                  labelKey: "some.scope.fields.categories.helperText",
-                },
-              },
-            },
           ],
         },
         {
@@ -517,6 +477,59 @@ describe("buildUiSchema: initiative edit", () => {
         },
         {
           type: "Section",
+          labelKey: "some.scope.sections.searchDiscoverability.label",
+          elements: [
+            {
+              labelKey: "some.scope.fields.categories.label",
+              scope: "/properties/categories",
+              type: "Control",
+              options: {
+                control: "hub-field-input-combobox",
+                items: [],
+                allowCustomValues: false,
+                selectionMode: "multiple",
+                placeholderIcon: "select-category",
+                helperText: {
+                  labelKey: "some.scope.fields.categories.helperText",
+                },
+              },
+            },
+            {
+              labelKey: "some.scope.fields.tags.label",
+              scope: "/properties/tags",
+              type: "Control",
+              options: {
+                control: "hub-field-input-combobox",
+                items: [],
+                allowCustomValues: true,
+                selectionMode: "multiple",
+                placeholderIcon: "label",
+                helperText: { labelKey: "some.scope.fields.tags.helperText" },
+              },
+            },
+            {
+              labelKey: "shared.fields._thumbnail.label",
+              scope: "/properties/_thumbnail",
+              type: "Control",
+              options: {
+                control: "hub-field-input-image-picker",
+                imgSrc: "https://some-thumbnail-url.com",
+                maxWidth: 727,
+                maxHeight: 484,
+                aspectRatio: 1.5,
+                helperText: {
+                  labelKey: "some.scope.fields._thumbnail.helperText",
+                },
+                sizeDescription: {
+                  labelKey: "shared.fields._thumbnail.sizeDescription",
+                },
+                messages: [],
+              },
+            },
+          ],
+        },
+        {
+          type: "Section",
           labelKey: "some.scope.sections.status.label",
           elements: [
             {
@@ -532,47 +545,48 @@ describe("buildUiSchema: initiative edit", () => {
             },
           ],
         },
-        {
-          type: "Section",
-          labelKey: "some.scope.sections.featuredContent.label",
-          options: {
-            helperText: {
-              labelKey: "some.scope.sections.featuredContent.helperText",
-            },
-          },
-          elements: [
-            {
-              scope: "/properties/view/properties/featuredContentIds",
-              type: "Control",
-              options: {
-                control: "hub-field-input-gallery-picker",
-                targetEntity: "item",
-                catalogs: {},
-                facets: [
-                  {
-                    label:
-                      "{{some.scope.fields.featuredContent.facets.type:translate}}",
-                    key: "type",
-                    display: "multi-select",
-                    field: "type",
-                    options: [],
-                    operation: "OR",
-                    aggLimit: 100,
-                  },
-                  {
-                    label:
-                      "{{some.scope.fields.featuredContent.facets.sharing:translate}}",
-                    key: "access",
-                    display: "multi-select",
-                    field: "access",
-                    options: [],
-                    operation: "OR",
-                  },
-                ],
-              },
-            },
-          ],
-        },
+        // Feature Content - hiding for MVP
+        // {
+        //   type: "Section",
+        //   labelKey: "some.scope.sections.featuredContent.label",
+        //   options: {
+        //     helperText: {
+        //       labelKey: "some.scope.sections.featuredContent.helperText",
+        //     },
+        //   },
+        //   elements: [
+        //     {
+        //       scope: "/properties/view/properties/featuredContentIds",
+        //       type: "Control",
+        //       options: {
+        //         control: "hub-field-input-gallery-picker",
+        //         targetEntity: "item",
+        //         catalogs: {},
+        //         facets: [
+        //           {
+        //             label:
+        //               "{{some.scope.fields.featuredContent.facets.type:translate}}",
+        //             key: "type",
+        //             display: "multi-select",
+        //             field: "type",
+        //             options: [],
+        //             operation: "OR",
+        //             aggLimit: 100,
+        //           },
+        //           {
+        //             label:
+        //               "{{some.scope.fields.featuredContent.facets.sharing:translate}}",
+        //             key: "access",
+        //             display: "multi-select",
+        //             field: "access",
+        //             options: [],
+        //             operation: "OR",
+        //           },
+        //         ],
+        //       },
+        //     },
+        //   ],
+        // },
       ],
     });
   });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Reorder fields in initiative editor in below order, hide featured content for MVP

- Basic Information
    - Name
    - Purpose
    - Description
    - Hero
- Location
- Search & discoverability
    - Tags
    - Categories
    - Thumbnail
- Status
- Featured Content

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
