### PR TITLE
fix(hub-common): get-events dto enum array types

### DIFF
--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -5,8 +5,31 @@
  * Hub Events Service
  * OpenAPI spec version: 0.0.1
  */
-import { Awaited } from "../awaited-type";
 import { customClient } from "../custom-client";
+import { Awaited } from "../awaited-type";
+
+export interface IUpdateRegistration {
+  /** Role of the user in the event */
+  role?: RegistrationRole;
+  /** Status of the registration */
+  status?: RegistrationStatus;
+  /** Attendance type for this registration */
+  type?: EventAttendanceType;
+}
+
+export interface IPagedRegistrationResponse {
+  items: IRegistration[];
+  nextStart: number;
+  total: number;
+}
+
+export enum RegistrationSort {
+  createdAt = "createdAt",
+  updatedAt = "updatedAt",
+  firstName = "firstName",
+  lastName = "lastName",
+  username = "username",
+}
 export type GetRegistrationsParams = {
   /**
    * Event id being registered for
@@ -60,7 +83,7 @@ export type GetRegistrationsParams = {
 
 export type GetEventsParams = {
   /**
-   * Comma separated string list of EventAccess
+   * Comma separated string list of EventAccess. Example: PRIVATE,ORG,PUBLIC
    */
   access?: string;
   /**
@@ -68,11 +91,11 @@ export type GetEventsParams = {
    */
   entityIds?: string;
   /**
-   * Comma separated string list of associated entity types
+   * Comma separated string list of associated entity types. Example: associations,registrations,creator,addresses,onlineMeetings
    */
   entityTypes?: string;
   /**
-   * Comma separated string list of relation fields to include in response
+   * Comma separated string list of relation fields to include in response. Example: associations,registrations,creator,addresses,onlineMeetings
    */
   include?: string;
   /**
@@ -84,7 +107,7 @@ export type GetEventsParams = {
    */
   startDateTimeAfter?: string;
   /**
-   * Comma separated string list of AttendanceTypes
+   * Comma separated string list of AttendanceTypes. Example:  VIRTUAL,IN_PERSON
    */
   attendanceTypes?: string;
   /**
@@ -92,7 +115,7 @@ export type GetEventsParams = {
    */
   categories?: string;
   /**
-   * comma separated string list of event statuses
+   * comma separated string list of event statuses. Example: PRIVATE,ORG,PUBLIC
    */
   status?: string;
   /**
@@ -121,28 +144,6 @@ export type GetEventsParams = {
   sortOrder?: SortOrder;
 };
 
-export interface IUpdateRegistration {
-  /** Role of the user in the event */
-  role?: RegistrationRole;
-  /** Status of the registration */
-  status?: RegistrationStatus;
-  /** Attendance type for this registration */
-  type?: EventAttendanceType;
-}
-
-export interface IPagedRegistrationResponse {
-  items: IRegistration[];
-  nextStart: number;
-  total: number;
-}
-
-export enum RegistrationSort {
-  createdAt = "createdAt",
-  updatedAt = "updatedAt",
-  firstName = "firstName",
-  lastName = "lastName",
-  username = "username",
-}
 export interface ICreateRegistration {
   /** ArcGIS Online id for a user. Will always be extracted from the token unless service token is used. */
   agoId?: string;


### PR DESCRIPTION
…dd entityIds and entityTypes to

1. Description: Updated `get-events-dto`'s parameters that are arrays based on enums to include their enum types

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
