### PR TITLE
fix: updates well known types to fix gallery query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.122.0",
+			"version": "14.121.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -347,6 +347,7 @@ export const WellKnownItemPredicates: IWellKnownItemPredicates = {
   $initiative: [
     {
       type: "Hub Initiative",
+      typekeywords: "hubInitiativeV2",
     },
   ],
   $experience: [


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
    - updates hub Initiative query to include  `typekeyword: hubInitiativeV2` 
1. Closes Issues: #[10065](https://devtopia.esri.com/dc/hub/issues/10065) (if appropriate)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
