### PR TITLE
feat(hub-common): update events schema for onlineMeetings

### DIFF
--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -34,11 +34,21 @@ export type GetEventsParams = {
   start?: number;
 };
 
-export interface IUpdateRegistration {
+export interface ICreateRegistration {
+  /** ArcGIS Online id for a user. Will always be extracted from the token unless service token is used. */
+  agoId?: string;
+  /** Email for the subscriber. Will always be extracted from the token unless service token is used. */
+  email?: string;
+  /** Event id being registered for */
+  eventId: string;
+  /** First name for the subscriber. Will always be extracted from the token unless service token is used. */
+  firstName?: string;
+  /** Last name for the subscriber. Will always be extracted from the token unless service token is used. */
+  lastName?: string;
   /** Role of the user in the event */
   role?: RegistrationRole;
-  /** Status of the registration */
-  status?: RegistrationStatus;
+  /** Username for the subscriber. Will always be extracted from the token unless service token is used. */
+  username?: string;
 }
 
 export interface IUpdateEvent {
@@ -87,21 +97,11 @@ export enum RegistrationRole {
   ORGANIZER = "ORGANIZER",
   ATTENDEE = "ATTENDEE",
 }
-export interface ICreateRegistration {
-  /** ArcGIS Online id for a user. Will always be extracted from the token unless service token is used. */
-  agoId?: string;
-  /** Email for the subscriber. Will always be extracted from the token unless service token is used. */
-  email?: string;
-  /** Event id being registered for */
-  eventId: string;
-  /** First name for the subscriber. Will always be extracted from the token unless service token is used. */
-  firstName?: string;
-  /** Last name for the subscriber. Will always be extracted from the token unless service token is used. */
-  lastName?: string;
+export interface IUpdateRegistration {
   /** Role of the user in the event */
   role?: RegistrationRole;
-  /** Username for the subscriber. Will always be extracted from the token unless service token is used. */
-  username?: string;
+  /** Status of the registration */
+  status?: RegistrationStatus;
 }
 
 export interface IRegistration {
@@ -145,6 +145,15 @@ export interface IUser {
  * GeoJSON formatted geometry related to the event
  */
 export type ICreateEventGeometry = { [key: string]: any };
+
+export interface ICreateOnlineMeeting {
+  /** Capacity of the online meeting. Minimum value is 1 */
+  capacity?: number;
+  /** Details related to the online meeting */
+  details?: string;
+  /** Url for the online meeting */
+  url: string;
+}
 
 export enum EventAttendanceType {
   VIRTUAL = "VIRTUAL",
@@ -211,7 +220,7 @@ export interface ICreateEvent {
   /** Flag to notify attendees */
   notifyAttendees?: boolean;
   /** Online meetings for the event. Required if attendanceType includes VIRTUAL */
-  onlineMeetings?: ICreateAddress[];
+  onlineMeetings?: ICreateOnlineMeeting[];
   /** ISO8601 start date-time for the event */
   startDateTime: string;
   /** Summary of the event */

--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -34,6 +34,13 @@ export type GetEventsParams = {
   start?: number;
 };
 
+export interface IUpdateRegistration {
+  /** Role of the user in the event */
+  role?: RegistrationRole;
+  /** Status of the registration */
+  status?: RegistrationStatus;
+}
+
 export interface IUpdateEvent {
   [key: string]: any;
 }
@@ -80,13 +87,6 @@ export enum RegistrationRole {
   ORGANIZER = "ORGANIZER",
   ATTENDEE = "ATTENDEE",
 }
-export interface IUpdateRegistration {
-  /** Role of the user in the event */
-  role?: RegistrationRole;
-  /** Status of the registration */
-  status?: RegistrationStatus;
-}
-
 export interface ICreateRegistration {
   /** ArcGIS Online id for a user. Will always be extracted from the token unless service token is used. */
   agoId?: string;
@@ -104,18 +104,6 @@ export interface ICreateRegistration {
   username?: string;
 }
 
-export interface IUser {
-  agoId: string;
-  createdAt: string;
-  deleted: boolean;
-  email: string;
-  firstName: string;
-  lastName: string;
-  optedOut: boolean;
-  updatedAt: string;
-  username: string;
-}
-
 export interface IRegistration {
   createdAt: string;
   createdBy?: IUser;
@@ -128,6 +116,29 @@ export interface IRegistration {
   updatedAt: string;
   user?: IUser;
   userId: string;
+}
+
+export interface IOnlineMeeting {
+  capacity: number | null;
+  createdAt: string;
+  details: string | null;
+  event?: IEvent;
+  eventId: string;
+  id: string;
+  updatedAt: string;
+  url: string;
+}
+
+export interface IUser {
+  agoId: string;
+  createdAt: string;
+  deleted: boolean;
+  email: string;
+  firstName: string;
+  lastName: string;
+  optedOut: boolean;
+  updatedAt: string;
+  username: string;
 }
 
 /**
@@ -152,7 +163,7 @@ export interface IEvent {
   geometry: IEventGeometry;
   id: string;
   notifyAttendees: boolean;
-  onlineLocations: string[];
+  onlineMeetings?: IOnlineMeeting[];
   recurrence: string | null;
   registrations?: IRegistration[];
   startDateTime: string;
@@ -199,8 +210,8 @@ export interface ICreateEvent {
   lastName?: string;
   /** Flag to notify attendees */
   notifyAttendees?: boolean;
-  /** Online locations for the event */
-  onlineLocations?: string[];
+  /** Online meetings for the event. Required if attendanceType includes VIRTUAL */
+  onlineMeetings?: ICreateAddress[];
   /** ISO8601 start date-time for the event */
   startDateTime: string;
   /** Summary of the event */

--- a/packages/common/test/events/api/events.test.ts
+++ b/packages/common/test/events/api/events.test.ts
@@ -58,7 +58,13 @@ describe("Events", () => {
             properties: {},
           },
           notifyAttendees: true,
-          onlineLocations: ["https://www.esri.com"],
+          onlineMeetings: [
+            {
+              url: "https://www.esri.com",
+              capacity: 50,
+              details: "Tacos online are here",
+            },
+          ],
           startDateTime: "2023-12-01T19:52:13.584Z",
           summary: "a summary",
           timeZone: "America/Los_Angeles",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Type updates for new events schema (event.onlineMeetings)

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
