### PR TITLE
fix: add permission for project associations

### DIFF
--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -89,6 +89,11 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:project:view"],
   },
   {
+    permission: "hub:project:associations",
+    availability: ["alpha"],
+    environments: ["devext", "qaext"],
+  },
+  {
     permission: "hub:project:workspace",
   },
   {
@@ -105,8 +110,11 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:project:workspace:initiatives",
-    availability: ["alpha"], // gate to just alpha for now
-    dependencies: ["hub:project:workspace", "hub:project:edit"],
+    dependencies: [
+      "hub:project:workspace",
+      "hub:project:associations",
+      "hub:project:edit",
+    ],
   },
   {
     permission: "hub:project:workspace:settings",

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -24,6 +24,7 @@ export const ProjectPermissions = [
   "hub:project:events",
   "hub:project:content",
   "hub:project:discussions",
+  "hub:project:associations",
   "hub:project:workspace",
   "hub:project:workspace:overview",
   "hub:project:workspace:dashboard",

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -91,7 +91,6 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:project:associations",
     availability: ["alpha"],
-    environments: ["devext", "qaext"],
   },
   {
     permission: "hub:project:workspace",

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -91,6 +91,7 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:project:associations",
     availability: ["alpha"],
+    dependencies: ["hub:project:view"],
   },
   {
     permission: "hub:project:workspace",


### PR DESCRIPTION
[8968](https://devtopia.esri.com/dc/hub/issues/8968)

### Description:
- add new `"hub:project:associations"` permission that gates associations to alpha dev/QA orgs
- update the existing `"hub:project:workspace:initiatives"` permission to depend on the new `"hub:project:associations"`

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.