### PR TITLE
fix: remove entityOwner check from template settings permission

### DIFF
--- a/packages/common/src/templates/_internal/TemplateBusinessRules.ts
+++ b/packages/common/src/templates/_internal/TemplateBusinessRules.ts
@@ -102,6 +102,5 @@ export const TemplatePermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:template:workspace:settings",
     dependencies: ["hub:template:workspace", "hub:template:manage"],
-    entityOwner: true,
   },
 ];


### PR DESCRIPTION
[10489](https://devtopia.esri.com/dc/hub/issues/10489)

### Description
Remove the `entityOwner` check from the `hub:template:workspace:settings` permission

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.