### PR TITLE
feat(): association group creation form and permission

### DIFF
--- a/packages/common/src/core/schemas/internal/getEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getEditorSchemas.ts
@@ -203,6 +203,8 @@ export async function getEditorSchemas(
       const groupModule = await {
         "hub:group:create:followers": () =>
           import("../../../groups/_internal/GroupUiSchemaCreateFollowers"),
+        "hub:group:create:association": () =>
+          import("../../../groups/_internal/GroupUiSchemaCreateAssociation"),
         "hub:group:edit": () =>
           import("../../../groups/_internal/GroupUiSchemaEdit"),
         "hub:group:settings": () =>

--- a/packages/common/src/core/schemas/internal/getEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getEditorSchemas.ts
@@ -5,6 +5,7 @@ import {
   IConfigurationSchema,
   IUiSchema,
   IEditorConfig,
+  IConfigurationValues,
 } from "../types";
 import { filterSchemaToUiSchema } from "./filterSchemaToUiSchema";
 import { SiteEditorType } from "../../../sites/_internal/SiteSchema";
@@ -46,6 +47,7 @@ export async function getEditorSchemas(
   // the entity type and the provided editor type
   let schema: IConfigurationSchema;
   let uiSchema: IUiSchema;
+  let defaults: IConfigurationValues;
   switch (editorType) {
     case "site":
       const { SiteSchema } = await import(
@@ -218,6 +220,12 @@ export async function getEditorSchemas(
         context
       );
 
+      defaults = await groupModule.buildDefaults(
+        i18nScope,
+        options as EntityEditorOptions,
+        context
+      );
+
       break;
 
     case "initiativeTemplate":
@@ -254,5 +262,5 @@ export async function getEditorSchemas(
   // filter out properties not used in the UI schema
   schema = filterSchemaToUiSchema(schema, uiSchema);
 
-  return Promise.resolve({ schema, uiSchema });
+  return Promise.resolve({ schema, uiSchema, defaults });
 }

--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -14,6 +14,7 @@ import { InitiativeTemplateEditorTypes } from "../../initiative-templates/_inter
 export interface IEditorConfig {
   schema: IConfigurationSchema;
   uiSchema: IUiSchema;
+  defaults?: IConfigurationValues;
 }
 
 /**

--- a/packages/common/src/groups/_internal/GroupSchema.ts
+++ b/packages/common/src/groups/_internal/GroupSchema.ts
@@ -13,6 +13,8 @@ export const GroupEditorTypes = [
   "hub:group:discussions",
   // editor to create a followers group
   "hub:group:create:followers",
+  // editor to create an association group
+  "hub:group:create:association",
 ] as const;
 
 /**

--- a/packages/common/src/groups/_internal/GroupUiSchemaCreateAssociation.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaCreateAssociation.ts
@@ -1,4 +1,8 @@
-import { IUiSchema, UiSchemaRuleEffects } from "../../core/schemas/types";
+import {
+  IConfigurationValues,
+  IUiSchema,
+  UiSchemaRuleEffects,
+} from "../../core/schemas/types";
 import { IArcGISContext } from "../../ArcGISContext";
 import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
 
@@ -113,5 +117,21 @@ export const buildUiSchema = async (
         ],
       },
     ],
+  };
+};
+
+export const buildDefaults = async (
+  i18nScope: string,
+  options: EntityEditorOptions,
+  context: IArcGISContext
+): Promise<IConfigurationValues> => {
+  const { name } = options;
+  return {
+    name: `${name} ${i18nScope}.associationGroup`,
+    summary: `${i18nScope}.createAssociationGroup.defaultSummary`,
+    access: "public",
+    isViewOnly: false,
+    autoJoin: false,
+    isInvitationOnly: false,
   };
 };

--- a/packages/common/src/groups/_internal/GroupUiSchemaCreateAssociation.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaCreateAssociation.ts
@@ -1,0 +1,117 @@
+import { IUiSchema, UiSchemaRuleEffects } from "../../core/schemas/types";
+import { IArcGISContext } from "../../ArcGISContext";
+import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
+
+/**
+ * @private
+ * constructs the complete uiSchema for creating an association
+ * group. This defines how the schema properties should be
+ * rendered in the association group creation experience
+ */
+export const buildUiSchema = async (
+  i18nScope: string,
+  options: EntityEditorOptions,
+  context: IArcGISContext
+): Promise<IUiSchema> => {
+  return {
+    type: "Layout",
+    elements: [
+      {
+        type: "Section",
+        options: { section: "stepper", scale: "l" },
+        elements: [
+          {
+            type: "Section",
+            labelKey: `${i18nScope}.sections.details.label`,
+            options: {
+              section: "step",
+            },
+            elements: [
+              {
+                labelKey: `${i18nScope}.fields.name.label`,
+                scope: "/properties/name",
+                type: "Control",
+                options: {
+                  messages: [
+                    {
+                      type: "ERROR",
+                      keyword: "required",
+                      icon: true,
+                      labelKey: `${i18nScope}.fields.name.requiredError`,
+                    },
+                    {
+                      type: "ERROR",
+                      keyword: "maxLength",
+                      icon: true,
+                      labelKey: `${i18nScope}.fields.name.maxLengthError`,
+                    },
+                  ],
+                },
+              },
+              {
+                labelKey: `${i18nScope}.fields.summary.label`,
+                scope: "/properties/summary",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-input",
+                  type: "textarea",
+                  rows: 4,
+                  messages: [
+                    {
+                      type: "ERROR",
+                      keyword: "maxLength",
+                      icon: true,
+                      labelKey: `${i18nScope}.fields.summary.maxLengthError`,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            type: "Section",
+            labelKey: `${i18nScope}.sections.membershipAccess.label`,
+            options: {
+              section: "step",
+            },
+            rule: {
+              effect: UiSchemaRuleEffects.DISABLE,
+              condition: {
+                scope: "/properties/name",
+                schema: { const: "" },
+              },
+            },
+            elements: [
+              {
+                labelKey: `${i18nScope}.fields.membershipAccess.label`,
+                scope: "/properties/membershipAccess",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-radio",
+                  labels: [
+                    `{{${i18nScope}.fields.membershipAccess.org:translate}}`,
+                    `{{${i18nScope}.fields.membershipAccess.collab:translate}}`,
+                    `{{${i18nScope}.fields.membershipAccess.createAssociation.any:translate}}`,
+                  ],
+                  disabled: [false, false, options.isSharedUpdate],
+                },
+              },
+              {
+                labelKey: `${i18nScope}.fields.contributeContent.label`,
+                scope: "/properties/isViewOnly",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-radio",
+                  labels: [
+                    `{{${i18nScope}.fields.contributeContent.all:translate}}`,
+                    `{{${i18nScope}.fields.contributeContent.createAssociation.admins:translate}}`,
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+};

--- a/packages/common/src/groups/_internal/GroupUiSchemaCreateFollowers.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaCreateFollowers.ts
@@ -1,4 +1,8 @@
-import { IUiSchema, UiSchemaRuleEffects } from "../../core/schemas/types";
+import {
+  IConfigurationValues,
+  IUiSchema,
+  UiSchemaRuleEffects,
+} from "../../core/schemas/types";
 import { IArcGISContext } from "../../ArcGISContext";
 import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
 
@@ -113,5 +117,30 @@ export const buildUiSchema = async (
         ],
       },
     ],
+  };
+};
+
+/**
+ * @private
+ * constructs the default values for creating a followers group.
+ * This is used to pre-populate the form with specific default values
+ * that are different from the normal Group Schema defualts.
+ * @param i18nScope
+ * @param options
+ * @param context
+ * @returns
+ */
+export const buildDefaults = async (
+  i18nScope: string,
+  options: EntityEditorOptions,
+  context: IArcGISContext
+): Promise<IConfigurationValues> => {
+  const { name } = options;
+  return {
+    name: `${name} ${i18nScope}.followers`,
+    summary: `${i18nScope}.createFollowersGroup.defaultSummary`,
+    access: "public",
+    isViewOnly: true,
+    autoJoin: true,
   };
 };

--- a/packages/common/src/groups/_internal/GroupUiSchemaDiscussions.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaDiscussions.ts
@@ -41,3 +41,11 @@ export const buildUiSchema = async (
     ],
   };
 };
+
+export const buildDefaults = async (
+  i18nScope: string,
+  options: EntityEditorOptions,
+  context: IArcGISContext
+): Promise<any> => {
+  return;
+};

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -91,3 +91,11 @@ export const buildUiSchema = async (
     ],
   };
 };
+
+export const buildDefaults = async (
+  i18nScope: string,
+  options: EntityEditorOptions,
+  context: IArcGISContext
+): Promise<any> => {
+  return;
+};

--- a/packages/common/src/groups/_internal/GroupUiSchemaSettings.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaSettings.ts
@@ -51,3 +51,11 @@ export const buildUiSchema = async (
     ],
   };
 };
+
+export const buildDefaults = async (
+  i18nScope: string,
+  options: EntityEditorOptions,
+  context: IArcGISContext
+): Promise<any> => {
+  return;
+};

--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -34,6 +34,7 @@ export const InitiativePermissions = [
   "hub:initiative:workspace:collaborators",
   "hub:initiative:workspace:content",
   "hub:initiative:workspace:metrics",
+  "hub:initiative:workspace:associationGroup:create",
   "hub:initiative:manage",
 ] as const;
 
@@ -147,5 +148,11 @@ export const InitiativePermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:initiative:manage",
     dependencies: ["hub:initiative:edit"],
+  },
+  // permission to create an association group
+  {
+    permission: "hub:initiative:workspace:associationGroup:create",
+    dependencies: ["hub:initiative:workspace:projects", "hub:group:create"],
+    privileges: ["portal:user:addExternalMembersToGroup"],
   },
 ];

--- a/packages/common/test/core/schemas/internal/getEditorSchemas.test.ts
+++ b/packages/common/test/core/schemas/internal/getEditorSchemas.test.ts
@@ -38,6 +38,7 @@ import * as GroupBuildEditUiSchema from "../../../../src/groups/_internal/GroupU
 import * as GroupBuildSettingsUiSchema from "../../../../src/groups/_internal/GroupUiSchemaSettings";
 import * as GroupBuildDiscussionsUiSchema from "../../../../src/groups/_internal/GroupUiSchemaDiscussions";
 import * as GroupBuildCreateFollowersUiSchema from "../../../../src/groups/_internal/GroupUiSchemaCreateFollowers";
+import * as GroupBuildCreateAssociationUiSchema from "../../../../src/groups/_internal/GroupUiSchemaCreateAssociation";
 
 import { InitiativeTemplateEditorTypes } from "../../../../src/initiative-templates/_internal/InitiativeTemplateSchema";
 import * as InitiativeTemplateBuildEditUiSchema from "../../../../src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit";
@@ -76,6 +77,7 @@ describe("getEditorSchemas: ", () => {
     { type: GroupEditorTypes[1], buildFn: GroupBuildSettingsUiSchema },
     { type: GroupEditorTypes[2], buildFn: GroupBuildDiscussionsUiSchema },
     { type: GroupEditorTypes[3], buildFn: GroupBuildCreateFollowersUiSchema },
+    { type: GroupEditorTypes[4], buildFn: GroupBuildCreateAssociationUiSchema },
     {
       type: InitiativeTemplateEditorTypes[0],
       buildFn: InitiativeTemplateBuildEditUiSchema,

--- a/packages/common/test/groups/_internal/GroupUiSchemaCreateAssociation.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaCreateAssociation.test.ts
@@ -1,0 +1,114 @@
+import { IHubGroup, UiSchemaRuleEffects } from "../../../src";
+import { buildUiSchema } from "../../../src/groups/_internal/GroupUiSchemaCreateAssociation";
+import { MOCK_CONTEXT } from "../../mocks/mock-auth";
+
+describe("buildUiSchema: create association group", () => {
+  it("returns the uiSchema to create a association group", async () => {
+    const uiSchema = await buildUiSchema(
+      "some.scope",
+      { isSharedUpdate: true } as IHubGroup,
+      MOCK_CONTEXT
+    );
+    expect(uiSchema).toEqual({
+      type: "Layout",
+      elements: [
+        {
+          type: "Section",
+          options: { section: "stepper", scale: "l" },
+          elements: [
+            {
+              type: "Section",
+              labelKey: "some.scope.sections.details.label",
+              options: {
+                section: "step",
+              },
+              elements: [
+                {
+                  labelKey: "some.scope.fields.name.label",
+                  scope: "/properties/name",
+                  type: "Control",
+                  options: {
+                    messages: [
+                      {
+                        type: "ERROR",
+                        keyword: "required",
+                        icon: true,
+                        labelKey: "some.scope.fields.name.requiredError",
+                      },
+                      {
+                        type: "ERROR",
+                        keyword: "maxLength",
+                        icon: true,
+                        labelKey: "some.scope.fields.name.maxLengthError",
+                      },
+                    ],
+                  },
+                },
+                {
+                  labelKey: "some.scope.fields.summary.label",
+                  scope: "/properties/summary",
+                  type: "Control",
+                  options: {
+                    control: "hub-field-input-input",
+                    type: "textarea",
+                    rows: 4,
+                    messages: [
+                      {
+                        type: "ERROR",
+                        keyword: "maxLength",
+                        icon: true,
+                        labelKey: "some.scope.fields.summary.maxLengthError",
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            {
+              type: "Section",
+              labelKey: "some.scope.sections.membershipAccess.label",
+              options: {
+                section: "step",
+              },
+              rule: {
+                effect: UiSchemaRuleEffects.DISABLE,
+                condition: {
+                  scope: "/properties/name",
+                  schema: { const: "" },
+                },
+              },
+              elements: [
+                {
+                  labelKey: "some.scope.fields.membershipAccess.label",
+                  scope: "/properties/membershipAccess",
+                  type: "Control",
+                  options: {
+                    control: "hub-field-input-radio",
+                    labels: [
+                      "{{some.scope.fields.membershipAccess.org:translate}}",
+                      "{{some.scope.fields.membershipAccess.collab:translate}}",
+                      "{{some.scope.fields.membershipAccess.createAssociation.any:translate}}",
+                    ],
+                    disabled: [false, false, true],
+                  },
+                },
+                {
+                  labelKey: "some.scope.fields.contributeContent.label",
+                  scope: "/properties/isViewOnly",
+                  type: "Control",
+                  options: {
+                    control: "hub-field-input-radio",
+                    labels: [
+                      "{{some.scope.fields.contributeContent.all:translate}}",
+                      "{{some.scope.fields.contributeContent.createAssociation.admins:translate}}",
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
