### PR TITLE
fix(hub-common): hide showAdditionalInfo field in event gallery card …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.189.0",
+			"version": "14.191.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
@@ -370,15 +370,16 @@ export async function buildUiSchema(
                   },
                 },
               },
-              {
-                label: `{{${i18nScope}.appearance.showAdditionalInfo.label:translate}}`,
-                scope: "/properties/showAdditionalInfo",
-                type: "Control",
-                options: {
-                  control: "hub-field-input-switch",
-                  layout: "inline-space-between",
-                },
-              },
+              // TODO: Re-add this once https://github.com/Esri/calcite-design-system/issues/10152 & https://github.com/Esri/calcite-design-system/issues/6059 are resolved
+              // {
+              //   label: `{{${i18nScope}.appearance.showAdditionalInfo.label:translate}}`,
+              //   scope: "/properties/showAdditionalInfo",
+              //   type: "Control",
+              //   options: {
+              //     control: "hub-field-input-switch",
+              //     layout: "inline-space-between",
+              //   },
+              // },
             ],
           },
           {

--- a/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
@@ -379,16 +379,17 @@ describe("EventGalleryCardUiSchema", () => {
                       enum: { i18nScope: "some.scope.appearance.shadow" },
                     },
                   },
-                  {
-                    label:
-                      "{{some.scope.appearance.showAdditionalInfo.label:translate}}",
-                    scope: "/properties/showAdditionalInfo",
-                    type: "Control",
-                    options: {
-                      control: "hub-field-input-switch",
-                      layout: "inline-space-between",
-                    },
-                  },
+                  // TODO: Re-add this once https://github.com/Esri/calcite-design-system/issues/10152 & https://github.com/Esri/calcite-design-system/issues/6059 are resolved
+                  // {
+                  //   label:
+                  //     "{{some.scope.appearance.showAdditionalInfo.label:translate}}",
+                  //   scope: "/properties/showAdditionalInfo",
+                  //   type: "Control",
+                  //   options: {
+                  //     control: "hub-field-input-switch",
+                  //     layout: "inline-space-between",
+                  //   },
+                  // },
                 ],
               },
               {


### PR DESCRIPTION
…schemas until calcite fixes bug

affects: @esri/hub-common

ISSUES CLOSED: 10959

1. Description:

* Hides `showAdditionalInfo` field in event gallery card schemas until calcite bugs [10152](https://github.com/Esri/calcite-design-system/issues/10152) & [6059](https://github.com/Esri/calcite-design-system/issues/6059) are fixed and Hub bumps to a version of calcite-components that includes those fixes.

1. Instructions for testing:

1. Closes Issues: #[10959](https://devtopia.esri.com/dc/hub/issues/10959)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
