### PR TITLE
feat(hub-common): add allowAsAnonymous to IChannel & ICreateChannelSe…

### DIFF
--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -594,6 +594,7 @@ export interface IUpdatePostStatus {
  * @interface IUpdatePost
  */
 export interface IUpdatePost {
+  asAnonymous?: boolean;
   title?: string;
   body?: string;
   discussion?: string | null;
@@ -771,6 +772,7 @@ export interface IChannelAclPermission
  * @interface ICreateChannelSettings
  */
 export interface ICreateChannelSettings {
+  allowAsAnonymous?: boolean;
   allowedReactions?: PostReaction[];
   allowReaction?: boolean;
   allowReply?: boolean;
@@ -842,6 +844,7 @@ export interface ICreateChannel
  */
 export interface IChannel extends IWithAuthor, IWithEditor, IWithTimestamps {
   access: SharingAccess;
+  allowAsAnonymous: boolean;
   allowAnonymous: boolean;
   allowedReactions: PostReaction[] | null;
   allowReaction: boolean;


### PR DESCRIPTION
…ttings. Add asAnonymous to IUpd

Issue: [9644](https://devtopia.esri.com/dc/hub/issues/9644)

affects: @esri/hub-common

1. Description: Update hub-discussions types. Add `asAnonymous` to `IUpdatePost`. Add `allowAsAnonymous` to `ICreateChannelSettings` and `IChannel`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
