### PR TITLE
fix(hub-common): add status to IUpdateEvent

### DIFF
--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -7,15 +7,30 @@
  */
 import { Awaited } from "../awaited-type";
 import { customClient } from "../custom-client";
+export type GetRegistrationsParams = {
+  /**
+   * Event id being registered for
+   */
+  eventId?: string;
+  /**
+   * ArcGIS Online id for a user. Will always be extracted from the token unless service token is used.
+   */
+  userAgoId?: string;
+  /**
+   * the max amount of registrations to return
+   */
+  num?: string;
+  /**
+   * the index to start at
+   */
+  start?: string;
+};
+
 export type GetEventsParams = {
   /**
-   * Include registrations with each event
+   * which relation fields to include in response
    */
-  includeRegistrations?: string;
-  /**
-   * Include creator with each event
-   */
-  includeCreator?: string;
+  include?: string;
   /**
    * latest ISO8601 start date-time for the events
    */
@@ -124,6 +139,8 @@ export interface IUpdateEvent {
   readGroups?: string[];
   /** ISO8601 start date-time for the event */
   startDateTime?: string;
+  /** Status of the event */
+  status?: EventStatus;
   /** Summary of the event */
   summary?: string;
   /** Tags for the event */
@@ -172,7 +189,7 @@ export interface IEvent {
   catalog: IEventCatalogItem[] | null;
   categories: string[];
   createdAt: string;
-  createdById: string;
+  createdById: string | null;
   creator?: IUser;
   description: string | null;
   editGroups: string[] | null;
@@ -432,16 +449,17 @@ export const createRegistration = (
 };
 
 export const getRegistrations = (
+  params?: GetRegistrationsParams,
   options?: SecondParameter<typeof customClient>
 ) => {
   return customClient<IRegistration[]>(
-    { url: `/api/events/v1/registrations`, method: "GET" },
+    { url: `/api/events/v1/registrations`, method: "GET", params },
     options
   );
 };
 
 export const getRegistration = (
-  id: number,
+  id: string,
   options?: SecondParameter<typeof customClient>
 ) => {
   return customClient<IRegistration>(

--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -459,7 +459,7 @@ export const getRegistrations = (
 };
 
 export const getRegistration = (
-  id: string,
+  id: number,
   options?: SecondParameter<typeof customClient>
 ) => {
   return customClient<IRegistration>(


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: add `status` to `IUpdateEvent`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
