### PR TITLE
fix(hub-common): fixes issue where derived entity location for site o…

### DIFF
--- a/packages/common/src/content/_internal/internalContentUtils.ts
+++ b/packages/common/src/content/_internal/internalContentUtils.ts
@@ -43,6 +43,7 @@ import { geojsonToArcGIS } from "@terraformer/arcgis";
 import { Polygon } from "geojson";
 import { getHubApiUrl } from "../../api";
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import { isSiteType } from "../compose";
 
 /**
  * Hashmap of Hub environment and application url surfix
@@ -141,8 +142,9 @@ export const deriveLocationFromItem = (item: IItem): IHubLocation => {
   const geometry: any = getExtentObject(extent);
   if (geometry) {
     // geometry constructed from bbox
+    const type = isSiteType(item.type) ? "org" : "custom";
     return {
-      type: "custom",
+      type,
       extent,
       geometries: [geometry],
       spatialReference: geometry.spatialReference,

--- a/packages/common/test/content/_internal/internalContentUtils.test.ts
+++ b/packages/common/test/content/_internal/internalContentUtils.test.ts
@@ -5,12 +5,12 @@ import {
   deriveLocationFromItem,
 } from "../../../src/content/_internal/internalContentUtils";
 import * as internalContentUtils from "../../../src/content/_internal/internalContentUtils";
+import * as Compose from "../../../src/content/compose";
 import { IHubRequestOptions } from "../../../src/types";
-import { cloneObject } from "../../../src/util";
+import { cloneObject, compose } from "../../../src/util";
 import { MOCK_HUB_REQOPTS } from "../../mocks/mock-auth";
 import { IHubLocation } from "../../../src";
 import * as _enrichmentsModule from "../../../src/items/_enrichments";
-import { IHubAdditionalResource } from "../../../src/core/types/IHubAdditionalResource";
 
 describe("getContentEditUrl", () => {
   let requestOptions: IHubRequestOptions;
@@ -348,6 +348,22 @@ describe("deriveLocationFromItem", () => {
     const _item = cloneObject(item);
     const chk = deriveLocationFromItem(_item);
     expect(chk).toEqual({ type: "none" });
+  });
+  it("should set correct location source type based on item type", () => {
+    const isSiteTypeSpy = spyOn(Compose, "isSiteType").and.callThrough();
+    const _item = cloneObject(item);
+    _item.type = "Site Application";
+    _item.extent = [
+      [0, 0],
+      [0, 0],
+    ];
+    const chk = deriveLocationFromItem(_item);
+    expect(chk.type).toEqual("org");
+    expect(isSiteTypeSpy).toHaveBeenCalled();
+    expect(isSiteTypeSpy).toHaveBeenCalledWith("Site Application");
+    _item.type = "Feature Service";
+    const chk2 = deriveLocationFromItem(_item);
+    expect(chk2.type).toEqual("custom");
   });
   it("should create custom location from item extent", () => {
     const getExtentObjectSpy = spyOn(


### PR DESCRIPTION
…rg extent was displaying as cus

affects: @esri/hub-common

The selected option in the location picker for a site item with no custom location should first be set as 'org'.  We were correctly getting the org extent, but setting the wrong type causing wrong option to be selected in the UI.

BEFORE - Showing incorrect 'custom' type from extent:

![incorrect_custom](https://github.com/Esri/hub.js/assets/3883995/1acc030b-85ca-4c05-ac9e-bc73fcd488fe)

AFTER - Correctly reflects 'org' type from extent:

![correct_org](https://github.com/Esri/hub.js/assets/3883995/ac7fa3e7-158c-45c1-95f9-f0056a1075dc)

ISSUES CLOSED: 10504

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
