### PR TITLE
feat: add a partners case to well known item catalog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22688,9 +22688,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22705,21 +22706,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22733,9 +22737,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22753,9 +22758,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -83465,7 +83471,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83480,17 +83487,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83504,7 +83514,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83521,7 +83532,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22688,10 +22688,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22706,24 +22705,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22737,10 +22733,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22758,10 +22753,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65016,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.133.4",
+			"version": "14.134.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -83471,8 +83465,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83487,20 +83480,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83514,8 +83504,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83532,8 +83521,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -250,6 +250,11 @@ export interface IArcGISContext {
   survey123Url: string;
 
   /**
+   * Is the current users org type a community org?
+   */
+  isCommunityOrg: boolean;
+
+  /**
    * Return the token for a given app, if defined
    * @param app
    */
@@ -799,6 +804,21 @@ export class ArcGISContext implements IArcGISContext {
    */
   public get trustedOrgs(): IHubTrustedOrgsResponse[] {
     return this._trustedOrgs;
+  }
+
+  /**
+   * Returns whether the current user's org type is a community org
+   */
+  public get isCommunityOrg(): boolean {
+    let result = false;
+    if (this._portalSelf) {
+      const orgType = getProp(
+        this._portalSelf,
+        "portalProperties.hub.settings.orgType"
+      );
+      result = orgType === "community";
+    }
+    return result;
   }
 
   /**

--- a/packages/common/src/associations/wellKnownAssociationCatalogs.ts
+++ b/packages/common/src/associations/wellKnownAssociationCatalogs.ts
@@ -161,15 +161,22 @@ export const getAvailableToRequestAssociationCatalogs = (
     associationType
   )?.filters;
   // Get Community org id. If the current org is a community org, use the first trusted org id, otherwise fall back to the communityOrgId
-  const communityOrgId = context?.isCommunityOrg
-    ? context?.trustedOrgIds[0]
-    : context?.communityOrgId;
+  // First pull out the community org / enterprise org relationship
+  const communityTrustedOrgRelationship = context.trustedOrgs?.find(
+    (org) => org.from.orgId === context.currentUser.orgId
+  );
+  // If we are in a community org, and there is a trusted org relationship, use the orgId from there (which would be the enterprise org id)
+  // Otherwise, use the community org id
+  // If neither exist, the communityOrgId will be undefined (which is fine, as it will not be added as a catalog in that case)
+  const communityOrgId =
+    context.isCommunityOrg && communityTrustedOrgRelationship
+      ? communityTrustedOrgRelationship.to.orgId
+      : context.communityOrgId;
   // Get trusted orgs that aren't the current user's org or the community org
   const trustedOrgIds =
-    context?.trustedOrgIds?.filter((orgId) => {
+    context.trustedOrgIds?.filter((orgId) => {
       return (
-        orgId !== context?.currentUser?.orgId &&
-        orgId !== context?.communityOrgId
+        orgId !== context.currentUser?.orgId && orgId !== context.communityOrgId
       );
     }) || [];
   // Default catalogs to include

--- a/packages/common/src/associations/wellKnownAssociationCatalogs.ts
+++ b/packages/common/src/associations/wellKnownAssociationCatalogs.ts
@@ -160,18 +160,27 @@ export const getAvailableToRequestAssociationCatalogs = (
     entity,
     associationType
   )?.filters;
+  // Get Community org id. If the current org is a community org, use the first trusted org id, otherwise fall back to the communityOrgId
+  const communityOrgId = context?.isCommunityOrg
+    ? context?.trustedOrgIds[0]
+    : context?.communityOrgId;
   // Get trusted orgs that aren't the current user's org or the community org
   const trustedOrgIds =
-    context.trustedOrgIds &&
-    context?.trustedOrgIds.filter((orgId) => {
+    context?.trustedOrgIds?.filter((orgId) => {
       return (
         orgId !== context?.currentUser?.orgId &&
         orgId !== context?.communityOrgId
       );
-    });
+    }) || [];
+  // Default catalogs to include
   const catalogNames: WellKnownCatalog[] = ["myContent", "organization"];
+  // If there are trusted orgs, include the partners catalog
   if (trustedOrgIds && trustedOrgIds.length > 0) {
     catalogNames.push("partners");
+  }
+  // If there is a community org id, include the community catalog
+  if (communityOrgId) {
+    catalogNames.push("community");
   }
   return catalogNames.map((name: WellKnownCatalog) => {
     const options: IGetWellKnownCatalogOptions = {
@@ -179,6 +188,7 @@ export const getAvailableToRequestAssociationCatalogs = (
       filters,
       collectionNames: [associationType as WellKnownCollection],
       trustedOrgIds,
+      communityOrgId,
     };
     return getWellKnownCatalog(i18nScope, name, "item", options);
   });

--- a/packages/common/src/associations/wellKnownAssociationCatalogs.ts
+++ b/packages/common/src/associations/wellKnownAssociationCatalogs.ts
@@ -175,9 +175,7 @@ export const getAvailableToRequestAssociationCatalogs = (
   // Get trusted orgs that aren't the current user's org or the community org
   const trustedOrgIds =
     context.trustedOrgIds?.filter((orgId) => {
-      return (
-        orgId !== context.currentUser?.orgId && orgId !== context.communityOrgId
-      );
+      return orgId !== context.currentUser?.orgId && orgId !== communityOrgId;
     }) || [];
   // Default catalogs to include
   const catalogNames: WellKnownCatalog[] = ["myContent", "organization"];

--- a/packages/common/src/associations/wellKnownAssociationCatalogs.ts
+++ b/packages/common/src/associations/wellKnownAssociationCatalogs.ts
@@ -160,17 +160,25 @@ export const getAvailableToRequestAssociationCatalogs = (
     entity,
     associationType
   )?.filters;
-  const catalogNames: WellKnownCatalog[] = [
-    "myContent",
-    "favorites",
-    "organization",
-    "world",
-  ];
+  // Get trusted orgs that aren't the current user's org or the community org
+  const trustedOrgIds =
+    context.trustedOrgIds &&
+    context?.trustedOrgIds.filter((orgId) => {
+      return (
+        orgId !== context?.currentUser?.orgId &&
+        orgId !== context?.communityOrgId
+      );
+    });
+  const catalogNames: WellKnownCatalog[] = ["myContent", "organization"];
+  if (trustedOrgIds && trustedOrgIds.length > 0) {
+    catalogNames.push("partners");
+  }
   return catalogNames.map((name: WellKnownCatalog) => {
     const options: IGetWellKnownCatalogOptions = {
       user: context.currentUser,
       filters,
       collectionNames: [associationType as WellKnownCollection],
+      trustedOrgIds,
     };
     return getWellKnownCatalog(i18nScope, name, "item", options);
   });

--- a/packages/common/src/associations/wellKnownAssociationCatalogs.ts
+++ b/packages/common/src/associations/wellKnownAssociationCatalogs.ts
@@ -174,13 +174,13 @@ export const getAvailableToRequestAssociationCatalogs = (
     }) || [];
   // Default catalogs to include
   const catalogNames: WellKnownCatalog[] = ["myContent", "organization"];
-  // If there are trusted orgs, include the partners catalog
-  if (trustedOrgIds && trustedOrgIds.length > 0) {
-    catalogNames.push("partners");
-  }
   // If there is a community org id, include the community catalog
   if (communityOrgId) {
     catalogNames.push("community");
+  }
+  // If there are trusted orgs, include the partners catalog
+  if (trustedOrgIds && trustedOrgIds.length > 0) {
+    catalogNames.push("partners");
   }
   return catalogNames.map((name: WellKnownCatalog) => {
     const options: IGetWellKnownCatalogOptions = {

--- a/packages/common/src/associations/wellKnownAssociationCatalogs.ts
+++ b/packages/common/src/associations/wellKnownAssociationCatalogs.ts
@@ -160,41 +160,24 @@ export const getAvailableToRequestAssociationCatalogs = (
     entity,
     associationType
   )?.filters;
-  // Get Community org id. If the current org is a community org, use the first trusted org id, otherwise fall back to the communityOrgId
-  // First pull out the community org / enterprise org relationship
-  const communityTrustedOrgRelationship = context.trustedOrgs?.find(
-    (org) => org.from.orgId === context.currentUser.orgId
-  );
-  // If we are in a community org, and there is a trusted org relationship, use the orgId from there (which would be the enterprise org id)
-  // Otherwise, use the community org id
-  // If neither exist, the communityOrgId will be undefined (which is fine, as it will not be added as a catalog in that case)
-  const communityOrgId =
-    context.isCommunityOrg && communityTrustedOrgRelationship
-      ? communityTrustedOrgRelationship.to.orgId
-      : context.communityOrgId;
-  // Get trusted orgs that aren't the current user's org or the community org
-  const trustedOrgIds =
-    context.trustedOrgIds?.filter((orgId) => {
-      return orgId !== context.currentUser?.orgId && orgId !== communityOrgId;
-    }) || [];
+
   // Default catalogs to include
-  const catalogNames: WellKnownCatalog[] = ["myContent", "organization"];
-  // If there is a community org id, include the community catalog
-  if (communityOrgId) {
-    catalogNames.push("community");
-  }
-  // If there are trusted orgs, include the partners catalog
-  if (trustedOrgIds && trustedOrgIds.length > 0) {
-    catalogNames.push("partners");
-  }
-  return catalogNames.map((name: WellKnownCatalog) => {
-    const options: IGetWellKnownCatalogOptions = {
-      user: context.currentUser,
-      filters,
-      collectionNames: [associationType as WellKnownCollection],
-      trustedOrgIds,
-      communityOrgId,
-    };
-    return getWellKnownCatalog(i18nScope, name, "item", options);
-  });
+  const catalogNames: WellKnownCatalog[] = [
+    "myContent",
+    "organization",
+    "community",
+    "partners",
+  ];
+
+  return catalogNames
+    .map((name: WellKnownCatalog) => {
+      const options: IGetWellKnownCatalogOptions = {
+        user: context.currentUser,
+        filters,
+        collectionNames: [associationType as WellKnownCollection],
+        context,
+      };
+      return getWellKnownCatalog(i18nScope, name, "item", options);
+    })
+    .filter(Boolean);
 };

--- a/packages/common/src/search/_internal/buildCatalog.ts
+++ b/packages/common/src/search/_internal/buildCatalog.ts
@@ -8,6 +8,8 @@ import { EntityType, IFilter, IHubCatalog, IHubCollection } from "../types";
  * @param catalogName - well known catalog name
  * @param filters - filters to build the catalog scope
  * @param collections - collections to include in the catalog
+ * @param targetEntity - target entity type for the catalog
+ * @param title - optional title override for the catalog
  * @returns {IHubCatalog}
  */
 export function buildCatalog(

--- a/packages/common/src/search/_internal/buildCatalog.ts
+++ b/packages/common/src/search/_internal/buildCatalog.ts
@@ -15,7 +15,8 @@ export function buildCatalog(
   catalogName: string,
   filters: IFilter[],
   collections: IHubCollection[],
-  targetEntity: EntityType
+  targetEntity: EntityType,
+  title?: string
 ): IHubCatalog {
   const scopes = {
     [targetEntity]: {
@@ -25,7 +26,7 @@ export function buildCatalog(
   };
   return {
     schemaVersion: 1,
-    title: `{{${i18nScope}catalog.${catalogName}:translate}}`,
+    title: title || `{{${i18nScope}catalog.${catalogName}:translate}}`,
     scopes,
     collections,
   };

--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -32,6 +32,9 @@ export type WellKnownCollection =
   | "solution"
   | "projectAndInitiative";
 
+/**TODO: On the next breaking change User and context should be
+ * removed from this interface and passed into the function as a single required context.
+ */
 /**
  * A list of optional arguments to pass into getWellKnownCatalog
  * user is the owner of the entity
@@ -96,6 +99,9 @@ function validateUserExistence(
   }
 }
 
+/** TODO: On the next breaking change we need to pull context and user out of options
+ * and make context a required parameter. User can be pulled out of context.
+ */
 /**
  * Get an ITEM catalog based on the name and optional requests
  * @param i18nScope Translation scope to be interpolated into the catalog

--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -155,7 +155,6 @@ function getWellknownItemCatalog(
       );
       break;
     case "partners":
-      validateUserExistence(catalogName, options);
       // Get trusted orgs that aren't the current user's org or the community org
       const trustedOrgIds = context.trustedOrgIds.filter((orgId: string) => {
         return (
@@ -185,7 +184,6 @@ function getWellknownItemCatalog(
       }
       break;
     case "community":
-      validateUserExistence(catalogName, options);
       const communityOrgId = _getCOrgOrEOrgId(context);
       // only build the catalog if there is a community org id
       if (communityOrgId) {

--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -16,7 +16,8 @@ export type WellKnownCatalog =
   | "world"
   | "editGroups"
   | "viewGroups"
-  | "allGroups";
+  | "allGroups"
+  | "partners";
 
 /**
  * This is used to determine what IHubCollection definition JSON object
@@ -40,6 +41,8 @@ export interface IGetWellKnownCatalogOptions {
   collectionNames?: WellKnownCollection[];
   /** additional filters to apply to the catalog scope */
   filters?: IFilter[];
+  /** partnered org ids that catalog might need */
+  trustedOrgIds?: string[];
 }
 
 /**
@@ -144,6 +147,26 @@ function getWellknownItemCatalog(
         i18nScope,
         catalogName,
         [{ predicates: [{ orgid: options.user.orgId }] }, ...additionalFilters],
+        collections,
+        "item"
+      );
+      break;
+    case "partners":
+      validateUserExistence(catalogName, options);
+      catalog = buildCatalog(
+        i18nScope,
+        catalogName,
+        [
+          {
+            predicates: [
+              {
+                orgid: options.trustedOrgIds,
+                searchUserAccess: "includeTrustedOrgs",
+              },
+            ],
+          },
+          ...additionalFilters,
+        ],
         collections,
         "item"
       );

--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -17,7 +17,8 @@ export type WellKnownCatalog =
   | "editGroups"
   | "viewGroups"
   | "allGroups"
-  | "partners";
+  | "partners"
+  | "community";
 
 /**
  * This is used to determine what IHubCollection definition JSON object
@@ -43,6 +44,8 @@ export interface IGetWellKnownCatalogOptions {
   filters?: IFilter[];
   /** partnered org ids that catalog might need */
   trustedOrgIds?: string[];
+  /** community org id that catalog might need */
+  communityOrgId?: string;
 }
 
 /**
@@ -165,6 +168,19 @@ function getWellknownItemCatalog(
               },
             ],
           },
+          ...additionalFilters,
+        ],
+        collections,
+        "item"
+      );
+      break;
+    case "community":
+      validateUserExistence(catalogName, options);
+      catalog = buildCatalog(
+        i18nScope,
+        catalogName,
+        [
+          { predicates: [{ orgid: options.communityOrgId }] },
           ...additionalFilters,
         ],
         collections,

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -61,6 +61,7 @@ const onlinePortalSelfResponse = {
           orgId: "FAKE_C_ORGID",
           portalHostname: "my-community.maps.arcgis.com",
         },
+        orgType: "enterprise",
       },
     },
   },
@@ -284,6 +285,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.hubEnabled).toBeFalsy();
       expect(mgr.context.isAlphaOrg).toBeFalsy();
       expect(mgr.context.isBetaOrg).toBeFalsy();
+      expect(mgr.context.isCommunityOrg).toBeFalsy();
       expect(mgr.context.environment).toBe("production");
       // Hub Urls
       const base = mgr.context.hubUrl;
@@ -489,6 +491,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.trustedOrgs).toEqual(
         onlinePartneredOrgResponse.trustedOrgs
       );
+      expect(mgr.context.isCommunityOrg).toBeFalsy();
     });
     it("verify tokens when passed session", async () => {
       const t = new Date().getTime();

--- a/packages/common/test/associations/wellKnownAssociationCatalogs.test.ts
+++ b/packages/common/test/associations/wellKnownAssociationCatalogs.test.ts
@@ -163,9 +163,9 @@ describe("getAvailableToRequestAssociationCatalogs", () => {
       "getWellKnownCatalog"
     ).and.returnValues(
       { schemaVersion: 1, title: "mock-myContent" },
-      { schemaVersion: 1, title: "mock-favorites" },
       { schemaVersion: 1, title: "mock-organization" },
-      { schemaVersion: 1, title: "mock-world" }
+      { schemaVersion: 1, title: "mock-community" },
+      { schemaVersion: 1, title: "mock-partners" }
     );
   });
   afterEach(() => {
@@ -206,7 +206,10 @@ describe("getAvailableToRequestAssociationCatalogs", () => {
       "some-scope",
       { type: "Hub Project" } as HubEntity,
       "initiative",
-      {} as ArcGISContext
+      {
+        trustedOrgIds: ["abc123", "def456", "ghi789"],
+        communityOrgId: "mock-community-org",
+      } as ArcGISContext
     );
 
     expect(getAvailableToRequestEntitiesQuerySpy).toHaveBeenCalledTimes(1);
@@ -214,9 +217,32 @@ describe("getAvailableToRequestAssociationCatalogs", () => {
     expect(catalogs.length).toBe(4);
     expect(catalogs).toEqual([
       { schemaVersion: 1, title: "mock-myContent" },
-      { schemaVersion: 1, title: "mock-favorites" },
       { schemaVersion: 1, title: "mock-organization" },
-      { schemaVersion: 1, title: "mock-world" },
+      { schemaVersion: 1, title: "mock-community" },
+      { schemaVersion: 1, title: "mock-partners" },
+    ]);
+  });
+  it('returns an array of valid "availableToRequest" catalogs in a community org', async () => {
+    const catalogs = await getAvailableToRequestAssociationCatalogs(
+      "some-scope",
+      { type: "Hub Project" } as HubEntity,
+      "initiative",
+      {
+        currentUser: { orgId: "abc123" },
+        isCommunityOrg: true,
+        trustedOrgIds: ["abc123", "def456", "ghi789"],
+        trustedOrgs: [{ from: { orgId: "abc123" }, to: { orgId: "def456" } }],
+      } as ArcGISContext
+    );
+
+    expect(getAvailableToRequestEntitiesQuerySpy).toHaveBeenCalledTimes(1);
+    expect(getWellknownCatalogSpy).toHaveBeenCalledTimes(4);
+    expect(catalogs.length).toBe(4);
+    expect(catalogs).toEqual([
+      { schemaVersion: 1, title: "mock-myContent" },
+      { schemaVersion: 1, title: "mock-organization" },
+      { schemaVersion: 1, title: "mock-community" },
+      { schemaVersion: 1, title: "mock-partners" },
     ]);
   });
 });

--- a/packages/common/test/associations/wellKnownAssociationCatalogs.test.ts
+++ b/packages/common/test/associations/wellKnownAssociationCatalogs.test.ts
@@ -222,27 +222,4 @@ describe("getAvailableToRequestAssociationCatalogs", () => {
       { schemaVersion: 1, title: "mock-partners" },
     ]);
   });
-  it('returns an array of valid "availableToRequest" catalogs in a community org', async () => {
-    const catalogs = await getAvailableToRequestAssociationCatalogs(
-      "some-scope",
-      { type: "Hub Project" } as HubEntity,
-      "initiative",
-      {
-        currentUser: { orgId: "abc123" },
-        isCommunityOrg: true,
-        trustedOrgIds: ["abc123", "def456", "ghi789"],
-        trustedOrgs: [{ from: { orgId: "abc123" }, to: { orgId: "def456" } }],
-      } as ArcGISContext
-    );
-
-    expect(getAvailableToRequestEntitiesQuerySpy).toHaveBeenCalledTimes(1);
-    expect(getWellknownCatalogSpy).toHaveBeenCalledTimes(4);
-    expect(catalogs.length).toBe(4);
-    expect(catalogs).toEqual([
-      { schemaVersion: 1, title: "mock-myContent" },
-      { schemaVersion: 1, title: "mock-organization" },
-      { schemaVersion: 1, title: "mock-community" },
-      { schemaVersion: 1, title: "mock-partners" },
-    ]);
-  });
 });

--- a/packages/common/test/search/wellKnownCatalog.test.ts
+++ b/packages/common/test/search/wellKnownCatalog.test.ts
@@ -16,6 +16,8 @@ describe("WellKnownCatalog", () => {
       options = {
         user: mockUser,
         collectionNames: [],
+        trustedOrgIds: ["abc123", "def456"],
+        communityOrgId: "communityOrgId",
       };
     });
     it("returns the expected catalog for items", () => {
@@ -41,6 +43,32 @@ describe("WellKnownCatalog", () => {
       expect(chk.scopes).toBeDefined();
       expect(chk.scopes?.item?.filters).toEqual([
         { predicates: [{ group: "7654321" }] },
+      ]);
+      expect(chk.collections?.map((c) => c.key)).toEqual([
+        "appAndMap",
+        "dataset",
+        "document",
+        "feedback",
+        "site",
+        "project",
+      ]);
+      chk = getWellKnownCatalog("mockI18nScope", "partners", "item", options);
+      expect(chk.scopes).toBeDefined();
+      expect(chk.scopes?.item?.filters[0].predicates).toEqual([
+        { orgid: ["abc123", "def456"], searchUserAccess: "includeTrustedOrgs" },
+      ]);
+      expect(chk.collections?.map((c) => c.key)).toEqual([
+        "appAndMap",
+        "dataset",
+        "document",
+        "feedback",
+        "site",
+        "project",
+      ]);
+      chk = getWellKnownCatalog("mockI18nScope", "community", "item", options);
+      expect(chk.scopes).toBeDefined();
+      expect(chk.scopes?.item?.filters).toEqual([
+        { predicates: [{ orgid: "communityOrgId" }] },
       ]);
       expect(chk.collections?.map((c) => c.key)).toEqual([
         "appAndMap",


### PR DESCRIPTION
1. Description: Adds a partners case to wellKnownItemCatalog and uses it over in getAvailableToRequestAssociationCatalogs

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
