### PR TITLE
fix: address invalid query serialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.170.0",
+			"version": "14.177.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65047,7 +65047,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "28.0.0",
+			"version": "28.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/src/search/serializeQueryForPortal.ts
+++ b/packages/common/src/search/serializeQueryForPortal.ts
@@ -208,15 +208,15 @@ function serializePredicate(predicate: IPredicate): ISearchOptions {
  */
 function serializeMatchOptions(key: string, value: IMatchOptions): string {
   let result = "";
-  if (value.any && value.any.length) {
+  if (value.any?.length) {
     result = `${serializeStringOrArray("OR", key, value.any)}`;
   }
-  if (value.all && value.not.length) {
+  if (value.all?.length) {
     result =
       (result ? result + " AND " : "") +
       `${serializeStringOrArray("AND", key, value.all)}`;
   }
-  if (value.not && value.not.length) {
+  if (value.not?.length) {
     // negate the entries if they are not
     result =
       (result ? result + " AND " : "") +

--- a/packages/common/test/search/serializeQueryForPortal.test.ts
+++ b/packages/common/test/search/serializeQueryForPortal.test.ts
@@ -388,4 +388,87 @@ describe("ifilter-utils:", () => {
       expect(chk.joined).toEqual("1691478000000,1692255599999");
     });
   });
+  describe("verify matchOption serialization", () => {
+    it("handles any", () => {
+      const p: IPredicate = {
+        type: { any: ["Web Map", "Hub Project"] },
+        tags: ["water", "rivers"],
+      };
+
+      const query: IQuery = {
+        targetEntity: "item",
+        filters: [
+          {
+            operation: "AND",
+            predicates: [p],
+          },
+        ],
+      };
+
+      const chk = serializeQueryForPortal(query);
+      expect(chk.q).toEqual(
+        '((type:"Web Map" OR type:"Hub Project") AND (tags:"water" OR tags:"rivers"))'
+      );
+    });
+    it("handles all", () => {
+      const p: IPredicate = {
+        type: { all: ["Web Map", "Hub Project"] },
+      };
+
+      const query: IQuery = {
+        targetEntity: "item",
+        filters: [
+          {
+            operation: "AND",
+            predicates: [p],
+          },
+        ],
+      };
+
+      const chk = serializeQueryForPortal(query);
+      expect(chk.q).toEqual(`((type:"Web Map" AND type:"Hub Project"))`);
+    });
+    it("handles not", () => {
+      const p: IPredicate = {
+        type: { not: ["Web Map", "Hub Project"] },
+      };
+
+      const query: IQuery = {
+        targetEntity: "item",
+        filters: [
+          {
+            operation: "AND",
+            predicates: [p],
+          },
+        ],
+      };
+
+      const chk = serializeQueryForPortal(query);
+      expect(chk.q).toEqual('((-type:"Web Map" OR -type:"Hub Project"))');
+    });
+    it("handles any/all/not", () => {
+      const p: IPredicate = {
+        type: {
+          any: ["Web Map", "Hub Project"],
+          not: ["Feature Layer"],
+          all: ["A", "B"],
+        },
+      };
+
+      const query: IQuery = {
+        targetEntity: "item",
+        filters: [
+          {
+            operation: "AND",
+            predicates: [p],
+          },
+        ],
+      };
+
+      const chk = serializeQueryForPortal(query);
+      expect(chk.q).toEqual(
+        '((type:"Web Map" OR type:"Hub Project") AND (type:"A" AND type:"B") AND -type:"Feature Layer")'
+      );
+    });
+  });
 });


### PR DESCRIPTION
1. Description:

Bug in `serializeMatchOptions` was found via hub-search system tests. Also added tests that verify the serialization permutations.

1. Instructions for testing: run tests

1. Closes Issues: n/a - reported by team members

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
