### PR TITLE
feat(hub-common): support KML format for create replica

### DIFF
--- a/packages/common/src/downloads/_internal/_types.ts
+++ b/packages/common/src/downloads/_internal/_types.ts
@@ -61,5 +61,6 @@ export const CREATE_REPLICA_FORMATS = [
   ServiceDownloadFormat.GEO_PACKAGE,
   ServiceDownloadFormat.SQLITE,
   ServiceDownloadFormat.JSON,
+  ServiceDownloadFormat.KML,
 ] as const;
 export type CreateReplicaFormat = (typeof CREATE_REPLICA_FORMATS)[number];

--- a/packages/common/src/downloads/_internal/format-fetchers/getCreateReplicaFormats.ts
+++ b/packages/common/src/downloads/_internal/format-fetchers/getCreateReplicaFormats.ts
@@ -20,12 +20,7 @@ export function getCreateReplicaFormats(
 
   // List any unrecognized formats (we'll append these to the end of the final array)
   const unrecognizedFormats = allFormats.filter(
-    (format) =>
-      !CREATE_REPLICA_FORMATS.includes(format as CreateReplicaFormat) &&
-      // KML is a valid createReplica format in QA and Dev, but not Prod.
-      // Once it's enabled in Prod, we can add KML to CREATE_REPLICA_FORMATS
-      // and remove this check.
-      format !== ServiceDownloadFormat.KML
+    (format) => !CREATE_REPLICA_FORMATS.includes(format as CreateReplicaFormat)
   );
 
   return [...recognizedFormats, ...unrecognizedFormats].map(

--- a/packages/common/test/downloads/_internal/format-fetchers/getCreateReplicaFormats.test.ts
+++ b/packages/common/test/downloads/_internal/format-fetchers/getCreateReplicaFormats.test.ts
@@ -37,19 +37,4 @@ describe("getCreateReplicaFormats", () => {
       "unknown-format" as ServiceDownloadFormat,
     ]);
   });
-  // TODO: Remove once createReplica supports KML in production
-  it("should filter out KML as a format", () => {
-    const entity = {
-      serverExtractFormats: [
-        ServiceDownloadFormat.GEOJSON,
-        ServiceDownloadFormat.KML,
-        ServiceDownloadFormat.JSON,
-      ],
-    } as unknown as IHubEditableContent;
-    const result = getCreateReplicaFormats(entity);
-    expect(result.map((r) => r.format)).toEqual([
-      ServiceDownloadFormat.GEOJSON,
-      ServiceDownloadFormat.JSON,
-    ]);
-  });
 });


### PR DESCRIPTION
1. Description: Add KML format for create replica.

1. Instructions for testing:

1. Closes Issues: #[10390](https://devtopia.esri.com/dc/hub/issues/10390)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
