### PR TITLE
feat(hub-common): add layout field for list and map views to event ga…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.191.0",
+			"version": "14.191.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.191.1",
+			"version": "14.192.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/core/schemas/internal/events/EventGalleryCardSchema.ts
+++ b/packages/common/src/core/schemas/internal/events/EventGalleryCardSchema.ts
@@ -60,5 +60,10 @@ export const EventGalleryCardSchema: IConfigurationSchema = {
       enum: ["same", "new"],
       default: "same",
     },
+    layout: {
+      type: "string",
+      enum: ["list", "map"],
+      default: "list",
+    },
   },
 };

--- a/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
@@ -380,6 +380,15 @@ export async function buildUiSchema(
               //     layout: "inline-space-between",
               //   },
               // },
+              {
+                label: `{{${i18nScope}.appearance.layout.label:translate}}`,
+                options: {
+                  control: "hub-field-input-select",
+                  enum: { i18nScope: `${i18nScope}.appearance.layout` },
+                },
+                scope: "/properties/layout",
+                type: "Control",
+              },
             ],
           },
           {

--- a/packages/common/src/events/_internal/PropertyMapper.ts
+++ b/packages/common/src/events/_internal/PropertyMapper.ts
@@ -20,6 +20,7 @@ import { HubEventAttendanceType, HubEventCapacityType } from "../types";
 import { computeLinks } from "./computeLinks";
 import { getEventSlug } from "./getEventSlug";
 import { getEventThumbnail } from "./getEventThumbnail";
+import { getLocationFromEvent } from "./getLocationFromEvent";
 
 /**
  * @private
@@ -105,14 +106,7 @@ export class EventPropertyMapper extends PropertyMapper<
     obj.view = {
       showMap: !!store.location,
     };
-    obj.location = store.location
-      ? {
-          type: store.location.type,
-          spatialReference: store.location.spatialReference,
-          extent: store.location.extent,
-          geometries: store.location.geometries,
-        }
-      : { type: "none" };
+    obj.location = getLocationFromEvent(store);
 
     return obj;
   }

--- a/packages/common/src/events/_internal/getLocationFromEvent.ts
+++ b/packages/common/src/events/_internal/getLocationFromEvent.ts
@@ -1,0 +1,13 @@
+import { IHubLocation } from "../../core/types/IHubLocation";
+import { IEvent } from "../api/orval/api/orval-events";
+
+export function getLocationFromEvent(event: Partial<IEvent>): IHubLocation {
+  return event.location
+    ? {
+        type: event.location.type,
+        spatialReference: event.location.spatialReference,
+        extent: event.location.extent,
+        geometries: event.location.geometries,
+      }
+    : { type: "none" };
+}

--- a/packages/common/src/search/_internal/hubEventsHelpers/eventToSearchResult.ts
+++ b/packages/common/src/search/_internal/hubEventsHelpers/eventToSearchResult.ts
@@ -5,6 +5,7 @@ import { IEvent } from "../../../events/api/orval/api/orval-events";
 import { AccessLevel } from "../../../core/types/types";
 import { HubFamily } from "../../../types";
 import { computeLinks } from "../../../events/_internal/computeLinks";
+import { getLocationFromEvent } from "../../../events/_internal/getLocationFromEvent";
 
 /**
  * Resolves an IHubSearchResult for the given IEvent record
@@ -23,6 +24,7 @@ export async function eventToSearchResult(
   const result = {
     access: event.access.toLowerCase() as AccessLevel,
     id: event.id,
+    location: getLocationFromEvent(event),
     type: "Event",
     name: event.title,
     owner: event.creator.username,

--- a/packages/common/src/search/_internal/hubSearchEvents.ts
+++ b/packages/common/src/search/_internal/hubSearchEvents.ts
@@ -57,7 +57,7 @@ export async function hubSearchEvents(
   const data: GetEventsParams = {
     ...processedFilters,
     ...processedOptions,
-    include: "creator",
+    include: "creator,location",
   };
   const { items, nextStart, total } = await getEvents({
     ...options.requestOptions,

--- a/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
@@ -390,6 +390,15 @@ describe("EventGalleryCardUiSchema", () => {
                   //     layout: "inline-space-between",
                   //   },
                   // },
+                  {
+                    label: `{{some.scope.appearance.layout.label:translate}}`,
+                    options: {
+                      control: "hub-field-input-select",
+                      enum: { i18nScope: `some.scope.appearance.layout` },
+                    },
+                    scope: "/properties/layout",
+                    type: "Control",
+                  },
                 ],
               },
               {

--- a/packages/common/test/events/_internal/PropertyMapper.test.ts
+++ b/packages/common/test/events/_internal/PropertyMapper.test.ts
@@ -14,12 +14,23 @@ import {
   HubEventAttendanceType,
   HubEventCapacityType,
 } from "../../../src/events/types";
+import * as getLocationFromEventModule from "../../../src/events/_internal/getLocationFromEvent";
+import { IHubLocation } from "../../../src/core/types/IHubLocation";
 
 describe("PropertyMapper", () => {
   let propertyMapper: EventPropertyMapper;
+  let getLocationFromEventSpy: jasmine.Spy;
+  let locationResult: IHubLocation;
 
   beforeEach(() => {
+    locationResult = {
+      type: "none",
+    };
     propertyMapper = new EventPropertyMapper(getPropertyMap());
+    getLocationFromEventSpy = spyOn(
+      getLocationFromEventModule,
+      "getLocationFromEvent"
+    ).and.returnValue(locationResult);
   });
 
   describe("storeToEntity", () => {
@@ -113,6 +124,8 @@ describe("PropertyMapper", () => {
         geometries: [],
       } as any;
       const res = propertyMapper.storeToEntity(eventRecord, {});
+      expect(getLocationFromEventSpy).toHaveBeenCalledTimes(1);
+      expect(getLocationFromEventSpy).toHaveBeenCalledWith(eventRecord);
       expect(res).toEqual({
         isAllDay: false,
         name: "event title",
@@ -141,12 +154,7 @@ describe("PropertyMapper", () => {
         inPersonCapacity: 30,
         inPersonRegistrationCount: 0,
         inPersonCapacityType: HubEventCapacityType.Fixed,
-        location: {
-          type: "none",
-          spatialReference: {},
-          extent: [[]],
-          geometries: [],
-        },
+        location: locationResult,
         onlineCapacity: null,
         onlineCapacityType: HubEventCapacityType.Unlimited,
         onlineDetails: null,

--- a/packages/common/test/events/_internal/getLocationFromEvent.test.ts
+++ b/packages/common/test/events/_internal/getLocationFromEvent.test.ts
@@ -1,0 +1,333 @@
+import { getLocationFromEvent } from "../../../src/events/_internal/getLocationFromEvent";
+import {
+  EventLocationType,
+  IEvent,
+} from "../../../src/events/api/orval/api/orval-events";
+
+describe("getLocationFromEvent", () => {
+  it('should return a location object of type "none"', () => {
+    const event: Partial<IEvent> = { id: "31c" };
+    expect(getLocationFromEvent(event)).toEqual({ type: "none" });
+  });
+  it('should return a location object of type "org"', () => {
+    const event: Partial<IEvent> = {
+      id: "31c",
+      location: {
+        id: "cm1faunz900i25y012lygo6b7",
+        addNum: null,
+        city: null,
+        cntryName: null,
+        eventId: "cm1fat0fl00hw5y01l95xp05j",
+        extent: [
+          [-134.7469999999955, 20.66992270076423],
+          [-55.69599999999812, 50.3089999999983],
+        ],
+        geometries: [
+          {
+            type: "polygon",
+            rings: [
+              [
+                [-134.7469999999955, 20.66992270076423],
+                [-134.7469999999955, 50.3089999999983],
+                [-55.69599999999812, 50.3089999999983],
+                [-55.69599999999812, 20.66992270076423],
+                [-134.7469999999955, 20.66992270076423],
+              ],
+            ],
+            spatialReference: {
+              wkid: 4326,
+            },
+          },
+        ],
+        nbrhd: null,
+        placeAddr: null,
+        placeName: null,
+        postal: null,
+        region: null,
+        spatialReference: {
+          wkid: 4326,
+        },
+        stDir: null,
+        stName: null,
+        stType: null,
+        subRegion: null,
+        type: EventLocationType.org,
+      },
+    };
+    expect(getLocationFromEvent(event)).toEqual({
+      type: "org",
+      spatialReference: { wkid: 4326 },
+      extent: [
+        [-134.7469999999955, 20.66992270076423],
+        [-55.69599999999812, 50.3089999999983],
+      ],
+      geometries: [
+        {
+          type: "polygon",
+          rings: [
+            [
+              [-134.7469999999955, 20.66992270076423],
+              [-134.7469999999955, 50.3089999999983],
+              [-55.69599999999812, 50.3089999999983],
+              [-55.69599999999812, 20.66992270076423],
+              [-134.7469999999955, 20.66992270076423],
+            ],
+          ],
+          spatialReference: Object({ wkid: 4326 }),
+        },
+      ],
+    });
+  });
+  it('should return a location object of type "custom" with a point', () => {
+    const event: Partial<IEvent> = {
+      id: "31c",
+      location: {
+        id: "cm1gtkbua00a23w01sbsxi82p",
+        addNum: null,
+        city: null,
+        cntryName: null,
+        eventId: "clzk9pssv007a6001c93uijky",
+        extent: [
+          [-76.86333891686775, 40.33607098418021],
+          [-76.85833891686775, 40.34107098418021],
+        ],
+        geometries: [
+          {
+            x: -76.86083891686775,
+            y: 40.33857098418021,
+            type: "point",
+            spatialReference: {
+              wkid: 4326,
+            },
+          },
+        ],
+        nbrhd: null,
+        placeAddr: null,
+        placeName: null,
+        postal: null,
+        region: null,
+        spatialReference: {
+          wkid: 4326,
+        },
+        stDir: null,
+        stName: null,
+        stType: null,
+        subRegion: null,
+        type: EventLocationType.custom,
+      },
+    };
+    expect(getLocationFromEvent(event)).toEqual({
+      type: "custom",
+      spatialReference: { wkid: 4326 },
+      extent: [
+        [-76.86333891686775, 40.33607098418021],
+        [-76.85833891686775, 40.34107098418021],
+      ],
+      geometries: [
+        {
+          x: -76.86083891686775,
+          y: 40.33857098418021,
+          type: "point",
+          spatialReference: Object({ wkid: 4326 }),
+        },
+      ],
+    });
+  });
+  it('should return a location object of type "custom" with a polyline', () => {
+    const event: Partial<IEvent> = {
+      id: "31c",
+      location: {
+        id: "cm1gtrscq00ad3v01rc1smyow",
+        addNum: null,
+        city: null,
+        cntryName: null,
+        eventId: "clzk9pssv007a6001c93uijky",
+        extent: [
+          [-76.86115443265787, 40.33838940207084],
+          [-76.860602316696, 40.33878393629663],
+        ],
+        geometries: [
+          {
+            type: "polyline",
+            paths: [
+              [
+                [-76.86060797448064, 40.33878393629663],
+                [-76.86097834982701, 40.33874384568065],
+                [-76.86115443265787, 40.33856219176634],
+                [-76.86096489687243, 40.33838940207084],
+                [-76.860602316696, 40.33848133940521],
+                [-76.8606066543309, 40.33878045432375],
+              ],
+            ],
+            spatialReference: {
+              wkid: 4326,
+            },
+          },
+        ],
+        nbrhd: null,
+        placeAddr: null,
+        placeName: null,
+        postal: null,
+        region: null,
+        spatialReference: {
+          wkid: 4326,
+        },
+        stDir: null,
+        stName: null,
+        stType: null,
+        subRegion: null,
+        type: EventLocationType.custom,
+      },
+    };
+    expect(getLocationFromEvent(event)).toEqual({
+      type: "custom",
+      spatialReference: { wkid: 4326 },
+      extent: [
+        [-76.86115443265787, 40.33838940207084],
+        [-76.860602316696, 40.33878393629663],
+      ],
+      geometries: [
+        {
+          type: "polyline",
+          paths: [
+            [
+              [-76.86060797448064, 40.33878393629663],
+              [-76.86097834982701, 40.33874384568065],
+              [-76.86115443265787, 40.33856219176634],
+              [-76.86096489687243, 40.33838940207084],
+              [-76.860602316696, 40.33848133940521],
+              [-76.8606066543309, 40.33878045432375],
+            ],
+          ],
+          spatialReference: { wkid: 4326 },
+        },
+      ],
+    });
+  });
+  it('should return a location object of type "custom" with a polygon', () => {
+    const event: Partial<IEvent> = {
+      id: "31c",
+      location: {
+        id: "cm1gtvv6t00a63w015j0118uf",
+        addNum: null,
+        city: null,
+        cntryName: null,
+        eventId: "clzk9pssv007a6001c93uijky",
+        extent: [
+          [-76.86100727787036, 40.33838789303515],
+          [-76.8607543120326, 40.33876690214137],
+        ],
+        geometries: [
+          {
+            type: "polygon",
+            rings: [
+              [
+                [-76.8607543120326, 40.33876690214137],
+                [-76.86080192124261, 40.33838789303515],
+                [-76.86100727787036, 40.33867088425338],
+                [-76.8607543120326, 40.33876690214137],
+              ],
+            ],
+            spatialReference: {
+              wkid: 4326,
+            },
+          },
+        ],
+        nbrhd: null,
+        placeAddr: null,
+        placeName: null,
+        postal: null,
+        region: null,
+        spatialReference: {
+          wkid: 4326,
+        },
+        stDir: null,
+        stName: null,
+        stType: null,
+        subRegion: null,
+        type: EventLocationType.custom,
+      },
+    };
+    expect(getLocationFromEvent(event)).toEqual({
+      type: "custom",
+      spatialReference: { wkid: 4326 },
+      extent: [
+        [-76.86100727787036, 40.33838789303515],
+        [-76.8607543120326, 40.33876690214137],
+      ],
+      geometries: [
+        {
+          type: "polygon",
+          rings: [
+            [
+              [-76.8607543120326, 40.33876690214137],
+              [-76.86080192124261, 40.33838789303515],
+              [-76.86100727787036, 40.33867088425338],
+              [-76.8607543120326, 40.33876690214137],
+            ],
+          ],
+          spatialReference: { wkid: 4326 },
+        },
+      ],
+    });
+  });
+  it('should return a location object of type "custom" with a extent', () => {
+    const event: Partial<IEvent> = {
+      id: "31c",
+      location: {
+        id: "cm1gu0kiv00ah3v01xl529ps4",
+        addNum: null,
+        city: null,
+        cntryName: null,
+        eventId: "clzk9pssv007a6001c93uijky",
+        extent: [
+          [-76.86100126909348, 40.33846250062182],
+          [-76.86068364735026, 40.33870983322092],
+        ],
+        geometries: [
+          {
+            type: "extent",
+            xmax: -76.86068364735026,
+            xmin: -76.86100126909348,
+            ymax: 40.33870983322092,
+            ymin: 40.33846250062182,
+            spatialReference: {
+              wkid: 4326,
+            },
+          },
+        ],
+        nbrhd: null,
+        placeAddr: null,
+        placeName: null,
+        postal: null,
+        region: null,
+        spatialReference: {
+          wkid: 4326,
+        },
+        stDir: null,
+        stName: null,
+        stType: null,
+        subRegion: null,
+        type: EventLocationType.custom,
+      },
+    };
+    expect(getLocationFromEvent(event)).toEqual({
+      type: "custom",
+      spatialReference: { wkid: 4326 },
+      extent: [
+        [-76.86100126909348, 40.33846250062182],
+        [-76.86068364735026, 40.33870983322092],
+      ],
+      geometries: [
+        {
+          type: "extent",
+          xmax: -76.86068364735026,
+          xmin: -76.86100126909348,
+          ymax: 40.33870983322092,
+          ymin: 40.33846250062182,
+          spatialReference: { wkid: 4326 },
+        },
+      ],
+    });
+  });
+});

--- a/packages/common/test/events/_internal/getLocationFromEvent.test.ts
+++ b/packages/common/test/events/_internal/getLocationFromEvent.test.ts
@@ -1,3 +1,4 @@
+import { IHubLocation } from "../../../src/core/types/IHubLocation";
 import { getLocationFromEvent } from "../../../src/events/_internal/getLocationFromEvent";
 import {
   EventLocationType,
@@ -76,7 +77,7 @@ describe("getLocationFromEvent", () => {
           spatialReference: Object({ wkid: 4326 }),
         },
       ],
-    });
+    } as unknown as IHubLocation);
   });
   it('should return a location object of type "custom" with a point', () => {
     const event: Partial<IEvent> = {
@@ -131,7 +132,7 @@ describe("getLocationFromEvent", () => {
           spatialReference: Object({ wkid: 4326 }),
         },
       ],
-    });
+    } as unknown as IHubLocation);
   });
   it('should return a location object of type "custom" with a polyline', () => {
     const event: Partial<IEvent> = {
@@ -202,7 +203,7 @@ describe("getLocationFromEvent", () => {
           spatialReference: { wkid: 4326 },
         },
       ],
-    });
+    } as unknown as IHubLocation);
   });
   it('should return a location object of type "custom" with a polygon', () => {
     const event: Partial<IEvent> = {
@@ -269,7 +270,7 @@ describe("getLocationFromEvent", () => {
           spatialReference: { wkid: 4326 },
         },
       ],
-    });
+    } as unknown as IHubLocation);
   });
   it('should return a location object of type "custom" with a extent', () => {
     const event: Partial<IEvent> = {
@@ -328,6 +329,6 @@ describe("getLocationFromEvent", () => {
           spatialReference: { wkid: 4326 },
         },
       ],
-    });
+    } as unknown as IHubLocation);
   });
 });

--- a/packages/common/test/search/_internal/hubEventsHelpers/eventToSearchResult.test.ts
+++ b/packages/common/test/search/_internal/hubEventsHelpers/eventToSearchResult.test.ts
@@ -1,9 +1,15 @@
 import * as restPortal from "@esri/arcgis-rest-portal";
 import { AccessLevel } from "../../../../src/core/types/types";
-import { EventAccess, IEvent } from "../../../../src/events/api/types";
+import {
+  EventAccess,
+  EventLocationType,
+  IEvent,
+} from "../../../../src/events/api/types";
 import { eventToSearchResult } from "../../../../src/search/_internal/hubEventsHelpers/eventToSearchResult";
 import { IHubSearchOptions } from "../../../../src/search/types/IHubSearchOptions";
 import { getEventThumbnail } from "../../../../src/events/_internal/getEventThumbnail";
+import * as getLocationFromEventModule from "../../../../src/events/_internal/getLocationFromEvent";
+import { IHubLocation } from "../../../../src/core/types/IHubLocation";
 
 describe("eventToSearchResult", () => {
   const options = {
@@ -16,6 +22,8 @@ describe("eventToSearchResult", () => {
   } as restPortal.IUser;
   let event: IEvent;
   let getUserSpy: jasmine.Spy;
+  let getLocationFromEventSpy: jasmine.Spy;
+  let locationResult: IHubLocation;
 
   beforeEach(() => {
     event = {
@@ -31,10 +39,64 @@ describe("eventToSearchResult", () => {
       updatedAt: "2024-04-22T12:57:00.189Z",
       tags: ["tag1"],
       categories: ["category1"],
-    } as IEvent;
+      location: {
+        id: "cm1gtkbua00a23w01sbsxi82p",
+        addNum: null,
+        city: null,
+        cntryName: null,
+        eventId: "clzk9pssv007a6001c93uijky",
+        extent: [
+          [-76.86333891686775, 40.33607098418021],
+          [-76.85833891686775, 40.34107098418021],
+        ],
+        geometries: [
+          {
+            x: -76.86083891686775,
+            y: 40.33857098418021,
+            type: "point",
+            spatialReference: {
+              wkid: 4326,
+            },
+          },
+        ],
+        nbrhd: null,
+        placeAddr: null,
+        placeName: null,
+        postal: null,
+        region: null,
+        spatialReference: {
+          wkid: 4326,
+        },
+        stDir: null,
+        stName: null,
+        stType: null,
+        subRegion: null,
+        type: EventLocationType.custom,
+      },
+    } as unknown as IEvent;
+    locationResult = {
+      type: "custom",
+      spatialReference: { wkid: 4326 },
+      extent: [
+        [-76.86333891686775, 40.33607098418021],
+        [-76.85833891686775, 40.34107098418021],
+      ],
+      geometries: [
+        {
+          x: -76.86083891686775,
+          y: 40.33857098418021,
+          type: "point",
+          spatialReference: Object({ wkid: 4326 }),
+        },
+      ],
+    };
     getUserSpy = spyOn(restPortal, "getUser").and.returnValue(
       Promise.resolve(user)
     );
+    getLocationFromEventSpy = spyOn(
+      getLocationFromEventModule,
+      "getLocationFromEvent"
+    ).and.returnValue(locationResult);
   });
 
   it("should return an IHubSearchResult for the event", async () => {
@@ -44,6 +106,8 @@ describe("eventToSearchResult", () => {
       username: event.creator?.username,
       ...options.requestOptions,
     });
+    expect(getLocationFromEventSpy).toHaveBeenCalledTimes(1);
+    expect(getLocationFromEventSpy).toHaveBeenCalledWith(event);
     expect(result).toEqual({
       access: event.access.toLowerCase() as AccessLevel,
       id: event.id,
@@ -67,6 +131,7 @@ describe("eventToSearchResult", () => {
       tags: event.tags,
       categories: event.categories,
       rawResult: event,
+      location: locationResult,
     });
     expect(result.createdDate.toISOString()).toEqual(event.createdAt);
     expect(result.updatedDate.toISOString()).toEqual(event.updatedAt);
@@ -80,6 +145,8 @@ describe("eventToSearchResult", () => {
       username: event.creator?.username,
       ...options.requestOptions,
     });
+    expect(getLocationFromEventSpy).toHaveBeenCalledTimes(1);
+    expect(getLocationFromEventSpy).toHaveBeenCalledWith(event);
     expect(result).toEqual({
       access: event.access.toLowerCase() as AccessLevel,
       id: event.id,
@@ -103,6 +170,7 @@ describe("eventToSearchResult", () => {
       tags: event.tags,
       categories: event.categories,
       rawResult: event,
+      location: locationResult,
     });
     expect(result.createdDate.toISOString()).toEqual(event.createdAt);
     expect(result.updatedDate.toISOString()).toEqual(event.updatedAt);

--- a/packages/common/test/search/_internal/hubEventsHelpers/eventToSearchResult.test.ts
+++ b/packages/common/test/search/_internal/hubEventsHelpers/eventToSearchResult.test.ts
@@ -89,7 +89,7 @@ describe("eventToSearchResult", () => {
           spatialReference: Object({ wkid: 4326 }),
         },
       ],
-    };
+    } as unknown as IHubLocation;
     getUserSpy = spyOn(restPortal, "getUser").and.returnValue(
       Promise.resolve(user)
     );

--- a/packages/common/test/search/_internal/hubSearchEvents.test.ts
+++ b/packages/common/test/search/_internal/hubSearchEvents.test.ts
@@ -250,7 +250,7 @@ describe("hubSearchEvents", () => {
       data: {
         ...processedFilters,
         ...processedOptions,
-        include: "creator",
+        include: "creator,location",
       },
     });
     expect(eventToSearchResultSpy).toHaveBeenCalledTimes(2);
@@ -295,7 +295,7 @@ describe("hubSearchEvents", () => {
           data: {
             ...processedFilters,
             ...processedOptions2,
-            include: "creator",
+            include: "creator,location",
           },
         },
       ],


### PR DESCRIPTION
…llery card schema and uiSchema

affects: @esri/hub-common

ISSUES CLOSED: 11024

1. Description:

- Adds `layout` field to the events gallery card editor schema & uiSchema

1. Instructions for testing:

1. Closes Issues: #[11024](https://devtopia.esri.com/dc/hub/issues/11024)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
