### PR TITLE
feat(hub-common): add IEventRegistrationCount to IEvent

### DIFF
--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -265,40 +265,9 @@ export interface IEventPermission {
   canSetStatusToRemoved: boolean;
 }
 
-export interface IEvent {
-  access: EventAccess;
-  allDay: boolean;
-  allowRegistration: boolean;
-  associations?: IEventAssociation[];
-  attendanceType: EventAttendanceType[];
-  categories: string[];
-  createdAt: string;
-  createdById: string | null;
-  creator?: IUser;
-  description: string | null;
-  editGroups: string[];
-  endDate: string;
-  endDateTime: string;
-  endTime: string;
-  id: string;
-  inPersonCapacity: number | null;
-  location?: IEventLocation;
-  notifyAttendees: boolean;
-  onlineMeetings?: IOnlineMeeting[];
-  orgId: string;
-  permission: IEventPermission;
-  readGroups: string[];
-  recurrence: string | null;
-  registrations?: IRegistration[];
-  startDate: string;
-  startDateTime: string;
-  startTime: string;
-  status: EventStatus;
-  summary: string | null;
-  tags: string[];
-  timeZone: string;
-  title: string;
-  updatedAt: string;
+export interface IEventRegistrationCount {
+  inPerson: number;
+  virtual: number;
 }
 
 export enum RegistrationStatus {
@@ -392,6 +361,43 @@ export interface IEventAssociation {
   entityId: string;
   entityType: EventAssociationEntityType;
   eventId: string;
+}
+
+export interface IEvent {
+  access: EventAccess;
+  allDay: boolean;
+  allowRegistration: boolean;
+  associations?: IEventAssociation[];
+  attendanceType: EventAttendanceType[];
+  categories: string[];
+  createdAt: string;
+  createdById: string | null;
+  creator?: IUser;
+  description: string | null;
+  editGroups: string[];
+  endDate: string;
+  endDateTime: string;
+  endTime: string;
+  id: string;
+  inPersonCapacity: number | null;
+  location?: IEventLocation;
+  notifyAttendees: boolean;
+  onlineMeetings?: IOnlineMeeting[];
+  orgId: string;
+  permission: IEventPermission;
+  readGroups: string[];
+  recurrence: string | null;
+  registrationCount?: IEventRegistrationCount;
+  registrations?: IRegistration[];
+  startDate: string;
+  startDateTime: string;
+  startTime: string;
+  status: EventStatus;
+  summary: string | null;
+  tags: string[];
+  timeZone: string;
+  title: string;
+  updatedAt: string;
 }
 
 export interface ICreateOnlineMeeting {

--- a/packages/common/src/events/api/types.ts
+++ b/packages/common/src/events/api/types.ts
@@ -17,6 +17,7 @@ export {
   ILocationSpatialReference,
   IEventLocationSpatialReference,
   ICreateLocationSpatialReference,
+  IEventRegistrationCount,
   ICreateEventLocation,
   ICreateEventLocationGeometriesItem,
   IRegistration,


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: add registration count to `IEvent`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
