### PR TITLE
fix(hub-common): refactor hubSearchChannels for more general use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.80.1",
+			"version": "14.83.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/discussions/utils.ts
+++ b/packages/common/src/discussions/utils.ts
@@ -7,7 +7,7 @@ import {
   IChannel,
   SharingAccess,
 } from "./api/types";
-import { IFilter, IPredicate, IQuery } from "../search";
+import { IFilter, IHubSearchResult, IPredicate, IQuery } from "../search";
 
 /**
  * Utility to determine if a given IGroup, IItem, IHubContent, or IHubItemEntity

--- a/packages/common/src/discussions/utils.ts
+++ b/packages/common/src/discussions/utils.ts
@@ -196,3 +196,36 @@ export function getChannelUsersQuery(
   };
   return query;
 }
+
+/**
+ * Transforms a given channel and optional channel groups array into a IHubSearchResult
+ * @param channel
+ * @param groups
+ * @returns
+ */
+export const channelToSearchResult = (
+  channel: IChannel,
+  groups?: IGroup[]
+): IHubSearchResult => {
+  return {
+    ...channel,
+    id: channel.id,
+    name: channel.name,
+    createdDate: new Date(channel.createdAt),
+    createdDateSource: "channel",
+    updatedDate: new Date(channel.updatedAt),
+    updatedDateSource: "channel",
+    type: "channel",
+    access: channel.access,
+    family: "channel",
+    owner: channel.creator,
+    links: {
+      // TODO: add links?
+      thumbnail: null,
+      self: null,
+      siteRelative: null,
+    },
+    includes: { groups },
+    rawResult: channel,
+  };
+};

--- a/packages/common/src/search/_internal/hubSearchChannels.ts
+++ b/packages/common/src/search/_internal/hubSearchChannels.ts
@@ -12,6 +12,7 @@ import {
   IPagedResponse,
   ISearchChannels,
   ISearchChannelsParams,
+  channelToSearchResult,
 } from "../../discussions";
 import { IGroup, getGroup } from "@esri/arcgis-rest-portal";
 
@@ -100,39 +101,6 @@ export const processSearchParams = (
       ...paginationProps,
       ...filterProps,
     },
-  };
-};
-
-/**
- * Transforms a given channel and optional channel groups array into a IHubSearchResult
- * @param channel
- * @param groups
- * @returns
- */
-export const channelToSearchResult = (
-  channel: IChannel,
-  groups?: IGroup[]
-): IHubSearchResult => {
-  return {
-    ...channel,
-    id: channel.id,
-    name: channel.name,
-    createdDate: new Date(channel.createdAt),
-    createdDateSource: "channel",
-    updatedDate: new Date(channel.updatedAt),
-    updatedDateSource: "channel",
-    type: "channel",
-    access: channel.access,
-    family: "channel",
-    owner: channel.creator,
-    links: {
-      // TODO: add links?
-      thumbnail: null,
-      self: null,
-      siteRelative: null,
-    },
-    includes: { groups },
-    rawResult: channel,
   };
 };
 

--- a/packages/common/test/search/_internal/hubSearchChannels.test.ts
+++ b/packages/common/test/search/_internal/hubSearchChannels.test.ts
@@ -11,7 +11,7 @@ import * as arcgisRestPortal from "@esri/arcgis-rest-portal";
 
 describe("discussionsSearchItems Module |", () => {
   let processSearchParamsSpy: jasmine.Spy;
-  let toHubSearchResultSpy: jasmine.Spy;
+  let toHubSearchResultsSpy: jasmine.Spy;
   let searchChannelsSpy: jasmine.Spy;
   let getGroupSpy: jasmine.Spy;
 
@@ -20,9 +20,9 @@ describe("discussionsSearchItems Module |", () => {
       hubSearchChannels,
       "processSearchParams"
     ).and.callThrough();
-    toHubSearchResultSpy = spyOn(
+    toHubSearchResultsSpy = spyOn(
       hubSearchChannels,
-      "toHubSearchResult"
+      "toHubSearchResults"
     ).and.callThrough();
     searchChannelsSpy = spyOn(API, "searchChannels").and.callFake(() => {
       return Promise.resolve(SEARCH_CHANNELS_RESPONSE);
@@ -60,7 +60,7 @@ describe("discussionsSearchItems Module |", () => {
     };
     const result = await hubSearchChannels.hubSearchChannels(qry, opts);
     expect(processSearchParamsSpy).toHaveBeenCalledTimes(1);
-    expect(toHubSearchResultSpy).toHaveBeenCalledTimes(1);
+    expect(toHubSearchResultsSpy).toHaveBeenCalledTimes(1);
     expect(searchChannelsSpy).toHaveBeenCalledTimes(1);
     expect(result).toBeTruthy();
     const nextResult = await result.next();
@@ -117,7 +117,7 @@ describe("discussionsSearchItems Module |", () => {
     };
     const result = await hubSearchChannels.hubSearchChannels(qry, opts);
     expect(processSearchParamsSpy).toHaveBeenCalledTimes(1);
-    expect(toHubSearchResultSpy).toHaveBeenCalledTimes(1);
+    expect(toHubSearchResultsSpy).toHaveBeenCalledTimes(1);
     expect(searchChannelsSpy).toHaveBeenCalledTimes(1);
     expect(result).toBeTruthy();
   });


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 8922

1. Description: Refactors hubSearchChannels for more general use.

1. Instructions for testing:

1. Closes Issues: #8922

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
