### PR TITLE
fix(hub-discussions): revert breaking change

### DIFF
--- a/packages/discussions/src/utils/reactions/can-create-reaction.ts
+++ b/packages/discussions/src/utils/reactions/can-create-reaction.ts
@@ -12,14 +12,15 @@ import { canReadChannel } from "../channels";
  */
 export function canCreateReaction(
   channel: IChannel,
-  value: PostReaction,
-  user: IUser | IDiscussionsUser = {}
+  value: PostReaction
+  // user: IUser | IDiscussionsUser = {}
 ): boolean {
-  if (!channelAllowsReaction(channel, value)) {
-    return false;
-  }
+  return channelAllowsReaction(channel, value);
+  // if (!channelAllowsReaction(channel, value)) {
+  //   return false;
+  // }
 
-  return canReadChannel(channel, user);
+  // return canReadChannel(channel, user);
 }
 
 function channelAllowsReaction(

--- a/packages/discussions/test/utils/reactions/can-create-reaction.test.ts
+++ b/packages/discussions/test/utils/reactions/can-create-reaction.test.ts
@@ -6,21 +6,21 @@ import * as canReadChannelModule from "../../../src/utils/channels/can-read-chan
 describe("Util: canCreateReaction", () => {
   const user: IUser = { username: "bob" };
 
-  // it("returns true if channel allows all reactions and canReadChannel returns true", () => {
-  //   const canReadChannelSpy = spyOn(
-  //     canReadChannelModule,
-  //     "canReadChannel"
-  //   ).and.returnValue(true);
-  //   const channel = {
-  //     allowReaction: true,
-  //     allowedReactions: null,
-  //   } as unknown as IChannel;
+  it("returns true if channel allows all reactions and canReadChannel returns true", () => {
+    const canReadChannelSpy = spyOn(
+      canReadChannelModule,
+      "canReadChannel"
+    ).and.returnValue(true);
+    const channel = {
+      allowReaction: true,
+      allowedReactions: null,
+    } as unknown as IChannel;
 
-  //   expect(canCreateReaction(channel, PostReaction.THUMBS_UP)).toBe(true);
-  //   // expect(canCreateReaction(channel, PostReaction.THUMBS_UP, user)).toBe(true);
-  //   // expect(canReadChannelSpy).toHaveBeenCalledTimes(1);
-  //   // expect(canReadChannelSpy).toHaveBeenCalledWith(channel, user);
-  // });
+    expect(canCreateReaction(channel, PostReaction.THUMBS_UP)).toBe(true);
+    // expect(canCreateReaction(channel, PostReaction.THUMBS_UP, user)).toBe(true);
+    // expect(canReadChannelSpy).toHaveBeenCalledTimes(1);
+    // expect(canReadChannelSpy).toHaveBeenCalledWith(channel, user);
+  });
 
   // it("returns true if user is undefined, channel allows all reactions, and canReadChannel returns true", () => {
   //   const canReadChannelSpy = spyOn(

--- a/packages/discussions/test/utils/reactions/can-create-reaction.test.ts
+++ b/packages/discussions/test/utils/reactions/can-create-reaction.test.ts
@@ -6,52 +6,55 @@ import * as canReadChannelModule from "../../../src/utils/channels/can-read-chan
 describe("Util: canCreateReaction", () => {
   const user: IUser = { username: "bob" };
 
-  it("returns true if channel allows all reactions and canReadChannel returns true", () => {
-    const canReadChannelSpy = spyOn(
-      canReadChannelModule,
-      "canReadChannel"
-    ).and.returnValue(true);
-    const channel = {
-      allowReaction: true,
-      allowedReactions: null,
-    } as unknown as IChannel;
+  // it("returns true if channel allows all reactions and canReadChannel returns true", () => {
+  //   const canReadChannelSpy = spyOn(
+  //     canReadChannelModule,
+  //     "canReadChannel"
+  //   ).and.returnValue(true);
+  //   const channel = {
+  //     allowReaction: true,
+  //     allowedReactions: null,
+  //   } as unknown as IChannel;
 
-    expect(canCreateReaction(channel, PostReaction.THUMBS_UP, user)).toBe(true);
-    expect(canReadChannelSpy).toHaveBeenCalledTimes(1);
-    expect(canReadChannelSpy).toHaveBeenCalledWith(channel, user);
-  });
+  //   expect(canCreateReaction(channel, PostReaction.THUMBS_UP)).toBe(true);
+  //   // expect(canCreateReaction(channel, PostReaction.THUMBS_UP, user)).toBe(true);
+  //   // expect(canReadChannelSpy).toHaveBeenCalledTimes(1);
+  //   // expect(canReadChannelSpy).toHaveBeenCalledWith(channel, user);
+  // });
 
-  it("returns true if user is undefined, channel allows all reactions, and canReadChannel returns true", () => {
-    const canReadChannelSpy = spyOn(
-      canReadChannelModule,
-      "canReadChannel"
-    ).and.returnValue(true);
-    const channel = {
-      allowReaction: true,
-      allowedReactions: null,
-    } as unknown as IChannel;
+  // it("returns true if user is undefined, channel allows all reactions, and canReadChannel returns true", () => {
+  //   const canReadChannelSpy = spyOn(
+  //     canReadChannelModule,
+  //     "canReadChannel"
+  //   ).and.returnValue(true);
+  //   const channel = {
+  //     allowReaction: true,
+  //     allowedReactions: null,
+  //   } as unknown as IChannel;
 
-    expect(canCreateReaction(channel, PostReaction.THUMBS_UP)).toBe(true);
-    expect(canReadChannelSpy).toHaveBeenCalledTimes(1);
-    expect(canReadChannelSpy).toHaveBeenCalledWith(channel, {});
-  });
+  //   expect(canCreateReaction(channel, PostReaction.THUMBS_UP)).toBe(true);
+  //   // expect(canCreateReaction(channel, PostReaction.THUMBS_UP)).toBe(true);
+  //   // expect(canReadChannelSpy).toHaveBeenCalledTimes(1);
+  //   // expect(canReadChannelSpy).toHaveBeenCalledWith(channel, {});
+  // });
 
-  it("returns false if channel allows all reactions and canReadChannel returns false", () => {
-    const canReadChannelSpy = spyOn(
-      canReadChannelModule,
-      "canReadChannel"
-    ).and.returnValue(false);
-    const channel = {
-      allowReaction: true,
-      allowedReactions: null,
-    } as unknown as IChannel;
+  // it("returns false if channel allows all reactions and canReadChannel returns false", () => {
+  //   const canReadChannelSpy = spyOn(
+  //     canReadChannelModule,
+  //     "canReadChannel"
+  //   ).and.returnValue(false);
+  //   const channel = {
+  //     allowReaction: true,
+  //     allowedReactions: null,
+  //   } as unknown as IChannel;
 
-    expect(canCreateReaction(channel, PostReaction.THUMBS_UP, user)).toBe(
-      false
-    );
-    expect(canReadChannelSpy).toHaveBeenCalledTimes(1);
-    expect(canReadChannelSpy).toHaveBeenCalledWith(channel, user);
-  });
+  //   expect(canCreateReaction(channel, PostReaction.THUMBS_UP)).toBe(
+  //   // expect(canCreateReaction(channel, PostReaction.THUMBS_UP, user)).toBe(
+  //     false
+  //   );
+  //   // expect(canReadChannelSpy).toHaveBeenCalledTimes(1);
+  //   // expect(canReadChannelSpy).toHaveBeenCalledWith(channel, user);
+  // });
 
   it("returns true if channel allows reaction, value included in allowed reactions, and canReadChannel returns true", () => {
     const canReadChannelSpy = spyOn(
@@ -63,9 +66,10 @@ describe("Util: canCreateReaction", () => {
       allowedReactions: ["thumbs_up"],
     } as IChannel;
 
-    expect(canCreateReaction(channel, PostReaction.THUMBS_UP, user)).toBe(true);
-    expect(canReadChannelSpy).toHaveBeenCalledTimes(1);
-    expect(canReadChannelSpy).toHaveBeenCalledWith(channel, user);
+    expect(canCreateReaction(channel, PostReaction.THUMBS_UP)).toBe(true);
+    // expect(canCreateReaction(channel, PostReaction.THUMBS_UP, user)).toBe(true);
+    // expect(canReadChannelSpy).toHaveBeenCalledTimes(1);
+    // expect(canReadChannelSpy).toHaveBeenCalledWith(channel, user);
   });
 
   it("returns false if channel allows reaction and value not included in allowed reactions", () => {
@@ -78,10 +82,11 @@ describe("Util: canCreateReaction", () => {
       allowedReactions: ["thumbs_up"],
     } as IChannel;
 
-    expect(canCreateReaction(channel, PostReaction.THUMBS_DOWN, user)).toBe(
+    expect(canCreateReaction(channel, PostReaction.THUMBS_DOWN)).toBe(
+      // expect(canCreateReaction(channel, PostReaction.THUMBS_DOWN, user)).toBe(
       false
     );
-    expect(canReadChannelSpy).not.toHaveBeenCalled();
+    // expect(canReadChannelSpy).not.toHaveBeenCalled();
   });
 
   it("returns false if channel does not allow reaction", () => {
@@ -91,9 +96,10 @@ describe("Util: canCreateReaction", () => {
     ).and.returnValue(true);
     const channel = { allowReaction: false } as IChannel;
 
-    expect(canCreateReaction(channel, PostReaction.THUMBS_DOWN, user)).toBe(
+    expect(canCreateReaction(channel, PostReaction.THUMBS_DOWN)).toBe(
+      // expect(canCreateReaction(channel, PostReaction.THUMBS_DOWN, user)).toBe(
       false
     );
-    expect(canReadChannelSpy).not.toHaveBeenCalled();
+    // expect(canReadChannelSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
affects: @esri/hub-discussions

1. Description: Revert breaking change

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
