### PR TITLE
feat(hub-common): oops, this new system status will break the build

### DIFF
--- a/packages/common/src/ArcGISContextManager.ts
+++ b/packages/common/src/ArcGISContextManager.ts
@@ -739,6 +739,7 @@ const HUB_SERVICE_STATUS: HubServiceStatus = {
   notifications: "online",
   "hub-search": "online",
   domains: "online",
+  testing: "online",
 };
 
 const ENTERPRISE_SITES_SERVICE_STATUS: HubServiceStatus = {
@@ -749,6 +750,7 @@ const ENTERPRISE_SITES_SERVICE_STATUS: HubServiceStatus = {
   notifications: "not-available",
   "hub-search": "not-available",
   domains: "not-available",
+  testing: "not-available",
 };
 
 const DEV_ALPHA_ORGS = [

--- a/packages/common/src/core/types/ISystemStatus.ts
+++ b/packages/common/src/core/types/ISystemStatus.ts
@@ -22,6 +22,7 @@ const validServices = [
   "notifications",
   "hub-search",
   "domains",
+  "testing",
 ] as const;
 
 export type HubService = (typeof validServices)[number];


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
