### PR TITLE
fix(hub-common): fix force content endpoint

### DIFF
--- a/packages/common/src/content/_internal/internalContentUtils.ts
+++ b/packages/common/src/content/_internal/internalContentUtils.ts
@@ -988,7 +988,7 @@ export const forceUpdateContent = async (
   requestOptions: IUserRequestOptions
 ) => {
   const hubApiUrlRoot = getHubApiUrl(requestOptions);
-  const url = `${hubApiUrlRoot}/api/v3/jobs/item/${itemId}/harvest`;
+  const url = `${hubApiUrlRoot}/api/v3/jobs/item/${itemId}/forceUpdate`;
   const options = {
     method: "POST",
     headers: {


### PR DESCRIPTION
1. Description: This PR updates API endpoint to force content update.

1. Instructions for testing:

1. Closes Issues: #[10347](https://devtopia.esri.com/dc/hub/issues/10347)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
