### PR TITLE
chore: re-enable branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ESRI_DCDEV_SERVICE_ACCOUNT_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          # This parameter is required to make sure sematic-relase exactly use the provided GitHub Token
+          # See https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions#pushing-package.json-changes-to-a-master-branch
+          persist-credentials: false
+
       - uses: actions/setup-node@v3
         with:
           node-version: 16.13


### PR DESCRIPTION
Update the GitHub token used in release to be a personal access token from Hub's GitHub service account. This will enable the implementation of the branch protection but allow the service account to bypass protection rules during the release (direct push to the master branch).

Compared to the original PR https://github.com/Esri/hub.js/pull/1349, this new PR adds a necessary parameter for the `checkout` action. It makes sure the `somatic-release` would use the provided token (not the one in the environment) for release. See discussion at https://github.com/semantic-release/semantic-release/issues/2636.

The secret has been created.