### PR TITLE
fix: add prod alpha orgs to hub:feature:workspace

### DIFF
--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -95,7 +95,7 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:feature:workspace",
     availability: ["alpha"],
-    environments: ["devext", "qaext"],
+    environments: ["devext", "qaext", "production"],
   },
   {
     // This is an experimental extension of the gallery to include `map layout`


### PR DESCRIPTION
1. Description:

Adds prod alpha orgs to `hub:feature:workspace`. This will be connected to draft PR -> https://github.com/ArcGIS/opendata-ui/pull/13197, where I've verified behavior against PROD

1. Instructions for testing:

1. Closes Issues: n/a

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
