### PR TITLE
fix(hub-common): fix the target api url in getSchedule(), setSchedule(), etc

### DIFF
--- a/packages/common/src/content/_internal/getSchedulerApiUrl.ts
+++ b/packages/common/src/content/_internal/getSchedulerApiUrl.ts
@@ -1,0 +1,12 @@
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { getHubApiUrl } from "../../api";
+
+export function getSchedulerApiUrl(
+  itemId: string,
+  requestOptions: IRequestOptions
+): string {
+  // sometimes the url has /api/v3 at the end, so we need to remove it
+  const hubApiUrlWithVersion = getHubApiUrl(requestOptions);
+  const hubApiUrlRoot = hubApiUrlWithVersion.replace(/\/api\/v3$/, "");
+  return `${hubApiUrlRoot}/api/download/v1/items/${itemId}/schedule`;
+}

--- a/packages/common/src/content/manageSchedule.ts
+++ b/packages/common/src/content/manageSchedule.ts
@@ -1,9 +1,9 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { getHubApiUrl } from "../api";
 import { IHubSchedule, IHubScheduleResponse } from "../core/types/IHubSchedule";
 import { cloneObject } from "../util";
 import { deepEqual } from "../objects/deepEqual";
 import { AccessLevel, IHubEditableContent } from "../core";
+import { getSchedulerApiUrl } from "./_internal/getSchedulerApiUrl";
 
 // Any code referencing these functions must first pass isDownloadSchedulingAvailable
 
@@ -134,15 +134,6 @@ export const maybeUpdateSchedule = async (
     }
   }
   return { message: "No action needed as schedules deepEqual each other." };
-};
-
-const getSchedulerApiUrl = (
-  itemId: string,
-  requestOptions: IRequestOptions
-): string => {
-  return `${getHubApiUrl(
-    requestOptions
-  )}/api/download/v1/items/${itemId}/schedule`;
 };
 
 /**

--- a/packages/common/test/content/manageSchedule.test.ts
+++ b/packages/common/test/content/manageSchedule.test.ts
@@ -11,10 +11,28 @@ import {
 import { MOCK_HUB_REQOPTS } from "../mocks/mock-auth";
 import { IHubEditableContent } from "../../src/core/types/IHubEditableContent";
 import * as fetchMock from "fetch-mock";
+import { getSchedulerApiUrl } from "../../src/content/_internal/getSchedulerApiUrl";
 
 describe("manageSchedule", () => {
   afterEach(() => {
     fetchMock.restore();
+  });
+  it("getSchedulerApiUrl: returns the correct url when no version is attached on requestOptions", () => {
+    const url = getSchedulerApiUrl("123", MOCK_HUB_REQOPTS);
+    expect(url).toEqual(
+      "https://hubqa.arcgis.com/api/download/v1/items/123/schedule"
+    );
+  });
+  it("getSchedulerApiUrl: returns the correct url when v3 is attached on requestOptions", () => {
+    const requestOptions = {
+      ...MOCK_HUB_REQOPTS,
+      hubApiUrl: "https://hubqa.arcgis.com/api/v3",
+    };
+
+    const url = getSchedulerApiUrl("123", requestOptions);
+    expect(url).toEqual(
+      "https://hubqa.arcgis.com/api/download/v1/items/123/schedule"
+    );
   });
 
   it("getSchedule: returns an error if no schedule is set", async () => {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Adds check in `getSchedulerApiUrl` to remove the occasional `/api/v3` path from `requestOptions.hubApiUrl`. This was resulting in incorrect urls such as:
https://opendataqa.arcgis.com/api/v3/api/download/v1/items/f4bcc1035b7d46cba95e977f4affb6be/schedule

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
 
