### PR TITLE
fix(): add call to action to project edit uiSchema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.71.2",
+			"version": "14.72.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -259,46 +259,45 @@ export const buildUiSchema = async (
           },
         ],
       },
-      // NOTE: temporarily commenting out for release.
-      // {
-      //   type: "Section",
-      //   labelKey: `${i18nScope}.sections.callToAction.label`,
-      //   options: {
-      //     helperText: {
-      //       labelKey: `${i18nScope}.sections.callToAction.helperText`,
-      //     },
-      //   },
-      //   elements: [
-      //     {
-      //       scope: "/properties/view/properties/heroActions",
-      //       type: "Control",
-      //       options: {
-      //         control: "hub-composite-input-action-links",
-      //         type: "button",
-      //         catalogs: getFeaturedContentCatalogs(context.currentUser), // for now we'll just re-use this util to get the catalogs
-      //         facets: [
-      //           {
-      //             label: `{{${i18nScope}.fields.callToAction.facets.type:translate}}`,
-      //             key: "type",
-      //             display: "multi-select",
-      //             field: "type",
-      //             options: [],
-      //             operation: "OR",
-      //             aggLimit: 100,
-      //           },
-      //           {
-      //             label: `{{${i18nScope}.fields.callToAction.facets.sharing:translate}}`,
-      //             key: "access",
-      //             display: "multi-select",
-      //             field: "access",
-      //             options: [],
-      //             operation: "OR",
-      //           },
-      //         ],
-      //       },
-      //     },
-      //   ],
-      // },
+      {
+        type: "Section",
+        labelKey: `${i18nScope}.sections.callToAction.label`,
+        options: {
+          helperText: {
+            labelKey: `${i18nScope}.sections.callToAction.helperText`,
+          },
+        },
+        elements: [
+          {
+            scope: "/properties/view/properties/heroActions",
+            type: "Control",
+            options: {
+              control: "hub-composite-input-action-links",
+              type: "button",
+              catalogs: getFeaturedContentCatalogs(context.currentUser), // for now we'll just re-use this util to get the catalogs
+              facets: [
+                {
+                  label: `{{${i18nScope}.fields.callToAction.facets.type:translate}}`,
+                  key: "type",
+                  display: "multi-select",
+                  field: "type",
+                  options: [],
+                  operation: "OR",
+                  aggLimit: 100,
+                },
+                {
+                  label: `{{${i18nScope}.fields.callToAction.facets.sharing:translate}}`,
+                  key: "access",
+                  display: "multi-select",
+                  field: "access",
+                  options: [],
+                  operation: "OR",
+                },
+              ],
+            },
+          },
+        ],
+      },
     ],
   };
 };

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -274,46 +274,45 @@ describe("buildUiSchema: project edit", () => {
             },
           ],
         },
-        // TODO: uncomment after release and we add CTA back
-        // {
-        //   type: "Section",
-        //   labelKey: "some.scope.sections.callToAction.label",
-        //   options: {
-        //     helperText: {
-        //       labelKey: "some.scope.sections.callToAction.helperText",
-        //     },
-        //   },
-        //   elements: [
-        //     {
-        //       scope: "/properties/view/properties/heroActions",
-        //       type: "Control",
-        //       options: {
-        //         control: "hub-composite-input-action-links",
-        //         type: "button",
-        //         catalogs: {},
-        //         facets: [
-        //           {
-        //             label: `{{some.scope.fields.callToAction.facets.type:translate}}`,
-        //             key: "type",
-        //             display: "multi-select",
-        //             field: "type",
-        //             options: [],
-        //             operation: "OR",
-        //             aggLimit: 100,
-        //           },
-        //           {
-        //             label: `{{some.scope.fields.callToAction.facets.sharing:translate}}`,
-        //             key: "access",
-        //             display: "multi-select",
-        //             field: "access",
-        //             options: [],
-        //             operation: "OR",
-        //           },
-        //         ],
-        //       },
-        //     },
-        //   ],
-        // },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.callToAction.label",
+          options: {
+            helperText: {
+              labelKey: "some.scope.sections.callToAction.helperText",
+            },
+          },
+          elements: [
+            {
+              scope: "/properties/view/properties/heroActions",
+              type: "Control",
+              options: {
+                control: "hub-composite-input-action-links",
+                type: "button",
+                catalogs: {},
+                facets: [
+                  {
+                    label: `{{some.scope.fields.callToAction.facets.type:translate}}`,
+                    key: "type",
+                    display: "multi-select",
+                    field: "type",
+                    options: [],
+                    operation: "OR",
+                    aggLimit: 100,
+                  },
+                  {
+                    label: `{{some.scope.fields.callToAction.facets.sharing:translate}}`,
+                    key: "access",
+                    display: "multi-select",
+                    field: "access",
+                    options: [],
+                    operation: "OR",
+                  },
+                ],
+              },
+            },
+          ],
+        },
       ],
     });
   });
@@ -586,46 +585,45 @@ describe("buildUiSchema: project edit", () => {
             },
           ],
         },
-        // TODO: uncomment after release and we add CTA back
-        // {
-        //   type: "Section",
-        //   labelKey: "some.scope.sections.callToAction.label",
-        //   options: {
-        //     helperText: {
-        //       labelKey: "some.scope.sections.callToAction.helperText",
-        //     },
-        //   },
-        //   elements: [
-        //     {
-        //       scope: "/properties/view/properties/heroActions",
-        //       type: "Control",
-        //       options: {
-        //         control: "hub-composite-input-action-links",
-        //         type: "button",
-        //         catalogs: {},
-        //         facets: [
-        //           {
-        //             label: `{{some.scope.fields.callToAction.facets.type:translate}}`,
-        //             key: "type",
-        //             display: "multi-select",
-        //             field: "type",
-        //             options: [],
-        //             operation: "OR",
-        //             aggLimit: 100,
-        //           },
-        //           {
-        //             label: `{{some.scope.fields.callToAction.facets.sharing:translate}}`,
-        //             key: "access",
-        //             display: "multi-select",
-        //             field: "access",
-        //             options: [],
-        //             operation: "OR",
-        //           },
-        //         ],
-        //       },
-        //     },
-        //   ],
-        // },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.callToAction.label",
+          options: {
+            helperText: {
+              labelKey: "some.scope.sections.callToAction.helperText",
+            },
+          },
+          elements: [
+            {
+              scope: "/properties/view/properties/heroActions",
+              type: "Control",
+              options: {
+                control: "hub-composite-input-action-links",
+                type: "button",
+                catalogs: {},
+                facets: [
+                  {
+                    label: `{{some.scope.fields.callToAction.facets.type:translate}}`,
+                    key: "type",
+                    display: "multi-select",
+                    field: "type",
+                    options: [],
+                    operation: "OR",
+                    aggLimit: 100,
+                  },
+                  {
+                    label: `{{some.scope.fields.callToAction.facets.sharing:translate}}`,
+                    key: "access",
+                    display: "multi-select",
+                    field: "access",
+                    options: [],
+                    operation: "OR",
+                  },
+                ],
+              },
+            },
+          ],
+        },
       ],
     });
   });


### PR DESCRIPTION
1. Description:
    - updates project ui schema to support action links

1. Instructions for testing:
    - will be included in opendata-ui pr

1. Closes Issues: #<number> (if appropriate)
    - [3630](https://devtopia.esri.com/dc/hub/issues/3630)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.