### PR TITLE
feat: add permission to manage on umbrella

### DIFF
--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -118,6 +118,20 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     availability: ["alpha"],
     licenses: ["hub-premium"],
   },
+  {
+    // When enabled, the edit & manage links will take the user to umbrella\
+    // Gated to dev + alpha as this is just meant as a demo enabled by feature flagging
+    permission: "hub:feature:workspace:umbrella",
+    availability: ["alpha"],
+    environments: ["devext"],
+  },
+  {
+    // When enabled, the edit & manage links will take the user to hub-home
+    // Gated to dev + alpha as this is just meant as a demo enabled by feature flagging
+    permission: "hub:feature:workspace:hubhome",
+    availability: ["alpha"],
+    environments: ["devext"],
+  },
 ];
 
 /**

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -119,18 +119,10 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     licenses: ["hub-premium"],
   },
   {
-    // When enabled, the edit & manage links will take the user to umbrella\
-    // Gated to dev + alpha as this is just meant as a demo enabled by feature flagging
+    // When enabled, the edit & manage links will take the user to umbrella
     permission: "hub:feature:workspace:umbrella",
     availability: ["alpha"],
-    environments: ["devext"],
-  },
-  {
-    // When enabled, the edit & manage links will take the user to hub-home
-    // Gated to dev + alpha as this is just meant as a demo enabled by feature flagging
-    permission: "hub:feature:workspace:hubhome",
-    availability: ["alpha"],
-    environments: ["devext"],
+    environments: ["qaext"],
   },
 ];
 

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -23,6 +23,8 @@ const SystemPermissions = [
   "hub:feature:gallery:map",
   "hub:feature:user:preferences",
   "hub:card:follow",
+  "hub:feature:workspace:umbrella",
+  "hub:feature:workspace:hubhome",
 ];
 
 const validPermissions = [

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -24,7 +24,6 @@ const SystemPermissions = [
   "hub:feature:user:preferences",
   "hub:card:follow",
   "hub:feature:workspace:umbrella",
-  "hub:feature:workspace:hubhome",
 ];
 
 const validPermissions = [


### PR DESCRIPTION
1. Description:
- add `hub:feature:workspace:umbrella` which is enabled for qa-alpha
- in UI (separate PR to follow), when this is enabled, the manage (⚙️) link will open the entity on the umbrella site for that env.


1. Instructions for testing: run tests

1. Closes Issues: #9260

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
