### PR TITLE
feat(hub-common): adds map settings to discussion board settings schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65010,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.148.1",
+			"version": "14.149.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaSettings.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaSettings.ts
@@ -41,7 +41,7 @@ export const buildUiSchema = async (
       },
       {
         type: "Section",
-        labelKey: `${i18nScope}.sections.mapSettings.label`,
+        labelKey: `shared.sections.mapSettings.label`,
         elements: [
           {
             type: "Control",

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaSettings.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaSettings.ts
@@ -39,6 +39,25 @@ export const buildUiSchema = async (
           },
         ],
       },
+      {
+        type: "Section",
+        labelKey: `${i18nScope}.sections.mapSettings.label`,
+        elements: [
+          {
+            type: "Control",
+            scope: "/properties/view/properties/mapSettings",
+            labelKey: `${i18nScope}.fields.mapSettings.label`,
+            options: {
+              type: "Control",
+              control: "hub-composite-input-map-settings",
+              // the settings that are visible for configuring the map
+              visibleSettings: ["gallery"],
+              // if the map preview is displayed
+              showPreview: true,
+            },
+          },
+        ],
+      },
     ],
   };
 };

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaSettings.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaSettings.ts
@@ -18,7 +18,7 @@ export const buildUiSchema = async (
     elements: [
       {
         type: "Section",
-        labelKey: `${i18nScope}.sections.mapSettings.label`,
+        labelKey: `shared.sections.mapSettings.label`,
         elements: [
           {
             type: "Control",

--- a/packages/common/src/projects/_internal/ProjectUiSchemaSettings.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaSettings.ts
@@ -18,7 +18,7 @@ export const buildUiSchema = async (
     elements: [
       {
         type: "Section",
-        labelKey: `${i18nScope}.sections.mapSettings.label`,
+        labelKey: `shared.sections.mapSettings.label`,
         elements: [
           {
             type: "Control",

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaSettings.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaSettings.test.ts
@@ -32,7 +32,7 @@ describe("buildUiSchema: discussions settings", () => {
         },
         {
           type: "Section",
-          labelKey: "some.scope.sections.mapSettings.label",
+          labelKey: "shared.sections.mapSettings.label",
           elements: [
             {
               type: "Control",

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaSettings.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaSettings.test.ts
@@ -30,6 +30,23 @@ describe("buildUiSchema: discussions settings", () => {
             },
           ],
         },
+        {
+          type: "Section",
+          labelKey: "some.scope.sections.mapSettings.label",
+          elements: [
+            {
+              type: "Control",
+              scope: "/properties/view/properties/mapSettings",
+              labelKey: "some.scope.fields.mapSettings.label",
+              options: {
+                type: "Control",
+                control: "hub-composite-input-map-settings",
+                visibleSettings: ["gallery"],
+                showPreview: true,
+              },
+            },
+          ],
+        },
       ],
     });
   });

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaSettings.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaSettings.test.ts
@@ -9,7 +9,7 @@ describe("buildUiSchema: initiatives settings", () => {
       elements: [
         {
           type: "Section",
-          labelKey: "some.scope.sections.mapSettings.label",
+          labelKey: "shared.sections.mapSettings.label",
           elements: [
             {
               type: "Control",

--- a/packages/common/test/projects/_internal/ProjectUiSchemaSettings.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaSettings.test.ts
@@ -10,7 +10,7 @@ describe("buildUiSchema: projects settings", () => {
       elements: [
         {
           type: "Section",
-          labelKey: "some.scope.sections.mapSettings.label",
+          labelKey: "shared.sections.mapSettings.label",
           elements: [
             {
               type: "Control",


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: #10461

1. Description: Adds map settings to Discussion Boards UI Schema

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
