### PR TITLE
fix: permissions for settings pane related to allow all editors

### DIFF
--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateBusinessRules.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateBusinessRules.ts
@@ -89,7 +89,6 @@ export const InitiativeTemplatePermissionPolicies: IPermissionPolicy[] = [
       "hub:initiativeTemplate:workspace",
       "hub:initiativeTemplate:edit",
     ],
-    entityOwner: true,
   },
   {
     permission: "hub:initiativeTemplate:manage",

--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -136,7 +136,6 @@ export const InitiativePermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:initiative:workspace:settings",
     dependencies: ["hub:initiative:workspace", "hub:initiative:edit"],
-    entityOwner: true,
   },
   {
     permission: "hub:initiative:workspace:collaborators",

--- a/packages/common/src/pages/_internal/PageBusinessRules.ts
+++ b/packages/common/src/pages/_internal/PageBusinessRules.ts
@@ -82,7 +82,6 @@ export const PagePermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:page:workspace:settings",
     dependencies: ["hub:page:workspace", "hub:page:edit"],
-    entityOwner: true,
   },
   {
     permission: "hub:page:manage",

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -120,7 +120,6 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:project:workspace:settings",
     dependencies: ["hub:project:workspace", "hub:project:edit"],
-    entityOwner: true,
   },
   {
     permission: "hub:project:workspace:collaborators",

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -118,7 +118,6 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:site:workspace:settings",
     dependencies: ["hub:site:workspace", "hub:site:edit"],
-    entityOwner: true,
   },
   {
     permission: "hub:site:workspace:collaborators",


### PR DESCRIPTION
1. Description:

Relax `:settings` permissions to allow all editors to access the pane. Components in the pane will utilize additional permissions to control access to delete and other actions

1. Instructions for testing: n/a - have verified by running in the app
![image](https://github.com/Esri/hub.js/assets/119129/31a61c31-e5ed-4375-bb32-05d2a08d320d)


1. Part of Issue: #9901

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
