### PR TITLE
fix: remove group sharing

### DIFF
--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -25,9 +25,6 @@ export const GroupPermissions = [
   "hub:group:workspace:members",
   "hub:group:shareContent",
   "hub:group:manage",
-  "hub:group:share",
-  "hub:group:share:view",
-  "hub:group:share:edit",
 ] as const;
 
 /**
@@ -129,27 +126,5 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:group:manage",
     dependencies: ["hub:group:edit"],
-  },
-  // These are meant for checking if you can share a group when in the context of an entity that is not a group
-  {
-    permission: "hub:group:share",
-    dependencies: ["hub:group"],
-    authenticated: true,
-    privileges: ["portal:user:shareToGroup"],
-  },
-  {
-    permission: "hub:group:share:view",
-    dependencies: ["hub:group:share"],
-  },
-  {
-    permission: "hub:group:share:edit",
-    dependencies: ["hub:group:share"],
-    assertions: [
-      {
-        property: "context:currentUser.username",
-        type: "eq",
-        value: "entity:owner",
-      },
-    ],
   },
 ];


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
