### PR TITLE
feat(hub-common): change public int ids to cuids

### DIFF
--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -287,7 +287,7 @@ export interface IRegistration {
   createdById: string;
   event?: IEvent;
   eventId: string;
-  id: number;
+  id: string;
   permission: IRegistrationPermission;
   role: RegistrationRole;
   status: RegistrationStatus;
@@ -331,7 +331,7 @@ export interface IEventLocation {
   eventId: string;
   extent: number[][] | null;
   geometries: IEventLocationGeometriesItem[] | null;
-  id: number;
+  id: string;
   nbrhd: string | null;
   placeAddr: string | null;
   placeName: string | null;
@@ -631,7 +631,7 @@ export const getRegistrations = (
 };
 
 export const getRegistration = (
-  id: number,
+  id: string,
   options?: SecondParameter<typeof customClient>
 ) => {
   return customClient<IRegistration>(
@@ -641,7 +641,7 @@ export const getRegistration = (
 };
 
 export const updateRegistration = (
-  id: number,
+  id: string,
   iUpdateRegistration: IUpdateRegistration,
   options?: SecondParameter<typeof customClient>
 ) => {
@@ -657,7 +657,7 @@ export const updateRegistration = (
 };
 
 export const deleteRegistration = (
-  id: number,
+  id: string,
   options?: SecondParameter<typeof customClient>
 ) => {
   return customClient<IRegistration>(

--- a/packages/common/src/events/api/types.ts
+++ b/packages/common/src/events/api/types.ts
@@ -87,12 +87,12 @@ export interface IGetRegistrationsParams extends IEventsRequestOptions {
   data: GetRegistrationsParams;
 }
 export interface IGetRegistrationParams extends IEventsRequestOptions {
-  registrationId: number;
+  registrationId: string;
 }
 export interface IUpdateRegistrationParams extends IEventsRequestOptions {
-  registrationId: number;
+  registrationId: string;
   data: IUpdateRegistration;
 }
 export interface IDeleteRegistrationParams extends IEventsRequestOptions {
-  registrationId: number;
+  registrationId: string;
 }

--- a/packages/common/src/events/edit.ts
+++ b/packages/common/src/events/edit.ts
@@ -152,7 +152,7 @@ export function createHubEventRegistration(
  * @returns Promise<void>
  */
 export async function deleteHubEventRegistration(
-  id: number,
+  id: string,
   requestOptions: IHubRequestOptions
 ): Promise<void> {
   await deleteRegistration({ registrationId: id, ...requestOptions });

--- a/packages/common/test/events/api/registrations.test.ts
+++ b/packages/common/test/events/api/registrations.test.ts
@@ -69,7 +69,7 @@ describe("Registrations", () => {
       ).and.callFake(async () => mockRegistration);
 
       const options: IGetRegistrationParams = {
-        registrationId: 111,
+        registrationId: "111",
       };
 
       const result = await getRegistration(options);
@@ -126,7 +126,7 @@ describe("Registrations", () => {
       ).and.callFake(async () => mockRegistration);
 
       const options: IUpdateRegistrationParams = {
-        registrationId: 111,
+        registrationId: "111",
         data: {
           role: RegistrationRole.ORGANIZER,
           status: RegistrationStatus.DECLINED,
@@ -157,7 +157,7 @@ describe("Registrations", () => {
       ).and.callFake(async () => mockRegistration);
 
       const options: IDeleteRegistrationParams = {
-        registrationId: 111,
+        registrationId: "111",
       };
 
       const result = await deleteRegistration(options);

--- a/packages/common/test/events/edit.test.ts
+++ b/packages/common/test/events/edit.test.ts
@@ -401,11 +401,11 @@ describe("HubEvents edit module", () => {
         return Promise.resolve();
       });
       await deleteHubEventRegistration(
-        0o1,
+        "0o1",
         authdCtxMgr.context.hubRequestOptions
       );
       expect(deleteRegistrationSpy).toHaveBeenCalledWith({
-        registrationId: 0o1,
+        registrationId: "0o1",
         ...authdCtxMgr.context.hubRequestOptions,
       });
     });

--- a/packages/common/test/search/_internal/hubEventsHelpers/eventAttendeeToSearchResult.test.ts
+++ b/packages/common/test/search/_internal/hubEventsHelpers/eventAttendeeToSearchResult.test.ts
@@ -18,7 +18,7 @@ describe("event search utils", () => {
           createdAt: "2024-04-17T15:30:42+0000",
           createdById: "a creator id",
           eventId: "an event id",
-          id: 0,
+          id: "0",
           permission: {
             canDelete: true,
             canEdit: true,

--- a/packages/common/test/search/_internal/hubSearchEventAttendees.test.ts
+++ b/packages/common/test/search/_internal/hubSearchEventAttendees.test.ts
@@ -23,7 +23,7 @@ describe("hubSearchEventAttendees", () => {
           createdAt: "2024-04-19T12:15:07.222Z",
           createdById: "t_miller",
           eventId: "event1Id",
-          id: 52123,
+          id: "52123",
           permission: {
             canDelete: false,
             canEdit: false,
@@ -38,7 +38,7 @@ describe("hubSearchEventAttendees", () => {
           createdAt: "2024-04-21T11:15:07.222Z",
           createdById: "t_miller",
           eventId: "event2Id",
-          id: 52124,
+          id: "52124",
           permission: {
             canDelete: false,
             canEdit: false,
@@ -60,7 +60,7 @@ describe("hubSearchEventAttendees", () => {
           createdAt: "2024-06-21T11:15:07.222Z",
           createdById: "c_boyd",
           eventId: "event3Id",
-          id: 52125,
+          id: "52125",
           permission: {
             canDelete: false,
             canEdit: false,
@@ -75,7 +75,7 @@ describe("hubSearchEventAttendees", () => {
           createdAt: "2024-07-21T11:15:07.222Z",
           createdById: "a_burns",
           eventId: "event3Id",
-          id: 52126,
+          id: "52126",
           permission: {
             canDelete: false,
             canEdit: false,

--- a/packages/common/test/search/_internal/hubSearchEvents.test.ts
+++ b/packages/common/test/search/_internal/hubSearchEvents.test.ts
@@ -91,7 +91,7 @@ describe("hubSearchEvents", () => {
             createdAt: "2024-04-19T12:15:07.222Z",
             createdById: "t_miller",
             eventId: "event1Id",
-            id: 52123,
+            id: "52123",
             permission: {
               canDelete: false,
               canEdit: false,
@@ -147,7 +147,7 @@ describe("hubSearchEvents", () => {
             createdAt: "2024-04-21T11:15:07.222Z",
             createdById: "t_miller",
             eventId: "event2Id",
-            id: 52124,
+            id: "52124",
             permission: {
               canDelete: false,
               canEdit: false,
@@ -213,7 +213,7 @@ describe("hubSearchEvents", () => {
             createdAt: "2024-06-21T11:15:07.222Z",
             createdById: "c_boyd",
             eventId: "event3Id",
-            id: 52125,
+            id: "52125",
             permission: {
               canDelete: false,
               canEdit: false,
@@ -228,7 +228,7 @@ describe("hubSearchEvents", () => {
             createdAt: "2024-07-21T11:15:07.222Z",
             createdById: "a_burns",
             eventId: "event3Id",
-            id: 52126,
+            id: "52126",
             permission: {
               canDelete: false,
               canEdit: false,


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
