### PR TITLE
fix: checkPermission tolerates context without userHubSettings

### DIFF
--- a/packages/common/src/permissions/checkPermission.ts
+++ b/packages/common/src/permissions/checkPermission.ts
@@ -108,7 +108,7 @@ export function checkPermission(
 
   // We also check the context.userHubSettings.preview array
   // which can also be used to enable features.
-  if (context.userHubSettings.preview) {
+  if (context.userHubSettings?.preview) {
     const preview = getWithDefault(
       context,
       "userHubSettings.preview",

--- a/packages/common/test/permissions/checkPermission.test.ts
+++ b/packages/common/test/permissions/checkPermission.test.ts
@@ -418,5 +418,11 @@ describe("checkPermission:", () => {
 
       expect(chk.access).toBe(true);
     });
+    it("tolerates context without userHubSettings", () => {
+      const localCtx = cloneObject(premiumCtxMgr.context);
+      delete localCtx.userHubSettings;
+      const chk = checkPermission("hub:feature:workspace", localCtx);
+      expect(chk.access).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
1. Description:

Since we don't enforce the passing of an `ArcGISContext` instance into `checkPermission`, we need to be tolerate of a context that does not have `userHubSettings` property.

1. Instructions for testing:

- run tests

1. Closes Issues: n/a

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
