### PR TITLE
feat(hub-common): add function getRegistrations and fix type for page…

### DIFF
--- a/packages/common/src/events/api/events.ts
+++ b/packages/common/src/events/api/events.ts
@@ -1,5 +1,6 @@
 import {
   IEvent,
+  GetEvents200,
   ICreateEventParams,
   IGetEventParams,
   IGetEventsParams,
@@ -32,9 +33,11 @@ export async function createEvent(
  * get events
  *
  * @param {IGetEventsParams} options
- * @return {Promise<IEvent[]>}
+ * @return {Promise<GetEvents200>}
  */
-export async function getEvents(options: IGetEventsParams): Promise<IEvent[]> {
+export async function getEvents(
+  options: IGetEventsParams
+): Promise<GetEvents200> {
   options.token = await authenticateRequest(options);
   return _getEvents(options.data, options);
 }

--- a/packages/common/src/events/api/events.ts
+++ b/packages/common/src/events/api/events.ts
@@ -1,6 +1,6 @@
 import {
   IEvent,
-  GetEvents200,
+  IPagedEventResponse,
   ICreateEventParams,
   IGetEventParams,
   IGetEventsParams,
@@ -33,11 +33,11 @@ export async function createEvent(
  * get events
  *
  * @param {IGetEventsParams} options
- * @return {Promise<GetEvents200>}
+ * @return {Promise<IPagedEventResponse>}
  */
 export async function getEvents(
   options: IGetEventsParams
-): Promise<GetEvents200> {
+): Promise<IPagedEventResponse> {
   options.token = await authenticateRequest(options);
   return _getEvents(options.data, options);
 }

--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -7,75 +7,11 @@
  */
 import { Awaited } from "../awaited-type";
 import { customClient } from "../custom-client";
-export type GetRegistrationsParams = {
-  /**
-   * Event id being registered for
-   */
-  eventId?: string;
-  /**
-   * ArcGIS Online id for a user. Will always be extracted from the token unless service token is used.
-   */
-  userAgoId?: string;
-  /**
-   * the max amount of registrations to return
-   */
-  num?: string;
-  /**
-   * the index to start at
-   */
-  start?: string;
-};
-
-export type GetEventsParams = {
-  /**
-   * which relation fields to include in response
-   */
-  include?: string;
-  /**
-   * latest ISO8601 start date-time for the events
-   */
-  startDateTimeBefore?: string;
-  /**
-   * earliest ISO8601 start date-time for the events
-   */
-  startDateTimeAfter?: string;
-  /**
-   * Comma separated string list of AttendanceTypes
-   */
-  attendanceTypes?: string;
-  /**
-   * Comma separated string list of categories
-   */
-  categories?: string;
-  /**
-   * comma separated string list of event statuses
-   */
-  status?: string;
-  /**
-   * Comma separated string list of tags
-   */
-  tags?: string;
-  /**
-   * string to match within an event title
-   */
-  title?: string;
-  /**
-   * the max amount of events to return
-   */
-  num?: string;
-  /**
-   * the index to start at
-   */
-  start?: string;
-  /**
-   * Event property to sort results by
-   */
-  sortBy?: EventSort;
-  /**
-   * sort results order desc or asc
-   */
-  sortOrder?: SortOrder;
-};
+export interface IPagedRegistrationResponse {
+  items: IRegistration[];
+  nextStart: number;
+  total: number;
+}
 
 export enum RegistrationSort {
   createdAt = "createdAt",
@@ -84,6 +20,53 @@ export enum RegistrationSort {
   lastName = "lastName",
   username = "username",
 }
+export type GetRegistrationsParams = {
+  /**
+   * Event id being registered for
+   */
+  eventId?: string;
+  /**
+   * ArcGIS Online id for a user
+   */
+  userId?: string;
+  /**
+   * comma separated string list of registration roles
+   */
+  role?: string;
+  /**
+   * comma separated string list of registration statuses
+   */
+  status?: string;
+  /**
+   * comma separated string list of registration types
+   */
+  type?: string;
+  /**
+   * latest ISO8601 updatedAt for the registrations
+   */
+  updatedAtBefore?: string;
+  /**
+   * earliest ISO8601 updatedAt for the registrations
+   */
+  updatedAtAfter?: string;
+  /**
+   * the max amount of registrations to return
+   */
+  num?: string;
+  /**
+   * the index to start at
+   */
+  start?: string;
+  /**
+   * property to sort results by
+   */
+  sortBy?: RegistrationSort;
+  /**
+   * sort order desc or asc
+   */
+  sortOrder?: SortOrder;
+};
+
 export interface ICreateRegistration {
   /** ArcGIS Online id for a user. Will always be extracted from the token unless service token is used. */
   agoId?: string;
@@ -149,41 +132,57 @@ export interface IUpdateEvent {
   title?: string;
 }
 
+export interface IPagedEventResponse {
+  items: IEvent[];
+  nextStart: number;
+  total: number;
+}
+
 export enum SortOrder {
   asc = "asc",
   desc = "desc",
 }
-export type GetRegistrationsParams = {
+export enum EventSort {
+  title = "title",
+  startDateTime = "startDateTime",
+  createdAt = "createdAt",
+  updatedAt = "updatedAt",
+}
+export type GetEventsParams = {
   /**
-   * Event id being registered for
+   * Comma separated string list of relation fields to include in response
    */
-  eventId?: string;
+  include?: string;
   /**
-   * ArcGIS Online id for a user
+   * latest ISO8601 start date-time for the events
    */
-  userId?: string;
+  startDateTimeBefore?: string;
   /**
-   * comma separated string list of registration roles
+   * earliest ISO8601 start date-time for the events
    */
-  role?: string;
+  startDateTimeAfter?: string;
   /**
-   * comma separated string list of registration statuses
+   * Comma separated string list of AttendanceTypes
+   */
+  attendanceTypes?: string;
+  /**
+   * Comma separated string list of categories
+   */
+  categories?: string;
+  /**
+   * comma separated string list of event statuses
    */
   status?: string;
   /**
-   * comma separated string list of registration types
+   * Comma separated string list of tags
    */
-  type?: string;
+  tags?: string;
   /**
-   * latest ISO8601 updatedAt for the registrations
+   * string to match within an event title
    */
-  updatedAtBefore?: string;
+  title?: string;
   /**
-   * earliest ISO8601 updatedAt for the registrations
-   */
-  updatedAtAfter?: string;
-  /**
-   * the max amount of registrations to return
+   * the max amount of events to return
    */
   num?: string;
   /**
@@ -191,25 +190,14 @@ export type GetRegistrationsParams = {
    */
   start?: string;
   /**
-   * property to sort results by
+   * Event property to sort results by
    */
-  sortBy?: RegistrationSort;
+  sortBy?: EventSort;
   /**
-   * sort order desc or asc
+   * sort results order desc or asc
    */
   sortOrder?: SortOrder;
 };
-
-export enum EventSort {
-  title = "title",
-  startDateTime = "startDateTime",
-  createdAt = "createdAt",
-  updatedAt = "updatedAt",
-}
-export interface IPagingParams {
-  nextStart: number;
-  total: number;
-}
 
 export interface IRegistrationPermission {
   canDelete: boolean;
@@ -450,7 +438,7 @@ export const getEvents = (
   params?: GetEventsParams,
   options?: SecondParameter<typeof customClient>
 ) => {
-  return customClient<GetEvents200>(
+  return customClient<IPagedEventResponse>(
     { url: `/api/events/v1/events`, method: "GET", params },
     options
   );
@@ -511,7 +499,7 @@ export const getRegistrations = (
   params?: GetRegistrationsParams,
   options?: SecondParameter<typeof customClient>
 ) => {
-  return customClient<IRegistration[]>(
+  return customClient<IPagedRegistrationResponse>(
     { url: `/api/events/v1/registrations`, method: "GET", params },
     options
   );

--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -77,15 +77,13 @@ export type GetEventsParams = {
   sortOrder?: SortOrder;
 };
 
-export interface IUpdateRegistration {
-  /** Role of the user in the event */
-  role?: RegistrationRole;
-  /** Status of the registration */
-  status?: RegistrationStatus;
-  /** Attendance type for this registration */
-  type?: EventAttendanceType;
+export enum RegistrationSort {
+  createdAt = "createdAt",
+  updatedAt = "updatedAt",
+  firstName = "firstName",
+  lastName = "lastName",
+  username = "username",
 }
-
 export interface ICreateRegistration {
   /** ArcGIS Online id for a user. Will always be extracted from the token unless service token is used. */
   agoId?: string;
@@ -155,12 +153,64 @@ export enum SortOrder {
   asc = "asc",
   desc = "desc",
 }
+export type GetRegistrationsParams = {
+  /**
+   * Event id being registered for
+   */
+  eventId?: string;
+  /**
+   * ArcGIS Online id for a user
+   */
+  userId?: string;
+  /**
+   * comma separated string list of registration roles
+   */
+  role?: string;
+  /**
+   * comma separated string list of registration statuses
+   */
+  status?: string;
+  /**
+   * comma separated string list of registration types
+   */
+  type?: string;
+  /**
+   * latest ISO8601 updatedAt for the registrations
+   */
+  updatedAtBefore?: string;
+  /**
+   * earliest ISO8601 updatedAt for the registrations
+   */
+  updatedAtAfter?: string;
+  /**
+   * the max amount of registrations to return
+   */
+  num?: string;
+  /**
+   * the index to start at
+   */
+  start?: string;
+  /**
+   * property to sort results by
+   */
+  sortBy?: RegistrationSort;
+  /**
+   * sort order desc or asc
+   */
+  sortOrder?: SortOrder;
+};
+
 export enum EventSort {
   title = "title",
   startDateTime = "startDateTime",
   createdAt = "createdAt",
   updatedAt = "updatedAt",
 }
+export interface IPagingParams {
+  nextStart: number;
+  total: number;
+}
+
 export interface IRegistrationPermission {
   canDelete: boolean;
   canEdit: boolean;
@@ -192,7 +242,7 @@ export interface IEvent {
   createdById: string | null;
   creator?: IUser;
   description: string | null;
-  editGroups: string[] | null;
+  editGroups: string[];
   endDateTime: string;
   geometry: IEventGeometry;
   id: string;
@@ -200,7 +250,7 @@ export interface IEvent {
   onlineMeetings?: IOnlineMeeting[];
   orgId: string;
   permission: IEventPermission;
-  readGroups: string[] | null;
+  readGroups: string[];
   recurrence: string | null;
   registrations?: IRegistration[];
   startDateTime: string;
@@ -223,6 +273,15 @@ export enum RegistrationRole {
   ORGANIZER = "ORGANIZER",
   ATTENDEE = "ATTENDEE",
 }
+export interface IUpdateRegistration {
+  /** Role of the user in the event */
+  role?: RegistrationRole;
+  /** Status of the registration */
+  status?: RegistrationStatus;
+  /** Attendance type for this registration */
+  type?: EventAttendanceType;
+}
+
 export enum EventStatus {
   PLANNED = "PLANNED",
   CANCELED = "CANCELED",
@@ -391,7 +450,7 @@ export const getEvents = (
   params?: GetEventsParams,
   options?: SecondParameter<typeof customClient>
 ) => {
-  return customClient<IEvent[]>(
+  return customClient<GetEvents200>(
     { url: `/api/events/v1/events`, method: "GET", params },
     options
   );

--- a/packages/common/src/events/api/registrations.ts
+++ b/packages/common/src/events/api/registrations.ts
@@ -5,7 +5,7 @@ import {
   IGetRegistrationParams,
   IUpdateRegistrationParams,
   IGetRegistrationsParams,
-  GetRegistrations200,
+  IPagedRegistrationResponse,
 } from "./types";
 import { authenticateRequest } from "./utils/authenticate-request";
 import {
@@ -19,8 +19,8 @@ import {
 /**
  * create an event registration
  *
- * @param {ICreateEventParams} options
- * @return {Promise<GetRegistrations200>}
+ * @param {ICreateRegistrationParams} options
+ * @return {Promise<IRegistration>}
  */
 export async function createRegistration(
   options: ICreateRegistrationParams
@@ -33,11 +33,11 @@ export async function createRegistration(
  * get registrations
  *
  * @param {IGetRegistrationsParams} options
- * @return {Promise<IRegistration[]>} // paged response?
+ * @return {Promise<IPagedRegistrationResponse>}
  */
 export async function getRegistrations(
   options: IGetRegistrationsParams
-): Promise<GetRegistrations200> {
+): Promise<IPagedRegistrationResponse> {
   options.token = await authenticateRequest(options);
   return _getRegistrations(options.data, options);
 }

--- a/packages/common/src/events/api/registrations.ts
+++ b/packages/common/src/events/api/registrations.ts
@@ -4,6 +4,8 @@ import {
   IDeleteRegistrationParams,
   IGetRegistrationParams,
   IUpdateRegistrationParams,
+  IGetRegistrationsParams,
+  GetRegistrations200,
 } from "./types";
 import { authenticateRequest } from "./utils/authenticate-request";
 import {
@@ -18,7 +20,7 @@ import {
  * create an event registration
  *
  * @param {ICreateEventParams} options
- * @return {Promise<IRegistration>}
+ * @return {Promise<GetRegistrations200>}
  */
 export async function createRegistration(
   options: ICreateRegistrationParams
@@ -27,18 +29,18 @@ export async function createRegistration(
   return _createRegistration(options.data, options);
 }
 
-// /**
-//  * get registrations
-//  *
-//  * @param {IGetRegistrationsParams} options
-//  * @return {Promise<IRegistration[]>} // paged response?
-//  */
-// export async function getRegistrations(
-//   options: IGetRegistrationsParams
-// ): Promise<IRegistration[]> {
-//   options.token = await authenticateRequest(options);
-//   return _getRegistrations(options.data, options);
-// }
+/**
+ * get registrations
+ *
+ * @param {IGetRegistrationsParams} options
+ * @return {Promise<IRegistration[]>} // paged response?
+ */
+export async function getRegistrations(
+  options: IGetRegistrationsParams
+): Promise<GetRegistrations200> {
+  options.token = await authenticateRequest(options);
+  return _getRegistrations(options.data, options);
+}
 
 /**
  * get a registration

--- a/packages/common/src/events/api/types.ts
+++ b/packages/common/src/events/api/types.ts
@@ -27,8 +27,8 @@ export {
   RegistrationSort,
   SortOrder,
   EventSort,
-  GetRegistrations200,
-  GetEvents200,
+  IPagedRegistrationResponse,
+  IPagedEventResponse,
 } from "./orval/api/orval-events";
 import { IHubRequestOptions } from "../../types";
 import {

--- a/packages/common/src/events/api/types.ts
+++ b/packages/common/src/events/api/types.ts
@@ -6,6 +6,8 @@ export {
   IAddress,
   IAddressExtent,
   IAddressLocation,
+  IOnlineMeeting,
+  ICreateOnlineMeeting,
   ICreateAddress,
   ICreateEvent,
   ICreateEventGeometry,
@@ -18,19 +20,24 @@ export {
   IRegistrationPermission,
   IUpdateEvent,
   IUpdateRegistration,
+  GetRegistrationsParams,
   IUser,
   RegistrationRole,
   RegistrationStatus,
+  RegistrationSort,
   SortOrder,
   EventSort,
+  GetRegistrations200,
+  GetEvents200,
 } from "./orval/api/orval-events";
 import { IHubRequestOptions } from "../../types";
 import {
   ICreateEvent,
   IUpdateEvent,
+  GetEventsParams,
   ICreateRegistration,
   IUpdateRegistration,
-  GetEventsParams,
+  GetRegistrationsParams,
 } from "./orval/api/orval-events";
 
 /**
@@ -71,9 +78,9 @@ export interface IDeleteEventParams extends IEventsRequestOptions {
 export interface ICreateRegistrationParams extends IEventsRequestOptions {
   data: ICreateRegistration;
 }
-// export interface IGetRegistrationsParams extends IEventsRequestOptions {
-//   data: any;
-// }
+export interface IGetRegistrationsParams extends IEventsRequestOptions {
+  data: GetRegistrationsParams;
+}
 export interface IGetRegistrationParams extends IEventsRequestOptions {
   registrationId: number;
 }

--- a/packages/common/test/events/api/events.test.ts
+++ b/packages/common/test/events/api/events.test.ts
@@ -11,7 +11,6 @@ import {
   updateEvent,
   IEvent,
   EventAttendanceType,
-  EventStatus,
   EventAccess,
 } from "../../../src/events/api";
 import * as authenticateRequestModule from "../../../src/events/api/utils/authenticate-request";
@@ -115,7 +114,7 @@ describe("Events", () => {
       const pagedResponse = {
         total: 1,
         nextStart: 2,
-        events: [mockEvent],
+        items: [mockEvent],
       };
       const getEventsSpy = spyOn(orvalModule, "getEvents").and.callFake(
         async () => pagedResponse

--- a/packages/common/test/events/api/events.test.ts
+++ b/packages/common/test/events/api/events.test.ts
@@ -112,8 +112,13 @@ describe("Events", () => {
   describe("getEvents", () => {
     it("should get events", async () => {
       const mockEvent = { burrito: "supreme" } as unknown as IEvent;
+      const pagedResponse = {
+        total: 1,
+        nextStart: 2,
+        events: [mockEvent],
+      };
       const getEventsSpy = spyOn(orvalModule, "getEvents").and.callFake(
-        async () => [mockEvent]
+        async () => pagedResponse
       );
 
       const options: IGetEventsParams = {
@@ -123,7 +128,7 @@ describe("Events", () => {
       };
 
       const result = await getEvents(options);
-      expect(result).toEqual([mockEvent]);
+      expect(result).toEqual(pagedResponse);
 
       expect(authenticateRequestSpy).toHaveBeenCalledWith(options);
       expect(getEventsSpy).toHaveBeenCalledWith(options.data, {

--- a/packages/common/test/events/api/registrations.test.ts
+++ b/packages/common/test/events/api/registrations.test.ts
@@ -2,10 +2,12 @@ import {
   ICreateRegistrationParams,
   IDeleteRegistrationParams,
   IGetRegistrationParams,
+  IGetRegistrationsParams,
   IUpdateRegistrationParams,
   createRegistration,
   deleteRegistration,
   getRegistration,
+  getRegistrations,
   updateRegistration,
   IRegistration,
   RegistrationRole,
@@ -57,7 +59,7 @@ describe("Registrations", () => {
   });
 
   describe("getRegistration", () => {
-    it("should get an event", async () => {
+    it("should get a registration", async () => {
       const mockRegistration = {
         burrito: "supreme",
       } as unknown as IRegistration;
@@ -75,6 +77,38 @@ describe("Registrations", () => {
 
       expect(authenticateRequestSpy).toHaveBeenCalledWith(options);
       expect(getRegistrationSpy).toHaveBeenCalledWith(options.registrationId, {
+        ...options,
+        token,
+      });
+    });
+  });
+
+  describe("getRegistrations", () => {
+    it("should get all registrations", async () => {
+      const mockRegistration = {
+        burrito: "supreme",
+      } as unknown as IRegistration;
+      const pagedResponse = {
+        total: 1,
+        nextStart: 2,
+        events: [mockRegistration],
+      };
+      const getRegistrationsSpy = spyOn(
+        orvalModule,
+        "getRegistrations"
+      ).and.callFake(async () => pagedResponse);
+
+      const options: IGetRegistrationsParams = {
+        data: {
+          eventId: "111",
+        },
+      };
+
+      const result = await getRegistrations(options);
+      expect(result).toEqual(pagedResponse);
+
+      expect(authenticateRequestSpy).toHaveBeenCalledWith(options);
+      expect(getRegistrationsSpy).toHaveBeenCalledWith(options.data, {
         ...options,
         token,
       });

--- a/packages/common/test/events/api/registrations.test.ts
+++ b/packages/common/test/events/api/registrations.test.ts
@@ -91,7 +91,7 @@ describe("Registrations", () => {
       const pagedResponse = {
         total: 1,
         nextStart: 2,
-        events: [mockRegistration],
+        items: [mockRegistration],
       };
       const getRegistrationsSpy = spyOn(
         orvalModule,


### PR DESCRIPTION
…d response

affects: @esri/hub-common

1. Description: add function `getRegistrations` with interface `IGetRegistrationsParams`. Also fixed paged responses for registrations and events

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
