### PR TITLE
feat(hub-common): disable categories field and provide notice when no options are available

### DIFF
--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -1,11 +1,11 @@
 import { IArcGISContext } from "../../ArcGISContext";
 import { getTagItems } from "../../core/schemas/internal/getTagItems";
-import { getCategoryItems } from "../../core/schemas/internal/getCategoryItems";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { IUiSchema } from "../../core/schemas/types";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
 import { IHubEditableContent } from "../../core/types";
+import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
 
 /**
  * @private
@@ -109,24 +109,7 @@ export const buildUiSchema = async (
             },
           },
           // categories
-          {
-            labelKey: `${i18nScope}.fields.categories.label`,
-            scope: "/properties/categories",
-            type: "Control",
-            options: {
-              control: "hub-field-input-combobox",
-              items: await getCategoryItems(
-                context.portal.id,
-                context.hubRequestOptions
-              ),
-              allowCustomValues: false,
-              selectionMode: "ancestors",
-              placeholderIcon: "select-category",
-              helperText: {
-                labelKey: `${i18nScope}.fields.categories.agolHint`, // TODO: hint should describe whether it can be set on Enterprise or Online
-              },
-            },
-          },
+          await fetchCategoriesUiSchemaElement(i18nScope, context),
           // license
           {
             labelKey: `${i18nScope}.fields.license.label`,

--- a/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
@@ -4,7 +4,7 @@ import {
   IUiSchemaMessage,
   UiSchemaMessageTypes,
 } from "../types";
-import { getCategoryItems } from "./getCategoryItems";
+import { fetchCategoryItems } from "./fetchCategoryItems";
 
 /**
  * Returns the UI schema element needed to render
@@ -18,7 +18,7 @@ export async function fetchCategoriesUiSchemaElement(
   i18nScope: string,
   context: IArcGISContext
 ): Promise<IUiSchemaElement> {
-  const categoryItems = await getCategoryItems(
+  const categoryItems = await fetchCategoryItems(
     context.portal.id,
     context.hubRequestOptions
   );

--- a/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
@@ -55,7 +55,6 @@ export async function fetchCategoriesUiSchemaElement(
             "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
           href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
           target: "_blank",
-          icon: "launch",
         },
         allowShowBeforeInteract: true,
         alwaysShow: true,

--- a/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
@@ -48,7 +48,6 @@ export async function fetchCategoriesUiSchemaElement(
         display: "notice",
         kind: "warning",
         icon: "exclamation-mark-triangle",
-        titleKey: "shared.fields.categories.noCategoriesNotice.title",
         labelKey: "shared.fields.categories.noCategoriesNotice.body",
         link: {
           href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",

--- a/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
@@ -1,0 +1,66 @@
+import { IArcGISContext } from "../../../ArcGISContext";
+import {
+  IUiSchemaElement,
+  IUiSchemaMessage,
+  UiSchemaMessageTypes,
+} from "../types";
+import { getCategoryItems } from "./getCategoryItems";
+
+/**
+ * Returns the UI schema element needed to render
+ * the categories editing control for an entity.
+ *
+ * @param i18nScope i18n scope for the entity translations
+ * @param entity The entity to build the UI schema for
+ * @returns the UI schema element for thumbnail editing
+ */
+export async function fetchCategoriesUiSchemaElement(
+  i18nScope: string,
+  context: IArcGISContext
+): Promise<IUiSchemaElement> {
+  const categoryItems = await getCategoryItems(
+    context.portal.id,
+    context.hubRequestOptions
+  );
+
+  const result: IUiSchemaElement = {
+    labelKey: `shared.fields.categories.label`,
+    scope: "/properties/categories",
+    type: "Control",
+    options: {
+      control: "hub-field-input-combobox",
+      items: categoryItems,
+      allowCustomValues: false,
+      selectionMode: "ancestors",
+      placeholderIcon: "select-category",
+      helperText: {
+        // helper text varies between entity types
+        labelKey: `${i18nScope}.fields.categories.helperText`,
+      },
+    },
+  };
+
+  if (!categoryItems.length) {
+    result.options.disabled = true;
+    result.options.messages = [
+      {
+        type: UiSchemaMessageTypes.custom,
+        display: "notice",
+        kind: "warning",
+        icon: "exclamation-mark-triangle",
+        titleKey: "shared.fields.categories.noCategoriesNotice.title",
+        labelKey: "shared.fields.categories.noCategoriesNotice.body",
+        link: {
+          href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
+          labelKey: "shared.fields.categories.noCategoriesNotice.link",
+          target: "_blank",
+          iconEnd: "launch",
+        },
+        allowShowBeforeInteract: true,
+        alwaysShow: true,
+      } as IUiSchemaMessage,
+    ];
+  }
+
+  return result;
+}

--- a/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
@@ -50,10 +50,12 @@ export async function fetchCategoriesUiSchemaElement(
         icon: "exclamation-mark-triangle",
         labelKey: "shared.fields.categories.noCategoriesNotice.body",
         link: {
+          kind: "external",
+          label:
+            "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
           href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
-          labelKey: "shared.fields.categories.noCategoriesNotice.link",
           target: "_blank",
-          iconEnd: "launch",
+          icon: "launch",
         },
         allowShowBeforeInteract: true,
         alwaysShow: true,

--- a/packages/common/src/core/schemas/internal/fetchCategoryItems.ts
+++ b/packages/common/src/core/schemas/internal/fetchCategoryItems.ts
@@ -11,7 +11,7 @@ import { IUiSchemaComboboxItem } from "../types";
  * @param hubRequestOptions The hub request options
  * @returns a _nested_ structure of categories
  */
-export async function getCategoryItems(
+export async function fetchCategoryItems(
   orgId: string,
   hubRequestOptions: IHubRequestOptions
 ): Promise<IUiSchemaComboboxItem[]> {

--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -250,6 +250,13 @@ export interface IUiSchemaMessage {
   labelKey?: string;
   icon?: boolean | string;
   kind?: "brand" | "danger" | "info" | "success" | "warning";
+  link?: {
+    href: string;
+    label?: string;
+    labelKey?: string;
+    target?: string;
+    iconEnd?: string;
+  };
   hidden?: boolean;
   // NOTE: condition is deprecated and remains for backwards compatibility only. Please use conditions instead.
   condition?: IUiSchemaCondition;

--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -17,6 +17,7 @@ import {
 } from "./internal/EditorOptions";
 import { IArcGISContext } from "../../ArcGISContext";
 import { EventEditorTypes } from "../../events/_internal/EventSchemaCreate";
+import { HubActionLink } from "../types";
 
 export interface IEditorConfig {
   schema: IConfigurationSchema;
@@ -250,13 +251,7 @@ export interface IUiSchemaMessage {
   labelKey?: string;
   icon?: boolean | string;
   kind?: "brand" | "danger" | "info" | "success" | "warning";
-  link?: {
-    href: string;
-    label?: string;
-    labelKey?: string;
-    target?: string;
-    iconEnd?: string;
-  };
+  link?: HubActionLink;
   hidden?: boolean;
   // NOTE: condition is deprecated and remains for backwards compatibility only. Please use conditions instead.
   condition?: IUiSchemaCondition;

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -1,11 +1,11 @@
 import { IUiSchema } from "../../core/schemas/types";
 import { IArcGISContext } from "../../ArcGISContext";
 import { getTagItems } from "../../core/schemas/internal/getTagItems";
-import { getCategoryItems } from "../../core/schemas/internal/getCategoryItems";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
 import { IHubDiscussion } from "../../core/types";
+import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
 
 /**
  * @private
@@ -121,21 +121,7 @@ export const buildUiSchema = async (
               placeholderIcon: "label",
             },
           },
-          {
-            labelKey: `${i18nScope}.fields.categories.label`,
-            scope: "/properties/categories",
-            type: "Control",
-            options: {
-              control: "hub-field-input-combobox",
-              items: await getCategoryItems(
-                context.portal.id,
-                context.hubRequestOptions
-              ),
-              allowCustomValues: false,
-              selectionMode: "ancestors",
-              placeholderIcon: "select-category",
-            },
-          },
+          await fetchCategoriesUiSchemaElement(i18nScope, context),
           {
             labelKey: `${i18nScope}.fields.summary.label`,
             scope: "/properties/summary",

--- a/packages/common/src/events/_internal/EventUiSchemaEdit.ts
+++ b/packages/common/src/events/_internal/EventUiSchemaEdit.ts
@@ -2,11 +2,11 @@ import { IUiSchema, UiSchemaRuleEffects } from "../../core/schemas/types";
 import { IArcGISContext } from "../../ArcGISContext";
 import { getDatePickerDate } from "../../utils/date/getDatePickerDate";
 import { IHubEvent } from "../../core/types/IHubEvent";
-import { getCategoryItems } from "../../core/schemas/internal/getCategoryItems";
 import { getTagItems } from "../../core/schemas/internal/getTagItems";
 import { HubEventAttendanceType, HubEventCapacityType } from "../types";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
+import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
 
 /**
  * @private
@@ -433,24 +433,7 @@ export const buildUiSchema = async (
               },
             },
           },
-          {
-            labelKey: `${i18nScope}.fields.categories.label`,
-            scope: "/properties/categories",
-            type: "Control",
-            options: {
-              control: "hub-field-input-combobox",
-              items: await getCategoryItems(
-                context.portal.id,
-                context.hubRequestOptions
-              ),
-              allowCustomValues: false,
-              selectionMode: "ancestors",
-              placeholderIcon: "select-category",
-              helperText: {
-                labelKey: `${i18nScope}.fields.categories.helperText`,
-              },
-            },
-          },
+          await fetchCategoriesUiSchemaElement(i18nScope, context),
           {
             labelKey: `${i18nScope}.fields.summary.label`,
             scope: "/properties/summary",

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -1,12 +1,12 @@
 import { IUiSchema, UiSchemaRuleEffects } from "../../core/schemas/types";
 import { IArcGISContext } from "../../ArcGISContext";
 import { getTagItems } from "../../core/schemas/internal/getTagItems";
-import { getCategoryItems } from "../../core/schemas/internal/getCategoryItems";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
 import { IHubInitiative } from "../../core";
 import { getAuthedImageUrl } from "../../core/_internal/getAuthedImageUrl";
+import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
 
 /**
  * @private
@@ -181,24 +181,7 @@ export const buildUiSchema = async (
         type: "Section",
         labelKey: `${i18nScope}.sections.searchDiscoverability.label`,
         elements: [
-          {
-            labelKey: `${i18nScope}.fields.categories.label`,
-            scope: "/properties/categories",
-            type: "Control",
-            options: {
-              control: "hub-field-input-combobox",
-              items: await getCategoryItems(
-                context.portal.id,
-                context.hubRequestOptions
-              ),
-              allowCustomValues: false,
-              selectionMode: "ancestors",
-              placeholderIcon: "select-category",
-              helperText: {
-                labelKey: `${i18nScope}.fields.categories.helperText`,
-              },
-            },
-          },
+          await fetchCategoriesUiSchemaElement(i18nScope, context),
           {
             labelKey: `${i18nScope}.fields.tags.label`,
             scope: "/properties/tags",

--- a/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
+++ b/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
@@ -1,11 +1,11 @@
 import { IUiSchema } from "../../core/schemas/types";
 import { IArcGISContext } from "../../ArcGISContext";
 import { getTagItems } from "../../core/schemas/internal/getTagItems";
-import { getCategoryItems } from "../../core/schemas/internal/getCategoryItems";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
 import { IHubPage } from "../../core/types";
+import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
 
 /**
  * @private
@@ -101,24 +101,7 @@ export const buildUiSchema = async (
               helperText: { labelKey: `${i18nScope}.fields.tags.helperText` },
             },
           },
-          {
-            labelKey: `${i18nScope}.fields.categories.label`,
-            scope: "/properties/categories",
-            type: "Control",
-            options: {
-              control: "hub-field-input-combobox",
-              items: await getCategoryItems(
-                context.portal.id,
-                context.hubRequestOptions
-              ),
-              allowCustomValues: false,
-              selectionMode: "ancestors",
-              placeholderIcon: "select-category",
-              helperText: {
-                labelKey: `${i18nScope}.fields.categories.helperText`,
-              },
-            },
-          },
+          await fetchCategoriesUiSchemaElement(i18nScope, context),
         ],
       },
       {

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -1,6 +1,5 @@
 import { IArcGISContext } from "../../ArcGISContext";
 import { IUiSchema } from "../../core/schemas/types";
-import { getCategoryItems } from "../../core/schemas/internal/getCategoryItems";
 import { getFeaturedContentCatalogs } from "../../core/schemas/internal/getFeaturedContentCatalogs";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
@@ -8,6 +7,7 @@ import { getTagItems } from "../../core/schemas/internal/getTagItems";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
 import { IHubProject } from "../../core/types";
 import { getAuthedImageUrl } from "../../core/_internal/getAuthedImageUrl";
+import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
 
 /**
  * @private
@@ -164,24 +164,7 @@ export const buildUiSchema = async (
               helperText: { labelKey: `${i18nScope}.fields.tags.helperText` },
             },
           },
-          {
-            labelKey: `${i18nScope}.fields.categories.label`,
-            scope: "/properties/categories",
-            type: "Control",
-            options: {
-              control: "hub-field-input-combobox",
-              items: await getCategoryItems(
-                context.portal.id,
-                context.hubRequestOptions
-              ),
-              allowCustomValues: false,
-              selectionMode: "ancestors",
-              placeholderIcon: "select-category",
-              helperText: {
-                labelKey: `${i18nScope}.fields.categories.helperText`,
-              },
-            },
-          },
+          await fetchCategoriesUiSchemaElement(i18nScope, context),
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -1,11 +1,11 @@
 import { IArcGISContext } from "../../ArcGISContext";
-import { getCategoryItems } from "../../core/schemas/internal/getCategoryItems";
 import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
 import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 import { getTagItems } from "../../core/schemas/internal/getTagItems";
 import { IUiSchema } from "../../core/schemas/types";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
 import { IHubSite } from "../../core/types";
+import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
 
 /**
  * @private
@@ -101,24 +101,7 @@ export const buildUiSchema = async (
               helperText: { labelKey: `${i18nScope}.fields.tags.helperText` },
             },
           },
-          {
-            labelKey: `${i18nScope}.fields.categories.label`,
-            scope: "/properties/categories",
-            type: "Control",
-            options: {
-              control: "hub-field-input-combobox",
-              items: await getCategoryItems(
-                context.portal.id,
-                context.hubRequestOptions
-              ),
-              allowCustomValues: false,
-              selectionMode: "ancestors",
-              placeholderIcon: "select-category",
-              helperText: {
-                labelKey: `${i18nScope}.fields.categories.helperText`,
-              },
-            },
-          },
+          await fetchCategoriesUiSchemaElement(i18nScope, context),
         ],
       },
       {

--- a/packages/common/src/surveys/_internal/SurveyUiSchemaEdit.ts
+++ b/packages/common/src/surveys/_internal/SurveyUiSchemaEdit.ts
@@ -1,5 +1,5 @@
 import { IArcGISContext } from "../../ArcGISContext";
-import { getCategoryItems } from "../../core/schemas/internal/getCategoryItems";
+import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
 import { getTagItems } from "../../core/schemas/internal/getTagItems";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
 import { IUiSchema } from "../../core/schemas/types";
@@ -99,21 +99,7 @@ export const buildUiSchema = async (
               placeholderIcon: "label",
             },
           },
-          {
-            labelKey: `${i18nScope}.fields.categories.label`,
-            scope: "/properties/categories",
-            type: "Control",
-            options: {
-              control: "hub-field-input-combobox",
-              items: await getCategoryItems(
-                context.portal.id,
-                context.hubRequestOptions
-              ),
-              allowCustomValues: false,
-              selectionMode: "ancestors",
-              placeholderIcon: "select-category",
-            },
-          },
+          await fetchCategoriesUiSchemaElement(i18nScope, context),
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,

--- a/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
@@ -1,13 +1,13 @@
 import { buildUiSchema } from "../../../src/content/_internal/ContentUiSchemaEdit";
 import { MOCK_CONTEXT } from "../../mocks/mock-auth";
-import * as getCategoryItemsModule from "../../../src/core/schemas/internal/getCategoryItems";
+import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fetchCategoryItems";
 import * as getLocationExtentModule from "../../../src/core/schemas/internal/getLocationExtent";
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
 
 describe("buildUiSchema: content edit", () => {
   it("returns the full content edit uiSchema", async () => {
-    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
           value: "/categories",

--- a/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
@@ -8,7 +8,12 @@ import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagIte
 describe("buildUiSchema: content edit", () => {
   it("returns the full content edit uiSchema", async () => {
     spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
-      Promise.resolve([])
+      Promise.resolve([
+        {
+          value: "/categories",
+          label: "/categories",
+        },
+      ])
     );
     spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
       Promise.resolve([])
@@ -126,17 +131,22 @@ describe("buildUiSchema: content edit", () => {
             },
             // categories
             {
-              labelKey: "some.scope.fields.categories.label",
+              labelKey: "shared.fields.categories.label",
               scope: "/properties/categories",
               type: "Control",
               options: {
                 control: "hub-field-input-combobox",
-                items: [],
+                items: [
+                  {
+                    value: "/categories",
+                    label: "/categories",
+                  },
+                ],
                 allowCustomValues: false,
                 selectionMode: "ancestors",
                 placeholderIcon: "select-category",
                 helperText: {
-                  labelKey: "some.scope.fields.categories.agolHint", // TODO: hint should describe whether it can be set on Enterprise or Online
+                  labelKey: "some.scope.fields.categories.helperText",
                 },
               },
             },

--- a/packages/common/test/core/schemas/internal/fetchCategoriesUiSchemaElement.test.ts
+++ b/packages/common/test/core/schemas/internal/fetchCategoriesUiSchemaElement.test.ts
@@ -1,10 +1,10 @@
 import { IArcGISContext } from "../../../../src/ArcGISContext";
 import { fetchCategoriesUiSchemaElement } from "../../../../src/core/schemas/internal/fetchCategoriesUiSchemaElement";
-import * as getCategoryItemsModule from "../../../../src/core/schemas/internal/getCategoryItems";
+import * as fetchCategoryItemsModule from "../../../../src/core/schemas/internal/fetchCategoryItems";
 
 describe("fetchCategoriesUiSchemaElement:", () => {
   it("excludes the no categories notice if category items are available", async () => {
-    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
           value: "/categories",
@@ -23,7 +23,7 @@ describe("fetchCategoriesUiSchemaElement:", () => {
   });
 
   it("includes the no categories notice if category items are not available", async () => {
-    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([])
     );
     const context = {

--- a/packages/common/test/core/schemas/internal/fetchCategoriesUiSchemaElement.test.ts
+++ b/packages/common/test/core/schemas/internal/fetchCategoriesUiSchemaElement.test.ts
@@ -37,5 +37,8 @@ describe("fetchCategoriesUiSchemaElement:", () => {
     expect(uiSchema.options?.messages[0].labelKey).toBe(
       "shared.fields.categories.noCategoriesNotice.body"
     );
+    expect(uiSchema.options?.messages[0].link.label).toBe(
+      "{{shared.fields.categories.noCategoriesNotice.link:translate}}"
+    );
   });
 });

--- a/packages/common/test/core/schemas/internal/fetchCategoriesUiSchemaElement.test.ts
+++ b/packages/common/test/core/schemas/internal/fetchCategoriesUiSchemaElement.test.ts
@@ -1,0 +1,41 @@
+import { IArcGISContext } from "../../../../src/ArcGISContext";
+import { fetchCategoriesUiSchemaElement } from "../../../../src/core/schemas/internal/fetchCategoriesUiSchemaElement";
+import * as getCategoryItemsModule from "../../../../src/core/schemas/internal/getCategoryItems";
+
+describe("fetchCategoriesUiSchemaElement:", () => {
+  it("excludes the no categories notice if category items are available", async () => {
+    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+      Promise.resolve([
+        {
+          value: "/categories",
+          label: "/categories",
+        },
+      ])
+    );
+    const context = {
+      portal: {
+        id: "some-org-id",
+        url: "some-org-url",
+      },
+    } as unknown as IArcGISContext;
+    const uiSchema = await fetchCategoriesUiSchemaElement("scope", context);
+    expect(uiSchema.options?.messages).toBeUndefined();
+  });
+
+  it("includes the no categories notice if category items are not available", async () => {
+    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+      Promise.resolve([])
+    );
+    const context = {
+      portal: {
+        id: "some-org-id",
+        url: "some-org-url",
+      },
+    } as unknown as IArcGISContext;
+    const uiSchema = await fetchCategoriesUiSchemaElement("scope", context);
+    expect(uiSchema.options?.messages?.length).toBe(1);
+    expect(uiSchema.options?.messages[0].labelKey).toBe(
+      "shared.fields.categories.noCategoriesNotice.body"
+    );
+  });
+});

--- a/packages/common/test/core/schemas/internal/fetchCategoryItems.test.ts
+++ b/packages/common/test/core/schemas/internal/fetchCategoryItems.test.ts
@@ -1,14 +1,14 @@
 import * as REQUEST_MODULE from "@esri/arcgis-rest-request";
-import { getCategoryItems } from "../../../../src/core/schemas/internal/getCategoryItems";
+import { fetchCategoryItems } from "../../../../src/core/schemas/internal/fetchCategoryItems";
 import { IHubRequestOptions } from "../../../../src";
 
-describe("getCategoryItems:", () => {
+describe("fetchCategoryItems:", () => {
   it("fetch schemas from org", async () => {
     const spy = spyOn(REQUEST_MODULE, "request").and.callFake(() => {
       return Promise.resolve(response);
     });
     const ro = {} as IHubRequestOptions;
-    const items = await getCategoryItems("orgId", ro);
+    const items = await fetchCategoryItems("orgId", ro);
     expect(spy).toHaveBeenCalled();
     expect(items.length).toBe(1); // expected changed from 3 to 1 because the response is now nested rather than flattened
     expect(items[0].children?.length).toBe(3);
@@ -19,7 +19,7 @@ describe("getCategoryItems:", () => {
       return Promise.reject();
     });
     const ro = {} as IHubRequestOptions;
-    const items = await getCategoryItems("orgId", ro);
+    const items = await fetchCategoryItems("orgId", ro);
     expect(spy).toHaveBeenCalled();
     expect(items.length).toBe(0);
   });

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -8,7 +8,12 @@ import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagIte
 describe("buildUiSchema: discussion edit", () => {
   it("returns the full discussion edit uiSchema", async () => {
     spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
-      Promise.resolve([])
+      Promise.resolve([
+        {
+          value: "/categories",
+          label: "/categories",
+        },
+      ])
     );
     spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
       Promise.resolve([])
@@ -133,15 +138,23 @@ describe("buildUiSchema: discussion edit", () => {
               },
             },
             {
-              labelKey: "some.scope.fields.categories.label",
+              labelKey: "shared.fields.categories.label",
               scope: "/properties/categories",
               type: "Control",
               options: {
                 control: "hub-field-input-combobox",
-                items: [],
+                items: [
+                  {
+                    value: "/categories",
+                    label: "/categories",
+                  },
+                ],
                 allowCustomValues: false,
                 selectionMode: "ancestors",
                 placeholderIcon: "select-category",
+                helperText: {
+                  labelKey: "some.scope.fields.categories.helperText",
+                },
               },
             },
             {
@@ -184,7 +197,12 @@ describe("buildUiSchema: discussion edit", () => {
   });
   it("returns the full discussion edit uiSchema when entity does have a view", async () => {
     spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
-      Promise.resolve([])
+      Promise.resolve([
+        {
+          value: "/categories",
+          label: "/categories",
+        },
+      ])
     );
     spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
       Promise.resolve([])
@@ -312,15 +330,23 @@ describe("buildUiSchema: discussion edit", () => {
               },
             },
             {
-              labelKey: "some.scope.fields.categories.label",
+              labelKey: "shared.fields.categories.label",
               scope: "/properties/categories",
               type: "Control",
               options: {
                 control: "hub-field-input-combobox",
-                items: [],
+                items: [
+                  {
+                    value: "/categories",
+                    label: "/categories",
+                  },
+                ],
                 allowCustomValues: false,
                 selectionMode: "ancestors",
                 placeholderIcon: "select-category",
+                helperText: {
+                  labelKey: "some.scope.fields.categories.helperText",
+                },
               },
             },
             {

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -1,13 +1,13 @@
 import { buildUiSchema } from "../../../src/discussions/_internal/DiscussionUiSchemaEdit";
 import { MOCK_CONTEXT } from "../../mocks/mock-auth";
-import * as getCategoryItemsModule from "../../../src/core/schemas/internal/getCategoryItems";
+import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fetchCategoryItems";
 import * as getLocationExtentModule from "../../../src/core/schemas/internal/getLocationExtent";
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
 
 describe("buildUiSchema: discussion edit", () => {
   it("returns the full discussion edit uiSchema", async () => {
-    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
           value: "/categories",
@@ -196,7 +196,7 @@ describe("buildUiSchema: discussion edit", () => {
     });
   });
   it("returns the full discussion edit uiSchema when entity does have a view", async () => {
-    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
           value: "/categories",

--- a/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
+++ b/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../src/events/types";
 import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
 import * as getDatePickerDateUtils from "../../../src/utils/date/getDatePickerDate";
-import * as getCategoryItemsModule from "../../../src/core/schemas/internal/getCategoryItems";
+import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fetchCategoryItems";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
 import * as getLocationExtentModule from "../../../src/core/schemas/internal/getLocationExtent";
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
@@ -85,9 +85,9 @@ describe("EventUiSchemaEdit", () => {
         "getTagItems"
       ).and.returnValue(Promise.resolve(tags));
       const categories = [{ value: "category1" }, { value: "category2" }];
-      const getCategoryItemsSpy = spyOn(
-        getCategoryItemsModule,
-        "getCategoryItems"
+      const fetchCategoryItemsSpy = spyOn(
+        fetchCategoryItemsModule,
+        "fetchCategoryItems"
       ).and.returnValue(Promise.resolve(categories));
       const res = await buildUiSchema(
         "myI18nScope",
@@ -105,8 +105,8 @@ describe("EventUiSchemaEdit", () => {
         authdCtxMgr.context.portal.id,
         authdCtxMgr.context.hubRequestOptions
       );
-      expect(getCategoryItemsSpy).toHaveBeenCalledTimes(1);
-      expect(getCategoryItemsSpy).toHaveBeenCalledWith(
+      expect(fetchCategoryItemsSpy).toHaveBeenCalledTimes(1);
+      expect(fetchCategoryItemsSpy).toHaveBeenCalledWith(
         authdCtxMgr.context.portal.id,
         authdCtxMgr.context.hubRequestOptions
       );

--- a/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
+++ b/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
@@ -510,7 +510,7 @@ describe("EventUiSchemaEdit", () => {
                 },
               },
               {
-                labelKey: `myI18nScope.fields.categories.label`,
+                labelKey: "shared.fields.categories.label",
                 scope: "/properties/categories",
                 type: "Control",
                 options: {
@@ -520,7 +520,7 @@ describe("EventUiSchemaEdit", () => {
                   selectionMode: "ancestors",
                   placeholderIcon: "select-category",
                   helperText: {
-                    labelKey: `myI18nScope.fields.categories.helperText`,
+                    labelKey: "myI18nScope.fields.categories.helperText",
                   },
                 },
               },

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -11,7 +11,12 @@ import * as getAuthedImageUrlModule from "../../../src/core/_internal/getAuthedI
 describe("buildUiSchema: initiative edit", () => {
   it("returns the full initiative edit uiSchema", async () => {
     spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
-      Promise.resolve([])
+      Promise.resolve([
+        {
+          value: "/categories",
+          label: "/categories",
+        },
+      ])
     );
     spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
       Promise.resolve([])
@@ -189,12 +194,17 @@ describe("buildUiSchema: initiative edit", () => {
           labelKey: "some.scope.sections.searchDiscoverability.label",
           elements: [
             {
-              labelKey: "some.scope.fields.categories.label",
+              labelKey: "shared.fields.categories.label",
               scope: "/properties/categories",
               type: "Control",
               options: {
                 control: "hub-field-input-combobox",
-                items: [],
+                items: [
+                  {
+                    value: "/categories",
+                    label: "/categories",
+                  },
+                ],
                 allowCustomValues: false,
                 selectionMode: "ancestors",
                 placeholderIcon: "select-category",
@@ -301,7 +311,12 @@ describe("buildUiSchema: initiative edit", () => {
   });
   it("returns the full initiative edit uiSchema with a defined view", async () => {
     spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
-      Promise.resolve([])
+      Promise.resolve([
+        {
+          value: "/categories",
+          label: "/categories",
+        },
+      ])
     );
     spyOn(
       getFeaturedContentCatalogsModule,
@@ -482,12 +497,17 @@ describe("buildUiSchema: initiative edit", () => {
           labelKey: "some.scope.sections.searchDiscoverability.label",
           elements: [
             {
-              labelKey: "some.scope.fields.categories.label",
+              labelKey: "shared.fields.categories.label",
               scope: "/properties/categories",
               type: "Control",
               options: {
                 control: "hub-field-input-combobox",
-                items: [],
+                items: [
+                  {
+                    value: "/categories",
+                    label: "/categories",
+                  },
+                ],
                 allowCustomValues: false,
                 selectionMode: "ancestors",
                 placeholderIcon: "select-category",

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -3,14 +3,14 @@ import { MOCK_CONTEXT } from "../../mocks/mock-auth";
 import * as getLocationExtentModule from "../../../src/core/schemas/internal/getLocationExtent";
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
-import * as getCategoryItemsModule from "../../../src/core/schemas/internal/getCategoryItems";
+import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fetchCategoryItems";
 import * as getFeaturedContentCatalogsModule from "../../../src/core/schemas/internal/getFeaturedContentCatalogs";
 import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
 import * as getAuthedImageUrlModule from "../../../src/core/_internal/getAuthedImageUrl";
 
 describe("buildUiSchema: initiative edit", () => {
   it("returns the full initiative edit uiSchema", async () => {
-    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
           value: "/categories",
@@ -310,7 +310,7 @@ describe("buildUiSchema: initiative edit", () => {
     });
   });
   it("returns the full initiative edit uiSchema with a defined view", async () => {
-    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
           value: "/categories",

--- a/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
+++ b/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
@@ -8,7 +8,12 @@ import * as getCategoryItemsModule from "../../../src/core/schemas/internal/getC
 describe("buildUiSchema: page edit", () => {
   it("returns the full page edit uiSchema", async () => {
     spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
-      Promise.resolve([])
+      Promise.resolve([
+        {
+          value: "/categories",
+          label: "/categories",
+        },
+      ])
     );
     spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
       Promise.resolve([])
@@ -122,12 +127,17 @@ describe("buildUiSchema: page edit", () => {
               },
             },
             {
-              labelKey: "some.scope.fields.categories.label",
+              labelKey: "shared.fields.categories.label",
               scope: "/properties/categories",
               type: "Control",
               options: {
                 control: "hub-field-input-combobox",
-                items: [],
+                items: [
+                  {
+                    value: "/categories",
+                    label: "/categories",
+                  },
+                ],
                 allowCustomValues: false,
                 selectionMode: "ancestors",
                 placeholderIcon: "select-category",

--- a/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
+++ b/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
@@ -3,11 +3,11 @@ import { MOCK_CONTEXT } from "../../mocks/mock-auth";
 import * as getLocationExtentModule from "../../../src/core/schemas/internal/getLocationExtent";
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
-import * as getCategoryItemsModule from "../../../src/core/schemas/internal/getCategoryItems";
+import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fetchCategoryItems";
 
 describe("buildUiSchema: page edit", () => {
   it("returns the full page edit uiSchema", async () => {
-    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
           value: "/categories",

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -1,6 +1,6 @@
 import { buildUiSchema } from "../../../src/projects/_internal/ProjectUiSchemaEdit";
 import { MOCK_CONTEXT } from "../../mocks/mock-auth";
-import * as getCategoryItemsModule from "../../../src/core/schemas/internal/getCategoryItems";
+import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fetchCategoryItems";
 import * as getFeaturedContentCatalogsModule from "../../../src/core/schemas/internal/getFeaturedContentCatalogs";
 import * as getAuthedImageUrlModule from "../../../src/core/_internal/getAuthedImageUrl";
 import * as getLocationExtentModule from "../../../src/core/schemas/internal/getLocationExtent";
@@ -9,7 +9,7 @@ import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagIte
 
 describe("buildUiSchema: project edit", () => {
   it("returns the full project edit uiSchema", async () => {
-    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
           value: "/categories",
@@ -327,7 +327,7 @@ describe("buildUiSchema: project edit", () => {
     });
   });
   it("returns the full project edit uiSchema with a defined view", async () => {
-    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
           value: "/categories",

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -10,7 +10,12 @@ import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagIte
 describe("buildUiSchema: project edit", () => {
   it("returns the full project edit uiSchema", async () => {
     spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
-      Promise.resolve([])
+      Promise.resolve([
+        {
+          value: "/categories",
+          label: "/categories",
+        },
+      ])
     );
     spyOn(
       getFeaturedContentCatalogsModule,
@@ -167,12 +172,17 @@ describe("buildUiSchema: project edit", () => {
               },
             },
             {
-              labelKey: "some.scope.fields.categories.label",
+              labelKey: "shared.fields.categories.label",
               scope: "/properties/categories",
               type: "Control",
               options: {
                 control: "hub-field-input-combobox",
-                items: [],
+                items: [
+                  {
+                    value: "/categories",
+                    label: "/categories",
+                  },
+                ],
                 allowCustomValues: false,
                 selectionMode: "ancestors",
                 placeholderIcon: "select-category",
@@ -318,7 +328,12 @@ describe("buildUiSchema: project edit", () => {
   });
   it("returns the full project edit uiSchema with a defined view", async () => {
     spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
-      Promise.resolve([])
+      Promise.resolve([
+        {
+          value: "/categories",
+          label: "/categories",
+        },
+      ])
     );
     spyOn(
       getFeaturedContentCatalogsModule,
@@ -478,12 +493,17 @@ describe("buildUiSchema: project edit", () => {
               },
             },
             {
-              labelKey: "some.scope.fields.categories.label",
+              labelKey: "shared.fields.categories.label",
               scope: "/properties/categories",
               type: "Control",
               options: {
                 control: "hub-field-input-combobox",
-                items: [],
+                items: [
+                  {
+                    value: "/categories",
+                    label: "/categories",
+                  },
+                ],
                 allowCustomValues: false,
                 selectionMode: "ancestors",
                 placeholderIcon: "select-category",

--- a/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
@@ -3,11 +3,11 @@ import { MOCK_CONTEXT } from "../../mocks/mock-auth";
 import * as getLocationExtentModule from "../../../src/core/schemas/internal/getLocationExtent";
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
-import * as getCategoryItemsModule from "../../../src/core/schemas/internal/getCategoryItems";
+import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fetchCategoryItems";
 
 describe("buildUiSchema: site edit", () => {
   it("returns the full site edit uiSchema", async () => {
-    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
           value: "/categories",

--- a/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
@@ -8,7 +8,12 @@ import * as getCategoryItemsModule from "../../../src/core/schemas/internal/getC
 describe("buildUiSchema: site edit", () => {
   it("returns the full site edit uiSchema", async () => {
     spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
-      Promise.resolve([])
+      Promise.resolve([
+        {
+          value: "/categories",
+          label: "/categories",
+        },
+      ])
     );
     spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
       Promise.resolve([])
@@ -122,12 +127,17 @@ describe("buildUiSchema: site edit", () => {
               },
             },
             {
-              labelKey: "some.scope.fields.categories.label",
+              labelKey: "shared.fields.categories.label",
               scope: "/properties/categories",
               type: "Control",
               options: {
                 control: "hub-field-input-combobox",
-                items: [],
+                items: [
+                  {
+                    value: "/categories",
+                    label: "/categories",
+                  },
+                ],
                 allowCustomValues: false,
                 selectionMode: "ancestors",
                 placeholderIcon: "select-category",

--- a/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
+++ b/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
@@ -1,11 +1,11 @@
 import { buildUiSchema } from "../../../src/surveys/_internal/SurveyUiSchemaEdit";
 import { MOCK_CONTEXT } from "../../mocks/mock-auth";
-import * as getCategoryItemsModule from "../../../src/core/schemas/internal/getCategoryItems";
+import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fetchCategoryItems";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
 
 describe("buildUiSchema: survey edit", () => {
   it("returns the full survey edit uiSchema", async () => {
-    spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
+    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
           value: "/categories",

--- a/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
+++ b/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
@@ -6,7 +6,12 @@ import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagIte
 describe("buildUiSchema: survey edit", () => {
   it("returns the full survey edit uiSchema", async () => {
     spyOn(getCategoryItemsModule, "getCategoryItems").and.returnValue(
-      Promise.resolve([])
+      Promise.resolve([
+        {
+          value: "/categories",
+          label: "/categories",
+        },
+      ])
     );
     spyOn(getTagItemsModule, "getTagItems").and.returnValue(
       Promise.resolve([])
@@ -103,15 +108,23 @@ describe("buildUiSchema: survey edit", () => {
               },
             },
             {
-              labelKey: "some.scope.fields.categories.label",
+              labelKey: "shared.fields.categories.label",
               scope: "/properties/categories",
               type: "Control",
               options: {
                 control: "hub-field-input-combobox",
-                items: [],
+                items: [
+                  {
+                    value: "/categories",
+                    label: "/categories",
+                  },
+                ],
                 allowCustomValues: false,
                 selectionMode: "ancestors",
                 placeholderIcon: "select-category",
+                helperText: {
+                  labelKey: "some.scope.fields.categories.helperText",
+                },
               },
             },
             {


### PR DESCRIPTION
1. Description:
Part of https://devtopia.esri.com/dc/hub/issues/10382

Highlights:
- Abstracts the creation of the categories ui schema field into a helper function to maintain consistency.
- Adds a notice to all categories schema fields when no categories are available within the user's org
- Adds a `link` configuration object to `IUiSchemaMessage` that can only be used when rendering notices

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
