### PR TITLE
feat(hub-common): adds default thumbnail for discussions

### DIFF
--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -88,7 +88,9 @@ export const buildUiSchema = async (
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
-            options.thumbnailUrl
+            options.thumbnailUrl,
+            "content",
+            context.requestOptions
           ),
           // tags
           {

--- a/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
@@ -1,8 +1,28 @@
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { getCdnAssetUrl } from "../../../urls";
+import { HubEntityType } from "../../types/HubEntityType";
 import {
   IUiSchemaElement,
   IUiSchemaMessage,
   UiSchemaMessageTypes,
 } from "../types";
+
+const DEFAULT_ENTITY_THUMBNAILS = {
+  discussion:
+    "/ember-arcgis-opendata-components/assets/images/placeholders/discussion.png",
+  site: "",
+  project: "",
+  initiative: "",
+  initiativeTemplate: "",
+  page: "",
+  content: "",
+  org: "",
+  group: "",
+  template: "",
+  survey: "",
+  event: "",
+  user: "",
+};
 
 /**
  * Returns the UI schema element needed to render
@@ -15,7 +35,9 @@ import {
 export function getThumbnailUiSchemaElement(
   i18nScope: string,
   thumbnail: string,
-  thumbnailUrl: string
+  thumbnailUrl: string,
+  entityType: HubEntityType,
+  requestOptions: IRequestOptions
 ): IUiSchemaElement {
   const messages: IUiSchemaMessage[] = [];
   // Advise the user if the entity's thumbnail is either of the default values
@@ -29,6 +51,10 @@ export function getThumbnailUiSchemaElement(
       alwaysShow: true,
     });
   }
+  const defaultImgSrc =
+    DEFAULT_ENTITY_THUMBNAILS[entityType] &&
+    getCdnAssetUrl(DEFAULT_ENTITY_THUMBNAILS[entityType], requestOptions);
+
   return {
     labelKey: "shared.fields._thumbnail.label",
     scope: "/properties/_thumbnail",
@@ -36,6 +62,7 @@ export function getThumbnailUiSchemaElement(
     options: {
       control: "hub-field-input-image-picker",
       imgSrc: thumbnailUrl,
+      defaultImgSrc,
       maxWidth: 727,
       maxHeight: 484,
       aspectRatio: 1.5,

--- a/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
@@ -47,8 +47,26 @@ export function getThumbnailUiSchemaElement(
     DEFAULT_ENTITY_THUMBNAILS[entityType] ?? DEFAULT_ENTITY_THUMBNAILS.content;
   const defaultImgUrl = getCdnAssetUrl(defaultEntityThumbnail, requestOptions);
 
+  const options =
+    entityType === "group"
+      ? {
+          aspectRatio: 1,
+          sizeDescription: {
+            labelKey: `${i18nScope}.fields._thumbnail.sizeDescription`,
+          },
+        }
+      : {
+          aspectRatio: 1.5,
+          sizeDescription: {
+            labelKey: "shared.fields._thumbnail.sizeDescription",
+          },
+        };
+
   return {
-    labelKey: "shared.fields._thumbnail.label",
+    labelKey:
+      entityType === "group"
+        ? `${i18nScope}.fields._thumbnail.label`
+        : "shared.fields._thumbnail.label",
     scope: "/properties/_thumbnail",
     type: "Control",
     options: {
@@ -57,15 +75,12 @@ export function getThumbnailUiSchemaElement(
       defaultImgUrl,
       maxWidth: 727,
       maxHeight: 484,
-      aspectRatio: 1.5,
       helperText: {
         // helper text varies between entity types
         labelKey: `${i18nScope}.fields._thumbnail.helperText`,
       },
-      sizeDescription: {
-        labelKey: "shared.fields._thumbnail.sizeDescription",
-      },
       messages,
+      ...options,
     },
   };
 }

--- a/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
@@ -7,21 +7,13 @@ import {
   UiSchemaMessageTypes,
 } from "../types";
 
-const DEFAULT_ENTITY_THUMBNAILS = {
+const DEFAULT_ENTITY_THUMBNAILS: Partial<Record<HubEntityType, string>> = {
   discussion:
     "/ember-arcgis-opendata-components/assets/images/placeholders/discussion.png",
-  site: "",
-  project: "",
-  initiative: "",
-  initiativeTemplate: "",
-  page: "",
-  content: "",
-  org: "",
-  group: "",
-  template: "",
-  survey: "",
-  event: "",
-  user: "",
+  group:
+    "/ember-arcgis-opendata-components/assets/images/placeholders/group.png",
+  content:
+    "/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
 };
 
 /**
@@ -51,9 +43,9 @@ export function getThumbnailUiSchemaElement(
       alwaysShow: true,
     });
   }
-  const defaultImgSrc =
-    DEFAULT_ENTITY_THUMBNAILS[entityType] &&
-    getCdnAssetUrl(DEFAULT_ENTITY_THUMBNAILS[entityType], requestOptions);
+  const defaultEntityThumbnail =
+    DEFAULT_ENTITY_THUMBNAILS[entityType] ?? DEFAULT_ENTITY_THUMBNAILS.content;
+  const defaultImgUrl = getCdnAssetUrl(defaultEntityThumbnail, requestOptions);
 
   return {
     labelKey: "shared.fields._thumbnail.label",
@@ -62,7 +54,7 @@ export function getThumbnailUiSchemaElement(
     options: {
       control: "hub-field-input-image-picker",
       imgSrc: thumbnailUrl,
-      defaultImgSrc,
+      defaultImgSrc: defaultImgUrl,
       maxWidth: 727,
       maxHeight: 484,
       aspectRatio: 1.5,

--- a/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
@@ -54,7 +54,7 @@ export function getThumbnailUiSchemaElement(
     options: {
       control: "hub-field-input-image-picker",
       imgSrc: thumbnailUrl,
-      defaultImgSrc: defaultImgUrl,
+      defaultImgUrl,
       maxWidth: 727,
       maxHeight: 484,
       aspectRatio: 1.5,

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -67,7 +67,9 @@ export const buildUiSchema = async (
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
-            options.thumbnailUrl
+            options.thumbnailUrl,
+            "discussion",
+            context.requestOptions
           ),
         ],
       },

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -2,6 +2,7 @@ import { IUiSchema } from "../../core/schemas/types";
 import { IArcGISContext } from "../../ArcGISContext";
 import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
 import { getEntityThumbnailUrl } from "../../core/getEntityThumbnailUrl";
+import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
 
 /**
  * @private
@@ -69,24 +70,13 @@ export const buildUiSchema = async (
               type: "textarea",
             },
           },
-          {
-            labelKey: `${i18nScope}.fields._thumbnail.label`,
-            scope: "/properties/_thumbnail",
-            type: "Control",
-            options: {
-              control: "hub-field-input-image-picker",
-              imgSrc: getEntityThumbnailUrl(options),
-              maxWidth: 727,
-              maxHeight: 484,
-              aspectRatio: 1,
-              helperText: {
-                labelKey: `${i18nScope}.fields._thumbnail.helperText`,
-              },
-              sizeDescription: {
-                labelKey: `${i18nScope}.fields._thumbnail.sizeDescription`,
-              },
-            },
-          },
+          getThumbnailUiSchemaElement(
+            i18nScope,
+            options.thumbnail,
+            getEntityThumbnailUrl(options),
+            "group",
+            context.requestOptions
+          ),
         ],
       },
     ],

--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
@@ -108,7 +108,9 @@ export const buildUiSchema = async (
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
-            getEntityThumbnailUrl(options)
+            getEntityThumbnailUrl(options),
+            "initiativeTemplate",
+            context.requestOptions
           ),
         ],
       },

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -202,7 +202,9 @@ export const buildUiSchema = async (
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
-            options.thumbnailUrl
+            options.thumbnailUrl,
+            "initiative",
+            context.requestOptions
           ),
         ],
       },

--- a/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
+++ b/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
@@ -82,7 +82,9 @@ export const buildUiSchema = async (
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
-            options.thumbnailUrl
+            options.thumbnailUrl,
+            "page",
+            context.requestOptions
           ),
           {
             labelKey: `${i18nScope}.fields.tags.label`,

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -168,7 +168,9 @@ export const buildUiSchema = async (
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
-            options.thumbnailUrl
+            options.thumbnailUrl,
+            "project",
+            context.requestOptions
           ),
         ],
       },

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -82,7 +82,9 @@ export const buildUiSchema = async (
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
-            options.thumbnailUrl
+            options.thumbnailUrl,
+            "site",
+            context.requestOptions
           ),
           {
             labelKey: `${i18nScope}.fields.tags.label`,

--- a/packages/common/src/surveys/_internal/SurveyUiSchemaEdit.ts
+++ b/packages/common/src/surveys/_internal/SurveyUiSchemaEdit.ts
@@ -103,7 +103,9 @@ export const buildUiSchema = async (
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
-            options.thumbnailUrl
+            options.thumbnailUrl,
+            "survey",
+            context.requestOptions
           ),
         ],
       },

--- a/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
+++ b/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
@@ -107,7 +107,9 @@ export const buildUiSchema = async (
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
-            getEntityThumbnailUrl(options)
+            getEntityThumbnailUrl(options),
+            "template",
+            context.requestOptions
           ),
         ],
       },

--- a/packages/common/src/urls/get-cdn-asset-url.ts
+++ b/packages/common/src/urls/get-cdn-asset-url.ts
@@ -1,0 +1,26 @@
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { getPortalUrl } from "./get-portal-url";
+
+/**
+ * Returns an env-specific CDN asset URL for the given `assetPath` and `requestOptions`.
+ * @param assetPath The CDN asset's path
+ * @param requestOptions An IRequestOptions object
+ */
+export function getCdnAssetUrl(
+  assetPath: string,
+  requestOptions: IRequestOptions
+): string {
+  const portalUrl = getPortalUrl(requestOptions);
+  let baseUrl: string;
+  if (/(devext|mapsdevext)\.arcgis\.com/.test(portalUrl)) {
+    baseUrl = "https://hubdevcdn.arcgis.com/opendata-ui/assets";
+  } else if (/(qaext|mapsqa)\.arcgis\.com/.test(portalUrl)) {
+    baseUrl = "https://hubqacdn.arcgis.com/opendata-ui/assets";
+  } else if (/(www|maps)\.arcgis\.com/.test(portalUrl)) {
+    baseUrl = "https://hubcdn.arcgis.com/opendata-ui/assets";
+  } else {
+    baseUrl = `${portalUrl}/apps/sites`;
+  }
+  const delimiter = assetPath.startsWith("/") ? "" : "/";
+  return [baseUrl, assetPath].join(delimiter);
+}

--- a/packages/common/src/urls/index.ts
+++ b/packages/common/src/urls/index.ts
@@ -21,6 +21,7 @@ export * from "./getUserHomeUrl";
 export * from "./get-campaign-url";
 export * from "./is-safe-redirect-url";
 export * from "./cacheBustUrl";
+export * from "./get-cdn-asset-url";
 // For some reason, if this is exported here, random tests
 // start failing. Resolved by moving to the root index
 // export * from "./getCardModelUrl";

--- a/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
@@ -104,7 +104,8 @@ describe("buildUiSchema: content edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc: "",
+                defaultImgSrc:
+                  "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
@@ -104,7 +104,7 @@ describe("buildUiSchema: content edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc:
+                defaultImgUrl:
                   "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,

--- a/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
@@ -104,6 +104,7 @@ describe("buildUiSchema: content edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
+                defaultImgSrc: "",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/core/schemas/internal/getThumbnailUiSchemaElement.test.ts
+++ b/packages/common/test/core/schemas/internal/getThumbnailUiSchemaElement.test.ts
@@ -2,6 +2,7 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IHubItemEntity } from "../../../../src";
 import { getThumbnailUiSchemaElement } from "../../../../src/core/schemas/internal/getThumbnailUiSchemaElement";
 import { HubEntityType } from "../../../../dist/types/core/types/HubEntityType";
+import * as urlUtils from "../../../../src/urls";
 
 describe("getThumbnailUiSchemaElement:", () => {
   it("excludes the default thumbnail notice if the entity has a thumbnail", () => {
@@ -85,5 +86,38 @@ describe("getThumbnailUiSchemaElement:", () => {
       requestOptions
     );
     expect(uiSchema.options?.messages.length).toBe(1);
+  });
+
+  it("sets default thumbnail when available", () => {
+    const defaultImageUrl = "www.example.com/assets/discussion";
+    const getCdnAssetUrlSpy = spyOn(urlUtils, "getCdnAssetUrl").and.returnValue(
+      defaultImageUrl
+    );
+    const entity: IHubItemEntity = {
+      thumbnail: "thumbnail/my-thumbnail.png",
+      itemControl: "",
+      owner: "",
+      schemaVersion: 0,
+      tags: [],
+      canEdit: false,
+      canDelete: false,
+      id: "aef",
+      name: "Test",
+      createdDate: new Date(),
+      createdDateSource: "item.created",
+      updatedDate: new Date(),
+      updatedDateSource: "item.modified",
+      type: "discussion",
+    };
+    const requestOptions = {} as IRequestOptions;
+    const uiSchema = getThumbnailUiSchemaElement(
+      "scope",
+      entity.thumbnail as unknown as string,
+      entity.thumbnailUrl as unknown as string,
+      entity.type as HubEntityType,
+      requestOptions
+    );
+    expect(getCdnAssetUrlSpy).toHaveBeenCalled();
+    expect(uiSchema.options?.defaultImgSrc).toBe(defaultImageUrl);
   });
 });

--- a/packages/common/test/core/schemas/internal/getThumbnailUiSchemaElement.test.ts
+++ b/packages/common/test/core/schemas/internal/getThumbnailUiSchemaElement.test.ts
@@ -118,6 +118,6 @@ describe("getThumbnailUiSchemaElement:", () => {
       requestOptions
     );
     expect(getCdnAssetUrlSpy).toHaveBeenCalled();
-    expect(uiSchema.options?.defaultImgSrc).toBe(defaultImageUrl);
+    expect(uiSchema.options?.defaultImgUrl).toBe(defaultImageUrl);
   });
 });

--- a/packages/common/test/core/schemas/internal/getThumbnailUiSchemaElement.test.ts
+++ b/packages/common/test/core/schemas/internal/getThumbnailUiSchemaElement.test.ts
@@ -1,5 +1,7 @@
+import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IHubItemEntity } from "../../../../src";
 import { getThumbnailUiSchemaElement } from "../../../../src/core/schemas/internal/getThumbnailUiSchemaElement";
+import { HubEntityType } from "../../../../dist/types/core/types/HubEntityType";
 
 describe("getThumbnailUiSchemaElement:", () => {
   it("excludes the default thumbnail notice if the entity has a thumbnail", () => {
@@ -19,10 +21,13 @@ describe("getThumbnailUiSchemaElement:", () => {
       updatedDateSource: "item.modified",
       type: "Feature Service",
     };
+    const requestOptions = {} as IRequestOptions;
     const uiSchema = getThumbnailUiSchemaElement(
       "scope",
       entity.thumbnail as unknown as string,
-      entity.thumbnailUrl as unknown as string
+      entity.thumbnailUrl as unknown as string,
+      entity.type as HubEntityType,
+      requestOptions
     );
     expect(uiSchema.options?.messages.length).toBe(0);
   });
@@ -43,10 +48,13 @@ describe("getThumbnailUiSchemaElement:", () => {
       updatedDateSource: "item.modified",
       type: "Feature Service",
     };
+    const requestOptions = {} as IRequestOptions;
     const uiSchema = getThumbnailUiSchemaElement(
       "scope",
       entity.thumbnail as unknown as string,
-      entity.thumbnailUrl as unknown as string
+      entity.thumbnailUrl as unknown as string,
+      entity.type as HubEntityType,
+      requestOptions
     );
     expect(uiSchema.options?.messages.length).toBe(1);
   });
@@ -68,10 +76,13 @@ describe("getThumbnailUiSchemaElement:", () => {
       updatedDateSource: "item.modified",
       type: "Feature Service",
     };
+    const requestOptions = {} as IRequestOptions;
     const uiSchema = getThumbnailUiSchemaElement(
       "scope",
       entity.thumbnail as string,
-      entity.thumbnailUrl as unknown as string
+      entity.thumbnailUrl as unknown as string,
+      entity.type as HubEntityType,
+      requestOptions
     );
     expect(uiSchema.options?.messages.length).toBe(1);
   });

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -86,6 +86,8 @@ describe("buildUiSchema: discussion edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
+                defaultImgSrc:
+                  "https://www.undefined/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/discussion.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,
@@ -278,6 +280,8 @@ describe("buildUiSchema: discussion edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
+                defaultImgSrc:
+                  "https://www.undefined/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/discussion.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -86,7 +86,7 @@ describe("buildUiSchema: discussion edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc:
+                defaultImgUrl:
                   "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/discussion.png",
                 maxWidth: 727,
                 maxHeight: 484,
@@ -280,7 +280,7 @@ describe("buildUiSchema: discussion edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc:
+                defaultImgUrl:
                   "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/discussion.png",
                 maxWidth: 727,
                 maxHeight: 484,

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -87,7 +87,7 @@ describe("buildUiSchema: discussion edit", () => {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
                 defaultImgSrc:
-                  "https://www.undefined/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/discussion.png",
+                  "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/discussion.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,
@@ -281,7 +281,7 @@ describe("buildUiSchema: discussion edit", () => {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
                 defaultImgSrc:
-                  "https://www.undefined/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/discussion.png",
+                  "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/discussion.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
@@ -70,6 +70,8 @@ describe("buildUiSchema: group edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
+                defaultImgUrl:
+                  "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/group.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1,
@@ -79,6 +81,16 @@ describe("buildUiSchema: group edit", () => {
                 sizeDescription: {
                   labelKey: "some.scope.fields._thumbnail.sizeDescription",
                 },
+                messages: [
+                  {
+                    type: "CUSTOM",
+                    display: "notice",
+                    labelKey: "shared.fields._thumbnail.defaultThumbnailNotice",
+                    icon: "lightbulb",
+                    allowShowBeforeInteract: true,
+                    alwaysShow: true,
+                  },
+                ],
               },
             },
           ],

--- a/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
@@ -108,7 +108,8 @@ describe("buildUiSchema: initiative template edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc: "",
+                defaultImgSrc:
+                  "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
@@ -108,7 +108,7 @@ describe("buildUiSchema: initiative template edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc:
+                defaultImgUrl:
                   "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,

--- a/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
@@ -108,6 +108,7 @@ describe("buildUiSchema: initiative template edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
+                defaultImgSrc: "",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -233,7 +233,7 @@ describe("buildUiSchema: initiative edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc:
+                defaultImgUrl:
                   "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,
@@ -538,7 +538,7 @@ describe("buildUiSchema: initiative edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc:
+                defaultImgUrl:
                   "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -233,6 +233,7 @@ describe("buildUiSchema: initiative edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
+                defaultImgSrc: "",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,
@@ -536,6 +537,7 @@ describe("buildUiSchema: initiative edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
+                defaultImgSrc: "",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -233,7 +233,8 @@ describe("buildUiSchema: initiative edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc: "",
+                defaultImgSrc:
+                  "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,
@@ -537,7 +538,8 @@ describe("buildUiSchema: initiative edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc: "",
+                defaultImgSrc:
+                  "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/mocks/mock-auth.ts
+++ b/packages/common/test/mocks/mock-auth.ts
@@ -135,6 +135,8 @@ export const MOCK_CONTEXT = new ArcGISContext({
     name: "My org",
     isPortal: false,
     urlKey: "www",
+    portalHostname: "host",
+    customBaseUrl: "customUrl",
   },
   serviceStatus: {
     portal: "online",

--- a/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
+++ b/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
@@ -101,7 +101,8 @@ describe("buildUiSchema: page edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc: "",
+                defaultImgSrc:
+                  "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
+++ b/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
@@ -101,7 +101,7 @@ describe("buildUiSchema: page edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc:
+                defaultImgUrl:
                   "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,

--- a/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
+++ b/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
@@ -101,6 +101,7 @@ describe("buildUiSchema: page edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
+                defaultImgSrc: "",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -198,6 +198,7 @@ describe("buildUiSchema: project edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
+                defaultImgSrc: "",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,
@@ -519,6 +520,7 @@ describe("buildUiSchema: project edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
+                defaultImgSrc: "",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -198,7 +198,8 @@ describe("buildUiSchema: project edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc: "",
+                defaultImgSrc:
+                  "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,
@@ -520,7 +521,8 @@ describe("buildUiSchema: project edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc: "",
+                defaultImgSrc:
+                  "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -198,7 +198,7 @@ describe("buildUiSchema: project edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc:
+                defaultImgUrl:
                   "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,
@@ -521,7 +521,7 @@ describe("buildUiSchema: project edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc:
+                defaultImgUrl:
                   "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,

--- a/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
@@ -101,7 +101,8 @@ describe("buildUiSchema: site edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc: "",
+                defaultImgSrc:
+                  "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
@@ -101,7 +101,7 @@ describe("buildUiSchema: site edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc:
+                defaultImgUrl:
                   "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,

--- a/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
@@ -101,6 +101,7 @@ describe("buildUiSchema: site edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
+                defaultImgSrc: "",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
+++ b/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
@@ -134,6 +134,7 @@ describe("buildUiSchema: survey edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
+                defaultImgSrc: "",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
+++ b/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
@@ -134,7 +134,8 @@ describe("buildUiSchema: survey edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc: "",
+                defaultImgSrc:
+                  "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
+++ b/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
@@ -134,7 +134,7 @@ describe("buildUiSchema: survey edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc:
+                defaultImgUrl:
                   "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,

--- a/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
@@ -102,7 +102,7 @@ describe("buildUiSchema: template edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc:
+                defaultImgUrl:
                   "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,

--- a/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
@@ -102,6 +102,7 @@ describe("buildUiSchema: template edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
+                defaultImgSrc: "",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
@@ -102,7 +102,8 @@ describe("buildUiSchema: template edit", () => {
               options: {
                 control: "hub-field-input-image-picker",
                 imgSrc: "https://some-thumbnail-url.com",
-                defaultImgSrc: "",
+                defaultImgSrc:
+                  "https://www.customUrl/apps/sites/ember-arcgis-opendata-components/assets/images/placeholders/content.png",
                 maxWidth: 727,
                 maxHeight: 484,
                 aspectRatio: 1.5,

--- a/packages/common/test/urls/get-cdn-asset-url.test.ts
+++ b/packages/common/test/urls/get-cdn-asset-url.test.ts
@@ -1,0 +1,69 @@
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { getCdnAssetUrl } from "../../src/urls/get-cdn-asset-url";
+
+describe("getCdnAssetUrl", () => {
+  const assetPath =
+    "/ember-arcgis-opendata-components/assets/images/placeholders/user.svg";
+
+  const ENVS = {
+    dev: {
+      anonymous: {
+        portal: "https://devext.arcgis.com/sharing/rest",
+        expected: `https://hubdevcdn.arcgis.com/opendata-ui/assets${assetPath}`,
+      },
+      authenticated: {
+        portal: "https://dev-pre-a-hub.mapsdevext.arcgis.com/sharing/rest",
+        expected: `https://hubdevcdn.arcgis.com/opendata-ui/assets${assetPath}`,
+      },
+    },
+    qa: {
+      anonymous: {
+        portal: "https://qaext.arcgis.com/sharing/rest",
+        expected: `https://hubqacdn.arcgis.com/opendata-ui/assets${assetPath}`,
+      },
+      authenticated: {
+        portal: "https://qa-pre-a-hub.mapsqa.arcgis.com/sharing/rest",
+        expected: `https://hubqacdn.arcgis.com/opendata-ui/assets${assetPath}`,
+      },
+    },
+    prod: {
+      anonymous: {
+        portal: "https://www.arcgis.com/sharing/rest",
+        expected: `https://hubcdn.arcgis.com/opendata-ui/assets${assetPath}`,
+      },
+      authenticated: {
+        portal: "https://prod-pre-a-hub.maps.arcgis.com/sharing/rest",
+        expected: `https://hubcdn.arcgis.com/opendata-ui/assets${assetPath}`,
+      },
+    },
+    enterpriseSites: {
+      anonymous: {
+        // this doesn't seem right, but is what's observed on enterprise sites today for anonymous users...
+        portal: "../../sharing/rest",
+        expected: `../../apps/sites${assetPath}`,
+      },
+      authenticated: {
+        portal: "https://rqawinbi01pt.ags.esri.com/gis/sharing/rest",
+        expected: `https://rqawinbi01pt.ags.esri.com/gis/apps/sites${assetPath}`,
+      },
+    },
+  };
+
+  Object.entries(ENVS).forEach(([env, envConfig]) => {
+    Object.entries(envConfig).forEach(([userType, { portal, expected }]) => {
+      it(`it should return "${expected}" for ${userType} in ${env}`, () => {
+        const requestOptions = { portal } as IRequestOptions;
+        const result = getCdnAssetUrl(assetPath, requestOptions);
+        expect(result).toEqual(expected);
+      });
+    });
+  });
+
+  it('prefixes the assetPath with "/"', () => {
+    const requestOptions = {
+      portal: ENVS.qa.authenticated.portal,
+    } as IRequestOptions;
+    const result = getCdnAssetUrl(assetPath.substring(1), requestOptions);
+    expect(result).toEqual(ENVS.qa.authenticated.expected);
+  });
+});


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #8591

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
