### PR TITLE
fix: fix the keyboard permission!

### DIFF
--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -24,6 +24,7 @@ const SystemPermissions = [
   "hub:feature:user:preferences",
   "hub:card:follow",
   "hub:feature:workspace:umbrella",
+  "hub:feature:keyboardshortcuts",
 ];
 
 const validPermissions = [


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Ugh i forgot something with the last pr

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
