### PR TITLE
feat: extend static download formats to support additional resources

### DIFF
--- a/packages/common/src/downloads/fetchDownloadFormats.ts
+++ b/packages/common/src/downloads/fetchDownloadFormats.ts
@@ -3,9 +3,9 @@ import { canUseExportImageFlow } from "./_internal/canUseExportImageFlow";
 import { canUseExportItemFlow } from "./_internal/canUseExportItemFlow";
 import { canUseHubDownloadApi } from "./canUseHubDownloadApi";
 import {
-  IAdditionalResourceDownloadFormat,
   IDownloadFormat,
   IFetchDownloadFormatsOptions,
+  IStaticDownloadFormat,
 } from "./types";
 
 /**
@@ -48,11 +48,13 @@ export async function fetchDownloadFormats(
 
 function toStaticFormat(
   resource: IHubAdditionalResource
-): IAdditionalResourceDownloadFormat {
+): IStaticDownloadFormat {
   return {
     type: "static",
-    label: resource.name,
+    label:
+      resource.name ||
+      (resource.isDataSource && `{{dataSource:translate}}`) || // if the additional resource is the datasource
+      `{{noTitle:translate}}`, // if the additional resource has no name
     url: resource.url,
-    isDataSource: resource.isDataSource,
   };
 }

--- a/packages/common/src/downloads/fetchDownloadFormats.ts
+++ b/packages/common/src/downloads/fetchDownloadFormats.ts
@@ -3,9 +3,9 @@ import { canUseExportImageFlow } from "./_internal/canUseExportImageFlow";
 import { canUseExportItemFlow } from "./_internal/canUseExportItemFlow";
 import { canUseHubDownloadApi } from "./canUseHubDownloadApi";
 import {
+  IAdditionalResourceDownloadFormat,
   IDownloadFormat,
   IFetchDownloadFormatsOptions,
-  IStaticDownloadFormat,
 } from "./types";
 
 /**
@@ -48,10 +48,11 @@ export async function fetchDownloadFormats(
 
 function toStaticFormat(
   resource: IHubAdditionalResource
-): IStaticDownloadFormat {
+): IAdditionalResourceDownloadFormat {
   return {
     type: "static",
     label: resource.name,
     url: resource.url,
+    isDataSource: resource.isDataSource,
   };
 }

--- a/packages/common/src/downloads/types.ts
+++ b/packages/common/src/downloads/types.ts
@@ -105,6 +105,15 @@ export interface IStaticDownloadFormat extends IDownloadFormat {
 }
 
 /**
+ * Extends the typical static download format, and is used
+ * by `toStaticFormat` in `packages/common/src/downloads/fetchDownloadFormats.ts`
+ */
+export interface IAdditionalResourceDownloadFormat
+  extends IStaticDownloadFormat {
+  isDataSource: boolean;
+}
+
+/**
  * Represents a dynamic download format that is generated on-the-fly when requested.
  * The `format` property will be set to the corresponding service format.
  */

--- a/packages/common/src/downloads/types.ts
+++ b/packages/common/src/downloads/types.ts
@@ -105,15 +105,6 @@ export interface IStaticDownloadFormat extends IDownloadFormat {
 }
 
 /**
- * Extends the typical static download format, and is used
- * by `toStaticFormat` in `packages/common/src/downloads/fetchDownloadFormats.ts`
- */
-export interface IAdditionalResourceDownloadFormat
-  extends IStaticDownloadFormat {
-  isDataSource: boolean;
-}
-
-/**
  * Represents a dynamic download format that is generated on-the-fly when requested.
  * The `format` property will be set to the corresponding service format.
  */

--- a/packages/common/test/downloads/fetchDownloadFormats.test.ts
+++ b/packages/common/test/downloads/fetchDownloadFormats.test.ts
@@ -78,6 +78,8 @@ describe("fetchDownloadFormats", () => {
       additionalResources: [
         { name: "Resource 1", url: "resource-1-url" },
         { name: "Resource 2", url: "resource-2-url" },
+        { url: "resource-3-url", isDataSource: true },
+        { url: "resource-4-url", isDataSource: false },
       ],
     } as unknown as IHubEditableContent;
 
@@ -89,6 +91,12 @@ describe("fetchDownloadFormats", () => {
     const expected = [
       { type: "static", label: "Resource 1", url: "resource-1-url" },
       { type: "static", label: "Resource 2", url: "resource-2-url" },
+      {
+        type: "static",
+        label: "{{dataSource:translate}}",
+        url: "resource-3-url",
+      },
+      { type: "static", label: "{{noTitle:translate}}", url: "resource-4-url" },
     ] as unknown as IDownloadFormat[];
 
     expect(results).toEqual(expected);


### PR DESCRIPTION
1. Description:

1. Instructions for testing:
- copy to opendata-ui w/ this PR: https://github.com/ArcGIS/opendata-ui/pull/13869
- visit this link: https://download-test-qa-pre-a-hub.hubqa.arcgis.com:4200/datasets/qa-pre-a-hub::qa-data-simple-point-100-hosted-service/about?pe=temp:hub:content:downloads:unifiedList
- open the download panel
- confirm the Data Source title is applied

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/10824

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
