### PR TITLE
fix: group workspace access

### DIFF
--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -63,7 +63,7 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:content:delete",
     authenticated: true,
     services: ["portal"],
-    entityEdit: true,
+    entityDelete: true,
   },
   {
     permission: "hub:content:canChangeAccess",

--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -57,7 +57,7 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:discussion:delete",
     authenticated: true,
     dependencies: ["hub:discussion"],
-    entityOwner: true,
+    entityDelete: true,
     licenses: ["hub-premium"],
   },
   {

--- a/packages/common/src/events/_internal/EventBusinessRules.ts
+++ b/packages/common/src/events/_internal/EventBusinessRules.ts
@@ -58,7 +58,7 @@ export const EventPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:event:delete",
     authenticated: true,
     dependencies: ["hub:event"],
-    entityOwner: true,
+    entityDelete: true,
   },
   {
     permission: "hub:event:owner",

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -15,6 +15,7 @@ export const GroupPermissions = [
   "hub:group:view",
   "hub:group:owner",
   "hub:group:canChangeAccess",
+  "hub:group:canAssignMembers",
   "hub:group:workspace",
   "hub:group:workspace:overview",
   "hub:group:workspace:dashboard",
@@ -37,6 +38,7 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:group",
     services: ["portal"],
   },
+  // general permission to create a group
   {
     permission: "hub:group:create",
     dependencies: ["hub:group"],
@@ -50,10 +52,12 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
       },
     ],
   },
+  // permission to create a view group
   {
     permission: "hub:group:create:view",
     dependencies: ["hub:group:create"],
   },
+  // permission to create an edit group
   {
     permission: "hub:group:create:edit",
     dependencies: ["hub:group:create"],
@@ -63,29 +67,14 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:group:view",
     dependencies: ["hub:group"],
   },
+  // permission to update a group's metadata
   {
     permission: "hub:group:edit",
     dependencies: ["hub:group"],
     authenticated: true,
-    entityEdit: true,
-  },
-  {
-    permission: "hub:group:delete",
-    dependencies: ["hub:group"],
-    authenticated: true,
-    entityOwner: true,
-  },
-  {
-    permission: "hub:group:owner",
-    dependencies: ["hub:group"],
-    authenticated: true,
-    entityOwner: true,
-  },
-  {
-    permission: "hub:group:canChangeAccess",
-    dependencies: ["hub:group"],
-    authenticated: true,
     assertions: [
+      // if the user is not a group admin, they must
+      // have the portal:admin:updateGroups privilege
       {
         conditions: [
           {
@@ -98,6 +87,8 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
         type: "contains",
         value: ["portal:admin:updateGroups"],
       },
+      // if the user does not have the portal:admin:updateGroups
+      // privilege, they must be a group admin
       {
         conditions: [
           {
@@ -112,43 +103,188 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
       },
     ],
   },
+  // permission to delete a group
+  {
+    permission: "hub:group:delete",
+    dependencies: ["hub:group"],
+    authenticated: true,
+    assertions: [
+      // if the user is not the group owner, they must
+      // have the portal:admin:deleteGroups priv
+      {
+        conditions: [
+          {
+            property: "context:currentUser",
+            type: "is-not-group-owner",
+            value: "entity:id",
+          },
+        ],
+        property: "context:currentUser.privileges",
+        type: "contains",
+        value: ["portal:admin:deleteGroups"],
+      },
+      // if the user does not have the portal:admin:deleteGroups
+      // priv, they must be the group owner
+      {
+        conditions: [
+          {
+            property: "context:currentUser.privileges",
+            type: "without",
+            value: ["portal:admin:deleteGroups"],
+          },
+        ],
+        property: "context:currentUser",
+        type: "is-group-owner",
+        value: "entity:id",
+      },
+    ],
+  },
+  // permission to manage a group (via workspace)
+  // note: pane actions are further gated individually
+  {
+    permission: "hub:group:manage",
+    assertions: [
+      // if the user is not a group admin,
+      // they must have one of the necessary
+      // privileges
+      {
+        conditions: [
+          {
+            property: "context:currentUser",
+            type: "is-not-group-admin",
+            value: "entity:id",
+          },
+        ],
+        property: "context:currentUser.privileges",
+        type: "contains-some",
+        value: [
+          "portal:admin:updateGroups",
+          "portal:admin:deleteGroups",
+          "portal:admin:assignToGroups",
+          "portal:admin:shareToGroup",
+        ],
+      },
+      // if the user does not have one of the
+      // necessary privileges, they must be a
+      // group admin
+      {
+        conditions: [
+          {
+            property: "context:currentUser.privileges",
+            type: "without",
+            value: [
+              "portal:admin:updateGroups",
+              "portal:admin:deleteGroups",
+              "portal:admin:assignToGroups",
+              "portal:admin:shareToGroup",
+            ],
+          },
+        ],
+        property: "context:currentUser",
+        type: "is-group-admin",
+        value: "entity:id",
+      },
+    ],
+  },
+  {
+    permission: "hub:group:owner",
+    dependencies: ["hub:group"],
+    authenticated: true,
+    entityOwner: true,
+  },
+  {
+    permission: "hub:group:canChangeAccess",
+    dependencies: ["hub:group:edit"],
+  },
+  // permission to add/remove group members,
+  // and update member role
+  {
+    permission: "hub:group:canAssignMembers",
+    dependencies: ["hub:group"],
+    authenticated: true,
+    assertions: [
+      // if the user is not a group admin, they must
+      // have the portal:admin:assignToGroups privilege
+      {
+        conditions: [
+          {
+            property: "context:currentUser",
+            type: "is-not-group-admin",
+            value: "entity:id",
+          },
+        ],
+        property: "context:currentUser.privileges",
+        type: "contains",
+        value: ["portal:admin:assignToGroups"],
+      },
+      // if the user does not have the portal:admin:assignToGroups
+      // privilege, they must be a group admin
+      {
+        conditions: [
+          {
+            property: "context:currentUser.privileges",
+            type: "without",
+            value: ["portal:admin:assignToGroups"],
+          },
+        ],
+        property: "context:currentUser",
+        type: "is-group-admin",
+        value: "entity:id",
+      },
+    ],
+  },
   {
     permission: "hub:group:workspace",
-    dependencies: ["hub:feature:workspace"],
+    dependencies: ["hub:feature:workspace", "hub:group:manage"],
   },
   {
     permission: "hub:group:workspace:overview",
     availability: ["alpha"],
-    dependencies: ["hub:group:workspace", "hub:group:view"],
+    dependencies: ["hub:group:workspace"],
   },
   {
     permission: "hub:group:workspace:details",
-    dependencies: ["hub:group:workspace", "hub:group:edit"],
+    dependencies: ["hub:group:workspace"],
   },
   {
     permission: "hub:group:workspace:discussion",
-    dependencies: ["hub:group:workspace", "hub:group:edit"],
+    dependencies: ["hub:group:workspace"],
   },
   {
     permission: "hub:group:workspace:settings",
-    dependencies: ["hub:group:workspace", "hub:group:edit"],
+    dependencies: ["hub:group:workspace"],
   },
   {
     permission: "hub:group:workspace:content",
-    dependencies: ["hub:group:workspace", "hub:group:view"],
+    dependencies: ["hub:group:workspace"],
   },
   {
     permission: "hub:group:workspace:members",
-    dependencies: ["hub:group:workspace", "hub:group:view"],
+    dependencies: ["hub:group:workspace"],
   },
-  // This is meant for checking if you can share content while within a group
+  // permission to check if you can add/remove content from groups
   {
     permission: "hub:group:shareContent",
     dependencies: ["hub:group"],
     authenticated: true,
     privileges: ["portal:user:shareToGroup"],
     assertions: [
-      // If the group is not view only, any member can share content
+      // If user is not a group member (owner, manager, or member),
+      // they must have the portal:admin:shareToGroup privilege
+      {
+        conditions: [
+          {
+            property: "context:currentUser",
+            type: "is-not-group-member",
+            value: "entity:id",
+          },
+        ],
+        property: "context:currentUser.privileges",
+        type: "contains",
+        value: ["portal:admin:shareToGroup"],
+      },
+      // If the group is not view only, any group member
+      // can share content
       {
         conditions: [
           {
@@ -162,7 +298,8 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
         value: "entity:id",
       },
 
-      // if the group is view only, only group admins can share content
+      // if the group is view only, only group admins can
+      // share content
       {
         conditions: [
           {
@@ -176,9 +313,5 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
         value: "entity:id",
       },
     ],
-  },
-  {
-    permission: "hub:group:manage",
-    dependencies: ["hub:group:edit"],
   },
 ];

--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateBusinessRules.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateBusinessRules.ts
@@ -56,7 +56,7 @@ export const InitiativeTemplatePermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:initiativeTemplate:delete",
     dependencies: ["hub:initiativeTemplate"],
     authenticated: true,
-    entityOwner: true,
+    entityDelete: true,
   },
   {
     permission: "hub:initiativeTemplate:canChangeAccess",

--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -81,8 +81,7 @@ export const InitiativePermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:initiative:delete",
     dependencies: ["hub:initiative"],
     authenticated: true,
-
-    entityOwner: true,
+    entityDelete: true,
   },
   {
     permission: "hub:initiative:canChangeAccess",

--- a/packages/common/src/pages/_internal/PageBusinessRules.ts
+++ b/packages/common/src/pages/_internal/PageBusinessRules.ts
@@ -57,7 +57,7 @@ export const PagePermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:page:delete",
     dependencies: ["hub:page"],
     authenticated: true,
-    entityOwner: true,
+    entityDelete: true,
   },
   {
     permission: "hub:page:canChangeAccess",

--- a/packages/common/src/permissions/_internal/checkDelete.ts
+++ b/packages/common/src/permissions/_internal/checkDelete.ts
@@ -1,0 +1,45 @@
+import { IArcGISContext } from "../../ArcGISContext";
+import { getWithDefault } from "../../objects";
+import { IPermissionPolicy, PolicyResponse, IPolicyCheck } from "../types";
+import { getPolicyResponseCode } from "./getPolicyResponseCode";
+
+/**
+ * Validate entityDelete policy - delegates to the
+ * entity's canDelete property
+ * @param policy
+ * @param context
+ * @param entity
+ * @returns
+ */
+export function checkDelete(
+  policy: IPermissionPolicy,
+  context: IArcGISContext,
+  entity?: Record<string, any>
+): IPolicyCheck[] {
+  const checks = [] as IPolicyCheck[];
+
+  if (policy.hasOwnProperty("entityDelete")) {
+    let response: PolicyResponse = "granted";
+    if (!entity) {
+      // fail b/c no entity
+      response = "entity-required";
+    } else {
+      if (policy.entityDelete && !entity.canDelete) {
+        response = "no-delete-access";
+      } else if (!policy.entityDelete && entity.canDelete) {
+        response = "delete-access";
+      }
+    }
+
+    // create the check
+    const check: IPolicyCheck = {
+      name: "entity delete required",
+      value: `entity.canDelete: ${getWithDefault(entity, "canDelete", false)}`,
+      code: getPolicyResponseCode(response),
+      response,
+    };
+    checks.push(check);
+  }
+
+  return checks;
+}

--- a/packages/common/src/permissions/checkPermission.ts
+++ b/packages/common/src/permissions/checkPermission.ts
@@ -7,6 +7,7 @@ import { getPolicyResponseCode } from "./_internal/getPolicyResponseCode";
 import { checkAuthentication } from "./_internal/checkAuthentication";
 import { checkOwner } from "./_internal/checkOwner";
 import { checkEdit } from "./_internal/checkEdit";
+import { checkDelete } from "./_internal/checkDelete";
 import { checkPrivileges } from "./_internal/checkPrivileges";
 import { checkEntityPolicy } from "./_internal/checkEntityPolicy";
 import { checkAssertions } from "./_internal/checkAssertions";
@@ -156,6 +157,7 @@ export function checkPermission(
     checkPrivileges,
     checkOwner,
     checkEdit,
+    checkDelete,
     checkLicense,
     checkAssertions,
   ];

--- a/packages/common/src/permissions/types/IPermissionPolicy.ts
+++ b/packages/common/src/permissions/types/IPermissionPolicy.ts
@@ -66,6 +66,11 @@ export interface IPermissionPolicy {
   entityEdit?: boolean;
 
   /**
+   * Can the user delete the entity being accessed?
+   */
+  entityDelete?: boolean;
+
+  /**
    * Must the user be the owner of the entity being accessed?
    */
   entityOwner?: boolean;
@@ -145,7 +150,9 @@ export type AssertionType =
   | "is-group-admin"
   | "is-not-group-admin"
   | "is-group-member"
+  | "is-not-group-member"
   | "is-group-owner"
+  | "is-not-group-owner"
   | "starts-with"
   | "ends-with"
   | "not-starts-with"

--- a/packages/common/src/permissions/types/PolicyResponse.ts
+++ b/packages/common/src/permissions/types/PolicyResponse.ts
@@ -19,6 +19,8 @@ export type PolicyResponse =
   | "not-granted" // user does not have permission
   | "no-edit-access" // user does not have edit access
   | "edit-access" // user has edit access but policy is for non-editors
+  | "no-delete-access" // user does not have delete access
+  | "delete-access" // user has delete access but policy is for non-deleters
   | "invalid-permission" // permission is invalid
   | "invalid-capability" // capability is invalid
   | "privilege-required" // user does not have required privilege
@@ -39,6 +41,8 @@ export type PolicyResponse =
   | "user-not-group-manager"
   | "user-not-group-owner"
   | "user-is-group-manager"
+  | "user-is-group-member"
+  | "user-is-group-owner"
   | "assertion-property-not-found"
   | "assertion-failed" // assertion condition was not met
   | "assertion-requires-numeric-values" // assertion requires numeric values

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -70,7 +70,7 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:project:delete",
     dependencies: ["hub:project"],
     authenticated: true,
-    entityOwner: true,
+    entityDelete: true,
   },
   {
     permission: "hub:project:owner",

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -73,7 +73,7 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:site:delete",
     dependencies: ["hub:site"],
     authenticated: true,
-    entityOwner: true,
+    entityDelete: true,
   },
   {
     permission: "hub:site:edit",

--- a/packages/common/src/surveys/_internal/SurveyBusinessRules.ts
+++ b/packages/common/src/surveys/_internal/SurveyBusinessRules.ts
@@ -56,7 +56,7 @@ export const SurveyPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:survey:delete",
     authenticated: true,
     dependencies: ["hub:survey"],
-    entityOwner: true,
+    entityDelete: true,
   },
   {
     permission: "hub:survey:owner",

--- a/packages/common/src/templates/_internal/TemplateBusinessRules.ts
+++ b/packages/common/src/templates/_internal/TemplateBusinessRules.ts
@@ -45,7 +45,7 @@ export const TemplatePermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:template:delete",
     dependencies: ["hub:template"],
     authenticated: true,
-    entityOwner: true,
+    entityDelete: true,
   },
   {
     permission: "hub:template:view",

--- a/packages/common/test/permissions/_internal/checkDelete.test.ts
+++ b/packages/common/test/permissions/_internal/checkDelete.test.ts
@@ -1,0 +1,61 @@
+import { HubEntity, IArcGISContext } from "../../../src";
+import { IPermissionPolicy } from "../../../src/permissions/types";
+import { checkDelete } from "../../../src/permissions/_internal/checkDelete";
+
+describe("checkDelete:", () => {
+  it("returns entity-required if not passed entity", () => {
+    const ctx = {} as unknown as IArcGISContext;
+    const policy = {
+      entityDelete: true,
+    } as unknown as IPermissionPolicy;
+
+    const chks = checkDelete(policy, ctx);
+    expect(chks.length).toBe(1);
+    expect(chks[0].response).toBe("entity-required");
+  });
+  it("returns granted if entity.canDelete is true", () => {
+    const ctx = {} as unknown as IArcGISContext;
+    const policy = {
+      entityDelete: true,
+    } as unknown as IPermissionPolicy;
+    const entity = {
+      canDelete: true,
+    } as unknown as HubEntity;
+    const chks = checkDelete(policy, ctx, entity);
+    expect(chks.length).toBe(1);
+    expect(chks[0].response).toBe("granted");
+  });
+  it("returns no-delete-access if entity.canDelete is false", () => {
+    const ctx = {} as unknown as IArcGISContext;
+    const policy = {
+      entityDelete: true,
+    } as unknown as IPermissionPolicy;
+    const entity = {
+      canDelete: false,
+    } as unknown as HubEntity;
+    const chks = checkDelete(policy, ctx, entity);
+    expect(chks.length).toBe(1);
+    expect(chks[0].response).toBe("no-delete-access");
+  });
+  it("returns empty array if policy does not specify entityDelete", () => {
+    const ctx = {} as unknown as IArcGISContext;
+    const policy = {} as unknown as IPermissionPolicy;
+    const entity = {
+      canDelete: true,
+    } as unknown as HubEntity;
+    const chks = checkDelete(policy, ctx, entity);
+    expect(chks.length).toBe(0);
+  });
+  it("returns edit-access if policy entityDelete is false", () => {
+    const ctx = {} as unknown as IArcGISContext;
+    const policy = {
+      entityDelete: false,
+    } as unknown as IPermissionPolicy;
+    const entity = {
+      canDelete: true,
+    } as unknown as HubEntity;
+    const chks = checkDelete(policy, ctx, entity);
+    expect(chks.length).toBe(1);
+    expect(chks[0].response).toBe("delete-access");
+  });
+});


### PR DESCRIPTION
[9918](https://devtopia.esri.com/dc/hub/issues/9918)

### Description
- adds new `checkDelete` to permission system. This delegates to checking `entity.canDelete`
- updates all `hub:<entity>:delete` permissions to delegate to the new `checkDelete` functionality
- adds new permission assertions
- updates and adds group business rules

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.