### PR TITLE
F/9273 new follow entity and related functionalities

### DIFF
--- a/packages/common/src/items/follow.ts
+++ b/packages/common/src/items/follow.ts
@@ -100,8 +100,6 @@ export async function followEntity(
     } catch (error) {
       throw new Error(`Error joining group: ${error}`);
     }
-  } else {
-    // handle if the entity doesn't have a followers group
   }
 }
 
@@ -150,7 +148,5 @@ export async function unfollowEntity(
     } catch (error) {
       throw new Error(`Error leaving group: ${error}`);
     }
-  } else {
-    // handle if the entity doesn't have a followers group
   }
 }

--- a/packages/common/src/items/follow.ts
+++ b/packages/common/src/items/follow.ts
@@ -1,0 +1,73 @@
+import { IGroup, IUser, joinGroup } from "@esri/arcgis-rest-portal";
+import { EntityType, IHubSearchOptions } from "../search";
+import { fetchSite } from "../sites";
+import { HubEntity } from "../core";
+
+// TODO: consider moving this to /groups
+export async function getEntityFollowersGroupId(
+  entityId: string,
+  entityType: EntityType,
+  hubSearchOptions: IHubSearchOptions
+): Promise<string> {
+  let entity: HubEntity;
+  let groupId: string;
+  if (entityType === ("site" as EntityType)) {
+    entity = await fetchSite(entityId, hubSearchOptions);
+    groupId = entity.followersGroupId;
+  }
+  // handle other entity types here...
+  return groupId;
+}
+
+export async function isUserFollowing(
+  entityId: string,
+  entityType: EntityType,
+  hubSearchOptions: IHubSearchOptions,
+  user: IUser
+): Promise<boolean> {
+  const groupId = await getEntityFollowersGroupId(
+    entityId,
+    entityType,
+    hubSearchOptions
+  );
+  const group: IGroup = user.groups.find((g) => g.id === groupId);
+  return !!group;
+}
+
+export async function followEntity(
+  entityId: string,
+  entityType: EntityType,
+  hubSearchOptions: IHubSearchOptions,
+  user: IUser
+): Promise<{ success: boolean; username: string }> {
+  const isFollowing = await isUserFollowing(
+    entityId,
+    entityType,
+    hubSearchOptions,
+    user
+  );
+  // don't update if user is already following
+  if (isFollowing) {
+    return Promise.reject(`User is already following this entity.`);
+  }
+  // if the entity has a followersGroupId, attempt to join it
+  const groupId = await getEntityFollowersGroupId(
+    entityId,
+    entityType,
+    hubSearchOptions
+  );
+  if (groupId) {
+    try {
+      await joinGroup({
+        id: groupId,
+        authentication: hubSearchOptions.authentication,
+      });
+      // the entity has a followers group and we successfully joined it
+      return { success: true, username: user.username };
+    } catch (error) {
+      throw new Error(`error joining group: ${error}`);
+    }
+  } else {
+    // handle if the entity doesn't have a followers group
+  }
+}

--- a/packages/common/src/items/index.ts
+++ b/packages/common/src/items/index.ts
@@ -24,6 +24,8 @@ export * from "./uploadImageResource";
 export * from "./is-services-directory-disabled";
 export * from "./getItemIdentifier";
 export * from "./deleteItemThumbnail";
+export * from "./deleteItemThumbnail";
+export * from "./follow";
 // No longer exported as the only App Hub needed this for was a Site
 // and that registration is now done in the domain service with a
 // signed HMAC request.


### PR DESCRIPTION
1. Description:

Add a new `follow.ts` that includes
- getEntityFollowersGroupId
- isUserFollowing
- followEntity
- unfollowEntity

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
