### PR TITLE
fix: image description in hero title select

### DIFF
--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -97,7 +97,7 @@ export const buildUiSchema = async (
               ],
               descriptions: [
                 `{{${i18nScope}.fields.hero.map.description:translate}}`,
-                `{{${i18nScope}.fields.hero.map.description:translate}}`,
+                `{{${i18nScope}.fields.hero.image.description:translate}}`,
               ],
               icons: ["map-pin", "image"],
             },

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -115,7 +115,7 @@ describe("buildUiSchema: initiative edit", () => {
                 ],
                 descriptions: [
                   `{{some.scope.fields.hero.map.description:translate}}`,
-                  `{{some.scope.fields.hero.map.description:translate}}`,
+                  `{{some.scope.fields.hero.image.description:translate}}`,
                 ],
                 icons: ["map-pin", "image"],
               },
@@ -405,7 +405,7 @@ describe("buildUiSchema: initiative edit", () => {
                 ],
                 descriptions: [
                   `{{some.scope.fields.hero.map.description:translate}}`,
-                  `{{some.scope.fields.hero.map.description:translate}}`,
+                  `{{some.scope.fields.hero.image.description:translate}}`,
                 ],
                 icons: ["map-pin", "image"],
               },


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Issue [9007](https://zentopia.esri.com/workspaces/collaboration-sprint-board-614f9bfc0946c40011ef574e/issues/gh/dc/hub/9007)

Fix the image description in initiative edit hero title select, it was previously set the same as the map mistakenly.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
