### PR TITLE
fix(): add clearOnHidden to values in metrics

### DIFF
--- a/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
@@ -86,6 +86,7 @@ export const buildUiSchema = (
             rule: SHOW_FOR_STATIC_AND_STRING_RULE_ENTITY,
             options: {
               control: "hub-field-input-input",
+              clearOnHidden: true,
               messages: [
                 {
                   type: "ERROR",
@@ -104,6 +105,7 @@ export const buildUiSchema = (
             options: {
               control: "hub-field-input-input",
               type: "number",
+              clearOnHidden: true,
               messages: [
                 {
                   type: "ERROR",

--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -126,6 +126,7 @@ export interface IUiSchemaRule {
 
 export interface IUiSchemaElement {
   type: string;
+  id?: string;
   labelKey?: string;
   label?: string;
   options?: {

--- a/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
@@ -90,6 +90,7 @@ describe("buildUiSchema: metric", () => {
               },
               options: {
                 control: "hub-field-input-input",
+                clearOnHidden: true,
                 messages: [
                   {
                     type: "ERROR",
@@ -122,6 +123,7 @@ describe("buildUiSchema: metric", () => {
               options: {
                 control: "hub-field-input-input",
                 type: "number",
+                clearOnHidden: true,
                 messages: [
                   {
                     type: "ERROR",


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: [#9074](https://zentopia.esri.com/workspaces/sprint-board-60340b9721bc3a4ab6367db5/issues/gh/dc/hub/9074)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
