### PR TITLE
feat(): enrich initiatives with correct links

### DIFF
--- a/packages/common/src/content/_internal/internalContentUtils.ts
+++ b/packages/common/src/content/_internal/internalContentUtils.ts
@@ -245,6 +245,7 @@ export const getHubRelativeUrl = (
       "map",
       "template",
       "project",
+      "initiative",
       "discussion",
     ];
     // default to the catchall content route

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -358,12 +358,7 @@ export async function enrichInitiativeSearchResult(
 
   // Handle links
   // TODO: Link handling should be an enrichment
-  result.links = {
-    ...computeLinks(item, requestOptions),
-    // TODO: remove once sites are separated from initiatives and
-    // the initiatives view route is released
-    siteRelative: getHubRelativeUrl(result.type, result.id),
-  };
+  result.links = computeLinks(item, requestOptions);
 
   return result;
 }

--- a/packages/common/src/initiatives/_internal/computeLinks.ts
+++ b/packages/common/src/initiatives/_internal/computeLinks.ts
@@ -6,6 +6,7 @@ import { IHubEntityLinks } from "../../core/types";
 import { getItemIdentifier } from "../../items";
 import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
 import { getItemThumbnailUrl } from "../../resources/get-item-thumbnail-url";
+import { getHubRelativeUrl } from "../../content/_internal/internalContentUtils";
 
 /**
  * Compute the links that get appended to a Hub Initiative
@@ -26,10 +27,7 @@ export function computeLinks(
 
   return {
     self: getItemHomeUrl(item.id, requestOptions),
-    // TODO: once the initiative view is moved to initiatives/:id,
-    // update and leverage the getHubRelativeUrl util to construct
-    // this url. For now, we hard-code to the initiatives2/:id route
-    siteRelative: `/initiatives2/${getItemIdentifier(item)}`,
+    siteRelative: getHubRelativeUrl(item.type, getItemIdentifier(item)),
     workspaceRelative: getRelativeWorkspaceUrl(
       item.type,
       getItemIdentifier(item)

--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -25,6 +25,7 @@ import { enrichContentSearchResult } from "../../content/search";
 import { cloneObject } from "../../util";
 import { getWellknownCollection } from "../wellKnownCatalog";
 import { getProp } from "../../objects";
+import { enrichInitiativeSearchResult } from "../../initiatives";
 
 /**
  * @internal
@@ -226,6 +227,9 @@ export async function itemToSearchResult(
       break;
     case "Hub Project":
       fn = enrichProjectSearchResult;
+      break;
+    case "Hub Initiative":
+      fn = enrichInitiativeSearchResult;
       break;
     case "Solution":
       fn = enrichTemplateSearchResult;

--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -5,6 +5,7 @@ import { serializeQueryForPortal } from "../serializeQueryForPortal";
 import { enrichPageSearchResult } from "../../pages/HubPages";
 import { enrichProjectSearchResult } from "../../projects";
 import { enrichSiteSearchResult } from "../../sites";
+import { enrichInitiativeSearchResult } from "../../initiatives/HubInitiatives";
 import { enrichTemplateSearchResult } from "../../templates/fetch";
 import { IHubRequestOptions } from "../../types";
 
@@ -25,7 +26,6 @@ import { enrichContentSearchResult } from "../../content/search";
 import { cloneObject } from "../../util";
 import { getWellknownCollection } from "../wellKnownCatalog";
 import { getProp } from "../../objects";
-import { enrichInitiativeSearchResult } from "../../initiatives";
 
 /**
  * @internal

--- a/packages/common/test/content/content.test.ts
+++ b/packages/common/test/content/content.test.ts
@@ -852,10 +852,6 @@ describe("content: ", () => {
         result = getHubRelativeUrl("Hub Initiative Template", identifier);
         expect(result).toBe(`/initiatives/templates/${identifier}/about`);
       });
-      it("should handle initiative items", () => {
-        const result = getHubRelativeUrl("Hub Initiative", identifier);
-        expect(result).toBe(`/content/${identifier}`);
-      });
       it("should handle solution templates", () => {
         let result = getHubRelativeUrl("Web Mapping Application", identifier, [
           "hubSolutionTemplate",

--- a/packages/common/test/initiatives/HubInitiatives.test.ts
+++ b/packages/common/test/initiatives/HubInitiatives.test.ts
@@ -393,7 +393,7 @@ describe("HubInitiatives:", () => {
       expect(chk.links?.self).toEqual(
         `https://some-server.com/gis/home/item.html?id=${ITM.id}`
       );
-      expect(chk.links?.siteRelative).toEqual(`/content/${ITM.id}`);
+      expect(chk.links?.siteRelative).toEqual(`/initiatives/${ITM.id}`);
       expect(chk.links?.thumbnail).toEqual(
         `${hubRo.portal}/content/items/${ITM.id}/info/${ITM.thumbnail}`
       );

--- a/packages/common/test/initiatives/_internal/computeLinks.test.ts
+++ b/packages/common/test/initiatives/_internal/computeLinks.test.ts
@@ -32,13 +32,13 @@ describe("computeLinks", () => {
     setProp("properties.slug", "mock-slug", item);
     const chk = computeLinks(item, authdCtxMgr.context.requestOptions);
 
-    expect(chk.siteRelative).toBe("/initiatives2/mock-slug");
+    expect(chk.siteRelative).toBe("/initiatives/mock-slug");
     expect(chk.workspaceRelative).toBe("/workspace/initiatives/mock-slug");
   });
   it("generates a links hash using the initiative's id when no slug is available", () => {
     const chk = computeLinks(item, authdCtxMgr.context.requestOptions);
 
-    expect(chk.siteRelative).toBe("/initiatives2/00c");
+    expect(chk.siteRelative).toBe("/initiatives/00c");
     expect(chk.workspaceRelative).toBe("/workspace/initiatives/00c");
   });
 });


### PR DESCRIPTION
1. Description:
Hooks up initiative enrichment on search results, and updates computeLinks so that we link to `/initiatives/:id` and not `/content/:id` or `/initiatives2/:id`. 

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
