### PR TITLE
fix(): findItemsBySlug short-circuits to resolve empty array when slug is falsey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22688,10 +22688,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22706,24 +22705,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22737,10 +22733,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22758,10 +22753,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65016,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.91.0",
+			"version": "14.93.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -83471,8 +83465,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83487,20 +83480,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83514,8 +83504,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83532,8 +83521,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/items/slugs.ts
+++ b/packages/common/src/items/slugs.ts
@@ -106,13 +106,16 @@ export function getItemBySlug(
  * @param requestOptions
  * @returns
  */
-export function findItemsBySlug(
+export async function findItemsBySlug(
   slugInfo: {
     slug: string;
     exclude?: string;
   },
   requestOptions: IRequestOptions
 ): Promise<IItem[]> {
+  if (!slugInfo.slug) {
+    return [];
+  }
   const filter = slugInfo.slug.startsWith(`${TYPEKEYWORD_SLUG_PREFIX}|`)
     ? slugInfo.slug
     : [TYPEKEYWORD_SLUG_PREFIX, slugInfo.slug].join("|");
@@ -133,13 +136,12 @@ export function findItemsBySlug(
   if (slugInfo.exclude) {
     opts.q = `NOT id:${slugInfo.exclude}`;
   }
-  return searchItems(opts)
-    .then((response) => {
-      return response.results;
-    })
-    .catch((e) => {
-      throw e;
-    });
+  try {
+    const response = await searchItems(opts);
+    return response.results;
+  } catch (e) {
+    throw e;
+  }
 }
 
 /**

--- a/packages/common/test/items/slugs.test.ts
+++ b/packages/common/test/items/slugs.test.ts
@@ -150,6 +150,20 @@ describe("slug utils: ", () => {
   });
 
   describe("findItemsBySlug:", () => {
+    fit("short-circuits with an empty array when slugInfo.slug is falsey", async () => {
+      const searchSpy = spyOn(portalModule, "searchItems").and.returnValue(
+        Promise.resolve({ results: [] })
+      );
+
+      const results = await slugModule.findItemsBySlug(
+        { slug: "", exclude: "bc3" },
+        {
+          authentication: MOCK_AUTH,
+        }
+      );
+      expect(results).toEqual([]);
+      expect(searchSpy.calls.count()).toBe(0);
+    });
     it("excludes specific item", async () => {
       const searchSpy = spyOn(portalModule, "searchItems").and.returnValue(
         Promise.resolve({
@@ -166,7 +180,6 @@ describe("slug utils: ", () => {
         }
       );
       expect(results[0].id).toBe("3ef");
-      // check if
       expect(searchSpy.calls.count()).toBe(1);
       const args = searchSpy.calls.argsFor(0)[0] as unknown as ISearchOptions;
       expect(args.filter).toBe(`typekeywords:"slug|foo-bar"`);

--- a/packages/common/test/items/slugs.test.ts
+++ b/packages/common/test/items/slugs.test.ts
@@ -150,7 +150,7 @@ describe("slug utils: ", () => {
   });
 
   describe("findItemsBySlug:", () => {
-    fit("short-circuits with an empty array when slugInfo.slug is falsey", async () => {
+    it("short-circuits with an empty array when slugInfo.slug is falsey", async () => {
       const searchSpy = spyOn(portalModule, "searchItems").and.returnValue(
         Promise.resolve({ results: [] })
       );


### PR DESCRIPTION
1. Description:
[9306](https://devtopia.esri.com/dc/hub/issues/9306)

- Fixes regression related to searching for items by slug when the provided slug is falsey

1. Instructions for testing:

1. Closes Issues: #9306

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
