### PR TITLE
fix(hub-common): events can be viewed by anon user

### DIFF
--- a/packages/common/src/events/HubEvent.ts
+++ b/packages/common/src/events/HubEvent.ts
@@ -63,7 +63,7 @@ export class HubEvent
   ): IHubEvent {
     // ensure we have the orgUrlKey
     if (!partialEvent.orgUrlKey) {
-      partialEvent.orgUrlKey = context.portal.urlKey;
+      partialEvent.orgUrlKey = context.portal?.urlKey;
     }
     // extend the partial over the defaults
     const pojo = {

--- a/packages/common/test/events/HubEvent.test.ts
+++ b/packages/common/test/events/HubEvent.test.ts
@@ -11,6 +11,7 @@ import * as shareEventWithGroupsModule from "../../src/events/_internal/shareEve
 import * as unshareEventWithGroupsModule from "../../src/events/_internal/unshareEventWithGroups";
 import * as getEventGroupsModule from "../../src/events/_internal/getEventGroups";
 import * as eventsModule from "../../src/events/api/events";
+import { IArcGISContext } from "../../src";
 
 /* @ts-ignore no-unnecessary-qualifier */
 describe("HubEvent Class:", () => {
@@ -116,6 +117,12 @@ describe("HubEvent Class:", () => {
     } catch (e) {
       expect(e.message).toEqual("HubEvent is already destroyed.");
     }
+  });
+
+  it("functions for anonymous user", () => {
+    const context: IArcGISContext = {} as any;
+    const chk = HubEvent.fromJson({ name: "Test Event" }, context);
+    expect(chk).toBeTruthy();
   });
 
   describe("IWithEditorBehavior:", () => {


### PR DESCRIPTION
1. Description: Events can be viewed by anon user

1. Instructions for testing:

1. Closes Issues: #9320

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
