### PR TITLE
fix: proper export path for schedule interfaces

### DIFF
--- a/packages/common/src/core/types/index.ts
+++ b/packages/common/src/core/types/index.ts
@@ -23,6 +23,7 @@ export * from "./IHubTemplate";
 export * from "./IHubSite";
 export * from "./IHubSiteTheme";
 export * from "./IHubTimeline";
+export * from "./IHubSchedule";
 export * from "./IItemEnrichments";
 export * from "./IReference";
 export * from "./IServerEnrichments";


### PR DESCRIPTION
1. Description: exports the interfaces used by the scheduler component from the types file and allows for cleaner imports from hub-common in other repos/packages

1. Closes Issues: [2068](https://devtopia.esri.com/dc/hub/issues/2068)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
