### PR TITLE
fix: deepFilter allows for blobs to pass through

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22688,10 +22688,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22706,24 +22705,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22737,10 +22733,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22758,10 +22753,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65016,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.133.4",
+			"version": "14.134.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -83471,8 +83465,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83487,20 +83480,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83514,8 +83504,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83532,8 +83521,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/objects/deepFilter.ts
+++ b/packages/common/src/objects/deepFilter.ts
@@ -71,9 +71,7 @@ export function deepFilter(
     return Object.keys(object).reduce((acc, entry) => {
       if (predicate(object[entry])) {
         if (isFindable(object[entry])) {
-          // Deep filter will run through a Blob and clear out the Blob specific properties
-          // That we want to keep, so we are explicilty checking for Blob here
-          // and not iterating down into it
+          // Explicilty checking for Blob here, and copying the reference forward so it is maintained
           if (typeof Blob !== "undefined" && object[entry] instanceof Blob) {
             (acc as any)[entry] = object[entry];
           } else {

--- a/packages/common/src/objects/deepFilter.ts
+++ b/packages/common/src/objects/deepFilter.ts
@@ -71,8 +71,15 @@ export function deepFilter(
     return Object.keys(object).reduce((acc, entry) => {
       if (predicate(object[entry])) {
         if (isFindable(object[entry])) {
-          const filteredEntry = deepFilter(object[entry], predicate);
-          (acc as any)[entry] = filteredEntry;
+          // Deep filter will run through a Blob and clear out the Blob specific properties
+          // That we want to keep, so we are explicilty checking for Blob here
+          // and not iterating down into it
+          if (typeof Blob !== "undefined" && object[entry] instanceof Blob) {
+            (acc as any)[entry] = object[entry];
+          } else {
+            const filteredEntry = deepFilter(object[entry], predicate);
+            (acc as any)[entry] = filteredEntry;
+          }
         } else {
           (acc as any)[entry] = object[entry];
         }

--- a/packages/common/test/objects/deepFilter.test.ts
+++ b/packages/common/test/objects/deepFilter.test.ts
@@ -113,6 +113,35 @@ describe("deepFilter:", () => {
       expect(chk.level1.level2.level3a).toBeUndefined();
       expect(chk.level1.level2.level3b.status).toBe("not-started");
     });
+    if (typeof Blob !== "undefined") {
+      it("allows Blobs through and does not filter into the blob", () => {
+        const blob = new Blob(["a"], { type: "text/plain" });
+        const test = {
+          id: "a",
+          image: {
+            blob,
+            name: "my-image",
+          },
+        };
+        const isFieldEmpty = (value: any) => {
+          let isEmpty = false;
+          if (typeof value === "string") {
+            isEmpty = value === "";
+          } else if (value instanceof Blob) {
+            isEmpty = false;
+          } else if (typeof value === "object") {
+            isEmpty = !Object.keys(value)?.length;
+          }
+
+          return isEmpty;
+        };
+        const predicate = (value: any) => !isFieldEmpty(value);
+        const chk = deepFilter(test, predicate);
+
+        expect(chk.id).toBe("a");
+        expect(chk.image.blob instanceof Blob).toBe(true);
+      });
+    }
     it("skips dates", () => {
       const test = new Date();
       const predicate = (obj: any) => obj.id === "b";


### PR DESCRIPTION
1. Description: Resolves issue where deepFilter was traversing into Blobs and clearing out the stuff we'd want to keep in a Blob.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
