### PR TITLE
feat: add orgId to IHubGroup

### DIFF
--- a/packages/common/src/core/types/IHubGroup.ts
+++ b/packages/common/src/core/types/IHubGroup.ts
@@ -82,6 +82,13 @@ export interface IHubGroup
   owner?: string;
 
   /**
+   * Id of the org that the group belongs to
+   * Depending who is fetching the group, and the owning org's settings
+   * this may not be returned from the Portal API
+   */
+  orgId?: string;
+
+  /**
    * Whether the group is protected or not
    * the group cannot be deleted if protected
    */

--- a/packages/common/src/groups/_internal/getPropertyMap.ts
+++ b/packages/common/src/groups/_internal/getPropertyMap.ts
@@ -30,6 +30,7 @@ export function getPropertyMap(): IPropertyMap[] {
     "isViewOnly",
     "membershipAccess",
     "owner",
+    "orgId",
     "protected",
     "sortField",
     "sortOrder",

--- a/packages/common/test/groups/HubGroups.test.ts
+++ b/packages/common/test/groups/HubGroups.test.ts
@@ -258,6 +258,7 @@ describe("HubGroups Module:", () => {
       });
       expect(chk.name).toBe("dev followers Content");
       expect(chk.description).toBe("dev followers Content summary");
+      expect(chk.orgId).toBe(TEST_GROUP.orgId);
       expect(portalGetGroupSpy).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
1. Description:

Needed so we can send telemetry with `orgId`

1. Instructions for testing:

1. Part of Issues: #9254 (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
