### PR TITLE
fix(hub-common): fix unified list feature flag, format order, and additional resource calculation

### DIFF
--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -138,6 +138,5 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "temp:hub:content:downloads:unifiedList",
     availability: ["flag"],
-    environments: ["qaext", "devext"],
   },
 ];

--- a/packages/common/src/content/fetch.ts
+++ b/packages/common/src/content/fetch.ts
@@ -267,11 +267,13 @@ export const fetchHubContent = async (
   const model = { item };
   const enrichments: IHubEditableContentEnrichments = {};
 
-  enrichments.metadata = await fetchItemEnrichments(
+  const { metadata } = await fetchItemEnrichments(
     item,
     ["metadata"],
     requestOptions as IHubRequestOptions
   );
+
+  enrichments.metadata = metadata;
 
   if (isHostedFeatureServiceItem(item)) {
     enrichments.server = await getService({

--- a/packages/common/src/downloads/_internal/_types.ts
+++ b/packages/common/src/downloads/_internal/_types.ts
@@ -36,28 +36,30 @@ export type ExportImageFormat = (typeof EXPORT_IMAGE_FORMATS)[number];
 
 /**
  * Formats supported by the paging operation endpoint of the Hub Download API.
+ * Listed in the default order of appearance in the UI.
  */
 export const HUB_PAGING_JOB_FORMATS = [
   ServiceDownloadFormat.CSV,
+  ServiceDownloadFormat.SHAPEFILE,
   ServiceDownloadFormat.GEOJSON,
   ServiceDownloadFormat.KML,
-  ServiceDownloadFormat.SHAPEFILE,
 ] as const;
 export type HubPagingJobFormat = (typeof HUB_PAGING_JOB_FORMATS)[number];
 
 /**
  * Known formats supported by the /createReplica endpoint of the Hub Download API.
+ * Listed in the default order of appearance in the UI.
  * NOTE: this is may be incomplete and should be updated as needed.
  */
 export const CREATE_REPLICA_FORMATS = [
   ServiceDownloadFormat.CSV,
-  ServiceDownloadFormat.EXCEL,
-  ServiceDownloadFormat.FEATURE_COLLECTION,
-  ServiceDownloadFormat.FILE_GDB,
-  ServiceDownloadFormat.GEOJSON,
-  ServiceDownloadFormat.GEO_PACKAGE,
-  ServiceDownloadFormat.JSON,
   ServiceDownloadFormat.SHAPEFILE,
+  ServiceDownloadFormat.GEOJSON,
+  ServiceDownloadFormat.FILE_GDB,
+  ServiceDownloadFormat.FEATURE_COLLECTION,
+  ServiceDownloadFormat.EXCEL,
+  ServiceDownloadFormat.GEO_PACKAGE,
   ServiceDownloadFormat.SQLITE,
+  ServiceDownloadFormat.JSON,
 ] as const;
 export type CreateReplicaFormat = (typeof CREATE_REPLICA_FORMATS)[number];

--- a/packages/common/src/downloads/_internal/format-fetchers/getCreateReplicaFormats.ts
+++ b/packages/common/src/downloads/_internal/format-fetchers/getCreateReplicaFormats.ts
@@ -1,6 +1,6 @@
 import { IHubEditableContent } from "../../../core/types/IHubEditableContent";
 import { IDynamicDownloadFormat } from "../../types";
-import { CreateReplicaFormat } from "../_types";
+import { CreateReplicaFormat, CREATE_REPLICA_FORMATS } from "../_types";
 
 /**
  * @private
@@ -12,8 +12,19 @@ import { CreateReplicaFormat } from "../_types";
 export function getCreateReplicaFormats(
   entity: IHubEditableContent
 ): IDynamicDownloadFormat[] {
-  return (entity.serverExtractFormats || []).map((format: string) => ({
-    type: "dynamic",
-    format: format as CreateReplicaFormat,
-  }));
+  const allFormats = entity.serverExtractFormats || [];
+  // List recognized formats in the order they are defined in CREATE_REPLICA_FORMATS
+  const recognizedFormats: CreateReplicaFormat[] =
+    CREATE_REPLICA_FORMATS.filter((format) => allFormats.includes(format));
+  // List any unrecognized formats (we'll append these to the end of the final array)
+  const unrecognizedFormats = allFormats.filter(
+    (format) => !CREATE_REPLICA_FORMATS.includes(format as CreateReplicaFormat)
+  );
+
+  return [...recognizedFormats, ...unrecognizedFormats].map(
+    (format: string) => ({
+      type: "dynamic",
+      format: format as CreateReplicaFormat,
+    })
+  );
 }

--- a/packages/common/test/downloads/_internal/format-fetchers/getCreateReplicaFormats.test.ts
+++ b/packages/common/test/downloads/_internal/format-fetchers/getCreateReplicaFormats.test.ts
@@ -3,22 +3,38 @@ import { IHubEditableContent } from "../../../../src/core/types/IHubEditableCont
 import { getCreateReplicaFormats } from "../../../../src/downloads/_internal/format-fetchers/getCreateReplicaFormats";
 
 describe("getCreateReplicaFormats", () => {
-  it("should return available createReplica formats", () => {
+  it("should return an empty array if there are no formats", () => {
+    const entity = {} as unknown as IHubEditableContent;
+    const result = getCreateReplicaFormats(entity);
+    expect(result).toEqual([]);
+  });
+  it("should return recognized createReplica formats in a predefined order", () => {
     const entity = {
       serverExtractFormats: [
+        // Out of order
         ServiceDownloadFormat.JSON,
         ServiceDownloadFormat.GEOJSON,
       ],
     } as unknown as IHubEditableContent;
     const result = getCreateReplicaFormats(entity);
     expect(result.map((r) => r.format)).toEqual([
-      ServiceDownloadFormat.JSON,
       ServiceDownloadFormat.GEOJSON,
+      ServiceDownloadFormat.JSON,
     ]);
   });
-  it("should return an empty array if there are no formats", () => {
-    const entity = {} as unknown as IHubEditableContent;
+  it("should return unrecognized createReplica formats at the end", () => {
+    const entity = {
+      serverExtractFormats: [
+        ServiceDownloadFormat.GEOJSON,
+        "unknown-format",
+        ServiceDownloadFormat.JSON,
+      ],
+    } as unknown as IHubEditableContent;
     const result = getCreateReplicaFormats(entity);
-    expect(result).toEqual([]);
+    expect(result.map((r) => r.format)).toEqual([
+      ServiceDownloadFormat.GEOJSON,
+      ServiceDownloadFormat.JSON,
+      "unknown-format" as ServiceDownloadFormat,
+    ]);
   });
 });


### PR DESCRIPTION
1. Description:
Part of https://devtopia.esri.com/dc/hub/issues/9543

Addresses a number of small bugs that appeared in the first iteration of the new unified download utils
1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
