### PR TITLE
feat: add deepDeletePropByValue and deepEqual util functions

### DIFF
--- a/packages/common/src/objects/deepDeletePropByValue.ts
+++ b/packages/common/src/objects/deepDeletePropByValue.ts
@@ -1,0 +1,66 @@
+import { deepEqual } from "./deepEqual";
+import { _isObject } from "./_deep-map-values";
+import { isFindable } from "./internal/isFindable";
+
+/**
+ * Recursively deletes properties from an object or array that have a
+ * specific value.
+ *
+ * Hub commonly applies migrations to entities on load. During those
+ * migrations, often we want to delete properties to clean things up.
+ * However, during the save process, we typically fetch the entity
+ * from it's backing store and spread the migrated entity over the top of
+ * the fetched entity. This results in the deleted props being re-added.
+ *
+ * To avoid this, instead of deleting the props in the migration,
+ * we can set them to a specific value (e.g. `remove-this-prop`) and then
+ * use this function to remove them, after the merge.
+ *
+ * @param object - The object or array to delete properties from.
+ * @param value - The value to match and delete.
+ * @returns The modified object or array with properties deleted.
+ */
+export function deepDeletePropByValue(object: any, value: any): any {
+  // If the object is the value we want to delete, return undefined
+  if (deepEqual(object, value)) {
+    return undefined;
+  }
+
+  // If the object is an array, iterate over the array and recurse
+  // on the entries
+  if (Array.isArray(object)) {
+    return object.reduce((acc, entry) => {
+      if (isFindable(entry)) {
+        const recursedObject = deepDeletePropByValue(entry, value);
+        if (recursedObject !== undefined) {
+          acc = [...acc, recursedObject];
+        }
+      } else {
+        if (entry !== value) {
+          acc = [...acc, entry];
+        } // else we are excluding this entry
+      }
+      return acc;
+    }, []);
+  }
+
+  if (_isObject(object)) {
+    return Object.keys(object).reduce((acc, key) => {
+      // if this is an object but not a date, regexp, or function, recurse
+      if (isFindable(object[key]) && !deepEqual(object[key], value)) {
+        const filteredEntry = deepDeletePropByValue(object[key], value);
+        (acc as any)[key] = filteredEntry;
+      } else {
+        // ensure the value is not the value we want to delete
+        if (!deepEqual(object[key], value)) {
+          acc = { ...acc, [key]: object[key] };
+        } // else this key matches the value and we are excluding it
+      }
+      return acc;
+    }, {});
+  } else {
+    // just return the object b/c it's not something we can compare
+    // e.g. a function
+    return object;
+  }
+}

--- a/packages/common/src/objects/deepEqual.ts
+++ b/packages/common/src/objects/deepEqual.ts
@@ -1,0 +1,31 @@
+import { _isObject } from "./_deep-map-values";
+
+/**
+ * Compares two values deeply for equality.
+ * Works for primatives, arrays and objects.
+ * Not verified for other types.
+ * @param a - The first value to compare.
+ * @param b - The second value to compare.
+ * @returns True if the values are deeply equal, false otherwise.
+ */
+export function deepEqual(a: any, b: any): boolean {
+  // Simple comparison for primitives
+  if (a === b) {
+    return true;
+  }
+  // object checks
+  if (a && b && _isObject(a) && _isObject(b)) {
+    // if either are not arrays, return false
+    if (Array.isArray(a) !== Array.isArray(b)) {
+      return false;
+    }
+    const keys = Object.keys(a);
+    // if key lengths are different, return false
+    if (keys.length !== Object.keys(b).length) {
+      return false;
+    }
+    // recurse on each key
+    return keys.every((key) => deepEqual(a[key], b[key]));
+  }
+  return false;
+}

--- a/packages/common/src/objects/index.ts
+++ b/packages/common/src/objects/index.ts
@@ -13,3 +13,5 @@ export * from "./deepFilter";
 export * from "./deepFind";
 export * from "./resolveReferences";
 export * from "./pickProps";
+export * from "./deepEqual";
+export * from "./deepDeletePropByValue";

--- a/packages/common/test/objects/deepDeletePropByValue.test.ts
+++ b/packages/common/test/objects/deepDeletePropByValue.test.ts
@@ -1,0 +1,97 @@
+import { deepDeletePropByValue } from "../../src/objects/deepDeletePropByValue";
+describe("deepDeletePropByValue: ", () => {
+  it("removes string from array", () => {
+    const test = ["remove-me", "keep-me"];
+    const chk = deepDeletePropByValue(test, "remove-me");
+    expect(chk.length).toBe(1);
+    expect(chk).toEqual(["keep-me"]);
+  });
+  it("removes objects from arrays", () => {
+    const test = [{ a: "b" }, { c: "d" }];
+    const chk = deepDeletePropByValue(test, { a: "b" });
+    expect(chk.length).toBe(1);
+    expect(chk).toEqual([{ c: "d" }]);
+  });
+  it("removes objects from deep.arrays", () => {
+    const test = { p: [{ a: "b" }, { c: "d" }] };
+    const chk = deepDeletePropByValue(test, { a: "b" });
+    expect(chk.p.length).toBe(1);
+    expect(chk).toEqual({ p: [{ c: "d" }] });
+  });
+
+  it("returns undefined if value matches string", () => {
+    const test = "remove-me";
+
+    const chk = deepDeletePropByValue(test, "remove-me");
+    expect(chk).toBe(undefined);
+  });
+  it("returns undefined if value matches object", () => {
+    const test = { a: "b" };
+
+    const chk = deepDeletePropByValue(test, { a: "b" });
+    expect(chk).toBe(undefined);
+  });
+  it("remove object prop if value matches", () => {
+    const test = { p: { a: "b" }, q: { a: "c" } };
+
+    const chk = deepDeletePropByValue(test, { a: "b" });
+    expect(chk).toEqual({ q: { a: "c" } });
+  });
+  it("delete prop from object", () => {
+    const test = {
+      prop: "remove-me",
+      other: "keep-me",
+    };
+    const chk = deepDeletePropByValue(test, "remove-me");
+    expect(chk).toEqual({ other: "keep-me" });
+  });
+  it("delete deep prop from object", () => {
+    const test = {
+      prop: "value1",
+      obj2: {
+        prop: "value2",
+        obj3: {
+          prop: "value3",
+          obj4: {
+            prop: "remove-me",
+            other: "prop",
+          },
+        },
+      },
+    };
+    const chk = deepDeletePropByValue(test, "remove-me");
+    expect(chk).toEqual({
+      prop: "value1",
+      obj2: {
+        prop: "value2",
+        obj3: {
+          prop: "value3",
+          obj4: {
+            other: "prop",
+          },
+        },
+      },
+    });
+  });
+  it("ignores function props", () => {
+    const test = {
+      f: () => {
+        return "remove-me";
+      },
+      p: "remove-me",
+    };
+    const chk = deepDeletePropByValue(test, "remove-me");
+    expect(typeof chk.f).toEqual("function");
+  });
+  it("ignores functions", () => {
+    const test = () => {
+      return "remove-me";
+    };
+    const chk = deepDeletePropByValue(test, "remove-me");
+    expect(typeof chk).toEqual("function");
+  });
+  it("ignores dates", () => {
+    const chk = deepDeletePropByValue({ d: new Date() }, "remove-me");
+    expect(chk.d instanceof Date).toBe(true);
+  });
+});

--- a/packages/common/test/objects/deepEqual.test.ts
+++ b/packages/common/test/objects/deepEqual.test.ts
@@ -1,0 +1,38 @@
+import { deepEqual } from "../../src/objects/deepEqual";
+
+describe("deepEqual:", () => {
+  it("works for primatives", () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual("a", "a")).toBe(true);
+    expect(deepEqual("a", "b")).toBe(false);
+  });
+  it("works for null and undefined", () => {
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(null, undefined)).toBe(false);
+    expect(deepEqual(undefined, undefined)).toBe(true);
+    expect(deepEqual(undefined, null)).toBe(false);
+  });
+  it("works for objects", () => {
+    expect(deepEqual({}, {})).toBe(true);
+    expect(deepEqual({ a: 1 }, { a: 1 })).toBe(true);
+    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true);
+  });
+  it("handles mixed types", () => {
+    expect(deepEqual({ a: 1, b: 2 }, [{ a: 1, b: "2" }])).toBe(false);
+  });
+  it("works for arrays of objects", () => {
+    expect(deepEqual([{ a: 1 }, { b: 2 }], [{ a: 1 }, { b: 2 }])).toBe(true);
+    expect(deepEqual([{ a: 1 }, { b: 2 }], [{ a: 1 }, { b: 3 }])).toBe(false);
+  });
+  it("works for same objects", () => {
+    const chk = { a: 1, b: 2 };
+    expect(deepEqual(chk, chk)).toBe(true);
+    const clone = { ...chk };
+    expect(deepEqual(chk, clone)).toBe(true);
+    const clone2 = { ...chk, c: 3 };
+    expect(deepEqual(chk, clone2)).toBe(false);
+  });
+});


### PR DESCRIPTION
1. Description:

Add `deepDeletePropByValue(obj, value):obj` and `deepEqual(a,b):boolean` util functions

Hub commonly applies migrations to entities on load. During those migrations, often we want to delete properties to clean things up. However, during the save process, we typically fetch the entity from it's backing store and spread the migrated entity over the top of the fetched entity. This results in the deleted props being re-added.

To avoid this, instead of deleting the props in the migration, we can set them to a specific value (e.g. `remove-this-prop`) and then use `deepDeletePropByValue` function to remove them, after the merge.

`deepEquals` was a useful side-effect of building this function.

This is a precursor to changes in some migrations.


1. Instructions for testing: run tests

1. Closes Issues: n/a - just did this on a Saturday w/ a lousy weather 🌧️

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
