### PR TITLE
feat(hub-common): removes hub:feature:gallery:map permission policy

### DIFF
--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -100,12 +100,6 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     environments: ["devext", "qaext", "production"],
   },
   {
-    // This is an experimental extension of the gallery to include `map layout`
-    // Similar to `hub:feature:privacy`, we want to deny permission unless explicity enabled with (?pe=hub:feature:gallery:map)
-    permission: "hub:feature:gallery:map",
-    environments: ["devext"],
-  },
-  {
     // Enables access to the user preferences section of the user profile
     // This will likely be removed when we swap the user profile to use workspace
     permission: "hub:feature:user:preferences",

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -22,7 +22,6 @@ const TempPermissions = ["temp:workspace:released"];
 const SystemPermissions = [
   "hub:feature:privacy",
   "hub:feature:workspace",
-  "hub:feature:gallery:map",
   "hub:feature:user:preferences",
   "hub:card:follow",
   "hub:feature:workspace:umbrella",


### PR DESCRIPTION
Removes hub:feature:gallery:map permission policy in preparation to ungate the gallery map layout option on /search.

affects: @esri/hub-common

ISSUES CLOSED: 10118

1. Description:

Removes permission policy

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
