### PR TITLE
feat(hub-common): set description to optional

### DIFF
--- a/packages/common/src/events/_internal/EventSchemaEdit.ts
+++ b/packages/common/src/events/_internal/EventSchemaEdit.ts
@@ -21,7 +21,7 @@ import { getDefaultEventDatesAndTimes } from "./getDefaultEventDatesAndTimes";
 export const buildSchema = (): IConfigurationSchema => {
   const { startDate: minStartDate } = getDefaultEventDatesAndTimes();
   return {
-    required: ["name", "description", "startDate", "endDate", "timeZone"],
+    required: ["name", "startDate", "endDate", "timeZone"],
     properties: {
       name: ENTITY_NAME_SCHEMA,
       description: {

--- a/packages/common/src/events/_internal/EventUiSchemaEdit.ts
+++ b/packages/common/src/events/_internal/EventUiSchemaEdit.ts
@@ -61,14 +61,6 @@ export const buildUiSchema = async (
               helperText: {
                 labelKey: `${i18nScope}.fields.description.helperText`,
               },
-              messages: [
-                {
-                  type: "ERROR",
-                  keyword: "required",
-                  icon: true,
-                  labelKey: `${i18nScope}.fields.description.requiredError`,
-                },
-              ],
             },
           },
         ],

--- a/packages/common/test/events/_internal/EventSchemaEdit.test.ts
+++ b/packages/common/test/events/_internal/EventSchemaEdit.test.ts
@@ -37,7 +37,7 @@ describe("EventSchemaEdit", () => {
       const res = buildSchema();
       expect(getDefaultEventDatesAndTimesSpy).toHaveBeenCalledTimes(1);
       expect(res).toEqual({
-        required: ["name", "description", "startDate", "endDate", "timeZone"],
+        required: ["name", "startDate", "endDate", "timeZone"],
         properties: {
           name: ENTITY_NAME_SCHEMA,
           description: {

--- a/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
+++ b/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
@@ -148,14 +148,6 @@ describe("EventUiSchemaEdit", () => {
                   helperText: {
                     labelKey: `myI18nScope.fields.description.helperText`,
                   },
-                  messages: [
-                    {
-                      type: "ERROR",
-                      keyword: "required",
-                      icon: true,
-                      labelKey: `myI18nScope.fields.description.requiredError`,
-                    },
-                  ],
                 },
               },
             ],


### PR DESCRIPTION
1. Description: Sets Events description prop to optional.

1. Instructions for testing:

1. Closes Issues: #11034

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
