### PR TITLE
feat: org thumbnail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22688,10 +22688,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22706,24 +22705,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22737,10 +22733,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22758,10 +22753,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65016,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.93.1",
+			"version": "14.97.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -83471,8 +83465,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83487,20 +83480,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83514,8 +83504,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83532,8 +83521,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -29,6 +29,7 @@ import {
 import { HubServiceStatus } from "./core/types/ISystemStatus";
 import { checkPermission } from "./permissions/checkPermission";
 import { HubEntity } from "./core/types/HubEntity";
+import { getPortalThumbnailUrl } from "./resources/get-portal-thumbnail-url";
 
 /**
  * Hash of Hub API end points so updates
@@ -237,6 +238,11 @@ export interface IArcGISContext {
    * @returns
    */
   history: IHubHistory;
+
+  /**
+   * Return the portal thumbnail url
+   */
+  portalThumbnailUrl: string;
 
   /**
    * Return the token for a given app, if defined
@@ -803,6 +809,14 @@ export class ArcGISContext implements IArcGISContext {
    */
   public get userHubSettings(): IUserHubSettings {
     return this._userHubSettings;
+  }
+
+  public get portalThumbnailUrl(): string {
+    return getPortalThumbnailUrl(
+      this.sharingApiUrl,
+      this.portal,
+      this.session?.token
+    );
   }
 
   /**

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -29,7 +29,7 @@ import {
 import { HubServiceStatus } from "./core/types/ISystemStatus";
 import { checkPermission } from "./permissions/checkPermission";
 import { HubEntity } from "./core/types/HubEntity";
-import { getPortalThumbnailUrl } from "./resources/get-portal-thumbnail-url";
+import { getOrgThumbnailUrl } from "./resources/get-org-thumbnail-url";
 
 /**
  * Hash of Hub API end points so updates
@@ -242,7 +242,7 @@ export interface IArcGISContext {
   /**
    * Return the portal thumbnail url
    */
-  portalThumbnailUrl: string;
+  orgThumbnailUrl: string;
 
   /**
    * Return the token for a given app, if defined
@@ -811,12 +811,8 @@ export class ArcGISContext implements IArcGISContext {
     return this._userHubSettings;
   }
 
-  public get portalThumbnailUrl(): string {
-    return getPortalThumbnailUrl(
-      this.sharingApiUrl,
-      this.portal,
-      this.session?.token
-    );
+  public get orgThumbnailUrl(): string {
+    return getOrgThumbnailUrl(this.portal, this.session?.token);
   }
 
   /**

--- a/packages/common/src/resources/get-org-thumbnail-url.ts
+++ b/packages/common/src/resources/get-org-thumbnail-url.ts
@@ -1,23 +1,20 @@
 import { IPortal } from "@esri/arcgis-rest-portal";
+import { getPortalUrl } from "../urls/get-portal-url";
 
 /**
  * Construct a the full url to a portal thumbnail
  *
  * - If the portal has a thumbnail, construct the full url
  * - If the portal is not public, append on the token
- * @param portalUrl
  * @param portal
  * @param token
  * @returns
  */
-export function getPortalThumbnailUrl(
-  portalUrl: string,
-  portal: IPortal,
-  token?: string
-): string {
+export function getOrgThumbnailUrl(portal: IPortal, token?: string): string {
   let thumbnailUrl = null;
   if (portal?.thumbnail) {
-    thumbnailUrl = `${portalUrl}/portals/self/resources/${portal.thumbnail}`;
+    const portalUrl = getPortalUrl(portal);
+    thumbnailUrl = `${portalUrl}/sharing/rest/portals/${portal.id}/resources/${portal.thumbnail}`;
     if (token && portal.access !== "public") {
       thumbnailUrl = `${thumbnailUrl}?token=${token}`;
     }

--- a/packages/common/src/resources/get-portal-thumbnail-url.ts
+++ b/packages/common/src/resources/get-portal-thumbnail-url.ts
@@ -1,0 +1,26 @@
+import { IPortal } from "@esri/arcgis-rest-portal";
+
+/**
+ * Construct a the full url to a portal thumbnail
+ *
+ * - If the portal has a thumbnail, construct the full url
+ * - If the portal is not public, append on the token
+ * @param portalUrl
+ * @param portal
+ * @param token
+ * @returns
+ */
+export function getPortalThumbnailUrl(
+  portalUrl: string,
+  portal: IPortal,
+  token?: string
+): string {
+  let thumbnailUrl = null;
+  if (portal?.thumbnail) {
+    thumbnailUrl = `${portalUrl}/portals/self/resources/${portal.thumbnail}`;
+    if (token && portal.access !== "public") {
+      thumbnailUrl = `${thumbnailUrl}?token=${token}`;
+    }
+  }
+  return thumbnailUrl;
+}

--- a/packages/common/src/resources/index.ts
+++ b/packages/common/src/resources/index.ts
@@ -5,7 +5,7 @@ export * from "./fetch-and-upload-thumbnail";
 export * from "./fetch-image-as-blob";
 export * from "./get-item-assets";
 export * from "./get-item-thumbnail-url";
-export * from "./get-portal-thumbnail-url";
+export * from "./get-org-thumbnail-url";
 export * from "./string-to-blob";
 export * from "./upload-resources-from-url";
 export * from "./add-solution-resource-url-to-assets";

--- a/packages/common/src/resources/index.ts
+++ b/packages/common/src/resources/index.ts
@@ -5,6 +5,7 @@ export * from "./fetch-and-upload-thumbnail";
 export * from "./fetch-image-as-blob";
 export * from "./get-item-assets";
 export * from "./get-item-thumbnail-url";
+export * from "./get-portal-thumbnail-url";
 export * from "./string-to-blob";
 export * from "./upload-resources-from-url";
 export * from "./add-solution-resource-url-to-assets";

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -65,6 +65,7 @@ const onlinePortalSelfResponse = {
     },
   },
   user: cloneObject(onlineUserResponse) as portalModule.IUser,
+  thumbnail: "fake-thumbnail.jpg",
 };
 
 const onlinePortalSelfWithLimitsResponse = {
@@ -302,6 +303,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.userHubSettings).toEqual({ schemaVersion: 1 });
       expect(mgr.context.isAlphaOrg).toEqual(false);
       expect(mgr.context.isBetaOrg).toEqual(false);
+      expect(mgr.context.portalThumbnailUrl).toBeNull();
     });
     it("verify alpha and beta orgs", async () => {
       const mgr = await ArcGISContextManager.create({
@@ -689,6 +691,9 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.properties.alphaOrgs).toEqual(["FAKEID", "FOTHERID"]);
       expect(mgr.context.isAlphaOrg).toBeTruthy();
       expect(mgr.context.isBetaOrg).toBeTruthy();
+      expect(mgr.context.portalThumbnailUrl).toBe(
+        `${MOCK_AUTH.portal}/portals/self/resources/fake-thumbnail.jpg?token=${MOCK_AUTH.token}`
+      );
     });
     it("verify props update setting session after", async () => {
       spyOn(portalModule, "getSelf").and.callFake(() => {

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -303,7 +303,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.userHubSettings).toEqual({ schemaVersion: 1 });
       expect(mgr.context.isAlphaOrg).toEqual(false);
       expect(mgr.context.isBetaOrg).toEqual(false);
-      expect(mgr.context.portalThumbnailUrl).toBeNull();
+      expect(mgr.context.orgThumbnailUrl).toBeNull();
     });
     it("verify alpha and beta orgs", async () => {
       const mgr = await ArcGISContextManager.create({
@@ -691,8 +691,8 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.properties.alphaOrgs).toEqual(["FAKEID", "FOTHERID"]);
       expect(mgr.context.isAlphaOrg).toBeTruthy();
       expect(mgr.context.isBetaOrg).toBeTruthy();
-      expect(mgr.context.portalThumbnailUrl).toBe(
-        `${MOCK_AUTH.portal}/portals/self/resources/fake-thumbnail.jpg?token=${MOCK_AUTH.token}`
+      expect(mgr.context.orgThumbnailUrl).toBe(
+        `${MOCK_AUTH.portal}/portals/FAKEID/resources/fake-thumbnail.jpg?token=${MOCK_AUTH.token}`
       );
     });
     it("verify props update setting session after", async () => {

--- a/packages/common/test/resources/get-portal-thumbnail-url.test.ts
+++ b/packages/common/test/resources/get-portal-thumbnail-url.test.ts
@@ -1,12 +1,11 @@
-import { getPortalThumbnailUrl } from "../../src";
+import { getOrgThumbnailUrl } from "../../src";
 import { IPortal } from "@esri/arcgis-rest-portal";
 
 describe("getPortalThumbnailUrl:", () => {
-  const portalUrl = "https://foo.com/sharing/rest";
   const token = "FAKE_TOKEN";
   it("returns null if no thumbnail present", () => {
     const portal = {} as IPortal;
-    expect(getPortalThumbnailUrl(portalUrl, portal, token)).toBeNull();
+    expect(getOrgThumbnailUrl(portal, token)).toBeNull();
   });
   it("constructs url without token for public portals", () => {
     const portal = {
@@ -16,8 +15,8 @@ describe("getPortalThumbnailUrl:", () => {
       isPortal: true,
       name: "jsmith",
     } as IPortal;
-    expect(getPortalThumbnailUrl(portalUrl, portal, token)).toEqual(
-      "https://foo.com/sharing/rest/portals/self/resources/photo.jpg"
+    expect(getOrgThumbnailUrl(portal, token)).toEqual(
+      "https://www.arcgis.com/sharing/rest/portals/abc123/resources/photo.jpg"
     );
   });
   it("constructs url with token for non-public portals", () => {
@@ -28,8 +27,8 @@ describe("getPortalThumbnailUrl:", () => {
       isPortal: true,
       name: "jsmith",
     } as IPortal;
-    expect(getPortalThumbnailUrl(portalUrl, portal, token)).toEqual(
-      "https://foo.com/sharing/rest/portals/self/resources/photo.jpg?token=FAKE_TOKEN"
+    expect(getOrgThumbnailUrl(portal, token)).toEqual(
+      "https://www.arcgis.com/sharing/rest/portals/abc123/resources/photo.jpg?token=FAKE_TOKEN"
     );
   });
 });

--- a/packages/common/test/resources/get-portal-thumbnail-url.test.ts
+++ b/packages/common/test/resources/get-portal-thumbnail-url.test.ts
@@ -1,0 +1,35 @@
+import { getPortalThumbnailUrl } from "../../src";
+import { IPortal } from "@esri/arcgis-rest-portal";
+
+describe("getPortalThumbnailUrl:", () => {
+  const portalUrl = "https://foo.com/sharing/rest";
+  const token = "FAKE_TOKEN";
+  it("returns null if no thumbnail present", () => {
+    const portal = {} as IPortal;
+    expect(getPortalThumbnailUrl(portalUrl, portal, token)).toBeNull();
+  });
+  it("constructs url without token for public portals", () => {
+    const portal = {
+      id: "abc123",
+      access: "public",
+      thumbnail: "photo.jpg",
+      isPortal: true,
+      name: "jsmith",
+    } as IPortal;
+    expect(getPortalThumbnailUrl(portalUrl, portal, token)).toEqual(
+      "https://foo.com/sharing/rest/portals/self/resources/photo.jpg"
+    );
+  });
+  it("constructs url with token for non-public portals", () => {
+    const portal = {
+      id: "abc123",
+      access: "org",
+      thumbnail: "photo.jpg",
+      isPortal: true,
+      name: "jsmith",
+    } as IPortal;
+    expect(getPortalThumbnailUrl(portalUrl, portal, token)).toEqual(
+      "https://foo.com/sharing/rest/portals/self/resources/photo.jpg?token=FAKE_TOKEN"
+    );
+  });
+});


### PR DESCRIPTION
1. Description:
- adds getOrgThumbnailUrl function
- adds orgThumbnailUrl to IArcGISContext

1. Instructions for testing: run the tests

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
