### PR TITLE
feat: expose hub:feature:user:preferences to production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65016,7 +65016,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.138.0",
+			"version": "14.140.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -106,7 +106,7 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:feature:user:preferences",
     // gated to qa/dev for now, but will be accessible on PROD when
     // we pass `?pe=hub:feature:user:preferences` in the URL
-    environments: ["devext", "qaext"],
+    environments: ["devext", "qaext", "production"],
   },
   {
     // When enabled, the new follow card will be loaded


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: opens hub:feature:user:preferences to production.

1. Instructions for testing:

1. Closes Issues: [8858](https://devtopia.esri.com/dc/hub/issues/8858)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
