### PR TITLE
feat(hub-common): add support to hubSearch for searching for events 3…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.181.0",
+			"version": "14.185.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.186.0",
+			"version": "14.187.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22695,10 +22695,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22713,24 +22712,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22744,10 +22740,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22765,10 +22760,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65023,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.185.0",
+			"version": "14.186.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -83487,8 +83481,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83503,20 +83496,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83530,8 +83520,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83548,8 +83537,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.188.0",
+			"version": "14.189.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.187.0",
+			"version": "14.188.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22695,9 +22695,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22712,21 +22713,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22740,9 +22744,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22760,9 +22765,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -83481,7 +83487,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83496,17 +83503,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83520,7 +83530,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83537,7 +83548,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/search/_internal/hubEventsHelpers/processFilters.ts
+++ b/packages/common/src/search/_internal/hubEventsHelpers/processFilters.ts
@@ -109,6 +109,8 @@ export async function processFilters(
     filters,
     "startDateRange"
   );
+  // if a startDateRange was provided, we prioritize that over individual startDateBefore or startDateAfter
+  // filters to prevent collisions
   if (startDateRange.length) {
     processedFilters.startDateTimeBefore = new Date(
       startDateRange[0].to
@@ -116,11 +118,33 @@ export async function processFilters(
     processedFilters.startDateTimeAfter = new Date(
       startDateRange[0].from
     ).toISOString();
+  } else {
+    // individual startDateBefore & startDateAfter filters
+    const startDateBefore = getPredicateValuesByKey<string | number>(
+      filters,
+      "startDateBefore"
+    );
+    if (startDateBefore.length) {
+      processedFilters.startDateTimeBefore = new Date(
+        startDateBefore[0]
+      ).toISOString();
+    }
+    const startDateAfter = getPredicateValuesByKey<string | number>(
+      filters,
+      "startDateAfter"
+    );
+    if (startDateAfter.length) {
+      processedFilters.startDateTimeAfter = new Date(
+        startDateAfter[0]
+      ).toISOString();
+    }
   }
   const endDateRange = getPredicateValuesByKey<IDateRange<string | number>>(
     filters,
     "endDateRange"
   );
+  // if a endDateRange was provided, we prioritize that over individual endDateBefore or endDateAfter
+  // filters to prevent collisions
   if (endDateRange.length) {
     // TODO: remove below ts-ignore once https://devtopia.esri.com/dc/hub/issues/11097 is resolved
     // @ts-ignore
@@ -132,6 +156,30 @@ export async function processFilters(
     processedFilters.endDateTimeAfter = new Date(
       endDateRange[0].from
     ).toISOString();
+  } else {
+    // individual endDateBefore & endDateAfter filters
+    const endDateBefore = getPredicateValuesByKey<string | number>(
+      filters,
+      "endDateBefore"
+    );
+    if (endDateBefore.length) {
+      // TODO: remove below ts-ignore once https://devtopia.esri.com/dc/hub/issues/11097 is resolved
+      // @ts-ignore
+      processedFilters.endDateTimeBefore = new Date(
+        endDateBefore[0]
+      ).toISOString();
+    }
+    const endDateAfter = getPredicateValuesByKey<string | number>(
+      filters,
+      "endDateAfter"
+    );
+    if (endDateAfter.length) {
+      // TODO: remove below ts-ignore once https://devtopia.esri.com/dc/hub/issues/11097 is resolved
+      // @ts-ignore
+      processedFilters.endDateTimeAfter = new Date(
+        endDateAfter[0]
+      ).toISOString();
+    }
   }
   return processedFilters;
 }

--- a/packages/common/src/search/_internal/hubSearchEvents.ts
+++ b/packages/common/src/search/_internal/hubSearchEvents.ts
@@ -26,8 +26,12 @@ import { processFilters } from "./hubEventsHelpers/processFilters";
  *   - attendanceType: 'virtual' | 'in_person' | Array<'virtual' | 'in_person'>;
  *   - owner: string | string[];
  *   - status: 'planned' | 'canceled' | 'removed' | Array<'planned' | 'canceled' | 'removed'>;
+ *   - startDateBefore: string | number;
+ *   - startDateAfter: string | number;
  *   - startDateRange: IDateRange<string | number>;
  *   - endDateRange: IDateRange<string | number>;
+ *   - endDateBefore: string | number;
+ *   - endDateAfter: string | number;
  * Currently supported sort fields include:
  *   - created
  *   - modified

--- a/packages/common/src/search/_internal/hubSearchEvents.ts
+++ b/packages/common/src/search/_internal/hubSearchEvents.ts
@@ -21,8 +21,11 @@ import { processFilters } from "./hubEventsHelpers/processFilters";
  *   - categories: string | string[];
  *   - tags: string | string[];
  *   - group: string | string[];
+ *   - notGroup: string | string[];
  *   - readGroupId: string | string[];
+ *   - notReadGroupId: string | string[];
  *   - editGroupId: string | string[];
+ *   - notEditGroupId: string | string[];
  *   - attendanceType: 'virtual' | 'in_person' | Array<'virtual' | 'in_person'>;
  *   - owner: string | string[];
  *   - status: 'planned' | 'canceled' | 'removed' | Array<'planned' | 'canceled' | 'removed'>;
@@ -32,6 +35,7 @@ import { processFilters } from "./hubEventsHelpers/processFilters";
  *   - endDateRange: IDateRange<string | number>;
  *   - endDateBefore: string | number;
  *   - endDateAfter: string | number;
+ *   - orgId: string;
  * Currently supported sort fields include:
  *   - created
  *   - modified

--- a/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
+++ b/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
@@ -74,7 +74,7 @@ const hubRequestOptions = {
   authentication: true,
 } as unknown as IHubRequestOptions;
 
-fdescribe("processFilters", () => {
+describe("processFilters", () => {
   describe("access", () => {
     it("should return undefined", async () => {
       const result = await processFilters(

--- a/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
+++ b/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
@@ -1,9 +1,9 @@
+import { IHubRequestOptions } from "../../../../src";
 import { processFilters } from "../../../../src/search/_internal/hubEventsHelpers/processFilters";
-import { IFilter } from "../../../../src/search/types/IHubCatalog";
 import * as arcgisRestPortal from "@esri/arcgis-rest-portal";
 
-const group1 = {
-  title: "This is the fake group",
+const editGroup1 = {
+  title: "This is an edit group",
   isOpenData: false,
   capabilities: ["updateitemcontrol"],
   owner: "jeffvader",
@@ -19,11 +19,11 @@ const group1 = {
   access: "public",
 } as arcgisRestPortal.IGroup;
 
-const group2 = {
-  title: "This is a fake group",
+const editGroup2 = {
+  title: "This is another edit group",
   isOpenData: false,
-  capabilities: [],
-  owner: "jhonvader",
+  capabilities: ["updateitemcontrol"],
+  owner: "jeffvader",
   id: "group2",
   protected: false,
   tags: ["wat"],
@@ -36,337 +36,868 @@ const group2 = {
   access: "public",
 } as arcgisRestPortal.IGroup;
 
-const MULTI_SELECT_FILTERS: IFilter[] = [
-  {
-    predicates: [
-      {
-        term: "abc",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        status: "planned",
-      },
-      {
-        status: "canceled",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        access: "public",
-      },
-      {
-        access: "org",
-      },
-      {
-        access: "private",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        attendanceType: "online",
-      },
-      {
-        attendanceType: "in_person",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        categories: "category1",
-      },
-      {
-        categories: "category2",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        tags: "tag1",
-      },
-      {
-        tags: "tag2",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        entityId: "entity1",
-      },
-      {
-        entityId: "entity2",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        entityType: "Hub Initiative",
-      },
-      {
-        entityType: "Hub Project",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        id: "event1",
-      },
-      {
-        id: "event2",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        readGroupId: "group1",
-      },
-      {
-        readGroupId: "group2",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        editGroupId: "group1",
-      },
-      {
-        editGroupId: "group2",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        owner: "owner",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        canEdit: "true",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        startDateRange: {
-          from: 1714276800000,
-          to: 1714363199999,
-        },
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        endDateRange: {
-          from: 1714376800000,
-          to: 1714463199999,
-        },
-      },
-    ],
-  },
-];
+const readGroup1 = {
+  title: "This is a read group",
+  isOpenData: false,
+  capabilities: [],
+  owner: "jhonvader",
+  id: "group3",
+  protected: false,
+  tags: ["wat"],
+  created: 12345,
+  modified: 23421,
+  isInvitationOnly: false,
+  isFav: false,
+  isViewOnly: false,
+  autoJoin: true,
+  access: "public",
+} as arcgisRestPortal.IGroup;
 
-const SINGLE_SELECT_FILTERS: IFilter[] = [
-  {
-    predicates: [
-      {
-        term: "abc",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        status: "planned",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        access: "public",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        attendanceType: "online",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        categories: "category1",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        tags: "tag1",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        owner: "owner",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        canEdit: "true",
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        startDateRange: {
-          from: 1714276800000,
-          to: 1714363199999,
-        },
-      },
-    ],
-  },
-  {
-    operation: "OR",
-    predicates: [
-      {
-        endDateRange: {
-          from: 1714376800000,
-          to: 1714463199999,
-        },
-      },
-    ],
-  },
-];
+const readGroup2 = {
+  title: "This is another read group",
+  isOpenData: false,
+  capabilities: [],
+  owner: "jhonvader",
+  id: "group4",
+  protected: false,
+  tags: ["wat"],
+  created: 12345,
+  modified: 23421,
+  isInvitationOnly: false,
+  isFav: false,
+  isViewOnly: false,
+  autoJoin: true,
+  access: "public",
+} as arcgisRestPortal.IGroup;
+
+const hubRequestOptions = {
+  authentication: true,
+} as unknown as IHubRequestOptions;
 
 describe("processFilters", () => {
-  it("should process multi-select filters", async () => {
-    const results = await processFilters(MULTI_SELECT_FILTERS, {});
-    expect(results).toEqual({
-      title: "abc",
-      categories: "category1,category2",
-      tags: "tag1,tag2",
-      access: "public,org,private",
-      attendanceTypes: "online,in_person",
-      status: "planned,canceled",
-      endDateTimeAfter: "2024-04-29T07:46:40.000Z",
-      endDateTimeBefore: "2024-04-30T07:46:39.999Z",
-      startDateTimeAfter: "2024-04-28T04:00:00.000Z",
-      startDateTimeBefore: "2024-04-29T03:59:59.999Z",
-      entityIds: "entity1,entity2",
-      entityTypes: "Hub Initiative,Hub Project",
-      eventIds: "event1,event2",
-      readGroups: "group1,group2",
-      editGroups: "group1,group2",
-      createdByIds: "owner",
-      canEdit: "true",
-    } as any);
-  });
-  it("should process groups", async () => {
-    spyOn(arcgisRestPortal, "searchGroups").and.returnValue({
-      results: [group1, group2],
+  describe("access", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.access).toBeUndefined();
     });
-    const filters: IFilter[] = [
-      {
-        operation: "OR",
-        predicates: [
+    it("should consolidate values from multiple filters & predicates", async () => {
+      const result = await processFilters(
+        [
           {
-            group: ["group1", "group2"],
+            predicates: [
+              {
+                access: "public",
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                access: "org",
+              },
+              {
+                access: ["private"],
+              },
+            ],
           },
         ],
-      },
-    ];
-    const results = await processFilters(filters, {});
-    expect(results).toEqual({
-      readGroups: "group2",
-      editGroups: "group1",
-      status: "planned,canceled",
+        hubRequestOptions
+      );
+      expect(result.access).toEqual("public,org,private");
     });
   });
-  it("should process groups when no groups are found", async () => {
-    spyOn(arcgisRestPortal, "searchGroups").and.returnValue({ results: [] });
-    const filters: IFilter[] = [
-      {
-        operation: "OR",
-        predicates: [
+  describe("canEdit", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.canEdit).toBeUndefined();
+    });
+    it("should use the first value and coerce to a string", async () => {
+      const result = await processFilters(
+        [
           {
-            group: ["group1", "group2"],
+            predicates: [
+              {
+                canEdit: true,
+              },
+              {
+                canEdit: false,
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                canEdit: false,
+              },
+            ],
           },
         ],
-      },
-    ];
-    const results = await processFilters(filters, {});
-    expect(results).toEqual({
-      status: "planned,canceled",
+        hubRequestOptions
+      );
+      expect(result.canEdit).toEqual("true");
     });
   });
-  it("should process single-select filters", async () => {
-    const results = await processFilters(SINGLE_SELECT_FILTERS, {});
-    expect(results).toEqual({
-      title: "abc",
-      categories: "category1",
-      tags: "tag1",
-      access: "public",
-      attendanceTypes: "online",
-      status: "planned",
-      endDateTimeAfter: "2024-04-29T07:46:40.000Z",
-      endDateTimeBefore: "2024-04-30T07:46:39.999Z",
-      startDateTimeAfter: "2024-04-28T04:00:00.000Z",
-      startDateTimeBefore: "2024-04-29T03:59:59.999Z",
-      createdByIds: "owner",
-      canEdit: "true",
-    } as any);
+  describe("entityId", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.entityIds).toBeUndefined();
+    });
+    it("should consolidate values from multiple filters & predicates", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                entityId: "abc",
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                entityId: "def",
+              },
+              {
+                entityId: ["ghi"],
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.entityIds).toEqual("abc,def,ghi");
+    });
   });
-  it("should set some defaults", async () => {
-    const results = await processFilters([], {});
-    expect(results).toEqual({
-      status: "planned,canceled",
-    } as any);
+  describe("entityType", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.entityTypes).toBeUndefined();
+    });
+    it("should consolidate values from multiple filters & predicates", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                entityType: "abc",
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                entityType: "def",
+              },
+              {
+                entityType: ["ghi"],
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.entityTypes).toEqual("abc,def,ghi");
+    });
+  });
+  describe("id", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.eventIds).toBeUndefined();
+    });
+    it("should consolidate values from multiple filters & predicates", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                id: "abc",
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                id: "def",
+              },
+              {
+                id: ["ghi"],
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.eventIds).toEqual("abc,def,ghi");
+    });
+  });
+  describe("term", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.title).toBeUndefined();
+    });
+    it("should use the first value", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                term: "abc",
+              },
+              {
+                term: "def",
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                term: "ghi",
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.title).toEqual("abc");
+    });
+  });
+  describe("categories", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.categories).toBeUndefined();
+    });
+    it("should consolidate values from multiple filters & predicates", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                categories: "abc",
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                categories: "def",
+              },
+              {
+                categories: ["ghi"],
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.categories).toEqual("abc,def,ghi");
+    });
+  });
+  describe("tags", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.tags).toBeUndefined();
+    });
+    it("should consolidate values from multiple filters & predicates", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                tags: "abc",
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                tags: "def",
+              },
+              {
+                tags: ["ghi"],
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.tags).toEqual("abc,def,ghi");
+    });
+  });
+  describe("attendanceType", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.attendanceTypes).toBeUndefined();
+    });
+    it("should consolidate values from multiple filters & predicates", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                attendanceType: "abc",
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                attendanceType: "def",
+              },
+              {
+                attendanceType: ["ghi"],
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.attendanceTypes).toEqual("abc,def,ghi");
+    });
+  });
+  describe("owner", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.createdByIds).toBeUndefined();
+    });
+    it("should consolidate values from multiple filters & predicates", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                owner: "abc",
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                owner: "def",
+              },
+              {
+                owner: ["ghi"],
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.createdByIds).toEqual("abc,def,ghi");
+    });
+  });
+  describe("status", () => {
+    it("should default to planned and canceled", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.status).toEqual("planned,canceled");
+    });
+    it("should consolidate values from multiple filters & predicates", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                status: "planned",
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                status: "canceled",
+              },
+              {
+                status: ["removed"],
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.status).toEqual("planned,canceled,removed");
+    });
+  });
+  describe("group", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.readGroups).toBeUndefined();
+      expect(result.editGroups).toBeUndefined();
+    });
+    it("should return readGroups and editGroups", async () => {
+      const searchGroupsSpy = spyOn(
+        arcgisRestPortal,
+        "searchGroups"
+      ).and.returnValue(
+        Promise.resolve({ results: [editGroup1, readGroup1, editGroup2] })
+      );
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                group: editGroup1.id,
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                group: [readGroup1.id, editGroup2.id],
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(searchGroupsSpy).toHaveBeenCalledTimes(1);
+      expect(searchGroupsSpy).toHaveBeenCalledWith({
+        q: `id:(${[editGroup1.id, readGroup1.id, editGroup2.id].join(" OR ")})`,
+        num: 3,
+        ...hubRequestOptions,
+      });
+      expect(result.readGroups).toEqual(readGroup1.id);
+      expect(result.editGroups).toEqual(
+        [editGroup1.id, editGroup2.id].join(",")
+      );
+    });
+    it("should filter out inaccessible groups", async () => {
+      const searchGroupsSpy = spyOn(
+        arcgisRestPortal,
+        "searchGroups"
+      ).and.returnValue(Promise.resolve({ results: [] }));
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                group: editGroup1.id,
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                group: [readGroup1.id, editGroup2.id],
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(searchGroupsSpy).toHaveBeenCalledTimes(1);
+      expect(searchGroupsSpy).toHaveBeenCalledWith({
+        q: `id:(${[editGroup1.id, readGroup1.id, editGroup2.id].join(" OR ")})`,
+        num: 3,
+        ...hubRequestOptions,
+      });
+      expect(result.readGroups).toBeUndefined();
+      expect(result.editGroups).toBeUndefined();
+    });
+    it("should be prioritized over individual readGroupId and editGroupId", async () => {
+      const searchGroupsSpy = spyOn(
+        arcgisRestPortal,
+        "searchGroups"
+      ).and.returnValue(
+        Promise.resolve({ results: [editGroup1, readGroup1, editGroup2] })
+      );
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                group: editGroup1.id,
+              },
+              {
+                readGroupId: "some-other-read-group-id",
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                group: [readGroup1.id, editGroup2.id],
+                editGroupId: ["some-other-edit-group-id"],
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(searchGroupsSpy).toHaveBeenCalledTimes(1);
+      expect(searchGroupsSpy).toHaveBeenCalledWith({
+        q: `id:(${[editGroup1.id, readGroup1.id, editGroup2.id].join(" OR ")})`,
+        num: 3,
+        ...hubRequestOptions,
+      });
+      expect(result.readGroups).toEqual(readGroup1.id);
+      expect(result.editGroups).toEqual(
+        [editGroup1.id, editGroup2.id].join(",")
+      );
+    });
+  });
+  describe("readGroupId", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.readGroups).toBeUndefined();
+    });
+    it("should consolidate values from multiple filters & predicates", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                readGroupId: readGroup1.id,
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                readGroupId: [readGroup2.id],
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.readGroups).toEqual(
+        [readGroup1.id, readGroup2.id].join(",")
+      );
+    });
+  });
+  describe("editGroupId", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.editGroups).toBeUndefined();
+    });
+    it("should consolidate values from multiple filters & predicates", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                editGroupId: editGroup1.id,
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                editGroupId: [editGroup2.id],
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.editGroups).toEqual(
+        [editGroup1.id, editGroup2.id].join(",")
+      );
+    });
+  });
+  describe("startDateRange", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.startDateTimeBefore).toBeUndefined();
+      expect(result.startDateTimeAfter).toBeUndefined();
+    });
+    it("should return startDateTimeBefore and startDateTimeAfter and only use first occurrence of startDateRange", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                startDateRange: {
+                  from: 1714276800000,
+                  to: 1714363199999,
+                },
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                startDateRange: {
+                  from: 1814276800000,
+                  to: 1814363199999,
+                },
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.startDateTimeBefore).toEqual("2024-04-29T03:59:59.999Z");
+      expect(result.startDateTimeAfter).toEqual("2024-04-28T04:00:00.000Z");
+    });
+    it("should be prioritized over individual startDateBefore and startDateAfter", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                startDateRange: {
+                  from: 1714276800000,
+                  to: 1714363199999,
+                },
+                startDateBefore: 1814363199999,
+                startDateAfter: 1814276800000,
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.startDateTimeBefore).toEqual("2024-04-29T03:59:59.999Z");
+      expect(result.startDateTimeAfter).toEqual("2024-04-28T04:00:00.000Z");
+    });
+  });
+  describe("startDateBefore", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.startDateTimeBefore).toBeUndefined();
+    });
+    it("should only use first occurrence", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                startDateBefore: 1714276800000,
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                startDateBefore: 1814276800000,
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.startDateTimeBefore).toEqual("2024-04-28T04:00:00.000Z");
+    });
+  });
+  describe("startDateAfter", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      expect(result.startDateTimeAfter).toBeUndefined();
+    });
+    it("should only use first occurrence", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                startDateAfter: 1714276800000,
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                startDateAfter: 1814276800000,
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      expect(result.startDateTimeAfter).toEqual("2024-04-28T04:00:00.000Z");
+    });
+  });
+  describe("endDateRange", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      // TODO: remove below ts-ignore once https://devtopia.esri.com/dc/hub/issues/11097 is resolved
+      // @ts-ignore
+      expect(result.endDateTimeBefore).toBeUndefined();
+      // TODO: remove below ts-ignore once https://devtopia.esri.com/dc/hub/issues/11097 is resolved
+      // @ts-ignore
+      expect(result.endDateTimeAfter).toBeUndefined();
+    });
+    it("should return endDateTimeBefore and endDateTimeAfter and only use first occurrence of endDateRange", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                endDateRange: {
+                  from: 1714276800000,
+                  to: 1714363199999,
+                },
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                endDateRange: {
+                  from: 1814276800000,
+                  to: 1814363199999,
+                },
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      // TODO: remove below ts-ignore once https://devtopia.esri.com/dc/hub/issues/11097 is resolved
+      // @ts-ignore
+      expect(result.endDateTimeBefore).toEqual("2024-04-29T03:59:59.999Z");
+      // TODO: remove below ts-ignore once https://devtopia.esri.com/dc/hub/issues/11097 is resolved
+      // @ts-ignore
+      expect(result.endDateTimeAfter).toEqual("2024-04-28T04:00:00.000Z");
+    });
+    it("should be prioritized over individual endDateBefore and endDateAfter", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                endDateRange: {
+                  from: 1714276800000,
+                  to: 1714363199999,
+                },
+                endDateBefore: 1814363199999,
+                endDateAfter: 1814276800000,
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      // TODO: remove below ts-ignore once https://devtopia.esri.com/dc/hub/issues/11097 is resolved
+      // @ts-ignore
+      expect(result.endDateTimeBefore).toEqual("2024-04-29T03:59:59.999Z");
+      // TODO: remove below ts-ignore once https://devtopia.esri.com/dc/hub/issues/11097 is resolved
+      // @ts-ignore
+      expect(result.endDateTimeAfter).toEqual("2024-04-28T04:00:00.000Z");
+    });
+  });
+  describe("endDateBefore", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      // TODO: remove below ts-ignore once https://devtopia.esri.com/dc/hub/issues/11097 is resolved
+      // @ts-ignore
+      expect(result.endDateTimeBefore).toBeUndefined();
+    });
+    it("should only use first occurrence", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                endDateBefore: 1714276800000,
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                endDateBefore: 1814276800000,
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      // TODO: remove below ts-ignore once https://devtopia.esri.com/dc/hub/issues/11097 is resolved
+      // @ts-ignore
+      expect(result.endDateTimeBefore).toEqual("2024-04-28T04:00:00.000Z");
+    });
+  });
+  describe("endDateAfter", () => {
+    it("should return undefined", async () => {
+      const result = await processFilters(
+        [{ predicates: [] }],
+        hubRequestOptions
+      );
+      // TODO: remove below ts-ignore once https://devtopia.esri.com/dc/hub/issues/11097 is resolved
+      // @ts-ignore
+      expect(result.endDateTimeAfter).toBeUndefined();
+    });
+    it("should only use first occurrence", async () => {
+      const result = await processFilters(
+        [
+          {
+            predicates: [
+              {
+                endDateAfter: 1714276800000,
+              },
+            ],
+          },
+          {
+            predicates: [
+              {
+                endDateAfter: 1814276800000,
+              },
+            ],
+          },
+        ],
+        hubRequestOptions
+      );
+      // TODO: remove below ts-ignore once https://devtopia.esri.com/dc/hub/issues/11097 is resolved
+      // @ts-ignore
+      expect(result.endDateTimeAfter).toEqual("2024-04-28T04:00:00.000Z");
+    });
   });
 });


### PR DESCRIPTION
… events using startDateBefore,

affects: @esri/hub-common

ISSUES CLOSED: 10959

1. Description:

Adds support to hubSearch for searching for Events 3 events by:
* startDateBefore
* startDateAfter
* endDateBefore
* endDateAfter

1. Instructions for testing:

1. Closes Issues: #[10959](https://devtopia.esri.com/dc/hub/issues/10959)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
