### PR TITLE
feat(hub-common): consolidates entity location construction and depre…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,9 @@
       "program": "${workspaceRoot}/node_modules/.bin/jasmine",
       "args": [
         "--config=jasmine.json"
-      ]
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
     },
     {
       "type": "node",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.74.1",
+			"version": "14.80.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65138,7 +65138,7 @@
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "14.2.1",
+			"version": "14.2.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -3,11 +3,7 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
 import { IModel } from "../../types";
 import { getItemHomeUrl } from "../../urls/get-item-home-url";
-import {
-  deriveLocationFromItem,
-  getContentEditUrl,
-  getHubRelativeUrl,
-} from "./internalContentUtils";
+import { getContentEditUrl, getHubRelativeUrl } from "./internalContentUtils";
 import { IHubEditableContent } from "../../core/types/IHubEditableContent";
 import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
 import { isDiscussable } from "../../discussions";

--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -16,6 +16,7 @@ import {
   ServiceCapabilities,
 } from "../hostedServiceUtils";
 import { IItemAndIServerEnrichments } from "../../items/_enrichments";
+import { computeBaseProps } from "../../core/_internal/computeBaseProps";
 
 export function computeProps(
   model: IModel,
@@ -28,6 +29,9 @@ export function computeProps(
     const session: UserSession = requestOptions.authentication as UserSession;
     token = session.token;
   }
+
+  // compute base properties on content
+  content = computeBaseProps(model.item, content);
 
   // thumbnail url
   const thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
@@ -47,8 +51,6 @@ export function computeProps(
   // cannot be null otherwise we'd get a validation
   // error that doesn't let us save the form
   content.licenseInfo = model.item.licenseInfo || "";
-
-  content.location = deriveLocationFromItem(model.item);
 
   content.isDiscussable = isDiscussable(content);
 

--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -2,11 +2,12 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
 import { IModel } from "../../types";
-import { bBoxToExtent, isBBox } from "../../extent";
-import { IExtent } from "@esri/arcgis-rest-types";
 import { getItemHomeUrl } from "../../urls/get-item-home-url";
-import { getContentEditUrl, getHubRelativeUrl } from "./internalContentUtils";
-import { IHubLocation } from "../../core/types/IHubLocation";
+import {
+  deriveLocationFromItem,
+  getContentEditUrl,
+  getHubRelativeUrl,
+} from "./internalContentUtils";
 import { IHubEditableContent } from "../../core/types/IHubEditableContent";
 import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
 import { isDiscussable } from "../../discussions";
@@ -15,24 +16,6 @@ import {
   ServiceCapabilities,
 } from "../hostedServiceUtils";
 import { IItemAndIServerEnrichments } from "../../items/_enrichments";
-
-// if called and valid, set 3 things -- else just return type custom
-export const getExtentObject = (itemExtent: number[][]): IExtent => {
-  return isBBox(itemExtent)
-    ? ({ ...bBoxToExtent(itemExtent), type: "extent" } as unknown as IExtent)
-    : undefined;
-};
-
-export function deriveLocationFromItemExtent(itemExtent?: number[][]) {
-  const location: IHubLocation = { type: "custom" };
-  const geometry: any = getExtentObject(itemExtent);
-  if (geometry) {
-    location.geometries = [geometry];
-    location.spatialReference = geometry.spatialReference;
-    location.extent = itemExtent;
-  }
-  return location;
-}
 
 export function computeProps(
   model: IModel,
@@ -65,13 +48,7 @@ export function computeProps(
   // error that doesn't let us save the form
   content.licenseInfo = model.item.licenseInfo || "";
 
-  if (!content.location) {
-    // build location if one does not exist based off of the boundary and the item's extent
-    content.location =
-      model.item.properties?.boundary === "none"
-        ? { type: "none" }
-        : deriveLocationFromItemExtent(model.item.extent);
-  }
+  content.location = deriveLocationFromItem(model.item);
 
   content.isDiscussable = isDiscussable(content);
 

--- a/packages/common/src/content/_internal/internalContentUtils.ts
+++ b/packages/common/src/content/_internal/internalContentUtils.ts
@@ -101,7 +101,7 @@ export const getContentBoundary = (item: IItem): IHubGeography => {
  * @param extent Raw item extent array
  * @returns IExtent
  */
-const getExtentObject = (extent: number[][]): IExtent => {
+export const getExtentObject = (extent: number[][]): IExtent => {
   return isBBox(extent)
     ? ({ ...bBoxToExtent(extent), type: "extent" } as unknown as IExtent)
     : undefined;
@@ -130,17 +130,23 @@ export const deriveLocationFromItem = (item: IItem): IHubLocation => {
     return { type: "none" };
   }
 
+  /* istanbul ignore else */
   if (!location) {
     // IHubLocation does not exist on item properties, so construct it
     // from item extent
     const geometry: any = getExtentObject(extent);
-    return {
-      type: "custom",
-      extent,
-      geometries: [geometry],
-      spatialReference: geometry.spatialReference,
-    };
+    if (geometry) {
+      return {
+        type: "custom",
+        extent,
+        geometries: [geometry],
+        spatialReference: geometry.spatialReference,
+      };
+    }
   }
+
+  // If we get here, we have no location and no extent, so return none
+  return { type: "none" };
 };
 
 /**

--- a/packages/common/src/content/_internal/internalContentUtils.ts
+++ b/packages/common/src/content/_internal/internalContentUtils.ts
@@ -111,30 +111,36 @@ const getExtentObject = (extent: number[][]): IExtent => {
  * Derives proper IHubLocation given an ArcGIS Item.  If no
  * location (item.properties.location) is present, one will be
  * constructed from the item's extent.
- * If item.properties.boundary === 'none', this function will strip
- * location and return { type: 'none' } per this document:
- * https://confluencewikidev.esri.com/display/Hub/Hub+Location+Management
  * @param item ArcGIS Item
  * @returns IHubLocation
  */
 export const deriveLocationFromItem = (item: IItem): IHubLocation => {
   const { properties, extent } = item;
+  const location: IHubLocation = properties?.location;
+
+  if (location) {
+    // IHubLocation already exists, so return it
+    return location;
+  }
+
   if (properties?.boundary === "none") {
+    // Per https://confluencewikidev.esri.com/display/Hub/Hub+Location+Management
+    // bounds = 'none' -> specifies not to show on map.  If this is true and
+    // no location is already present, opt to not generate location from item extent
     return { type: "none" };
   }
-  let location: IHubLocation = properties?.location;
+
   if (!location) {
     // IHubLocation does not exist on item properties, so construct it
     // from item extent
     const geometry: any = getExtentObject(item.extent);
-    location = {
+    return {
       type: "custom",
       extent,
       geometries: [geometry],
       spatialReference: geometry.spatialReference,
     };
   }
-  return location;
 };
 
 /**

--- a/packages/common/src/content/_internal/internalContentUtils.ts
+++ b/packages/common/src/content/_internal/internalContentUtils.ts
@@ -130,23 +130,20 @@ export const deriveLocationFromItem = (item: IItem): IHubLocation => {
     return { type: "none" };
   }
 
-  /* istanbul ignore else */
-  if (!location) {
-    // IHubLocation does not exist on item properties, so construct it
-    // from item extent
-    const geometry: any = getExtentObject(extent);
-    if (geometry) {
-      return {
-        type: "custom",
-        extent,
-        geometries: [geometry],
-        spatialReference: geometry.spatialReference,
-      };
-    }
+  // IHubLocation does not exist on item properties, so construct it
+  // from item extent
+  const geometry: any = getExtentObject(extent);
+  if (geometry) {
+    return {
+      type: "custom",
+      extent,
+      geometries: [geometry],
+      spatialReference: geometry.spatialReference,
+    };
+  } else {
+    // Could not construct extent object, so return none
+    return { type: "none" };
   }
-
-  // If we get here, we have no location and no extent, so return none
-  return { type: "none" };
 };
 
 /**

--- a/packages/common/src/content/_internal/internalContentUtils.ts
+++ b/packages/common/src/content/_internal/internalContentUtils.ts
@@ -133,7 +133,7 @@ export const deriveLocationFromItem = (item: IItem): IHubLocation => {
   if (!location) {
     // IHubLocation does not exist on item properties, so construct it
     // from item extent
-    const geometry: any = getExtentObject(item.extent);
+    const geometry: any = getExtentObject(extent);
     return {
       type: "custom",
       extent,

--- a/packages/common/src/content/search.ts
+++ b/packages/common/src/content/search.ts
@@ -9,8 +9,10 @@ import { getItemHomeUrl } from "../urls";
 import { unique } from "../util";
 import { mapBy } from "../utils";
 import { getFamily } from "./get-family";
-import { getHubRelativeUrl } from "./_internal/internalContentUtils";
-import { bBoxToExtent, extentToPolygon, isBBox } from "../extent";
+import {
+  deriveLocationFromItem,
+  getHubRelativeUrl,
+} from "./_internal/internalContentUtils";
 
 /**
  * Enrich a generic search result
@@ -45,21 +47,9 @@ export async function enrichContentSearchResult(
       siteRelative: "not-implemented",
       thumbnail: "not-implemented",
     },
-    location: item.properties?.location,
+    location: deriveLocationFromItem(item),
     rawResult: item,
   };
-
-  // Include geometry in IHubSearchResult
-  if (isBBox(item.extent)) {
-    // PR Reference: https://github.com/Esri/hub.js/pull/987
-    const extent = bBoxToExtent(item.extent);
-    const geometryPolygon = extentToPolygon(extent);
-    result.geometry = {
-      geometry: { type: "polygon", ...geometryPolygon },
-      provenance: "item",
-      spatialReference: extent.spatialReference,
-    };
-  }
 
   // default includes
   const DEFAULTS: string[] = [];

--- a/packages/common/src/core/_internal/computeBaseProps.ts
+++ b/packages/common/src/core/_internal/computeBaseProps.ts
@@ -15,6 +15,6 @@ export function computeBaseProps<T extends Partial<IHubItemEntity>>(
   // TODO: Currently only location is determined for base
   // properties, but all properties that are commonly shared
   // across items should be moved here.
-  entity.location = deriveLocationFromItem(item);
+  entity.location = entity.location || deriveLocationFromItem(item);
   return entity;
 }

--- a/packages/common/src/core/_internal/computeBaseProps.ts
+++ b/packages/common/src/core/_internal/computeBaseProps.ts
@@ -12,6 +12,9 @@ export function computeBaseProps<T extends Partial<IHubItemEntity>>(
   item: IItem,
   entity: T
 ): T {
+  // TODO: Currently only location is determined for base
+  // properties, but all properties that are commonly shared
+  // across items should be moved here.
   entity.location = deriveLocationFromItem(item);
   return entity;
 }

--- a/packages/common/src/core/_internal/computeBaseProps.ts
+++ b/packages/common/src/core/_internal/computeBaseProps.ts
@@ -8,10 +8,10 @@ import { deriveLocationFromItem } from "../../content/_internal/internalContentU
  * @param entity IHubItemEntity
  * @returns
  */
-export function computeBaseProps<EntityType extends Partial<IHubItemEntity>>(
+export function computeBaseProps<T extends Partial<IHubItemEntity>>(
   item: IItem,
-  entity: EntityType
-): EntityType {
+  entity: T
+): T {
   entity.location = deriveLocationFromItem(item);
   return entity;
 }

--- a/packages/common/src/core/_internal/computeBaseProps.ts
+++ b/packages/common/src/core/_internal/computeBaseProps.ts
@@ -1,0 +1,17 @@
+import { IItem } from "@esri/arcgis-rest-types";
+import { IHubItemEntity } from "../types";
+import { deriveLocationFromItem } from "../../content/_internal/internalContentUtils";
+
+/**
+ * Base property mapping for item backed entity types
+ * @param item IItem
+ * @param entity IHubItemEntity
+ * @returns
+ */
+export function computeBaseProps<EntityType extends Partial<IHubItemEntity>>(
+  item: IItem,
+  entity: EntityType
+): EntityType {
+  entity.location = deriveLocationFromItem(item);
+  return entity;
+}

--- a/packages/common/src/discussions/_internal/computeProps.ts
+++ b/packages/common/src/discussions/_internal/computeProps.ts
@@ -6,6 +6,7 @@ import { IModel } from "../../types";
 import { IHubDiscussion } from "../../core";
 
 import { isDiscussable } from "../utils";
+import { computeBaseProps } from "../../core/_internal/computeBaseProps";
 
 /**
  * Given a model and a Discussion, set various computed properties that can't be directly mapped
@@ -25,6 +26,8 @@ export function computeProps(
     const session: UserSession = requestOptions.authentication as UserSession;
     token = session.token;
   }
+  // compute base properties on discussion
+  discussion = computeBaseProps(model.item, discussion);
 
   // thumbnail url
   discussion.thumbnailUrl = getItemThumbnailUrl(

--- a/packages/common/src/discussions/edit.ts
+++ b/packages/common/src/discussions/edit.ts
@@ -131,6 +131,7 @@ export async function updateDiscussion(
   // persist location geometries to discussion settings as Polygon[]
   let allowedLocations: Polygon[];
   try {
+    /* istanbul ignore next: optional chaining appears not picked up in coverage */
     allowedLocations =
       updatedDiscussion.location?.geometries?.map(
         (geometry) => arcgisToGeoJSON(geometry) as any as Polygon

--- a/packages/common/src/discussions/edit.ts
+++ b/packages/common/src/discussions/edit.ts
@@ -131,9 +131,8 @@ export async function updateDiscussion(
   // persist location geometries to discussion settings as Polygon[]
   let allowedLocations: Polygon[];
   try {
-    /* istanbul ignore next: optional chaining appears not picked up in coverage */
     allowedLocations =
-      updatedDiscussion.location?.geometries?.map(
+      updatedDiscussion.location.geometries?.map(
         (geometry) => arcgisToGeoJSON(geometry) as any as Polygon
       ) || null;
   } catch (e) {

--- a/packages/common/src/initiative-templates/_internal/computeProps.ts
+++ b/packages/common/src/initiative-templates/_internal/computeProps.ts
@@ -7,6 +7,7 @@ import { getItemThumbnailUrl } from "../../resources";
 import { IModel } from "../../types";
 import { InitiativeTemplateDefaultFeatures } from "./InitiativeTemplateBusinessRules";
 import { computeLinks } from "./computeLinks";
+import { computeBaseProps } from "../../core/_internal/computeBaseProps";
 
 /**
  * Given a model and an initiative template, set various computed properties that can't be directly mapped
@@ -26,6 +27,9 @@ export function computeProps(
     const session: UserSession = requestOptions.authentication as UserSession;
     token = session.token;
   }
+
+  // compute base properties on initiativeTemplate
+  initiativeTemplate = computeBaseProps(model.item, initiativeTemplate);
 
   // thumbnail url
   initiativeTemplate.thumbnailUrl = getItemThumbnailUrl(

--- a/packages/common/src/initiative-templates/fetch.ts
+++ b/packages/common/src/initiative-templates/fetch.ts
@@ -2,7 +2,10 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { getItem, IItem } from "@esri/arcgis-rest-portal";
 
 import { getFamily } from "../content/get-family";
-import { getHubRelativeUrl } from "../content/_internal/internalContentUtils";
+import {
+  deriveLocationFromItem,
+  getHubRelativeUrl,
+} from "../content/_internal/internalContentUtils";
 import { IHubInitiativeTemplate } from "../core/types";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
 import { getItemBySlug } from "../items/slugs";
@@ -82,6 +85,7 @@ export async function enrichInitiativeTemplateSearchResult(
       thumbnail: "not-implemented",
       workspaceRelative: "not-implemented",
     },
+    location: deriveLocationFromItem(item),
     rawResult: item,
   };
 

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -50,7 +50,10 @@ import { portalSearchItemsAsItems } from "../search/_internal/portalSearchItems"
 import { getTypeWithKeywordQuery } from "../associations/internal/getTypeWithKeywordQuery";
 import { negateGroupPredicates } from "../search/_internal/negateGroupPredicates";
 import { computeLinks } from "./_internal/computeLinks";
-import { getHubRelativeUrl } from "../content/_internal/internalContentUtils";
+import {
+  deriveLocationFromItem,
+  getHubRelativeUrl,
+} from "../content/_internal/internalContentUtils";
 import { setEntityStatusKeyword } from "../utils/internal/setEntityStatusKeyword";
 
 /**
@@ -269,6 +272,7 @@ export async function enrichInitiativeSearchResult(
       thumbnail: "not-implemented",
       workspaceRelative: "not-implemented",
     },
+    location: deriveLocationFromItem(item),
     rawResult: item,
   };
 

--- a/packages/common/src/initiatives/_internal/computeProps.ts
+++ b/packages/common/src/initiatives/_internal/computeProps.ts
@@ -10,6 +10,7 @@ import { processEntityFeatures } from "../../permissions/_internal/processEntity
 import { InitiativeDefaultFeatures } from "./InitiativeBusinessRules";
 import { computeLinks } from "./computeLinks";
 import { getAuthedImageUrl } from "../../core/_internal/getAuthedImageUrl";
+import { computeBaseProps } from "../../core/_internal/computeBaseProps";
 
 /**
  * Given a model and an Initiative, set various computed properties that can't be directly mapped
@@ -29,6 +30,9 @@ export function computeProps(
     const session: UserSession = requestOptions.authentication as UserSession;
     token = session.token;
   }
+
+  // compute base properties on initiative
+  initiative = computeBaseProps(model.item, initiative);
 
   // thumbnail url
   initiative.thumbnailUrl = getItemThumbnailUrl(

--- a/packages/common/src/pages/HubPages.ts
+++ b/packages/common/src/pages/HubPages.ts
@@ -1,5 +1,8 @@
 import { getFamily } from "../content/get-family";
-import { getHubRelativeUrl } from "../content/_internal/internalContentUtils";
+import {
+  deriveLocationFromItem,
+  getHubRelativeUrl,
+} from "../content/_internal/internalContentUtils";
 import { fetchItemEnrichments } from "../items/_enrichments";
 import { getProp } from "../objects";
 import { getItemThumbnailUrl } from "../resources";
@@ -214,6 +217,7 @@ export async function enrichPageSearchResult(
       siteRelative: "not-implemented",
       thumbnail: "not-implemented",
     },
+    location: deriveLocationFromItem(item),
     rawResult: item,
   };
 

--- a/packages/common/src/pages/_internal/computeProps.ts
+++ b/packages/common/src/pages/_internal/computeProps.ts
@@ -8,6 +8,7 @@ import { PageDefaultFeatures } from "./PageBusinessRules";
 import { getItemHomeUrl } from "../../urls/get-item-home-url";
 import { IHubPage } from "../../core/types/IHubPage";
 import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
+import { computeBaseProps } from "../../core/_internal/computeBaseProps";
 
 /**
  * Given a model and a page, set various computed properties that can't be directly mapped
@@ -27,6 +28,8 @@ export function computeProps(
     const session: UserSession = requestOptions.authentication as UserSession;
     token = session.token;
   }
+  // compute base properties on page
+  page = computeBaseProps(model.item, page);
   // thumbnail url
   const thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
   // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead

--- a/packages/common/src/projects/_internal/computeProps.ts
+++ b/packages/common/src/projects/_internal/computeProps.ts
@@ -8,6 +8,7 @@ import { processEntityFeatures } from "../../permissions/_internal/processEntity
 import { ProjectDefaultFeatures } from "./ProjectBusinessRules";
 import { computeLinks } from "./computeLinks";
 import { getAuthedImageUrl } from "../../core/_internal/getAuthedImageUrl";
+import { computeBaseProps } from "../../core/_internal/computeBaseProps";
 
 /**
  * Given a model and a project, set various computed properties that can't be directly mapped
@@ -27,6 +28,8 @@ export function computeProps(
     const session: UserSession = requestOptions.authentication as UserSession;
     token = session.token;
   }
+  // compute base properties on project
+  project = computeBaseProps(model.item, project);
   // thumbnail url
   project.thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
 

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -20,6 +20,7 @@ import { getProp } from "../objects/get-prop";
 import { listAssociations } from "../associations";
 import { getTypeByIdsQuery } from "../associations/internal/getTypeByIdsQuery";
 import { computeLinks } from "./_internal/computeLinks";
+import { deriveLocationFromItem } from "../content/_internal/internalContentUtils";
 
 /**
  * @private
@@ -100,6 +101,7 @@ export async function enrichProjectSearchResult(
       thumbnail: "not-implemented",
       workspaceRelative: "not-implemented",
     },
+    location: deriveLocationFromItem(item),
     rawResult: item,
   };
 

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
@@ -22,18 +22,5 @@ export async function ogcItemToSearchResult(
   // Expose extraneous members like `license`, `source`, `properties.location` and `geometry`
   result.source = ogcItem.properties.source;
   result.license = ogcItem.properties.license;
-  result.location = ogcItem.properties.properties?.location;
-  // Add IHubGeography to result
-  if (ogcItem.geometry) {
-    try {
-      result.geometry = {
-        geometry: geojsonToArcGIS(ogcItem.geometry) as IPolygonProperties,
-      };
-    } catch {
-      // If geojsonToArcGIS throws an error from an invalid input geometry,
-      // just ignore for now
-    }
-  }
-
   return result;
 }

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
@@ -19,7 +19,7 @@ export async function ogcItemToSearchResult(
   // as `license` and `source` if the OgcItem came from the index.
   const pseudoItem = ogcItem.properties as IItem;
   const result = await itemToSearchResult(pseudoItem, includes, requestOptions);
-  // Expose extraneous members like `license`, `source`, `properties.location` and `geometry`
+  // Expose extraneous members like `license` and `source`
   result.source = ogcItem.properties.source;
   result.license = ogcItem.properties.license;
   return result;

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
@@ -7,7 +7,6 @@ import {
 import { IHubSearchResult } from "../../types/IHubSearchResult";
 import { itemToSearchResult } from "../portalSearchItems";
 import { IOgcItem } from "./interfaces";
-import { geojsonToArcGIS } from "@terraformer/arcgis";
 
 export async function ogcItemToSearchResult(
   ogcItem: IOgcItem,

--- a/packages/common/src/search/types/IHubSearchResult.ts
+++ b/packages/common/src/search/types/IHubSearchResult.ts
@@ -40,6 +40,10 @@ export interface IHubSearchResult extends IHubEntityBase {
   typeKeywords?: string[];
 
   /**
+   * @deprecated geometry is being dropped and replaced
+   * with 'location' for all location specific information
+   * on a search result
+   *
    * Geometry connected to this entity
    * For items, it will default to the extent,
    * but may be derived from a boundary resource

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -7,7 +7,10 @@ import { handleDomainChanges } from "./_internal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { fetchItemEnrichments } from "../items/_enrichments";
 import { parseInclude } from "../search/_internal/parseInclude";
-import { getHubRelativeUrl } from "../content/_internal/internalContentUtils";
+import {
+  deriveLocationFromItem,
+  getHubRelativeUrl,
+} from "../content/_internal/internalContentUtils";
 import { applyPermissionMigration } from "./_internal/applyPermissionMigration";
 import { computeProps } from "./_internal/computeProps";
 import { getPropertyMap } from "./_internal/getPropertyMap";
@@ -491,6 +494,7 @@ export async function enrichSiteSearchResult(
       siteRelative: "not-implemented",
       thumbnail: "not-implemented",
     },
+    location: deriveLocationFromItem(item),
     rawResult: item,
   };
 

--- a/packages/common/src/sites/_internal/computeProps.ts
+++ b/packages/common/src/sites/_internal/computeProps.ts
@@ -9,6 +9,7 @@ import { SiteDefaultFeatures } from "./SiteBusinessRules";
 import { getItemHomeUrl } from "../../urls/get-item-home-url";
 import { IHubSite } from "../../core/types/IHubSite";
 import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
+import { computeBaseProps } from "../../core/_internal/computeBaseProps";
 
 /**
  * Given a model and a site, set various computed properties that can't be directly mapped
@@ -28,7 +29,8 @@ export function computeProps(
     const session: UserSession = requestOptions.authentication as UserSession;
     token = session.token;
   }
-
+  // compute base properties on site
+  site = computeBaseProps(model.item, site);
   // thumbnail url
   const thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
   // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead

--- a/packages/common/src/templates/_internal/computeProps.ts
+++ b/packages/common/src/templates/_internal/computeProps.ts
@@ -7,6 +7,7 @@ import { IHubTemplate } from "../../core/types/IHubTemplate";
 import { computeLinks } from "./computeLinks";
 import { getProp } from "../../objects";
 import { getDeployedTemplateType } from "../utils";
+import { computeBaseProps } from "../../core/_internal/computeBaseProps";
 
 /**
  * @private
@@ -22,33 +23,36 @@ export function computeProps(
   template: Partial<IHubTemplate>,
   requestOptions: IRequestOptions
 ): IHubTemplate {
-  // 1. compute relevant template links
+  // 1. compute base properties on template
+  template = computeBaseProps(model.item, template);
+
+  // 2. compute relevant template links
   template.links = computeLinks(model.item, requestOptions);
 
-  // 2. append the template's thumbnail url at the top-level
+  // 3. append the template's thumbnail url at the top-level
   template.thumbnailUrl = template.links.thumbnail;
 
-  // 3. compute relevant template dates
+  // 4. compute relevant template dates
   template.createdDate = new Date(model.item.created);
   template.createdDateSource = "item.created";
   template.updatedDate = new Date(model.item.modified);
   template.updatedDateSource = "item.modified";
 
-  // 4. determine whether the template is discussable
+  // 5. determine whether the template is discussable
   template.isDiscussable = isDiscussable(template);
 
-  // 5. process features that can be disabled by the entity owner
+  // 6. process features that can be disabled by the entity owner
   template.features = processEntityFeatures(
     getProp(model, "data.settings.features") || {},
     TemplateDefaultFeatures
   );
 
-  // 6. compute additional template-specific properties
+  // 7. compute additional template-specific properties
   template.isDeployed = (getProp(model, "item.typeKeywords") || []).includes(
     "Deployed"
   );
   template.deployedType = getDeployedTemplateType(model.item);
 
-  // 7. cast b/c this takes a partial but returns a full template
+  // 8. cast b/c this takes a partial but returns a full template
   return template as IHubTemplate;
 }

--- a/packages/common/src/templates/fetch.ts
+++ b/packages/common/src/templates/fetch.ts
@@ -16,6 +16,7 @@ import { fetchItemEnrichments } from "../items/_enrichments";
 import { getProp } from "../objects";
 import { computeLinks } from "./_internal/computeLinks";
 import { getDeployedTemplateType } from "./utils";
+import { deriveLocationFromItem } from "../content/_internal/internalContentUtils";
 
 /**
  * @private
@@ -98,6 +99,7 @@ export async function enrichTemplateSearchResult(
       thumbnail: "not-implemented",
       workspaceRelative: "not-implemented",
     },
+    location: deriveLocationFromItem(item),
     rawResult: item,
   };
 

--- a/packages/common/test/content/_internal/internalContentUtils.test.ts
+++ b/packages/common/test/content/_internal/internalContentUtils.test.ts
@@ -381,9 +381,4 @@ describe("deriveLocationFromItem", () => {
       },
     });
   });
-  it("should finally resolve to none", () => {
-    const _item = cloneObject(item);
-    const chk = deriveLocationFromItem(_item);
-    expect(chk).toEqual({ type: "none" });
-  });
 });

--- a/packages/common/test/content/_internal/internalContentUtils.test.ts
+++ b/packages/common/test/content/_internal/internalContentUtils.test.ts
@@ -1,8 +1,14 @@
 import { IItem } from "@esri/arcgis-rest-types";
-import { getContentEditUrl } from "../../../src/content/_internal/internalContentUtils";
+import {
+  getContentEditUrl,
+  getExtentObject,
+  deriveLocationFromItem,
+} from "../../../src/content/_internal/internalContentUtils";
+import * as internalContentUtils from "../../../src/content/_internal/internalContentUtils";
 import { IHubRequestOptions } from "../../../src/types";
 import { cloneObject } from "../../../src/util";
 import { MOCK_HUB_REQOPTS } from "../../mocks/mock-auth";
+import { IHubLocation } from "../../../src";
 
 describe("getContentEditUrl", () => {
   let requestOptions: IHubRequestOptions;
@@ -287,5 +293,97 @@ describe("getContentEditUrl", () => {
     const chk = getContentEditUrl(item, requestOptions);
 
     expect(chk).toBe("https://myserver.gis/home/item.html?id=9001");
+  });
+});
+
+describe("getExtentObject", () => {
+  it("getExtentObject isBBox is true", () => {
+    const chk = getExtentObject([
+      [100, 100],
+      [120, 120],
+    ]);
+    expect(chk.xmin).toBe(100);
+    expect(chk.ymin).toBe(100);
+    expect(chk.xmax).toBe(120);
+    expect(chk.ymax).toBe(120);
+  });
+  it("getExtentObject isBBox is true", () => {
+    const chk = getExtentObject([]);
+    expect(chk).toBeUndefined();
+  });
+});
+
+describe("deriveLocationFromItem", () => {
+  const item: IItem = {
+    type: "Dashboard",
+    id: "9001",
+    created: new Date().getTime(),
+    modified: new Date().getTime(),
+    properties: {},
+    typeKeywords: ["ArcGIS Dashboards"],
+  } as IItem;
+  it("should return existing IHubLocation", () => {
+    const _item = cloneObject(item);
+    const location = {
+      type: "custom",
+      extent: [[0], [0]],
+    } as IHubLocation;
+    _item.properties = {
+      location,
+    };
+    const chk = deriveLocationFromItem(_item);
+    expect(chk).toEqual(location);
+  });
+  it("should return boundary if type none", () => {
+    const _item = cloneObject(item);
+    _item.properties = {
+      boundary: { type: "none" },
+    };
+    const chk = deriveLocationFromItem(_item);
+    expect(chk).toEqual({ type: "none" });
+  });
+  it("should return boundary if no extent on item", () => {
+    const _item = cloneObject(item);
+    const chk = deriveLocationFromItem(_item);
+    expect(chk).toEqual({ type: "none" });
+  });
+  it("should create custom location from item extent", () => {
+    const getExtentObjectSpy = spyOn(
+      internalContentUtils,
+      "getExtentObject"
+    ).and.callThrough();
+    const _item = cloneObject(item);
+    _item.extent = [
+      [0, 0],
+      [0, 0],
+    ];
+    const chk = deriveLocationFromItem(_item);
+    expect(chk).toEqual({
+      type: "custom",
+      extent: [
+        [0, 0],
+        [0, 0],
+      ],
+      geometries: [
+        {
+          xmin: 0,
+          ymin: 0,
+          xmax: 0,
+          ymax: 0,
+          spatialReference: {
+            wkid: 4326,
+          },
+          type: "extent",
+        } as any,
+      ],
+      spatialReference: {
+        wkid: 4326,
+      },
+    });
+  });
+  it("should finally resolve to none", () => {
+    const _item = cloneObject(item);
+    const chk = deriveLocationFromItem(_item);
+    expect(chk).toEqual({ type: "none" });
   });
 });

--- a/packages/common/test/content/_internal/internalContentUtils.test.ts
+++ b/packages/common/test/content/_internal/internalContentUtils.test.ts
@@ -381,4 +381,91 @@ describe("deriveLocationFromItem", () => {
       },
     });
   });
+  it("should construct location from geojson if getExtentObject undefined", () => {
+    const _item = cloneObject(item);
+    _item.spatialReference = "102100" as any;
+    _item.extent = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [-14999967.4259, 6499962.1704],
+          [-6200050.3592, 6499962.1704],
+          [-6200050.3592, 2352563.6343],
+          [-14999967.4259, 2352563.6343],
+          [-14999967.4259, 6499962.1704],
+        ],
+      ],
+    } as any;
+    const chk = deriveLocationFromItem(_item);
+    expect(chk).toEqual({
+      type: "custom",
+      extent: [
+        [-14999967.4259, 2352563.6343],
+        [-6200050.3592, 6499962.1704],
+      ],
+      geometries: [
+        {
+          type: "polygon",
+          rings: [
+            [
+              [-14999967.4259, 6499962.1704],
+              [-6200050.3592, 6499962.1704],
+              [-6200050.3592, 2352563.6343],
+              [-14999967.4259, 2352563.6343],
+              [-14999967.4259, 6499962.1704],
+            ],
+          ],
+          spatialReference: {
+            wkid: 102100,
+          } as any,
+        } as any,
+      ],
+      spatialReference: {
+        wkid: 102100,
+      },
+    });
+  });
+  it("should construct location from geojson and return default spatial reference if none defined", () => {
+    const _item = cloneObject(item);
+    _item.extent = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [-14999967.4259, 6499962.1704],
+          [-6200050.3592, 6499962.1704],
+          [-6200050.3592, 2352563.6343],
+          [-14999967.4259, 2352563.6343],
+          [-14999967.4259, 6499962.1704],
+        ],
+      ],
+    } as any;
+    const chk = deriveLocationFromItem(_item);
+    expect(chk).toEqual({
+      type: "custom",
+      extent: [
+        [-14999967.4259, 2352563.6343],
+        [-6200050.3592, 6499962.1704],
+      ],
+      geometries: [
+        {
+          type: "polygon",
+          rings: [
+            [
+              [-14999967.4259, 6499962.1704],
+              [-6200050.3592, 6499962.1704],
+              [-6200050.3592, 2352563.6343],
+              [-14999967.4259, 2352563.6343],
+              [-14999967.4259, 6499962.1704],
+            ],
+          ],
+          spatialReference: {
+            wkid: 4326,
+          } as any,
+        } as any,
+      ],
+      spatialReference: {
+        wkid: 4326,
+      },
+    });
+  });
 });

--- a/packages/common/test/content/computeProps.test.ts
+++ b/packages/common/test/content/computeProps.test.ts
@@ -1,8 +1,4 @@
-import {
-  computeProps,
-  deriveLocationFromItemExtent,
-  getExtentObject,
-} from "../../src/content/_internal/computeProps";
+import { computeProps } from "../../src/content/_internal/computeProps";
 import { IHubEditableContent } from "../../src/core/types/IHubEditableContent";
 import { IItemAndIServerEnrichments } from "../../src/items/_enrichments";
 import { IHubRequestOptions, IModel } from "../../src/types";
@@ -23,6 +19,10 @@ describe("content computeProps", () => {
   it("handles when properties are undefined", () => {
     const model: IModel = {
       item: {
+        extent: [
+          [0, 0],
+          [0, 0],
+        ],
         type: "Feature Service",
         id: "9001",
         created: new Date().getTime(),
@@ -44,6 +44,10 @@ describe("content computeProps", () => {
   it("handles when boundary is undefined", () => {
     const model: IModel = {
       item: {
+        extent: [
+          [0, 0],
+          [0, 0],
+        ],
         type: "Feature Service",
         id: "9001",
         created: new Date().getTime(),
@@ -179,29 +183,5 @@ describe("content computeProps", () => {
 
     const chk = computeProps(model, content, withoutAuth);
     expect(chk.thumbnail).toBeUndefined();
-  });
-});
-
-describe("getItemExtent", () => {
-  it("getItemExtent isBBox is true", () => {
-    const chk = getExtentObject([
-      [100, 100],
-      [120, 120],
-    ]);
-    expect(chk.xmin).toBe(100);
-    expect(chk.ymin).toBe(100);
-    expect(chk.xmax).toBe(120);
-    expect(chk.ymax).toBe(120);
-  });
-});
-
-describe("deriveLocationFromItemExtent", () => {
-  it("deriveLocationFromItemExtent valid extent", () => {
-    const chk = deriveLocationFromItemExtent([
-      [100, 100],
-      [120, 120],
-    ]);
-    expect(chk.geometries?.length).toBe(1);
-    expect(chk.type).toBe("custom");
   });
 });

--- a/packages/common/test/core/_internal/computeBaseProps.tests.ts
+++ b/packages/common/test/core/_internal/computeBaseProps.tests.ts
@@ -1,0 +1,18 @@
+import { computeBaseProps } from "../../../src/core/_internal/computeBaseProps";
+import { IItem } from "@esri/arcgis-rest-types";
+import { IHubItemEntity } from "../../../src";
+import * as internalContentUtils from "../../../src/content/_internal/internalContentUtils";
+
+describe("computeBaseProps", () => {
+  const item: IItem = {} as IItem;
+  const entity: Partial<IHubItemEntity> = {};
+  it("sets base properties on entity", () => {
+    const deriveLocationFromItemSpy = spyOn(
+      internalContentUtils,
+      "deriveLocationFromItem"
+    ).and.callThrough();
+    const chk = computeBaseProps(item, entity);
+    expect(chk.location).toEqual({ type: "none" });
+    expect(deriveLocationFromItemSpy.calls.count()).toEqual(1);
+  });
+});

--- a/packages/common/test/extent/extent.test.ts
+++ b/packages/common/test/extent/extent.test.ts
@@ -1,30 +1,146 @@
-import { isValidExtent } from "../../src/extent";
+import {
+  isValidExtent,
+  allCoordinatesPossiblyWGS84,
+  GeoJSONPolygonToBBox,
+} from "../../src/extent";
 import { IExtent } from "@esri/arcgis-rest-types";
 
-describe("isValidExtent", function() {
-  it("identifies valid extent coordinate array", function() {
-    const extent: object = [[-122.68, 45.53], [-122.45, 45.6]];
+describe("isValidExtent", function () {
+  it("identifies valid extent coordinate array", function () {
+    const extent: object = [
+      [-122.68, 45.53],
+      [-122.45, 45.6],
+    ];
     const result = isValidExtent(extent);
     expect(result).toBeTruthy();
   });
-  it("identifies valid extent JSON", function() {
+  it("identifies valid extent JSON", function () {
     const extent: IExtent = {
       xmin: -122.68,
       ymin: 45.53,
       xmax: -122.45,
       ymax: 45.6,
       spatialReference: {
-        wkid: 4326
-      }
+        wkid: 4326,
+      },
     };
     const result = isValidExtent(extent);
     expect(result).toBeTruthy();
   });
-  it("identifies invalid extent", function() {
+  it("identifies invalid extent", function () {
     const extent: object = {
-      str: "I am invalid"
+      str: "I am invalid",
     };
     const result = isValidExtent(extent);
     expect(result).toBeFalsy();
+  });
+});
+
+describe("allCoordinatesPossiblyWGS84", function () {
+  it("returns true for valid WGS84 coordinates", function () {
+    const coordinates: number[][] = [
+      [-122.68, 45.53],
+      [-122.45, 45.6],
+    ];
+    const result = allCoordinatesPossiblyWGS84(coordinates);
+    expect(result).toBeTruthy();
+  });
+
+  it("returns false for invalid WGS84 coordinates", function () {
+    const coordinates: number[][] = [
+      [-122.68, 45.53],
+      [-122.45, 95.6],
+    ];
+    const result = allCoordinatesPossiblyWGS84(coordinates);
+    expect(result).toBeFalsy();
+  });
+
+  it("returns true for valid single coordinate", function () {
+    const coordinates: number[] = [-122.68, 45.53];
+    const result = allCoordinatesPossiblyWGS84(coordinates);
+    expect(result).toBeTruthy();
+  });
+
+  it("returns false for invalid single coordinate", function () {
+    const coordinates: number[] = [-122.68, 195.53];
+    const result = allCoordinatesPossiblyWGS84(coordinates);
+    expect(result).toBeFalsy();
+  });
+});
+
+describe("GeoJSONPolygonToBBox", function () {
+  it("returns the correct bounding box for a polygon", function () {
+    const polygon = {
+      coordinates: [
+        [
+          [-122.68, 45.53],
+          [-122.45, 45.6],
+          [-122.6, 45.7],
+          [-122.8, 45.8],
+          [-122.68, 45.53],
+        ],
+      ],
+    };
+    const result = GeoJSONPolygonToBBox(polygon);
+    expect(result).toEqual([
+      [-122.8, 45.53],
+      [-122.45, 45.8],
+    ]);
+  });
+
+  it("returns the correct bounding box for a polygon with multiple rings", function () {
+    const polygon = {
+      coordinates: [
+        [
+          [-122.68, 45.53],
+          [-122.45, 45.6],
+          [-122.6, 45.7],
+          [-122.8, 45.8],
+          [-122.68, 45.53],
+        ],
+        [
+          [-122.7, 45.55],
+          [-122.55, 45.62],
+          [-122.65, 45.72],
+          [-122.85, 45.82],
+          [-122.7, 45.55],
+        ],
+      ],
+    };
+    const result = GeoJSONPolygonToBBox(polygon);
+    expect(result).toEqual([
+      [-122.85, 45.53],
+      [-122.45, 45.82],
+    ]);
+  });
+
+  it("returns the correct bounding box for a polygon with negative coordinates", function () {
+    const polygon = {
+      coordinates: [
+        [
+          [-122.68, -45.53],
+          [-122.45, -45.6],
+          [-122.6, -45.7],
+          [-122.8, -45.8],
+          [-122.68, -45.53],
+        ],
+      ],
+    };
+    const result = GeoJSONPolygonToBBox(polygon);
+    expect(result).toEqual([
+      [-122.8, -45.8],
+      [-122.45, -45.53],
+    ]);
+  });
+
+  it("returns the correct bounding box for a polygon with a single point", function () {
+    const polygon = {
+      coordinates: [[[-122.68, 45.53]]],
+    };
+    const result = GeoJSONPolygonToBBox(polygon);
+    expect(result).toEqual([
+      [-122.68, 45.53],
+      [-122.68, 45.53],
+    ]);
   });
 });

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -675,23 +675,7 @@ describe("hubSearchItems Module |", () => {
       },
       // TODO: fill this and add some verification
       rawResult: ogcItemsResponse.features[0].properties as IOgcItem,
-      geometry: {
-        geometry: {
-          rings: [
-            [
-              [-121.11799999999793, 39.37030746927015],
-              [-119.00899999999801, 39.37030746927015],
-              [-119.00899999999801, 38.67499450446548],
-              [-121.11799999999793, 38.67499450446548],
-              [-121.11799999999793, 39.37030746927015],
-            ],
-          ],
-          spatialReference: {
-            wkid: 4326,
-          },
-        },
-      } as any,
-      location: undefined,
+      location: { type: "none" },
     },
   ];
 
@@ -778,7 +762,6 @@ describe("hubSearchItems Module |", () => {
           ...mockedItemToSearchResultResponse,
           source: "my-source",
           license: "CC-BY-4.0",
-          location: undefined,
         });
       });
       it("adds item.properties.location on result", async () => {
@@ -790,9 +773,7 @@ describe("hubSearchItems Module |", () => {
         const delegateSpy = spyOn(
           portalSearchItemsModule,
           "itemToSearchResult"
-        ).and.returnValue(
-          Promise.resolve(cloneObject(mockedItemToSearchResultResponse))
-        );
+        ).and.callThrough();
         const _ogcItemProperties = {
           ...cloneObject(ogcItemProperties),
           properties: {
@@ -821,40 +802,7 @@ describe("hubSearchItems Module |", () => {
           includes,
           requestOptions
         );
-        expect(result).toEqual({
-          ...mockedItemToSearchResultResponse,
-          source: "my-source",
-          license: "CC-BY-4.0",
-          location: LOCATION,
-        });
-      });
-      it("adds arcgis geometry to result", async () => {
-        const geojsonToArcGISSpy = spyOn(
-          Terraformer,
-          "geojsonToArcGIS"
-        ).and.callThrough();
-        const includes: string[] = [];
-        const requestOptions: IHubRequestOptions = {};
-        await ogcItemToSearchResult(
-          ogcItemsResponse.features[0],
-          includes,
-          requestOptions
-        );
-        expect(geojsonToArcGISSpy.calls.count()).toBe(
-          1,
-          "Calls geojsonToArcGIS()"
-        );
-        expect(geojsonToArcGISSpy.calls.allArgs()[0]).toEqual([
-          ogcItemsResponse.features[0].geometry,
-        ]);
-
-        geojsonToArcGISSpy.and.throwError("Error");
-        await ogcItemToSearchResult(
-          ogcItemsResponse.features[0],
-          includes,
-          requestOptions
-        );
-        expect(geojsonToArcGISSpy).toThrowError("Error");
+        expect(result.location).toEqual(ogcItem.properties.properties.location);
       });
     });
 

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -11,8 +11,6 @@ import {
 } from "../../../src";
 
 import { UserSession } from "@esri/arcgis-rest-auth";
-import * as Terraformer from "@terraformer/arcgis";
-
 import {
   formatPredicate,
   formatFilterBlock,
@@ -675,7 +673,33 @@ describe("hubSearchItems Module |", () => {
       },
       // TODO: fill this and add some verification
       rawResult: ogcItemsResponse.features[0].properties as IOgcItem,
-      location: { type: "none" },
+      location: {
+        type: "custom",
+        extent: [
+          [-121.11799999999793, 38.67499450446548],
+          [-119.00899999999801, 39.37030746927015],
+        ],
+        geometries: [
+          {
+            type: "polygon",
+            rings: [
+              [
+                [-121.11799999999793, 39.37030746927015],
+                [-119.00899999999801, 39.37030746927015],
+                [-119.00899999999801, 38.67499450446548],
+                [-121.11799999999793, 38.67499450446548],
+                [-121.11799999999793, 39.37030746927015],
+              ],
+            ],
+            spatialReference: {
+              wkid: 4326,
+            } as any,
+          } as any,
+        ],
+        spatialReference: {
+          wkid: 4326,
+        },
+      },
     },
   ];
 


### PR DESCRIPTION
…cates IHubSearchResult geometry

affects: @esri/hub-common

1. Description: Deprecates `IHubSearchResult` `geometry` property, now preferring all location be consolidated to the `location: IHubLocation` property.  To consolidate logic and provide consistent `location` property across workflows, the creation of location from item extent has been moved to `internalContentUtils` and used in both `computeProps` and `search`.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
