### PR TITLE
feat(): implement assertion conditions

### DIFF
--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -116,9 +116,31 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
     authenticated: true,
     privileges: ["portal:user:shareToGroup"],
     assertions: [
+      // If the group is not view only, any member can share content
       {
+        conditions: [
+          {
+            property: "entity:isViewOnly",
+            type: "eq",
+            value: false,
+          },
+        ],
         property: "context:currentUser",
         type: "is-group-member",
+        value: "entity:id",
+      },
+
+      // if the group is view only, only group admins can share content
+      {
+        conditions: [
+          {
+            property: "entity:isViewOnly",
+            type: "eq",
+            value: true,
+          },
+        ],
+        property: "context:currentUser",
+        type: "is-group-admin",
         value: "entity:id",
       },
     ],

--- a/packages/common/src/permissions/_internal/checkAssertions.ts
+++ b/packages/common/src/permissions/_internal/checkAssertions.ts
@@ -20,11 +20,11 @@ export function checkAssertions(
     // iterate over the assertions, creating a check for each entry
     checks = policy.assertions.reduce(
       (acc: IPolicyCheck[], assertion: IPolicyAssertion) => {
-        let conditionResult = true;
+        let shouldCheckAssertion = true;
 
         // if conditions, check them first
         if (assertion.conditions?.length) {
-          conditionResult = assertion.conditions.every(
+          shouldCheckAssertion = assertion.conditions.every(
             (condition: IPolicyAssertion) =>
               checkAssertion(condition, entity, context).response === "granted"
           );
@@ -32,7 +32,7 @@ export function checkAssertions(
 
         // if we pass all conditions/there are no conditions, we evaluate the assertion
         // otherwise, the assertion is ignored
-        if (conditionResult) {
+        if (shouldCheckAssertion) {
           const chk = checkAssertion(assertion, entity, context);
           acc = [...acc, chk];
         }

--- a/packages/common/src/permissions/_internal/checkAssertions.ts
+++ b/packages/common/src/permissions/_internal/checkAssertions.ts
@@ -22,8 +22,7 @@ export function checkAssertions(
       (acc: IPolicyCheck[], assertion: IPolicyAssertion) => {
         let conditionResult = true;
 
-        // if the assertion has conditions, we need to check them first
-        // to determine if the assertion itself needs to be checked in the first place.
+        // if conditions, check them first
         if (assertion.conditions?.length) {
           conditionResult = assertion.conditions.every(
             (condition: IPolicyAssertion) =>
@@ -31,8 +30,8 @@ export function checkAssertions(
           );
         }
 
-        // if we pass the conditions, we should check the assertion
-        // otherwise, this assertion is irrelevant and we should skip it
+        // if we pass all conditions/there are no conditions, we evaluate the assertion
+        // otherwise, the assertion is ignored
         if (conditionResult) {
           const chk = checkAssertion(assertion, entity, context);
           acc = [...acc, chk];

--- a/packages/common/src/permissions/types/IPermissionPolicy.ts
+++ b/packages/common/src/permissions/types/IPermissionPolicy.ts
@@ -119,6 +119,11 @@ export interface IPolicyAssertion {
   property: string;
   type: AssertionType;
   value: any;
+
+  /** A condition dictates if an assertion should be evaluated. If any condition evaluates to false,
+   * the assertion should be ignored. If the conditions evaluate to true, or if there are no conditions,
+   * the assertion should be evaluated.
+   */
   conditions?: IPolicyAssertion[];
 }
 

--- a/packages/common/src/permissions/types/IPermissionPolicy.ts
+++ b/packages/common/src/permissions/types/IPermissionPolicy.ts
@@ -119,6 +119,7 @@ export interface IPolicyAssertion {
   property: string;
   type: AssertionType;
   value: any;
+  conditions?: IPolicyAssertion[];
 }
 
 /**

--- a/packages/common/test/permissions/_internal/checkAssertions.test.ts
+++ b/packages/common/test/permissions/_internal/checkAssertions.test.ts
@@ -49,4 +49,60 @@ describe("checkAssertions:", () => {
     expect(checks.length).toBe(2);
     expect(spy.calls.count()).toBe(2);
   });
+  it("checks conditions", () => {
+    const policy: IPermissionPolicy = {
+      permission: "hub:group:shareContent",
+      assertions: [
+        {
+          conditions: [
+            {
+              property: "entity:isViewOnly",
+              type: "eq",
+              value: false,
+            },
+          ],
+          property: "context:currentUser",
+          type: "is-group-member",
+          value: "entity:id",
+        },
+        {
+          conditions: [
+            {
+              property: "entity:isViewOnly",
+              type: "eq",
+              value: true,
+            },
+          ],
+          property: "context:currentUser",
+          type: "is-group-admin",
+          value: "entity:id",
+        },
+      ],
+    };
+
+    const ctx = {
+      isAuthenticated: true,
+    } as unknown as IArcGISContext;
+    const entity = {
+      group: {
+        id: "123",
+      },
+    };
+
+    const spy = spyOn(AssertionModule, "checkAssertion").and.returnValues(
+      {
+        response: "granted",
+      },
+      {
+        response: "granted",
+      },
+      {
+        response: "assertion-failed",
+      }
+    );
+
+    const checks = checkAssertions(policy, ctx, entity);
+    expect(checks.length).toBe(1);
+    expect(spy.calls.count()).toBe(3);
+  });
 });


### PR DESCRIPTION
1. Description:
Adds conditions to assertion logic. A condition dictates if an assertion should be checked or not. If the condition evaluates to false, the assertion can be ignored. 

We implement this logic at the checkAssertions level, as we want to determine if an assertion is relevant first before evaluating it. 

Use case: Groups with `isViewOnly: false` allow any group member to share content; groups with `isViewOnly: true` allow only group admins to share content. To use just one permission for sharing content, we use a condition on `entity.isViewOnly` to understand which assertion currently applies: `is-group-member` or `is-group-admin`. 

1. Instructions for testing:

1. Closes Issues: #9090 (if appropriate)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
