### PR TITLE
fix: pass optional list of catalogs to getAvailableToRequestAssociati…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22688,9 +22688,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22705,21 +22706,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22733,9 +22737,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22753,9 +22758,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -83465,7 +83471,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83480,17 +83487,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83504,7 +83514,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83521,7 +83532,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.137.0",
+			"version": "14.138.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/associations/wellKnownAssociationCatalogs.ts
+++ b/packages/common/src/associations/wellKnownAssociationCatalogs.ts
@@ -138,13 +138,15 @@ export async function getWellKnownAssociationsCatalog(
  * @param entity - primary entity the catalog is being built for
  * @param associationType - type of entity the primary entity wants to view associations for
  * @param context - contextual auth and portal information
+ * @param catalogs - optional list of well-known catalogs to include
  * @returns {IHubCatalog[]}
  */
 export const getAvailableToRequestAssociationCatalogs = (
   i18nScope: string,
   entity: HubEntity,
   associationType: HubEntityType,
-  context: IArcGISContext
+  context: IArcGISContext,
+  catalogs?: WellKnownCatalog[]
 ) => {
   const entityType = getTypeFromEntity(entity);
   const isSupported = isAssociationSupported(entityType, associationType);
@@ -162,11 +164,11 @@ export const getAvailableToRequestAssociationCatalogs = (
   )?.filters;
 
   // Default catalogs to include
-  const catalogNames: WellKnownCatalog[] = [
+  const catalogNames: WellKnownCatalog[] = catalogs || [
     "myContent",
+    "favorites",
     "organization",
-    "community",
-    "partners",
+    "world",
   ];
 
   return catalogNames

--- a/packages/common/test/associations/wellKnownAssociationCatalogs.test.ts
+++ b/packages/common/test/associations/wellKnownAssociationCatalogs.test.ts
@@ -163,9 +163,9 @@ describe("getAvailableToRequestAssociationCatalogs", () => {
       "getWellKnownCatalog"
     ).and.returnValues(
       { schemaVersion: 1, title: "mock-myContent" },
+      { schemaVersion: 1, title: "mock-favorites" },
       { schemaVersion: 1, title: "mock-organization" },
-      { schemaVersion: 1, title: "mock-community" },
-      { schemaVersion: 1, title: "mock-partners" }
+      { schemaVersion: 1, title: "mock-world" }
     );
   });
   afterEach(() => {
@@ -206,10 +206,37 @@ describe("getAvailableToRequestAssociationCatalogs", () => {
       "some-scope",
       { type: "Hub Project" } as HubEntity,
       "initiative",
+      {} as ArcGISContext
+    );
+
+    expect(getAvailableToRequestEntitiesQuerySpy).toHaveBeenCalledTimes(1);
+    expect(getWellknownCatalogSpy).toHaveBeenCalledTimes(4);
+    expect(catalogs.length).toBe(4);
+    expect(catalogs).toEqual([
+      { schemaVersion: 1, title: "mock-myContent" },
+      { schemaVersion: 1, title: "mock-favorites" },
+      { schemaVersion: 1, title: "mock-organization" },
+      { schemaVersion: 1, title: "mock-world" },
+    ]);
+  });
+
+  it('returns an array of valid "availableToRequest" catalogs when given an array of catalogs', async () => {
+    getWellknownCatalogSpy.and.returnValues(
+      { schemaVersion: 1, title: "mock-myContent" },
+      { schemaVersion: 1, title: "mock-organization" },
+      { schemaVersion: 1, title: "mock-community" },
+      { schemaVersion: 1, title: "mock-partners" }
+    );
+
+    const catalogs = await getAvailableToRequestAssociationCatalogs(
+      "some-scope",
+      { type: "Hub Project" } as HubEntity,
+      "initiative",
       {
         trustedOrgIds: ["abc123", "def456", "ghi789"],
         communityOrgId: "mock-community-org",
-      } as ArcGISContext
+      } as ArcGISContext,
+      ["myContent", "organization", "community", "partners"]
     );
 
     expect(getAvailableToRequestEntitiesQuerySpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
…onCatalogs func

1. Description: As discussed adds new catalogs optional func param

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
