### PR TITLE
feat: swap to new notice implementation for uiSchemas

### DIFF
--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -111,7 +111,7 @@ export const buildUiSchema = async (
             },
           },
           // categories
-          await fetchCategoriesUiSchemaElement(i18nScope, context),
+          ...(await fetchCategoriesUiSchemaElement(i18nScope, context)),
           // license
           {
             labelKey: `${i18nScope}.fields.license.label`,

--- a/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaEdit.ts
@@ -85,7 +85,7 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(
+          ...getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
             options.thumbnailUrl,

--- a/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
@@ -64,18 +64,23 @@ export const buildUiSchema = async (
     if (options.access !== "public") {
       // Disable the schedule control and add the unavailable notice
       scheduleControlElement.options.disabled = true;
-      scheduleControlElement.options.messages = [
-        {
-          type: UiSchemaMessageTypes.custom,
-          display: "notice",
-          kind: "warning",
-          icon: "exclamation-mark-triangle",
-          titleKey: `${i18nScope}.fields.schedule.unavailableNotice.title`,
-          labelKey: `${i18nScope}.fields.schedule.unavailableNotice.body`,
-          allowShowBeforeInteract: true,
-          alwaysShow: true,
+      scheduleSectionElements.push({
+        type: "Notice",
+        options: {
+          notice: {
+            configuration: {
+              id: "schedule-unavailable-notice",
+              noticeType: "notice",
+              closable: false,
+              kind: "warning",
+              scale: "m",
+            },
+            title: `${i18nScope}.fields.schedule.unavailableNotice.title`,
+            message: `${i18nScope}.fields.schedule.unavailableNotice.body`,
+            autoShow: true,
+          },
         },
-      ] as IUiSchemaMessage[];
+      });
     } else {
       // force update checkbox -- TODO: replace with button once available
       scheduleSectionElements.push({

--- a/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
@@ -3,8 +3,7 @@ import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
 import {
   IUiSchema,
   IUiSchemaElement,
-  IUiSchemaMessage,
-  UiSchemaMessageTypes,
+  UiSchemaRuleEffects,
 } from "../../core/schemas/types";
 import { IHubEditableContent } from "../../core/types/IHubEditableContent";
 import { checkPermission } from "../../permissions/checkPermission";
@@ -33,38 +32,37 @@ export const buildUiSchema = async (
       options
     ).access
   ) {
-    const scheduleControlElement: IUiSchemaElement = {
-      type: "Control",
-      scope: "/properties/schedule",
-      labelKey: `${i18nScope}.sections.schedule.helperText`,
-      options: {
+    const scheduleSectionElements: IUiSchemaElement[] = [
+      {
         type: "Control",
-        control: "hub-field-input-scheduler",
-        labelKey: "fieldHeader",
-        format: "radio",
-        inputs: [
-          { type: "automatic" },
-          { type: "daily" },
-          { type: "weekly" },
-          { type: "monthly" },
-          { type: "yearly" },
+        scope: "/properties/schedule",
+        labelKey: `${i18nScope}.sections.schedule.helperText`,
+        options: {
+          type: "Control",
+          control: "hub-field-input-scheduler",
+          labelKey: "fieldHeader",
+          format: "radio",
+          inputs: [
+            { type: "automatic" },
+            { type: "daily" },
+            { type: "weekly" },
+            { type: "monthly" },
+            { type: "yearly" },
+            {
+              type: "manual",
+              helperActionIcon: "information-f",
+              helperActionText: `{{${i18nScope}.fields.schedule.manual.helperActionText:translate}}`,
+            },
+          ],
+        },
+        rules: [
           {
-            type: "manual",
-            helperActionIcon: "information-f",
-            helperActionText: `{{${i18nScope}.fields.schedule.manual.helperActionText:translate}}`,
+            effect: UiSchemaRuleEffects.DISABLE,
+            conditions: [options.access !== "public"],
           },
         ],
       },
-    };
-
-    const scheduleSectionElements: IUiSchemaElement[] = [
-      scheduleControlElement,
-    ];
-
-    if (options.access !== "public") {
-      // Disable the schedule control and add the unavailable notice
-      scheduleControlElement.options.disabled = true;
-      scheduleSectionElements.push({
+      {
         type: "Notice",
         options: {
           notice: {
@@ -73,17 +71,22 @@ export const buildUiSchema = async (
               noticeType: "notice",
               closable: false,
               kind: "warning",
+              icon: "exclamation-mark-triangle",
               scale: "m",
             },
-            title: `${i18nScope}.fields.schedule.unavailableNotice.title`,
-            message: `${i18nScope}.fields.schedule.unavailableNotice.body`,
+            title: `{{${i18nScope}.fields.schedule.unavailableNotice.title:translate}}`,
+            message: `{{${i18nScope}.fields.schedule.unavailableNotice.body:translate}}`,
             autoShow: true,
           },
         },
-      });
-    } else {
-      // force update checkbox -- TODO: replace with button once available
-      scheduleSectionElements.push({
+        rules: [
+          {
+            effect: UiSchemaRuleEffects.SHOW,
+            conditions: [options.access !== "public"],
+          },
+        ],
+      },
+      {
         type: "Control",
         scope: "/properties/_forceUpdate",
         options: {
@@ -96,8 +99,14 @@ export const buildUiSchema = async (
             `{{${i18nScope}.fields.schedule.forceUpdateButton.description:translate}}`,
           ],
         },
-      });
-    }
+        rules: [
+          {
+            effect: UiSchemaRuleEffects.SHOW,
+            conditions: [options.access === "public"],
+          },
+        ],
+      },
+    ];
 
     uiSchema.elements.push({
       type: "Section",

--- a/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
@@ -391,23 +391,31 @@ export async function buildUiSchema(
                   enum: {
                     i18nScope: `${i18nScope}.options.openIn`,
                   },
-                  messages: [
-                    {
-                      type: UiSchemaMessageTypes.custom,
-                      display: "notice",
+                },
+              },
+              {
+                type: "Notice",
+                options: {
+                  notice: {
+                    configuration: {
+                      id: "open-in-notice",
+                      noticeType: "notice",
+                      closeable: false,
                       kind: "brand",
-                      titleKey: `${i18nScope}.options.openIn.notice.title`,
-                      label: `{{${i18nScope}.options.openIn.notice.body:translate}}`,
-                      link: {
-                        kind: "external",
+                      scale: "m",
+                    },
+                    title: `{{${i18nScope}.options.openIn.notice.title:translate}}`,
+                    body: `{{${i18nScope}.options.openIn.notice.body:translate}}`,
+                    autoShow: true,
+                    actions: [
+                      {
                         label: `{{${i18nScope}.options.openIn.notice.link:translate}}`,
+                        icon: "launch",
                         href: "https://www.w3.org/TR/WCAG20-TECHS/G200.html",
                         target: "_blank",
                       },
-                      allowShowBeforeInteract: true,
-                      alwaysShow: true,
-                    },
-                  ],
+                    ],
+                  },
                 },
               },
             ],

--- a/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
@@ -18,7 +18,18 @@ export async function buildUiSchema(
     `${i18nScope}.content`,
     context
   );
-  delete categoriesUiSchema.options.helperText;
+  categoriesUiSchema[0].rules = [
+    {
+      effect: UiSchemaRuleEffects.SHOW,
+      conditions: [
+        {
+          scope: "/properties/selectionMode",
+          schema: { const: "dynamic" },
+        },
+      ],
+    },
+  ];
+  delete categoriesUiSchema[0].options.helperText;
   return {
     type: "Layout",
     elements: [
@@ -106,20 +117,7 @@ export async function buildUiSchema(
                   },
                 ],
               },
-              {
-                ...categoriesUiSchema,
-                rules: [
-                  {
-                    effect: UiSchemaRuleEffects.SHOW,
-                    conditions: [
-                      {
-                        scope: "/properties/selectionMode",
-                        schema: { const: "dynamic" },
-                      },
-                    ],
-                  },
-                ],
-              },
+              ...categoriesUiSchema,
               {
                 scope: "/properties/entityIds",
                 type: "Control",

--- a/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
@@ -17,13 +17,13 @@ import { fetchCategoryItems } from "./fetchCategoryItems";
 export async function fetchCategoriesUiSchemaElement(
   i18nScope: string,
   context: IArcGISContext
-): Promise<IUiSchemaElement> {
+): Promise<IUiSchemaElement[]> {
   const categoryItems = await fetchCategoryItems(
     context.portal.id,
     context.hubRequestOptions
   );
 
-  const result: IUiSchemaElement = {
+  const categories: IUiSchemaElement = {
     labelKey: `shared.fields.categories.label`,
     scope: "/properties/categories",
     type: "Control",
@@ -40,26 +40,35 @@ export async function fetchCategoriesUiSchemaElement(
     },
   };
 
+  const result: IUiSchemaElement[] = [categories];
+
   if (!categoryItems.length) {
-    result.options.disabled = true;
-    result.options.messages = [
-      {
-        type: UiSchemaMessageTypes.custom,
-        display: "notice",
-        kind: "warning",
-        icon: "exclamation-mark-triangle",
-        labelKey: "shared.fields.categories.noCategoriesNotice.body",
-        link: {
-          kind: "external",
-          label:
-            "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
-          href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
-          target: "_blank",
+    categories.options.disabled = true;
+    result.push({
+      type: "Notice",
+      options: {
+        notice: {
+          configuration: {
+            id: "no-categories-notice",
+            noticeType: "notice",
+            closable: false,
+            kind: "warning",
+            scale: "m",
+          },
+          message: `shared.fields.categories.noCategoriesNotice.body`,
+          autoShow: true,
+          actions: [
+            {
+              label:
+                "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
+              icon: "launch",
+              href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
+              target: "_blank",
+            },
+          ],
         },
-        allowShowBeforeInteract: true,
-        alwaysShow: true,
-      } as IUiSchemaMessage,
-    ];
+      },
+    });
   }
 
   return result;

--- a/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
@@ -1,9 +1,5 @@
 import { IArcGISContext } from "../../../ArcGISContext";
-import {
-  IUiSchemaElement,
-  IUiSchemaMessage,
-  UiSchemaMessageTypes,
-} from "../types";
+import { IUiSchemaElement, UiSchemaRuleEffects } from "../types";
 import { fetchCategoryItems } from "./fetchCategoryItems";
 
 /**
@@ -23,28 +19,30 @@ export async function fetchCategoriesUiSchemaElement(
     context.hubRequestOptions
   );
 
-  const categories: IUiSchemaElement = {
-    labelKey: `shared.fields.categories.label`,
-    scope: "/properties/categories",
-    type: "Control",
-    options: {
-      control: "hub-field-input-combobox",
-      items: categoryItems,
-      allowCustomValues: false,
-      selectionMode: "ancestors",
-      placeholderIcon: "select-category",
-      helperText: {
-        // helper text varies between entity types
-        labelKey: `${i18nScope}.fields.categories.helperText`,
+  return [
+    {
+      labelKey: `shared.fields.categories.label`,
+      scope: "/properties/categories",
+      type: "Control",
+      options: {
+        control: "hub-field-input-combobox",
+        items: categoryItems,
+        allowCustomValues: false,
+        selectionMode: "ancestors",
+        placeholderIcon: "select-category",
+        helperText: {
+          // helper text varies between entity types
+          labelKey: `${i18nScope}.fields.categories.helperText`,
+        },
       },
+      rules: [
+        {
+          effect: UiSchemaRuleEffects.DISABLE,
+          conditions: [!categoryItems.length],
+        },
+      ],
     },
-  };
-
-  const result: IUiSchemaElement[] = [categories];
-
-  if (!categoryItems.length) {
-    categories.options.disabled = true;
-    result.push({
+    {
       type: "Notice",
       options: {
         notice: {
@@ -70,8 +68,12 @@ export async function fetchCategoriesUiSchemaElement(
           ],
         },
       },
-    });
-  }
-
-  return result;
+      rules: [
+        {
+          effect: UiSchemaRuleEffects.SHOW,
+          conditions: [!categoryItems.length],
+        },
+      ],
+    },
+  ];
 }

--- a/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/fetchCategoriesUiSchemaElement.ts
@@ -52,10 +52,12 @@ export async function fetchCategoriesUiSchemaElement(
             id: "no-categories-notice",
             noticeType: "notice",
             closable: false,
+            icon: "exclamation-mark-triangle",
             kind: "warning",
             scale: "m",
           },
-          message: `shared.fields.categories.noCategoriesNotice.body`,
+          message:
+            "{{shared.fields.categories.noCategoriesNotice.body:translate}}",
           autoShow: true,
           actions: [
             {

--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -253,22 +253,29 @@ export interface IUiSchemaCondition {
  * A message to display for a uiSchema element.
  *
  * NOTE: `.condition` is deprecated and remains for backwards compatibility only. Please use `.conditions` instead.
+ * NOTE: `.display`, `.title`, `.titleKey`, `.kind`, `.alwaysShow` are deprecated and remain for backwards compatibility only. Please use the new method of notices in the configuration editor instead.
  */
 export interface IUiSchemaMessage {
   type: UiSchemaMessageTypes;
-  display?: "message" | "notice";
   keyword?: string;
-  title?: string;
-  titleKey?: string;
   label?: string;
   labelKey?: string;
   icon?: boolean | string;
-  kind?: "brand" | "danger" | "info" | "success" | "warning";
   link?: HubActionLink;
   hidden?: boolean;
-  // NOTE: condition is deprecated and remains for backwards compatibility only. Please use conditions instead.
-  condition?: IUiSchemaCondition;
   conditions?: Array<IUiSchemaCondition | boolean>;
   allowShowBeforeInteract?: boolean;
+  /** DEPRECATED */
+  // NOTE: condition is deprecated and remains for backwards compatibility only. Please use conditions instead.
+  condition?: IUiSchemaCondition;
+  // NOTE: display is deprecated and remains for backwards compatibility only. Please use the new method of notices in the configuration editor instead.
+  display?: "message" | "notice";
+  // NOTE: title is deprecated and remains for backwards compatibility only. Please use the new method of notices in the configuration editor instead.
+  title?: string;
+  // NOTE: titleKey is deprecated and remains for backwards compatibility only. Please use the new method of notices in the configuration editor instead.
+  titleKey?: string;
+  // NOTE: kind is deprecated and remains for backwards compatibility only. Please use the new method of notices in the configuration editor instead.
+  kind?: "brand" | "danger" | "info" | "success" | "warning";
+  // NOTE: alwaysShow is deprecated and remains for backwards compatibility only. Please use the new method of notices in the configuration editor instead.
   alwaysShow?: boolean;
 }

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -64,7 +64,7 @@ export const buildUiSchema = async (
               ],
             },
           },
-          getThumbnailUiSchemaElement(
+          ...getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
             options.thumbnailUrl,

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -123,7 +123,7 @@ export const buildUiSchema = async (
               placeholderIcon: "label",
             },
           },
-          await fetchCategoriesUiSchemaElement(i18nScope, context),
+          ...(await fetchCategoriesUiSchemaElement(i18nScope, context)),
           {
             labelKey: `${i18nScope}.fields.summary.label`,
             scope: "/properties/summary",

--- a/packages/common/src/events/_internal/EventUiSchemaEdit.ts
+++ b/packages/common/src/events/_internal/EventUiSchemaEdit.ts
@@ -424,7 +424,7 @@ export const buildUiSchema = async (
               },
             },
           },
-          await fetchCategoriesUiSchemaElement(i18nScope, context),
+          ...(await fetchCategoriesUiSchemaElement(i18nScope, context)),
           {
             labelKey: `${i18nScope}.fields.summary.label`,
             scope: "/properties/summary",

--- a/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaEdit.ts
@@ -70,7 +70,7 @@ export const buildUiSchema = async (
               type: "textarea",
             },
           },
-          getThumbnailUiSchemaElement(
+          ...getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
             getEntityThumbnailUrl(options),

--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
@@ -105,7 +105,7 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(
+          ...getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
             getEntityThumbnailUrl(options),

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -181,7 +181,7 @@ export const buildUiSchema = async (
         type: "Section",
         labelKey: `${i18nScope}.sections.searchDiscoverability.label`,
         elements: [
-          await fetchCategoriesUiSchemaElement(i18nScope, context),
+          ...(await fetchCategoriesUiSchemaElement(i18nScope, context)),
           {
             labelKey: `${i18nScope}.fields.tags.label`,
             scope: "/properties/tags",

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -199,7 +199,7 @@ export const buildUiSchema = async (
               helperText: { labelKey: `${i18nScope}.fields.tags.helperText` },
             },
           },
-          getThumbnailUiSchemaElement(
+          ...getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
             options.thumbnailUrl,

--- a/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
+++ b/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
@@ -79,7 +79,7 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(
+          ...getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
             options.thumbnailUrl,

--- a/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
+++ b/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
@@ -103,7 +103,7 @@ export const buildUiSchema = async (
               helperText: { labelKey: `${i18nScope}.fields.tags.helperText` },
             },
           },
-          await fetchCategoriesUiSchemaElement(i18nScope, context),
+          ...(await fetchCategoriesUiSchemaElement(i18nScope, context)),
         ],
       },
       {

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -165,7 +165,7 @@ export const buildUiSchema = async (
             },
           },
           ...(await fetchCategoriesUiSchemaElement(i18nScope, context)),
-          getThumbnailUiSchemaElement(
+          ...getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
             options.thumbnailUrl,

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -164,7 +164,7 @@ export const buildUiSchema = async (
               helperText: { labelKey: `${i18nScope}.fields.tags.helperText` },
             },
           },
-          await fetchCategoriesUiSchemaElement(i18nScope, context),
+          ...(await fetchCategoriesUiSchemaElement(i18nScope, context)),
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -79,7 +79,7 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(
+          ...getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
             options.thumbnailUrl,

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -103,7 +103,7 @@ export const buildUiSchema = async (
               helperText: { labelKey: `${i18nScope}.fields.tags.helperText` },
             },
           },
-          await fetchCategoriesUiSchemaElement(i18nScope, context),
+          ...(await fetchCategoriesUiSchemaElement(i18nScope, context)),
         ],
       },
       {

--- a/packages/common/src/surveys/_internal/SurveyUiSchemaEdit.ts
+++ b/packages/common/src/surveys/_internal/SurveyUiSchemaEdit.ts
@@ -100,7 +100,7 @@ export const buildUiSchema = async (
             },
           },
           ...(await fetchCategoriesUiSchemaElement(i18nScope, context)),
-          getThumbnailUiSchemaElement(
+          ...getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
             options.thumbnailUrl,

--- a/packages/common/src/surveys/_internal/SurveyUiSchemaEdit.ts
+++ b/packages/common/src/surveys/_internal/SurveyUiSchemaEdit.ts
@@ -99,7 +99,7 @@ export const buildUiSchema = async (
               placeholderIcon: "label",
             },
           },
-          await fetchCategoriesUiSchemaElement(i18nScope, context),
+          ...(await fetchCategoriesUiSchemaElement(i18nScope, context)),
           getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,

--- a/packages/common/src/surveys/_internal/SurveyUiSchemaSettings.ts
+++ b/packages/common/src/surveys/_internal/SurveyUiSchemaSettings.ts
@@ -1,10 +1,6 @@
 import { IArcGISContext } from "../../ArcGISContext";
 import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
-import {
-  IUiSchema,
-  UiSchemaMessageTypes,
-  UiSchemaRuleEffects,
-} from "../../core/schemas/types";
+import { IUiSchema, UiSchemaRuleEffects } from "../../core/schemas/types";
 import { IHubSurvey } from "../../core/types/IHubSurvey";
 
 /**
@@ -18,6 +14,9 @@ export const buildUiSchema = async (
   options: EntityEditorOptions,
   context: IArcGISContext
 ): Promise<IUiSchema> => {
+  // We want to conver it over to a boolean as it can be undefined which doesn't play well
+  // with the rules in our schema system
+  const hasMapQuestion = !(options as IHubSurvey).hasMapQuestion;
   return {
     type: "Layout",
     elements: [
@@ -49,20 +48,30 @@ export const buildUiSchema = async (
               ],
               icons: ["sidecar", "form-elements"],
               layout: "horizontal",
-              messages: (options as IHubSurvey).hasMapQuestion
-                ? []
-                : [
-                    {
-                      type: UiSchemaMessageTypes.custom,
-                      display: "notice",
-                      keyword: "mapQuestion",
-                      titleKey: `${i18nScope}.fields.displayMap.notice.title`,
-                      labelKey: `${i18nScope}.fields.displayMap.notice.message`,
-                      allowShowBeforeInteract: true,
-                      alwaysShow: true,
-                    },
-                  ],
             },
+          },
+          {
+            type: "Notice",
+            options: {
+              notice: {
+                configuration: {
+                  id: "map-question-notice",
+                  noticeType: "notice",
+                  closable: false,
+                  kind: "info",
+                  scale: "m",
+                },
+                title: `{{${i18nScope}.fields.displayMap.notice.title:translate}}`,
+                body: `{{${i18nScope}.fields.displayMap.notice.message:translate}}`,
+                autoShow: true,
+              },
+            },
+            rules: [
+              {
+                effect: UiSchemaRuleEffects.SHOW,
+                conditions: [hasMapQuestion],
+              },
+            ],
           },
         ],
       },

--- a/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
+++ b/packages/common/src/templates/_internal/TemplateUiSchemaEdit.ts
@@ -104,7 +104,7 @@ export const buildUiSchema = async (
               },
             },
           },
-          getThumbnailUiSchemaElement(
+          ...getThumbnailUiSchemaElement(
             i18nScope,
             options.thumbnail,
             getEntityThumbnailUrl(options),

--- a/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
@@ -4,6 +4,7 @@ import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fe
 import * as getLocationExtentModule from "../../../src/core/schemas/internal/getLocationExtent";
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
+import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
 
 describe("buildUiSchema: content edit", () => {
   it("returns the full content edit uiSchema", async () => {
@@ -115,8 +116,31 @@ describe("buildUiSchema: content edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
-                messages: [],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-thumbnail-or-png-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "lightbulb",
+                    kind: "info",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
             {
               labelKey: "some.scope.fields.tags.label",
@@ -151,6 +175,45 @@ describe("buildUiSchema: content edit", () => {
                   labelKey: "some.scope.fields.categories.helperText",
                 },
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.DISABLE,
+                  conditions: [false],
+                },
+              ],
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-categories-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "exclamation-mark-triangle",
+                    kind: "warning",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields.categories.noCategoriesNotice.body:translate}}",
+                  autoShow: true,
+                  actions: [
+                    {
+                      label:
+                        "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
+                      icon: "launch",
+                      href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
+                      target: "_blank",
+                    },
+                  ],
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
             {
               labelKey: "some.scope.fields.license.label",

--- a/packages/common/test/content/_internal/ContentUiSchemaSettings.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaSettings.test.ts
@@ -150,6 +150,36 @@ describe("buildUiSchema: content settings", () => {
                   },
                 ],
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.DISABLE,
+                  conditions: [false],
+                },
+              ],
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "schedule-unavailable-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    kind: "warning",
+                    icon: "exclamation-mark-triangle",
+                    scale: "m",
+                  },
+                  title: `{{some.scope.fields.schedule.unavailableNotice.title:translate}}`,
+                  message: `{{some.scope.fields.schedule.unavailableNotice.body:translate}}`,
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
             {
               type: "Control",
@@ -164,6 +194,12 @@ describe("buildUiSchema: content settings", () => {
                   `{{some.scope.fields.schedule.forceUpdateButton.description:translate}}`,
                 ],
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [true],
+                },
+              ],
             },
           ],
         },
@@ -197,7 +233,6 @@ describe("buildUiSchema: content settings", () => {
               options: {
                 type: "Control",
                 control: "hub-field-input-scheduler",
-                disabled: true,
                 labelKey: "fieldHeader",
                 format: "radio",
                 inputs: [
@@ -213,6 +248,12 @@ describe("buildUiSchema: content settings", () => {
                   },
                 ],
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.DISABLE,
+                  conditions: [true],
+                },
+              ],
             },
             {
               type: "Notice",
@@ -223,13 +264,40 @@ describe("buildUiSchema: content settings", () => {
                     noticeType: "notice",
                     closable: false,
                     kind: "warning",
+                    icon: "exclamation-mark-triangle",
                     scale: "m",
                   },
-                  title: `some.scope.fields.schedule.unavailableNotice.title`,
-                  message: `some.scope.fields.schedule.unavailableNotice.body`,
+                  title: `{{some.scope.fields.schedule.unavailableNotice.title:translate}}`,
+                  message: `{{some.scope.fields.schedule.unavailableNotice.body:translate}}`,
                   autoShow: true,
                 },
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [true],
+                },
+              ],
+            },
+            {
+              type: "Control",
+              scope: "/properties/_forceUpdate",
+              options: {
+                control: "hub-field-input-tile-select",
+                type: "checkbox",
+                labels: [
+                  `{{some.scope.fields.schedule.forceUpdateButton.label:translate}}`,
+                ],
+                descriptions: [
+                  `{{some.scope.fields.schedule.forceUpdateButton.description:translate}}`,
+                ],
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
           ],
         },

--- a/packages/common/test/content/_internal/ContentUiSchemaSettings.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaSettings.test.ts
@@ -212,20 +212,23 @@ describe("buildUiSchema: content settings", () => {
                     helperActionText: `{{some.scope.fields.schedule.manual.helperActionText:translate}}`,
                   },
                 ],
-                messages: [
-                  {
-                    type: "CUSTOM",
-                    display: "notice",
+              },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "schedule-unavailable-notice",
+                    noticeType: "notice",
+                    closable: false,
                     kind: "warning",
-                    icon: "exclamation-mark-triangle",
-                    titleKey:
-                      "some.scope.fields.schedule.unavailableNotice.title",
-                    labelKey:
-                      "some.scope.fields.schedule.unavailableNotice.body",
-                    allowShowBeforeInteract: true,
-                    alwaysShow: true,
+                    scale: "m",
                   },
-                ],
+                  title: `some.scope.fields.schedule.unavailableNotice.title`,
+                  message: `some.scope.fields.schedule.unavailableNotice.body`,
+                  autoShow: true,
+                },
               },
             },
           ],

--- a/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
@@ -397,25 +397,31 @@ describe("EventGalleryCardUiSchema", () => {
                     options: {
                       control: "hub-field-input-select",
                       enum: { i18nScope: "some.scope.options.openIn" },
-                      messages: [
-                        {
-                          type: "CUSTOM",
-                          display: "notice",
+                    },
+                  },
+                  {
+                    type: "Notice",
+                    options: {
+                      notice: {
+                        configuration: {
+                          id: "open-in-notice",
+                          noticeType: "notice",
+                          closeable: false,
                           kind: "brand",
-                          titleKey: "some.scope.options.openIn.notice.title",
-                          label:
-                            "{{some.scope.options.openIn.notice.body:translate}}",
-                          link: {
-                            kind: "external",
-                            label:
-                              "{{some.scope.options.openIn.notice.link:translate}}",
+                          scale: "m",
+                        },
+                        title: `{{some.scope.options.openIn.notice.title:translate}}`,
+                        body: `{{some.scope.options.openIn.notice.body:translate}}`,
+                        autoShow: true,
+                        actions: [
+                          {
+                            label: `{{some.scope.options.openIn.notice.link:translate}}`,
+                            icon: "launch",
                             href: "https://www.w3.org/TR/WCAG20-TECHS/G200.html",
                             target: "_blank",
                           },
-                          allowShowBeforeInteract: true,
-                          alwaysShow: true,
-                        },
-                      ],
+                        ],
+                      },
                     },
                   },
                 ],

--- a/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
@@ -29,19 +29,21 @@ describe("EventGalleryCardUiSchema", () => {
           children: [],
         } as IUiSchemaComboboxItem,
       ];
-      const categoriesUiSchemaElement = {
-        type: "Control",
-        scope: "/properties/categories",
-        rules: [],
-        options: {
-          helperText: {
-            labelKey: "some.label.key",
+      const categoriesUiSchemaElement = [
+        {
+          type: "Control",
+          scope: "/properties/categories",
+          rules: [],
+          options: {
+            helperText: {
+              labelKey: "some.label.key",
+            },
           },
+          label: "Categories",
         },
-        label: "Categories",
-      } as IUiSchemaElement;
+      ] as IUiSchemaElement[];
       const categoriesUiSchemaElementWithoutHelperText = cloneObject(
-        categoriesUiSchemaElement
+        categoriesUiSchemaElement[0]
       );
       delete categoriesUiSchemaElementWithoutHelperText.options?.helperText;
       const catalog = {

--- a/packages/common/test/core/schemas/internal/fetchCategoriesUiSchemaElement.test.ts
+++ b/packages/common/test/core/schemas/internal/fetchCategoriesUiSchemaElement.test.ts
@@ -35,7 +35,7 @@ describe("fetchCategoriesUiSchemaElement:", () => {
     const uiSchema = await fetchCategoriesUiSchemaElement("scope", context);
     expect(uiSchema.length).toBe(2);
     expect(uiSchema[1].options?.notice.message).toBe(
-      "shared.fields.categories.noCategoriesNotice.body"
+      "{{shared.fields.categories.noCategoriesNotice.body:translate}}"
     );
     expect(uiSchema[1].options?.notice.actions[0].label).toBe(
       "{{shared.fields.categories.noCategoriesNotice.link:translate}}"

--- a/packages/common/test/core/schemas/internal/fetchCategoriesUiSchemaElement.test.ts
+++ b/packages/common/test/core/schemas/internal/fetchCategoriesUiSchemaElement.test.ts
@@ -19,7 +19,7 @@ describe("fetchCategoriesUiSchemaElement:", () => {
       },
     } as unknown as IArcGISContext;
     const uiSchema = await fetchCategoriesUiSchemaElement("scope", context);
-    expect(uiSchema.length).toBe(1);
+    expect(uiSchema.length).toBe(2);
   });
 
   it("includes the no categories notice if category items are not available", async () => {

--- a/packages/common/test/core/schemas/internal/fetchCategoriesUiSchemaElement.test.ts
+++ b/packages/common/test/core/schemas/internal/fetchCategoriesUiSchemaElement.test.ts
@@ -19,7 +19,7 @@ describe("fetchCategoriesUiSchemaElement:", () => {
       },
     } as unknown as IArcGISContext;
     const uiSchema = await fetchCategoriesUiSchemaElement("scope", context);
-    expect(uiSchema.options?.messages).toBeUndefined();
+    expect(uiSchema.length).toBe(1);
   });
 
   it("includes the no categories notice if category items are not available", async () => {
@@ -33,11 +33,11 @@ describe("fetchCategoriesUiSchemaElement:", () => {
       },
     } as unknown as IArcGISContext;
     const uiSchema = await fetchCategoriesUiSchemaElement("scope", context);
-    expect(uiSchema.options?.messages?.length).toBe(1);
-    expect(uiSchema.options?.messages[0].labelKey).toBe(
+    expect(uiSchema.length).toBe(2);
+    expect(uiSchema[1].options?.notice.message).toBe(
       "shared.fields.categories.noCategoriesNotice.body"
     );
-    expect(uiSchema.options?.messages[0].link.label).toBe(
+    expect(uiSchema[1].options?.notice.actions[0].label).toBe(
       "{{shared.fields.categories.noCategoriesNotice.link:translate}}"
     );
   });

--- a/packages/common/test/core/schemas/internal/getThumbnailUiSchemaElement.test.ts
+++ b/packages/common/test/core/schemas/internal/getThumbnailUiSchemaElement.test.ts
@@ -3,6 +3,7 @@ import { IHubItemEntity } from "../../../../src";
 import { getThumbnailUiSchemaElement } from "../../../../src/core/schemas/internal/getThumbnailUiSchemaElement";
 import { HubEntityType } from "../../../../dist/types/core/types/HubEntityType";
 import * as urlUtils from "../../../../src/urls";
+import { UiSchemaRuleEffects } from "../../../../src/core/schemas/types";
 
 describe("getThumbnailUiSchemaElement:", () => {
   it("excludes the default thumbnail notice if the entity has a thumbnail", () => {
@@ -30,7 +31,13 @@ describe("getThumbnailUiSchemaElement:", () => {
       entity.type as HubEntityType,
       requestOptions
     );
-    expect(uiSchema.options?.messages.length).toBe(0);
+    expect(uiSchema.length).toBe(2);
+    expect(uiSchema[1].rules).toEqual([
+      {
+        effect: UiSchemaRuleEffects.SHOW,
+        conditions: [false],
+      },
+    ]);
   });
 
   it("includes the default thumbnail notice if the entity has no thumbnail", () => {
@@ -57,7 +64,13 @@ describe("getThumbnailUiSchemaElement:", () => {
       entity.type as HubEntityType,
       requestOptions
     );
-    expect(uiSchema.options?.messages.length).toBe(1);
+    expect(uiSchema.length).toBe(2);
+    expect(uiSchema[1].rules).toEqual([
+      {
+        effect: UiSchemaRuleEffects.SHOW,
+        conditions: [true],
+      },
+    ]);
   });
 
   it("includes the default thumbnail notice if the entity has the default thumbnail", () => {
@@ -85,7 +98,13 @@ describe("getThumbnailUiSchemaElement:", () => {
       entity.type as HubEntityType,
       requestOptions
     );
-    expect(uiSchema.options?.messages.length).toBe(1);
+    expect(uiSchema.length).toBe(2);
+    expect(uiSchema[1].rules).toEqual([
+      {
+        effect: UiSchemaRuleEffects.SHOW,
+        conditions: [true],
+      },
+    ]);
   });
 
   it("sets default thumbnail when available", () => {
@@ -118,6 +137,6 @@ describe("getThumbnailUiSchemaElement:", () => {
       requestOptions
     );
     expect(getCdnAssetUrlSpy).toHaveBeenCalled();
-    expect(uiSchema.options?.defaultImgUrl).toBe(defaultImageUrl);
+    expect(uiSchema[0].options?.defaultImgUrl).toBe(defaultImageUrl);
   });
 });

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -4,6 +4,7 @@ import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fe
 import * as getLocationExtentModule from "../../../src/core/schemas/internal/getLocationExtent";
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
+import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
 
 describe("buildUiSchema: discussion edit", () => {
   it("returns the full discussion edit uiSchema", async () => {
@@ -97,8 +98,31 @@ describe("buildUiSchema: discussion edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
-                messages: [],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-thumbnail-or-png-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "lightbulb",
+                    kind: "info",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
           ],
         },
@@ -158,6 +182,45 @@ describe("buildUiSchema: discussion edit", () => {
                   labelKey: "some.scope.fields.categories.helperText",
                 },
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.DISABLE,
+                  conditions: [false],
+                },
+              ],
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-categories-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "exclamation-mark-triangle",
+                    kind: "warning",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields.categories.noCategoriesNotice.body:translate}}",
+                  autoShow: true,
+                  actions: [
+                    {
+                      label:
+                        "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
+                      icon: "launch",
+                      href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
+                      target: "_blank",
+                    },
+                  ],
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
             {
               labelKey: "some.scope.fields.summary.label",
@@ -291,8 +354,31 @@ describe("buildUiSchema: discussion edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
-                messages: [],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-thumbnail-or-png-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "lightbulb",
+                    kind: "info",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
           ],
         },
@@ -352,6 +438,45 @@ describe("buildUiSchema: discussion edit", () => {
                   labelKey: "some.scope.fields.categories.helperText",
                 },
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.DISABLE,
+                  conditions: [false],
+                },
+              ],
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-categories-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "exclamation-mark-triangle",
+                    kind: "warning",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields.categories.noCategoriesNotice.body:translate}}",
+                  autoShow: true,
+                  actions: [
+                    {
+                      label:
+                        "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
+                      icon: "launch",
+                      href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
+                      target: "_blank",
+                    },
+                  ],
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
             {
               labelKey: "some.scope.fields.summary.label",

--- a/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
+++ b/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
@@ -514,6 +514,45 @@ describe("EventUiSchemaEdit", () => {
                     labelKey: "myI18nScope.fields.categories.helperText",
                   },
                 },
+                rules: [
+                  {
+                    effect: UiSchemaRuleEffects.DISABLE,
+                    conditions: [false],
+                  },
+                ],
+              },
+              {
+                type: "Notice",
+                options: {
+                  notice: {
+                    configuration: {
+                      id: "no-categories-notice",
+                      noticeType: "notice",
+                      closable: false,
+                      icon: "exclamation-mark-triangle",
+                      kind: "warning",
+                      scale: "m",
+                    },
+                    message:
+                      "{{shared.fields.categories.noCategoriesNotice.body:translate}}",
+                    autoShow: true,
+                    actions: [
+                      {
+                        label:
+                          "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
+                        icon: "launch",
+                        href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
+                        target: "_blank",
+                      },
+                    ],
+                  },
+                },
+                rules: [
+                  {
+                    effect: UiSchemaRuleEffects.SHOW,
+                    conditions: [false],
+                  },
+                ],
               },
               {
                 labelKey: `myI18nScope.fields.summary.label`,

--- a/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
@@ -1,3 +1,4 @@
+import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
 import { buildUiSchema } from "../../../src/groups/_internal/GroupUiSchemaEdit";
 import { MOCK_CONTEXT } from "../../mocks/mock-auth";
 
@@ -81,17 +82,31 @@ describe("buildUiSchema: group edit", () => {
                 sizeDescription: {
                   labelKey: "some.scope.fields._thumbnail.sizeDescription",
                 },
-                messages: [
-                  {
-                    type: "CUSTOM",
-                    display: "notice",
-                    labelKey: "shared.fields._thumbnail.defaultThumbnailNotice",
-                    icon: "lightbulb",
-                    allowShowBeforeInteract: true,
-                    alwaysShow: true,
-                  },
-                ],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-thumbnail-or-png-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "lightbulb",
+                    kind: "info",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [true],
+                },
+              ],
             },
           ],
         },

--- a/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
@@ -1,6 +1,9 @@
 import { buildUiSchema } from "../../../src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit";
 import { MOCK_CONTEXT } from "../../mocks/mock-auth";
-import { UiSchemaMessageTypes } from "../../../src/core/schemas/types";
+import {
+  UiSchemaMessageTypes,
+  UiSchemaRuleEffects,
+} from "../../../src/core/schemas/types";
 import * as getRecommendedTemplatesCatalogModule from "../../../src/initiative-templates/_internal/getRecommendedTemplatesCatalog";
 
 describe("buildUiSchema: initiative template edit", () => {
@@ -119,8 +122,31 @@ describe("buildUiSchema: initiative template edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
-                messages: [],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-thumbnail-or-png-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "lightbulb",
+                    kind: "info",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
           ],
         },

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -212,6 +212,45 @@ describe("buildUiSchema: initiative edit", () => {
                   labelKey: "some.scope.fields.categories.helperText",
                 },
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.DISABLE,
+                  conditions: [false],
+                },
+              ],
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-categories-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "exclamation-mark-triangle",
+                    kind: "warning",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields.categories.noCategoriesNotice.body:translate}}",
+                  autoShow: true,
+                  actions: [
+                    {
+                      label:
+                        "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
+                      icon: "launch",
+                      href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
+                      target: "_blank",
+                    },
+                  ],
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
             {
               labelKey: "some.scope.fields.tags.label",
@@ -244,8 +283,31 @@ describe("buildUiSchema: initiative edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
-                messages: [],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-thumbnail-or-png-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "lightbulb",
+                    kind: "info",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
           ],
         },
@@ -517,6 +579,45 @@ describe("buildUiSchema: initiative edit", () => {
                   labelKey: "some.scope.fields.categories.helperText",
                 },
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.DISABLE,
+                  conditions: [false],
+                },
+              ],
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-categories-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "exclamation-mark-triangle",
+                    kind: "warning",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields.categories.noCategoriesNotice.body:translate}}",
+                  autoShow: true,
+                  actions: [
+                    {
+                      label:
+                        "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
+                      icon: "launch",
+                      href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
+                      target: "_blank",
+                    },
+                  ],
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
             {
               labelKey: "some.scope.fields.tags.label",
@@ -549,8 +650,31 @@ describe("buildUiSchema: initiative edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
-                messages: [],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-thumbnail-or-png-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "lightbulb",
+                    kind: "info",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
           ],
         },

--- a/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
+++ b/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
@@ -4,6 +4,7 @@ import * as getLocationExtentModule from "../../../src/core/schemas/internal/get
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
 import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fetchCategoryItems";
+import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
 
 describe("buildUiSchema: page edit", () => {
   it("returns the full page edit uiSchema", async () => {
@@ -112,8 +113,31 @@ describe("buildUiSchema: page edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
-                messages: [],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-thumbnail-or-png-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "lightbulb",
+                    kind: "info",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
             {
               labelKey: "some.scope.fields.tags.label",
@@ -147,6 +171,45 @@ describe("buildUiSchema: page edit", () => {
                   labelKey: "some.scope.fields.categories.helperText",
                 },
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.DISABLE,
+                  conditions: [false],
+                },
+              ],
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-categories-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "exclamation-mark-triangle",
+                    kind: "warning",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields.categories.noCategoriesNotice.body:translate}}",
+                  autoShow: true,
+                  actions: [
+                    {
+                      label:
+                        "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
+                      icon: "launch",
+                      href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
+                      target: "_blank",
+                    },
+                  ],
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
           ],
         },

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -6,6 +6,7 @@ import * as getAuthedImageUrlModule from "../../../src/core/_internal/getAuthedI
 import * as getLocationExtentModule from "../../../src/core/schemas/internal/getLocationExtent";
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
+import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
 
 describe("buildUiSchema: project edit", () => {
   it("returns the full project edit uiSchema", async () => {
@@ -190,6 +191,45 @@ describe("buildUiSchema: project edit", () => {
                   labelKey: "some.scope.fields.categories.helperText",
                 },
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.DISABLE,
+                  conditions: [false],
+                },
+              ],
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-categories-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "exclamation-mark-triangle",
+                    kind: "warning",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields.categories.noCategoriesNotice.body:translate}}",
+                  autoShow: true,
+                  actions: [
+                    {
+                      label:
+                        "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
+                      icon: "launch",
+                      href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
+                      target: "_blank",
+                    },
+                  ],
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
             {
               labelKey: "shared.fields._thumbnail.label",
@@ -209,8 +249,31 @@ describe("buildUiSchema: project edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
-                messages: [],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-thumbnail-or-png-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "lightbulb",
+                    kind: "info",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
           ],
         },
@@ -530,6 +593,45 @@ describe("buildUiSchema: project edit", () => {
                   labelKey: "some.scope.fields.categories.helperText",
                 },
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.DISABLE,
+                  conditions: [false],
+                },
+              ],
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-categories-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "exclamation-mark-triangle",
+                    kind: "warning",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields.categories.noCategoriesNotice.body:translate}}",
+                  autoShow: true,
+                  actions: [
+                    {
+                      label:
+                        "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
+                      icon: "launch",
+                      href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
+                      target: "_blank",
+                    },
+                  ],
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
             {
               labelKey: "shared.fields._thumbnail.label",
@@ -549,8 +651,31 @@ describe("buildUiSchema: project edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
-                messages: [],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-thumbnail-or-png-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "lightbulb",
+                    kind: "info",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
           ],
         },

--- a/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
@@ -4,6 +4,7 @@ import * as getLocationExtentModule from "../../../src/core/schemas/internal/get
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
 import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fetchCategoryItems";
+import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
 
 describe("buildUiSchema: site edit", () => {
   it("returns the full site edit uiSchema", async () => {
@@ -112,8 +113,31 @@ describe("buildUiSchema: site edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
-                messages: [],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-thumbnail-or-png-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "lightbulb",
+                    kind: "info",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
             {
               labelKey: "some.scope.fields.tags.label",
@@ -147,6 +171,45 @@ describe("buildUiSchema: site edit", () => {
                   labelKey: "some.scope.fields.categories.helperText",
                 },
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.DISABLE,
+                  conditions: [false],
+                },
+              ],
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-categories-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "exclamation-mark-triangle",
+                    kind: "warning",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields.categories.noCategoriesNotice.body:translate}}",
+                  autoShow: true,
+                  actions: [
+                    {
+                      label:
+                        "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
+                      icon: "launch",
+                      href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
+                      target: "_blank",
+                    },
+                  ],
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
           ],
         },

--- a/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
+++ b/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
@@ -2,6 +2,7 @@ import { buildUiSchema } from "../../../src/surveys/_internal/SurveyUiSchemaEdit
 import { MOCK_CONTEXT } from "../../mocks/mock-auth";
 import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fetchCategoryItems";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
+import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
 
 describe("buildUiSchema: survey edit", () => {
   it("returns the full survey edit uiSchema", async () => {
@@ -126,6 +127,45 @@ describe("buildUiSchema: survey edit", () => {
                   labelKey: "some.scope.fields.categories.helperText",
                 },
               },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.DISABLE,
+                  conditions: [false],
+                },
+              ],
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-categories-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "exclamation-mark-triangle",
+                    kind: "warning",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields.categories.noCategoriesNotice.body:translate}}",
+                  autoShow: true,
+                  actions: [
+                    {
+                      label:
+                        "{{shared.fields.categories.noCategoriesNotice.link:translate}}",
+                      icon: "launch",
+                      href: "https://doc.arcgis.com/en/arcgis-online/reference/content-categories.htm",
+                      target: "_blank",
+                    },
+                  ],
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
             {
               labelKey: "shared.fields._thumbnail.label",
@@ -145,8 +185,31 @@ describe("buildUiSchema: survey edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
-                messages: [],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-thumbnail-or-png-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "lightbulb",
+                    kind: "info",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
           ],
         },

--- a/packages/common/test/surveys/_internal/SurveyUiSchemaSettings.test.ts
+++ b/packages/common/test/surveys/_internal/SurveyUiSchemaSettings.test.ts
@@ -39,18 +39,30 @@ describe("buildUiSchema: survey settings", () => {
                 ],
                 icons: ["sidecar", "form-elements"],
                 layout: "horizontal",
-                messages: [
-                  {
-                    type: "CUSTOM",
-                    display: "notice",
-                    keyword: "mapQuestion",
-                    titleKey: "some.scope.fields.displayMap.notice.title",
-                    labelKey: "some.scope.fields.displayMap.notice.message",
-                    allowShowBeforeInteract: true,
-                    alwaysShow: true,
-                  },
-                ],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "map-question-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    kind: "info",
+                    scale: "m",
+                  },
+                  title: `{{some.scope.fields.displayMap.notice.title:translate}}`,
+                  body: `{{some.scope.fields.displayMap.notice.message:translate}}`,
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [true],
+                },
+              ],
             },
           ],
         },
@@ -97,8 +109,30 @@ describe("buildUiSchema: survey settings", () => {
                 ],
                 icons: ["sidecar", "form-elements"],
                 layout: "horizontal",
-                messages: [],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "map-question-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    kind: "info",
+                    scale: "m",
+                  },
+                  title: `{{some.scope.fields.displayMap.notice.title:translate}}`,
+                  body: `{{some.scope.fields.displayMap.notice.message:translate}}`,
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
           ],
         },

--- a/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
@@ -1,3 +1,4 @@
+import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
 import { buildUiSchema } from "../../../src/templates/_internal/TemplateUiSchemaEdit";
 import { MOCK_CONTEXT } from "../../mocks/mock-auth";
 
@@ -113,8 +114,31 @@ describe("buildUiSchema: template edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
-                messages: [],
               },
+            },
+            {
+              type: "Notice",
+              options: {
+                notice: {
+                  configuration: {
+                    id: "no-thumbnail-or-png-notice",
+                    noticeType: "notice",
+                    closable: false,
+                    icon: "lightbulb",
+                    kind: "info",
+                    scale: "m",
+                  },
+                  message:
+                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
+                  autoShow: true,
+                },
+              },
+              rules: [
+                {
+                  effect: UiSchemaRuleEffects.SHOW,
+                  conditions: [false],
+                },
+              ],
             },
           ],
         },


### PR DESCRIPTION
1. Description: Swaps old notice implementations for the new implementation.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
