### PR TITLE
feat: description fields to rich text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.71.0",
+			"version": "14.71.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -78,7 +78,7 @@ export const buildUiSchema = async (
             scope: "/properties/description",
             type: "Control",
             options: {
-              control: "hub-field-input-input",
+              control: "hub-field-input-rich-text",
               type: "textarea",
               helperText: {
                 labelKey: `${i18nScope}.fields.description.hint`,

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -154,7 +154,7 @@ export const buildUiSchema = async (
             scope: "/properties/description",
             type: "Control",
             options: {
-              control: "hub-field-input-input",
+              control: "hub-field-input-rich-text",
               type: "textarea",
               helperText: {
                 labelKey: `${i18nScope}.fields.description.helperText`,

--- a/packages/common/src/groups/_internal/GroupSchema.ts
+++ b/packages/common/src/groups/_internal/GroupSchema.ts
@@ -29,6 +29,7 @@ export const GroupSchema: IConfigurationSchema = {
       // a max char limit of 250
       maxLength: 250,
     },
+    description: { type: "string" },
     _thumbnail: ENTITY_IMAGE_SCHEMA,
     membershipAccess: {
       type: "string",

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -60,6 +60,18 @@ export const buildUiSchema = async (
             },
           },
           {
+            labelKey: `${i18nScope}.fields.description.label`,
+            scope: "/properties/description",
+            type: "Control",
+            options: {
+              control: "hub-field-input-rich-text",
+              type: "textarea",
+              helperText: {
+                labelKey: `${i18nScope}.fields.description.helperText`,
+              },
+            },
+          },
+          {
             labelKey: `${i18nScope}.fields._thumbnail.label`,
             scope: "/properties/_thumbnail",
             type: "Control",

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -66,9 +66,6 @@ export const buildUiSchema = async (
             options: {
               control: "hub-field-input-rich-text",
               type: "textarea",
-              helperText: {
-                labelKey: `${i18nScope}.fields.description.helperText`,
-              },
             },
           },
           {

--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
@@ -97,7 +97,7 @@ export const buildUiSchema = async (
             scope: "/properties/description",
             labelKey: `${i18nScope}.fields.description.label`,
             options: {
-              control: "hub-field-input-input",
+              control: "hub-field-input-rich-text",
               type: "textarea",
               helperText: {
                 labelKey: `${i18nScope}.fields.description.helperText`,

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -79,8 +79,6 @@ export const buildUiSchema = async (
               helperText: {
                 labelKey: `${i18nScope}.fields.description.helperText`,
               },
-              toolbar:
-                "heading,|,bold,italic,blockQuote,removeFormat,link,|,bulletedList,numberedList,alignment,outdent,indent,|,undo,redo",
             },
           },
           {

--- a/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
+++ b/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
@@ -72,7 +72,7 @@ export const buildUiSchema = async (
             scope: "/properties/description",
             type: "Control",
             options: {
-              control: "hub-field-input-input",
+              control: "hub-field-input-rich-text",
               type: "textarea",
               helperText: {
                 labelKey: `${i18nScope}.fields.description.helperText`,

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -79,8 +79,6 @@ export const buildUiSchema = async (
               helperText: {
                 labelKey: `${i18nScope}.fields.description.helperText`,
               },
-              toolbar:
-                "heading,|,bold,italic,blockQuote,removeFormat,link,|,bulletedList,numberedList,alignment,outdent,indent,|,undo,redo",
             },
           },
           {

--- a/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
+++ b/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
@@ -96,7 +96,7 @@ export const buildUiSchema = async (
             scope: "/properties/description",
             type: "Control",
             options: {
-              control: "hub-field-input-input",
+              control: "hub-field-input-rich-text",
               type: "textarea",
               helperText: {
                 labelKey: `${i18nScope}.fields.description.helperText`,

--- a/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
@@ -85,7 +85,7 @@ describe("buildUiSchema: content edit", () => {
               scope: "/properties/description",
               type: "Control",
               options: {
-                control: "hub-field-input-input",
+                control: "hub-field-input-rich-text",
                 type: "textarea",
                 helperText: {
                   labelKey: "some.scope.fields.description.hint",

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -162,7 +162,7 @@ describe("buildUiSchema: discussion edit", () => {
               scope: "/properties/description",
               type: "Control",
               options: {
-                control: "hub-field-input-input",
+                control: "hub-field-input-rich-text",
                 type: "textarea",
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",
@@ -333,7 +333,7 @@ describe("buildUiSchema: discussion edit", () => {
               scope: "/properties/description",
               type: "Control",
               options: {
-                control: "hub-field-input-input",
+                control: "hub-field-input-rich-text",
                 type: "textarea",
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",

--- a/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
@@ -55,6 +55,18 @@ describe("buildUiSchema: group edit", () => {
               },
             },
             {
+              labelKey: `some.scope.fields.description.label`,
+              scope: "/properties/description",
+              type: "Control",
+              options: {
+                control: "hub-field-input-rich-text",
+                type: "textarea",
+                helperText: {
+                  labelKey: "some.scope.fields.description.helperText",
+                },
+              },
+            },
+            {
               labelKey: "some.scope.fields._thumbnail.label",
               scope: "/properties/_thumbnail",
               type: "Control",

--- a/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
@@ -61,9 +61,6 @@ describe("buildUiSchema: group edit", () => {
               options: {
                 control: "hub-field-input-rich-text",
                 type: "textarea",
-                helperText: {
-                  labelKey: "some.scope.fields.description.helperText",
-                },
               },
             },
             {

--- a/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
@@ -94,7 +94,7 @@ describe("buildUiSchema: initiative template edit", () => {
               scope: "/properties/description",
               labelKey: `some.scope.fields.description.label`,
               options: {
-                control: "hub-field-input-input",
+                control: "hub-field-input-rich-text",
                 type: "textarea",
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -97,8 +97,6 @@ describe("buildUiSchema: initiative edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",
                 },
-                toolbar:
-                  "heading,|,bold,italic,blockQuote,removeFormat,link,|,bulletedList,numberedList,alignment,outdent,indent,|,undo,redo",
               },
             },
             {
@@ -389,8 +387,6 @@ describe("buildUiSchema: initiative edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",
                 },
-                toolbar:
-                  "heading,|,bold,italic,blockQuote,removeFormat,link,|,bulletedList,numberedList,alignment,outdent,indent,|,undo,redo",
               },
             },
             {

--- a/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
+++ b/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
@@ -82,7 +82,7 @@ describe("buildUiSchema: page edit", () => {
               scope: "/properties/description",
               type: "Control",
               options: {
-                control: "hub-field-input-input",
+                control: "hub-field-input-rich-text",
                 type: "textarea",
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -96,8 +96,6 @@ describe("buildUiSchema: project edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",
                 },
-                toolbar:
-                  "heading,|,bold,italic,blockQuote,removeFormat,link,|,bulletedList,numberedList,alignment,outdent,indent,|,undo,redo",
               },
             },
             {
@@ -409,8 +407,6 @@ describe("buildUiSchema: project edit", () => {
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",
                 },
-                toolbar:
-                  "heading,|,bold,italic,blockQuote,removeFormat,link,|,bulletedList,numberedList,alignment,outdent,indent,|,undo,redo",
               },
             },
             {

--- a/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
@@ -88,7 +88,7 @@ describe("buildUiSchema: template edit", () => {
               scope: "/properties/description",
               type: "Control",
               options: {
-                control: "hub-field-input-input",
+                control: "hub-field-input-rich-text",
                 type: "textarea",
                 helperText: {
                   labelKey: "some.scope.fields.description.helperText",


### PR DESCRIPTION
1. Description: Transitions all description fields for workspace entities to be rich text fields

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
