### PR TITLE
feat: added permission for download errors

### DIFF
--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -27,6 +27,7 @@ export const ContentPermissions = [
   "hub:content:workspace:collaborators",
   "hub:content:manage",
   "hub:content:canRecordDownloadErrors",
+  "hub:content:downloads:displayErrors",
 ] as const;
 
 /**
@@ -119,6 +120,11 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:content:canRecordDownloadErrors",
+    environments: ["qaext", "devext"],
+  },
+  {
+    permission: "hub:content:downloads:displayErrors",
+    availability: ["alpha"],
     environments: ["qaext", "devext"],
   },
 ];


### PR DESCRIPTION
1. Description:

Adding permission for errors that we want to display in accordions in opendata-ui

**confirmed with Dave that this is the permission structure he wanted**

1. Instructions for testing:

1. Closes Issues: #[1522](https://devtopia.esri.com/dc/hub/issues/1522)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
