### PR TITLE
fix: update fetchHubGroup ro and follow card permission

### DIFF
--- a/packages/common/e2e/hub-groups.e2e.ts
+++ b/packages/common/e2e/hub-groups.e2e.ts
@@ -32,7 +32,7 @@ describe("Hub Groups", () => {
       expect(newGroup.membershipAccess).toBe("organization");
       const fetchedGroup = await fetchHubGroup(
         newGroup.id,
-        ctxMgr.context.userRequestOptions
+        ctxMgr.context.hubRequestOptions
       );
       // verify can* flags
       expect(fetchedGroup.canDelete).toBe(true);
@@ -51,7 +51,7 @@ describe("Hub Groups", () => {
       expect(updatedGroup.membershipAccess).toBe("anyone");
       await deleteHubGroup(newGroup.id, ctxMgr.context.userRequestOptions);
       try {
-        await fetchHubGroup(newGroup.id, ctxMgr.context.userRequestOptions);
+        await fetchHubGroup(newGroup.id, ctxMgr.context.hubRequestOptions);
         fail("should have thrown error");
       } catch (e) {
         expect((e as any).message).toBe(

--- a/packages/common/src/core/fetchHubEntity.ts
+++ b/packages/common/src/core/fetchHubEntity.ts
@@ -49,7 +49,7 @@ export async function fetchHubEntity(
       result = await fetchTemplate(identifier, context.requestOptions);
       break;
     case "group":
-      result = await fetchHubGroup(identifier, context.userRequestOptions);
+      result = await fetchHubGroup(identifier, context.hubRequestOptions);
       break;
     case "survey":
       result = await fetchSurvey(identifier, context.hubRequestOptions);

--- a/packages/common/src/groups/HubGroup.ts
+++ b/packages/common/src/groups/HubGroup.ts
@@ -121,7 +121,7 @@ export class HubGroup
     context: IArcGISContext
   ): Promise<HubGroup> {
     try {
-      const group = await fetchHubGroup(identifier, context.userRequestOptions);
+      const group = await fetchHubGroup(identifier, context.hubRequestOptions);
       // create an instance of HubGroup from the group
       return HubGroup.fromJson(group, context);
     } catch (ex) {

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -142,7 +142,7 @@ export async function createHubGroup(
  */
 export async function fetchHubGroup(
   identifier: string,
-  requestOptions: IUserRequestOptions
+  requestOptions: IHubRequestOptions
 ): Promise<IHubGroup> {
   const group = await getGroup(identifier, requestOptions);
   return convertGroupToHubGroup(group, requestOptions);

--- a/packages/common/src/groups/_internal/convertGroupToHubGroup.ts
+++ b/packages/common/src/groups/_internal/convertGroupToHubGroup.ts
@@ -3,7 +3,7 @@ import { PropertyMapper } from "../../core/_internal/PropertyMapper";
 import { IHubGroup } from "../../core/types/IHubGroup";
 import { computeProps } from "./computeProps";
 import { getPropertyMap } from "./getPropertyMap";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import { IHubRequestOptions } from "../../types";
 
 /**
  * Convert an IGroup to a Hub Group
@@ -13,7 +13,7 @@ import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 export function convertGroupToHubGroup(
   group: IGroup,
-  requestOptions: IUserRequestOptions
+  requestOptions: IHubRequestOptions
 ): IHubGroup {
   const mapper = new PropertyMapper<Partial<IHubGroup>, IGroup>(
     getPropertyMap()

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -121,7 +121,7 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:card:follow",
     environments: ["qaext"],
     availability: ["flag"],
-    licenses: ["hub-premium"],
+    licenses: ["hub-basic", "hub-premium"],
   },
   {
     // When enabled, the edit & manage links will take the user to umbrella

--- a/packages/common/test/core/fetchHubEntity.test.ts
+++ b/packages/common/test/core/fetchHubEntity.test.ts
@@ -87,7 +87,7 @@ describe("fetchHubEntity:", () => {
   });
   it("fetches group", async () => {
     const ctx = {
-      userRequestOptions: "fakeRequestOptions",
+      hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
     const spy = spyOn(
       require("../../src/groups/HubGroups"),


### PR DESCRIPTION
1. Description:

- change the ro parameter that `fetchHubGroup` takes from `userRequestOptions` to `hubRequestOptions`, so anonymous users can fetch public groups from public sites
- add "hub-basic" license to follow card permission so hub basic users have access to follow cards

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
