### PR TITLE
fix(hub-common): add event icon to getContentTypeIcon method

### DIFF
--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -245,6 +245,7 @@ export const getContentTypeIcon = (contentType: string) => {
     desktopApplication: "desktop",
     discussion: "speech-bubbles",
     documentLink: "link",
+    event: "event",
     excaliburImageryProject: "file",
     explorerMap: "file",
     exportPackage: "file",


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 9318

1. Description:

- Adds `event` icon to `getContentTypeIcon` method

1. Instructions for testing:

1. Closes Issues: #9318

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
