### PR TITLE
fix(): constructSlug accounts for typekeyword max length of 256 chars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.88.0",
+			"version": "14.90.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22688,9 +22688,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22705,21 +22706,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22733,9 +22737,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22753,9 +22758,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -83465,7 +83471,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83480,17 +83487,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83504,7 +83514,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83521,7 +83532,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/items/slugs.ts
+++ b/packages/common/src/items/slugs.ts
@@ -4,9 +4,9 @@ import { IItem } from "@esri/arcgis-rest-types";
 import { slugify } from "../utils";
 import { uriSlugToKeywordSlug } from "./_internal/slugConverters";
 
-export const TYPEKEYWORD_SLUG_PREFIX = "slug";
+const TYPEKEYWORD_SLUG_PREFIX = "slug";
 
-export const TYPEKEYWORD_MAX_LENGTH = 256;
+const TYPEKEYWORD_MAX_LENGTH = 256;
 
 /**
  * Create a slug, namespaced to an org and accounting for the 256 character limit

--- a/packages/common/test/items/slugs.test.ts
+++ b/packages/common/test/items/slugs.test.ts
@@ -174,6 +174,30 @@ describe("slug utils: ", () => {
       expect(args.authentication).toBe(MOCK_AUTH);
     });
 
+    it("does not add slug prefix when already present", async () => {
+      const searchSpy = spyOn(portalModule, "searchItems").and.returnValue(
+        Promise.resolve({
+          results: [
+            { id: "3ef", title: "Fake", typeKeywords: ["one", "slug|foo-bar"] },
+          ],
+        })
+      );
+
+      const results = await slugModule.findItemsBySlug(
+        { slug: "slug|foo-bar", exclude: "bc3" },
+        {
+          authentication: MOCK_AUTH,
+        }
+      );
+      expect(results[0].id).toBe("3ef");
+      // check if
+      expect(searchSpy.calls.count()).toBe(1);
+      const args = searchSpy.calls.argsFor(0)[0] as unknown as ISearchOptions;
+      expect(args.filter).toBe(`typekeywords:"slug|foo-bar"`);
+      expect(args.q).toBe(`NOT id:bc3`);
+      expect(args.authentication).toBe(MOCK_AUTH);
+    });
+
     it("passes an undefined q query when no exclusion is provided", async () => {
       const searchSpy = spyOn(portalModule, "searchItems").and.returnValue(
         Promise.resolve({

--- a/packages/common/test/items/slugs.test.ts
+++ b/packages/common/test/items/slugs.test.ts
@@ -12,6 +12,24 @@ describe("slug utils: ", () => {
       expect(slugModule.constructSlug("E2E Test Project", "qa-bas-hub")).toBe(
         "qa-bas-hub|e2e-test-project"
       );
+      expect(
+        slugModule.constructSlug(
+          "A really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really long title",
+          "qa-bas-hub"
+        )
+      ).toBe(
+        "qa-bas-hub|a-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-rea",
+        "does not exceed 256 chars taking into account slug prefix and orgKey"
+      );
+      expect(
+        slugModule.constructSlug(
+          "A really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really reallllly really long title",
+          "qa-bas-hub"
+        )
+      ).toBe(
+        "qa-bas-hub|a-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-reallllly",
+        "does not end with hyphen"
+      );
     });
   });
   describe("setSlugKeyword:", () => {
@@ -269,6 +287,26 @@ describe("slug utils: ", () => {
       expect(args.authentication).toBe(MOCK_AUTH);
       expect(slug).toBe("foo-bar");
     });
+    it("excludes item with existingId", async () => {
+      const searchSpy = spyOn(portalModule, "searchItems").and.returnValue(
+        Promise.resolve({
+          results: [],
+        })
+      );
+      const slug = await slugModule.getUniqueSlug(
+        { slug: "foo-bar", existingId: "31c" },
+        {
+          authentication: MOCK_AUTH,
+        }
+      );
+
+      expect(searchSpy.calls.count()).toBe(1);
+      const args = searchSpy.calls.argsFor(0)[0] as unknown as ISearchOptions;
+      expect(args.filter).toBe(`typekeywords:"slug|foo-bar"`);
+      expect(args.authentication).toBe(MOCK_AUTH);
+      expect(args.q).toBe("NOT id:31c");
+      expect(slug).toBe("foo-bar");
+    });
     it("increments if item found", async () => {
       let callCount = 0;
       // semantics for jasmine spies are lacking
@@ -276,7 +314,7 @@ describe("slug utils: ", () => {
         const response = {
           results: [] as portalModule.IItem[],
         };
-        if (callCount === 0) {
+        if (callCount < 2) {
           response.results.push({
             id: "3ef",
             title: "Fake",
@@ -293,12 +331,14 @@ describe("slug utils: ", () => {
           authentication: MOCK_AUTH,
         }
       );
-      expect(slug).toBe("foo-bar-1");
-      expect(searchSpy.calls.count()).toBe(2);
+      expect(slug).toBe("foo-bar-2");
+      expect(searchSpy.calls.count()).toBe(3);
       const args = searchSpy.calls.argsFor(0)[0] as unknown as ISearchOptions;
       expect(args.filter).toBe(`typekeywords:"slug|foo-bar"`);
       const args2 = searchSpy.calls.argsFor(1)[0] as unknown as ISearchOptions;
       expect(args2.filter).toBe(`typekeywords:"slug|foo-bar-1"`);
+      const args3 = searchSpy.calls.argsFor(2)[0] as unknown as ISearchOptions;
+      expect(args3.filter).toBe(`typekeywords:"slug|foo-bar-2"`);
     });
     it("re-throws exceptions", async () => {
       const searchSpy = spyOn(portalModule, "searchItems").and.returnValue(


### PR DESCRIPTION
1. Description:
[9306](https://devtopia.esri.com/dc/hub/issues/9306)

- Refactors `constructSlug` to take into account that individual typeKeywords have a max length of 256 characters

1. Instructions for testing:

1. Closes Issues: #9306 (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
