### PR TITLE
feat: remove props from site and page draft whitelists

### DIFF
--- a/packages/sites/src/drafts/page-draft-include-list.ts
+++ b/packages/sites/src/drafts/page-draft-include-list.ts
@@ -2,9 +2,4 @@
  * This is the list of page model properties
  * that are included in a page's draft
  */
-export const PAGE_DRAFT_INCLUDE_LIST = [
-  "item.title",
-  "item.snippet",
-  "data.values.layout",
-  "data.values.headContent",
-];
+export const PAGE_DRAFT_INCLUDE_LIST = ["data.values.layout"];

--- a/packages/sites/src/drafts/site-draft-include-list.ts
+++ b/packages/sites/src/drafts/site-draft-include-list.ts
@@ -3,21 +3,11 @@
  * that are included in a site's draft
  */
 export const SITE_DRAFT_INCLUDE_LIST = [
-  "item.title",
-  "item.snippet",
   "item.properties.schemaVersion",
-  "item.properties.telemetry",
   "data.values.layout",
   "data.values.theme",
   "data.values.headerCss",
   "data.values.headerSass",
   "data.values.footerSass",
   "data.values.footerCss",
-  "data.values.faviconUrl",
-  "data.values.telemetry",
-  "data.values.map",
-  "data.values.capabilities",
-  "data.values.contentViews",
-  "data.values.headContent",
-  "data.telemetry",
 ];


### PR DESCRIPTION
affects: @esri/hub-sites

1. Description: Removes most props from site and page draft whitelists.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
