### PR TITLE
fix(hub-common): enable editing for past events

### DIFF
--- a/packages/common/src/events/_internal/EventSchemaEdit.ts
+++ b/packages/common/src/events/_internal/EventSchemaEdit.ts
@@ -38,7 +38,6 @@ export const buildSchema = (): IConfigurationSchema => {
       startDate: {
         type: "string",
         format: "date",
-        formatMinimum: minStartDate,
       },
       endDate: {
         type: "string",

--- a/packages/common/src/events/_internal/EventUiSchemaEdit.ts
+++ b/packages/common/src/events/_internal/EventUiSchemaEdit.ts
@@ -82,19 +82,12 @@ export const buildUiSchema = async (
             type: "Control",
             options: {
               control: "hub-field-input-date",
-              min: minStartEndDate,
               messages: [
                 {
                   type: "ERROR",
                   keyword: "required",
                   icon: true,
                   labelKey: `${i18nScope}.fields.startDate.requiredError`,
-                },
-                {
-                  type: "ERROR",
-                  keyword: "formatMinimum",
-                  icon: true,
-                  labelKey: `${i18nScope}.fields.startDate.minDateError`,
                 },
               ],
             },
@@ -105,19 +98,12 @@ export const buildUiSchema = async (
             type: "Control",
             options: {
               control: "hub-field-input-date",
-              min: minStartEndDate,
               messages: [
                 {
                   type: "ERROR",
                   keyword: "required",
                   icon: true,
                   labelKey: `${i18nScope}.fields.endDate.requiredError`,
-                },
-                {
-                  type: "ERROR",
-                  keyword: "formatMinimum",
-                  icon: true,
-                  labelKey: `${i18nScope}.fields.endDate.minDateError`,
                 },
               ],
             },

--- a/packages/common/src/events/_internal/EventUiSchemaEdit.ts
+++ b/packages/common/src/events/_internal/EventUiSchemaEdit.ts
@@ -105,6 +105,12 @@ export const buildUiSchema = async (
                   icon: true,
                   labelKey: `${i18nScope}.fields.endDate.requiredError`,
                 },
+                {
+                  type: "ERROR",
+                  keyword: "formatMinimum",
+                  icon: true,
+                  labelKey: `${i18nScope}.fields.endDate.minDateError`,
+                },
               ],
             },
           },

--- a/packages/common/test/events/_internal/EventSchemaEdit.test.ts
+++ b/packages/common/test/events/_internal/EventSchemaEdit.test.ts
@@ -54,7 +54,6 @@ describe("EventSchemaEdit", () => {
           startDate: {
             type: "string",
             format: "date",
-            formatMinimum: datesAndTimes.startDate,
           },
           endDate: {
             type: "string",

--- a/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
+++ b/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
@@ -162,19 +162,12 @@ describe("EventUiSchemaEdit", () => {
                 type: "Control",
                 options: {
                   control: "hub-field-input-date",
-                  min: "2024-04-03",
                   messages: [
                     {
                       type: "ERROR",
                       keyword: "required",
                       icon: true,
                       labelKey: `myI18nScope.fields.startDate.requiredError`,
-                    },
-                    {
-                      type: "ERROR",
-                      keyword: "formatMinimum",
-                      icon: true,
-                      labelKey: `myI18nScope.fields.startDate.minDateError`,
                     },
                   ],
                 },
@@ -185,19 +178,12 @@ describe("EventUiSchemaEdit", () => {
                 type: "Control",
                 options: {
                   control: "hub-field-input-date",
-                  min: "2024-04-03",
                   messages: [
                     {
                       type: "ERROR",
                       keyword: "required",
                       icon: true,
                       labelKey: `myI18nScope.fields.endDate.requiredError`,
-                    },
-                    {
-                      type: "ERROR",
-                      keyword: "formatMinimum",
-                      icon: true,
-                      labelKey: `myI18nScope.fields.endDate.minDateError`,
                     },
                   ],
                 },

--- a/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
+++ b/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
@@ -185,6 +185,12 @@ describe("EventUiSchemaEdit", () => {
                       icon: true,
                       labelKey: `myI18nScope.fields.endDate.requiredError`,
                     },
+                    {
+                      type: "ERROR",
+                      keyword: "formatMinimum",
+                      icon: true,
+                      labelKey: `myI18nScope.fields.endDate.minDateError`,
+                    },
                   ],
                 },
               },


### PR DESCRIPTION
1. Description: Removes minimum start date so that past events can be edited.

1. Instructions for testing:

1. Closes Issues: #10549

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
