### PR TITLE
fix: gate the new follow card behind the feature flag

### DIFF
--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -113,9 +113,13 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     environments: ["devext", "qaext"],
   },
   {
+    // When enabled, the new follow card will be loaded
+    // instead of the old follow initiative card.
+    // To enable it, we need to pass the feature flag
+    // (?pe=hub:card:follow) into the URL
     permission: "hub:card:follow",
     environments: ["qaext"],
-    availability: ["alpha"],
+    availability: ["flag"],
     licenses: ["hub-premium"],
   },
   {

--- a/packages/common/src/permissions/_internal/checkAvailability.ts
+++ b/packages/common/src/permissions/_internal/checkAvailability.ts
@@ -36,13 +36,23 @@ export function checkAvailability(
 
     // reduce over the policy.availability array, adding a check for each
     // value that is not included in the contextAvailability array
+    // the 'flag' is only used when we want to gate the feature behind
+    // a feature flag, e.g. ?pe=hub:card:follow
     checks = policy.availability.reduce((acc: IPolicyCheck[], value) => {
       let result: PolicyResponse = "granted";
       if (!contextAvailability.includes(value)) {
-        result = `not-${value}-org` as PolicyResponse;
+        if (value === "flag") {
+          result = `feature-flag-required`;
+        } else {
+          result = `not-${value}-org` as PolicyResponse;
+        }
+      }
+      let name = `user in ${value} org`;
+      if (value === "flag") {
+        name = `with feature flag`;
       }
       const check: IPolicyCheck = {
-        name: `user in ${value} org`,
+        name,
         value: contextAvailability.join(", "),
         code: getPolicyResponseCode(result),
         response: result,

--- a/packages/common/src/permissions/types/IPermissionPolicy.ts
+++ b/packages/common/src/permissions/types/IPermissionPolicy.ts
@@ -100,7 +100,7 @@ export interface IFeatureFlags extends Record<Permission, boolean> {}
 /**
  * Hub Availability levels
  */
-export type HubAvailability = "alpha" | "beta" | "general";
+export type HubAvailability = "alpha" | "beta" | "general" | "flag";
 
 /**
  * Hub Run-time environments

--- a/packages/common/src/permissions/types/PolicyResponse.ts
+++ b/packages/common/src/permissions/types/PolicyResponse.ts
@@ -45,4 +45,5 @@ export type PolicyResponse =
   | "feature-disabled" // feature has been disabled for the entity
   | "feature-enabled" // feature has been enabled for the entity
   | "not-in-environment" // user is not in an allowed environment
-  | "no-policy-exists"; // policy is not defined for this permission
+  | "no-policy-exists" // policy is not defined for this permission
+  | "feature-flag-required"; // feature flag is not passed;

--- a/packages/common/test/permissions/_internal/checkAvailability.test.ts
+++ b/packages/common/test/permissions/_internal/checkAvailability.test.ts
@@ -12,6 +12,11 @@ describe("checkAvailability: ", () => {
     availability: ["beta"],
   };
 
+  const policyFlag: IPermissionPolicy = {
+    permission: "hub:project",
+    availability: ["flag"],
+  };
+
   const policyGA: IPermissionPolicy = {
     permission: "hub:project",
     availability: ["general"],
@@ -71,6 +76,13 @@ describe("checkAvailability: ", () => {
     expect(checks4.length).toBe(1);
     expect(checks4[0].name).toBe("user in alpha org");
     expect(checks4[0].response).toBe("not-alpha-org");
+  });
+
+  it("fails check when policy is flag", () => {
+    const checks = checkAvailability(policyFlag, contextAlpha);
+    expect(checks.length).toBe(1);
+    expect(checks[0].name).toBe("with feature flag");
+    expect(checks[0].response).toBe("feature-flag-required");
   });
 
   it("should return an empty array when available is not defined in the policy", () => {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Add a 'flag' option to `HubAvailability` and gate the new follow card behind the feature flag (?pe=hub:card:follow)

1. Instructions for testing:

https://github.com/Esri/hub.js/assets/16672774/717667ac-cbe5-4953-8793-9cc45e5fa01b


1. Closes Issues: [9161](https://zentopia.esri.com/workspaces/sprint-board-60340b9721bc3a4ab6367db5/issues/gh/dc/hub/9161)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
