### PR TITLE
feat(hub-common): add orgId to IChannel

### DIFF
--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -853,6 +853,7 @@ export interface IChannel extends IWithAuthor, IWithEditor, IWithTimestamps {
   metadata: IChannelMetadata | null;
   id: string;
   name: string | null;
+  orgId: string;
   orgs: string[];
   posts?: IPost[];
   softDelete: boolean;


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Add property `orgId` to discussions type `IChannel`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
