### PR TITLE
fix(hub-common): added name filter to GetRegistrationsParams

### DIFF
--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -50,6 +50,10 @@ export type GetRegistrationsParams = {
    */
   updatedAtAfter?: string;
   /**
+   * filter to be matched to firstName, lastName, or username
+   */
+  name?: string;
+  /**
    * the max amount of registrations to return
    */
   num?: string;


### PR DESCRIPTION
…dd entityIds and entityTypes to

affects: @esri/hub-common

1. Description: Allow filtering by user's `firstName`, `lastName`, or `username` for `GET /registrations`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
 
