### PR TITLE
fix: remove alpha gating from templates

### DIFF
--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateBusinessRules.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateBusinessRules.ts
@@ -34,7 +34,6 @@ export const InitiativeTemplatePermissions = [
 export const InitiativeTemplatePermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:initiativeTemplate",
-    availability: ["alpha"], // gate to just alpha for now
     services: ["portal"],
   },
   {

--- a/packages/common/src/templates/_internal/TemplateBusinessRules.ts
+++ b/packages/common/src/templates/_internal/TemplateBusinessRules.ts
@@ -33,7 +33,6 @@ export const TemplatePermissions = [
 export const TemplatePermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:template",
-    availability: ["alpha"], // gate to alpha for now
     services: ["portal"],
   },
   {


### PR DESCRIPTION
[10435](https://devtopia.esri.com/dc/hub/issues/10435)

### Description:
- removed `alpha` gating from initiative templates
- removed `alpha` gating from solution templates 

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.