### PR TITLE
feat: 9161 follow card schema update

### DIFF
--- a/packages/common/src/core/schemas/internal/follow/FollowCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/follow/FollowCardUiSchema.ts
@@ -17,7 +17,7 @@ export const buildUiSchema = (
     elements: [
       {
         label: "Select Entity to Follow",
-        scope: "/properties/followedItemId",
+        scope: "/properties/entityId",
         type: "Control",
         options: {
           control: "hub-field-input-gallery-picker",
@@ -33,7 +33,7 @@ export const buildUiSchema = (
                     {
                       predicates: [
                         {
-                          type: "Hub Project",
+                          type: "Hub Site Application",
                         },
                       ],
                     },
@@ -46,40 +46,39 @@ export const buildUiSchema = (
       },
       {
         label: "Call-to-Action",
-        scope: "/properties/callToAction",
+        scope: "/properties/callToActionText",
         type: "Control",
+        options: {
+          type: "textarea",
+          rows: 4,
+        },
       },
       {
         label: "Alignment",
-        scope: "/properties/callToActionAlignment",
+        scope: "/properties/callToActionAlign",
         type: "Control",
         options: {
           control: "hub-field-input-alignment",
+          layout: "inline-space-between",
         },
       },
       {
-        label: "Button State",
-        scope: "/properties/followStateText",
+        label: "Follow",
+        scope: "/properties/buttonText",
         type: "Control",
-        options: {
-          control: "hub-field-input-input",
-          type: "textarea",
-        },
       },
       {
-        scope: "/properties/unfollowStateText",
+        label: "Unfollow",
+        scope: "/properties/unfollowButtonText",
         type: "Control",
-        options: {
-          control: "hub-field-input-input",
-          type: "textarea",
-        },
       },
       {
         label: "Button Alignment",
-        scope: "/properties/callToActionAlignment",
+        scope: "/properties/buttonAlign",
         type: "Control",
         options: {
           control: "hub-field-input-alignment",
+          layout: "inline-space-between",
         },
       },
       {
@@ -88,7 +87,7 @@ export const buildUiSchema = (
         type: "Control",
         options: {
           control: "hub-field-input-select",
-          labels: ["Solid Background", "Ounline"],
+          labels: ["Solid Background", "Outline"],
         },
       },
     ],

--- a/packages/common/src/core/schemas/internal/follow/FollowSchema.ts
+++ b/packages/common/src/core/schemas/internal/follow/FollowSchema.ts
@@ -12,25 +12,28 @@ export const FollowSchema: IConfigurationSchema = {
       maxItems: 10,
       default: [],
     },
-    callToAction: {
+    entityId: {
+      type: "string",
+    },
+    callToActionText: {
       type: "string",
       default:
         "By following this site you will get updates about new events, surveys, and tools that you can use to help us achieve our goals.",
     },
-    callToActionAlignment: {
+    callToActionAlign: {
       enum: ["start", "center", "end"],
       default: "center",
       type: "string",
     },
-    followStateText: {
+    buttonText: {
       type: "string",
       default: "Follow",
     },
-    unfollowStateText: {
+    unfollowButtonText: {
       type: "string",
       default: "Unfollow",
     },
-    buttonAlignment: {
+    buttonAlign: {
       enum: ["start", "center", "end"],
       default: "center",
       type: "string",

--- a/packages/common/test/core/schemas/internal/follow/FollowCardUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/follow/FollowCardUiSchema.test.ts
@@ -8,10 +8,11 @@ describe("buildUiSchema: follow", () => {
 
     expect(uiSchema.type).toBe("Layout");
     expect(uiSchema.elements?.length).toBe(7);
-    expect(uiSchema.elements![0].scope).toBe("/properties/followedItemId");
+    expect(uiSchema.elements![0].scope).toBe("/properties/entityId");
     expect(uiSchema.elements![0].options!.control).toBe(
       "hub-field-input-gallery-picker"
     );
     // TODO: add more explicit tests when we complete the ui schema
+    // (still waiting for final card editor design)
   });
 });


### PR DESCRIPTION
1. Description:

Update some follow card schema and UiSchema to better align with the design

1. Instructions for testing:

1. Closes Issues: [9161](https://zentopia.esri.com/workspaces/sprint-board-60340b9721bc3a4ab6367db5/issues/gh/dc/hub/9161)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
