### PR TITLE
fix: tempoarily remove call to action from project edit uiSchema

### DIFF
--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -259,45 +259,46 @@ export const buildUiSchema = async (
           },
         ],
       },
-      {
-        type: "Section",
-        labelKey: `${i18nScope}.sections.callToAction.label`,
-        options: {
-          helperText: {
-            labelKey: `${i18nScope}.sections.callToAction.helperText`,
-          },
-        },
-        elements: [
-          {
-            scope: "/properties/view/properties/heroActions",
-            type: "Control",
-            options: {
-              control: "hub-composite-input-action-links",
-              type: "button",
-              catalogs: getFeaturedContentCatalogs(context.currentUser), // for now we'll just re-use this util to get the catalogs
-              facets: [
-                {
-                  label: `{{${i18nScope}.fields.callToAction.facets.type:translate}}`,
-                  key: "type",
-                  display: "multi-select",
-                  field: "type",
-                  options: [],
-                  operation: "OR",
-                  aggLimit: 100,
-                },
-                {
-                  label: `{{${i18nScope}.fields.callToAction.facets.sharing:translate}}`,
-                  key: "access",
-                  display: "multi-select",
-                  field: "access",
-                  options: [],
-                  operation: "OR",
-                },
-              ],
-            },
-          },
-        ],
-      },
+      // NOTE: temporarily commenting out for release
+      // {
+      //   type: "Section",
+      //   labelKey: `${i18nScope}.sections.callToAction.label`,
+      //   options: {
+      //     helperText: {
+      //       labelKey: `${i18nScope}.sections.callToAction.helperText`,
+      //     },
+      //   },
+      //   elements: [
+      //     {
+      //       scope: "/properties/view/properties/heroActions",
+      //       type: "Control",
+      //       options: {
+      //         control: "hub-composite-input-action-links",
+      //         type: "button",
+      //         catalogs: getFeaturedContentCatalogs(context.currentUser), // for now we'll just re-use this util to get the catalogs
+      //         facets: [
+      //           {
+      //             label: `{{${i18nScope}.fields.callToAction.facets.type:translate}}`,
+      //             key: "type",
+      //             display: "multi-select",
+      //             field: "type",
+      //             options: [],
+      //             operation: "OR",
+      //             aggLimit: 100,
+      //           },
+      //           {
+      //             label: `{{${i18nScope}.fields.callToAction.facets.sharing:translate}}`,
+      //             key: "access",
+      //             display: "multi-select",
+      //             field: "access",
+      //             options: [],
+      //             operation: "OR",
+      //           },
+      //         ],
+      //       },
+      //     },
+      //   ],
+      // },
     ],
   };
 };

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -259,7 +259,7 @@ export const buildUiSchema = async (
           },
         ],
       },
-      // NOTE: temporarily commenting out for release
+      // NOTE: temporarily commenting out for release.
       // {
       //   type: "Section",
       //   labelKey: `${i18nScope}.sections.callToAction.label`,

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -274,45 +274,46 @@ describe("buildUiSchema: project edit", () => {
             },
           ],
         },
-        {
-          type: "Section",
-          labelKey: "some.scope.sections.callToAction.label",
-          options: {
-            helperText: {
-              labelKey: "some.scope.sections.callToAction.helperText",
-            },
-          },
-          elements: [
-            {
-              scope: "/properties/view/properties/heroActions",
-              type: "Control",
-              options: {
-                control: "hub-composite-input-action-links",
-                type: "button",
-                catalogs: {},
-                facets: [
-                  {
-                    label: `{{some.scope.fields.callToAction.facets.type:translate}}`,
-                    key: "type",
-                    display: "multi-select",
-                    field: "type",
-                    options: [],
-                    operation: "OR",
-                    aggLimit: 100,
-                  },
-                  {
-                    label: `{{some.scope.fields.callToAction.facets.sharing:translate}}`,
-                    key: "access",
-                    display: "multi-select",
-                    field: "access",
-                    options: [],
-                    operation: "OR",
-                  },
-                ],
-              },
-            },
-          ],
-        },
+        // TODO: uncomment after release and we add CTA back
+        // {
+        //   type: "Section",
+        //   labelKey: "some.scope.sections.callToAction.label",
+        //   options: {
+        //     helperText: {
+        //       labelKey: "some.scope.sections.callToAction.helperText",
+        //     },
+        //   },
+        //   elements: [
+        //     {
+        //       scope: "/properties/view/properties/heroActions",
+        //       type: "Control",
+        //       options: {
+        //         control: "hub-composite-input-action-links",
+        //         type: "button",
+        //         catalogs: {},
+        //         facets: [
+        //           {
+        //             label: `{{some.scope.fields.callToAction.facets.type:translate}}`,
+        //             key: "type",
+        //             display: "multi-select",
+        //             field: "type",
+        //             options: [],
+        //             operation: "OR",
+        //             aggLimit: 100,
+        //           },
+        //           {
+        //             label: `{{some.scope.fields.callToAction.facets.sharing:translate}}`,
+        //             key: "access",
+        //             display: "multi-select",
+        //             field: "access",
+        //             options: [],
+        //             operation: "OR",
+        //           },
+        //         ],
+        //       },
+        //     },
+        //   ],
+        // },
       ],
     });
   });
@@ -585,45 +586,46 @@ describe("buildUiSchema: project edit", () => {
             },
           ],
         },
-        {
-          type: "Section",
-          labelKey: "some.scope.sections.callToAction.label",
-          options: {
-            helperText: {
-              labelKey: "some.scope.sections.callToAction.helperText",
-            },
-          },
-          elements: [
-            {
-              scope: "/properties/view/properties/heroActions",
-              type: "Control",
-              options: {
-                control: "hub-composite-input-action-links",
-                type: "button",
-                catalogs: {},
-                facets: [
-                  {
-                    label: `{{some.scope.fields.callToAction.facets.type:translate}}`,
-                    key: "type",
-                    display: "multi-select",
-                    field: "type",
-                    options: [],
-                    operation: "OR",
-                    aggLimit: 100,
-                  },
-                  {
-                    label: `{{some.scope.fields.callToAction.facets.sharing:translate}}`,
-                    key: "access",
-                    display: "multi-select",
-                    field: "access",
-                    options: [],
-                    operation: "OR",
-                  },
-                ],
-              },
-            },
-          ],
-        },
+        // TODO: uncomment after release and we add CTA back
+        // {
+        //   type: "Section",
+        //   labelKey: "some.scope.sections.callToAction.label",
+        //   options: {
+        //     helperText: {
+        //       labelKey: "some.scope.sections.callToAction.helperText",
+        //     },
+        //   },
+        //   elements: [
+        //     {
+        //       scope: "/properties/view/properties/heroActions",
+        //       type: "Control",
+        //       options: {
+        //         control: "hub-composite-input-action-links",
+        //         type: "button",
+        //         catalogs: {},
+        //         facets: [
+        //           {
+        //             label: `{{some.scope.fields.callToAction.facets.type:translate}}`,
+        //             key: "type",
+        //             display: "multi-select",
+        //             field: "type",
+        //             options: [],
+        //             operation: "OR",
+        //             aggLimit: 100,
+        //           },
+        //           {
+        //             label: `{{some.scope.fields.callToAction.facets.sharing:translate}}`,
+        //             key: "access",
+        //             display: "multi-select",
+        //             field: "access",
+        //             options: [],
+        //             operation: "OR",
+        //           },
+        //         ],
+        //       },
+        //     },
+        //   ],
+        // },
       ],
     });
   });


### PR DESCRIPTION
[3630](https://devtopia.esri.com/dc/hub/issues/3630)

### Description
Commenting out the CTA field on the project edit `uiSchema` until the `opendata-ui` side of changes are ready to be merged. 

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.