### PR TITLE
fix(hub-common): survey workspace handles draft surveys

### DIFF
--- a/packages/common/src/surveys/_internal/computeProps.ts
+++ b/packages/common/src/surveys/_internal/computeProps.ts
@@ -38,7 +38,7 @@ export function computeProps(
   survey.updatedDate = new Date(model.item.modified);
   survey.updatedDateSource = "item.modified";
   survey.isDiscussable = isDiscussable(survey);
-  survey.hasMapQuestion = hasMapQuestion(model.formJSON.questions);
+  survey.hasMapQuestion = hasMapQuestion(model.formJSON?.questions || []);
   survey.displayMap = shouldDisplayMap(model.item);
 
   // cast b/c this takes a partial but returns a full object

--- a/packages/common/src/surveys/utils/get-form-json.ts
+++ b/packages/common/src/surveys/utils/get-form-json.ts
@@ -6,6 +6,7 @@ import {
 import { getFormInfoJson } from "./get-form-info-json";
 import { isSurvey123Connect } from "./is-survey123-connect";
 import { decodeForm } from "./decode-form";
+import { isDraft } from "./is-draft";
 
 /**
  * Given a Survey Item, return the form json, if it exists.
@@ -17,6 +18,9 @@ export const getFormJson = async (
   item: IItem,
   requestOptions: IGetItemInfoOptions
 ) => {
+  if (isDraft(item)) {
+    return null;
+  }
   const { name } = await getFormInfoJson(item.id, requestOptions);
   let promise;
   if (isSurvey123Connect(item)) {

--- a/packages/common/src/surveys/utils/index.ts
+++ b/packages/common/src/surveys/utils/index.ts
@@ -9,6 +9,7 @@ export * from "./get-source-feature-service-model-from-fieldworker";
 export * from "./get-stakeholder-model";
 export * from "./get-survey-models";
 export * from "./has-map-question";
+export * from "./is-draft";
 export * from "./is-fieldworker-view";
 export * from "./is-map-question";
 export * from "./is-page-question";

--- a/packages/common/src/surveys/utils/is-draft.ts
+++ b/packages/common/src/surveys/utils/is-draft.ts
@@ -1,6 +1,3 @@
-/* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
- * Apache-2.0 */
-
 import { IItem } from "@esri/arcgis-rest-types";
 
 /**

--- a/packages/common/test/surveys/_internal/computeProps.test.ts
+++ b/packages/common/test/surveys/_internal/computeProps.test.ts
@@ -105,4 +105,35 @@ describe("surveys: computeProps:", () => {
     expect(chk.hasMapQuestion).toBeTruthy();
     expect(chk.displayMap).toBeTruthy();
   });
+
+  it("handles a draft survey", async () => {
+    authdCtxMgr = await ArcGISContextManager.create({
+      authentication: MOCK_AUTH,
+      currentUser: {
+        username: "casey",
+        privileges: ["portal:user:updateSurvey"],
+      } as unknown as IUser,
+      portal: {
+        name: "DC R&D Center",
+        id: "BRXFAKE",
+        urlKey: "fake-org",
+        properties: {
+          hub: {
+            enabled: true,
+          },
+        },
+      } as unknown as IPortal,
+      portalUrl: "https://org.maps.arcgis.com",
+    });
+    model.formJSON = null;
+
+    const chk = computeProps(model, survey, authdCtxMgr.context.requestOptions);
+    expect(chk.createdDate).toBeDefined();
+    expect(chk.createdDateSource).toBe("item.created");
+    expect(chk.updatedDate).toBeDefined();
+    expect(chk.updatedDateSource).toBe("item.modified");
+    expect(chk.isDiscussable).toBeTruthy();
+    expect(chk.hasMapQuestion).toBeFalsy();
+    expect(chk.displayMap).toBeTruthy();
+  });
 });

--- a/packages/common/test/surveys/utils/get-form-json.test.ts
+++ b/packages/common/test/surveys/utils/get-form-json.test.ts
@@ -3,6 +3,8 @@ import * as getFormInfoJsonUtil from "../../../src/surveys/utils/get-form-info-j
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { mockUserSession } from "../../test-helpers/fake-user-session";
 import { getFormJson } from "../../../src/surveys/utils/get-form-json";
+import * as FormItemDraft from "../../mocks/items/form-item-draft.json";
+import * as FormItemPublished from "../../mocks/items/form-item-published.json";
 
 describe("getFormJson", () => {
   let requestOptions: IRequestOptions;
@@ -18,7 +20,7 @@ describe("getFormJson", () => {
     spyOn(restPortal, "getItemInfo").and.returnValue(
       Promise.resolve({ questions: [{ description: "hello%20world" }] })
     );
-    const survey = { id: "3ef" } as any as restPortal.IItem;
+    const survey = FormItemPublished as any as restPortal.IItem;
     const result = await getFormJson(survey, requestOptions);
     expect(result).toEqual({ questions: [{ description: "hello world" }] });
   });
@@ -44,9 +46,15 @@ describe("getFormJson", () => {
     });
   });
 
+  it("returns null when survey is draft", async () => {
+    const survey = FormItemDraft as any as restPortal.IItem;
+    const result = await getFormJson(survey, requestOptions);
+    expect(result).toBeFalsy();
+  });
+
   it("handle when form is null", async () => {
     spyOn(restPortal, "getItemInfo").and.returnValues(Promise.resolve(null));
-    const survey = { id: "3ef" } as any as restPortal.IItem;
+    const survey = FormItemPublished as any as restPortal.IItem;
     const result = await getFormJson(survey, requestOptions);
     expect(result).toEqual(null);
   });

--- a/packages/common/test/surveys/utils/is-draft.test.ts
+++ b/packages/common/test/surveys/utils/is-draft.test.ts
@@ -1,13 +1,14 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { isDraft } from "../../src/utils/is-draft";
-import * as FormItemDraft from "../../../common/test/mocks/items/form-item-draft.json";
-import * as FormItemPublished from "../../../common/test/mocks/items/form-item-published.json";
+import { IItem } from "@esri/arcgis-rest-types";
+import { isDraft } from "../../../src/surveys/utils/is-draft";
+import * as FormItemDraft from "../../mocks/items/form-item-draft.json";
+import * as FormItemPublished from "../../mocks/items/form-item-published.json";
 
 describe("isDraft", function () {
   it('should return true when typeKeywords includes "Draft"', function () {
-    expect(isDraft(FormItemDraft)).toBe(true);
+    expect(isDraft(FormItemDraft as unknown as IItem)).toBe(true);
   });
 
   it('should return false when typeKeywords excludes "Draft"', function () {

--- a/packages/common/test/surveys/utils/is-survey123-connect.test.ts
+++ b/packages/common/test/surveys/utils/is-survey123-connect.test.ts
@@ -18,6 +18,12 @@ describe("isSurvey123Connect", () => {
     expect(result).toBeFalsy();
   });
 
+  it("handles when typekeywords is null", () => {
+    const result = isSurvey123Connect({} as any as IItem);
+
+    expect(result).toBeFalsy();
+  });
+
   it("handles null input", () => {
     const result = isSurvey123Connect(null as any);
 

--- a/packages/surveys/src/utils/index.ts
+++ b/packages/surveys/src/utils/index.ts
@@ -1,8 +1,7 @@
 /* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-export * from "./is-draft";
 export * from "./is-published";
 export * from "./status-utils";
 export * from "./results-availability";
-export { isFieldworkerView } from "@esri/hub-common";
+export { isFieldworkerView, isDraft } from "@esri/hub-common";

--- a/packages/surveys/src/utils/is-published.ts
+++ b/packages/surveys/src/utils/is-published.ts
@@ -2,7 +2,7 @@
  * Apache-2.0 */
 
 import { IItem } from "@esri/arcgis-rest-types";
-import { isDraft } from "./is-draft";
+import { isDraft } from "@esri/hub-common";
 
 /**
  * Determines if a given Form item has been published

--- a/packages/surveys/test/utils/is-published.test.ts
+++ b/packages/surveys/test/utils/is-published.test.ts
@@ -2,14 +2,15 @@
  * Apache-2.0 */
 
 import { isPublished } from "../../src/utils/is-published";
-import * as publishUtils from "../../src/utils/is-draft";
+import * as publishUtils from "@esri/hub-common";
 import * as FormItemDraft from "../../../common/test/mocks/items/form-item-draft.json";
 import * as FormItemPublished from "../../../common/test/mocks/items/form-item-published.json";
+import { IItem } from "@esri/arcgis-rest-types";
 
 describe("isPublished", function () {
   it("should return true when isDraft returns false", function () {
     const isDraftStub = spyOn(publishUtils, "isDraft").and.returnValue(false);
-    const result = isPublished(FormItemDraft);
+    const result = isPublished(FormItemDraft as unknown as IItem);
     expect(isDraftStub.calls.count()).toBe(1);
     expect(isDraftStub.calls.argsFor(0)).toEqual([FormItemDraft]);
     expect(result).toBe(true);


### PR DESCRIPTION
1. Description: Fixes bug where survey workspace would fail to open for draft surveys.

1. Instructions for testing:

1. Closes Issues: #10594

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
