### PR TITLE
feat(): add buildDefaults for metrics

### DIFF
--- a/packages/common/src/core/schemas/internal/getEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getEditorSchemas.ts
@@ -144,9 +144,6 @@ export async function getEditorSchemas(
       );
 
       // if we have the buildDefaults fn, then construct the defaults
-      // TODO: when first implementing buildDefaults for projects, remove the ignore line
-
-      /* istanbul ignore next */
       if (projectModule.buildDefaults) {
         defaults = await projectModule.buildDefaults(
           i18nScope,
@@ -182,9 +179,6 @@ export async function getEditorSchemas(
       );
 
       // if we have the buildDefaults fn, then construct the defaults
-      // TODO: when first implementing buildDefaults for initiatives, remove the ignore line
-
-      /* istanbul ignore next */
       if (initiativeModule.buildDefaults) {
         defaults = await initiativeModule.buildDefaults(
           i18nScope,

--- a/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
@@ -1,5 +1,5 @@
 import { IArcGISContext } from "../../../../ArcGISContext";
-import { IUiSchema } from "../../types";
+import { IConfigurationValues, IUiSchema } from "../../types";
 import { EntityEditorOptions } from "../EditorOptions";
 import {
   SHOW_FOR_STATIC_RULE_ENTITY,
@@ -261,5 +261,28 @@ export const buildUiSchema = async (
         ],
       },
     ],
+  };
+};
+
+/**
+ * @private
+ * constructs the default values for the initiative metrics editor.
+ * This is used to pre-populate the metrics editor with specific default values
+ * that are different from the Schema default values, or contain translated
+ * values.
+ * @param i18nScope
+ * @param options
+ * @param context
+ * @returns
+ */
+export const buildDefaults = async (
+  i18nScope: string,
+  options: EntityEditorOptions,
+  context: IArcGISContext
+): Promise<IConfigurationValues> => {
+  return {
+    _metric: {
+      cardTitle: `{{${i18nScope}.shared.fields.metrics.cardTitle.label:translate}}`,
+    },
   };
 };

--- a/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
@@ -282,7 +282,7 @@ export const buildDefaults = async (
 ): Promise<IConfigurationValues> => {
   return {
     _metric: {
-      cardTitle: `{{${i18nScope}.shared.fields.metrics.cardTitle.label:translate}}`,
+      cardTitle: `{{arcgis-hub-entity-editor.shared.fields.metrics.cardTitle.label:translate}}`,
     },
   };
 };

--- a/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
@@ -282,7 +282,7 @@ export const buildDefaults = async (
 ): Promise<IConfigurationValues> => {
   return {
     _metric: {
-      cardTitle: `{{arcgis-hub-entity-editor.shared.fields.metrics.cardTitle.label:translate}}`,
+      cardTitle: `{{shared.fields.metrics.cardTitle.label:translate}}`,
     },
   };
 };

--- a/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
@@ -278,7 +278,7 @@ export const buildDefaults = async (
 ): Promise<IConfigurationValues> => {
   return {
     _metric: {
-      cardTitle: `{{arcgis-hub-entity-editor.shared.fields.metrics.cardTitle.label:translate}}`,
+      cardTitle: `{{shared.fields.metrics.cardTitle.label:translate}}`,
     },
   };
 };

--- a/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
@@ -1,5 +1,5 @@
 import { IArcGISContext } from "../../../../ArcGISContext";
-import { IUiSchema } from "../../types";
+import { IConfigurationValues, IUiSchema } from "../../types";
 import { EntityEditorOptions } from "../EditorOptions";
 import {
   SHOW_FOR_STATIC_RULE_ENTITY,
@@ -257,5 +257,28 @@ export const buildUiSchema = async (
         ],
       },
     ],
+  };
+};
+
+/**
+ * @private
+ * constructs the default values for the project metrics editor.
+ * This is used to pre-populate the metrics editor with specific default values
+ * that are different from the Schema default values, or contain translated
+ * values.
+ * @param i18nScope
+ * @param options
+ * @param context
+ * @returns
+ */
+export const buildDefaults = async (
+  i18nScope: string,
+  options: EntityEditorOptions,
+  context: IArcGISContext
+): Promise<IConfigurationValues> => {
+  return {
+    _metric: {
+      cardTitle: `{{${i18nScope}.shared.fields.metrics.cardTitle.label:translate}}`,
+    },
   };
 };

--- a/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
@@ -278,7 +278,7 @@ export const buildDefaults = async (
 ): Promise<IConfigurationValues> => {
   return {
     _metric: {
-      cardTitle: `{{${i18nScope}.shared.fields.metrics.cardTitle.label:translate}}`,
+      cardTitle: `{{arcgis-hub-entity-editor.shared.fields.metrics.cardTitle.label:translate}}`,
     },
   };
 };

--- a/packages/common/test/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.test.ts
@@ -1,4 +1,7 @@
-import { buildUiSchema } from "../../../../../src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics";
+import {
+  buildDefaults,
+  buildUiSchema,
+} from "../../../../../src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics";
 import { MOCK_CONTEXT } from "../../../../mocks/mock-auth";
 import { EntityEditorOptions } from "../../../../../src/core/schemas/internal/EditorOptions";
 
@@ -23,6 +26,23 @@ describe("InitiativeUiSchemaMetrics", () => {
       expect(uiSchema.elements![1].elements![0].options!.control).toBe(
         "hub-field-input-tile-select"
       );
+    });
+  });
+
+  describe("buildDefaults", () => {
+    it("returns the default values for the initiative metrics", async () => {
+      const defaults = await buildDefaults(
+        "some.scope",
+        {} as EntityEditorOptions,
+        MOCK_CONTEXT
+      );
+
+      expect(defaults).toEqual({
+        _metric: {
+          cardTitle:
+            "{{some.scope.shared.fields.metrics.cardTitle.label:translate}}",
+        },
+      });
     });
   });
 });

--- a/packages/common/test/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.test.ts
@@ -40,7 +40,7 @@ describe("InitiativeUiSchemaMetrics", () => {
       expect(defaults).toEqual({
         _metric: {
           cardTitle:
-            "{{some.scope.shared.fields.metrics.cardTitle.label:translate}}",
+            "{{arcgis-hub-entity-editor.shared.fields.metrics.cardTitle.label:translate}}",
         },
       });
     });

--- a/packages/common/test/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.test.ts
@@ -39,8 +39,7 @@ describe("InitiativeUiSchemaMetrics", () => {
 
       expect(defaults).toEqual({
         _metric: {
-          cardTitle:
-            "{{arcgis-hub-entity-editor.shared.fields.metrics.cardTitle.label:translate}}",
+          cardTitle: "{{shared.fields.metrics.cardTitle.label:translate}}",
         },
       });
     });

--- a/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
@@ -1,7 +1,11 @@
-import { buildUiSchema } from "../../../../../src/core/schemas/internal/metrics/ProjectUiSchemaMetrics";
+import {
+  buildUiSchema,
+  buildDefaults,
+} from "../../../../../src/core/schemas/internal/metrics/ProjectUiSchemaMetrics";
 import { MOCK_CONTEXT } from "../../../../mocks/mock-auth";
 import { UiSchemaRuleEffects } from "../../../../../src/core/schemas/types";
 import { EntityEditorOptions } from "../../../../../src/core/schemas/internal/EditorOptions";
+import { IHubProject } from "../../../../../src/core/types";
 
 describe("ProjectUiSchemaMetrics", () => {
   describe("buildUiSchema", () => {
@@ -328,6 +332,22 @@ describe("ProjectUiSchemaMetrics", () => {
             ],
           },
         ],
+      });
+    });
+  });
+
+  describe("buildDefaults: project metrics", () => {
+    it("returns the defaults to create a project metric", async () => {
+      const defaults = await buildDefaults(
+        "some.scope",
+        {} as IHubProject,
+        MOCK_CONTEXT
+      );
+      expect(defaults).toEqual({
+        _metric: {
+          cardTitle:
+            "{{some.scope.shared.fields.metrics.cardTitle.label:translate}}",
+        },
       });
     });
   });

--- a/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
@@ -345,8 +345,7 @@ describe("ProjectUiSchemaMetrics", () => {
       );
       expect(defaults).toEqual({
         _metric: {
-          cardTitle:
-            "{{arcgis-hub-entity-editor.shared.fields.metrics.cardTitle.label:translate}}",
+          cardTitle: "{{shared.fields.metrics.cardTitle.label:translate}}",
         },
       });
     });

--- a/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
@@ -346,7 +346,7 @@ describe("ProjectUiSchemaMetrics", () => {
       expect(defaults).toEqual({
         _metric: {
           cardTitle:
-            "{{some.scope.shared.fields.metrics.cardTitle.label:translate}}",
+            "{{arcgis-hub-entity-editor.shared.fields.metrics.cardTitle.label:translate}}",
         },
       });
     });


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
