### PR TITLE
fix: update groups uiSchemas

### DIFF
--- a/packages/common/src/groups/_internal/GroupSchema.ts
+++ b/packages/common/src/groups/_internal/GroupSchema.ts
@@ -60,7 +60,7 @@ export const GroupSchema: IConfigurationSchema = {
       then: {
         properties: {
           membershipAccess: {
-            enum: ["organization", "collaborators"],
+            pattern: "(organization|collaborators)",
           },
         },
       },

--- a/packages/common/src/groups/_internal/GroupUiSchemaCreate.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaCreate.ts
@@ -66,7 +66,14 @@ export const buildUiSchema = async (
             `{{${i18nScope}.fields.membershipAccess.any:translate}}`,
           ],
           rules: [
-            undefined,
+            [
+              // we should be able to use undefined in this position but when used with entityEditor, we run this through interpolateTranslations
+              // which filters out the undefined which makes this not work as expected
+              // so for now we add a rule that doesn't do anything
+              {
+                effect: UiSchemaRuleEffects.NONE,
+              },
+            ],
             [
               {
                 effect: UiSchemaRuleEffects.DISABLE,

--- a/packages/common/src/groups/_internal/GroupUiSchemaCreateAssociation.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaCreateAssociation.ts
@@ -89,6 +89,18 @@ export const buildUiSchema = async (
             },
             elements: [
               {
+                // there are schema rules that use this so it must be present or they break, so we hide it when its value is false which is always the case for this uiSchema
+                scope: "/properties/isSharedUpdate",
+                type: "Control",
+                rule: {
+                  effect: UiSchemaRuleEffects.HIDE,
+                  condition: {
+                    scope: "/properties/isSharedUpdate",
+                    schema: { const: false },
+                  },
+                },
+              },
+              {
                 labelKey: `${i18nScope}.fields.membershipAccess.label`,
                 scope: "/properties/membershipAccess",
                 type: "Control",

--- a/packages/common/src/groups/_internal/GroupUiSchemaCreateFollowers.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaCreateFollowers.ts
@@ -90,6 +90,18 @@ export const buildUiSchema = async (
             },
             elements: [
               {
+                // there are schema rules that use this so it must be present or they break, so we hide it when its value is false which is always the case for this uiSchema
+                scope: "/properties/isSharedUpdate",
+                type: "Control",
+                rule: {
+                  effect: UiSchemaRuleEffects.HIDE,
+                  condition: {
+                    scope: "/properties/isSharedUpdate",
+                    schema: { const: false },
+                  },
+                },
+              },
+              {
                 labelKey: `${i18nScope}.fields.membershipAccess.label`,
                 scope: "/properties/membershipAccess",
                 type: "Control",

--- a/packages/common/src/groups/_internal/GroupUiSchemaSettings.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaSettings.ts
@@ -1,4 +1,4 @@
-import { IUiSchema } from "../../core";
+import { IUiSchema, UiSchemaRuleEffects } from "../../core";
 import { IArcGISContext } from "../../ArcGISContext";
 import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
 import { IHubGroup } from "../../core";
@@ -22,6 +22,18 @@ export const buildUiSchema = async (
         type: "Section",
         labelKey: `${i18nScope}.sections.membershipAccess.label`,
         elements: [
+          {
+            // there are schema rules that use this so it must be present or they break, so we hide it when its value is false which is always the case for this uiSchema
+            scope: "/properties/isSharedUpdate",
+            type: "Control",
+            rule: {
+              effect: UiSchemaRuleEffects.HIDE,
+              condition: {
+                scope: "/properties/isSharedUpdate",
+                schema: { const: false },
+              },
+            },
+          },
           {
             labelKey: `${i18nScope}.fields.membershipAccess.label`,
             scope: "/properties/membershipAccess",

--- a/packages/common/test/groups/_internal/GroupUiSchemaCreate.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaCreate.test.ts
@@ -63,7 +63,11 @@ describe("GroupUiSchemaCreate", () => {
                 `{{some.scope.fields.membershipAccess.any:translate}}`,
               ],
               rules: [
-                undefined,
+                [
+                  {
+                    effect: UiSchemaRuleEffects.NONE,
+                  },
+                ],
                 [
                   {
                     effect: UiSchemaRuleEffects.DISABLE,

--- a/packages/common/test/groups/_internal/GroupUiSchemaCreateAssociation.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaCreateAssociation.test.ts
@@ -86,6 +86,17 @@ describe("GroupUiSchemaCreateAssociation", () => {
                 },
                 elements: [
                   {
+                    scope: "/properties/isSharedUpdate",
+                    type: "Control",
+                    rule: {
+                      effect: UiSchemaRuleEffects.HIDE,
+                      condition: {
+                        scope: "/properties/isSharedUpdate",
+                        schema: { const: false },
+                      },
+                    },
+                  },
+                  {
                     labelKey: "some.scope.fields.membershipAccess.label",
                     scope: "/properties/membershipAccess",
                     type: "Control",

--- a/packages/common/test/groups/_internal/GroupUiSchemaCreateFollowers.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaCreateFollowers.test.ts
@@ -83,6 +83,17 @@ describe("GroupUiSchemaCreateFollowers", () => {
                 },
                 elements: [
                   {
+                    scope: "/properties/isSharedUpdate",
+                    type: "Control",
+                    rule: {
+                      effect: UiSchemaRuleEffects.HIDE,
+                      condition: {
+                        scope: "/properties/isSharedUpdate",
+                        schema: { const: false },
+                      },
+                    },
+                  },
+                  {
                     labelKey: "some.scope.fields.membershipAccess.label",
                     scope: "/properties/membershipAccess",
                     type: "Control",

--- a/packages/common/test/groups/_internal/GroupUiSchemaSettings.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaSettings.test.ts
@@ -1,3 +1,4 @@
+import { UiSchemaRuleEffects } from "../../../src";
 import { buildUiSchema } from "../../../src/groups/_internal/GroupUiSchemaSettings";
 import { MOCK_CONTEXT } from "../../mocks/mock-auth";
 
@@ -15,6 +16,17 @@ describe("buildUiSchema: group settings", () => {
           type: "Section",
           labelKey: "some.scope.sections.membershipAccess.label",
           elements: [
+            {
+              scope: "/properties/isSharedUpdate",
+              type: "Control",
+              rule: {
+                effect: UiSchemaRuleEffects.HIDE,
+                condition: {
+                  scope: "/properties/isSharedUpdate",
+                  schema: { const: false },
+                },
+              },
+            },
             {
               labelKey: "some.scope.fields.membershipAccess.label",
               scope: "/properties/membershipAccess",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
