### PR TITLE
feat(): add helper text to image

### DIFF
--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
@@ -156,6 +156,11 @@ export const buildUiSchema = async (
               {
                 type: "Section",
                 labelKey: `${i18nScope}.fields.featuredImage.label`,
+                options: {
+                  helperText: {
+                    labelKey: `${i18nScope}.fields.featuredImage.helperText`,
+                  },
+                },
                 rule: {
                   effect: UiSchemaRuleEffects.HIDE,
                   condition: {

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
@@ -156,11 +156,6 @@ export const buildUiSchema = async (
               {
                 type: "Section",
                 labelKey: `${i18nScope}.fields.featuredImage.label`,
-                options: {
-                  helperText: {
-                    labelKey: `${i18nScope}.fields.featuredImage.helperText`,
-                  },
-                },
                 rule: {
                   effect: UiSchemaRuleEffects.HIDE,
                   condition: {
@@ -183,6 +178,9 @@ export const buildUiSchema = async (
                       aspectRatio: 1.5,
                       sizeDescription: {
                         labelKey: `${i18nScope}.fields.featuredImage.sizeDescription`,
+                      },
+                      helperText: {
+                        labelKey: `${i18nScope}.fields.featuredImage.helperText`,
                       },
                     },
                   },

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaCreate.ts
@@ -156,6 +156,11 @@ export const buildUiSchema = async (
               {
                 type: "Section",
                 labelKey: `${i18nScope}.fields.featuredImage.label`,
+                options: {
+                  helperText: {
+                    labelKey: `${i18nScope}.fields.featuredImage.helperText`,
+                  },
+                },
                 rule: {
                   effect: UiSchemaRuleEffects.HIDE,
                   condition: {
@@ -178,9 +183,6 @@ export const buildUiSchema = async (
                       aspectRatio: 1.5,
                       sizeDescription: {
                         labelKey: `${i18nScope}.fields.featuredImage.sizeDescription`,
-                      },
-                      helperText: {
-                        labelKey: `${i18nScope}.fields.featuredImage.helperText`,
                       },
                     },
                   },

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -125,6 +125,9 @@ export const buildUiSchema = async (
               sizeDescription: {
                 labelKey: `${i18nScope}.fields.featuredImage.sizeDescription`,
               },
+              helperText: {
+                labelKey: `${i18nScope}.fields.featuredImage.helperText`,
+              },
             },
           },
           {

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
@@ -393,7 +393,11 @@ describe("buildUiSchema: initiative create", () => {
                 {
                   type: "Section",
                   labelKey: "some.scope.fields.featuredImage.label",
-
+                  options: {
+                    helperText: {
+                      labelKey: `some.scope.fields.featuredImage.helperText`,
+                    },
+                  },
                   rule: {
                     effect: UiSchemaRuleEffects.HIDE,
                     condition: {

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
@@ -393,6 +393,11 @@ describe("buildUiSchema: initiative create", () => {
                 {
                   type: "Section",
                   labelKey: "some.scope.fields.featuredImage.label",
+                  options: {
+                    helperText: {
+                      labelKey: `some.scope.fields.featuredImage.helperText`,
+                    },
+                  },
                   rule: {
                     effect: UiSchemaRuleEffects.HIDE,
                     condition: {

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
@@ -154,6 +154,11 @@ describe("buildUiSchema: initiative create", () => {
                 {
                   type: "Section",
                   labelKey: "some.scope.fields.featuredImage.label",
+                  options: {
+                    helperText: {
+                      labelKey: `some.scope.fields.featuredImage.helperText`,
+                    },
+                  },
                   rule: {
                     effect: UiSchemaRuleEffects.HIDE,
                     condition: {

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
@@ -415,9 +415,6 @@ describe("buildUiSchema: initiative create", () => {
                           labelKey:
                             "some.scope.fields.featuredImage.sizeDescription",
                         },
-                        helperText: {
-                          labelKey: `some.scope.fields.featuredImage.helperText`,
-                        },
                       },
                     },
                     {

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
@@ -154,6 +154,11 @@ describe("buildUiSchema: initiative create", () => {
                 {
                   type: "Section",
                   labelKey: "some.scope.fields.featuredImage.label",
+                  options: {
+                    helperText: {
+                      labelKey: `some.scope.fields.featuredImage.helperText`,
+                    },
+                  },
                   rule: {
                     effect: UiSchemaRuleEffects.HIDE,
                     condition: {
@@ -174,9 +179,6 @@ describe("buildUiSchema: initiative create", () => {
                         sizeDescription: {
                           labelKey:
                             "some.scope.fields.featuredImage.sizeDescription",
-                        },
-                        helperText: {
-                          labelKey: `some.scope.fields.featuredImage.helperText`,
                         },
                       },
                     },

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaCreate.test.ts
@@ -154,11 +154,6 @@ describe("buildUiSchema: initiative create", () => {
                 {
                   type: "Section",
                   labelKey: "some.scope.fields.featuredImage.label",
-                  options: {
-                    helperText: {
-                      labelKey: `some.scope.fields.featuredImage.helperText`,
-                    },
-                  },
                   rule: {
                     effect: UiSchemaRuleEffects.HIDE,
                     condition: {
@@ -179,6 +174,9 @@ describe("buildUiSchema: initiative create", () => {
                         sizeDescription: {
                           labelKey:
                             "some.scope.fields.featuredImage.sizeDescription",
+                        },
+                        helperText: {
+                          labelKey: `some.scope.fields.featuredImage.helperText`,
                         },
                       },
                     },
@@ -393,11 +391,7 @@ describe("buildUiSchema: initiative create", () => {
                 {
                   type: "Section",
                   labelKey: "some.scope.fields.featuredImage.label",
-                  options: {
-                    helperText: {
-                      labelKey: `some.scope.fields.featuredImage.helperText`,
-                    },
-                  },
+
                   rule: {
                     effect: UiSchemaRuleEffects.HIDE,
                     condition: {
@@ -418,6 +412,9 @@ describe("buildUiSchema: initiative create", () => {
                         sizeDescription: {
                           labelKey:
                             "some.scope.fields.featuredImage.sizeDescription",
+                        },
+                        helperText: {
+                          labelKey: `some.scope.fields.featuredImage.helperText`,
                         },
                       },
                     },

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -433,6 +433,9 @@ describe("buildUiSchema: initiative edit", () => {
                 sizeDescription: {
                   labelKey: `some.scope.fields.featuredImage.sizeDescription`,
                 },
+                helperText: {
+                  labelKey: `some.scope.fields.featuredImage.helperText`,
+                },
               },
             },
             {

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -140,6 +140,9 @@ describe("buildUiSchema: initiative edit", () => {
                 sizeDescription: {
                   labelKey: `some.scope.fields.featuredImage.sizeDescription`,
                 },
+                helperText: {
+                  labelKey: `some.scope.fields.featuredImage.helperText`,
+                },
               },
             },
             {


### PR DESCRIPTION
1. Description:
Adds helper text to the featured image flow. 

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
