### PR TITLE
fix: 9948 stat card editor error messaging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.112.1",
+			"version": "14.115.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
@@ -195,6 +195,18 @@ export const buildUiSchema = async (
                   labelKey: "shared.fields.metrics.sourceLink.message.required",
                   allowShowBeforeInteract: true,
                 },
+                {
+                  type: "ERROR",
+                  keyword: "format",
+                  icon: true,
+                  labelKey:
+                    "shared.fields.metrics.sourceLink.message.formatError",
+                },
+                {
+                  type: "ERROR",
+                  keyword: "if",
+                  hidden: true,
+                },
               ],
             },
           },

--- a/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
@@ -192,6 +192,18 @@ export const buildUiSchema = async (
                   labelKey: "shared.fields.metrics.sourceLink.message.required",
                   allowShowBeforeInteract: true,
                 },
+                {
+                  type: "ERROR",
+                  keyword: "format",
+                  icon: true,
+                  labelKey:
+                    "shared.fields.metrics.sourceLink.message.formatError",
+                },
+                {
+                  type: "ERROR",
+                  keyword: "if",
+                  hidden: true,
+                },
               ],
             },
           },

--- a/packages/common/src/core/schemas/internal/metrics/StatCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/metrics/StatCardUiSchema.ts
@@ -184,6 +184,17 @@ export const buildUiSchema = async (
                       labelKey: `errors.sourceLink.required`,
                       allowShowBeforeInteract: true,
                     },
+                    {
+                      type: "ERROR",
+                      keyword: "format",
+                      icon: true,
+                      labelKey: `errors.sourceLink.formatError`,
+                    },
+                    {
+                      type: "ERROR",
+                      keyword: "if",
+                      hidden: true,
+                    },
                   ],
                 },
               },


### PR DESCRIPTION
1. Description: Adds message rules to the uischema for stat cards, project/initiative metrics

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
