### PR TITLE
fix: export IWithFollowers

### DIFF
--- a/packages/common/src/core/traits/index.ts
+++ b/packages/common/src/core/traits/index.ts
@@ -7,3 +7,4 @@ export * from "./IWithCatalog";
 export * from "./IWithViewSettings";
 export * from "./IWithDiscussions";
 export * from "./ICapabilityConfig";
+export * from "./IWithFollowers";


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Export `IWithFollowers` so we can assign it to certain hub entities as only entities extend `IWithFollowers` have access to the `followersGroupId`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
