### PR TITLE
fix: add helper texts and remove "Favorite" filter in follow card editor

### DIFF
--- a/packages/common/src/core/schemas/internal/follow/FollowCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/follow/FollowCardUiSchema.ts
@@ -11,11 +11,7 @@ import { IHubCatalog } from "../../../../search/types/IHubCatalog";
 
 // Get the catalogs for the entity gallery picker
 function getCatalogs(user: IUser): IHubCatalog[] {
-  const catalogNames: WellKnownCatalog[] = [
-    "myContent",
-    "favorites",
-    "organization",
-  ];
+  const catalogNames: WellKnownCatalog[] = ["myContent", "organization"];
   return catalogNames.map((name: WellKnownCatalog) => {
     const opts = {
       user,
@@ -61,11 +57,19 @@ export const buildUiSchema = (
       },
       {
         type: "Section",
+        elements: [
+          {
+            type: "Slot",
+            options: { name: "notice-slot" },
+          },
+        ],
+      },
+      {
+        type: "Section",
         labelKey: "callToAction.title",
         rule: HIDE_FOR_NO_ENTITY_ID,
         elements: [
           {
-            labelKey: "callToAction.description",
             scope: "/properties/callToActionText",
             type: "Control",
             options: {

--- a/packages/common/src/core/schemas/internal/follow/FollowCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/follow/FollowCardUiSchema.ts
@@ -68,6 +68,11 @@ export const buildUiSchema = (
         type: "Section",
         labelKey: "callToAction.title",
         rule: HIDE_FOR_NO_ENTITY_ID,
+        options: {
+          helperText: {
+            labelKey: "callToAction.helperText",
+          },
+        },
         elements: [
           {
             scope: "/properties/callToActionText",
@@ -91,7 +96,9 @@ export const buildUiSchema = (
         type: "Section",
         labelKey: "followButton.title",
         options: {
-          labelKey: "followButton.description",
+          helperText: {
+            labelKey: "followButton.helperText",
+          },
         },
         rule: HIDE_FOR_NO_ENTITY_ID,
         elements: [

--- a/packages/common/src/core/schemas/internal/follow/FollowCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/follow/FollowCardUiSchema.ts
@@ -57,15 +57,6 @@ export const buildUiSchema = (
       },
       {
         type: "Section",
-        elements: [
-          {
-            type: "Slot",
-            options: { name: "notice-slot" },
-          },
-        ],
-      },
-      {
-        type: "Section",
         labelKey: "callToAction.title",
         rule: HIDE_FOR_NO_ENTITY_ID,
         options: {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

- add helper texts for follow card editor
- remove "Favorite" filter

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
