### PR TITLE
feat: hub:feature:workspace:user permission

### DIFF
--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -135,6 +135,14 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     // When enabled, the manage links will take the user the org home site
+    permission: "hub:feature:workspace:user",
+    // NOTE: alpha might seem redundant, given that hub:feature:workspace is alpha
+    // but we allow users to "opt-in" which overrides that
+    availability: ["alpha"],
+    dependencies: ["hub:feature:workspace"],
+  },
+  {
+    // When enabled, the manage links will take the user the org home site
     permission: "hub:feature:workspace:org",
     availability: ["alpha"],
     environments: ["qaext"],


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 10750

1. Description: adds hub:feature:workspace:user permission to gate the user workspace

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
