### PR TITLE
fix: initiative fromEditor creates new initiatives before attempting …

### DIFF
--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -330,7 +330,7 @@ export class HubInitiative
 
     // 3. If the entity hasn't been created then we need to do that before we can
     // create a featured image, if one has been provided.
-    if (!entity.id) {
+    if (!entity.id && featuredImage) {
       // update this.entity so that the save method will work
       this.entity = entity;
       // save the entity to get an id / create it

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -326,9 +326,20 @@ export class HubInitiative
     const autoShareGroups = editor._groups || [];
 
     // 2. convert the editor values back to a initiative entity
-    const entity = await editorToInitiative(editor, this.context);
+    let entity = await editorToInitiative(editor, this.context);
 
-    // 3. set the thumbnailCache to ensure that
+    // 3. If the entity hasn't been created then we need to do that before we can
+    // create a featured image, if one has been provided.
+    if (!entity.id) {
+      // update this.entity so that the save method will work
+      this.entity = entity;
+      // save the entity to get an id / create it
+      await this.save();
+      // update the local entity let so that the featured image call can pick up the id
+      entity = this.entity;
+    }
+
+    // 4. set the thumbnailCache to ensure that
     // the thumbnail is updated on the next save
     if (thumbnail) {
       if (thumbnail.blob) {
@@ -344,7 +355,7 @@ export class HubInitiative
       }
     }
 
-    // 4. upsert or remove the configured featured image
+    // 5. upsert or remove the configured featured image
     if (featuredImage) {
       let featuredImageUrl: string | null = null;
       if (featuredImage.blob) {
@@ -376,11 +387,11 @@ export class HubInitiative
       };
     }
 
-    // 5. save or create the entity
+    // 6. save or create the entity
     this.entity = entity;
     await this.save();
 
-    // 6. share the entity with the configured groups
+    // 7. share the entity with the configured groups
     const isCreate = !editor.id;
     if (isCreate) {
       await this.setAccess(editor.access as SettableAccessLevel);

--- a/packages/common/test/initiatives/HubInitiative.test.ts
+++ b/packages/common/test/initiatives/HubInitiative.test.ts
@@ -594,6 +594,41 @@ describe("HubInitiative Class:", () => {
         expect(createSpy).not.toHaveBeenCalled();
         expect(upsertResourceSpy).toHaveBeenCalledTimes(1);
       });
+      it("handles setting featured image on creation", async () => {
+        const chk = HubInitiative.fromJson(
+          {
+            name: "Test Entity",
+          },
+          authdCtxMgr.context
+        );
+        const editor = await chk.toEditor();
+        editor.view = {
+          featuredImage: {
+            blob: "some blob",
+            filename: "some-featuredImage.png",
+          },
+        };
+        const upsertResourceSpy = spyOn(
+          upsertResourceModule,
+          "upsertResource"
+        ).and.returnValue(
+          Promise.resolve("https://blah.com/some-featuredImage.png")
+        );
+
+        editor.access = "org";
+
+        const accessSpy = spyOn(
+          HubItemEntity.prototype,
+          "setAccess"
+        ).and.returnValue(Promise.resolve());
+
+        await chk.fromEditor(editor);
+        expect(createSpy).toHaveBeenCalledTimes(1);
+        expect(updateSpy).toHaveBeenCalledTimes(1);
+        expect(upsertResourceSpy).toHaveBeenCalledTimes(1);
+        expect(accessSpy).toHaveBeenCalledTimes(1);
+        expect(accessSpy).toHaveBeenCalledWith("org");
+      });
       it("handles setting featured image and clearing prior image", async () => {
         const chk = HubInitiative.fromJson(
           {


### PR DESCRIPTION
…thumbnail/featured image logic

1. Description: Runs create logic in fromEditor before featured image creation.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
