### PR TITLE
feat(hub-common): change order of download button for KML format

### DIFF
--- a/packages/common/src/downloads/_internal/_types.ts
+++ b/packages/common/src/downloads/_internal/_types.ts
@@ -63,12 +63,12 @@ export const CREATE_REPLICA_FORMATS = [
   ServiceDownloadFormat.CSV,
   ServiceDownloadFormat.SHAPEFILE,
   ServiceDownloadFormat.GEOJSON,
+  ServiceDownloadFormat.KML,
   ServiceDownloadFormat.FILE_GDB,
   ServiceDownloadFormat.FEATURE_COLLECTION,
   ServiceDownloadFormat.EXCEL,
   ServiceDownloadFormat.GEO_PACKAGE,
   ServiceDownloadFormat.SQLITE,
   ServiceDownloadFormat.JSON,
-  ServiceDownloadFormat.KML,
 ] as const;
 export type CreateReplicaFormat = (typeof CREATE_REPLICA_FORMATS)[number];


### PR DESCRIPTION
1. Description: This PR changes the position of KML download button for updated download card as suggested [here](https://devtopia.esri.com/dc/hub/issues/10390#issuecomment-4874200).

1. Instructions for testing:

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/10390

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
