### PR TITLE
feat: add projectAndInitiative as a new collection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.126.3",
+			"version": "14.127.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -26,7 +26,8 @@ export type WellKnownCatalog =
 export type WellKnownCollection =
   | Exclude<HubFamily, "app" | "map">
   | "appAndMap"
-  | "solution";
+  | "solution"
+  | "projectAndInitiative";
 
 /**
  * A list of optional arguments to pass into getWellKnownCatalog
@@ -360,6 +361,33 @@ function getAllCollectionsMap(i18nScope: string, entityType: EntityType): any {
         filters: [
           {
             predicates: [
+              {
+                type: getFamilyTypes("initiative"),
+                // only include v2 initiatives
+                typekeywords: ["hubInitiativeV2"],
+              },
+            ],
+          },
+        ],
+      },
+    } as IHubCollection,
+    // note: For now, this is not included in the default collection names.
+    // It would need to be explicitly passed into getWellknownCollections
+    // to be returned
+    projectAndInitiative: {
+      key: "projectAndInitiative",
+      label: `{{${i18nScope}collection.projectsAndInitiatives:translate}}`,
+      targetEntity: entityType,
+      include: [],
+      scope: {
+        targetEntity: entityType,
+        filters: [
+          {
+            operation: "OR",
+            predicates: [
+              {
+                type: getFamilyTypes("project"),
+              },
               {
                 type: getFamilyTypes("initiative"),
                 // only include v2 initiatives


### PR DESCRIPTION
1. Description: Adds a new projectAndInitiative collection

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
