### PR TITLE
feat: remove underlinedLinks capability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22688,9 +22688,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22705,21 +22706,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22733,9 +22737,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22753,9 +22758,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65010,7 +65016,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.140.3",
+			"version": "14.141.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -83465,7 +83471,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83480,17 +83487,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83504,7 +83514,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83521,7 +83532,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/sites/_internal/_migrate-link-underlines-capability.ts
+++ b/packages/common/src/sites/_internal/_migrate-link-underlines-capability.ts
@@ -1,0 +1,26 @@
+import { getProp } from "../../objects";
+import { IModel, IDraft } from "../../types";
+import { cloneObject } from "../../util";
+
+/**
+ * Remove underlinedLinks capability from site model
+ * @private
+ * @param {object} model Site Model
+ * @returns {object}
+ */
+export function _migrateLinkUnderlinesCapability<T extends IModel | IDraft>(
+  model: T
+): T {
+  // apply migration
+  const clone = cloneObject(model);
+  const capabilities = getProp(model, "data.values.capabilities");
+
+  if (capabilities) {
+    // migrate capabilities - remove underlinedLinks
+    clone.data.values.capabilities = capabilities.filter(
+      (capability: string) => capability !== "underlinedLinks"
+    );
+  }
+
+  return clone;
+}

--- a/packages/common/src/sites/index.ts
+++ b/packages/common/src/sites/index.ts
@@ -6,6 +6,7 @@ export * from "./_internal/_migrate-feed-config";
 export * from "./_internal/_migrate-event-list-card-configs";
 export * from "./_internal/_migrate-telemetry-config";
 export * from "./_internal/migrateBadBasemap";
+export * from "./_internal/_migrate-link-underlines-capability";
 export * from "./_internal/migrateWebMappingApplicationSites";
 export * from "./domains";
 export * from "./drafts";

--- a/packages/common/src/sites/upgrade-site-schema.ts
+++ b/packages/common/src/sites/upgrade-site-schema.ts
@@ -13,6 +13,7 @@ import { _migrateTelemetryConfig } from "./_internal/_migrate-telemetry-config";
 import { migrateBadBasemap } from "./_internal/migrateBadBasemap";
 import { ensureBaseTelemetry } from "./_internal/ensureBaseTelemetry";
 import { migrateWebMappingApplicationSites } from "./_internal/migrateWebMappingApplicationSites";
+import { _migrateLinkUnderlinesCapability } from "./_internal/_migrate-link-underlines-capability";
 
 /**
  * Upgrades the schema upgrades
@@ -41,5 +42,6 @@ export function upgradeSiteSchema(model: IModel) {
   model = migrateBadBasemap(model);
   model = ensureBaseTelemetry(model);
   model = migrateWebMappingApplicationSites(model);
+  model = _migrateLinkUnderlinesCapability(model);
   return model;
 }

--- a/packages/common/test/sites/_internal/_migrate-link-underlines-capability.test.ts
+++ b/packages/common/test/sites/_internal/_migrate-link-underlines-capability.test.ts
@@ -1,0 +1,49 @@
+import { IModel } from "../../../src";
+import { _migrateLinkUnderlinesCapability } from "../../../src/sites/_internal/_migrate-link-underlines-capability";
+
+describe("_migrateLinkUnderlinesCapability", () => {
+  it("removes underlinedLinks capability if it exists", () => {
+    const model = {
+      item: {},
+      data: {
+        values: {
+          capabilities: ["foo", "underlinedLinks", "consentNotice", "bar"],
+        },
+      },
+    };
+    const result = _migrateLinkUnderlinesCapability(model);
+    expect(result.data.values.capabilities as any).toEqual([
+      "foo",
+      "consentNotice",
+      "bar",
+    ]);
+  });
+
+  it("should not alter capabilities if underlinedLinks does not exist", () => {
+    const model = {
+      item: {},
+      data: {
+        values: {
+          capabilities: ["foo", "consentNotice", "bar"],
+        },
+      },
+    };
+    const result = _migrateLinkUnderlinesCapability(model);
+    expect(result.data.values.capabilities as any).toEqual([
+      "foo",
+      "consentNotice",
+      "bar",
+    ]);
+  });
+
+  it("should do nothing if capabilities do not exist", () => {
+    const model = {
+      item: {},
+      data: {
+        values: {},
+      },
+    };
+    const result = _migrateLinkUnderlinesCapability(model);
+    expect((result.data.values as any).capabilities).toBeUndefined();
+  });
+});

--- a/packages/common/test/sites/upgrade-site-schema.test.ts
+++ b/packages/common/test/sites/upgrade-site-schema.test.ts
@@ -8,6 +8,7 @@ import * as _migrateFeedConfigModule from "../../src/sites/_internal/_migrate-fe
 import * as _migrateEventListCardConfigs from "../../src/sites/_internal/_migrate-event-list-card-configs";
 import * as migrateLegacyCapabilitiesToFeatures from "../../src/sites/_internal/capabilities/migrateLegacyCapabilitiesToFeatures";
 import * as _migrateTelemetryConfig from "../../src/sites/_internal/_migrate-telemetry-config";
+import * as _migrateLinkUnderlinesCapability from "../../src/sites/_internal/_migrate-link-underlines-capability";
 import * as migrateBadBasemapModule from "../../src/sites/_internal/migrateBadBasemap";
 import * as ensureBaseTelemetry from "../../src/sites/_internal/ensureBaseTelemetry";
 import { IModel } from "../../src";
@@ -24,6 +25,7 @@ describe("upgradeSiteSchema", () => {
   let migrateEventListCardConfigsSpy: jasmine.Spy;
   let migrateLegacyCapabilitiesToFeaturesSpy: jasmine.Spy;
   let migrateTelemetryConfigSpy: jasmine.Spy;
+  let migrateLinkUnderlinesCapabilitySpy: jasmine.Spy;
   let migrateBadBasemapSpy: jasmine.Spy;
   let ensureBaseTelemetrySpy: jasmine.Spy;
   beforeEach(() => {
@@ -62,6 +64,10 @@ describe("upgradeSiteSchema", () => {
       _migrateTelemetryConfig,
       "_migrateTelemetryConfig"
     ).and.callFake((model: IModel) => model);
+    migrateLinkUnderlinesCapabilitySpy = spyOn(
+      _migrateLinkUnderlinesCapability,
+      "_migrateLinkUnderlinesCapability"
+    ).and.callFake((model: IModel) => model);
     migrateBadBasemapSpy = spyOn(
       migrateBadBasemapModule,
       "migrateBadBasemap"
@@ -96,6 +102,7 @@ describe("upgradeSiteSchema", () => {
         migrateTelemetryConfigSpy,
         migrateBadBasemapSpy,
         ensureBaseTelemetrySpy,
+        migrateLinkUnderlinesCapabilitySpy,
       ],
       expect
     );
@@ -130,5 +137,11 @@ describe("upgradeSiteSchema", () => {
     // Versionless migrations should still run
     expectAll([migrateBadBasemapSpy], "toHaveBeenCalled", true, expect);
     expectAll([ensureBaseTelemetrySpy], "toHaveBeenCalled", true, expect);
+    expectAll(
+      [migrateLinkUnderlinesCapabilitySpy],
+      "toHaveBeenCalled",
+      true,
+      expect
+    );
   });
 });


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 10599

1. Description: Removes underlindLinks capability

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
