### PR TITLE
feat(hub-common): enable all map tools

### DIFF
--- a/packages/common/src/events/_internal/EventUiSchemaEdit.ts
+++ b/packages/common/src/events/_internal/EventUiSchemaEdit.ts
@@ -223,7 +223,6 @@ export const buildUiSchema = async (
                 context.portal.name,
                 context.hubRequestOptions
               ),
-              mapTools: ["polygon", "rectangle"],
             },
           },
           {

--- a/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
+++ b/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
@@ -301,7 +301,6 @@ describe("EventUiSchemaEdit", () => {
                   control: "hub-field-input-location-picker",
                   extent: [],
                   options: [],
-                  mapTools: ["polygon", "rectangle"],
                 },
               },
               {


### PR DESCRIPTION
1. Description: Enables all possible map tools for event location picker.

1. Instructions for testing:

1. Closes Issues: #10850

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
