### PR TITLE
fix(hub-common): fix discussion board and survey permissions

### DIFF
--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -43,7 +43,7 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:discussion:view",
     dependencies: ["hub:discussion"],
     authenticated: false,
-    licenses: ["hub-premium"],
+    licenses: ["hub-basic", "hub-premium"],
   },
   {
     permission: "hub:discussion:edit",
@@ -88,7 +88,6 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:discussion:workspace:dashboard",
     dependencies: ["hub:discussion:view"],
-    environments: ["devext", "qaext"],
   },
   {
     permission: "hub:discussion:workspace:details",

--- a/packages/common/src/surveys/_internal/SurveyBusinessRules.ts
+++ b/packages/common/src/surveys/_internal/SurveyBusinessRules.ts
@@ -28,9 +28,6 @@ export const SurveyPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:survey",
     services: ["portal"],
-    // gated for now
-    availability: ["alpha"],
-    environments: ["devext", "qaext"],
   },
   {
     permission: "hub:survey:view",


### PR DESCRIPTION
1. Description:
Fixes issues with Survey & Discussion Board permissions

1. Instructions for testing:

1. Closes Issues: [9924](https://devtopia.esri.com/dc/hub/issues/9924) & [9925](https://devtopia.esri.com/dc/hub/issues/9925)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
