### PR TITLE
fix: limit project content and events to qa alpha

### DIFF
--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -153,11 +153,13 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:project:workspace:content",
     dependencies: ["hub:project:workspace", "hub:project:edit"],
     availability: ["alpha"],
+    environments: ["qaext"],
   },
   {
     permission: "hub:project:workspace:events",
     dependencies: ["hub:project:workspace", "hub:project:edit"],
     availability: ["alpha"],
+    environments: ["qaext"],
   },
   {
     permission: "hub:project:workspace:metrics",


### PR DESCRIPTION
1. Description:

Minor fix to restrict project content & events panes to qaext + alpha.

Related: USFS was an alpha org, and during user testing, we saw that these panes were available 😱 We are investigating how/why USFS is still an alpha org, despite being removed from the config files back in February

1. Instructions for testing:

1. Closes Issues: n/a

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
