### PR TITLE
fix: getIncludesAndReferencesQuery accounts for no association group

### DIFF
--- a/packages/common/src/associations/internal/getIncludesAndReferencesQuery.ts
+++ b/packages/common/src/associations/internal/getIncludesAndReferencesQuery.ts
@@ -29,6 +29,14 @@ export const getIncludesAndReferencesQuery = async (
 ): Promise<IQuery> => {
   if (isParent) {
     /**
+     * 0. exit early if the parent's association group
+     * hasn't been created yet - there can be no associations
+     */
+    if (!getProp(entity, "associations")) {
+      return null;
+    }
+
+    /**
      * 1. build query that returns child entities WITH a
      * typeKeyword reference to the parent
      */

--- a/packages/common/test/associations/internal/getIncludesAndReferencesQuery.test.ts
+++ b/packages/common/test/associations/internal/getIncludesAndReferencesQuery.test.ts
@@ -1,4 +1,4 @@
-import { cloneObject } from "../../../src";
+import { HubEntity, cloneObject } from "../../../src";
 import { IArcGISContext } from "../../../src/ArcGISContext";
 import { getIncludesAndReferencesQuery } from "../../../src/associations/internal/getIncludesAndReferencesQuery";
 import { MOCK_PARENT_ENTITY, MOCK_CHILD_ENTITY } from "../fixtures";
@@ -6,6 +6,16 @@ import * as ItemsModule from "@esri/arcgis-rest-portal";
 
 describe("getIncludesAndReferencesQuery:", () => {
   describe("from the parent entity perspective", () => {
+    it("returns null if the parent's association group hasn't been created yet", async () => {
+      const query = await getIncludesAndReferencesQuery(
+        {} as HubEntity,
+        "project",
+        true,
+        {} as IArcGISContext
+      );
+
+      expect(query).toBeNull();
+    });
     it("returns a valid IQuery to fetch child entities", async () => {
       const query = await getIncludesAndReferencesQuery(
         MOCK_PARENT_ENTITY,


### PR DESCRIPTION
[10863](https://devtopia.esri.com/dc/hub/issues/10863)

### Description
updates the `getIncludesAndReferencesQuery` to account for a parent that doesn't yet have an association group. In this case, no full associations could have been formed, and we should exit early with a `null` query. 

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.