### PR TITLE
fix(hub-common): fix undefined token when getSchedule is called

### DIFF
--- a/packages/common/src/content/fetch.ts
+++ b/packages/common/src/content/fetch.ts
@@ -283,13 +283,12 @@ export const fetchHubContent = async (
     });
   }
 
-  if (isDownloadSchedulingAvailable(requestOptions, access)) {
+  if (
+    isDownloadSchedulingAvailable(requestOptions as IHubRequestOptions, access)
+  ) {
     // fetch schedule and add it to enrichments if it exists in schedule API
     enrichments.schedule = (
-      await getSchedule(
-        item.id,
-        requestOptions as unknown as IUserRequestOptions
-      )
+      await getSchedule(item.id, requestOptions as IUserRequestOptions)
     ).schedule || { mode: "automatic" };
   }
 

--- a/packages/common/src/content/manageSchedule.ts
+++ b/packages/common/src/content/manageSchedule.ts
@@ -1,10 +1,10 @@
-import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IHubSchedule, IHubScheduleResponse } from "../core/types/IHubSchedule";
 import { cloneObject } from "../util";
 import { deepEqual } from "../objects/deepEqual";
 import { AccessLevel, IHubEditableContent } from "../core";
 import { getSchedulerApiUrl } from "./_internal/internalContentUtils";
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import { IHubRequestOptions } from "../types";
 
 // Any code referencing these functions must first pass isDownloadSchedulingAvailable
 
@@ -160,8 +160,13 @@ export const maybeUpdateSchedule = async (
  * @returns Whether or not the scheduling feature is available
  */
 export const isDownloadSchedulingAvailable = (
-  requestOptions: IRequestOptions,
+  requestOptions: IHubRequestOptions,
   access: AccessLevel
 ): boolean => {
-  return requestOptions.portal?.includes("arcgis.com") && access === "public";
+  const token = requestOptions.authentication.token;
+  return (
+    requestOptions.portal?.includes("arcgis.com") &&
+    access === "public" &&
+    !!token
+  );
 };


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
