### PR TITLE
fix: added util for confirming service is not secure proxy

### DIFF
--- a/packages/common/src/content/hostedServiceUtils.ts
+++ b/packages/common/src/content/hostedServiceUtils.ts
@@ -100,6 +100,8 @@ export function isAGOFeatureServiceUrl(url: string): boolean {
  * - /usrsvcs/servers/
  * - /usrsvcs/appservices/
  *
+ * This function was given to us by the JSAPI team, so we trust the regex's are correct,
+ * and won't be adding additional tests for it.
  * @param url
  */
 export function isSecureProxyServiceUrl(url: string): boolean {

--- a/packages/common/src/content/hostedServiceUtils.ts
+++ b/packages/common/src/content/hostedServiceUtils.ts
@@ -86,8 +86,24 @@ export function isAGOFeatureServiceUrl(url: string): boolean {
   // TODO: we should really centralize this regex somewhere
   const FEATURE_SERVICE_URL_REGEX = /(feature)server(\/|\/(\d+))?$/i;
   return (
-    !!url && url.includes("arcgis.com") && FEATURE_SERVICE_URL_REGEX.test(url)
+    !!url &&
+    url.includes("arcgis.com") &&
+    FEATURE_SERVICE_URL_REGEX.test(url) &&
+    !isSecureProxyServiceUrl(url)
   );
+}
+
+/**
+ * Portal secure proxy services are identified by looking for these patterns in the `url`:
+ * - /sharing/servers/
+ * - /sharing/appservices/
+ * - /usrsvcs/servers/
+ * - /usrsvcs/appservices/
+ *
+ * @param url
+ */
+export function isSecureProxyServiceUrl(url: string): boolean {
+  return /\/(sharing|usrsvcs)\/(appservices|servers)\//i.test(url);
 }
 
 export enum ServiceCapabilities {


### PR DESCRIPTION
1. Description:
- attempt to rectify changes from previous hub.js PR: https://github.com/Esri/hub.js/pull/1642
- validates that the service URL is not that of a secure proxy service
  - if it is, don't show the hosted downloads badge!


1. Instructions for testing: 
- copy this to opendata-ui; run `yarn start:prod`
- test here: https://apierrortest-cantechsupport.hub.arcgis.com:4200/datasets/fc63ae8402054d5180587eeabe9022f1_0/explore?location=44.672990%2C-63.658450%2C12.66

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/11360

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
