### PR TITLE
fix(hub-common): add canEdit to GetEventsParams

### DIFF
--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -13,6 +13,22 @@ export type GetEventsParams = {
    */
   access?: string;
   /**
+   * Comma separated string list of AttendanceTypes. Example:  VIRTUAL,IN_PERSON
+   */
+  attendanceTypes?: string;
+  /**
+   * boolean to filter events that can be edited by the user
+   */
+  canEdit?: string;
+  /**
+   * Comma separated string list of categories
+   */
+  categories?: string;
+  /**
+   * Comma separated string list of edit groupIds
+   */
+  editGroups?: string;
+  /**
    * Comma separated string list of associated entityIds
    */
   entityIds?: string;
@@ -29,21 +45,33 @@ export type GetEventsParams = {
    */
   include?: string;
   /**
-   * latest ISO8601 start date-time for the events
+   * the max amount of events to return
    */
-  startDateTimeBefore?: string;
+  num?: string;
+  /**
+   * Comma separated string list of read groupIds
+   */
+  readGroups?: string;
+  /**
+   * Event property to sort results by
+   */
+  sortBy?: EventSort;
+  /**
+   * sort results order desc or asc
+   */
+  sortOrder?: EventSortOrder;
+  /**
+   * the index to start at
+   */
+  start?: string;
   /**
    * earliest ISO8601 start date-time for the events
    */
   startDateTimeAfter?: string;
   /**
-   * Comma separated string list of AttendanceTypes. Example:  VIRTUAL,IN_PERSON
+   * latest ISO8601 start date-time for the events
    */
-  attendanceTypes?: string;
-  /**
-   * Comma separated string list of categories
-   */
-  categories?: string;
+  startDateTimeBefore?: string;
   /**
    * comma separated string list of event statuses. Example: PRIVATE,ORG,PUBLIC
    */
@@ -56,30 +84,6 @@ export type GetEventsParams = {
    * string to match within an event title
    */
   title?: string;
-  /**
-   * Comma separated string list of read groupIds
-   */
-  readGroups?: string;
-  /**
-   * Comma separated string list of edit groupIds
-   */
-  editGroups?: string;
-  /**
-   * the max amount of events to return
-   */
-  num?: string;
-  /**
-   * the index to start at
-   */
-  start?: string;
-  /**
-   * Event property to sort results by
-   */
-  sortBy?: EventSort;
-  /**
-   * sort results order desc or asc
-   */
-  sortOrder?: EventSortOrder;
 };
 
 export interface IUpdateRegistration {
@@ -405,14 +409,14 @@ export enum EventAttendanceType {
   VIRTUAL = "VIRTUAL",
   IN_PERSON = "IN_PERSON",
 }
-export enum EventAssociationEntityType {
+export enum AssociationEntityType {
   Hub_Site_Application = "Hub Site Application",
   Hub_Initiative = "Hub Initiative",
   Hub_Project = "Hub Project",
 }
 export interface IEventAssociation {
   entityId: string;
-  entityType: EventAssociationEntityType;
+  entityType: AssociationEntityType;
   eventId: string;
 }
 
@@ -420,7 +424,7 @@ export interface ICreateEventAssociation {
   /** Entity Id */
   entityId: string;
   /** Entity type */
-  entityType: EventAssociationEntityType;
+  entityType: AssociationEntityType;
 }
 
 export enum EventAccess {

--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -409,14 +409,14 @@ export enum EventAttendanceType {
   VIRTUAL = "VIRTUAL",
   IN_PERSON = "IN_PERSON",
 }
-export enum AssociationEntityType {
+export enum EventAssociationEntityType {
   Hub_Site_Application = "Hub Site Application",
   Hub_Initiative = "Hub Initiative",
   Hub_Project = "Hub Project",
 }
 export interface IEventAssociation {
   entityId: string;
-  entityType: AssociationEntityType;
+  entityType: EventAssociationEntityType;
   eventId: string;
 }
 
@@ -424,7 +424,7 @@ export interface ICreateEventAssociation {
   /** Entity Id */
   entityId: string;
   /** Entity type */
-  entityType: AssociationEntityType;
+  entityType: EventAssociationEntityType;
 }
 
 export enum EventAccess {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Add new filter parameter `canEdit` to `GetEventsParams`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
