### PR TITLE
feat(hub-common): add permission to capture download errors

### DIFF
--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -26,6 +26,7 @@ export const ContentPermissions = [
   "hub:content:workspace:settings",
   "hub:content:workspace:collaborators",
   "hub:content:manage",
+  "hub:content:canRecordDownloadErrors",
 ] as const;
 
 /**
@@ -115,5 +116,9 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:content:manage",
     dependencies: ["hub:content:edit"],
+  },
+  {
+    permission: "hub:content:canRecordDownloadErrors",
+    environments: ["qaext", "devext"],
   },
 ];


### PR DESCRIPTION
1. Description:

This PR adds a permission to enable recording of download errors from hosted download cards for only DEV and QA environments.

1. Instructions for testing:

1. Closes Issues: [#9591 ](https://devtopia.esri.com/dc/hub/issues/9591)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
