### PR TITLE
feat(hub-common): show disabled scheduler setting with advisory notice for private items

### DIFF
--- a/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
@@ -1,15 +1,13 @@
-import { checkPermission } from "../..";
 import { IArcGISContext } from "../../ArcGISContext";
 import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
 import {
   IUiSchema,
   IUiSchemaElement,
   IUiSchemaMessage,
-  IUiSchemaRule,
   UiSchemaMessageTypes,
-  UiSchemaRuleEffects,
 } from "../../core/schemas/types";
 import { IHubEditableContent } from "../../core/types/IHubEditableContent";
+import { checkPermission } from "../../permissions/checkPermission";
 import { isHostedFeatureServiceEntity } from "../hostedServiceUtils";
 
 /**
@@ -72,7 +70,7 @@ export const buildUiSchema = async (
     if (options.access !== "public") {
       // Disable the schedule and force update controls
       scheduleControlElement.options.disabled = true;
-      forceUpdateControlElement.options.disabled = true;
+      forceUpdateControlElement.options.disabled = [true];
 
       // Add a notice to the bottom of the force update control
       forceUpdateControlElement.options.messages = [

--- a/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
@@ -51,29 +51,15 @@ export const buildUiSchema = async (
         ],
       },
     };
-    // force update checkbox -- TODO: replace with button once available
-    const forceUpdateControlElement: IUiSchemaElement = {
-      type: "Control",
-      scope: "/properties/_forceUpdate",
-      options: {
-        control: "hub-field-input-tile-select",
-        type: "checkbox",
-        labels: [
-          `{{${i18nScope}.fields.schedule.forceUpdateButton.label:translate}}`,
-        ],
-        descriptions: [
-          `{{${i18nScope}.fields.schedule.forceUpdateButton.description:translate}}`,
-        ],
-      },
-    };
+
+    const scheduleSectionElements: IUiSchemaElement[] = [
+      scheduleControlElement,
+    ];
 
     if (options.access !== "public") {
-      // Disable the schedule and force update controls
+      // Disable the schedule control and add the unavailable notice
       scheduleControlElement.options.disabled = true;
-      forceUpdateControlElement.options.disabled = [true];
-
-      // Add a notice to the bottom of the force update control
-      forceUpdateControlElement.options.messages = [
+      scheduleControlElement.options.messages = [
         {
           type: UiSchemaMessageTypes.custom,
           display: "notice",
@@ -85,12 +71,28 @@ export const buildUiSchema = async (
           alwaysShow: true,
         },
       ] as IUiSchemaMessage[];
+    } else {
+      // force update checkbox -- TODO: replace with button once available
+      scheduleSectionElements.push({
+        type: "Control",
+        scope: "/properties/_forceUpdate",
+        options: {
+          control: "hub-field-input-tile-select",
+          type: "checkbox",
+          labels: [
+            `{{${i18nScope}.fields.schedule.forceUpdateButton.label:translate}}`,
+          ],
+          descriptions: [
+            `{{${i18nScope}.fields.schedule.forceUpdateButton.description:translate}}`,
+          ],
+        },
+      });
     }
 
     uiSchema.elements.push({
       type: "Section",
       labelKey: `${i18nScope}.sections.schedule.label`,
-      elements: [scheduleControlElement, forceUpdateControlElement],
+      elements: scheduleSectionElements,
     });
   }
 

--- a/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
@@ -3,6 +3,8 @@ import { IArcGISContext } from "../../ArcGISContext";
 import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
 import {
   IUiSchema,
+  IUiSchemaElement,
+  IUiSchemaMessage,
   IUiSchemaRule,
   UiSchemaMessageTypes,
   UiSchemaRuleEffects,
@@ -25,95 +27,125 @@ export const buildUiSchema = async (
     type: "Layout",
     elements: [],
   };
-
   if (
     checkPermission("hub:content:workspace:settings:schedule", _context).access
   ) {
-    // NOTE: unfortunately we have to add a hidden "access" field so
-    // we can use the value of "access" in other UI Schema rules.
-    const alwaysHiddenRule: IUiSchemaRule = {
-      effect: UiSchemaRuleEffects.SHOW,
-      condition: {
-        scope: "/properties/access",
-        schema: {
-          const: "non-existent-access-type",
-        },
-      },
-    };
-    uiSchema.elements.push({
+    const scheduleControlElement: IUiSchemaElement = {
       type: "Control",
-      scope: "/properties/access",
-      rule: alwaysHiddenRule,
-    });
-
-    const isNotPublicCondition: IUiSchemaRule["condition"] = {
-      scope: "/properties/access",
-      schema: {
-        enum: ["private", "org", "shared"],
+      scope: "/properties/schedule",
+      labelKey: `${i18nScope}.sections.schedule.helperText`,
+      options: {
+        type: "Control",
+        control: "hub-field-input-scheduler",
+        labelKey: "fieldHeader",
+        format: "radio",
+        inputs: [
+          { type: "automatic" },
+          { type: "daily" },
+          { type: "weekly" },
+          { type: "monthly" },
+          { type: "yearly" },
+          {
+            type: "manual",
+            helperActionIcon: "information-f",
+            helperActionText: `{{${i18nScope}.fields.schedule.manual.helperActionText:translate}}`,
+          },
+        ],
       },
     };
-    const disableScheduleRule: IUiSchemaRule = {
-      effect: UiSchemaRuleEffects.DISABLE,
-      condition: isNotPublicCondition,
+    // force update checkbox -- TODO: replace with button once available
+    const forceUpdateControlElement: IUiSchemaElement = {
+      type: "Control",
+      scope: "/properties/_forceUpdate",
+      options: {
+        control: "hub-field-input-tile-select",
+        type: "checkbox",
+        labels: [
+          `{{${i18nScope}.fields.schedule.forceUpdateButton.label:translate}}`,
+        ],
+        descriptions: [
+          `{{${i18nScope}.fields.schedule.forceUpdateButton.description:translate}}`,
+        ],
+      },
     };
+
+    /**
+     * NOTE: Some crazy gymnastics up ahead if the content is not public.
+     *
+     * The entity editor component will re-calculate the _UI Schema_ passed into the configuration editor
+     * if the underlying entity has been changed from the outside (e.g., via the sharing level controls).
+     * However, it will not change _the values_ passed into the configuration editor.
+     *
+     * This means that `options.access` is guaranteed to be up-to-date, but the underlying
+     * configuration editor's `values.access` _will not be updated_.
+     *
+     * As such we cannot rely on an IUiSchemaRule to update the disabled state of the
+     * schedule and force update controls, because the rule will be evaluated against
+     * _the old value_ of `values.access`.
+     *
+     * Also, the configuration editor also does not provide a way to statically set the disabled
+     * state of a control. We have to rely on an IUiSchemaRule to disable a field.
+     *
+     * So, here's what we do as a workaround:
+     *
+     * - Create a "disabled" rule with a condition that always evaluates to true (i.e., this.entity.type === this.entity.type)
+     * - Create a "hide" rule with a condition that always evaluates to true (i.e., this.entity.type === this.entity.type)
+     * - Add a hidden "type" field to the UI Schema (needed so we can use the value of entity.type in a the "disabled" and "hide" rules)
+     * - Add the "disabled" rule to the schedule and force update controls
+     * - Add a special notice to the bottom of the force update control which informs the user that scheduling is unavailable
+     */
+    if (options.access !== "public") {
+      // checks if this.values.type === options.type, which is always true
+      const alwaysTrueCondition: IUiSchemaRule["condition"] = {
+        scope: "/properties/type",
+        schema: {
+          const: options.type,
+        },
+      };
+
+      // This rule will cause a control to always be hidden
+      const alwaysHiddenRule: IUiSchemaRule = {
+        effect: UiSchemaRuleEffects.HIDE,
+        condition: alwaysTrueCondition,
+      };
+
+      // This rule will cause a control to always be disabled
+      const alwaysDisabledRule: IUiSchemaRule = {
+        effect: UiSchemaRuleEffects.DISABLE,
+        condition: alwaysTrueCondition,
+      };
+
+      // NOTE: unfortunately we have to add a hidden "type" field to the ui schema. If we don't, we won't
+      // have access to `this.values.type` when evaluating `alwaysDisabledRule` or `alwaysHiddenRule`
+      uiSchema.elements.push({
+        type: "Control",
+        scope: "/properties/type",
+        rule: alwaysHiddenRule,
+      });
+
+      // Disable the schedule and force update controls
+      scheduleControlElement.rule = alwaysDisabledRule;
+      forceUpdateControlElement.rule = alwaysDisabledRule;
+
+      // Add a notice to the bottom of the force update control
+      forceUpdateControlElement.options.messages = [
+        {
+          type: UiSchemaMessageTypes.custom,
+          display: "notice",
+          kind: "warning",
+          icon: "exclamation-mark-triangle",
+          titleKey: `${i18nScope}.fields.schedule.unavailableNotice.title`,
+          labelKey: `${i18nScope}.fields.schedule.unavailableNotice.body`,
+          allowShowBeforeInteract: true,
+          alwaysShow: true,
+        },
+      ] as IUiSchemaMessage[];
+    }
 
     uiSchema.elements.push({
       type: "Section",
       labelKey: `${i18nScope}.sections.schedule.label`,
-      elements: [
-        {
-          type: "Control",
-          scope: "/properties/schedule",
-          labelKey: `${i18nScope}.sections.schedule.helperText`,
-          rule: disableScheduleRule,
-          options: {
-            type: "Control",
-            control: "hub-field-input-scheduler",
-            labelKey: "fieldHeader",
-            format: "radio",
-            inputs: [
-              { type: "automatic" },
-              { type: "daily" },
-              { type: "weekly" },
-              { type: "monthly" },
-              { type: "yearly" },
-              {
-                type: "manual",
-                helperActionIcon: "information-f",
-                helperActionText: `{{${i18nScope}.fields.schedule.manual.helperActionText:translate}}`,
-              },
-            ],
-          },
-        },
-        // force update checkbox -- TODO: replace with button once available
-        {
-          type: "Control",
-          scope: "/properties/_forceUpdate",
-          rule: disableScheduleRule,
-          options: {
-            control: "hub-field-input-tile-select",
-            type: "checkbox",
-            labels: [
-              `{{${i18nScope}.fields.schedule.forceUpdateButton.label:translate}}`,
-            ],
-            descriptions: [
-              `{{${i18nScope}.fields.schedule.forceUpdateButton.description:translate}}`,
-            ],
-            messages: [
-              {
-                type: UiSchemaMessageTypes.custom,
-                display: "notice",
-                kind: "warning",
-                icon: "exclamation-mark-triangle",
-                titleKey: `${i18nScope}.fields.schedule.unavailableNotice.title`,
-                labelKey: `${i18nScope}.fields.schedule.unavailableNotice.body`,
-                allowShowBeforeInteract: true,
-                condition: isNotPublicCondition,
-              },
-            ],
-          },
-        },
-      ],
+      elements: [scheduleControlElement, forceUpdateControlElement],
     });
   }
 

--- a/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
@@ -1,7 +1,12 @@
 import { checkPermission } from "../..";
 import { IArcGISContext } from "../../ArcGISContext";
 import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
-import { IUiSchema, UiSchemaRuleEffects } from "../../core/schemas/types";
+import {
+  IUiSchema,
+  IUiSchemaRule,
+  UiSchemaMessageTypes,
+  UiSchemaRuleEffects,
+} from "../../core/schemas/types";
 import { IHubEditableContent } from "../../core/types/IHubEditableContent";
 import { isHostedFeatureServiceEntity } from "../hostedServiceUtils";
 
@@ -22,10 +27,36 @@ export const buildUiSchema = async (
   };
 
   if (
-    checkPermission("hub:content:workspace:settings:schedule", _context)
-      .access &&
-    options.access === "public"
+    checkPermission("hub:content:workspace:settings:schedule", _context).access
   ) {
+    // NOTE: unfortunately we have to add a hidden "access" field so
+    // we can use the value of "access" in other UI Schema rules.
+    const alwaysHiddenRule: IUiSchemaRule = {
+      effect: UiSchemaRuleEffects.SHOW,
+      condition: {
+        scope: "/properties/access",
+        schema: {
+          const: "non-existent-access-type",
+        },
+      },
+    };
+    uiSchema.elements.push({
+      type: "Control",
+      scope: "/properties/access",
+      rule: alwaysHiddenRule,
+    });
+
+    const isNotPublicCondition: IUiSchemaRule["condition"] = {
+      scope: "/properties/access",
+      schema: {
+        enum: ["private", "org", "shared"],
+      },
+    };
+    const disableScheduleRule: IUiSchemaRule = {
+      effect: UiSchemaRuleEffects.DISABLE,
+      condition: isNotPublicCondition,
+    };
+
     uiSchema.elements.push({
       type: "Section",
       labelKey: `${i18nScope}.sections.schedule.label`,
@@ -34,6 +65,7 @@ export const buildUiSchema = async (
           type: "Control",
           scope: "/properties/schedule",
           labelKey: `${i18nScope}.sections.schedule.helperText`,
+          rule: disableScheduleRule,
           options: {
             type: "Control",
             control: "hub-field-input-scheduler",
@@ -57,6 +89,7 @@ export const buildUiSchema = async (
         {
           type: "Control",
           scope: "/properties/_forceUpdate",
+          rule: disableScheduleRule,
           options: {
             control: "hub-field-input-tile-select",
             type: "checkbox",
@@ -65,6 +98,18 @@ export const buildUiSchema = async (
             ],
             descriptions: [
               `{{${i18nScope}.fields.schedule.forceUpdateButton.description:translate}}`,
+            ],
+            messages: [
+              {
+                type: UiSchemaMessageTypes.custom,
+                display: "notice",
+                kind: "warning",
+                icon: "exclamation-mark-triangle",
+                titleKey: `${i18nScope}.fields.schedule.unavailableNotice.title`,
+                labelKey: `${i18nScope}.fields.schedule.unavailableNotice.body`,
+                allowShowBeforeInteract: true,
+                condition: isNotPublicCondition,
+              },
             ],
           },
         },

--- a/packages/common/test/content/_internal/ContentUiSchemaSettings.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaSettings.test.ts
@@ -163,21 +163,6 @@ describe("buildUiSchema: content settings", () => {
                     helperActionText: `{{some.scope.fields.schedule.manual.helperActionText:translate}}`,
                   },
                 ],
-              },
-            },
-            {
-              type: "Control",
-              scope: "/properties/_forceUpdate",
-              options: {
-                control: "hub-field-input-tile-select",
-                disabled: [true],
-                type: "checkbox",
-                labels: [
-                  `{{some.scope.fields.schedule.forceUpdateButton.label:translate}}`,
-                ],
-                descriptions: [
-                  `{{some.scope.fields.schedule.forceUpdateButton.description:translate}}`,
-                ],
                 messages: [
                   {
                     type: "CUSTOM",

--- a/packages/common/test/content/_internal/ContentUiSchemaSettings.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaSettings.test.ts
@@ -1,7 +1,7 @@
 import { buildUiSchema } from "../../../src/content/_internal/ContentUiSchemaSettings";
 import { MOCK_CONTEXT } from "../../mocks/mock-auth";
 import * as hostedServiceUtilsModule from "../../../src/content/hostedServiceUtils";
-import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
+import * as checkPermissionModule from "../../../src/permissions/checkPermission";
 
 describe("buildUiSchema: content settings", () => {
   it("includes download fields for hosted feature service entities", async () => {
@@ -9,17 +9,68 @@ describe("buildUiSchema: content settings", () => {
       hostedServiceUtilsModule,
       "isHostedFeatureServiceEntity"
     ).and.returnValue(true);
-
-    const contextWithPermission = {
-      ...MOCK_CONTEXT,
-      featureFlags: {
-        "hub:content:workspace:settings:schedule": true,
-      },
-    };
+    spyOn(checkPermissionModule, "checkPermission").and.returnValue({
+      access: false,
+    });
     const uiSchema = await buildUiSchema(
       "some.scope",
       { access: "public" } as any,
-      contextWithPermission
+      MOCK_CONTEXT
+    );
+    expect(uiSchema).toEqual({
+      type: "Layout",
+      elements: [
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.downloads.label",
+          options: {
+            helperText: {
+              labelKey: "some.scope.sections.downloads.helperText",
+            },
+          },
+          elements: [
+            {
+              labelKey: "some.scope.fields.serverExtractCapability.label",
+              scope: "/properties/serverExtractCapability",
+              type: "Control",
+              options: {
+                helperText: {
+                  labelKey:
+                    "some.scope.fields.serverExtractCapability.helperText",
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+  it("excludes download fields for other entities", async () => {
+    spyOn(
+      hostedServiceUtilsModule,
+      "isHostedFeatureServiceEntity"
+    ).and.returnValue(false);
+    spyOn(checkPermissionModule, "checkPermission").and.returnValue({
+      access: false,
+    });
+    const uiSchema = await buildUiSchema("some.scope", {} as any, MOCK_CONTEXT);
+    expect(uiSchema).toEqual({
+      type: "Layout",
+      elements: [],
+    });
+  });
+  it("includes enabled schedule fields for public entities", async () => {
+    spyOn(
+      hostedServiceUtilsModule,
+      "isHostedFeatureServiceEntity"
+    ).and.returnValue(false);
+    spyOn(checkPermissionModule, "checkPermission").and.returnValue({
+      access: true,
+    });
+    const uiSchema = await buildUiSchema(
+      "some.scope",
+      { access: "public" } as any,
+      MOCK_CONTEXT
     );
     expect(uiSchema).toEqual({
       type: "Layout",
@@ -67,41 +118,85 @@ describe("buildUiSchema: content settings", () => {
             },
           ],
         },
+      ],
+    });
+  });
+  it("includes disabled schedule fields for private entities", async () => {
+    spyOn(
+      hostedServiceUtilsModule,
+      "isHostedFeatureServiceEntity"
+    ).and.returnValue(false);
+    spyOn(checkPermissionModule, "checkPermission").and.returnValue({
+      access: true,
+    });
+    const uiSchema = await buildUiSchema(
+      "some.scope",
+      { access: "private" } as any,
+      MOCK_CONTEXT
+    );
+    expect(uiSchema).toEqual({
+      type: "Layout",
+      elements: [
         {
           type: "Section",
-          labelKey: "some.scope.sections.downloads.label",
-          options: {
-            helperText: {
-              labelKey: "some.scope.sections.downloads.helperText",
-            },
-          },
+          labelKey: `some.scope.sections.schedule.label`,
           elements: [
             {
-              labelKey: "some.scope.fields.serverExtractCapability.label",
-              scope: "/properties/serverExtractCapability",
               type: "Control",
+              scope: "/properties/schedule",
+              labelKey: `some.scope.sections.schedule.helperText`,
               options: {
-                helperText: {
-                  labelKey:
-                    "some.scope.fields.serverExtractCapability.helperText",
-                },
+                type: "Control",
+                control: "hub-field-input-scheduler",
+                disabled: true,
+                labelKey: "fieldHeader",
+                format: "radio",
+                inputs: [
+                  { type: "automatic" },
+                  { type: "daily" },
+                  { type: "weekly" },
+                  { type: "monthly" },
+                  { type: "yearly" },
+                  {
+                    type: "manual",
+                    helperActionIcon: "information-f",
+                    helperActionText: `{{some.scope.fields.schedule.manual.helperActionText:translate}}`,
+                  },
+                ],
+              },
+            },
+            {
+              type: "Control",
+              scope: "/properties/_forceUpdate",
+              options: {
+                control: "hub-field-input-tile-select",
+                disabled: [true],
+                type: "checkbox",
+                labels: [
+                  `{{some.scope.fields.schedule.forceUpdateButton.label:translate}}`,
+                ],
+                descriptions: [
+                  `{{some.scope.fields.schedule.forceUpdateButton.description:translate}}`,
+                ],
+                messages: [
+                  {
+                    type: "CUSTOM",
+                    display: "notice",
+                    kind: "warning",
+                    icon: "exclamation-mark-triangle",
+                    titleKey:
+                      "some.scope.fields.schedule.unavailableNotice.title",
+                    labelKey:
+                      "some.scope.fields.schedule.unavailableNotice.body",
+                    allowShowBeforeInteract: true,
+                    alwaysShow: true,
+                  },
+                ],
               },
             },
           ],
         },
       ],
-    });
-  });
-  it("excludes download fields for other entities", async () => {
-    spyOn(
-      hostedServiceUtilsModule,
-      "isHostedFeatureServiceEntity"
-    ).and.returnValue(false);
-
-    const uiSchema = await buildUiSchema("some.scope", {} as any, MOCK_CONTEXT);
-    expect(uiSchema).toEqual({
-      type: "Layout",
-      elements: [],
     });
   });
 });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Part of https://devtopia.esri.com/dc/hub/issues/10170

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
