### PR TITLE
fix: isDiscussable handles undefined subject

### DIFF
--- a/packages/common/src/discussions/utils.ts
+++ b/packages/common/src/discussions/utils.ts
@@ -18,7 +18,12 @@ import { IFilter, IHubSearchResult, IPredicate, IQuery } from "../search";
 export function isDiscussable(
   subject: Partial<IGroup | IItem | IHubContent | IHubItemEntity>
 ) {
-  return !(subject.typeKeywords ?? []).includes(CANNOT_DISCUSS);
+  let result = false;
+  if (subject) {
+    const typeKeywords = subject.typeKeywords || [];
+    result = !typeKeywords.includes(CANNOT_DISCUSS);
+  }
+  return result;
 }
 
 /**

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -428,11 +428,7 @@ export class HubSite
     );
 
     const followersGroup = await this.getFollowersGroup();
-    setProp(
-      "_followers.isDiscussable",
-      isDiscussable(followersGroup || {}),
-      editor
-    );
+    setProp("_followers.isDiscussable", isDiscussable(followersGroup), editor);
 
     editor._discussions = this.entity.features["hub:site:feature:discussions"];
 

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -614,13 +614,13 @@ describe("HubSite Class:", () => {
           expect(result._followers?.showFollowAction).toBe(true);
         });
         describe("_followers.isDiscussable", () => {
-          it("set to true by default (when no followers group is returned)", async () => {
+          it("set to false by default (when no followers group is returned)", async () => {
             getFollowersGroupSpy = spyOn(
               chk,
               "getFollowersGroup"
             ).and.returnValue(Promise.resolve(null));
             const result = await chk.toEditor();
-            expect(result._followers?.isDiscussable).toBe(true);
+            expect(result._followers?.isDiscussable).toBe(false);
           });
           it("set to true when the followers group is discussable", async () => {
             getFollowersGroupSpy = spyOn(


### PR DESCRIPTION
affects: @esri/hub-common, @esri/hub-sites

ISSUES CLOSED: 10185

1. Description:

1. Instructions for testing:

1. Closes Issues: [#<number> (if appropriate)](https://devtopia.esri.com/dc/hub/issues/10185)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
