### PR TITLE
feat: context has user history

### DIFF
--- a/packages/common/src/core/hubHistory.ts
+++ b/packages/common/src/core/hubHistory.ts
@@ -1,0 +1,121 @@
+import { cloneObject } from "../util";
+import { HubEntityType } from "./types/HubEntityType";
+
+/**
+ * History is a way to track a set of sites/projects/initiatives/pages that a user has visited
+ * Any content can be added to the history, but there will be different limits for different types
+ * Please see the addHistoryEntry function for more details
+ */
+export interface IHubHistory {
+  // Modelled as an object so we can easily extend without requiring a schema change
+  entries: IHubHistoryEntry[];
+}
+
+/**
+ * History entry
+ */
+export interface IHubHistoryEntry {
+  /**
+   * Entity Type
+   */
+  type: HubEntityType;
+  /**
+   * What action was last taken on the entity
+   * In the future this can expand to "replied to", "shared with" etc
+   */
+  action: "view" | "workspace";
+  /**
+   * Url the user visited
+   */
+  url: string;
+  /**
+   * Unique identifier for the entity
+   */
+  id: string;
+  /**
+   * Title of the entity
+   */
+  title: string;
+  /**
+   * Owner of the entity
+   */
+  owner?: string;
+  /**
+   * timestamp the entity was last visited
+   */
+  visited?: number;
+  /**
+   * Additional parameters that can be used to rehydrate the entity
+   */
+  params?: any;
+}
+
+/**
+ * Add an entry to the history. This handles the limits per type,
+ * and ensures that the most recent entry is at the top of the list.
+ * This function does not persist the history, it only updates the object.
+ * @param entry
+ * @param history
+ * @returns
+ */
+export function addHistoryEntry(
+  entry: IHubHistoryEntry,
+  history: IHubHistory
+): IHubHistory {
+  // Define limits to how many of each type of history we store
+  const limits = {
+    sites: 10,
+    entities: 50,
+  };
+
+  // Anything other than "site" is considered an "entity" for history purposes
+  // When we disply the list of history, we use the underlying type to determine the icon and route
+  const type = entry.type === "site" ? "sites" : "entities";
+  // get a clone of the existing entries
+  let entries: IHubHistoryEntry[] = cloneObject(history.entries);
+  // split into two arrays, one for the type and one for everything else
+  const siteEntries = entries.filter((e) => e.type === "site");
+  const otherEntries = entries.filter((e) => e.type !== "site");
+
+  // Depending on the type, choose the list to work with
+  if (entry.type === "site") {
+    entries = siteEntries;
+  } else {
+    entries = otherEntries;
+  }
+  // If there is an existing entry, remove it
+  entries = entries.filter((e) => e.id !== entry.id);
+  // if the count of the type is below the limit, add the new entry to the start of the array
+  if (entries.length < limits[type]) {
+    entries.unshift(entry);
+  } else {
+    // otherwise, remove the last entry and add the new entry to the start of the array
+    entries.pop();
+    entries.unshift(entry);
+  }
+  // merge up the arrays and sort by visited date
+  // depending on tne type, we may need to merge the arrays in a different order
+  if (entry.type === "site") {
+    history.entries = [...entries, ...otherEntries];
+  } else {
+    history.entries = [...siteEntries, ...entries];
+  }
+
+  // return the updated history
+  return history;
+}
+
+/**
+ * Remove a specific entry from the user's history
+ * @param entry
+ * @returns
+ */
+export function removeHistoryEntry(
+  entry: IHubHistoryEntry,
+  history: IHubHistory
+): IHubHistory {
+  // remove the entry from the history
+  const updated = cloneObject(history);
+  updated.entries = updated.entries.filter((e) => e.id !== entry.id);
+  return updated;
+}

--- a/packages/common/src/core/index.ts
+++ b/packages/common/src/core/index.ts
@@ -10,6 +10,7 @@ export * from "./getRelativeWorkspaceUrl";
 export * from "./isValidEntityType";
 export * from "./processActionLinks";
 
-// For sme reason, if updateHubEntity is exported here,
-// it is not actually exported in the final package.
+// For sme reason, if these are exported here,
+// they are not actually exported in the final package.
 // export * from "./updateHubEntity";
+// export * from "./hubHistory";

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -48,6 +48,7 @@ export * from "./core/EntityEditor";
 // Unclear _why_ this needs to be here vs. in search/index.ts
 // but if it's exported there, it's not actually exporeted
 export * from "./search/explainQueryResult";
+export * from "./core/hubHistory";
 
 import OperationStack from "./OperationStack";
 import OperationError from "./OperationError";

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -127,6 +127,13 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
   {
     // when enabled keyboard shortcuts will be available
     permission: "hub:feature:keyboardshortcuts",
+    availability: ["alpha"],
+    environments: ["devext", "qaext"],
+  },
+  {
+    // Enables the history feature
+    permission: "hub:feature:history",
+    availability: ["alpha"],
     environments: ["devext", "qaext"],
   },
 ];

--- a/packages/common/src/permissions/checkPermission.ts
+++ b/packages/common/src/permissions/checkPermission.ts
@@ -108,7 +108,7 @@ export function checkPermission(
 
   // We also check the context.userHubSettings.preview array
   // which can also be used to enable features.
-  if (context.userHubSettings?.preview) {
+  if (context.userHubSettings.preview) {
     const preview = getWithDefault(
       context,
       "userHubSettings.preview",

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -25,6 +25,7 @@ const SystemPermissions = [
   "hub:card:follow",
   "hub:feature:workspace:umbrella",
   "hub:feature:keyboardshortcuts",
+  "hub:feature:history",
 ];
 
 const validPermissions = [

--- a/packages/common/src/utils/hubUserAppResources.ts
+++ b/packages/common/src/utils/hubUserAppResources.ts
@@ -14,6 +14,7 @@ import {
   setUserResource,
 } from "./internal/userAppResources";
 import { fetchAndMigrateUserHubSettings } from "./internal/fetchAndMigrateUserHubSettings";
+import { IHubHistory } from "../core/hubHistory";
 
 /**
  * Site Level Settings
@@ -50,6 +51,10 @@ export interface IUserHubSettings {
      */
     workspace: boolean;
   };
+  /**
+   * Optional history of sites/content the user has visited
+   */
+  history?: IHubHistory;
 }
 
 /**

--- a/packages/common/test/ArcGISContext.test.ts
+++ b/packages/common/test/ArcGISContext.test.ts
@@ -1,0 +1,289 @@
+import { IHubHistoryEntry } from "../src/core/hubHistory";
+import { HubEntityType } from "../src/core/types/HubEntityType";
+import { createId } from "../src/util";
+import { createMockContext, createMockAnonContext } from "./mocks/mock-auth";
+import { IUserHubSettings } from "../src";
+import * as PermissionsModule from "../src/permissions/checkPermission";
+import * as UserSettingsModule from "../src/utils/hubUserAppResources";
+import { IHubHistory } from "../dist/types";
+
+describe("ArcGISContext:", () => {
+  describe("history:", () => {
+    it("empty context returns stucture", () => {
+      const ctx = createMockContext();
+      expect(ctx.history).toBeDefined();
+      expect(ctx.history).toEqual({ entries: [] });
+    });
+    describe("addToHistory: ", () => {
+      it(" adds entry and updates userHubSettings", async () => {
+        const ctx = createMockContext();
+        // We don't flex the limits etc as all that's handled in the util fn
+        // create spy on updateUserHubSettings method
+        const updateSettingsSpy = spyOn(
+          ctx,
+          "updateUserHubSettings"
+        ).and.callFake(() => Promise.resolve());
+        // ensure checkPermission returns access:true
+        const permissionSpy = spyOn(ctx, "checkPermission").and.returnValue({
+          access: true,
+        } as any);
+
+        await ctx.addToHistory(createFakeHistoryEntry("site"));
+
+        expect(ctx.history.entries.length).toBe(1);
+        expect(updateSettingsSpy).toHaveBeenCalled();
+        expect(permissionSpy).toHaveBeenCalled();
+        // get the args from the first call
+        const args = updateSettingsSpy.calls.first()
+          .args[0] as unknown as IUserHubSettings;
+        expect(args.history).toEqual(ctx.history);
+      });
+      it("exits early if user lacks permission", async () => {
+        const ctx = createMockContext();
+        const updateSettingsSpy = spyOn(
+          ctx,
+          "updateUserHubSettings"
+        ).and.callFake(() => Promise.resolve());
+        // ensure checkPermission returns access:true
+        const permissionSpy = spyOn(ctx, "checkPermission").and.returnValue({
+          access: false,
+        } as any);
+
+        await ctx.addToHistory(createFakeHistoryEntry("site"));
+
+        expect(ctx.history.entries.length).toBe(0);
+        expect(updateSettingsSpy).not.toHaveBeenCalled();
+        expect(permissionSpy).toHaveBeenCalled();
+      });
+      it("early exits if not authd", async () => {
+        const anonCtx = createMockAnonContext();
+        const updateSettingsSpy = spyOn(
+          anonCtx,
+          "updateUserHubSettings"
+        ).and.callFake(() => Promise.resolve());
+
+        const permissionSpy = spyOn(anonCtx, "checkPermission").and.returnValue(
+          {
+            access: false,
+          } as any
+        );
+
+        await anonCtx.addToHistory(createFakeHistoryEntry("site"));
+
+        expect(anonCtx.history.entries.length).toBe(0);
+        expect(updateSettingsSpy).not.toHaveBeenCalled();
+        expect(permissionSpy).not.toHaveBeenCalled();
+      });
+    });
+    describe("removeFromHistory:", () => {
+      it("removeFromHistory removes entry and updates userHubSettings", async () => {
+        const ctx = createMockContext();
+        // create spy on updateUserHubSettings method
+        const updateSettingsSpy = spyOn(
+          ctx,
+          "updateUserHubSettings"
+        ).and.callFake(() => Promise.resolve());
+        const permissionSpy = spyOn(ctx, "checkPermission").and.returnValue({
+          access: true,
+        } as any);
+        const entry = createFakeHistoryEntry("site");
+        await ctx.addToHistory(entry);
+        expect(ctx.history.entries.length).toBe(1);
+        // now remove it
+        await ctx.removeFromHistory(entry);
+        expect(ctx.history.entries.length).toBe(0);
+        expect(updateSettingsSpy).toHaveBeenCalledTimes(2);
+        expect(permissionSpy).toHaveBeenCalledTimes(2);
+      });
+      it("early exits if not authd", async () => {
+        const anonCtx = createMockAnonContext();
+        const updateSettingsSpy = spyOn(
+          anonCtx,
+          "updateUserHubSettings"
+        ).and.callFake(() => Promise.resolve());
+
+        const permissionSpy = spyOn(anonCtx, "checkPermission").and.returnValue(
+          {
+            access: false,
+          } as any
+        );
+
+        await anonCtx.removeFromHistory(createFakeHistoryEntry("site"));
+
+        expect(anonCtx.history.entries.length).toBe(0);
+        expect(updateSettingsSpy).not.toHaveBeenCalled();
+        expect(permissionSpy).not.toHaveBeenCalled();
+      });
+
+      it("exits early if user lacks permission", async () => {
+        const ctx = createMockContext();
+        const updateSettingsSpy = spyOn(
+          ctx,
+          "updateUserHubSettings"
+        ).and.callFake(() => Promise.resolve());
+        // ensure checkPermission returns access:true
+        const permissionSpy = spyOn(ctx, "checkPermission").and.returnValue({
+          access: false,
+        } as any);
+
+        await ctx.removeFromHistory(createFakeHistoryEntry("site"));
+
+        expect(ctx.history.entries.length).toBe(0);
+        expect(updateSettingsSpy).not.toHaveBeenCalled();
+        expect(permissionSpy).toHaveBeenCalled();
+      });
+    });
+    describe("clearHistory:", () => {
+      it("clears all entries", async () => {
+        const ctx = createMockContext();
+        // We don't flex the limits etc as all that's handled in the util fn
+        // create spy on updateUserHubSettings method
+        const updateSettingsSpy = spyOn(
+          ctx,
+          "updateUserHubSettings"
+        ).and.callFake(() => Promise.resolve());
+        // ensure checkPermission returns access:true
+        const permissionSpy = spyOn(ctx, "checkPermission").and.returnValue({
+          access: true,
+        } as any);
+
+        await ctx.addToHistory(createFakeHistoryEntry("site"));
+        await ctx.addToHistory(createFakeHistoryEntry("project"));
+
+        expect(ctx.history.entries.length).toBe(2);
+        await ctx.clearHistory();
+        expect(ctx.history.entries.length).toBe(0);
+        expect(updateSettingsSpy).toHaveBeenCalledTimes(3);
+        expect(permissionSpy).toHaveBeenCalledTimes(3);
+      });
+      it("exits early if user lacks permission", async () => {
+        const ctx = createMockContext();
+        const updateSettingsSpy = spyOn(
+          ctx,
+          "updateUserHubSettings"
+        ).and.callFake(() => Promise.resolve());
+        // ensure checkPermission returns access:true
+        const permissionSpy = spyOn(ctx, "checkPermission").and.returnValue({
+          access: false,
+        } as any);
+
+        await ctx.clearHistory();
+
+        expect(ctx.history.entries.length).toBe(0);
+        expect(updateSettingsSpy).not.toHaveBeenCalled();
+        expect(permissionSpy).toHaveBeenCalled();
+      });
+      it("early exits if not authd", async () => {
+        const anonCtx = createMockAnonContext();
+        const updateSettingsSpy = spyOn(
+          anonCtx,
+          "updateUserHubSettings"
+        ).and.callFake(() => Promise.resolve());
+
+        const permissionSpy = spyOn(anonCtx, "checkPermission").and.returnValue(
+          {
+            access: false,
+          } as any
+        );
+
+        await anonCtx.clearHistory();
+
+        expect(anonCtx.history.entries.length).toBe(0);
+        expect(updateSettingsSpy).not.toHaveBeenCalled();
+        expect(permissionSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+  describe("checkPermission:", () => {
+    it("delegates to checkPermission", () => {
+      const ctx = createMockContext();
+      const permissionSpy = spyOn(
+        PermissionsModule,
+        "checkPermission"
+      ).and.returnValue({
+        access: true,
+      } as any);
+      const chk = ctx.checkPermission("hub:feature:workspace");
+      expect(chk.access).toEqual(true);
+      expect(permissionSpy).toHaveBeenCalled();
+      // get the first arg for the first call
+      expect(permissionSpy.calls.first().args[0]).toEqual(
+        "hub:feature:workspace"
+      );
+    });
+  });
+  describe("updateUserHubSettings:", () => {
+    it("early exits if not authd", async () => {
+      const uarSpy = spyOn(
+        UserSettingsModule,
+        "updateUserHubSettings"
+      ).and.callFake(() => Promise.resolve());
+      const anonCtx = createMockAnonContext();
+      try {
+        await anonCtx.updateUserHubSettings({} as IUserHubSettings);
+      } catch (ex) {
+        // we expect this to throw
+        expect((ex as any).message).toEqual(
+          "Cannot update user hub settings without an authenticated user"
+        );
+      }
+      expect(uarSpy).not.toHaveBeenCalled();
+    });
+    it("stores settings", async () => {
+      const uarSpy = spyOn(
+        UserSettingsModule,
+        "updateUserHubSettings"
+      ).and.callFake(() => Promise.resolve());
+      const ctx = createMockContext();
+      await ctx.updateUserHubSettings({
+        schemaVersion: 1,
+        history: { entries: ["WAT"] },
+      } as unknown as IUserHubSettings);
+      expect(uarSpy).toHaveBeenCalled();
+      expect(uarSpy.calls.first().args[0]).toEqual({
+        schemaVersion: 1,
+        history: { entries: ["WAT"] },
+      });
+      expect(ctx.history).toEqual({
+        entries: ["WAT"],
+      } as unknown as IHubHistory);
+    });
+    it("adds and deletes feature flags", async () => {
+      const uarSpy = spyOn(
+        UserSettingsModule,
+        "updateUserHubSettings"
+      ).and.callFake(() => Promise.resolve());
+      const ctx = createMockContext();
+      await ctx.updateUserHubSettings({
+        schemaVersion: 1,
+        preview: {
+          workspace: true,
+        },
+      } as unknown as IUserHubSettings);
+      expect(uarSpy).toHaveBeenCalled();
+      expect(ctx.featureFlags["hub:feature:workspace"]).toBeDefined();
+      await ctx.updateUserHubSettings({
+        schemaVersion: 1,
+        preview: {
+          workspace: false,
+        },
+      } as unknown as IUserHubSettings);
+      expect(ctx.featureFlags["hub:feature:workspace"]).not.toBeDefined();
+    });
+  });
+});
+
+function createFakeHistoryEntry(type: HubEntityType): IHubHistoryEntry {
+  const id = createId("h");
+  // Create a random visited timestamp that is in the past
+  const visited = Date.now() - Math.floor(Math.random() * 100000);
+  return {
+    id,
+    type,
+    title: `Fake ${type} ${id}`,
+    url: `https://hub.arcgis.com/workspaces/${type}s/${id}`,
+    visited,
+    action: "view",
+    params: {},
+  };
+}

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -299,7 +299,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.trustedOrgIds).toEqual([]);
       expect(mgr.context.trustedOrgs).toEqual([]);
       expect(mgr.context.userResourceTokens).toEqual([]);
-      expect(mgr.context.userHubSettings).toBeNull();
+      expect(mgr.context.userHubSettings).toEqual({ schemaVersion: 1 });
       expect(mgr.context.isAlphaOrg).toEqual(false);
       expect(mgr.context.isBetaOrg).toEqual(false);
     });

--- a/packages/common/test/core/hubHistory.test.ts
+++ b/packages/common/test/core/hubHistory.test.ts
@@ -1,0 +1,101 @@
+import {
+  IHubHistory,
+  IHubHistoryEntry,
+  addHistoryEntry,
+  removeHistoryEntry,
+} from "../../src/core/hubHistory";
+import { HubEntityType } from "../../src/core/types/HubEntityType";
+import { createId } from "../../src/util";
+
+describe("hubHistory:", () => {
+  describe("simple add and remove:", () => {
+    it("adding site entry", () => {
+      const history: IHubHistory = { entries: [] };
+      const entry = createFakeHistoryEntry("site");
+      const updated = addHistoryEntry(entry, history);
+      expect(updated.entries.length).toBe(1);
+      expect(updated.entries[0].id).toBe(entry.id);
+    });
+    it("adding entity entry", () => {
+      const history: IHubHistory = { entries: [] };
+      const entry = createFakeHistoryEntry("project");
+      const updated = addHistoryEntry(entry, history);
+      expect(updated.entries.length).toBe(1);
+      expect(updated.entries[0].id).toBe(entry.id);
+    });
+    it("adding newer entity entry", () => {
+      const history: IHubHistory = { entries: [] };
+      const entry = createFakeHistoryEntry("project");
+      const updated = addHistoryEntry(entry, history);
+      expect(updated.entries.length).toBe(1);
+      expect(updated.entries[0].id).toBe(entry.id);
+      entry.visited = Date.now();
+      const updated2 = addHistoryEntry(entry, updated);
+      expect(updated2.entries.length).toBe(1);
+      expect(updated2.entries[0].id).toBe(entry.id);
+      // verify that the visited date is updated
+      expect(updated2.entries[0].visited).toBe(entry.visited);
+    });
+    it("removing entry", () => {
+      const history: IHubHistory = { entries: [] };
+      for (let i = 0; i < 3; i++) {
+        history.entries.push(createFakeHistoryEntry("site"));
+      }
+      // get the second entry and remove it
+      const entry = history.entries[1];
+
+      const removed = removeHistoryEntry(entry, history);
+      expect(removed.entries.length).toBe(2);
+      // ensure the id of the removed entry is not present
+      expect(removed.entries.filter((e) => e.id === entry.id).length).toBe(0);
+    });
+  });
+  describe("limits:", () => {
+    const history: IHubHistory = { entries: [] };
+    beforeAll(() => {
+      // Load up the history with 10 sites and 50 entities so we're at the limits
+      for (let i = 0; i < 10; i++) {
+        history.entries.push(createFakeHistoryEntry("site"));
+      }
+
+      for (let i = 0; i < 50; i++) {
+        history.entries.push(createFakeHistoryEntry("project"));
+      }
+    });
+    it("adding site entry respects limits", () => {
+      const entry = createFakeHistoryEntry("site");
+      const updated = addHistoryEntry(entry, history);
+      // Should still be 10 sites
+      expect(updated.entries.filter((e) => e.type === "site").length).toBe(10);
+      // Should still be 50 projects
+      expect(updated.entries.filter((e) => e.type === "project").length).toBe(
+        50
+      );
+    });
+    it("adding entity entry respects limits", () => {
+      const entry = createFakeHistoryEntry("project");
+      const updated = addHistoryEntry(entry, history);
+      // Should still be 10 sites
+      expect(updated.entries.filter((e) => e.type === "site").length).toBe(10);
+      // Should still be 50 projects
+      expect(updated.entries.filter((e) => e.type === "project").length).toBe(
+        50
+      );
+    });
+  });
+});
+
+function createFakeHistoryEntry(type: HubEntityType): IHubHistoryEntry {
+  const id = createId("h");
+  // Create a random visited timestamp that is in the past
+  const visited = Date.now() - Math.floor(Math.random() * 100000);
+  return {
+    id,
+    type,
+    title: `Fake ${type} ${id}`,
+    url: `https://hub.arcgis.com/workspaces/${type}s/${id}`,
+    visited,
+    action: "view",
+    params: {},
+  };
+}

--- a/packages/common/test/mocks/mock-auth.ts
+++ b/packages/common/test/mocks/mock-auth.ts
@@ -94,4 +94,93 @@ export const MOCK_CONTEXT = new ArcGISContext({
     "hub-search": "online",
     domains: "online",
   },
+  userHubSettings: {
+    schemaVersion: 1,
+  },
 }) as IArcGISContext;
+
+export const MOCK_ANON_CONTEXT = new ArcGISContext({
+  id: 123,
+  currentUser: null,
+  portalUrl: "https://qaext.arcgis.com",
+  hubUrl: "https://hubqa.arcgis.com",
+  authentication: null,
+  portalSelf: {
+    id: "123",
+    name: "My org",
+    isPortal: false,
+    urlKey: "www",
+  },
+  serviceStatus: {
+    portal: "online",
+    discussions: "online",
+    events: "online",
+    metrics: "online",
+    notifications: "online",
+    "hub-search": "online",
+    domains: "online",
+  },
+  userHubSettings: {
+    schemaVersion: 1,
+  },
+}) as IArcGISContext;
+
+export function createMockContext(): ArcGISContext {
+  return new ArcGISContext({
+    id: 123,
+    currentUser: {
+      username: "mock_user",
+      favGroupId: "456abc",
+      orgId: "789def",
+    },
+    portalUrl: "https://qaext.arcgis.com",
+    hubUrl: "https://hubqa.arcgis.com",
+    authentication: MOCK_AUTH,
+    portalSelf: {
+      id: "123",
+      name: "My org",
+      isPortal: false,
+      urlKey: "www",
+    },
+    serviceStatus: {
+      portal: "online",
+      discussions: "online",
+      events: "online",
+      metrics: "online",
+      notifications: "online",
+      "hub-search": "online",
+      domains: "online",
+    },
+    userHubSettings: {
+      schemaVersion: 1,
+    },
+  });
+}
+
+export function createMockAnonContext(): ArcGISContext {
+  return new ArcGISContext({
+    id: 123,
+    currentUser: null,
+    portalUrl: "https://qaext.arcgis.com",
+    hubUrl: "https://hubqa.arcgis.com",
+    authentication: null,
+    portalSelf: {
+      id: "123",
+      name: "My org",
+      isPortal: false,
+      urlKey: "www",
+    },
+    serviceStatus: {
+      portal: "online",
+      discussions: "online",
+      events: "online",
+      metrics: "online",
+      notifications: "online",
+      "hub-search": "online",
+      domains: "online",
+    },
+    userHubSettings: {
+      schemaVersion: 1,
+    },
+  });
+}


### PR DESCRIPTION
1. Description:

Add methods to context to add and removed entries from the auth'd users history, as well as option to clear the entire history. Also adds `updateUserHubSettings(...)` method as it was needed for the other methods, and streamlines some other use-cases

1. Instructions for testing: run tests

1. Closes Issues: #9265

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
