### PR TITLE
feat(hub-common): release project map settings

### DIFF
--- a/packages/common/test/projects/_internal/ProjectUiSchemaSettings.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaSettings.test.ts
@@ -1,6 +1,7 @@
 import { buildUiSchema } from "../../../src/projects/_internal/ProjectUiSchemaSettings";
 import { MOCK_CONTEXT } from "../../mocks/mock-auth";
 
+// ProjectUiSchemaSettings tests
 describe("buildUiSchema: projects settings", () => {
   it("returns the full projeccts settings uiSchema", async () => {
     const uiSchema = await buildUiSchema("some.scope", {} as any, MOCK_CONTEXT);


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: PR just to trigger release via semantic commit message

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
