### PR TITLE
fix(hub-common): fix undefined token when getting schedule

### DIFF
--- a/packages/common/src/content/manageSchedule.ts
+++ b/packages/common/src/content/manageSchedule.ts
@@ -163,7 +163,7 @@ export const isDownloadSchedulingAvailable = (
   requestOptions: IHubRequestOptions,
   access: AccessLevel
 ): boolean => {
-  const token = requestOptions.authentication.token;
+  const token = requestOptions.authentication?.token;
   return (
     requestOptions.portal?.includes("arcgis.com") &&
     access === "public" &&

--- a/packages/common/test/content/fetch.test.ts
+++ b/packages/common/test/content/fetch.test.ts
@@ -709,53 +709,6 @@ describe("fetchHubContent", () => {
     expect(fetchItemEnrichmentsSpy.calls.argsFor(1)[1]).toEqual(["metadata"]);
   });
 
-  it("should not get schedule without token", async () => {
-    const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
-      Promise.resolve(HOSTED_FEATURE_SERVICE_ITEM)
-    );
-    const getServiceSpy = spyOn(
-      featureLayerModule,
-      "getService"
-    ).and.returnValue(HOSTED_FEATURE_SERVICE_DEFINITION);
-    const fetchItemEnrichmentsSpy = spyOn(
-      _enrichmentsModule,
-      "fetchItemEnrichments"
-    ).and.returnValue({ metadata: null });
-
-    const getScheduleSpy = spyOn(scheduleModule, "getSchedule").and.returnValue(
-      Promise.resolve({
-        mode: "manual",
-      })
-    );
-
-    const chk = await fetchHubContent(
-      HOSTED_FEATURE_SERVICE_GUID,
-      MOCK_NOAUTH_HUB_REQOPTS
-    );
-
-    // test for schedule
-    expect(chk.schedule).not.toBeDefined();
-    expect(getScheduleSpy.calls.count()).toBe(0);
-
-    expect(chk.id).toBe(HOSTED_FEATURE_SERVICE_GUID);
-    expect(chk.owner).toBe(HOSTED_FEATURE_SERVICE_ITEM.owner);
-    expect(chk.serverExtractCapability).toBeTruthy();
-
-    expect(getItemSpy.calls.count()).toBe(1);
-    expect(getItemSpy.calls.argsFor(0)[0]).toBe(HOSTED_FEATURE_SERVICE_GUID);
-    expect(getServiceSpy.calls.count()).toBe(1);
-    expect(getServiceSpy.calls.argsFor(0)[0].url).toBe(
-      HOSTED_FEATURE_SERVICE_URL
-    );
-    // NOTE: the first call to fetchItemEnrichments is done by fetchContent under the hood,
-    // while the second call is done by fetchHubContent. We only care about the second call here
-    expect(fetchItemEnrichmentsSpy.calls.count()).toBe(2);
-    expect(fetchItemEnrichmentsSpy.calls.argsFor(1)[0]).toBe(
-      HOSTED_FEATURE_SERVICE_ITEM
-    );
-    expect(fetchItemEnrichmentsSpy.calls.argsFor(1)[1]).toEqual(["metadata"]);
-  });
-
   it("gets non-hosted feature service", async () => {
     const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
       Promise.resolve(NON_HOSTED_FEATURE_SERVICE_ITEM)
@@ -831,5 +784,52 @@ describe("fetchHubContent", () => {
     });
 
     expect(chk.type).toBe("Hub Site Application");
+  });
+
+  it("should not get schedule without token", async () => {
+    const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
+      Promise.resolve(HOSTED_FEATURE_SERVICE_ITEM)
+    );
+    const getServiceSpy = spyOn(
+      featureLayerModule,
+      "getService"
+    ).and.returnValue(HOSTED_FEATURE_SERVICE_DEFINITION);
+    const fetchItemEnrichmentsSpy = spyOn(
+      _enrichmentsModule,
+      "fetchItemEnrichments"
+    ).and.returnValue({ metadata: null });
+
+    const getScheduleSpy = spyOn(scheduleModule, "getSchedule").and.returnValue(
+      Promise.resolve({
+        mode: "manual",
+      })
+    );
+
+    const chk = await fetchHubContent(
+      HOSTED_FEATURE_SERVICE_GUID,
+      MOCK_NOAUTH_HUB_REQOPTS
+    );
+
+    // test for schedule
+    expect(chk.schedule).not.toBeDefined();
+    expect(getScheduleSpy.calls.count()).toBe(0);
+
+    expect(chk.id).toBe(HOSTED_FEATURE_SERVICE_GUID);
+    expect(chk.owner).toBe(HOSTED_FEATURE_SERVICE_ITEM.owner);
+    expect(chk.serverExtractCapability).toBeTruthy();
+
+    expect(getItemSpy.calls.count()).toBe(1);
+    expect(getItemSpy.calls.argsFor(0)[0]).toBe(HOSTED_FEATURE_SERVICE_GUID);
+    expect(getServiceSpy.calls.count()).toBe(1);
+    expect(getServiceSpy.calls.argsFor(0)[0].url).toBe(
+      HOSTED_FEATURE_SERVICE_URL
+    );
+    // NOTE: the first call to fetchItemEnrichments is done by fetchContent under the hood,
+    // while the second call is done by fetchHubContent. We only care about the second call here
+    expect(fetchItemEnrichmentsSpy.calls.count()).toBe(2);
+    expect(fetchItemEnrichmentsSpy.calls.argsFor(1)[0]).toBe(
+      HOSTED_FEATURE_SERVICE_ITEM
+    );
+    expect(fetchItemEnrichmentsSpy.calls.argsFor(1)[1]).toEqual(["metadata"]);
   });
 });

--- a/packages/common/test/content/fetch.test.ts
+++ b/packages/common/test/content/fetch.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../src";
 import * as _enrichmentsModule from "../../src/items/_enrichments";
 import * as _fetchModule from "../../src/content/_fetch";
+import * as scheduleModule from "../../src/content/manageSchedule";
 import * as documentItem from "../mocks/items/document.json";
 import * as multiLayerFeatureServiceItem from "../mocks/items/multi-layer-feature-service.json";
 import {
@@ -23,7 +24,7 @@ import {
   PDF_GUID,
   PDF_ITEM,
 } from "./fixtures";
-import { MOCK_AUTH } from "../mocks/mock-auth";
+import { MOCK_AUTH, MOCK_NOAUTH_HUB_REQOPTS } from "../mocks/mock-auth";
 
 // mock the item enrichments that would be returned for a multi-layer service
 const getMultiLayerItemEnrichments = () => {
@@ -689,6 +690,53 @@ describe("fetchHubContent", () => {
       portal: MOCK_AUTH.portal,
       authentication: MOCK_AUTH,
     });
+    expect(chk.id).toBe(HOSTED_FEATURE_SERVICE_GUID);
+    expect(chk.owner).toBe(HOSTED_FEATURE_SERVICE_ITEM.owner);
+    expect(chk.serverExtractCapability).toBeTruthy();
+
+    expect(getItemSpy.calls.count()).toBe(1);
+    expect(getItemSpy.calls.argsFor(0)[0]).toBe(HOSTED_FEATURE_SERVICE_GUID);
+    expect(getServiceSpy.calls.count()).toBe(1);
+    expect(getServiceSpy.calls.argsFor(0)[0].url).toBe(
+      HOSTED_FEATURE_SERVICE_URL
+    );
+    // NOTE: the first call to fetchItemEnrichments is done by fetchContent under the hood,
+    // while the second call is done by fetchHubContent. We only care about the second call here
+    expect(fetchItemEnrichmentsSpy.calls.count()).toBe(2);
+    expect(fetchItemEnrichmentsSpy.calls.argsFor(1)[0]).toBe(
+      HOSTED_FEATURE_SERVICE_ITEM
+    );
+    expect(fetchItemEnrichmentsSpy.calls.argsFor(1)[1]).toEqual(["metadata"]);
+  });
+
+  it("should not get schedule without token", async () => {
+    const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
+      Promise.resolve(HOSTED_FEATURE_SERVICE_ITEM)
+    );
+    const getServiceSpy = spyOn(
+      featureLayerModule,
+      "getService"
+    ).and.returnValue(HOSTED_FEATURE_SERVICE_DEFINITION);
+    const fetchItemEnrichmentsSpy = spyOn(
+      _enrichmentsModule,
+      "fetchItemEnrichments"
+    ).and.returnValue({ metadata: null });
+
+    const getScheduleSpy = spyOn(scheduleModule, "getSchedule").and.returnValue(
+      Promise.resolve({
+        mode: "manual",
+      })
+    );
+
+    const chk = await fetchHubContent(
+      HOSTED_FEATURE_SERVICE_GUID,
+      MOCK_NOAUTH_HUB_REQOPTS
+    );
+
+    // test for schedule
+    expect(chk.schedule).not.toBeDefined();
+    expect(getScheduleSpy.calls.count()).toBe(0);
+
     expect(chk.id).toBe(HOSTED_FEATURE_SERVICE_GUID);
     expect(chk.owner).toBe(HOSTED_FEATURE_SERVICE_ITEM.owner);
     expect(chk.serverExtractCapability).toBeTruthy();

--- a/packages/common/test/content/fetch.test.ts
+++ b/packages/common/test/content/fetch.test.ts
@@ -786,7 +786,54 @@ describe("fetchHubContent", () => {
     expect(chk.type).toBe("Hub Site Application");
   });
 
-  it("should not get schedule without token", async () => {
+  it("should get schedule for request with a token", async () => {
+    const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
+      Promise.resolve(HOSTED_FEATURE_SERVICE_ITEM)
+    );
+    const getServiceSpy = spyOn(
+      featureLayerModule,
+      "getService"
+    ).and.returnValue(HOSTED_FEATURE_SERVICE_DEFINITION);
+    const fetchItemEnrichmentsSpy = spyOn(
+      _enrichmentsModule,
+      "fetchItemEnrichments"
+    ).and.returnValue({ metadata: null });
+
+    const getScheduleSpy = spyOn(scheduleModule, "getSchedule").and.returnValue(
+      Promise.resolve({
+        mode: "manual",
+      })
+    );
+
+    const chk = await fetchHubContent(HOSTED_FEATURE_SERVICE_GUID, {
+      portal: MOCK_AUTH.portal,
+      authentication: MOCK_AUTH,
+    });
+
+    // test for schedule
+    expect(chk.schedule).toBeDefined();
+    expect(getScheduleSpy.calls.count()).toBe(1);
+
+    expect(chk.id).toBe(HOSTED_FEATURE_SERVICE_GUID);
+    expect(chk.owner).toBe(HOSTED_FEATURE_SERVICE_ITEM.owner);
+    expect(chk.serverExtractCapability).toBeTruthy();
+
+    expect(getItemSpy.calls.count()).toBe(1);
+    expect(getItemSpy.calls.argsFor(0)[0]).toBe(HOSTED_FEATURE_SERVICE_GUID);
+    expect(getServiceSpy.calls.count()).toBe(1);
+    expect(getServiceSpy.calls.argsFor(0)[0].url).toBe(
+      HOSTED_FEATURE_SERVICE_URL
+    );
+    // NOTE: the first call to fetchItemEnrichments is done by fetchContent under the hood,
+    // while the second call is done by fetchHubContent. We only care about the second call here
+    expect(fetchItemEnrichmentsSpy.calls.count()).toBe(2);
+    expect(fetchItemEnrichmentsSpy.calls.argsFor(1)[0]).toBe(
+      HOSTED_FEATURE_SERVICE_ITEM
+    );
+    expect(fetchItemEnrichmentsSpy.calls.argsFor(1)[1]).toEqual(["metadata"]);
+  });
+
+  it("should not get schedule for request without a token", async () => {
     const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
       Promise.resolve(HOSTED_FEATURE_SERVICE_ITEM)
     );


### PR DESCRIPTION
1. Description: My bad! I missed this in my previous [PR](https://github.com/Esri/hub.js/pull/1505). Sometimes `authentication` key of `requestOptions` could be `undefined` so `token` need to be retrieved using optional operator to avoid error.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
