### PR TITLE
feat: Removed sharing section on metric pane in initiative and project entities

### DIFF
--- a/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
@@ -227,39 +227,6 @@ export const buildUiSchema = async (
           },
         ],
       },
-      {
-        type: "Section",
-        labelKey: "shared.sections.metrics.sharing.label",
-        elements: [
-          {
-            labelKey: "shared.fields.metrics.showShareIcon.label",
-            scope: "/properties/_metric/properties/shareable",
-            type: "Control",
-            options: {
-              helperText: {
-                labelKey:
-                  "shared.fields.metrics.showShareIcon.helperText.label",
-              },
-              control: "hub-field-input-switch",
-              layout: "inline-space-between",
-            },
-          },
-          {
-            labelKey: "shared.fields.metrics.shareableOnHover.label",
-            scope: "/properties/_metric/properties/shareableOnHover",
-            type: "Control",
-            rule: SHOW_FOR_SHARING_RULE_ENTITY,
-            options: {
-              control: "hub-field-input-switch",
-              helperText: {
-                labelKey:
-                  "shared.fields.metrics.shareableOnHover.helperText.label",
-              },
-              layout: "inline-space-between",
-            },
-          },
-        ],
-      },
     ],
   };
 };

--- a/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
@@ -223,39 +223,6 @@ export const buildUiSchema = async (
           },
         ],
       },
-      {
-        type: "Section",
-        labelKey: "shared.sections.metrics.sharing.label",
-        elements: [
-          {
-            labelKey: "shared.fields.metrics.showShareIcon.label",
-            scope: "/properties/_metric/properties/shareable",
-            type: "Control",
-            options: {
-              helperText: {
-                labelKey:
-                  "shared.fields.metrics.showShareIcon.helperText.label",
-              },
-              control: "hub-field-input-switch",
-              layout: "inline-space-between",
-            },
-          },
-          {
-            labelKey: "shared.fields.metrics.shareableOnHover.label",
-            scope: "/properties/_metric/properties/shareableOnHover",
-            type: "Control",
-            rule: SHOW_FOR_SHARING_RULE_ENTITY,
-            options: {
-              control: "hub-field-input-switch",
-              helperText: {
-                labelKey:
-                  "shared.fields.metrics.shareableOnHover.helperText.label",
-              },
-              layout: "inline-space-between",
-            },
-          },
-        ],
-      },
     ],
   };
 };

--- a/packages/common/test/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.test.ts
@@ -18,7 +18,7 @@ describe("InitiativeUiSchemaMetrics", () => {
       // can be difficult to maintain over time), we simply validate
       // a minimal set of properties in the uiSchema
       expect(uiSchema.type).toBe("Layout");
-      expect(uiSchema.elements?.length).toBe(4);
+      expect(uiSchema.elements?.length).toBe(3);
       expect(uiSchema.elements![0].type).toBe("Section");
       expect(uiSchema.elements![0].elements![0].scope).toBe(
         "/properties/_metric/properties/cardTitle"

--- a/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
@@ -294,43 +294,6 @@ describe("ProjectUiSchemaMetrics", () => {
               },
             ],
           },
-          {
-            type: "Section",
-            labelKey: `shared.sections.metrics.sharing.label`,
-            elements: [
-              {
-                labelKey: `shared.fields.metrics.showShareIcon.label`,
-                scope: "/properties/_metric/properties/shareable",
-                type: "Control",
-                options: {
-                  helperText: {
-                    labelKey: `shared.fields.metrics.showShareIcon.helperText.label`,
-                  },
-                  control: "hub-field-input-switch",
-                  layout: "inline-space-between",
-                },
-              },
-              {
-                labelKey: `shared.fields.metrics.shareableOnHover.label`,
-                scope: "/properties/_metric/properties/shareableOnHover",
-                type: "Control",
-                rule: {
-                  condition: {
-                    scope: "/properties/_metric/properties/shareable",
-                    schema: { const: true },
-                  },
-                  effect: UiSchemaRuleEffects.SHOW,
-                },
-                options: {
-                  control: "hub-field-input-switch",
-                  helperText: {
-                    labelKey: `shared.fields.metrics.shareableOnHover.helperText.label`,
-                  },
-                  layout: "inline-space-between",
-                },
-              },
-            ],
-          },
         ],
       });
     });


### PR DESCRIPTION
1. Description:
2. 
Removed sharing section on metric pane for initiative and project entities

1. Instructions for testing:

1. Closes Issues: [10737](https://zentopia.esri.com/workspaces/sprint-board-60340b9721bc3a4ab6367db5/issues/gh/dc/hub/10737)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
