### PR TITLE
feat(hub-common): enable content settings for admins and add content delete permission

### DIFF
--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -14,8 +14,7 @@ export const ContentDefaultFeatures: IFeatureFlags = {
  */
 export const ContentPermissions = [
   "hub:content:create",
-  // TODO: verify if this is needed:
-  // "hub:content:delete",
+  "hub:content:delete",
   "hub:content:edit",
   "hub:content:view",
   "hub:content:workspace",
@@ -51,13 +50,12 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
     services: ["portal"],
     entityEdit: true,
   },
-  // TODO: verify if this is needed
-  // {
-  //   permission: "hub:content:delete",
-  //   authenticated: true,
-  //   entityOwner: true,
-  //   licenses: ["hub-basic", "hub-premium", "enterprise-sites"],
-  // },
+  {
+    permission: "hub:content:delete",
+    authenticated: true,
+    services: ["portal"],
+    entityEdit: true,
+  },
   {
     permission: "hub:content:workspace",
     dependencies: ["hub:feature:workspace"],

--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -81,7 +81,6 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:content:workspace:settings",
     dependencies: ["hub:content:workspace", "hub:content:edit"],
-    entityOwner: true,
   },
   {
     permission: "hub:content:workspace:collaborators",


### PR DESCRIPTION
1. Description:
Part of https://devtopia.esri.com/dc/hub/issues/2872

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
