### PR TITLE
feat(hub-sites): initiatives are no longer created during site creation

### DIFF
--- a/packages/sites/src/create-site-model-from-template.ts
+++ b/packages/sites/src/create-site-model-from-template.ts
@@ -102,6 +102,7 @@ export function createSiteModelFromTemplate(
       return ensureUniqueDomainName(slugify(domainTitle), hubRequestOptions);
     })
     .then((uniqueSubdomain) => {
+      debugger;
       const portal = hubRequestOptions.portalSelf;
       // TODO: Revisit this if/when we do more site templates which we want to maintain their theme
       settings.solution.theme = getOrgDefaultTheme(portal);
@@ -121,6 +122,7 @@ export function createSiteModelFromTemplate(
       }
     })
     .then((_) => {
+      debugger;
       const siteModel = interpolateSite(template, settings, transforms);
 
       // Special logic for the site title

--- a/packages/sites/src/create-site-model-from-template.ts
+++ b/packages/sites/src/create-site-model-from-template.ts
@@ -41,8 +41,6 @@ export function createSiteModelFromTemplate(
   transforms: any,
   hubRequestOptions: IHubRequestOptions
 ) {
-  console.log("HUB.JS - CREATE SITE MODEL FROM TEMPLATE START");
-  console.trace();
   // add url to the assets, ref'ing the original location
   template.assets = addSolutionResourceUrlToAssets(template, hubRequestOptions);
   // We may have templates which lack .properties so let's ensure that exists
@@ -132,9 +130,6 @@ export function createSiteModelFromTemplate(
         siteModel.item.title = getProp(settings, "solution.title");
         siteModel.data.values.title = getProp(settings, "solution.title");
       }
-
-      console.log("HUB.JS - CREATE SITE MODEL FROM TEMPLATE END", siteModel);
-      console.trace();
 
       return siteModel;
     })

--- a/packages/sites/src/create-site-model-from-template.ts
+++ b/packages/sites/src/create-site-model-from-template.ts
@@ -41,8 +41,8 @@ export function createSiteModelFromTemplate(
   transforms: any,
   hubRequestOptions: IHubRequestOptions
 ) {
-  debugger;
-  console.log('HUB.JS - CREATE SITE MODEL FROM TEMPLATE START')
+  console.log("HUB.JS - CREATE SITE MODEL FROM TEMPLATE START");
+  console.trace();
   // add url to the assets, ref'ing the original location
   template.assets = addSolutionResourceUrlToAssets(template, hubRequestOptions);
   // We may have templates which lack .properties so let's ensure that exists
@@ -133,7 +133,8 @@ export function createSiteModelFromTemplate(
         siteModel.data.values.title = getProp(settings, "solution.title");
       }
 
-      console.log('HUB.JS - CREATE SITE MODEL FROM TEMPLATE END', siteModel);
+      console.log("HUB.JS - CREATE SITE MODEL FROM TEMPLATE END", siteModel);
+      console.trace();
 
       return siteModel;
     })

--- a/packages/sites/src/create-site-model-from-template.ts
+++ b/packages/sites/src/create-site-model-from-template.ts
@@ -41,6 +41,8 @@ export function createSiteModelFromTemplate(
   transforms: any,
   hubRequestOptions: IHubRequestOptions
 ) {
+  debugger;
+  console.log('HUB.JS - CREATE SITE MODEL FROM TEMPLATE START')
   // add url to the assets, ref'ing the original location
   template.assets = addSolutionResourceUrlToAssets(template, hubRequestOptions);
   // We may have templates which lack .properties so let's ensure that exists
@@ -102,7 +104,6 @@ export function createSiteModelFromTemplate(
       return ensureUniqueDomainName(slugify(domainTitle), hubRequestOptions);
     })
     .then((uniqueSubdomain) => {
-      debugger;
       const portal = hubRequestOptions.portalSelf;
       // TODO: Revisit this if/when we do more site templates which we want to maintain their theme
       settings.solution.theme = getOrgDefaultTheme(portal);
@@ -122,7 +123,6 @@ export function createSiteModelFromTemplate(
       }
     })
     .then((_) => {
-      debugger;
       const siteModel = interpolateSite(template, settings, transforms);
 
       // Special logic for the site title
@@ -132,6 +132,8 @@ export function createSiteModelFromTemplate(
         siteModel.item.title = getProp(settings, "solution.title");
         siteModel.data.values.title = getProp(settings, "solution.title");
       }
+
+      console.log('HUB.JS - CREATE SITE MODEL FROM TEMPLATE END', siteModel);
 
       return siteModel;
     })

--- a/packages/sites/src/create-site-model-from-template.ts
+++ b/packages/sites/src/create-site-model-from-template.ts
@@ -119,37 +119,6 @@ export function createSiteModelFromTemplate(
         settings.solution.defaultHostname = `${uniqueSubdomain}-${portal.urlKey}.${base}`;
         settings.solution.url = `https://${uniqueSubdomain}-${portal.urlKey}.${base}`;
       }
-
-      // create the initiative
-      let handleInitiative = Promise.resolve(null);
-
-      if (product !== "portal") {
-        handleInitiative = _createSiteInitiative(
-          template,
-          settings,
-          transforms,
-          hubRequestOptions
-        );
-      }
-      return handleInitiative;
-    })
-    .then((maybeInitiative) => {
-      // if we got an initiative back...
-      let teamUpdatePromise = Promise.resolve(null);
-      if (maybeInitiative) {
-        // add to settings hash so it's available to the site
-        // typically all that's used is initiative.item.id
-        settings.initiative = maybeInitiative;
-        // directly set the parentInitiativeId vs relying on adlib
-        template.item.properties.parentInitiativeId = maybeInitiative.item.id;
-        // check if we created a followers team because we need to add the initiativeId into a tag
-        teamUpdatePromise = _updateTeamTags(
-          maybeInitiative,
-          state.teams,
-          hubRequestOptions
-        );
-      }
-      return teamUpdatePromise;
     })
     .then((_) => {
       const siteModel = interpolateSite(template, settings, transforms);

--- a/packages/sites/test/create-site-model-from-template.test.ts
+++ b/packages/sites/test/create-site-model-from-template.test.ts
@@ -133,8 +133,6 @@ describe("createSiteModelFromTemplate", () => {
   let getProductSpy: jasmine.Spy;
   let createTeamsSpy: jasmine.Spy;
   let ensureDomainSpy: jasmine.Spy;
-  let createInitiativeSpy: jasmine.Spy;
-  let updateTeamTagsSpy: jasmine.Spy;
   beforeEach(() => {
     getProductSpy = spyOn(commonModule, "getHubProduct").and.returnValue(
       "premium"
@@ -148,16 +146,6 @@ describe("createSiteModelFromTemplate", () => {
       commonModule,
       "ensureUniqueDomainName"
     ).and.returnValue(Promise.resolve(uniqueDomain));
-
-    createInitiativeSpy = spyOn(
-      createSiteModule,
-      "_createSiteInitiative"
-    ).and.returnValue(Promise.resolve(initiativeResponse));
-
-    updateTeamTagsSpy = spyOn(
-      updateTagsModule,
-      "_updateTeamTags"
-    ).and.returnValue(Promise.resolve());
   });
 
   it("creates the site on premium", async () => {
@@ -189,10 +177,7 @@ describe("createSiteModelFromTemplate", () => {
     );
     expect(createdSite.data.values.subdomain).toBe(`unique-domain`);
 
-    expectAllCalled(
-      [createTeamsSpy, ensureDomainSpy, createInitiativeSpy, updateTeamTagsSpy],
-      expect
-    );
+    expectAllCalled([createTeamsSpy, ensureDomainSpy], expect);
 
     expect(createdSite.item.properties.contentGroupId).toBe(
       teams.props.contentGroupId
@@ -234,10 +219,7 @@ describe("createSiteModelFromTemplate", () => {
     );
     expect(createdSite.data.values.subdomain).toBe(`unique-domain`);
 
-    expectAllCalled(
-      [createTeamsSpy, ensureDomainSpy, createInitiativeSpy, updateTeamTagsSpy],
-      expect
-    );
+    expectAllCalled([createTeamsSpy, ensureDomainSpy], expect);
 
     expect(createdSite.item.properties.contentGroupId).toBe(
       teams.props.contentGroupId
@@ -281,13 +263,6 @@ describe("createSiteModelFromTemplate", () => {
     expect(createdSite.data.values.subdomain).toBe(`unique-domain`);
 
     expectAllCalled([createTeamsSpy, ensureDomainSpy], expect);
-    // create initiative stuff shouldnt be called on portal
-    expectAll(
-      [createInitiativeSpy, updateTeamTagsSpy],
-      "toHaveBeenCalled",
-      false,
-      expect
-    );
 
     expect(createdSite.item.properties.contentGroupId).toBe(
       teams.props.contentGroupId


### PR DESCRIPTION
[10005](https://devtopia.esri.com/dc/hub/issues/10005)

### Description
**BREAKING CHANGE**: removes logic to automatically create an initiative during the site creation process

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.