### PR TITLE
feat: introduce addCollection method to Catalog class

### DIFF
--- a/packages/common/src/search/Catalog.ts
+++ b/packages/common/src/search/Catalog.ts
@@ -167,6 +167,16 @@ export class Catalog implements IHubCatalog {
   }
 
   /**
+   * Add a collection
+   * @param {IHubCollection} collection
+   */
+  addCollection(collection: IHubCollection) {
+    this._catalog.collections?.length
+      ? this._catalog.collections.push(collection)
+      : (this._catalog.collections = [collection]);
+  }
+
+  /**
    * Get the Collection json by name
    * @param name
    * @returns

--- a/packages/common/test/search/Catalog.test.ts
+++ b/packages/common/test/search/Catalog.test.ts
@@ -232,6 +232,36 @@ describe("Catalog Class:", () => {
       expect(teamsCollection.scope.filters.length).toBe(1);
     });
   });
+  describe("addCollection", () => {
+    const newCollection = {
+      key: "new-collection",
+      label: "New Collection",
+      targetEntity: "item",
+      scope: {
+        targetEntity: "item",
+        filters: [{ predicates: [] }],
+      },
+    } as IHubCollection;
+
+    it("adds a new collection to an empty array of collections", () => {
+      const catalogJsonWithNoCollections = cloneObject(catalogJson);
+      delete catalogJsonWithNoCollections.collections;
+
+      const instance = Catalog.fromJson(catalogJsonWithNoCollections, context);
+
+      instance.addCollection(newCollection);
+      expect(instance.collections.length).toBe(1);
+      expect(instance.collections[0].key).toBe("new-collection");
+    });
+    it("adds a new collection to existing collections", () => {
+      const instance = Catalog.fromJson(cloneObject(catalogJson), context);
+      expect(instance.collections.length).toBe(2);
+
+      instance.addCollection(newCollection);
+      expect(instance.collections.length).toBe(3);
+      expect(instance.collections[2].key).toBe("new-collection");
+    });
+  });
   describe("getCustomCollection:", () => {
     it("returns base scope if no filters passed", () => {
       const instance = Catalog.fromJson(cloneObject(catalogJson), context);


### PR DESCRIPTION
[11435](https://devtopia.esri.com/dc/hub/issues/11435)

### Description
adds a new method, `addCollection` to the `Catalog` class

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.