### PR TITLE
fix: add content to site propertyMap, allow more props on ICapabilityConfig

### DIFF
--- a/packages/common/src/core/traits/ICapabilityConfig.ts
+++ b/packages/common/src/core/traits/ICapabilityConfig.ts
@@ -1,4 +1,4 @@
-import { IFilter, IHubCatalog } from "../../search/types/IHubCatalog";
+import { IHubCatalog } from "../../search/types/IHubCatalog";
 
 export type HubCapability =
   | "events"
@@ -14,16 +14,16 @@ export type HubCapability =
  */
 export interface ICapabilityConfig {
   enabled: boolean;
-  /**
-   * If defined, the filter will be injected into
-   * the entitie's content catalog's scope when the gallery is
-   * rendered
-   */
-  filter?: IFilter;
+
   /**
    * If defined, this catalog is used to render the gallery
    */
   catalog?: IHubCatalog;
+
+  /**
+   * Enable extensibiliy as we prototype
+   */
+  [key: string]: any;
 }
 /**
  * We intentionally want these interfaces to exist even if they are empty

--- a/packages/common/src/sites/_internal/getPropertyMap.ts
+++ b/packages/common/src/sites/_internal/getPropertyMap.ts
@@ -35,6 +35,7 @@ export function getPropertyMap(): IPropertyMap[] {
   map.push({ entityKey: "events", storeKey: "data.events" });
   map.push({ entityKey: "initiatives", storeKey: "data.initiatives" });
   map.push({ entityKey: "projects", storeKey: "data.projects" });
+  map.push({ entityKey: "content", storeKey: "data.content" });
 
   // Deeper/Indirect mappings
   map.push({


### PR DESCRIPTION
1. Description:

Small changes to enable prototyping of capability config

1. Instructions for testing: run tests

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
