### PR TITLE
feat(hub-common): add s123 url to context

### DIFF
--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -245,6 +245,11 @@ export interface IArcGISContext {
   orgThumbnailUrl: string;
 
   /**
+   * Return the Survey123 url
+   */
+  survey123Url: string;
+
+  /**
    * Return the token for a given app, if defined
    * @param app
    */
@@ -813,6 +818,18 @@ export class ArcGISContext implements IArcGISContext {
 
   public get orgThumbnailUrl(): string {
     return getOrgThumbnailUrl(this.portal, this.session?.token);
+  }
+
+  /**
+   * Return the survey123 url
+   */
+  public get survey123Url(): string {
+    const suffixes: Partial<Record<HubEnvironment, string>> = {
+      qaext: "qa",
+      devext: "dev",
+    };
+    const suffix = suffixes[this.environment] ?? "";
+    return `https://survey123${suffix}.arcgis.com`;
   }
 
   /**

--- a/packages/common/src/surveys/utils/get-s123-share-url.ts
+++ b/packages/common/src/surveys/utils/get-s123-share-url.ts
@@ -1,0 +1,7 @@
+import { IArcGISContext } from "../../ArcGISContext";
+
+export function getS123ShareUrl(id: string, context: IArcGISContext) {
+  return `${context.survey123Url}/share/${id}?portalUrl=${encodeURIComponent(
+    context.portalUrl
+  )}`;
+}

--- a/packages/common/src/surveys/utils/index.ts
+++ b/packages/common/src/surveys/utils/index.ts
@@ -3,6 +3,7 @@ export * from "./get-form-info-json";
 export * from "./get-form-json";
 export * from "./get-input-feature-service-model";
 export * from "./get-map-question";
+export * from "./get-s123-share-url";
 export * from "./get-source-feature-service-model-from-fieldworker";
 export * from "./get-stakeholder-model";
 export * from "./get-survey-models";

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -1129,6 +1129,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.discussionsServiceUrl).toBeUndefined();
       expect(mgr.context.hubSearchServiceUrl).toBeUndefined();
       expect(mgr.context.domainServiceUrl).toBeUndefined();
+      expect(mgr.context.survey123Url).toEqual("https://survey123.arcgis.com");
       expect(mgr.context.hubLicense).toBe("enterprise-sites");
     });
     it("verify props when passed session", async () => {
@@ -1153,6 +1154,7 @@ describe("ArcGISContext:", () => {
         MOCK_ENTERPRISE_AUTH.portal.replace(`/sharing/rest`, "")
       );
       expect(mgr.context.sharingApiUrl).toBe(MOCK_ENTERPRISE_AUTH.portal);
+      expect(mgr.context.survey123Url).toEqual("https://survey123.arcgis.com");
       // Partnered orgs
       expect(mgr.context.trustedOrgIds).toEqual([]);
       expect(mgr.context.trustedOrgs).toEqual([]);
@@ -1182,10 +1184,11 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.portalUrl).toBe(
         MOCK_ENTERPRISE_AUTH.portal.replace(`/sharing/rest`, "")
       );
+      expect(mgr.context.survey123Url).toEqual("https://survey123.arcgis.com");
     });
   });
   describe("extra coverage:", () => {
-    it("handles qaext hubUrl", async () => {
+    it("handles devext urls", async () => {
       const mgr = await ArcGISContextManager.create({
         portalUrl: "https://qaext.arcgis.com",
       });
@@ -1194,7 +1197,7 @@ describe("ArcGISContext:", () => {
         "https://survey123qa.arcgis.com"
       );
     });
-    it("handles devext hubUrl", async () => {
+    it("handles devext urls", async () => {
       const mgr = await ArcGISContextManager.create({
         portalUrl: "https://devext.arcgis.com",
       });
@@ -1211,6 +1214,9 @@ describe("ArcGISContext:", () => {
       mgr.clearAuthentication();
       expect(mgr.context.hubUrl).toBe("https://hubqa.arcgis.com");
       expect(mgr.context.portalUrl).toBe("https://qaext.arcgis.com");
+      expect(mgr.context.survey123Url).toEqual(
+        "https://survey123qa.arcgis.com"
+      );
     });
     it("sign out on dev, resets portalUrl correctly", async () => {
       const mgr = await ArcGISContextManager.create({
@@ -1220,6 +1226,9 @@ describe("ArcGISContext:", () => {
       mgr.clearAuthentication();
       expect(mgr.context.hubUrl).toBe("https://hubdev.arcgis.com");
       expect(mgr.context.portalUrl).toBe("https://devext.arcgis.com");
+      expect(mgr.context.survey123Url).toEqual(
+        "https://survey123dev.arcgis.com"
+      );
     });
     it("handles ArcGISContext properties undefined", () => {
       const ctx = new ArcGISContext({

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -304,6 +304,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.isAlphaOrg).toEqual(false);
       expect(mgr.context.isBetaOrg).toEqual(false);
       expect(mgr.context.orgThumbnailUrl).toBeNull();
+      expect(mgr.context.survey123Url).toEqual("https://survey123.arcgis.com");
     });
     it("verify alpha and beta orgs", async () => {
       const mgr = await ArcGISContextManager.create({
@@ -694,6 +695,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.orgThumbnailUrl).toBe(
         `${MOCK_AUTH.portal}/portals/FAKEID/resources/fake-thumbnail.jpg?token=${MOCK_AUTH.token}`
       );
+      expect(mgr.context.survey123Url).toEqual("https://survey123.arcgis.com");
     });
     it("verify props update setting session after", async () => {
       spyOn(portalModule, "getSelf").and.callFake(() => {
@@ -1188,12 +1190,18 @@ describe("ArcGISContext:", () => {
         portalUrl: "https://qaext.arcgis.com",
       });
       expect(mgr.context.hubUrl).toBe("https://hubqa.arcgis.com");
+      expect(mgr.context.survey123Url).toEqual(
+        "https://survey123qa.arcgis.com"
+      );
     });
     it("handles devext hubUrl", async () => {
       const mgr = await ArcGISContextManager.create({
         portalUrl: "https://devext.arcgis.com",
       });
       expect(mgr.context.hubUrl).toBe("https://hubdev.arcgis.com");
+      expect(mgr.context.survey123Url).toEqual(
+        "https://survey123dev.arcgis.com"
+      );
     });
     it("sign out on qa, resets portalUrl correctly", async () => {
       const mgr = await ArcGISContextManager.create({

--- a/packages/common/test/surveys/edit.test.ts
+++ b/packages/common/test/surveys/edit.test.ts
@@ -3,8 +3,8 @@ import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as modelUtils from "../../src/models";
 import { IModel } from "../../src/types";
 import { deleteSurvey, updateSurvey } from "../../src/surveys/edit";
-import { IHubSurvey } from "../../dist/types/core/types/IHubSurvey";
 import * as getFormJsonUtil from "../../src/surveys/utils/get-form-json";
+import { IHubSurvey } from "../../src/core/types/IHubSurvey";
 
 const GUID = "9b77674e43cf4bbd9ecad5189b3f1fdc";
 

--- a/packages/common/test/surveys/utils/get-s123-share-url.test.ts
+++ b/packages/common/test/surveys/utils/get-s123-share-url.test.ts
@@ -1,0 +1,13 @@
+import { IArcGISContext } from "../../../src/ArcGISContext";
+import { getS123ShareUrl } from "../../../src/surveys/utils/get-s123-share-url";
+
+describe("getS123ShareUrl", () => {
+  it("gets url", () => {
+    const context = {
+      survey123Url: "survey-url",
+      portalUrl: "portal-url",
+    } as any as IArcGISContext;
+    const result = getS123ShareUrl("survey-id", context);
+    expect(result).toEqual("survey-url/share/survey-id?portalUrl=portal-url");
+  });
+});


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #9581 

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
