### PR TITLE
feat: add catalogs permissions

### DIFF
--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -38,6 +38,7 @@ export const InitiativePermissions = [
   "hub:initiative:workspace:content",
   "hub:initiative:workspace:events",
   "hub:initiative:workspace:metrics",
+  "hub:initiative:workspace:catalogs",
   "hub:initiative:workspace:associationGroup:create",
   "hub:initiative:manage",
 ] as const;
@@ -184,6 +185,14 @@ export const InitiativePermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:initiative:workspace:metrics",
     dependencies: ["hub:initiative:workspace", "hub:initiative:edit"],
+  },
+  {
+    permission: "hub:initiative:workspace:catalogs",
+    dependencies: [
+      "hub:initiative:workspace",
+      "hub:feature:catalogs",
+      "hub:initiative:edit",
+    ],
   },
   {
     permission: "hub:initiative:manage",

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -171,6 +171,12 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     availability: ["alpha"],
     environments: ["devext", "qaext"],
   },
+  {
+    // Enables catalog configuration and viewing
+    permission: "hub:feature:catalogs",
+    environments: ["qaext"],
+    availability: ["alpha"],
+  },
   // NOTE: only use this permission if necessary. Use the licenses check on a permission to check license when able instead of a separate permission.
   // checks if using hub-premium
   {

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -33,6 +33,7 @@ const SystemPermissions = [
   "hub:feature:workspace:umbrella",
   "hub:feature:keyboardshortcuts",
   "hub:feature:history",
+  "hub:feature:catalogs",
   "hub:license:hub-premium",
   "hub:license:hub-basic",
   "hub:license:enterprise-sites",

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -36,6 +36,7 @@ export const ProjectPermissions = [
   "hub:project:workspace:content",
   "hub:project:workspace:events",
   "hub:project:workspace:metrics",
+  "hub:project:workspace:catalogs",
   "hub:project:manage",
 ] as const;
 
@@ -164,6 +165,14 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:project:workspace:metrics",
     dependencies: ["hub:project:workspace", "hub:project:edit"],
+  },
+  {
+    permission: "hub:project:workspace:catalogs",
+    dependencies: [
+      "hub:project:workspace",
+      "hub:feature:catalogs",
+      "hub:project:edit",
+    ],
   },
   {
     permission: "hub:project:manage",


### PR DESCRIPTION
[11416](https://devtopia.esri.com/dc/hub/issues/11416)

### Description
- Adds a permission policy for configuring/viewing catalogs 
- Adds a business rule to projects for the catalogs pane
- Adds a business rule to initiatives for the catalogs pane

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages 
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.