### PR TITLE
fix: setFeaturedImage can now clear out orphaned featured image resou…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.72.2",
+			"version": "14.74.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/core/behaviors/IWithFeaturedImageBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithFeaturedImageBehavior.ts
@@ -5,9 +5,9 @@ export interface IWithFeaturedImageBehavior {
   /**
    * Set the featured image for the item
    * @param file
-   * @param filename
+   * @param clearExisting
    */
-  setFeaturedImage(file: any, filename: string): Promise<void>;
+  setFeaturedImage(file: any, clearExisting: boolean): Promise<void>;
   /**
    * Clears the featured image for the item
    * @param filename

--- a/packages/common/src/projects/_internal/computeProps.ts
+++ b/packages/common/src/projects/_internal/computeProps.ts
@@ -7,6 +7,7 @@ import { isDiscussable } from "../../discussions";
 import { processEntityFeatures } from "../../permissions/_internal/processEntityFeatures";
 import { ProjectDefaultFeatures } from "./ProjectBusinessRules";
 import { computeLinks } from "./computeLinks";
+import { getAuthedImageUrl } from "../../core/_internal/getAuthedImageUrl";
 
 /**
  * Given a model and a project, set various computed properties that can't be directly mapped
@@ -35,6 +36,14 @@ export function computeProps(
   project.updatedDate = new Date(model.item.modified);
   project.updatedDateSource = "item.modified";
   project.isDiscussable = isDiscussable(project);
+
+  project.view = {
+    ...model.data.view,
+    featuredImageUrl: getAuthedImageUrl(
+      model.data.view?.featuredImageUrl,
+      requestOptions
+    ),
+  };
 
   /**
    * Features that can be disabled by the entity owner


### PR DESCRIPTION
…rces

1. Description: clear orphaned featured image resource and projects properly set featured images.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
