### PR TITLE
fix: remove unused scope on subblock section in stat card editor uiSchema

### DIFF
--- a/packages/common/src/core/schemas/internal/metrics/StatCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/metrics/StatCardUiSchema.ts
@@ -61,7 +61,6 @@ export const buildUiSchema = async (
               section: "subblock",
               scale: "m",
               toggleDisplay: "switch",
-              scope: "/properties/unit",
             },
             elements: [
               {

--- a/packages/common/test/core/schemas/internal/metrics/StatCardUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/StatCardUiSchema.test.ts
@@ -70,7 +70,6 @@ describe("buildUiSchema: stat", () => {
                 section: "subblock",
                 scale: "m",
                 toggleDisplay: "switch",
-                scope: "/properties/unit",
               },
               elements: [
                 {


### PR DESCRIPTION
[9537](https://devtopia.esri.com/dc/hub/issues/9537)

### Description
Removes the unused `scope` on the `subblock` section in the stat card editor `uiSchema`. 

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
