### PR TITLE
feat(): added info feature on summary-statistic card

### DIFF
--- a/packages/common/src/core/schemas/internal/metrics/MetricSchema.ts
+++ b/packages/common/src/core/schemas/internal/metrics/MetricSchema.ts
@@ -102,11 +102,16 @@ export const MetricSchema: IConfigurationSchema = {
       type: "boolean",
       default: true,
     },
-    popoverTitle: {
+    styleSpecificInfo: {
       type: "string",
     },
-    popoverDescription: {
+    popoverText: {
       type: "string",
+      maxLength: 180,
+    },
+    publisherText: {
+      type: "string",
+      maxLength: 50,
     },
   },
   allOf: [
@@ -119,11 +124,11 @@ export const MetricSchema: IConfigurationSchema = {
     "if-layout-moreinfo-then-require-popover-title-description": {
       if: {
         type: "object",
-        properties: { layout: { const: LAYOUTS.moreInfo } },
+        properties: { layout: { const: LAYOUTS.informational } },
         required: ["layout"],
       },
       then: {
-        required: ["popoverTitle", "popoverDescription"],
+        required: ["styleSpecificInfo", "popoverText", "publisherText"],
       },
     },
     "if-source-title-then-source-link": {

--- a/packages/common/src/core/schemas/internal/metrics/StatCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/metrics/StatCardUiSchema.ts
@@ -227,11 +227,10 @@ export const buildUiSchema = async (
             labelKey: `appearance.layout.label`,
             scope: "/properties/layout",
             type: "Control",
-            rule: HIDE_FOR_ALL, // Temporary while no layouts
             options: {
               control: "hub-field-input-select",
               enum: {
-                i18nScope: `layout.enum`,
+                i18nScope: `appearance.layout.enum`,
               },
             },
           },
@@ -239,7 +238,6 @@ export const buildUiSchema = async (
             labelKey: `appearance.textAlign`,
             scope: "/properties/textAlign",
             type: "Control",
-            rule: HIDE_FOR_DATA_VIZ_RULE,
             options: {
               control: "hub-field-input-alignment",
             },
@@ -265,7 +263,6 @@ export const buildUiSchema = async (
               },
             },
           },
-
           {
             labelKey: `appearance.visualInterest.label`,
             scope: "/properties/visualInterest",
@@ -279,16 +276,50 @@ export const buildUiSchema = async (
             },
           },
           {
-            labelKey: `appearance.popoverTitle`,
-            scope: "/properties/popoverTitle",
-            type: "Control",
+            labelKey: `appearance.styleSpecificInfo.label`,
+            scope: "/properties/styleSpecificInfo",
+            type: "Section",
             rule: SHOW_FOR_MORE_INFO_RULE,
+            options: {
+              helperText: {
+                labelKey: `appearance.styleSpecificInfo.helperText`,
+              },
+            },
           },
           {
-            labelKey: `appearance.popoverDescription`,
-            scope: "/properties/popoverDescription",
+            labelKey: `appearance.popoverText.label`,
+            scope: "/properties/popoverText",
             type: "Control",
             rule: SHOW_FOR_MORE_INFO_RULE,
+            options: {
+              control: "hub-field-input-input",
+              type: "textarea",
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `appearance.popoverText.maxLengthError`,
+                },
+              ],
+            },
+          },
+          {
+            labelKey: `appearance.publisherText.label`,
+            scope: "/properties/publisherText",
+            type: "Control",
+            rule: SHOW_FOR_MORE_INFO_RULE,
+            options: {
+              control: "hub-field-input-input",
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "maxLength",
+                  icon: true,
+                  labelKey: `appearance.publisherText.maxLengthError`,
+                },
+              ],
+            },
           },
         ],
       },
@@ -344,19 +375,11 @@ const HIDE_FOR_ALL = {
   },
 };
 
-const HIDE_FOR_DATA_VIZ_RULE = {
-  effect: UiSchemaRuleEffects.HIDE,
-  condition: {
-    scope: "/properties/layout",
-    schema: { enum: ["dataViz"] },
-  },
-};
-
 const SHOW_FOR_MORE_INFO_RULE = {
   effect: UiSchemaRuleEffects.SHOW,
   condition: {
     scope: "/properties/layout",
-    schema: { const: "moreInfo" },
+    schema: { const: "informational" },
   },
 };
 

--- a/packages/common/src/core/schemas/internal/metrics/interfaces.ts
+++ b/packages/common/src/core/schemas/internal/metrics/interfaces.ts
@@ -1,7 +1,6 @@
 export enum LAYOUTS {
   simple = "simple",
-  dataViz = "dataViz",
-  moreInfo = "moreInfo",
+  informational = "informational",
 }
 export enum SCALE {
   small = "s",

--- a/packages/common/test/core/schemas/internal/metrics/StatCardUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/StatCardUiSchema.test.ts
@@ -292,17 +292,10 @@ describe("buildUiSchema: stat", () => {
               labelKey: `appearance.layout.label`,
               scope: "/properties/layout",
               type: "Control",
-              rule: {
-                effect: UiSchemaRuleEffects.HIDE,
-                condition: {
-                  scope: "/properties/type",
-                  schema: { enum: ["static", "dynamic"] },
-                },
-              },
               options: {
                 control: "hub-field-input-select",
                 enum: {
-                  i18nScope: `layout.enum`,
+                  i18nScope: `appearance.layout.enum`,
                 },
               },
             },
@@ -310,13 +303,6 @@ describe("buildUiSchema: stat", () => {
               labelKey: `appearance.textAlign`,
               scope: "/properties/textAlign",
               type: "Control",
-              rule: {
-                effect: UiSchemaRuleEffects.HIDE,
-                condition: {
-                  scope: "/properties/layout",
-                  schema: { enum: ["dataViz"] },
-                },
-              },
               options: {
                 control: "hub-field-input-alignment",
               },
@@ -380,27 +366,67 @@ describe("buildUiSchema: stat", () => {
             //   }
             // },
             {
-              labelKey: `appearance.popoverTitle`,
-              scope: "/properties/popoverTitle",
-              type: "Control",
+              labelKey: `appearance.styleSpecificInfo.label`,
+              scope: "/properties/styleSpecificInfo",
+              type: "Section",
               rule: {
                 effect: UiSchemaRuleEffects.SHOW,
                 condition: {
                   scope: "/properties/layout",
-                  schema: { const: "moreInfo" },
+                  schema: { const: "informational" },
+                },
+              },
+              options: {
+                helperText: {
+                  labelKey: `appearance.styleSpecificInfo.helperText`,
                 },
               },
             },
             {
-              labelKey: `appearance.popoverDescription`,
-              scope: "/properties/popoverDescription",
+              labelKey: `appearance.popoverText.label`,
+              scope: "/properties/popoverText",
               type: "Control",
               rule: {
                 effect: UiSchemaRuleEffects.SHOW,
                 condition: {
                   scope: "/properties/layout",
-                  schema: { const: "moreInfo" },
+                  schema: { const: "informational" },
                 },
+              },
+              options: {
+                control: "hub-field-input-input",
+                type: "textarea",
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `appearance.popoverText.maxLengthError`,
+                  },
+                ],
+              },
+            },
+            {
+              labelKey: `appearance.publisherText.label`,
+              scope: "/properties/publisherText",
+              type: "Control",
+              rule: {
+                effect: UiSchemaRuleEffects.SHOW,
+                condition: {
+                  scope: "/properties/layout",
+                  schema: { const: "informational" },
+                },
+              },
+              options: {
+                control: "hub-field-input-input",
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "maxLength",
+                    icon: true,
+                    labelKey: `appearance.publisherText.maxLengthError`,
+                  },
+                ],
               },
             },
           ],


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
