### PR TITLE
feat: scaffold catalog configuration experience

### DIFF
--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -1,0 +1,70 @@
+import { EntityType, targetEntities } from "../../../search/types/IHubCatalog";
+import { IConfigurationSchema } from "../types";
+
+export const PredicateSchema: IConfigurationSchema = {
+  type: "object",
+};
+
+export const FilterSchema: IConfigurationSchema = {
+  type: "object",
+  required: ["predicates"],
+  properties: {
+    operation: {
+      type: "string",
+      enum: ["AND", "OR"],
+    },
+    predicates: {
+      type: "array",
+      items: PredicateSchema,
+    },
+  },
+};
+
+export const QuerySchema: IConfigurationSchema = {
+  type: "object",
+  required: ["targetEntity"],
+  properties: {
+    targetEntity: {
+      type: "string",
+      enum: [...targetEntities],
+    },
+    filters: {
+      type: "array",
+      items: FilterSchema,
+    },
+  },
+};
+
+export const CollectionSchema: IConfigurationSchema = {
+  type: "object",
+  required: ["label"],
+  properties: {
+    label: {
+      type: "string",
+    },
+    scope: QuerySchema,
+  },
+};
+
+export const CatalogSchema: IConfigurationSchema = {
+  type: "object",
+  properties: {
+    title: {
+      type: "string",
+    },
+    scopes: {
+      type: "object",
+      properties: targetEntities.reduce(
+        (acc: Record<EntityType, any>, targetEntity: EntityType) => {
+          acc[targetEntity] = QuerySchema;
+          return acc;
+        },
+        {} as Record<EntityType, any>
+      ),
+    },
+    collections: {
+      type: "array",
+      items: CollectionSchema,
+    },
+  },
+};

--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -7,7 +7,6 @@ export const PredicateSchema: IConfigurationSchema = {
 
 export const FilterSchema: IConfigurationSchema = {
   type: "object",
-  required: ["predicates"],
   properties: {
     operation: {
       type: "string",
@@ -15,6 +14,7 @@ export const FilterSchema: IConfigurationSchema = {
     },
     predicates: {
       type: "array",
+      minItems: 1,
       items: PredicateSchema,
     },
   },

--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -1,10 +1,12 @@
 import { EntityType, targetEntities } from "../../../search/types/IHubCatalog";
 import { IConfigurationSchema } from "../types";
 
+/** JSON schema for an IPredicate */
 export const PredicateSchema: IConfigurationSchema = {
   type: "object",
 };
 
+/** JSON schema for an IFilter */
 export const FilterSchema: IConfigurationSchema = {
   type: "object",
   properties: {
@@ -20,6 +22,7 @@ export const FilterSchema: IConfigurationSchema = {
   },
 };
 
+/** JSON schema for an IQuery */
 export const QuerySchema: IConfigurationSchema = {
   type: "object",
   required: ["targetEntity"],
@@ -35,6 +38,7 @@ export const QuerySchema: IConfigurationSchema = {
   },
 };
 
+/** JSON schema for an IHubCollection */
 export const CollectionSchema: IConfigurationSchema = {
   type: "object",
   required: ["label"],
@@ -46,6 +50,7 @@ export const CollectionSchema: IConfigurationSchema = {
   },
 };
 
+/** JSON schema for an IHubCatalog */
 export const CatalogSchema: IConfigurationSchema = {
   type: "object",
   properties: {

--- a/packages/common/src/core/schemas/shared/index.ts
+++ b/packages/common/src/core/schemas/shared/index.ts
@@ -1,1 +1,2 @@
 export * from "./subschemas";
+export * from "./CatalogSchema";

--- a/packages/common/src/search/types/IHubCatalog.ts
+++ b/packages/common/src/search/types/IHubCatalog.ts
@@ -67,18 +67,19 @@ export interface IHubCollection {
   targetEntity: EntityType;
 }
 
-export type EntityType =
-  | "item"
-  | "group"
-  | "user"
-  | "portalUser"
-  | "communityUser"
-  | "groupMember"
-  | "event"
-  | "channel"
-  | "discussionPost"
-  | "event"
-  | "eventAttendee";
+export const targetEntities = [
+  "item",
+  "group",
+  "user",
+  "portalUser",
+  "communityUser",
+  "groupMember",
+  "event",
+  "channel",
+  "discussionPost",
+  "eventAttendee",
+] as const;
+export type EntityType = (typeof targetEntities)[number];
 
 /**
  * @private

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -538,6 +538,7 @@ export enum ItemType {
   "OneDrive" = "OneDrive",
   "StoryMap" = "StoryMap",
   "Dashboard" = "Dashboard",
+  "Hub Project" = "Hub Project",
   "Hub Initiative" = "Hub Initiative",
   "Hub Site Application" = "Hub Site Application",
   "Web Experience" = "Web Experience",


### PR DESCRIPTION
[11435](https://devtopia.esri.com/dc/hub/issues/11435)

## Description:
- adds JSON schema definitions that map to the relevant `IHubCatalog` interfaces
- adds exported const of target entity types
- adds "Hub Project" to the exported enum of AGO item types

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.