### PR TITLE
fix(hub-common): hub-common missing @types/arcgis-js-api dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
 				"@esri/arcgis-rest-types": "^3.1.1",
 				"@semantic-release/changelog": "^6.0.1",
 				"@semantic-release/git": "^10.0.1",
-				"@types/arcgis-js-api": "~4.26.0",
 				"@types/es6-promise": "0.0.32",
 				"@types/fetch-mock": "^7.0.0",
 				"@types/isomorphic-fetch": "0.0.34",
@@ -10244,10 +10243,13 @@
 			"dev": true
 		},
 		"node_modules/@types/arcgis-js-api": {
-			"version": "4.26.0",
-			"resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.26.0.tgz",
-			"integrity": "sha512-rQSgYUy2FqPTFu47h2ibXhh5RdoQ/dgIXNdUcLTwebJ8OeXFvuzF5+hHmzKr2aLfX8w34W08ZIhUwiE4m+vBLQ==",
-			"dev": true
+			"version": "4.28.0",
+			"resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.28.0.tgz",
+			"integrity": "sha512-BYNaT12l3T2GQ+Bj7jbMUhe1K6CaCSMj/uaAOmZYwV/FaR8wJ8UBYwdEaX6oFus7oHgLX0NcbfTrj4TgUcGSpg==",
+			"deprecated": "This is a stub types definition. arcgis-js-api provides its own type definitions, so you do not need this installed.",
+			"dependencies": {
+				"arcgis-js-api": "*"
+			}
 		},
 		"node_modules/@types/arcgis-rest-api": {
 			"version": "10.4.8",
@@ -11823,6 +11825,11 @@
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 			"dev": true
+		},
+		"node_modules/arcgis-js-api": {
+			"version": "4.30.9",
+			"resolved": "https://registry.npmjs.org/arcgis-js-api/-/arcgis-js-api-4.30.9.tgz",
+			"integrity": "sha512-FFHAX6Yh5m/pldBpA58+vg9oSUASOtokMuE2PKV9As6TKF9VbT3C6FlExv/3ln/T2Bc2dlAmcGMdrrvNbQqepA=="
 		},
 		"node_modules/are-we-there-yet": {
 			"version": "1.1.7",
@@ -65010,10 +65017,11 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.165.0",
+			"version": "14.168.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
+				"@types/arcgis-js-api": "~4.28.0",
 				"abab": "^2.0.5",
 				"adlib": "^3.0.8",
 				"ajv": "^6.12.6",
@@ -68755,6 +68763,7 @@
 			"requires": {
 				"@terraformer/arcgis": "^2.1.2",
 				"@types/adlib": "^3.0.1",
+				"@types/arcgis-js-api": "~4.28.0",
 				"@types/geojson": "^7946.0.13",
 				"@types/terraformer__arcgis": "^2.0.5",
 				"abab": "^2.0.5",
@@ -73138,10 +73147,12 @@
 			"dev": true
 		},
 		"@types/arcgis-js-api": {
-			"version": "4.26.0",
-			"resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.26.0.tgz",
-			"integrity": "sha512-rQSgYUy2FqPTFu47h2ibXhh5RdoQ/dgIXNdUcLTwebJ8OeXFvuzF5+hHmzKr2aLfX8w34W08ZIhUwiE4m+vBLQ==",
-			"dev": true
+			"version": "4.28.0",
+			"resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.28.0.tgz",
+			"integrity": "sha512-BYNaT12l3T2GQ+Bj7jbMUhe1K6CaCSMj/uaAOmZYwV/FaR8wJ8UBYwdEaX6oFus7oHgLX0NcbfTrj4TgUcGSpg==",
+			"requires": {
+				"arcgis-js-api": "*"
+			}
 		},
 		"@types/arcgis-rest-api": {
 			"version": "10.4.8",
@@ -74487,6 +74498,11 @@
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 			"dev": true
+		},
+		"arcgis-js-api": {
+			"version": "4.30.9",
+			"resolved": "https://registry.npmjs.org/arcgis-js-api/-/arcgis-js-api-4.30.9.tgz",
+			"integrity": "sha512-FFHAX6Yh5m/pldBpA58+vg9oSUASOtokMuE2PKV9As6TKF9VbT3C6FlExv/3ln/T2Bc2dlAmcGMdrrvNbQqepA=="
 		},
 		"are-we-there-yet": {
 			"version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"@esri/arcgis-rest-types": "^3.1.1",
 		"@semantic-release/changelog": "^6.0.1",
 		"@semantic-release/git": "^10.0.1",
-		"@types/arcgis-js-api": "~4.26.0",
 		"@types/es6-promise": "0.0.32",
 		"@types/fetch-mock": "^7.0.0",
 		"@types/isomorphic-fetch": "0.0.34",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,6 +13,7 @@
   ],
   "dependencies": {
     "@terraformer/arcgis": "^2.1.2",
+    "@types/arcgis-js-api": "~4.28.0",
     "abab": "^2.0.5",
     "adlib": "^3.0.8",
     "ajv": "^6.12.6",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

@esri/hub-common was missing a dependency on @types/arcgis-js-api which would cause build failures when used in a TS project

1. Instructions for testing:

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/7246

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
