### PR TITLE
feat(hub-discussions): add future v2 priv checks for updating channel

### DIFF
--- a/packages/discussions/src/utils/channel-permission.ts
+++ b/packages/discussions/src/utils/channel-permission.ts
@@ -27,19 +27,19 @@ enum ChannelAction {
 
 // See confluence for privs documentation: https://confluencewikidev.esri.com/pages/viewpage.action?pageId=153747776#Roles&Privileges-ApplicationtoChannels
 const CHANNEL_ACTION_PRIVS = {
-  ADD_REMOVE_OWNERS: [Role.OWNER],
-  ADD_REMOVE_MANAGERS: [Role.OWNER, Role.MANAGE],
-  ADD_REMOVE_MODERATORS: [Role.OWNER, Role.MANAGE],
-  ADD_REMOVE_ORGS: [Role.OWNER, Role.MANAGE],
-  ADD_REMOVE_GROUPS: [Role.OWNER, Role.MANAGE],
-  ADD_REMOVE_USERS: [Role.OWNER, Role.MANAGE],
-  ADD_REMOVE_AUTHENTICATED_USERS: [Role.OWNER, Role.MANAGE],
+  UPDATE_OWNERS: [Role.OWNER],
+  UPDATE_MANAGERS: [Role.OWNER, Role.MANAGE],
+  UPDATE_MODERATORS: [Role.OWNER, Role.MANAGE],
+  UPDATE_ORGS: [Role.OWNER, Role.MANAGE],
+  UPDATE_GROUPS: [Role.OWNER, Role.MANAGE],
+  UPDATE_USERS: [Role.OWNER, Role.MANAGE],
+  UPDATE_AUTHENTICATED_USERS: [Role.OWNER, Role.MANAGE],
   UPDATE_ANONYMOUS_USERS: [Role.OWNER, Role.MANAGE],
-  ENABLE_DISABLE_POST_REPLIES: [Role.OWNER, Role.MANAGE, Role.MODERATE],
-  ENABLE_DISABLE_POST_REACTIONS: [Role.OWNER, Role.MANAGE, Role.MODERATE],
-  ADD_REMOVE_ALLOWED_REACTIONS: [Role.OWNER, Role.MANAGE, Role.MODERATE],
+  UPDATE_POST_REPLIES: [Role.OWNER, Role.MANAGE, Role.MODERATE],
+  UPDATE_POST_REACTIONS: [Role.OWNER, Role.MANAGE, Role.MODERATE],
+  UPDATE_ALLOWED_REACTIONS: [Role.OWNER, Role.MANAGE, Role.MODERATE],
   UPDATE_DEFAULT_POST_STATUS: [Role.OWNER, Role.MANAGE, Role.MODERATE],
-  ADD_REMOVE_BLOCKED_WORDS: [Role.OWNER, Role.MANAGE, Role.MODERATE],
+  UPDATE_BLOCKED_WORDS: [Role.OWNER, Role.MANAGE, Role.MODERATE],
   UPDATE_CHANNEL_NAME: [Role.OWNER, Role.MANAGE],
   UPDATE_SOFT_DELETE_SETTING: [Role.OWNER, Role.MANAGE],
 };
@@ -154,23 +154,19 @@ export class ChannelPermission {
       // add or remove users
       // add or remove authenticated users
       // update anonymous users
-      (updates.allowReply &&
-        !CHANNEL_ACTION_PRIVS.ENABLE_DISABLE_POST_REPLIES.includes(userRole)) ||
-      (updates.allowReaction &&
-        !CHANNEL_ACTION_PRIVS.ENABLE_DISABLE_POST_REACTIONS.includes(
-          userRole
-        )) ||
-      (updates.allowedReactions &&
-        !CHANNEL_ACTION_PRIVS.ADD_REMOVE_ALLOWED_REACTIONS.includes(
-          userRole
-        )) ||
-      (updates.defaultPostStatus &&
+      (updates.hasOwnProperty("allowReply") &&
+        !CHANNEL_ACTION_PRIVS.UPDATE_POST_REPLIES.includes(userRole)) ||
+      (updates.hasOwnProperty("allowReaction") &&
+        !CHANNEL_ACTION_PRIVS.UPDATE_POST_REACTIONS.includes(userRole)) ||
+      (updates.hasOwnProperty("allowedReactions") &&
+        !CHANNEL_ACTION_PRIVS.UPDATE_ALLOWED_REACTIONS.includes(userRole)) ||
+      (updates.hasOwnProperty("defaultPostStatus") &&
         !CHANNEL_ACTION_PRIVS.UPDATE_DEFAULT_POST_STATUS.includes(userRole)) ||
-      (updates.blockWords &&
-        !CHANNEL_ACTION_PRIVS.ADD_REMOVE_BLOCKED_WORDS.includes(userRole)) ||
-      (updates.name &&
+      (updates.hasOwnProperty("blockWords") &&
+        !CHANNEL_ACTION_PRIVS.UPDATE_BLOCKED_WORDS.includes(userRole)) ||
+      (updates.hasOwnProperty("name") &&
         !CHANNEL_ACTION_PRIVS.UPDATE_CHANNEL_NAME.includes(userRole)) ||
-      (updates.softDelete &&
+      (updates.hasOwnProperty("softDelete") &&
         !CHANNEL_ACTION_PRIVS.UPDATE_SOFT_DELETE_SETTING.includes(userRole))
     ) {
       return false;

--- a/packages/discussions/src/utils/channel-permission.ts
+++ b/packages/discussions/src/utils/channel-permission.ts
@@ -6,6 +6,7 @@ import {
   IChannelAclPermission,
   IChannelAclPermissionDefinition,
   IDiscussionsUser,
+  IUpdateChannel,
   Role,
 } from "../types";
 import { CANNOT_DISCUSS } from "./constants";
@@ -19,7 +20,29 @@ enum ChannelAction {
   READ_POSTS = "readPosts",
   WRITE_POSTS = "writePosts",
   MODERATE_CHANNEL = "moderateChannel",
+  IS_MODERATOR = "isModerator",
+  IS_MANAGER = "isManager",
+  IS_OWNER = "isOwner",
 }
+
+// See confluence for privs documentation: https://confluencewikidev.esri.com/pages/viewpage.action?pageId=153747776#Roles&Privileges-ApplicationtoChannels
+const CHANNEL_ACTION_PRIVS = {
+  ADD_REMOVE_OWNERS: [Role.OWNER],
+  ADD_REMOVE_MANAGERS: [Role.OWNER, Role.MANAGE],
+  ADD_REMOVE_MODERATORS: [Role.OWNER, Role.MANAGE],
+  ADD_REMOVE_ORGS: [Role.OWNER, Role.MANAGE],
+  ADD_REMOVE_GROUPS: [Role.OWNER, Role.MANAGE],
+  ADD_REMOVE_USERS: [Role.OWNER, Role.MANAGE],
+  ADD_REMOVE_AUTHENTICATED_USERS: [Role.OWNER, Role.MANAGE],
+  UPDATE_ANONYMOUS_USERS: [Role.OWNER, Role.MANAGE],
+  ENABLE_DISABLE_POST_REPLIES: [Role.OWNER, Role.MANAGE, Role.MODERATE],
+  ENABLE_DISABLE_POST_REACTIONS: [Role.OWNER, Role.MANAGE, Role.MODERATE],
+  ADD_REMOVE_ALLOWED_REACTIONS: [Role.OWNER, Role.MANAGE, Role.MODERATE],
+  UPDATE_DEFAULT_POST_STATUS: [Role.OWNER, Role.MANAGE, Role.MODERATE],
+  ADD_REMOVE_BLOCKED_WORDS: [Role.OWNER, Role.MANAGE, Role.MODERATE],
+  UPDATE_CHANNEL_NAME: [Role.OWNER, Role.MANAGE],
+  UPDATE_SOFT_DELETE_SETTING: [Role.OWNER, Role.MANAGE],
+};
 
 /**
  * @internal
@@ -109,6 +132,51 @@ export class ChannelPermission {
       this.canSomeUserGroup(ChannelAction.READ_POSTS, user) ||
       this.canSomeUserOrg(ChannelAction.READ_POSTS, user)
     );
+  }
+
+  /**
+   * Expose this function and call from the can-modify-channel.ts file when V2 released
+   * @internal
+   */
+  canUpdateProperties(
+    user: IDiscussionsUser,
+    updates: IUpdateChannel
+  ): boolean {
+    const userRole = this.determineUserRole(user);
+
+    if (
+      // @TODO when we have access to channel ACL obj when v2 udpate-channel-dto is hoisted we can add these additional property action checks
+      // add or remove owners
+      // add or remove managers
+      // add or remove moderators
+      // add or remove orgs
+      // add or remove groups
+      // add or remove users
+      // add or remove authenticated users
+      // update anonymous users
+      (updates.allowReply &&
+        !CHANNEL_ACTION_PRIVS.ENABLE_DISABLE_POST_REPLIES.includes(userRole)) ||
+      (updates.allowReaction &&
+        !CHANNEL_ACTION_PRIVS.ENABLE_DISABLE_POST_REACTIONS.includes(
+          userRole
+        )) ||
+      (updates.allowedReactions &&
+        !CHANNEL_ACTION_PRIVS.ADD_REMOVE_ALLOWED_REACTIONS.includes(
+          userRole
+        )) ||
+      (updates.defaultPostStatus &&
+        !CHANNEL_ACTION_PRIVS.UPDATE_DEFAULT_POST_STATUS.includes(userRole)) ||
+      (updates.blockWords &&
+        !CHANNEL_ACTION_PRIVS.ADD_REMOVE_BLOCKED_WORDS.includes(userRole)) ||
+      (updates.name &&
+        !CHANNEL_ACTION_PRIVS.UPDATE_CHANNEL_NAME.includes(userRole)) ||
+      (updates.softDelete &&
+        !CHANNEL_ACTION_PRIVS.UPDATE_SOFT_DELETE_SETTING.includes(userRole))
+    ) {
+      return false;
+    }
+
+    return true;
   }
 
   private canAnyUser(action: ChannelAction): boolean {
@@ -260,6 +328,42 @@ export class ChannelPermission {
     } = userGroup;
     return this.ALLOWED_GROUP_MEMBER_TYPES.includes(memberType);
   }
+
+  private determineUserRole(user: IDiscussionsUser): Role {
+    if (this.isOwner(user)) {
+      return Role.OWNER;
+    } else if (this.isManager(user)) {
+      return Role.MANAGE;
+    } else if (this.isModerator(user)) {
+      return Role.MODERATE;
+    } else {
+      return Role.READ; // default to null or something else
+    }
+  }
+
+  private isOwner(user: IDiscussionsUser): boolean {
+    return (
+      this.canSomeUser(ChannelAction.IS_OWNER, user) ||
+      this.canSomeUserGroup(ChannelAction.IS_OWNER, user) ||
+      this.canSomeUserOrg(ChannelAction.IS_OWNER, user)
+    );
+  }
+
+  private isManager(user: IDiscussionsUser): boolean {
+    return (
+      this.canSomeUser(ChannelAction.IS_MANAGER, user) ||
+      this.canSomeUserGroup(ChannelAction.IS_MANAGER, user) ||
+      this.canSomeUserOrg(ChannelAction.IS_MANAGER, user)
+    );
+  }
+
+  private isModerator(user: IDiscussionsUser): boolean {
+    return (
+      this.canSomeUser(ChannelAction.IS_MODERATOR, user) ||
+      this.canSomeUserGroup(ChannelAction.IS_MODERATOR, user) ||
+      this.canSomeUserOrg(ChannelAction.IS_MODERATOR, user)
+    );
+  }
 }
 
 function isGroupDiscussable(userGroup: IGroup): boolean {
@@ -304,6 +408,18 @@ function channelActionLookup(action: ChannelAction): Role[] {
 
   if (action === ChannelAction.MODERATE_CHANNEL) {
     return [Role.MODERATE, Role.MANAGE, Role.OWNER];
+  }
+
+  if (action === ChannelAction.IS_MODERATOR) {
+    return [Role.MODERATE];
+  }
+
+  if (action === ChannelAction.IS_MANAGER) {
+    return [Role.MANAGE];
+  }
+
+  if (action === ChannelAction.IS_OWNER) {
+    return [Role.OWNER];
   }
 
   // default to read action

--- a/packages/discussions/src/utils/channel-permission.ts
+++ b/packages/discussions/src/utils/channel-permission.ts
@@ -337,7 +337,7 @@ export class ChannelPermission {
     } else if (this.isModerator(user)) {
       return Role.MODERATE;
     } else {
-      return Role.READ; // default to null or something else
+      return Role.READ;
     }
   }
 

--- a/packages/discussions/src/utils/channels/can-modify-channel.ts
+++ b/packages/discussions/src/utils/channels/can-modify-channel.ts
@@ -1,5 +1,8 @@
 import { IUser } from "@esri/arcgis-rest-types";
-import { IChannel, IDiscussionsUser, SharingAccess } from "../../types";
+import {
+  IChannel,
+  IDiscussionsUser,
+} from "../../types";
 import { ChannelPermission } from "../channel-permission";
 import { isOrgAdminInOrg } from "../platform";
 import { isAuthorizedToModifyChannelByLegacyPermissions } from "./is-authorized-to-modify-channel-by-legacy-permissions";
@@ -14,6 +17,7 @@ import { isAuthorizedToModifyChannelByLegacyPermissions } from "./is-authorized-
 export function canModifyChannel(
   channel: IChannel,
   user: IUser | IDiscussionsUser = {}
+  // channelUpdates: IUpdateChannel,
 ): boolean {
   if (isOrgAdminInOrg(user, channel.orgId)) {
     return true;
@@ -22,6 +26,7 @@ export function canModifyChannel(
   if (channel.channelAcl) {
     const channelPermission = new ChannelPermission(channel);
     return channelPermission.canModerateChannel(user as IDiscussionsUser);
+    // for V2: && channelPermission.canUpdateProperties(user as IDiscussionsUser, channelUpdates)
   }
 
   return isAuthorizedToModifyChannelByLegacyPermissions(user, channel);

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -1210,7 +1210,7 @@ describe("ChannelPermission class", () => {
     });
   });
 
-  fdescribe("canUpdateProperties", () => {
+  describe("canUpdateProperties", () => {
     describe("update allowReply required role", () => {
       it("returns true if user has a role of moderate", () => {
         const user = buildUser();

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -1222,7 +1222,8 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           allowReply: true,
@@ -1237,7 +1238,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           allowReply: true,
@@ -1252,7 +1254,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           allowReply: true,
@@ -1271,7 +1274,8 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           allowReply: true,
@@ -1294,7 +1298,8 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           allowReaction: true,
@@ -1309,7 +1314,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           allowReaction: true,
@@ -1324,7 +1330,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           allowReaction: true,
@@ -1343,7 +1350,8 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           allowReaction: true,
@@ -1366,7 +1374,8 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           allowedReactions: [],
@@ -1381,7 +1390,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           allowedReactions: [],
@@ -1396,7 +1406,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           allowedReactions: [],
@@ -1415,7 +1426,8 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           allowedReactions: [],
@@ -1438,7 +1450,8 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           defaultPostStatus: PostStatus.APPROVED,
@@ -1453,7 +1466,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           defaultPostStatus: PostStatus.APPROVED,
@@ -1468,7 +1482,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           defaultPostStatus: PostStatus.APPROVED,
@@ -1487,7 +1502,8 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           defaultPostStatus: PostStatus.APPROVED,
@@ -1510,7 +1526,8 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           blockWords: [],
@@ -1525,7 +1542,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           blockWords: [],
@@ -1540,7 +1558,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           blockWords: [],
@@ -1559,7 +1578,8 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           blockWords: [],
@@ -1578,7 +1598,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           softDelete: true,
@@ -1593,7 +1614,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           softDelete: true,
@@ -1612,7 +1634,8 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           softDelete: true,
@@ -1631,7 +1654,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           name: "foo",
@@ -1646,7 +1670,8 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           name: "foo",
@@ -1665,7 +1690,8 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channelPermission = new ChannelPermission(channelAcl, "foo");
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
           name: "foo",

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -5,6 +5,8 @@ import {
   IChannel,
   IChannelAclPermission,
   IDiscussionsUser,
+  IUpdateChannel,
+  PostStatus,
   Role,
 } from "../../src/types";
 import { ChannelPermission } from "../../src/utils/channel-permission";
@@ -1204,6 +1206,474 @@ describe("ChannelPermission class", () => {
         const channelPermission = new ChannelPermission(channel);
 
         expect(channelPermission.canModerateChannel(user)).toBe(false);
+      });
+    });
+  });
+
+  fdescribe("canUpdateProperties", () => {
+    describe("update allowReply required role", () => {
+      it("returns true if user has a role of moderate", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.MODERATE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          allowReply: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of manage", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          allowReply: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of owner", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.OWNER },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          allowReply: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns false if user does not have a minimum role of moderate", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.READWRITE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          allowReply: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+          false
+        );
+      });
+    });
+
+    describe("update allowReaction required role", () => {
+      it("returns true if user has a role of moderate", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.MODERATE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          allowReaction: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of manage", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          allowReaction: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of owner", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.OWNER },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          allowReaction: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns false if user does not have a minimum role of moderate", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.READWRITE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          allowReaction: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+          false
+        );
+      });
+    });
+
+    describe("update allowedReactions required role", () => {
+      it("returns true if user has a role of moderate", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.MODERATE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          allowedReactions: [],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of manage", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          allowedReactions: [],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of owner", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.OWNER },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          allowedReactions: [],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns false if user does not have a minimum role of moderate", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.READWRITE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          allowedReactions: [],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+          false
+        );
+      });
+    });
+
+    describe("update defaultPostStatus required role", () => {
+      it("returns true if user has a role of moderate", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.MODERATE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          defaultPostStatus: PostStatus.APPROVED,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of manage", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          defaultPostStatus: PostStatus.APPROVED,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of owner", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.OWNER },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          defaultPostStatus: PostStatus.APPROVED,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns false if user does not have a minimum role of moderate", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.READWRITE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          defaultPostStatus: PostStatus.APPROVED,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+          false
+        );
+      });
+    });
+
+    describe("update blockWords required role", () => {
+      it("returns true if user has a role of moderate", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.MODERATE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          blockWords: [],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of manage", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          blockWords: [],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of owner", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.OWNER },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          blockWords: [],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns false if user does not have a minimum role of moderate", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.READWRITE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          blockWords: [],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+          false
+        );
+      });
+    });
+
+    describe("update softDelete required role", () => {
+      it("returns true if user has a role of manage", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          softDelete: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of owner", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.OWNER },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          softDelete: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns false if user does not have a minimum role of manage", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.MODERATE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          softDelete: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+          false
+        );
+      });
+    });
+
+    describe("update name required role", () => {
+      it("returns true if user has a role of manage", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          name: "foo",
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of owner", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.OWNER },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          name: "foo",
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns false if user does not have a minimum role of manage", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.MODERATE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channelPermission = new ChannelPermission(channelAcl, "foo");
+
+        const updates: IUpdateChannel = {
+          name: "foo",
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+          false
+        );
       });
     });
   });


### PR DESCRIPTION
affects: @esri/hub-discussions

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
