### PR TITLE
feat(hub-common): add token to schedule api endpoints

### DIFF
--- a/packages/common/src/content/_internal/internalContentUtils.ts
+++ b/packages/common/src/content/_internal/internalContentUtils.ts
@@ -971,10 +971,10 @@ const isPortalFromUrl = (portalUrl: string): boolean => {
 
 export function getSchedulerApiUrl(
   itemId: string,
-  requestOptions: IRequestOptions
+  requestOptions: IUserRequestOptions
 ): string {
   const hubApiUrlRoot = getHubApiUrlRoot(requestOptions);
-  return `${hubApiUrlRoot}/api/download/v1/items/${itemId}/schedule`;
+  return `${hubApiUrlRoot}/api/download/v1/items/${itemId}/schedule?token=${requestOptions.authentication.token}`;
 }
 
 export function getHubApiUrlRoot(requestOptions: IRequestOptions): string {

--- a/packages/common/src/content/fetch.ts
+++ b/packages/common/src/content/fetch.ts
@@ -36,6 +36,7 @@ import { computeProps } from "./_internal/computeProps";
 import { isHostedFeatureServiceItem } from "./hostedServiceUtils";
 import { setProp } from "../objects";
 import { getSchedule, isDownloadSchedulingAvailable } from "./manageSchedule";
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 const hasFeatures = (contentType: string) =>
   ["Feature Layer", "Table"].includes(contentType);
@@ -284,8 +285,12 @@ export const fetchHubContent = async (
 
   if (isDownloadSchedulingAvailable(requestOptions, access)) {
     // fetch schedule and add it to enrichments if it exists in schedule API
-    enrichments.schedule = (await getSchedule(item.id, requestOptions))
-      .schedule || { mode: "automatic" };
+    enrichments.schedule = (
+      await getSchedule(
+        item.id,
+        requestOptions as unknown as IUserRequestOptions
+      )
+    ).schedule || { mode: "automatic" };
   }
 
   return modelToHubEditableContent(model, requestOptions, enrichments);

--- a/packages/common/src/content/manageSchedule.ts
+++ b/packages/common/src/content/manageSchedule.ts
@@ -4,6 +4,7 @@ import { cloneObject } from "../util";
 import { deepEqual } from "../objects/deepEqual";
 import { AccessLevel, IHubEditableContent } from "../core";
 import { getSchedulerApiUrl } from "./_internal/internalContentUtils";
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 // Any code referencing these functions must first pass isDownloadSchedulingAvailable
 
@@ -15,7 +16,7 @@ import { getSchedulerApiUrl } from "./_internal/internalContentUtils";
  */
 export const getSchedule = async (
   itemId: string,
-  requestOptions: IRequestOptions
+  requestOptions: IUserRequestOptions
 ): Promise<IHubScheduleResponse> => {
   const fetchResponse = await fetch(getSchedulerApiUrl(itemId, requestOptions));
   const schedule = await fetchResponse.json();
@@ -65,7 +66,7 @@ export const getSchedule = async (
 export const setSchedule = async (
   itemId: string,
   schedule: IHubSchedule,
-  requestOptions: IRequestOptions
+  requestOptions: IUserRequestOptions
 ): Promise<IHubScheduleResponse> => {
   const body = cloneObject(schedule);
   if (body.mode !== "manual") {
@@ -98,7 +99,7 @@ export const setSchedule = async (
  */
 export const deleteSchedule = async (
   itemId: string,
-  requestOptions: IRequestOptions
+  requestOptions: IUserRequestOptions
 ): Promise<IHubScheduleResponse> => {
   const url = getSchedulerApiUrl(itemId, requestOptions);
   const options = {
@@ -121,7 +122,7 @@ export const deleteSchedule = async (
  */
 export const maybeUpdateSchedule = async (
   content: IHubEditableContent,
-  requestOptions: IRequestOptions
+  requestOptions: IUserRequestOptions
 ): Promise<IHubScheduleResponse> => {
   const scheduleResponse = await getSchedule(content.id, requestOptions);
 

--- a/packages/common/test/content/manageSchedule.test.ts
+++ b/packages/common/test/content/manageSchedule.test.ts
@@ -12,6 +12,7 @@ import { MOCK_HUB_REQOPTS } from "../mocks/mock-auth";
 import { IHubEditableContent } from "../../src/core/types/IHubEditableContent";
 import * as fetchMock from "fetch-mock";
 import { getSchedulerApiUrl } from "../../src/content/_internal/internalContentUtils";
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 describe("manageSchedule", () => {
   afterEach(() => {
@@ -20,7 +21,7 @@ describe("manageSchedule", () => {
   it("getSchedulerApiUrl: returns the correct url when no version is attached on requestOptions", () => {
     const url = getSchedulerApiUrl("123", MOCK_HUB_REQOPTS);
     expect(url).toEqual(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/schedule"
+      "https://hubqa.arcgis.com/api/download/v1/items/123/schedule?token=fake-token"
     );
   });
   it("getSchedulerApiUrl: returns the correct url when v3 is attached on requestOptions", () => {
@@ -31,13 +32,13 @@ describe("manageSchedule", () => {
 
     const url = getSchedulerApiUrl("123", requestOptions);
     expect(url).toEqual(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/schedule"
+      "https://hubqa.arcgis.com/api/download/v1/items/123/schedule?token=fake-token"
     );
   });
   it("getSchedule: returns an error if no schedule is set", async () => {
     const item = { id: "123" };
     fetchMock.once(
-      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule`,
+      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule?token=fake-token`,
       {
         error: "Not Found",
         message: `Download schedule for the item ${item.id} is not found.`,
@@ -56,7 +57,7 @@ describe("manageSchedule", () => {
   it("getSchedule: returns schedule of mode 'scheduled' if set", async () => {
     const item = { id: "123" };
     fetchMock.once(
-      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule`,
+      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule?token=fake-token`,
       {
         cadence: "daily",
         hour: 0,
@@ -79,7 +80,7 @@ describe("manageSchedule", () => {
   it("getSchedule: returns schedule of mode 'manual' if set", async () => {
     const item = { id: "123" };
     fetchMock.once(
-      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule`,
+      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule?token=fake-token`,
       {
         mode: "manual",
         itemId: "123",
@@ -104,7 +105,7 @@ describe("manageSchedule", () => {
     } as IHubSchedule;
 
     fetchMock.post(
-      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule`,
+      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule?token=fake-token`,
       {
         message: "Download schedule set successfully.",
       }
@@ -121,7 +122,7 @@ describe("manageSchedule", () => {
     } as IHubSchedule;
 
     fetchMock.post(
-      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule`,
+      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule?token=fake-token`,
       {
         message: "Download schedule set successfully.",
       }
@@ -141,7 +142,7 @@ describe("manageSchedule", () => {
     } as IHubSchedule;
 
     fetchMock.post(
-      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule`,
+      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule?token=fake-token`,
       {
         title: "unit out of range",
         message:
@@ -159,7 +160,7 @@ describe("manageSchedule", () => {
     const item = { id: "123" };
 
     fetchMock.delete(
-      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule`,
+      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule?token=fake-token`,
       {
         message: "Download schedule deleted successfully.",
       }
@@ -177,7 +178,7 @@ describe("manageSchedule", () => {
     } as IHubEditableContent;
 
     fetchMock.get(
-      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule`,
+      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule?token=fake-token`,
       {
         error: "Not Found",
         message: `Download schedule for the item ${item.id} is not found.`,
@@ -205,7 +206,7 @@ describe("manageSchedule", () => {
 
     fetchMock
       .get(
-        `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule`,
+        `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule?token=fake-token`,
         {
           error: "Not Found",
           message: `Download schedule for the item ${item.id} is not found.`,
@@ -213,7 +214,7 @@ describe("manageSchedule", () => {
         }
       )
       .post(
-        `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule`,
+        `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule?token=fake-token`,
         {
           message: "Download schedule set successfully.",
         }
@@ -232,7 +233,7 @@ describe("manageSchedule", () => {
 
     fetchMock
       .get(
-        `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule`,
+        `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule?token=fake-token`,
         {
           cadence: "daily",
           hour: 0,
@@ -240,7 +241,7 @@ describe("manageSchedule", () => {
         }
       )
       .delete(
-        `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule`,
+        `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule?token=fake-token`,
         {
           message: "Download schedule deleted successfully.",
         }
@@ -263,7 +264,7 @@ describe("manageSchedule", () => {
     } as IHubEditableContent;
 
     fetchMock.get(
-      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule`,
+      `https://hubqa.arcgis.com/api/download/v1/items/${item.id}/schedule?token=fake-token`,
       {
         cadence: "daily",
         hour: 0,

--- a/packages/common/test/content/manageSchedule.test.ts
+++ b/packages/common/test/content/manageSchedule.test.ts
@@ -19,7 +19,10 @@ describe("manageSchedule", () => {
     fetchMock.restore();
   });
   it("getSchedulerApiUrl: returns the correct url when no version is attached on requestOptions", () => {
-    const url = getSchedulerApiUrl("123", MOCK_HUB_REQOPTS);
+    const url = getSchedulerApiUrl(
+      "123",
+      MOCK_HUB_REQOPTS as IUserRequestOptions
+    );
     expect(url).toEqual(
       "https://hubqa.arcgis.com/api/download/v1/items/123/schedule?token=fake-token"
     );
@@ -30,7 +33,10 @@ describe("manageSchedule", () => {
       hubApiUrl: "https://hubqa.arcgis.com/api/v3",
     };
 
-    const url = getSchedulerApiUrl("123", requestOptions);
+    const url = getSchedulerApiUrl(
+      "123",
+      requestOptions as IUserRequestOptions
+    );
     expect(url).toEqual(
       "https://hubqa.arcgis.com/api/download/v1/items/123/schedule?token=fake-token"
     );
@@ -47,7 +53,7 @@ describe("manageSchedule", () => {
     );
     const response: IHubScheduleResponse = await getSchedule(
       item.id,
-      MOCK_HUB_REQOPTS
+      MOCK_HUB_REQOPTS as IUserRequestOptions
     );
     expect(response.message).toEqual(
       `Download schedule not found for item ${item.id}`
@@ -67,7 +73,7 @@ describe("manageSchedule", () => {
     );
     const response: IHubScheduleResponse = await getSchedule(
       item.id,
-      MOCK_HUB_REQOPTS
+      MOCK_HUB_REQOPTS as IUserRequestOptions
     );
     expect(response.schedule).toEqual({
       mode: "scheduled",
@@ -88,7 +94,7 @@ describe("manageSchedule", () => {
     );
     const response: IHubScheduleResponse = await getSchedule(
       item.id,
-      MOCK_HUB_REQOPTS
+      MOCK_HUB_REQOPTS as IUserRequestOptions
     );
     expect(response.schedule).toEqual({
       mode: "manual",
@@ -111,7 +117,11 @@ describe("manageSchedule", () => {
       }
     );
 
-    const response = await setSchedule(item.id, schedule, MOCK_HUB_REQOPTS);
+    const response = await setSchedule(
+      item.id,
+      schedule,
+      MOCK_HUB_REQOPTS as IUserRequestOptions
+    );
     expect(response.message).toEqual("Download schedule set successfully.");
     expect(fetchMock.calls().length).toBe(1);
   });
@@ -128,7 +138,11 @@ describe("manageSchedule", () => {
       }
     );
 
-    const response = await setSchedule(item.id, schedule, MOCK_HUB_REQOPTS);
+    const response = await setSchedule(
+      item.id,
+      schedule,
+      MOCK_HUB_REQOPTS as IUserRequestOptions
+    );
     expect(response.message).toEqual("Download schedule set successfully.");
     expect(fetchMock.calls().length).toBe(1);
   });
@@ -150,7 +164,11 @@ describe("manageSchedule", () => {
       }
     );
 
-    const response = await setSchedule(item.id, schedule, MOCK_HUB_REQOPTS);
+    const response = await setSchedule(
+      item.id,
+      schedule,
+      MOCK_HUB_REQOPTS as IUserRequestOptions
+    );
     expect(response.message).toEqual(
       "you specified 26 (of type number) as a hour, which is invalid"
     );
@@ -166,7 +184,10 @@ describe("manageSchedule", () => {
       }
     );
 
-    const response = await deleteSchedule(item.id, MOCK_HUB_REQOPTS);
+    const response = await deleteSchedule(
+      item.id,
+      MOCK_HUB_REQOPTS as IUserRequestOptions
+    );
     expect(response.message).toEqual("Download schedule deleted successfully.");
     expect(fetchMock.calls().length).toBe(1);
   });
@@ -186,7 +207,10 @@ describe("manageSchedule", () => {
       }
     );
 
-    const response = await maybeUpdateSchedule(content, MOCK_HUB_REQOPTS);
+    const response = await maybeUpdateSchedule(
+      content,
+      MOCK_HUB_REQOPTS as IUserRequestOptions
+    );
     expect(response.message).toEqual(
       `No schedule set, and incoming schedule is automatic.`
     );
@@ -220,7 +244,10 @@ describe("manageSchedule", () => {
         }
       );
 
-    const response = await maybeUpdateSchedule(content, MOCK_HUB_REQOPTS);
+    const response = await maybeUpdateSchedule(
+      content,
+      MOCK_HUB_REQOPTS as IUserRequestOptions
+    );
     expect(response.message).toEqual("Download schedule set successfully.");
     expect(fetchMock.calls().length).toBe(2);
   });
@@ -247,7 +274,10 @@ describe("manageSchedule", () => {
         }
       );
 
-    const response = await maybeUpdateSchedule(content, MOCK_HUB_REQOPTS);
+    const response = await maybeUpdateSchedule(
+      content,
+      MOCK_HUB_REQOPTS as IUserRequestOptions
+    );
     expect(response.message).toEqual("Download schedule deleted successfully.");
     expect(fetchMock.calls().length).toBe(2);
   });
@@ -272,7 +302,10 @@ describe("manageSchedule", () => {
       }
     );
 
-    const response = await maybeUpdateSchedule(content, MOCK_HUB_REQOPTS);
+    const response = await maybeUpdateSchedule(
+      content,
+      MOCK_HUB_REQOPTS as IUserRequestOptions
+    );
     expect(response.message).toEqual(
       "No action needed as schedules deepEqual each other."
     );


### PR DESCRIPTION
1. Description: This PR adds  authenticated user `token` to content update schedule API endpoint. Soon, the schedule API will only accept request that have valid token in query parameter. PR implementing token in API endpoint is [here](https://github.com/ArcGIS/hub-download-api/pull/36). This PR has to be merged before the backend API PR. 

1. Instructions for testing:

1. Closes Issues: #[9348](https://devtopia.esri.com/dc/hub/issues/9348)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
