### PR TITLE
fix(hub-common): enables discussions settings pane for users with edi…

### DIFF
--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -74,7 +74,6 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:discussion:workspace:settings",
     dependencies: ["hub:discussion:edit"],
-    entityOwner: true,
   },
   {
     permission: "hub:discussion:workspace:collaborators",


### PR DESCRIPTION
…t access

affects: @esri/hub-common

ISSUES CLOSED: 8825

1. Description: Enables discussions settings pane for users with edit access.

1. Instructions for testing:

1. Closes Issues: #8825

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
