### PR TITLE
fix: broaden check for isDiscussable to handle falsey, not just undefined

### DIFF
--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -465,7 +465,7 @@ export class HubSite
     delete editor._thumbnail;
 
     // set whether or not the followers group is discussable
-    if (editor._followers?.isDiscussable !== undefined) {
+    if (editor._followers?.isDiscussable) {
       await this.setFollowersGroupIsDiscussable(
         editor._followers.isDiscussable
       );


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 10185

1. Description: broaden check for isDiscussable to handle faley, not just undefined

1. Instructions for testing:

1. Closes Issues: 10185

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
