### PR TITLE
feat(): handle association group settings

### DIFF
--- a/packages/common/src/core/HubItemEntity.ts
+++ b/packages/common/src/core/HubItemEntity.ts
@@ -41,6 +41,8 @@ import { AssociationType, IAssociationInfo } from "../associations/types";
 import { listAssociations } from "../associations/listAssociations";
 import { addAssociation } from "../associations/addAssociation";
 import { removeAssociation } from "../associations/removeAssociation";
+import { IQuery, getGroupPredicate } from "../search";
+import { getProp, setProp } from "../objects";
 
 const FEATURED_IMAGE_FILENAME = "featuredImage.png";
 
@@ -273,6 +275,91 @@ export abstract class HubItemEntity<T extends IHubItemEntity>
       },
       authentication: this.context.session,
     });
+  }
+
+  /**
+   * Sets the access level of the association group
+   * @access access level to set
+   */
+  async setAssociationsGroupAccess(access: SettableAccessLevel): Promise<void> {
+    await updateGroup({
+      group: {
+        id: this.entity.associationsGroupId,
+        access,
+      },
+      authentication: this.context.session,
+    });
+  }
+
+  /**
+   * Sets the membership access level of the association group
+   * @param membershipAccess membership access level to set
+   */
+  async setAssociationsMembershipAccess(
+    membershipAccess: "organization" | "collaborators" | "anyone"
+  ): Promise<void> {
+    await updateGroup({
+      group: {
+        id: this.entity.associationsGroupId,
+        membershipAccess,
+      },
+      authentication: this.context.session,
+    });
+  }
+
+  /**
+   * Adds or removes the association group from the entity catalog
+   * @param includeInCatalog
+   */
+  setAssociationsIncludeInCatalog(includeInCatalog: boolean): void {
+    // Handle entities that don't have a catalog scope defined
+    if (!getProp(this.entity, "catalog.scopes.item")) {
+      setProp(
+        "catalog.scopes.item",
+        { targetEntity: "item", filters: [] } as IQuery,
+        this.entity
+      );
+    }
+
+    // current group ids in the predicate
+    let groupIds: string[] = [];
+
+    // get the current group predicate
+    const groupPredicate = getGroupPredicate(this.entity.catalog.scopes.item);
+    if (groupPredicate) {
+      const { group: groupClause } = groupPredicate;
+      groupIds = Array.isArray(groupClause) ? groupClause : [groupClause];
+    }
+
+    // update the group ids list based on the includeInCatalog flag and whether
+    // the group is already in the list
+    if (
+      includeInCatalog &&
+      !groupIds.includes(this.entity.associationsGroupId)
+    ) {
+      groupIds.push(this.entity.associationsGroupId);
+    } else if (
+      !includeInCatalog &&
+      groupIds.includes(this.entity.associationsGroupId)
+    ) {
+      groupIds.splice(groupIds.indexOf(this.entity.associationsGroupId), 1);
+    }
+
+    // if we already have a group predicate, update the group clause
+    if (groupPredicate) {
+      groupPredicate.group = groupIds;
+    }
+    // else there is no group predicate, so create it
+    else {
+      this.entity.catalog.scopes.item.filters.push({
+        operation: "OR",
+        predicates: [
+          {
+            group: groupIds,
+          },
+        ],
+      });
+    }
   }
 
   /**

--- a/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
+++ b/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
@@ -45,6 +45,24 @@ export const HubItemEntitySchema: IConfigurationSchema = {
         isDiscussable: ENTITY_IS_DISCUSSABLE_SCHEMA,
       },
     },
+    _associations: {
+      type: "object",
+      properties: {
+        groupAccess: {
+          ...ENTITY_ACCESS_SCHEMA,
+          enum: ["private", "org", "public"],
+        },
+        membershipAccess: {
+          type: "string",
+          enum: ["organization", "collaborators", "anyone"],
+        },
+        includeInCatalog: {
+          type: "boolean",
+          enum: [false, true],
+          default: false,
+        },
+      },
+    },
     view: {
       type: "object",
       properties: {

--- a/packages/common/src/core/types/IHubItemEntity.ts
+++ b/packages/common/src/core/types/IHubItemEntity.ts
@@ -159,5 +159,16 @@ export type IHubItemEntityEditor<T> = Omit<T, "extent"> & {
     showFollowAction?: boolean;
     isDiscussable?: boolean;
   };
+
+  /**
+   * Association group settings. These settings are only used in the
+   * Editor and is persisted appropriately in the fromEditor
+   * method on the Class
+   */
+  _associations?: {
+    groupAccess?: AccessLevel;
+    membershipAccess?: "organization" | "collaborators" | "anyone";
+    includeInCatalog?: boolean;
+  };
   _metric?: IMetricEditorValues;
 };

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_INITIATIVE } from "./defaults";
 import { getEditorConfig } from "../core/schemas/getEditorConfig";
 import { IEntityEditorContext } from "../core/types/HubEntityEditor";
-import { cloneObject } from "../util";
+import { cloneObject, isNil } from "../util";
 import {
   createInitiative,
   deleteInitiative,
@@ -342,6 +342,27 @@ export class HubInitiative
     // b/c the first thing we do is create/update the initiative
     const featuredImage = editor.view.featuredImage;
     delete editor.view.featuredImage;
+
+    // handle association group settings -- access level
+    if (editor._associations?.groupAccess) {
+      await this.setAssociationsGroupAccess(
+        editor._associations.groupAccess as SettableAccessLevel
+      );
+    }
+
+    // handle association group settings -- membership access
+    if (editor._associations?.membershipAccess) {
+      await this.setAssociationsMembershipAccess(
+        editor._associations.membershipAccess
+      );
+    }
+
+    // handle association group settings -- include in catalog
+    if (!isNil(editor._associations?.includeInCatalog)) {
+      this.setAssociationsIncludeInCatalog(
+        editor._associations.includeInCatalog
+      );
+    }
 
     // convert back to an entity
     const entity = editorToInitiative(editor, this.context.portal);

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaAssociations.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaAssociations.ts
@@ -1,0 +1,83 @@
+import { checkPermission } from "../..";
+import { IArcGISContext } from "../../ArcGISContext";
+import { IUiSchema } from "../../core/schemas/types";
+import { IHubInitiative } from "../../core/types";
+
+/**
+ * @private
+ * constructs the minimal association group settings uiSchema for Hub Initiatives.
+ * This defines how the schema properties should be rendered
+ * in the initiative creation experience
+ */
+export const buildUiSchema = async (
+  i18nScope: string,
+  options: Partial<IHubInitiative>,
+  context: IArcGISContext
+): Promise<IUiSchema> => {
+  return {
+    type: "Layout",
+    elements: [
+      {
+        type: "Section",
+        elements: [
+          {
+            labelKey: `${i18nScope}.fields.settings.groupAccess.label`,
+            scope: "/properties/_associations/properties/groupAccess",
+            type: "Control",
+            options: {
+              control: "hub-field-input-tile-select",
+              layout: "horizontal",
+              helperText: {
+                labelKey: `${i18nScope}.fields.settings.groupAccess.helperText`,
+              },
+              labels: [
+                `{{${i18nScope}.fields.settings.groupAccess.private.label:translate}}`,
+                `{{${i18nScope}.fields.settings.groupAccess.org.label:translate}}`,
+                `{{${i18nScope}.fields.settings.groupAccess.public.label:translate}}`,
+              ],
+              descriptions: [
+                `{{${i18nScope}.fields.associations.groupAccess.private.description:translate}}`,
+                `{{${i18nScope}.fields.settings.groupAccess.org.description:translate}}`,
+                `{{${i18nScope}.fields.settings.groupAccess.public.description:translate}}`,
+              ],
+              icons: ["users", "organization", "globe"],
+              styles: { "max-width": "45rem" },
+            },
+          },
+          {
+            labelKey: `${i18nScope}.fields.membershipAccess.label`,
+            scope: "/properties/membershipAccess",
+            type: "Control",
+            options: {
+              control: "hub-field-input-radio",
+              labels: [
+                `{{${i18nScope}.fields.membershipAccess.org:translate}}`,
+                `{{${i18nScope}.fields.membershipAccess.collab:translate}}`,
+                `{{${i18nScope}.fields.membershipAccess.createAssociation.any:translate}}`,
+              ],
+              disabled: [
+                false,
+                !checkPermission(
+                  "platform:portal:user:addExternalMembersToGroup",
+                  context
+                ).access,
+                !checkPermission(
+                  "platform:portal:user:addExternalMembersToGroup",
+                  context
+                ).access,
+              ],
+            },
+          },
+          {
+            labelKey: `${i18nScope}.fields.includeInCatalog.label`,
+            scope: "/properties/includeInCatalog",
+            type: "Control",
+            options: {
+              control: "hub-field-input-switch",
+            },
+          },
+        ],
+      },
+    ],
+  };
+};

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -30,7 +30,7 @@ import {
   IHubCardViewModel,
 } from "../core/types/IHubCardViewModel";
 import { projectToCardModel } from "./view";
-import { camelize, cloneObject, createId, isNil } from "../util";
+import { camelize, cloneObject, createId } from "../util";
 import { createProject, editorToProject, updateProject } from "./edit";
 import { ProjectEditorType } from "./_internal/ProjectSchema";
 import { enrichEntity } from "../core/enrichEntity";
@@ -283,27 +283,6 @@ export class HubProject
     // b/c the first thing we do is create/update the project
     const featuredImage = editor.view.featuredImage;
     delete editor.view.featuredImage;
-
-    // handle association group settings -- access level
-    if (editor._associations?.groupAccess) {
-      await this.setAssociationsGroupAccess(
-        editor._associations.groupAccess as SettableAccessLevel
-      );
-    }
-
-    // handle association group settings -- membership access
-    if (editor._associations?.membershipAccess) {
-      await this.setAssociationsMembershipAccess(
-        editor._associations.membershipAccess
-      );
-    }
-
-    // handle association group settings -- include in catalog
-    if (!isNil(editor._associations?.includeInCatalog)) {
-      this.setAssociationsIncludeInCatalog(
-        editor._associations.includeInCatalog
-      );
-    }
 
     // convert back to an entity
     let entity = editorToProject(editor, this.context.portal);

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -30,7 +30,7 @@ import {
   IHubCardViewModel,
 } from "../core/types/IHubCardViewModel";
 import { projectToCardModel } from "./view";
-import { camelize, cloneObject, createId } from "../util";
+import { camelize, cloneObject, createId, isNil } from "../util";
 import { createProject, editorToProject, updateProject } from "./edit";
 import { ProjectEditorType } from "./_internal/ProjectSchema";
 import { enrichEntity } from "../core/enrichEntity";
@@ -283,6 +283,27 @@ export class HubProject
     // b/c the first thing we do is create/update the project
     const featuredImage = editor.view.featuredImage;
     delete editor.view.featuredImage;
+
+    // handle association group settings -- access level
+    if (editor._associations?.groupAccess) {
+      await this.setAssociationsGroupAccess(
+        editor._associations.groupAccess as SettableAccessLevel
+      );
+    }
+
+    // handle association group settings -- membership access
+    if (editor._associations?.membershipAccess) {
+      await this.setAssociationsMembershipAccess(
+        editor._associations.membershipAccess
+      );
+    }
+
+    // handle association group settings -- include in catalog
+    if (!isNil(editor._associations?.includeInCatalog)) {
+      this.setAssociationsIncludeInCatalog(
+        editor._associations.includeInCatalog
+      );
+    }
 
     // convert back to an entity
     let entity = editorToProject(editor, this.context.portal);


### PR DESCRIPTION
1. Description:
Adds logic for handling association group settings for an entity. 

1. Instructions for testing:

1. Closes Issues: works to close [#9091](https://zentopia.esri.com/workspaces/sprint-board-60340b9721bc3a4ab6367db5/issues/gh/dc/hub/9091)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
