### PR TITLE
feat: add canEditAccess permission to all entities

### DIFF
--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -17,6 +17,7 @@ export const ContentPermissions = [
   "hub:content:delete",
   "hub:content:edit",
   "hub:content:view",
+  "hub:content:canEditAccess",
   "hub:content:workspace",
   "hub:content:workspace:overview",
   "hub:content:workspace:dashboard",
@@ -33,6 +34,10 @@ export const ContentPermissions = [
  * @private
  */
 export const ContentPermissionPolicies: IPermissionPolicy[] = [
+  {
+    permission: "hub:content",
+    services: ["portal"],
+  },
   {
     permission: "hub:content:create",
     services: ["portal"],
@@ -55,6 +60,28 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
     authenticated: true,
     services: ["portal"],
     entityEdit: true,
+  },
+  {
+    permission: "hub:content:canEditAccess",
+    dependencies: ["hub:content"],
+    authenticated: true,
+    assertions: [
+      {
+        property: "context:currentUser.privileges",
+        type: "contains-some",
+        value: [
+          "portal:admin:shareToPublic",
+          "portal:admin:shareToOrg",
+          "portal:user:shareToPublic",
+          "portal:user:shareToOrg",
+        ],
+      },
+      {
+        property: "entity:itemControl",
+        type: "eq",
+        value: "admin",
+      },
+    ],
   },
   {
     permission: "hub:content:workspace",

--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -17,7 +17,7 @@ export const ContentPermissions = [
   "hub:content:delete",
   "hub:content:edit",
   "hub:content:view",
-  "hub:content:canEditAccess",
+  "hub:content:canChangeAccess",
   "hub:content:workspace",
   "hub:content:workspace:overview",
   "hub:content:workspace:dashboard",
@@ -62,7 +62,7 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
     entityEdit: true,
   },
   {
-    permission: "hub:content:canEditAccess",
+    permission: "hub:content:canChangeAccess",
     dependencies: ["hub:content"],
     authenticated: true,
     assertions: [

--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -11,6 +11,7 @@ export const DiscussionPermissions = [
   "hub:discussion:delete",
   "hub:discussion:edit",
   "hub:discussion:view",
+  "hub:discussion:canEditAccess",
   "hub:discussion:workspace:overview",
   "hub:discussion:workspace:dashboard",
   "hub:discussion:workspace:details",
@@ -57,6 +58,28 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:discussion"],
     entityOwner: true,
     licenses: ["hub-premium"],
+  },
+  {
+    permission: "hub:discussion:canEditAccess",
+    dependencies: ["hub:discussion"],
+    authenticated: true,
+    assertions: [
+      {
+        property: "context:currentUser.privileges",
+        type: "contains-some",
+        value: [
+          "portal:admin:shareToPublic",
+          "portal:admin:shareToOrg",
+          "portal:user:shareToPublic",
+          "portal:user:shareToOrg",
+        ],
+      },
+      {
+        property: "entity:itemControl",
+        type: "eq",
+        value: "admin",
+      },
+    ],
   },
   {
     permission: "hub:discussion:workspace:overview",

--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -11,7 +11,7 @@ export const DiscussionPermissions = [
   "hub:discussion:delete",
   "hub:discussion:edit",
   "hub:discussion:view",
-  "hub:discussion:canEditAccess",
+  "hub:discussion:canChangeAccess",
   "hub:discussion:workspace:overview",
   "hub:discussion:workspace:dashboard",
   "hub:discussion:workspace:details",
@@ -60,7 +60,7 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
     licenses: ["hub-premium"],
   },
   {
-    permission: "hub:discussion:canEditAccess",
+    permission: "hub:discussion:canChangeAccess",
     dependencies: ["hub:discussion"],
     authenticated: true,
     assertions: [

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -14,7 +14,7 @@ export const GroupPermissions = [
   "hub:group:edit",
   "hub:group:view",
   "hub:group:owner",
-  "hub:group:canEditAccess",
+  "hub:group:canChangeAccess",
   "hub:group:workspace",
   "hub:group:workspace:overview",
   "hub:group:workspace:dashboard",
@@ -82,7 +82,7 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
     entityOwner: true,
   },
   {
-    permission: "hub:group:canEditAccess",
+    permission: "hub:group:canChangeAccess",
     dependencies: ["hub:group"],
     authenticated: true,
     assertions: [

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -87,11 +87,25 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
     authenticated: true,
     assertions: [
       {
+        conditions: [
+          {
+            property: "context:currentUser",
+            type: "is-not-group-admin",
+            value: "entity:id",
+          },
+        ],
         property: "context:currentUser.privileges",
-        type: "contains-some",
+        type: "contains",
         value: ["portal:admin:updateGroups"],
       },
       {
+        conditions: [
+          {
+            property: "context:currentUser.privileges",
+            type: "without",
+            value: ["portal:admin:updateGroups"],
+          },
+        ],
         property: "context:currentUser",
         type: "is-group-admin",
         value: "entity:id",

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -14,6 +14,7 @@ export const GroupPermissions = [
   "hub:group:edit",
   "hub:group:view",
   "hub:group:owner",
+  "hub:group:canEditAccess",
   "hub:group:workspace",
   "hub:group:workspace:overview",
   "hub:group:workspace:dashboard",
@@ -79,6 +80,23 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:group"],
     authenticated: true,
     entityOwner: true,
+  },
+  {
+    permission: "hub:group:canEditAccess",
+    dependencies: ["hub:group"],
+    authenticated: true,
+    assertions: [
+      {
+        property: "context:currentUser.privileges",
+        type: "contains-some",
+        value: ["portal:admin:updateGroups"],
+      },
+      {
+        property: "context:currentUser",
+        type: "is-group-admin",
+        value: "entity:id",
+      },
+    ],
   },
   {
     permission: "hub:group:workspace",

--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateBusinessRules.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateBusinessRules.ts
@@ -18,6 +18,7 @@ export const InitiativeTemplatePermissions = [
   "hub:initiativeTemplate:delete",
   "hub:initiativeTemplate:edit",
   "hub:initiativeTemplate:view",
+  "hub:initiativeTemplate:canEditAccess",
   "hub:initiativeTemplate:workspace",
   "hub:initiativeTemplate:workspace:dashboard",
   "hub:initiativeTemplate:workspace:details",
@@ -57,6 +58,28 @@ export const InitiativeTemplatePermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:initiativeTemplate"],
     authenticated: true,
     entityOwner: true,
+  },
+  {
+    permission: "hub:initiativeTemplate:canEditAccess",
+    dependencies: ["hub:initiativeTemplate"],
+    authenticated: true,
+    assertions: [
+      {
+        property: "context:currentUser.privileges",
+        type: "contains-some",
+        value: [
+          "portal:admin:shareToPublic",
+          "portal:admin:shareToOrg",
+          "portal:user:shareToPublic",
+          "portal:user:shareToOrg",
+        ],
+      },
+      {
+        property: "entity:itemControl",
+        type: "eq",
+        value: "admin",
+      },
+    ],
   },
   {
     permission: "hub:initiativeTemplate:workspace",

--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateBusinessRules.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateBusinessRules.ts
@@ -18,7 +18,7 @@ export const InitiativeTemplatePermissions = [
   "hub:initiativeTemplate:delete",
   "hub:initiativeTemplate:edit",
   "hub:initiativeTemplate:view",
-  "hub:initiativeTemplate:canEditAccess",
+  "hub:initiativeTemplate:canChangeAccess",
   "hub:initiativeTemplate:workspace",
   "hub:initiativeTemplate:workspace:dashboard",
   "hub:initiativeTemplate:workspace:details",
@@ -60,7 +60,7 @@ export const InitiativeTemplatePermissionPolicies: IPermissionPolicy[] = [
     entityOwner: true,
   },
   {
-    permission: "hub:initiativeTemplate:canEditAccess",
+    permission: "hub:initiativeTemplate:canChangeAccess",
     dependencies: ["hub:initiativeTemplate"],
     authenticated: true,
     assertions: [

--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -20,7 +20,7 @@ export const InitiativePermissions = [
   "hub:initiative:delete",
   "hub:initiative:edit",
   "hub:initiative:view",
-  "hub:initiative:canEditAccess",
+  "hub:initiative:canChangeAccess",
   "hub:initiative:events",
   "hub:initiative:content",
   "hub:initiative:discussions",
@@ -76,7 +76,7 @@ export const InitiativePermissionPolicies: IPermissionPolicy[] = [
     entityOwner: true,
   },
   {
-    permission: "hub:initiative:canEditAccess",
+    permission: "hub:initiative:canChangeAccess",
     dependencies: ["hub:initiative"],
     authenticated: true,
     assertions: [

--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -20,6 +20,7 @@ export const InitiativePermissions = [
   "hub:initiative:delete",
   "hub:initiative:edit",
   "hub:initiative:view",
+  "hub:initiative:canEditAccess",
   "hub:initiative:events",
   "hub:initiative:content",
   "hub:initiative:discussions",
@@ -73,6 +74,28 @@ export const InitiativePermissionPolicies: IPermissionPolicy[] = [
     authenticated: true,
 
     entityOwner: true,
+  },
+  {
+    permission: "hub:initiative:canEditAccess",
+    dependencies: ["hub:initiative"],
+    authenticated: true,
+    assertions: [
+      {
+        property: "context:currentUser.privileges",
+        type: "contains-some",
+        value: [
+          "portal:admin:shareToPublic",
+          "portal:admin:shareToOrg",
+          "portal:user:shareToPublic",
+          "portal:user:shareToOrg",
+        ],
+      },
+      {
+        property: "entity:itemControl",
+        type: "eq",
+        value: "admin",
+      },
+    ],
   },
   {
     permission: "hub:initiative:events",

--- a/packages/common/src/pages/_internal/PageBusinessRules.ts
+++ b/packages/common/src/pages/_internal/PageBusinessRules.ts
@@ -18,7 +18,7 @@ export const PagePermissions = [
   "hub:page:delete",
   "hub:page:edit",
   "hub:page:view",
-  "hub:page:canEditAccess",
+  "hub:page:canChangeAccess",
   "hub:page:workspace",
   "hub:page:workspace:overview",
   "hub:page:workspace:dashboard",
@@ -60,7 +60,7 @@ export const PagePermissionPolicies: IPermissionPolicy[] = [
     entityOwner: true,
   },
   {
-    permission: "hub:page:canEditAccess",
+    permission: "hub:page:canChangeAccess",
     dependencies: ["hub:page"],
     authenticated: true,
     assertions: [

--- a/packages/common/src/pages/_internal/PageBusinessRules.ts
+++ b/packages/common/src/pages/_internal/PageBusinessRules.ts
@@ -18,6 +18,7 @@ export const PagePermissions = [
   "hub:page:delete",
   "hub:page:edit",
   "hub:page:view",
+  "hub:page:canEditAccess",
   "hub:page:workspace",
   "hub:page:workspace:overview",
   "hub:page:workspace:dashboard",
@@ -57,6 +58,28 @@ export const PagePermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:page"],
     authenticated: true,
     entityOwner: true,
+  },
+  {
+    permission: "hub:page:canEditAccess",
+    dependencies: ["hub:page"],
+    authenticated: true,
+    assertions: [
+      {
+        property: "context:currentUser.privileges",
+        type: "contains-some",
+        value: [
+          "portal:admin:shareToPublic",
+          "portal:admin:shareToOrg",
+          "portal:user:shareToPublic",
+          "portal:user:shareToOrg",
+        ],
+      },
+      {
+        property: "entity:itemControl",
+        type: "eq",
+        value: "admin",
+      },
+    ],
   },
   {
     permission: "hub:page:workspace",

--- a/packages/common/src/permissions/_internal/checkAssertion.ts
+++ b/packages/common/src/permissions/_internal/checkAssertion.ts
@@ -71,6 +71,7 @@ export function checkAssertion(
         response = lengthAssertions(assertion, propValue, val);
         break;
       case "is-group-admin":
+      case "is-not-group-admin":
       case "is-group-member":
       case "is-group-owner":
         response = groupAssertions(assertion, propValue, val, context);
@@ -110,6 +111,11 @@ function groupAssertions(
   if (assertion.type === "is-group-admin") {
     failResponse = "user-not-group-manager";
     groups = filterByMembershipType(userGroups, ["admin", "owner"]);
+  }
+
+  if (assertion.type === "is-not-group-admin") {
+    failResponse = "user-is-group-manager";
+    groups = filterByMembershipType(userGroups, ["member"]);
   }
 
   if (assertion.type === "is-group-owner") {

--- a/packages/common/src/permissions/_internal/checkAssertion.ts
+++ b/packages/common/src/permissions/_internal/checkAssertion.ts
@@ -55,6 +55,7 @@ export function checkAssertion(
         response = stringAssertions(assertion, propValue, val);
         break;
       case "contains":
+      case "contains-some":
       case "without":
         response = arrayAssertions(assertion, propValue, val);
         break;
@@ -280,6 +281,16 @@ function arrayAssertions(
     const arrayContainsValue = arrayProp.includes(val);
     if (assertion.type === "contains" && !arrayContainsValue) {
       response = "array-missing-required-value";
+    }
+    if (assertion.type === "contains-some") {
+      if (!Array.isArray(val)) {
+        response = "assertion-requires-array-value";
+      } else {
+        const containsSome = val.some((v) => arrayProp.includes(v));
+        if (!containsSome) {
+          response = "array-missing-required-value";
+        }
+      }
     }
     if (assertion.type === "without" && arrayContainsValue) {
       response = "array-contains-invalid-value";

--- a/packages/common/src/permissions/types/IPermissionPolicy.ts
+++ b/packages/common/src/permissions/types/IPermissionPolicy.ts
@@ -143,6 +143,7 @@ export type AssertionType =
   | "without"
   | "included-in"
   | "is-group-admin"
+  | "is-not-group-admin"
   | "is-group-member"
   | "is-group-owner"
   | "starts-with"

--- a/packages/common/src/permissions/types/IPermissionPolicy.ts
+++ b/packages/common/src/permissions/types/IPermissionPolicy.ts
@@ -139,6 +139,7 @@ export type AssertionType =
   | "length-lt"
   | "contains"
   | "contains-all"
+  | "contains-some"
   | "without"
   | "included-in"
   | "is-group-admin"

--- a/packages/common/src/permissions/types/PolicyResponse.ts
+++ b/packages/common/src/permissions/types/PolicyResponse.ts
@@ -38,6 +38,7 @@ export type PolicyResponse =
   | "user-not-group-member"
   | "user-not-group-manager"
   | "user-not-group-owner"
+  | "user-is-group-manager"
   | "assertion-property-not-found"
   | "assertion-failed" // assertion condition was not met
   | "assertion-requires-numeric-values" // assertion requires numeric values

--- a/packages/common/src/permissions/types/PolicyResponse.ts
+++ b/packages/common/src/permissions/types/PolicyResponse.ts
@@ -41,6 +41,7 @@ export type PolicyResponse =
   | "assertion-property-not-found"
   | "assertion-failed" // assertion condition was not met
   | "assertion-requires-numeric-values" // assertion requires numeric values
+  | "assertion-requires-array-value" // assertion requires array value
   | "property-match"
   | "feature-disabled" // feature has been disabled for the entity
   | "feature-enabled" // feature has been enabled for the entity

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -21,7 +21,7 @@ export const ProjectPermissions = [
   "hub:project:edit",
   "hub:project:view",
   "hub:project:owner",
-  "hub:project:canEditAccess",
+  "hub:project:canChangeAccess",
   "hub:project:events",
   "hub:project:content",
   "hub:project:discussions",
@@ -78,7 +78,7 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
     entityOwner: true,
   },
   {
-    permission: "hub:project:canEditAccess",
+    permission: "hub:project:canChangeAccess",
     dependencies: ["hub:project"],
     authenticated: true,
     assertions: [

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -21,6 +21,7 @@ export const ProjectPermissions = [
   "hub:project:edit",
   "hub:project:view",
   "hub:project:owner",
+  "hub:project:canEditAccess",
   "hub:project:events",
   "hub:project:content",
   "hub:project:discussions",
@@ -75,6 +76,28 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:project"],
     authenticated: true,
     entityOwner: true,
+  },
+  {
+    permission: "hub:project:canEditAccess",
+    dependencies: ["hub:project"],
+    authenticated: true,
+    assertions: [
+      {
+        property: "context:currentUser.privileges",
+        type: "contains-some",
+        value: [
+          "portal:admin:shareToPublic",
+          "portal:admin:shareToOrg",
+          "portal:user:shareToPublic",
+          "portal:user:shareToOrg",
+        ],
+      },
+      {
+        property: "entity:itemControl",
+        type: "eq",
+        value: "admin",
+      },
+    ],
   },
   {
     permission: "hub:project:events",

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -22,7 +22,7 @@ export const SitePermissions = [
   "hub:site:edit",
   "hub:site:view",
   "hub:site:owner",
-  "hub:site:canEditAccess",
+  "hub:site:canChangeAccess",
   "hub:site:events",
   "hub:site:content",
   "hub:site:discussions",
@@ -78,7 +78,7 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
     authenticated: true,
   },
   {
-    permission: "hub:site:canEditAccess",
+    permission: "hub:site:canChangeAccess",
     dependencies: ["hub:site"],
     authenticated: true,
     assertions: [

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -22,6 +22,7 @@ export const SitePermissions = [
   "hub:site:edit",
   "hub:site:view",
   "hub:site:owner",
+  "hub:site:canEditAccess",
   "hub:site:events",
   "hub:site:content",
   "hub:site:discussions",
@@ -75,6 +76,28 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
     entityEdit: true,
     dependencies: ["hub:site"],
     authenticated: true,
+  },
+  {
+    permission: "hub:site:canEditAccess",
+    dependencies: ["hub:site"],
+    authenticated: true,
+    assertions: [
+      {
+        property: "context:currentUser.privileges",
+        type: "contains-some",
+        value: [
+          "portal:admin:shareToPublic",
+          "portal:admin:shareToOrg",
+          "portal:user:shareToPublic",
+          "portal:user:shareToOrg",
+        ],
+      },
+      {
+        property: "entity:itemControl",
+        type: "eq",
+        value: "admin",
+      },
+    ],
   },
   {
     permission: "hub:site:events",

--- a/packages/common/src/surveys/_internal/SurveyBusinessRules.ts
+++ b/packages/common/src/surveys/_internal/SurveyBusinessRules.ts
@@ -11,7 +11,7 @@ export const SurveyPermissions = [
   "hub:survey:delete",
   "hub:survey:edit",
   "hub:survey:view",
-  "hub:survey:canEditAccess",
+  "hub:survey:canChangeAccess",
   "hub:survey:workspace",
   "hub:survey:workspace:dashboard",
   "hub:survey:workspace:details",
@@ -55,7 +55,7 @@ export const SurveyPermissionPolicies: IPermissionPolicy[] = [
     entityOwner: true,
   },
   {
-    permission: "hub:survey:canEditAccess",
+    permission: "hub:survey:canChangeAccess",
     dependencies: ["hub:survey"],
     authenticated: true,
     assertions: [

--- a/packages/common/src/surveys/_internal/SurveyBusinessRules.ts
+++ b/packages/common/src/surveys/_internal/SurveyBusinessRules.ts
@@ -11,6 +11,7 @@ export const SurveyPermissions = [
   "hub:survey:delete",
   "hub:survey:edit",
   "hub:survey:view",
+  "hub:survey:canEditAccess",
   "hub:survey:workspace",
   "hub:survey:workspace:dashboard",
   "hub:survey:workspace:details",
@@ -52,6 +53,28 @@ export const SurveyPermissionPolicies: IPermissionPolicy[] = [
     authenticated: true,
     dependencies: ["hub:survey"],
     entityOwner: true,
+  },
+  {
+    permission: "hub:survey:canEditAccess",
+    dependencies: ["hub:survey"],
+    authenticated: true,
+    assertions: [
+      {
+        property: "context:currentUser.privileges",
+        type: "contains-some",
+        value: [
+          "portal:admin:shareToPublic",
+          "portal:admin:shareToOrg",
+          "portal:user:shareToPublic",
+          "portal:user:shareToOrg",
+        ],
+      },
+      {
+        property: "entity:itemControl",
+        type: "eq",
+        value: "admin",
+      },
+    ],
   },
   {
     permission: "hub:survey:workspace",

--- a/packages/common/src/templates/_internal/TemplateBusinessRules.ts
+++ b/packages/common/src/templates/_internal/TemplateBusinessRules.ts
@@ -18,6 +18,7 @@ export const TemplatePermissions = [
   "hub:template:edit",
   "hub:template:manage",
   "hub:template:view",
+  "hub:template:canEditAccess",
   "hub:template:workspace",
   "hub:template:workspace:details",
   "hub:template:workspace:dashboard",
@@ -60,6 +61,28 @@ export const TemplatePermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:template:manage",
     dependencies: ["hub:template:edit"],
+  },
+  {
+    permission: "hub:template:canEditAccess",
+    dependencies: ["hub:template"],
+    authenticated: true,
+    assertions: [
+      {
+        property: "context:currentUser.privileges",
+        type: "contains-some",
+        value: [
+          "portal:admin:shareToPublic",
+          "portal:admin:shareToOrg",
+          "portal:user:shareToPublic",
+          "portal:user:shareToOrg",
+        ],
+      },
+      {
+        property: "entity:itemControl",
+        type: "eq",
+        value: "admin",
+      },
+    ],
   },
   {
     permission: "hub:template:workspace",

--- a/packages/common/src/templates/_internal/TemplateBusinessRules.ts
+++ b/packages/common/src/templates/_internal/TemplateBusinessRules.ts
@@ -18,7 +18,7 @@ export const TemplatePermissions = [
   "hub:template:edit",
   "hub:template:manage",
   "hub:template:view",
-  "hub:template:canEditAccess",
+  "hub:template:canChangeAccess",
   "hub:template:workspace",
   "hub:template:workspace:details",
   "hub:template:workspace:dashboard",
@@ -63,7 +63,7 @@ export const TemplatePermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:template:edit"],
   },
   {
-    permission: "hub:template:canEditAccess",
+    permission: "hub:template:canChangeAccess",
     dependencies: ["hub:template"],
     authenticated: true,
     assertions: [

--- a/packages/common/test/permissions/_internal/checkAssertion.test.ts
+++ b/packages/common/test/permissions/_internal/checkAssertion.test.ts
@@ -336,6 +336,31 @@ describe("checkAssertion:", () => {
       expect(fail.response).toBe("array-missing-required-value");
     });
 
+    it("entity prop contains-some val", () => {
+      const assertion: IPolicyAssertion = {
+        property: "context:currentUser.privileges",
+        type: "contains-some",
+        value: [
+          "portal:admin:shareToPublic",
+          "portal:admin:shareToOrg",
+          "portal:user:shareToPublic",
+          "portal:user:shareToOrg",
+        ],
+      };
+      const ctx = {
+        currentUser: {
+          privileges: ["portal:admin:shareToOrg"],
+        },
+      } as unknown as IArcGISContext;
+
+      const chk = checkAssertion(assertion, {}, ctx);
+      expect(chk.response).toBe("granted");
+
+      ctx.currentUser.privileges = [];
+      const fail = checkAssertion(assertion, {}, ctx);
+      expect(fail.response).toBe("array-missing-required-value");
+    });
+
     it("entity prop without val", () => {
       const assertion: IPolicyAssertion = {
         property: "colors",

--- a/packages/common/test/permissions/_internal/checkAssertion.test.ts
+++ b/packages/common/test/permissions/_internal/checkAssertion.test.ts
@@ -353,12 +353,16 @@ describe("checkAssertion:", () => {
         },
       } as unknown as IArcGISContext;
 
-      const chk = checkAssertion(assertion, {}, ctx);
-      expect(chk.response).toBe("granted");
+      const chk1 = checkAssertion(assertion, {}, ctx);
+      expect(chk1.response).toBe("granted");
 
       ctx.currentUser.privileges = [];
-      const fail = checkAssertion(assertion, {}, ctx);
-      expect(fail.response).toBe("array-missing-required-value");
+      const chk2 = checkAssertion(assertion, {}, ctx);
+      expect(chk2.response).toBe("array-missing-required-value");
+
+      assertion.value = "some string";
+      const chk3 = checkAssertion(assertion, {}, ctx);
+      expect(chk3.response).toBe("assertion-requires-array-value");
     });
 
     it("entity prop without val", () => {

--- a/packages/common/test/permissions/_internal/checkAssertion.test.ts
+++ b/packages/common/test/permissions/_internal/checkAssertion.test.ts
@@ -674,7 +674,7 @@ describe("checkAssertion:", () => {
         ],
       },
     } as unknown as IArcGISContext;
-    it("is-group-manager", () => {
+    it("is-group-admin", () => {
       const assertion: IPolicyAssertion = {
         property: "context:currentUser",
         type: "is-group-admin",
@@ -762,6 +762,38 @@ describe("checkAssertion:", () => {
         ctx
       );
       expect(fail.response).toBe("user-not-group-owner");
+    });
+    it("is-not-group-admin", () => {
+      const assertion: IPolicyAssertion = {
+        property: "context:currentUser",
+        type: "is-not-group-admin",
+        value: "entity:group.id",
+      };
+
+      const chk1 = checkAssertion(
+        assertion,
+        {
+          group: { id: "00a" },
+        },
+        ctx
+      );
+      expect(chk1.response).toBe("granted");
+      const chk2 = checkAssertion(
+        assertion,
+        {
+          group: { id: "00b" },
+        },
+        ctx
+      );
+      expect(chk2.response).toBe("user-is-group-manager");
+      const chk3 = checkAssertion(
+        assertion,
+        {
+          group: { id: "00c" },
+        },
+        ctx
+      );
+      expect(chk3.response).toBe("user-is-group-manager");
     });
     it("user has no groups", () => {
       const cloneCtx = cloneObject(ctx);


### PR DESCRIPTION
[9580](https://devtopia.esri.com/dc/hub/issues/9580)

### Description:

- extends the permission assertion types to support "contains-some"
- adds a new `hub:{entity}:canChangeAccess` to all entities based on the following logic to determine whether the current user can edit the access of the entity:

    **For item entities:**
    1. user has the (`portal:admin:shareToOrg` OR `portal:admin:shareToPublic`) OR (`portal:user:shareToOrg` OR `portal:user:shareToPublic`) privileges
    AND
    3. user has admin privileges over the item (`itemControl:admin`)
    
    **For group entities:**
    1. user has the `portal:admin:updateGroups` privilege
    OR
    4. user has admin or owner membership in the group

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.