### PR TITLE
fix: update unfollow button to outline-fill

### DIFF
--- a/packages/common/src/core/schemas/internal/follow/FollowSchema.ts
+++ b/packages/common/src/core/schemas/internal/follow/FollowSchema.ts
@@ -34,7 +34,7 @@ export const FollowSchema: IConfigurationSchema = {
     },
     buttonStyle: {
       type: "string",
-      enum: ["solid", "outline"],
+      enum: ["solid", "outline-fill"],
       default: "solid",
     },
   },


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
update unfollow button to from outline to outline-fill

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
