### PR TITLE
fix: migrate malformed basemap hash resulting from hub.py bug

### DIFF
--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -330,6 +330,24 @@ export async function updateSite(
     getPropertyMap()
   );
   let modelToUpdate = mapper.entityToStore(site, currentModel);
+  // ============================================================
+  // Entity to Store can not handle scenarios where deep properties have been removed
+  // via a run-time migration.
+  // At this time we don't have a comprehensize solution for this, so we just remove
+  // the well-known-invalid properties from the model here.
+  // NOTES:
+  // * Add test logic into the `describe("updateSite removes properties:"...` section
+  // * We ignore coverage on the delete statements below because they
+  // use the optional property chaining, but we don't want to add a bunch of
+  // complex test cases just to satisfy the coverage tool.
+  // The tests do verify that the properties are removed.
+  // ============================================================
+
+  // Old telemetry props: migrated to correct property path in _migrateTelemetryConfig
+  /* istanbul ignore next */
+  delete modelToUpdate.data?.values?.telemetry;
+  /* istanbul ignore next */
+  delete modelToUpdate.item?.properties?.telemetry;
 
   // handle any domain changes
   await handleDomainChanges(modelToUpdate, currentModel, requestOptions);

--- a/packages/common/src/sites/_internal/migrateBadBasemap.ts
+++ b/packages/common/src/sites/_internal/migrateBadBasemap.ts
@@ -1,5 +1,5 @@
 import { getProp } from "../../objects";
-import { IModel } from "../../types";
+import { IDraft, IModel } from "../../types";
 import { cloneObject } from "../../util";
 
 /**
@@ -9,7 +9,7 @@ import { cloneObject } from "../../util";
  * @param {Object} model Site Model
  * @private
  */
-export function migrateBadBasemap(model: IModel) {
+export function migrateBadBasemap<T extends IModel | IDraft>(model: T) {
   // Unlike other migrations, this is not based on a version
   // rather it checks for a bad confirmation and fixes it.
 

--- a/packages/common/src/sites/_internal/migrateBadBasemap.ts
+++ b/packages/common/src/sites/_internal/migrateBadBasemap.ts
@@ -1,0 +1,41 @@
+import { getProp } from "../../objects";
+import { IModel } from "../../types";
+import { cloneObject } from "../../util";
+
+/**
+ * During a period in late 2023 and early 2024, the python api
+ * was writing a bad confirmation for basemaps as part of the site
+ * cloning process. This migration will fix that.
+ * @param {Object} model Site Model
+ * @private
+ */
+export function migrateBadBasemap(model: IModel) {
+  // Unlike other migrations, this is not based on a version
+  // rather it checks for a bad confirmation and fixes it.
+
+  // Early exit if the bad confirmation is not present
+  if (getProp(model, "data.values.map.basemaps")) return model;
+
+  // Check for the bad confirmation
+  if (getProp(model, "data.values.map.baseMapLayers")) {
+    // create a clone...
+    const clone = cloneObject(model);
+    // get the values we need
+    const baseMapLayers = getProp(model, "data.values.map.baseMapLayers");
+    const title = getProp(model, "data.values.map.title");
+    // remove the bad props
+    delete clone.data.values.map.baseMapLayers;
+    delete clone.data.values.map.title;
+    // assign the new structure
+    clone.data.values.map.basemaps = {
+      primary: {
+        baseMapLayers,
+        title,
+      },
+    };
+    return clone;
+  } else {
+    // This should not happen, but if it does, just return the model
+    return model;
+  }
+}

--- a/packages/common/src/sites/index.ts
+++ b/packages/common/src/sites/index.ts
@@ -1,7 +1,11 @@
+// These internals need to be exported from the common package
+// so they can be accessed by sites package, specifically
+// the upgradeDraftSchema function
 export * from "./_internal/_ensure-telemetry";
 export * from "./_internal/_migrate-feed-config";
 export * from "./_internal/_migrate-event-list-card-configs";
 export * from "./_internal/_migrate-telemetry-config";
+export * from "./_internal/migrateBadBasemap";
 export * from "./domains";
 export * from "./drafts";
 export * from "./fetchSiteModel";

--- a/packages/common/src/sites/upgrade-site-schema.ts
+++ b/packages/common/src/sites/upgrade-site-schema.ts
@@ -33,28 +33,4 @@ export function upgradeSiteSchema(model: IModel) {
   // apply versionless migrations
   model = migrateBadBasemap(model);
   return model;
-
-  // if (getProp(model, "item.properties.schemaVersion") === SITE_SCHEMA_VERSION) {
-  //   // still apply versionless migrations
-  //   model = migrateBadBasemap(model);
-  //   return model;
-  // } else {
-  //   // apply upgrade functions in order...
-  //   model = _applySiteSchema(model);
-  //   model = _enforceLowercaseDomains(model);
-  //   model = _ensureCatalog(model);
-  //   model = _purgeNonGuidsFromCatalog(model);
-  //   model = _ensureTelemetry<IModel>(model);
-  //   model = _migrateFeedConfig(model);
-  //   model = _migrateEventListCardConfigs(model);
-  //   model = migrateLegacyCapabilitiesToFeatures(model);
-  //   model = _migrateTelemetryConfig(model);
-  //   // versionless migrations
-  //   model = migrateBadBasemap(model);
-
-  //   // WARNING - If you are writing a site schema migration,
-  //   // you probably need to apply it to site drafts as well!
-  //   // See https://github.com/Esri/hub.js/issues/498 for more details.
-  //   return model;
-  // }
 }

--- a/packages/common/src/sites/upgrade-site-schema.ts
+++ b/packages/common/src/sites/upgrade-site-schema.ts
@@ -10,15 +10,14 @@ import { _migrateFeedConfig } from "./_internal/_migrate-feed-config";
 import { _migrateEventListCardConfigs } from "./_internal/_migrate-event-list-card-configs";
 import { migrateLegacyCapabilitiesToFeatures } from "./_internal/capabilities/migrateLegacyCapabilitiesToFeatures";
 import { _migrateTelemetryConfig } from "./_internal/_migrate-telemetry-config";
+import { migrateBadBasemap } from "./_internal/migrateBadBasemap";
 
 /**
  * Upgrades the schema upgrades
  * @param model IModel
  */
 export function upgradeSiteSchema(model: IModel) {
-  if (getProp(model, "item.properties.schemaVersion") === SITE_SCHEMA_VERSION) {
-    return model;
-  } else {
+  if (getProp(model, "item.properties.schemaVersion") !== SITE_SCHEMA_VERSION) {
     // apply upgrade functions in order...
     model = _applySiteSchema(model);
     model = _enforceLowercaseDomains(model);
@@ -29,10 +28,33 @@ export function upgradeSiteSchema(model: IModel) {
     model = _migrateEventListCardConfigs(model);
     model = migrateLegacyCapabilitiesToFeatures(model);
     model = _migrateTelemetryConfig(model);
-
-    // WARNING - If you are writing a site schema migration,
-    // you probably need to apply it to site drafts as well!
-    // See https://github.com/Esri/hub.js/issues/498 for more details.
-    return model;
   }
+
+  // apply versionless migrations
+  model = migrateBadBasemap(model);
+  return model;
+
+  // if (getProp(model, "item.properties.schemaVersion") === SITE_SCHEMA_VERSION) {
+  //   // still apply versionless migrations
+  //   model = migrateBadBasemap(model);
+  //   return model;
+  // } else {
+  //   // apply upgrade functions in order...
+  //   model = _applySiteSchema(model);
+  //   model = _enforceLowercaseDomains(model);
+  //   model = _ensureCatalog(model);
+  //   model = _purgeNonGuidsFromCatalog(model);
+  //   model = _ensureTelemetry<IModel>(model);
+  //   model = _migrateFeedConfig(model);
+  //   model = _migrateEventListCardConfigs(model);
+  //   model = migrateLegacyCapabilitiesToFeatures(model);
+  //   model = _migrateTelemetryConfig(model);
+  //   // versionless migrations
+  //   model = migrateBadBasemap(model);
+
+  //   // WARNING - If you are writing a site schema migration,
+  //   // you probably need to apply it to site drafts as well!
+  //   // See https://github.com/Esri/hub.js/issues/498 for more details.
+  //   return model;
+  // }
 }

--- a/packages/common/src/sites/upgrade-site-schema.ts
+++ b/packages/common/src/sites/upgrade-site-schema.ts
@@ -17,6 +17,11 @@ import { migrateBadBasemap } from "./_internal/migrateBadBasemap";
  * @param model IModel
  */
 export function upgradeSiteSchema(model: IModel) {
+  // WARNING - If you are writing a site schema migration,
+  // you probably need to apply it to site drafts as well!
+  // Specifically, add the migration to upgrade-draft-schema.ts file
+  // in the sites package.
+  // See https://github.com/Esri/hub.js/issues/498 for more details.
   if (getProp(model, "item.properties.schemaVersion") !== SITE_SCHEMA_VERSION) {
     // apply upgrade functions in order...
     model = _applySiteSchema(model);

--- a/packages/common/test/sites/_internal/migrateBadBasemaps.test.ts
+++ b/packages/common/test/sites/_internal/migrateBadBasemaps.test.ts
@@ -1,0 +1,55 @@
+import { IModel } from "../../../src";
+import { migrateBadBasemap } from "../../../src/sites/_internal/migrateBadBasemap";
+
+describe("migrate bad basemaps:", () => {
+  it("returns model if bad config not present", () => {
+    const model: IModel = {
+      data: {
+        values: {
+          map: {
+            basemaps: {
+              primary: {
+                baseMapLayers: [],
+                title: "title",
+              },
+            },
+          },
+        },
+      },
+    } as unknown as IModel;
+    const chk = migrateBadBasemap(model);
+    expect(chk).toBe(model);
+  });
+
+  it("returns clone without bad props, with updated  ", () => {
+    const model: IModel = {
+      data: {
+        values: {
+          map: {
+            baseMapLayers: ["fake"],
+            title: "fake title",
+          },
+        },
+      },
+    } as unknown as IModel;
+    const chk = migrateBadBasemap(model);
+    expect(chk).not.toBe(model);
+    expect(chk?.data?.values.map.basemaps.primary.baseMapLayers).toEqual([
+      "fake",
+    ]);
+    expect(chk?.data?.values.map.basemaps.primary.title).toEqual("fake title");
+  });
+  it("returns model wo either condition  ", () => {
+    const model: IModel = {
+      data: {
+        values: {
+          map: {
+            title: "fake title",
+          },
+        },
+      },
+    } as unknown as IModel;
+    const chk = migrateBadBasemap(model);
+    expect(chk).toBe(model);
+  });
+});

--- a/packages/common/test/sites/upgrade-site-schema.test.ts
+++ b/packages/common/test/sites/upgrade-site-schema.test.ts
@@ -8,6 +8,7 @@ import * as _migrateFeedConfigModule from "../../src/sites/_internal/_migrate-fe
 import * as _migrateEventListCardConfigs from "../../src/sites/_internal/_migrate-event-list-card-configs";
 import * as migrateLegacyCapabilitiesToFeatures from "../../src/sites/_internal/capabilities/migrateLegacyCapabilitiesToFeatures";
 import * as _migrateTelemetryConfig from "../../src/sites/_internal/_migrate-telemetry-config";
+import * as migrateBadBasemapModule from "../../src/sites/_internal/migrateBadBasemap";
 import { IModel } from "../../src";
 import { SITE_SCHEMA_VERSION } from "../../src/sites/site-schema-version";
 import { expectAllCalled, expectAll } from "./test-helpers.test";
@@ -22,6 +23,7 @@ describe("upgradeSiteSchema", () => {
   let migrateEventListCardConfigsSpy: jasmine.Spy;
   let migrateLegacyCapabilitiesToFeaturesSpy: jasmine.Spy;
   let migrateTelemetryConfigSpy: jasmine.Spy;
+  let migrateBadBasemapSpy: jasmine.Spy;
   beforeEach(() => {
     applySpy = spyOn(_applySiteSchemaModule, "_applySiteSchema").and.callFake(
       (model: IModel) => model
@@ -58,6 +60,10 @@ describe("upgradeSiteSchema", () => {
       _migrateTelemetryConfig,
       "_migrateTelemetryConfig"
     ).and.callFake((model: IModel) => model);
+    migrateBadBasemapSpy = spyOn(
+      migrateBadBasemapModule,
+      "migrateBadBasemap"
+    ).and.callFake((model: IModel) => model);
   });
 
   it("runs schema upgrades", async () => {
@@ -82,6 +88,7 @@ describe("upgradeSiteSchema", () => {
         migrateEventListCardConfigsSpy,
         migrateLegacyCapabilitiesToFeaturesSpy,
         migrateTelemetryConfigSpy,
+        migrateBadBasemapSpy,
       ],
       expect
     );
@@ -113,5 +120,7 @@ describe("upgradeSiteSchema", () => {
       false,
       expect
     );
+    // Versionless migrations should still run
+    expectAll([migrateBadBasemapSpy], "toHaveBeenCalled", true, expect);
   });
 });

--- a/packages/sites/src/drafts/upgrade-draft-schema.ts
+++ b/packages/sites/src/drafts/upgrade-draft-schema.ts
@@ -5,6 +5,7 @@ import {
   _migrateFeedConfig,
   _migrateEventListCardConfigs,
   _migrateTelemetryConfig,
+  migrateBadBasemap,
 } from "@esri/hub-common";
 
 const schemaVersionPath = "item.properties.schemaVersion";
@@ -18,6 +19,9 @@ export function upgradeDraftSchema(draft: IDraft) {
   if (getProp(draft, "item.properties.schemaVersion") === undefined) {
     deepSet(draft, schemaVersionPath, initialDraftVersion);
   }
+
+  // Migrations that should always be applied
+  draft = migrateBadBasemap<IDraft>(draft);
 
   if (getProp(draft, "item.properties.schemaVersion") === SITE_SCHEMA_VERSION) {
     return draft;

--- a/packages/sites/test/drafts/upgrade-draft-schema.test.ts
+++ b/packages/sites/test/drafts/upgrade-draft-schema.test.ts
@@ -10,6 +10,7 @@ describe("upgradeDraftSchema", () => {
   let migrateFeedConfigSpy: jasmine.Spy;
   let migrateEventListCardConfigsSpy: jasmine.Spy;
   let migrateTelemetryConfigSpy: jasmine.Spy;
+  let migrateBadBasemapSpy: jasmine.Spy;
   beforeEach(() => {
     ensureTelemetrySpy = spyOn(commonModule, "_ensureTelemetry").and.callFake(
       (model: IModel) => model
@@ -25,6 +26,10 @@ describe("upgradeDraftSchema", () => {
     migrateTelemetryConfigSpy = spyOn(
       commonModule,
       "_migrateTelemetryConfig"
+    ).and.callFake((model: IModel) => model);
+    migrateBadBasemapSpy = spyOn(
+      commonModule,
+      "migrateBadBasemap"
     ).and.callFake((model: IModel) => model);
   });
 
@@ -45,6 +50,7 @@ describe("upgradeDraftSchema", () => {
         migrateFeedConfigSpy,
         migrateEventListCardConfigsSpy,
         migrateTelemetryConfigSpy,
+        migrateBadBasemapSpy,
       ],
       expect
     );
@@ -65,6 +71,7 @@ describe("upgradeDraftSchema", () => {
         migrateFeedConfigSpy,
         migrateEventListCardConfigsSpy,
         migrateTelemetryConfigSpy,
+        migrateBadBasemapSpy,
       ],
       expect
     );
@@ -87,6 +94,7 @@ describe("upgradeDraftSchema", () => {
         migrateFeedConfigSpy,
         migrateEventListCardConfigsSpy,
         migrateTelemetryConfigSpy,
+        migrateBadBasemapSpy,
       ],
       expect
     );
@@ -114,5 +122,7 @@ describe("upgradeDraftSchema", () => {
       false,
       expect
     );
+    // should still run versionless migrations
+    expectAllCalled([migrateBadBasemapSpy], expect);
   });
 });


### PR DESCRIPTION
1. Description:

Add "versonless" migration that looks for this the condition described in the issue, and resolving it.

1. Instructions for testing:

1. Closes Issues: #[9049](https://devtopia.esri.com/dc/hub/issues/9049)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
