### PR TITLE
fix: update can-edit-event to work in cases where initiative is deleted

### DIFF
--- a/packages/common/src/access/can-edit-event.ts
+++ b/packages/common/src/access/can-edit-event.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-types";
+import { IItem, IUser } from "@esri/arcgis-rest-types";
 import { IInitiativeModel } from "../types";
 import { getProp } from "../objects";
 import { findBy } from "../util";
@@ -6,6 +6,7 @@ import { hasBasePriv } from "./has-base-priv";
 
 export interface IEventModel {
   initiative: IInitiativeModel;
+  site: IItem;
   [propName: string]: any;
 }
 
@@ -18,10 +19,9 @@ export interface IEventModel {
 export function canEditEvent(model: IEventModel, user: IUser): boolean {
   let res = false;
   if (hasBasePriv(user)) {
-    const coreTeamId = getProp(
-      model,
-      "initiative.item.properties.collaborationGroupId"
-    );
+    const coreTeamId = model.initiative
+      ? getProp(model, "initiative.item.properties.collaborationGroupId")
+      : getProp(model, "site.properties.collaborationGroupId");
     const { groups = [] } = user;
     res = !!coreTeamId && !!findBy(groups, "id", coreTeamId);
   }

--- a/packages/common/test/access/can-edit-event.test.ts
+++ b/packages/common/test/access/can-edit-event.test.ts
@@ -3,12 +3,12 @@ import { canEditEvent, IEventModel } from "../../src/access/can-edit-event";
 import * as baseUtils from "../../src/access/has-base-priv";
 import { IModel } from "../../src/types";
 
-describe("canEditEvent", function() {
+describe("canEditEvent", function () {
   const getModel = (collaborationGroupId: any): IEventModel => {
     const item = {
       properties: {
-        collaborationGroupId
-      }
+        collaborationGroupId,
+      },
     } as IItem;
     const initiative = { item } as IModel;
     return { initiative } as IEventModel;
@@ -26,7 +26,7 @@ describe("canEditEvent", function() {
     hasBasePrivSpy.calls.reset();
   });
 
-  it(`returns true when user has base priv and is member of event's related initiative collab group`, function() {
+  it(`returns true when user has base priv and is member of event's related initiative collab group`, function () {
     const groupId = "foo";
     const model = getModel(groupId);
     const group = getGroup({ id: groupId });
@@ -37,7 +37,20 @@ describe("canEditEvent", function() {
     expect(hasBasePrivSpy.calls.argsFor(0)).toEqual([user]);
   });
 
-  it(`returns false when user has base priv and is not member of event's related initiative collab group`, function() {
+  it(`returns true when user has base priv and is member of event's related site collab group`, function () {
+    const groupId = "foo";
+    const model = {
+      site: { properties: { collaborationGroupId: groupId } },
+    } as IEventModel;
+    const group = getGroup({ id: groupId });
+    const user = getUser({ groups: [group] });
+    const res = canEditEvent(model, user);
+    expect(res).toBe(true);
+    expect(hasBasePrivSpy.calls.count()).toBe(1);
+    expect(hasBasePrivSpy.calls.argsFor(0)).toEqual([user]);
+  });
+
+  it(`returns false when user has base priv and is not member of event's related initiative/site collab group`, function () {
     const groupId = "foo";
     const model = getModel(groupId);
     const user = getUser({});
@@ -47,7 +60,14 @@ describe("canEditEvent", function() {
     expect(hasBasePrivSpy.calls.argsFor(0)).toEqual([user]);
   });
 
-  it(`returns false when user lacks base priv`, function() {
+  it("returns false if there is no collaborationGroupId", function () {
+    const model = {} as IEventModel;
+    const user = getUser({});
+    const res = canEditEvent(model, user);
+    expect(res).toBe(false);
+  });
+
+  it(`returns false when user lacks base priv`, function () {
     hasBasePrivSpy.and.returnValue(false);
     const groupId = "foo";
     const model = getModel(groupId);


### PR DESCRIPTION
[10051](https://devtopia.esri.com/dc/hub/issues/10051)

### Description
update the `can-edit-event` util to fallback to the `collaborationGroupId` stored on the `site.properties`

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.