### PR TITLE
fix: ensure sites have telemetry

### DIFF
--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -84,6 +84,7 @@ const DEFAULT_SITE: Partial<IHubSite> = {
       feedback: true,
     },
   },
+  telemetry: {},
 };
 
 /**

--- a/packages/common/src/sites/_internal/ensureBaseTelemetry.ts
+++ b/packages/common/src/sites/_internal/ensureBaseTelemetry.ts
@@ -1,0 +1,25 @@
+import { getProp } from "../../objects";
+import { IDraft, IModel } from "../../types";
+import { cloneObject } from "../../util";
+
+/**
+ * During a period in late 2023 and early 2024, the python api
+ * was writing a bad confirmation for basemaps as part of the site
+ * cloning process. This migration will fix that.
+ * @param {Object} model Site Model
+ * @private
+ */
+export function ensureBaseTelemetry<T extends IModel | IDraft>(model: T) {
+  // Unlike other migrations, this is not based on a version
+  // rather it checks for a missing telemetry property.
+
+  // Early exit if the telemetry is there
+  if (getProp(model, "data.telemetry")) {
+    return model;
+  }
+
+  const clone = cloneObject(model);
+  clone.data.telemetry = {};
+
+  return clone;
+}

--- a/packages/common/src/sites/upgrade-site-schema.ts
+++ b/packages/common/src/sites/upgrade-site-schema.ts
@@ -11,6 +11,7 @@ import { _migrateEventListCardConfigs } from "./_internal/_migrate-event-list-ca
 import { migrateLegacyCapabilitiesToFeatures } from "./_internal/capabilities/migrateLegacyCapabilitiesToFeatures";
 import { _migrateTelemetryConfig } from "./_internal/_migrate-telemetry-config";
 import { migrateBadBasemap } from "./_internal/migrateBadBasemap";
+import { ensureBaseTelemetry } from "./_internal/ensureBaseTelemetry";
 
 /**
  * Upgrades the schema upgrades
@@ -37,5 +38,6 @@ export function upgradeSiteSchema(model: IModel) {
 
   // apply versionless migrations
   model = migrateBadBasemap(model);
+  model = ensureBaseTelemetry(model);
   return model;
 }

--- a/packages/common/test/sites/_internal/ensureBaseTelemetry.test.ts
+++ b/packages/common/test/sites/_internal/ensureBaseTelemetry.test.ts
@@ -1,0 +1,23 @@
+import { IModel } from "../../../src";
+import { ensureBaseTelemetry } from "../../../src/sites/_internal/ensureBaseTelemetry";
+
+describe("ensure base telemtry:", () => {
+  it("returns model if telemetry is present", () => {
+    const model: IModel = {
+      data: {
+        telemetry: {},
+      },
+    } as unknown as IModel;
+    const chk = ensureBaseTelemetry(model);
+    expect(chk).toBe(model);
+  });
+
+  it("returns clone with telemetry when telemetry is not present", () => {
+    const model: IModel = {
+      data: {},
+    } as unknown as IModel;
+    const chk = ensureBaseTelemetry(model);
+    expect(chk).not.toBe(model);
+    expect(chk?.data?.telemetry).toBeDefined();
+  });
+});

--- a/packages/common/test/sites/upgrade-site-schema.test.ts
+++ b/packages/common/test/sites/upgrade-site-schema.test.ts
@@ -9,6 +9,7 @@ import * as _migrateEventListCardConfigs from "../../src/sites/_internal/_migrat
 import * as migrateLegacyCapabilitiesToFeatures from "../../src/sites/_internal/capabilities/migrateLegacyCapabilitiesToFeatures";
 import * as _migrateTelemetryConfig from "../../src/sites/_internal/_migrate-telemetry-config";
 import * as migrateBadBasemapModule from "../../src/sites/_internal/migrateBadBasemap";
+import * as ensureBaseTelemetry from "../../src/sites/_internal/ensureBaseTelemetry";
 import { IModel } from "../../src";
 import { SITE_SCHEMA_VERSION } from "../../src/sites/site-schema-version";
 import { expectAllCalled, expectAll } from "./test-helpers.test";
@@ -24,6 +25,7 @@ describe("upgradeSiteSchema", () => {
   let migrateLegacyCapabilitiesToFeaturesSpy: jasmine.Spy;
   let migrateTelemetryConfigSpy: jasmine.Spy;
   let migrateBadBasemapSpy: jasmine.Spy;
+  let ensureBaseTelemetrySpy: jasmine.Spy;
   beforeEach(() => {
     applySpy = spyOn(_applySiteSchemaModule, "_applySiteSchema").and.callFake(
       (model: IModel) => model
@@ -64,6 +66,10 @@ describe("upgradeSiteSchema", () => {
       migrateBadBasemapModule,
       "migrateBadBasemap"
     ).and.callFake((model: IModel) => model);
+    ensureBaseTelemetrySpy = spyOn(
+      ensureBaseTelemetry,
+      "ensureBaseTelemetry"
+    ).and.callFake((model: IModel) => model);
   });
 
   it("runs schema upgrades", async () => {
@@ -89,6 +95,7 @@ describe("upgradeSiteSchema", () => {
         migrateLegacyCapabilitiesToFeaturesSpy,
         migrateTelemetryConfigSpy,
         migrateBadBasemapSpy,
+        ensureBaseTelemetrySpy,
       ],
       expect
     );
@@ -122,5 +129,6 @@ describe("upgradeSiteSchema", () => {
     );
     // Versionless migrations should still run
     expectAll([migrateBadBasemapSpy], "toHaveBeenCalled", true, expect);
+    expectAll([ensureBaseTelemetrySpy], "toHaveBeenCalled", true, expect);
   });
 });

--- a/packages/sites/src/ensure-required-site-properties.ts
+++ b/packages/sites/src/ensure-required-site-properties.ts
@@ -77,6 +77,9 @@ export function ensureRequiredSiteProperties(
     caps.push("socialSharing");
   }
   deepSet(model, "data.values.capabilities", caps);
+  if (!getProp(model, "data.telemetry")) {
+    deepSet(model, "data.telemetry", {});
+  }
   // return the clone
   return model;
 }

--- a/packages/sites/test/ensure-required-site-properties.test.ts
+++ b/packages/sites/test/ensure-required-site-properties.test.ts
@@ -115,6 +115,7 @@ describe("ensureRequiredSiteProperties", () => {
     const model = {
       item: {},
       data: {
+        telemetry: {},
         values: {
           subdomain: "name-org",
           defaultHostname: "name-org.hub.arcgis.com",


### PR DESCRIPTION
1. Description: Fixes newly created sites do not have telemetry

1. Instructions for testing: Run the tests

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
