### PR TITLE
deleted uiSchema of sharing section in metric in Initiative and Project entities

### DIFF
--- a/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
@@ -227,39 +227,6 @@ export const buildUiSchema = async (
           },
         ],
       },
-      {
-        type: "Section",
-        labelKey: "shared.sections.metrics.sharing.label",
-        elements: [
-          {
-            labelKey: "shared.fields.metrics.showShareIcon.label",
-            scope: "/properties/_metric/properties/shareable",
-            type: "Control",
-            options: {
-              helperText: {
-                labelKey:
-                  "shared.fields.metrics.showShareIcon.helperText.label",
-              },
-              control: "hub-field-input-switch",
-              layout: "inline-space-between",
-            },
-          },
-          {
-            labelKey: "shared.fields.metrics.shareableOnHover.label",
-            scope: "/properties/_metric/properties/shareableOnHover",
-            type: "Control",
-            rule: SHOW_FOR_SHARING_RULE_ENTITY,
-            options: {
-              control: "hub-field-input-switch",
-              helperText: {
-                labelKey:
-                  "shared.fields.metrics.shareableOnHover.helperText.label",
-              },
-              layout: "inline-space-between",
-            },
-          },
-        ],
-      },
     ],
   };
 };

--- a/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
@@ -223,39 +223,6 @@ export const buildUiSchema = async (
           },
         ],
       },
-      {
-        type: "Section",
-        labelKey: "shared.sections.metrics.sharing.label",
-        elements: [
-          {
-            labelKey: "shared.fields.metrics.showShareIcon.label",
-            scope: "/properties/_metric/properties/shareable",
-            type: "Control",
-            options: {
-              helperText: {
-                labelKey:
-                  "shared.fields.metrics.showShareIcon.helperText.label",
-              },
-              control: "hub-field-input-switch",
-              layout: "inline-space-between",
-            },
-          },
-          {
-            labelKey: "shared.fields.metrics.shareableOnHover.label",
-            scope: "/properties/_metric/properties/shareableOnHover",
-            type: "Control",
-            rule: SHOW_FOR_SHARING_RULE_ENTITY,
-            options: {
-              control: "hub-field-input-switch",
-              helperText: {
-                labelKey:
-                  "shared.fields.metrics.shareableOnHover.helperText.label",
-              },
-              layout: "inline-space-between",
-            },
-          },
-        ],
-      },
     ],
   };
 };


### PR DESCRIPTION
1. Description: deleted uiSchema to delete sharing section on metric pane in Initiative and Project entities

1. Instructions for testing:

1. Closes Issues: #<10737> (https://zentopia.esri.com/workspaces/sprint-board-60340b9721bc3a4ab6367db5/issues/gh/dc/hub/10737)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
