### PR TITLE
feat(hub-common): refactor event gallery card editor uiSchema to use …

### DIFF
--- a/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
@@ -48,10 +48,19 @@ export async function buildUiSchema(
                 scope: "/properties/access",
                 type: "Control",
                 options: {
-                  control: "hub-field-input-checkbox-group",
-                  enum: {
-                    i18nScope: `${i18nScope}.content.access`,
-                  },
+                  control: "hub-field-input-tile-select",
+                  descriptions: [
+                    `{{${i18nScope}.content.access.private.description:translate}}`,
+                    `{{${i18nScope}.content.access.org.description:translate}}`,
+                    `{{${i18nScope}.content.access.public.description:translate}}`,
+                  ],
+                  icons: ["users", "organization", "globe"],
+                  labels: [
+                    `{{${i18nScope}.content.access.private.label:translate}}`,
+                    `{{${i18nScope}.content.access.org.label:translate}}`,
+                    `{{${i18nScope}.content.access.public.label:translate}}`,
+                  ],
+                  type: "checkbox",
                 },
                 rules: [
                   {

--- a/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
@@ -14,6 +14,11 @@ export async function buildUiSchema(
   options: IEventGalleryCardEditorOptions,
   context: IArcGISContext
 ): Promise<IUiSchema> {
+  const categoriesUiSchema = await fetchCategoriesUiSchemaElement(
+    `${i18nScope}.content`,
+    context
+  );
+  delete categoriesUiSchema.options.helperText;
   return {
     type: "Layout",
     elements: [
@@ -102,10 +107,7 @@ export async function buildUiSchema(
                 ],
               },
               {
-                ...(await fetchCategoriesUiSchemaElement(
-                  `${i18nScope}.content`,
-                  context
-                )),
+                ...categoriesUiSchema,
                 rules: [
                   {
                     effect: UiSchemaRuleEffects.SHOW,

--- a/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
@@ -103,8 +103,19 @@ describe("EventGalleryCardUiSchema", () => {
                     scope: "/properties/access",
                     type: "Control",
                     options: {
-                      control: "hub-field-input-checkbox-group",
-                      enum: { i18nScope: "some.scope.content.access" },
+                      control: "hub-field-input-tile-select",
+                      descriptions: [
+                        "{{some.scope.content.access.private.description:translate}}",
+                        "{{some.scope.content.access.org.description:translate}}",
+                        "{{some.scope.content.access.public.description:translate}}",
+                      ],
+                      icons: ["users", "organization", "globe"],
+                      labels: [
+                        "{{some.scope.content.access.private.label:translate}}",
+                        "{{some.scope.content.access.org.label:translate}}",
+                        "{{some.scope.content.access.public.label:translate}}",
+                      ],
+                      type: "checkbox",
                     },
                     rules: [
                       {

--- a/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
@@ -1,4 +1,5 @@
 import {
+  cloneObject,
   IArcGISContext,
   IHubCatalog,
   IUiSchemaComboboxItem,
@@ -32,9 +33,17 @@ describe("EventGalleryCardUiSchema", () => {
         type: "Control",
         scope: "/properties/categories",
         rules: [],
-        options: {},
+        options: {
+          helperText: {
+            labelKey: "some.label.key",
+          },
+        },
         label: "Categories",
       } as IUiSchemaElement;
+      const categoriesUiSchemaElementWithoutHelperText = cloneObject(
+        categoriesUiSchemaElement
+      );
+      delete categoriesUiSchemaElementWithoutHelperText.options?.helperText;
       const catalog = {
         title: "My catalog",
         scopes: {},
@@ -153,7 +162,7 @@ describe("EventGalleryCardUiSchema", () => {
                     ],
                   },
                   {
-                    ...categoriesUiSchemaElement,
+                    ...categoriesUiSchemaElementWithoutHelperText,
                     rules: [
                       {
                         effect: UiSchemaRuleEffects.SHOW,


### PR DESCRIPTION
…calcite-tile-select vs calcite-

affects: @esri/hub-common

ISSUES CLOSED: 10958

1. Description:

- Refactors event gallery card editor uiSchema to use `calcite-tile-select` vs `calcite-checkbox`.

1. Instructions for testing:

1. Closes Issues: [#10958](https://devtopia.esri.com/dc/hub/issues/10958)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
