### PR TITLE
fix(hub-common): add tags and categories to events

### DIFF
--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -52,6 +52,14 @@ export type GetEventsParams = {
    * the index to start at
    */
   start?: string;
+  /**
+   * Event property to sort results by
+   */
+  sortBy?: EventSort;
+  /**
+   * sort results order desc or asc
+   */
+  sortOrder?: SortOrder;
 };
 
 export interface IUpdateRegistration {
@@ -126,6 +134,16 @@ export interface IUpdateEvent {
   title?: string;
 }
 
+export enum SortOrder {
+  asc = "asc",
+  desc = "desc",
+}
+export enum EventSort {
+  title = "title",
+  startDateTime = "startDateTime",
+  createdAt = "createdAt",
+  updatedAt = "updatedAt",
+}
 export interface IRegistrationPermission {
   canDelete: boolean;
   canEdit: boolean;

--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -25,13 +25,21 @@ export type GetEventsParams = {
    */
   startDateTimeAfter?: string;
   /**
-   * Comma separated sting list of AttendanceTypes
+   * Comma separated string list of AttendanceTypes
    */
   attendanceTypes?: string;
+  /**
+   * Comma separated string list of categories
+   */
+  categories?: string;
   /**
    * comma separated string list of event statuses
    */
   status?: string;
+  /**
+   * Comma separated string list of tags
+   */
+  tags?: string;
   /**
    * string to match within an event title
    */
@@ -90,6 +98,8 @@ export interface IUpdateEvent {
   allowRegistration?: boolean;
   /** Valid ways to attend the event */
   attendanceType?: EventAttendanceType[];
+  /** categories for the event */
+  categories?: string[];
   /** Description of the event */
   description?: string;
   /** Groups with edit access to the event */
@@ -108,6 +118,8 @@ export interface IUpdateEvent {
   startDateTime?: string;
   /** Summary of the event */
   summary?: string;
+  /** Tags for the event */
+  tags?: string[];
   /** IANA time zone for the event */
   timeZone?: string;
   /** Title of the event */
@@ -140,6 +152,7 @@ export interface IEvent {
   allowRegistration: boolean;
   attendanceType: EventAttendanceType[];
   catalog: IEventCatalogItem[] | null;
+  categories: string[];
   createdAt: string;
   createdById: string;
   creator?: IUser;
@@ -158,6 +171,7 @@ export interface IEvent {
   startDateTime: string;
   status: EventStatus;
   summary: string | null;
+  tags: string[];
   timeZone: string;
   title: string;
   updatedAt: string;
@@ -285,6 +299,8 @@ export interface ICreateEvent {
   allowRegistration?: boolean;
   /** Valid ways to attend the event */
   attendanceType?: EventAttendanceType[];
+  /** categories for the event */
+  categories?: string[];
   /** Description of the event */
   description?: string;
   /** Groups with edit access to the event */
@@ -309,6 +325,8 @@ export interface ICreateEvent {
   startDateTime: string;
   /** Summary of the event */
   summary?: string;
+  /** Tags for the event */
+  tags?: string[];
   /** IANA time zone for the event */
   timeZone: string;
   /** Title of the event */

--- a/packages/common/src/events/api/types.ts
+++ b/packages/common/src/events/api/types.ts
@@ -21,6 +21,8 @@ export {
   IUser,
   RegistrationRole,
   RegistrationStatus,
+  SortOrder,
+  EventSort,
 } from "./orval/api/orval-events";
 import { IHubRequestOptions } from "../../types";
 import {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
  - Add tags and categories to events. (`IEvent`, `ICreateEvent`, `IUpdateEvent`, `GetEventsParams`)
  - Add events enums `SortOrder` and `EventSort`
  - Add `sortBy` and `sortOrder` to `GetEventsParams`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
