### PR TITLE
fix: actually makes hub:feature:workspace:user a valid permission

### DIFF
--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -26,6 +26,7 @@ const SystemPermissions = [
   "hub:feature:workspace",
   "hub:feature:user:preferences",
   "hub:card:follow",
+  "hub:feature:workspace:user",
   "hub:feature:workspace:org",
   // DEPRECATED: This permission has been replaced by hub:feature:workspace:org,
   // remove this at the next breaking version


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 10750

1. Description: Actually exposes hub:feature:workspace:user

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
