### PR TITLE
feat(hub-common): add HubSite.isUmbrella() and isOpenDataGroup()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.169.0",
+			"version": "14.170.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/core/types/IHubSite.ts
+++ b/packages/common/src/core/types/IHubSite.ts
@@ -81,9 +81,14 @@ export interface IHubSite
   legacyTeams: string[];
 
   /**
-   * True when the site is a "Hub Home" site
+   * True when the site is a "Hub Home" site for an organization
    */
   isHubHome: boolean;
+
+  /**
+   * True when the site is the "Umbrella" site for an environment (i.e. hub.arcgis.com)
+   */
+  isUmbrella: boolean;
 }
 
 export type IHubSiteEditor = IHubItemEntityEditor<IHubSite> & {

--- a/packages/common/src/groups/index.ts
+++ b/packages/common/src/groups/index.ts
@@ -5,6 +5,7 @@ export * from "./HubGroups";
 export * from "./HubGroup";
 export * from "./addGroupMembers";
 export * from "./getWellKnownGroup";
+export * from "./isOpenDataGroup";
 // TODO: The below are being used in hub-teams. When we deprecate that package we can move
 // The below into _internal and remove the exports from here. They were previously in
 // the add-users-workflow directory

--- a/packages/common/src/groups/isOpenDataGroup.ts
+++ b/packages/common/src/groups/isOpenDataGroup.ts
@@ -1,0 +1,3 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+
+export const isOpenDataGroup = (group: IGroup) => !!group.isOpenData;

--- a/packages/common/src/sites/_internal/getPropertyMap.ts
+++ b/packages/common/src/sites/_internal/getPropertyMap.ts
@@ -27,6 +27,7 @@ export function getPropertyMap(): IPropertyMap[] {
     "headerSass",
     "headContent",
     "layout",
+    "isUmbrella",
   ];
   valueProps.forEach((entry) => {
     map.push({ entityKey: entry, storeKey: `data.values.${entry}` });

--- a/packages/common/test/groups/isOpenDataGroup.test.ts
+++ b/packages/common/test/groups/isOpenDataGroup.test.ts
@@ -1,0 +1,13 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import { isOpenDataGroup } from "../../src/groups/isOpenDataGroup";
+
+describe("isOpenDataGroup: ", () => {
+  it("returns true when group is OD", () => {
+    const group = { isOpenData: true } as unknown as IGroup;
+    expect(isOpenDataGroup(group)).toBe(true);
+  });
+  it("returns false when isOpenData is undefined", () => {
+    const group = {} as unknown as IGroup;
+    expect(isOpenDataGroup(group)).toBe(false);
+  });
+});


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
