### PR TITLE
feat(hub-common): add isHubHome prop

### DIFF
--- a/packages/common/src/core/types/IHubSite.ts
+++ b/packages/common/src/core/types/IHubSite.ts
@@ -81,7 +81,7 @@ export interface IHubSite
   legacyTeams: string[];
 
   /**
-   * Whether or not the site is an org site--should be removed when no longer necessary
+   * True when the site is a "Hub Home" site
    */
   isHubHome: boolean;
 }

--- a/packages/common/src/core/types/IHubSite.ts
+++ b/packages/common/src/core/types/IHubSite.ts
@@ -79,6 +79,11 @@ export interface IHubSite
 
   /** Legacy teams - list of ids */
   legacyTeams: string[];
+
+  /**
+   * Whether or not the site is an org site--should be removed when no longer necessary
+   */
+  isHubHome: boolean;
 }
 
 export type IHubSiteEditor = IHubItemEntityEditor<IHubSite> & {

--- a/packages/common/src/sites/_internal/computeProps.ts
+++ b/packages/common/src/sites/_internal/computeProps.ts
@@ -42,6 +42,10 @@ export function computeProps(
   site.updatedDate = new Date(model.item.modified);
   site.updatedDateSource = "item.modified";
   site.isDiscussable = isDiscussable(site);
+
+  // set isHubHome
+  site.isHubHome = Boolean(model.item.properties?.isHubHome);
+
   /**
    * Features that can be disabled by the entity owner
    */

--- a/packages/common/src/sites/_internal/computeProps.ts
+++ b/packages/common/src/sites/_internal/computeProps.ts
@@ -43,9 +43,6 @@ export function computeProps(
   site.updatedDateSource = "item.modified";
   site.isDiscussable = isDiscussable(site);
 
-  // set isHubHome
-  site.isHubHome = Boolean(model.item.properties?.isHubHome);
-
   /**
    * Features that can be disabled by the entity owner
    */

--- a/packages/common/src/sites/_internal/getPropertyMap.ts
+++ b/packages/common/src/sites/_internal/getPropertyMap.ts
@@ -66,6 +66,10 @@ export function getPropertyMap(): IPropertyMap[] {
     entityKey: "legacyTeams",
     storeKey: "item.properties.teams",
   });
+  map.push({
+    entityKey: "isHubHome",
+    storeKey: "item.properties.isHubHome",
+  });
   map.push({ entityKey: "catalog", storeKey: "data.catalog" });
 
   map.push({


### PR DESCRIPTION
1. Description: Adds the isHubHome prop so we can determine if a site is an org site or not.

1. Instructions for testing:

1. Closes Issues: #10379

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
