### PR TITLE
fix(hub-common): add inPersonCapacityType to IHubEvent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22688,10 +22688,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22706,24 +22705,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22737,10 +22733,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22758,10 +22753,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65016,7 +65010,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.152.0",
+			"version": "14.160.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -83471,8 +83465,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83487,20 +83480,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83514,8 +83504,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83532,8 +83521,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/core/types/IHubEvent.ts
+++ b/packages/common/src/core/types/IHubEvent.ts
@@ -78,7 +78,12 @@ export interface IHubEvent extends IHubItemEntity, IWithPermissions, IWithSlug {
   /**
    * The maximum capacity for in-person attendance
    */
-  inPersonCapacity?: number | null;
+  inPersonCapacity: number | null;
+
+  /**
+   * The capacity type for an in-person event, either `unlimited` or `fixed`
+   */
+  inPersonCapacityType: HubEventCapacityType;
 
   /**
    * The current number of in-person registrants with a registration status of `accepted`
@@ -118,7 +123,7 @@ export interface IHubEvent extends IHubItemEntity, IWithPermissions, IWithSlug {
   /**
    * The maximum attendance capacity for an online event
    */
-  onlineCapacity?: number | null;
+  onlineCapacity: number | null;
 
   /**
    * The current number of online registrants with a registration status of `accepted`
@@ -128,7 +133,7 @@ export interface IHubEvent extends IHubItemEntity, IWithPermissions, IWithSlug {
   /**
    * The capacity type for an online event, either `unlimited` or `fixed`
    */
-  onlineCapacityType?: HubEventCapacityType;
+  onlineCapacityType: HubEventCapacityType;
 
   /**
    * The details for an online event

--- a/packages/common/src/events/_internal/PropertyMapper.ts
+++ b/packages/common/src/events/_internal/PropertyMapper.ts
@@ -68,7 +68,6 @@ export class EventPropertyMapper extends PropertyMapper<
     obj.onlineCapacityType = store.onlineMeeting?.capacity
       ? HubEventCapacityType.Fixed
       : HubEventCapacityType.Unlimited;
-    obj.inPersonCapacity = store.inPersonCapacity ?? null;
     obj.inPersonCapacityType = store.inPersonCapacity
       ? HubEventCapacityType.Fixed
       : HubEventCapacityType.Unlimited;

--- a/packages/common/src/events/_internal/PropertyMapper.ts
+++ b/packages/common/src/events/_internal/PropertyMapper.ts
@@ -167,8 +167,6 @@ export class EventPropertyMapper extends PropertyMapper<
             : null,
         url: clonedEntity.onlineUrl,
       } as IOnlineMeeting;
-    } else {
-      obj.onlineMeeting = null;
     }
     if (
       [HubEventAttendanceType.InPerson, HubEventAttendanceType.Both].includes(

--- a/packages/common/src/events/_internal/PropertyMapper.ts
+++ b/packages/common/src/events/_internal/PropertyMapper.ts
@@ -68,6 +68,7 @@ export class EventPropertyMapper extends PropertyMapper<
     obj.onlineCapacityType = store.onlineMeeting?.capacity
       ? HubEventCapacityType.Fixed
       : HubEventCapacityType.Unlimited;
+    obj.inPersonCapacity = store.inPersonCapacity ?? null;
     obj.inPersonCapacityType = store.inPersonCapacity
       ? HubEventCapacityType.Fixed
       : HubEventCapacityType.Unlimited;
@@ -166,6 +167,8 @@ export class EventPropertyMapper extends PropertyMapper<
             : null,
         url: clonedEntity.onlineUrl,
       } as IOnlineMeeting;
+    } else {
+      obj.onlineMeeting = null;
     }
     if (
       [HubEventAttendanceType.InPerson, HubEventAttendanceType.Both].includes(
@@ -176,6 +179,8 @@ export class EventPropertyMapper extends PropertyMapper<
         clonedEntity.inPersonCapacityType === HubEventCapacityType.Fixed
           ? clonedEntity.inPersonCapacity
           : null;
+    } else {
+      obj.inPersonCapacity = null;
     }
 
     // override startTime & endTime for all-day events

--- a/packages/common/src/events/_internal/PropertyMapper.ts
+++ b/packages/common/src/events/_internal/PropertyMapper.ts
@@ -68,6 +68,7 @@ export class EventPropertyMapper extends PropertyMapper<
     obj.onlineCapacityType = store.onlineMeeting?.capacity
       ? HubEventCapacityType.Fixed
       : HubEventCapacityType.Unlimited;
+    obj.inPersonCapacity = store.inPersonCapacity ?? null;
     obj.inPersonCapacityType = store.inPersonCapacity
       ? HubEventCapacityType.Fixed
       : HubEventCapacityType.Unlimited;

--- a/packages/common/src/events/_internal/getPropertyMap.ts
+++ b/packages/common/src/events/_internal/getPropertyMap.ts
@@ -21,7 +21,6 @@ export function getPropertyMap(): IPropertyMap[] {
     "startTime",
     "endDate",
     "endTime",
-    "inPersonCapacity",
   ];
   return commonPropNames.reduce(
     (acc, propName) => [...acc, { entityKey: propName, storeKey: propName }],

--- a/packages/common/src/events/_internal/getPropertyMap.ts
+++ b/packages/common/src/events/_internal/getPropertyMap.ts
@@ -21,6 +21,7 @@ export function getPropertyMap(): IPropertyMap[] {
     "startTime",
     "endDate",
     "endTime",
+    "inPersonCapacity",
   ];
   return commonPropNames.reduce(
     (acc, propName) => [...acc, { entityKey: propName, storeKey: propName }],

--- a/packages/common/test/events/_internal/PropertyMapper.test.ts
+++ b/packages/common/test/events/_internal/PropertyMapper.test.ts
@@ -314,7 +314,6 @@ describe("PropertyMapper", () => {
         location: null,
         readGroups: [],
         editGroups: [],
-        onlineMeeting: null,
       } as any as IEvent);
     });
 
@@ -353,7 +352,6 @@ describe("PropertyMapper", () => {
         location: null,
         readGroups: [],
         editGroups: [],
-        onlineMeeting: null,
       } as any as IEvent);
     });
 
@@ -392,7 +390,6 @@ describe("PropertyMapper", () => {
         location: null,
         readGroups: [],
         editGroups: [],
-        onlineMeeting: null,
       } as any as IEvent);
     });
 
@@ -575,7 +572,6 @@ describe("PropertyMapper", () => {
         location: null,
         readGroups: [],
         editGroups: [],
-        onlineMeeting: null,
       } as any as IEvent);
     });
 
@@ -614,7 +610,6 @@ describe("PropertyMapper", () => {
         location: null,
         readGroups: [],
         editGroups: [],
-        onlineMeeting: null,
       } as any as IEvent);
     });
   });

--- a/packages/common/test/events/_internal/PropertyMapper.test.ts
+++ b/packages/common/test/events/_internal/PropertyMapper.test.ts
@@ -314,6 +314,7 @@ describe("PropertyMapper", () => {
         location: null,
         readGroups: [],
         editGroups: [],
+        onlineMeeting: null,
       } as any as IEvent);
     });
 
@@ -352,6 +353,7 @@ describe("PropertyMapper", () => {
         location: null,
         readGroups: [],
         editGroups: [],
+        onlineMeeting: null,
       } as any as IEvent);
     });
 
@@ -390,6 +392,7 @@ describe("PropertyMapper", () => {
         location: null,
         readGroups: [],
         editGroups: [],
+        onlineMeeting: null,
       } as any as IEvent);
     });
 
@@ -433,7 +436,7 @@ describe("PropertyMapper", () => {
         startTime: jasmine.any(String) as unknown as string,
         endDate: jasmine.any(String) as unknown as string,
         endTime: jasmine.any(String) as unknown as string,
-        inPersonCapacity: 30,
+        inPersonCapacity: null,
         location: null,
         readGroups: [],
         editGroups: [],
@@ -480,7 +483,7 @@ describe("PropertyMapper", () => {
         startTime: jasmine.any(String) as unknown as string,
         endDate: jasmine.any(String) as unknown as string,
         endTime: jasmine.any(String) as unknown as string,
-        inPersonCapacity: 30,
+        inPersonCapacity: null,
         location: null,
         readGroups: [],
         editGroups: [],
@@ -572,6 +575,7 @@ describe("PropertyMapper", () => {
         location: null,
         readGroups: [],
         editGroups: [],
+        onlineMeeting: null,
       } as any as IEvent);
     });
 
@@ -610,6 +614,7 @@ describe("PropertyMapper", () => {
         location: null,
         readGroups: [],
         editGroups: [],
+        onlineMeeting: null,
       } as any as IEvent);
     });
   });

--- a/packages/common/test/events/_internal/PropertyMapper.test.ts
+++ b/packages/common/test/events/_internal/PropertyMapper.test.ts
@@ -133,7 +133,7 @@ describe("PropertyMapper", () => {
         attendanceType: HubEventAttendanceType.InPerson,
         inPersonCapacity: 30,
         inPersonRegistrationCount: 0,
-        inPersonCapacityType: "fixed",
+        inPersonCapacityType: HubEventCapacityType.Fixed,
         location: {
           type: "none",
           spatialReference: {},


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

- Adds `inPersonCapacityType` to `IHubEvent` pojo

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
