### PR TITLE
fix: view edit isviewonly

### DIFF
--- a/packages/common/src/groups/getWellKnownGroup.ts
+++ b/packages/common/src/groups/getWellKnownGroup.ts
@@ -19,7 +19,7 @@ export function getWellKnownGroup(
       autoJoin: false,
       isInvitationOnly: false,
       hiddenMembers: false,
-      isViewOnly: true,
+      isViewOnly: false,
       tags: ["Hub Group"],
       membershipAccess: checkPermission(
         "platform:portal:user:addExternalMembersToGroup",
@@ -34,7 +34,7 @@ export function getWellKnownGroup(
       isSharedUpdate: true,
       isInvitationOnly: false,
       hiddenMembers: false,
-      isViewOnly: true,
+      isViewOnly: false,
       tags: ["Hub Group"],
       membershipAccess: checkPermission(
         "platform:portal:user:addExternalMembersToGroup",

--- a/packages/common/test/groups/getWellKnownGroup.test.ts
+++ b/packages/common/test/groups/getWellKnownGroup.test.ts
@@ -49,7 +49,7 @@ describe("getWellKnownGroup: ", () => {
       autoJoin: false,
       isInvitationOnly: false,
       hiddenMembers: false,
-      isViewOnly: true,
+      isViewOnly: false,
       tags: ["Hub Group"],
       membershipAccess: "organization",
     });
@@ -64,7 +64,7 @@ describe("getWellKnownGroup: ", () => {
       autoJoin: false,
       isInvitationOnly: false,
       hiddenMembers: false,
-      isViewOnly: true,
+      isViewOnly: false,
       tags: ["Hub Group"],
       membershipAccess: "anyone",
     });
@@ -77,7 +77,7 @@ describe("getWellKnownGroup: ", () => {
       isSharedUpdate: true,
       isInvitationOnly: false,
       hiddenMembers: false,
-      isViewOnly: true,
+      isViewOnly: false,
       tags: ["Hub Group"],
       membershipAccess: "organization",
     });
@@ -93,7 +93,7 @@ describe("getWellKnownGroup: ", () => {
       isSharedUpdate: true,
       isInvitationOnly: false,
       hiddenMembers: false,
-      isViewOnly: true,
+      isViewOnly: false,
       tags: ["Hub Group"],
       membershipAccess: "collaborators",
     });


### PR DESCRIPTION
1. Description: Per Jay we want to default to isViewOnly: false for view/edit groups.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
