### PR TITLE
fix: config editor cleanup - update schemas

### DIFF
--- a/packages/common/src/core/schemas/internal/metrics/StatCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/metrics/StatCardUiSchema.ts
@@ -59,6 +59,7 @@ export const buildUiSchema = (
             scope: "/properties/allowUnitFormatting",
             options: {
               section: "subblock",
+              scale: "m",
               toggleDisplay: "switch",
               scope: "/properties/unit",
             },
@@ -94,6 +95,7 @@ export const buildUiSchema = (
             labelKey: `advancedConfig.label`,
             options: {
               section: "subblock",
+              scale: "m",
             },
             rule: SHOW_FOR_DYNAMIC_RULE,
             elements: [
@@ -163,6 +165,7 @@ export const buildUiSchema = (
             scope: "/properties/allowLink",
             options: {
               section: "subblock",
+              scale: "m",
               toggleDisplay: "switch",
             },
             rule: SHOW_FOR_STATIC_RULE,

--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -65,9 +65,7 @@ export enum UiSchemaRuleEffects {
 }
 
 export enum UiSchemaElementTypes {
-  accordionItem = "AccordionItem",
   section = "Section",
-  step = "Step",
   control = "Control",
   layout = "Layout",
   slot = "Slot",
@@ -75,8 +73,10 @@ export enum UiSchemaElementTypes {
 
 export enum UiSchemaSectionTypes {
   accordion = "accordion",
+  accordionItem = "accordionItem",
   block = "block",
   stepper = "stepper",
+  step = "step",
   subblock = "subblock",
   card = "card",
 }

--- a/packages/common/src/groups/_internal/GroupUiSchemaCreateFollowers.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaCreateFollowers.ts
@@ -21,8 +21,11 @@ export const buildUiSchema = async (
         options: { section: "stepper", scale: "l" },
         elements: [
           {
-            type: "Step",
+            type: "Section",
             labelKey: `${i18nScope}.sections.details.label`,
+            options: {
+              section: "step",
+            },
             elements: [
               {
                 labelKey: `${i18nScope}.fields.name.label`,
@@ -66,8 +69,11 @@ export const buildUiSchema = async (
             ],
           },
           {
-            type: "Step",
+            type: "Section",
             labelKey: `${i18nScope}.sections.membershipAccess.label`,
+            options: {
+              section: "step",
+            },
             rule: {
               effect: UiSchemaRuleEffects.DISABLE,
               condition: {

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
@@ -26,8 +26,11 @@ export const buildUiSchema = async (
         options: { section: "stepper", scale: "l" },
         elements: [
           {
-            type: "Step",
+            type: "Section",
             labelKey: `${i18nScope}.sections.details.label`,
+            options: {
+              section: "step",
+            },
             elements: [
               {
                 type: "Section",
@@ -101,8 +104,11 @@ export const buildUiSchema = async (
             ],
           },
           {
-            type: "Step",
+            type: "Section",
             labelKey: `${i18nScope}.sections.hero.label`,
+            options: {
+              section: "step",
+            },
             rule: {
               effect: UiSchemaRuleEffects.DISABLE,
               condition: {
@@ -190,8 +196,11 @@ export const buildUiSchema = async (
             ],
           },
           {
-            type: "Step",
+            type: "Section",
             labelKey: `${i18nScope}.sections.sharing.label`,
+            options: {
+              section: "step",
+            },
             rule: {
               effect: UiSchemaRuleEffects.DISABLE,
               condition: {

--- a/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaCreate.ts
@@ -25,8 +25,11 @@ export const buildUiSchema = async (
         options: { section: "stepper", scale: "l" },
         elements: [
           {
-            type: "Step",
+            type: "Section",
             labelKey: `${i18nScope}.sections.details.label`,
+            options: {
+              section: "step",
+            },
             elements: [
               {
                 type: "Section",
@@ -90,8 +93,11 @@ export const buildUiSchema = async (
             ],
           },
           {
-            type: "Step",
+            type: "Section",
             labelKey: `${i18nScope}.sections.location.label`,
+            options: {
+              section: "step",
+            },
             rule: {
               effect: UiSchemaRuleEffects.DISABLE,
               condition: {
@@ -132,8 +138,11 @@ export const buildUiSchema = async (
             ],
           },
           {
-            type: "Step",
+            type: "Section",
             labelKey: `${i18nScope}.sections.sharing.label`,
+            options: {
+              section: "step",
+            },
             rule: {
               effect: UiSchemaRuleEffects.DISABLE,
               condition: {

--- a/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
@@ -28,8 +28,11 @@ export const buildUiSchema = async (
         options: { section: "stepper", scale: "l" },
         elements: [
           {
-            type: "Step",
+            type: "Section",
             labelKey: `${i18nScope}.sections.details.label`,
+            options: {
+              section: "step",
+            },
             elements: [
               {
                 type: "Section",
@@ -82,8 +85,11 @@ export const buildUiSchema = async (
             ],
           },
           {
-            type: "Step",
+            type: "Section",
             labelKey: `${i18nScope}.sections.location.label`,
+            options: {
+              section: "step",
+            },
             rule: {
               effect: UiSchemaRuleEffects.DISABLE,
               condition: {
@@ -124,8 +130,11 @@ export const buildUiSchema = async (
             ],
           },
           {
-            type: "Step",
+            type: "Section",
             labelKey: `${i18nScope}.sections.sharing.label`,
+            options: {
+              section: "step",
+            },
             rule: {
               effect: UiSchemaRuleEffects.DISABLE,
               condition: {

--- a/packages/common/test/core/schemas/internal/filterSchemaToUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/filterSchemaToUiSchema.test.ts
@@ -31,8 +31,7 @@ describe("filterSchemaToUiSchema util:", () => {
           type: "Section",
           labelKey: "section1.label.key",
           options: {
-            section: "stepper",
-            open: true,
+            section: "stepper"
           },
           elements: [
             {

--- a/packages/common/test/core/schemas/internal/getUiSchemaProps.test.ts
+++ b/packages/common/test/core/schemas/internal/getUiSchemaProps.test.ts
@@ -129,8 +129,11 @@ const SteppedUiSchema: IUiSchema = {
       },
       elements: [
         {
-          type: "Step",
+          type: "Section",
           labelKey: "step1.label.key",
+          options: {
+            section: "step",
+          },
           elements: [
             {
               labelKey: "property1.label.key",
@@ -145,8 +148,11 @@ const SteppedUiSchema: IUiSchema = {
           ],
         },
         {
-          type: "Step",
+          type: "Section",
           labelKey: "step2.label.key",
+          options: {
+            section: "step",
+          },
           elements: [
             {
               labelKey: "property3.label.key",

--- a/packages/common/test/core/schemas/internal/metrics/StatCardUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/StatCardUiSchema.test.ts
@@ -68,6 +68,7 @@ describe("buildUiSchema: stat", () => {
               scope: "/properties/allowUnitFormatting",
               options: {
                 section: "subblock",
+                scale: "m",
                 toggleDisplay: "switch",
                 scope: "/properties/unit",
               },
@@ -115,6 +116,7 @@ describe("buildUiSchema: stat", () => {
               labelKey: `advancedConfig.label`,
               options: {
                 section: "subblock",
+                scale: "m",
               },
               rule: {
                 condition: {
@@ -196,6 +198,7 @@ describe("buildUiSchema: stat", () => {
               scope: "/properties/allowLink",
               options: {
                 section: "subblock",
+                scale: "m",
                 toggleDisplay: "switch",
               },
               rule: {

--- a/packages/common/test/core/schemas/internal/subsetSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/subsetSchema.test.ts
@@ -45,8 +45,11 @@ const SteppedUiSchema: IUiSchema = {
       },
       elements: [
         {
-          type: "Step",
+          type: "Section",
           labelKey: "step1.label.key",
+          options: {
+            section: "step",
+          },
           elements: [
             {
               labelKey: "property1.label.key",

--- a/packages/common/test/groups/_internal/GroupUiSchemaCreateFollowers.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaCreateFollowers.test.ts
@@ -17,8 +17,11 @@ describe("buildUiSchema: create followers group", () => {
           options: { section: "stepper", scale: "l" },
           elements: [
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.details.label",
+              options: {
+                section: "step",
+              },
               elements: [
                 {
                   labelKey: "some.scope.fields.name.label",
@@ -62,8 +65,11 @@ describe("buildUiSchema: create followers group", () => {
               ],
             },
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.membershipAccess.label",
+              options: {
+                section: "step",
+              },
               rule: {
                 effect: UiSchemaRuleEffects.DISABLE,
                 condition: {

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
@@ -33,8 +33,11 @@ describe("buildUiSchema: initiative create", () => {
           options: { section: "stepper", scale: "l" },
           elements: [
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.details.label",
+              options: {
+                section: "step",
+              },
               elements: [
                 {
                   type: "Section",
@@ -108,8 +111,11 @@ describe("buildUiSchema: initiative create", () => {
               ],
             },
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.hero.label",
+              options: {
+                section: "step",
+              },
               rule: {
                 effect: UiSchemaRuleEffects.DISABLE,
                 condition: {
@@ -187,8 +193,11 @@ describe("buildUiSchema: initiative create", () => {
               ],
             },
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.sharing.label",
+              options: {
+                section: "step",
+              },
               rule: {
                 effect: UiSchemaRuleEffects.DISABLE,
                 condition: {
@@ -258,8 +267,11 @@ describe("buildUiSchema: initiative create", () => {
           options: { section: "stepper", scale: "l" },
           elements: [
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.details.label",
+              options: {
+                section: "step",
+              },
               elements: [
                 {
                   type: "Section",
@@ -333,8 +345,11 @@ describe("buildUiSchema: initiative create", () => {
               ],
             },
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.hero.label",
+              options: {
+                section: "step",
+              },
               rule: {
                 effect: UiSchemaRuleEffects.DISABLE,
                 condition: {
@@ -412,8 +427,11 @@ describe("buildUiSchema: initiative create", () => {
               ],
             },
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.sharing.label",
+              options: {
+                section: "step",
+              },
               rule: {
                 effect: UiSchemaRuleEffects.DISABLE,
                 condition: {

--- a/packages/common/test/projects/_internal/ProjectUiSchemaCreate.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaCreate.test.ts
@@ -29,8 +29,11 @@ describe("buildUiSchema: project create", () => {
           options: { section: "stepper", scale: "l" },
           elements: [
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.details.label",
+              options: {
+                section: "step",
+              },
               elements: [
                 {
                   type: "Section",
@@ -94,8 +97,11 @@ describe("buildUiSchema: project create", () => {
               ],
             },
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.location.label",
+              options: {
+                section: "step",
+              },
               rule: {
                 effect: UiSchemaRuleEffects.DISABLE,
                 condition: {
@@ -127,8 +133,11 @@ describe("buildUiSchema: project create", () => {
               ],
             },
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.sharing.label",
+              options: {
+                section: "step",
+              },
               rule: {
                 effect: UiSchemaRuleEffects.DISABLE,
                 condition: {

--- a/packages/common/test/sites/_internal/SiteUiSchemaCreate.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaCreate.test.ts
@@ -29,8 +29,11 @@ describe("buildUiSchema: site create", () => {
           options: { section: "stepper", scale: "l" },
           elements: [
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.details.label",
+              options: {
+                section: "step",
+              },
               elements: [
                 {
                   type: "Section",
@@ -83,8 +86,11 @@ describe("buildUiSchema: site create", () => {
               ],
             },
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.location.label",
+              options: {
+                section: "step",
+              },
               rule: {
                 effect: UiSchemaRuleEffects.DISABLE,
                 condition: {
@@ -116,8 +122,11 @@ describe("buildUiSchema: site create", () => {
               ],
             },
             {
-              type: "Step",
+              type: "Section",
               labelKey: "some.scope.sections.sharing.label",
+              options: {
+                section: "step",
+              },
               rule: {
                 effect: UiSchemaRuleEffects.DISABLE,
                 condition: {


### PR DESCRIPTION
[9010](https://devtopia.esri.com/dc/hub/issues/9010)

### Description
We're doing a refactor of our section implementation in the configuration editor over in `opendata-ui`. We need to update relevant `schemas`/`uiSchemas` accommodate these changes

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.