### PR TITLE
feat(hub-discussions): attempt to trigger a major version release of …

### DIFF
--- a/packages/discussions/src/utils/reactions/can-create-reaction.ts
+++ b/packages/discussions/src/utils/reactions/can-create-reaction.ts
@@ -15,7 +15,6 @@ export function canCreateReaction(
   value: PostReaction,
   user: IUser | IDiscussionsUser = {}
 ): boolean {
-  // return false when the channel does not allow reactions
   if (!channelAllowsReaction(channel, value)) {
     return false;
   }


### PR DESCRIPTION
…hub-discussions

affects: @esri/hub-discussions

BREAKING CHANGE:
adds user parameter to function canCreateReaction

ISSUES CLOSED: #10700

1. Description: attemp to trigger a major version release of hub-discussions

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
