### PR TITLE
feat: group schema and create group uischema

### DIFF
--- a/packages/common/src/core/types/IHubGroup.ts
+++ b/packages/common/src/core/types/IHubGroup.ts
@@ -139,6 +139,23 @@ export interface IHubGroup
 
   /** Whether members of the group are hidden */
   hiddenMembers?: boolean;
+
+  /**
+   * Is it an admin group / is leaving disallowed
+   */
+  leavingDisallowed?: boolean;
+
+  /**
+   * Whether the group is an open data group
+   */
+  isOpenData?: boolean;
+
+  /**
+   * The join type for the group
+   * (invite, request, auto)
+   * This is mapped to isInvitationOnly and autoJoin
+   */
+  _join?: "invite" | "request" | "auto";
 }
 
 /**

--- a/packages/common/src/groups/_internal/convertHubGroupToGroup.ts
+++ b/packages/common/src/groups/_internal/convertHubGroupToGroup.ts
@@ -9,6 +9,22 @@ import { getPropertyMap } from "./getPropertyMap";
  */
 
 export function convertHubGroupToGroup(hubGroup: IHubGroup): IGroup {
+  // take the _join props and map them to isInvitationOnly and autoJoin
+  switch (hubGroup._join) {
+    case "invite":
+      hubGroup.isInvitationOnly = true;
+      hubGroup.autoJoin = false;
+      break;
+    case "request":
+      hubGroup.isInvitationOnly = false;
+      hubGroup.autoJoin = false;
+      break;
+    case "auto":
+      hubGroup.isInvitationOnly = false;
+      hubGroup.autoJoin = true;
+      break;
+  }
+
   const mapper = new PropertyMapper<Partial<IHubGroup>, IGroup>(
     getPropertyMap()
   );

--- a/packages/common/src/groups/_internal/getPropertyMap.ts
+++ b/packages/common/src/groups/_internal/getPropertyMap.ts
@@ -39,6 +39,9 @@ export function getPropertyMap(): IPropertyMap[] {
     "thumbnailUrl",
     "typeKeywords",
     "userMembership",
+    "isOpenData",
+    "hiddenMembers",
+    "leavingDisallowed",
   ];
   groupProps.forEach((entry) => {
     map.push({ entityKey: entry, storeKey: entry });

--- a/packages/common/src/groups/getWellKnownGroup.ts
+++ b/packages/common/src/groups/getWellKnownGroup.ts
@@ -3,6 +3,7 @@ import { checkPermission } from "../permissions";
 import { IArcGISContext } from "../ArcGISContext";
 
 type WellKnownGroup =
+  | "hubGroup"
   | "hubViewGroup"
   | "hubEditGroup"
   | "hubFollowersGroup"
@@ -18,6 +19,16 @@ export function getWellKnownGroup(
   context: IArcGISContext
 ): Partial<IHubGroup> {
   const configs: Record<WellKnownGroup, Partial<IHubGroup>> = {
+    hubGroup: {
+      access: "private",
+      autoJoin: false,
+      isSharedUpdate: false,
+      isInvitationOnly: false,
+      hiddenMembers: false,
+      isViewOnly: false,
+      tags: ["Hub Group"],
+      membershipAccess: "organization",
+    },
     hubViewGroup: {
       access: "org",
       autoJoin: false,

--- a/packages/common/src/permissions/PlatformPermissionPolicies.ts
+++ b/packages/common/src/permissions/PlatformPermissionPolicies.ts
@@ -17,6 +17,7 @@ export const PlatformPermissions = [
   "platform:portal:admin:changeUserRoles",
   "platform:portal:admin:createGPWebhook",
   "platform:portal:admin:createUpdateCapableGroup",
+  "platform:portal:admin:createLeavingDisallowedGroup",
   "platform:portal:admin:deleteGroups",
   "platform:portal:admin:deleteItems",
   "platform:portal:admin:deleteUsers",
@@ -187,6 +188,12 @@ export const PlatformPermissionPolicies: IPermissionPolicy[] = [
     services: ["portal"],
     authenticated: true,
     privileges: ["portal:admin:createUpdateCapableGroup"],
+  },
+  {
+    permission: "platform:portal:admin:createLeavingDisallowedGroup",
+    services: ["portal"],
+    authenticated: true,
+    privileges: ["portal:admin:createLeavingDisallowedGroup"],
   },
   {
     permission: "platform:portal:admin:deleteGroups",

--- a/packages/common/src/permissions/types/PlatformPrivilege.ts
+++ b/packages/common/src/permissions/types/PlatformPrivilege.ts
@@ -17,6 +17,7 @@ export type PlatformPrivilege =
   | "portal:admin:changeUserRoles"
   | "portal:admin:createGPWebhook"
   | "portal:admin:createUpdateCapableGroup"
+  | "portal:admin:createLeavingDisallowedGroup"
   | "portal:admin:deleteGroups"
   | "portal:admin:deleteItems"
   | "portal:admin:deleteUsers"

--- a/packages/common/test/groups/_internal/GroupUiSchemaCreate.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaCreate.test.ts
@@ -20,97 +20,397 @@ describe("GroupUiSchemaCreate", () => {
         type: "Layout",
         elements: [
           {
-            labelKey: `some.scope.fields.name.label`,
-            scope: "/properties/name",
-            type: "Control",
-            options: {
-              messages: [
-                {
-                  type: "ERROR",
-                  keyword: "required",
-                  icon: true,
-                  labelKey: `some.scope.fields.name.requiredError`,
+            type: "Section",
+            labelKey: `some.scope.sections.basicInfo.label`,
+            elements: [
+              {
+                labelKey: `some.scope.fields.name.label`,
+                scope: "/properties/name",
+                type: "Control",
+                options: {
+                  messages: [
+                    {
+                      type: "ERROR",
+                      keyword: "required",
+                      icon: true,
+                      labelKey: `some.scope.fields.name.requiredError`,
+                    },
+                    {
+                      type: "ERROR",
+                      keyword: "maxLength",
+                      icon: true,
+                      labelKey: `some.scope.fields.name.maxLengthError`,
+                    },
+                  ],
                 },
-                {
-                  type: "ERROR",
-                  keyword: "maxLength",
-                  icon: true,
-                  labelKey: `some.scope.fields.name.maxLengthError`,
-                },
-              ],
-            },
-          },
-          {
-            labelKey: `some.scope.fields.isSharedUpdate.label`,
-            scope: "/properties/isSharedUpdate",
-            type: "Control",
-            options: {
-              control: "hub-field-input-switch",
-              helperText: {
-                labelKey: `some.scope.fields.isSharedUpdate.helperText`,
               },
-            },
+              {
+                labelKey: `some.scope.fields.access.label`,
+                scope: "/properties/access",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-tile-select",
+                  descriptions: [
+                    `{{some.scope.fields.access.private.description:translate}}`,
+                    `{{some.scope.fields.access.org.description:translate}}`,
+                    `{{some.scope.fields.access.public.description:translate}}`,
+                  ],
+                  icons: ["users", "organization", "globe"],
+                  labels: [
+                    `{{some.scope.fields.access.private.label:translate}}`,
+                    `{{some.scope.fields.access.org.label:translate}}`,
+                    `{{some.scope.fields.access.public.label:translate}}`,
+                  ],
+                  rules: [
+                    {
+                      effect: UiSchemaRuleEffects.NONE,
+                    },
+                    {
+                      effect: UiSchemaRuleEffects.ENABLE,
+                      conditions: [false],
+                    },
+                    {
+                      effect: UiSchemaRuleEffects.ENABLE,
+                      conditions: [false],
+                    },
+                  ],
+                },
+              },
+            ],
           },
           {
-            labelKey: `some.scope.fields.membershipAccess.label`,
-            scope: "/properties/membershipAccess",
-            type: "Control",
-            options: {
-              control: "hub-field-input-radio",
-              labels: [
-                `{{some.scope.fields.membershipAccess.org:translate}}`,
-                `{{some.scope.fields.membershipAccess.collab:translate}}`,
-                `{{some.scope.fields.membershipAccess.any:translate}}`,
-              ],
-              rules: [
-                [
+            type: "Section",
+            labelKey: `some.scope.sections.capabilities.label`,
+            elements: [
+              {
+                labelKey: `some.scope.fields.isSharedUpdate.label`,
+                scope: "/properties/isSharedUpdate",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-switch",
+                  helperText: {
+                    labelKey: `some.scope.fields.isSharedUpdate.helperText`,
+                  },
+                },
+                rule: {
+                  effect: UiSchemaRuleEffects.ENABLE,
+                  conditions: [false],
+                },
+              },
+              {
+                labelKey: `some.scope.fields.isAdmin.label`,
+                scope: "/properties/leavingDisallowed",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-switch",
+                  helperText: {
+                    labelKey: `some.scope.fields.isAdmin.helperText`,
+                  },
+                },
+                rules: [
                   {
-                    effect: UiSchemaRuleEffects.NONE,
+                    effect: UiSchemaRuleEffects.ENABLE,
+                    conditions: [false],
                   },
                 ],
-                [
+              },
+              {
+                labelKey: `some.scope.fields.isOpenData.label`,
+                scope: "/properties/isOpenData",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-switch",
+                  helperText: {
+                    labelKey: `some.scope.fields.isOpenData.helperText`,
+                  },
+                  messages: [
+                    {
+                      type: "ERROR",
+                      keyword: "const",
+                      icon: true,
+                      labelKey: `some.scope.fields.isOpenData.constError`,
+                    },
+                  ],
+                },
+                rules: [
                   {
-                    effect: UiSchemaRuleEffects.DISABLE,
-                    conditions: [true],
+                    effect: UiSchemaRuleEffects.ENABLE,
+                    conditions: [
+                      {
+                        scope: "/properties/access",
+                        schema: { const: "public" },
+                      },
+                      false,
+                    ],
+                  },
+                  {
+                    effect: UiSchemaRuleEffects.RESET,
+                    conditions: [
+                      {
+                        scope: "/properties/access",
+                        schema: { not: { const: "public" } },
+                      },
+                    ],
+                  },
+                  {
+                    effect: UiSchemaRuleEffects.SHOW,
+                    conditions: [false],
                   },
                 ],
-                [
+              },
+            ],
+          },
+          {
+            type: "Section",
+            labelKey: `some.scope.sections.membershipAccess.label`,
+            elements: [
+              {
+                labelKey: `some.scope.fields.membershipAccess.label`,
+                scope: "/properties/membershipAccess",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-tile-select",
+                  labels: [
+                    `{{some.scope.fields.membershipAccess.org.label:translate}}`,
+                    `{{some.scope.fields.membershipAccess.collab.label:translate}}`,
+                    `{{some.scope.fields.membershipAccess.any.label:translate}}`,
+                  ],
+                  descriptions: [
+                    `{{some.scope.fields.membershipAccess.org.description:translate}}`,
+                    `{{some.scope.fields.membershipAccess.collab.description:translate}}`,
+                    `{{some.scope.fields.membershipAccess.any.description:translate}}`,
+                  ],
+                  // rules that pertain to the individual options
+                  rules: [
+                    [
+                      {
+                        effect: UiSchemaRuleEffects.NONE,
+                      },
+                    ],
+                    [
+                      {
+                        effect: UiSchemaRuleEffects.DISABLE,
+                        conditions: [
+                          {
+                            scope: "/properties/leavingDisallowed",
+                            schema: { const: true },
+                          },
+                        ],
+                      },
+                    ],
+                    [
+                      {
+                        effect: UiSchemaRuleEffects.DISABLE,
+                        conditions: [
+                          {
+                            scope: "/properties/leavingDisallowed",
+                            schema: { const: true },
+                          },
+                        ],
+                      },
+                      {
+                        effect: UiSchemaRuleEffects.DISABLE,
+                        conditions: [
+                          {
+                            scope: "/properties/isSharedUpdate",
+                            schema: { const: true },
+                          },
+                        ],
+                      },
+                    ],
+                  ],
+                  messages: [
+                    {
+                      type: "ERROR",
+                      keyword: "pattern",
+                      icon: true,
+                      labelKey: `some.scope.fields.membershipAccess.patternError`,
+                    },
+                    {
+                      type: "ERROR",
+                      keyword: "const",
+                      icon: true,
+                      labelKey: `some.scope.fields.membershipAccess.constError`,
+                    },
+                  ],
+                },
+                // rules that pertain to the control as a whole
+                rules: [
                   {
-                    effect: UiSchemaRuleEffects.DISABLE,
-                    conditions: [true],
+                    effect: UiSchemaRuleEffects.RESET,
+                    conditions: [
+                      {
+                        scope: "/properties/leavingDisallowed",
+                        schema: { const: true },
+                      },
+                    ],
                   },
                   {
-                    effect: UiSchemaRuleEffects.DISABLE,
+                    effect: UiSchemaRuleEffects.RESET,
                     conditions: [
                       {
                         scope: "/properties/isSharedUpdate",
                         schema: { const: true },
                       },
+                      {
+                        scope: "/properties/membershipAccess",
+                        schema: { const: "anyone" },
+                      },
                     ],
                   },
                 ],
-              ],
-              messages: [
-                {
-                  type: "ERROR",
-                  keyword: "enum",
-                  icon: true,
-                  labelKey: `some.scope.fields.membershipAccess.enumError`,
+              },
+              {
+                labelKey: `some.scope.fields.join.label`,
+                scope: "/properties/_join",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-tile-select",
+                  labels: [
+                    `{{some.scope.fields.join.invite.label:translate}}`,
+                    `{{some.scope.fields.join.request.label:translate}}`,
+                    `{{some.scope.fields.join.auto.label:translate}}`,
+                  ],
+                  descriptions: [
+                    `{{some.scope.fields.join.invite.description:translate}}`,
+                    `{{some.scope.fields.join.request.description:translate}}`,
+                    `{{some.scope.fields.join.auto.description:translate}}`,
+                  ],
+                  // rules that pertain to the individual options
+                  rules: [
+                    [
+                      {
+                        effect: UiSchemaRuleEffects.NONE,
+                      },
+                    ],
+                    [
+                      {
+                        effect: UiSchemaRuleEffects.DISABLE,
+                        conditions: [
+                          {
+                            scope: "/properties/access",
+                            schema: { const: "private" },
+                          },
+                        ],
+                      },
+                    ],
+                    [
+                      {
+                        effect: UiSchemaRuleEffects.DISABLE,
+                        conditions: [
+                          {
+                            scope: "/properties/access",
+                            schema: { const: "private" },
+                          },
+                        ],
+                      },
+                      {
+                        effect: UiSchemaRuleEffects.DISABLE,
+                        conditions: [
+                          {
+                            scope: "/properties/leavingDisallowed",
+                            schema: { const: true },
+                          },
+                        ],
+                      },
+                      {
+                        effect: UiSchemaRuleEffects.DISABLE,
+                        conditions: [
+                          {
+                            scope: "/properties/isSharedUpdate",
+                            schema: { const: true },
+                          },
+                        ],
+                      },
+                    ],
+                  ],
+                  messages: [
+                    {
+                      type: "ERROR",
+                      keyword: "const",
+                      icon: true,
+                      labelKey: `some.scope.fields.join.constError`,
+                    },
+                    {
+                      type: "ERROR",
+                      keyword: "pattern",
+                      icon: true,
+                      labelKey: `some.scope.fields.join.patternError`,
+                    },
+                  ],
                 },
-              ],
-            },
-          },
-          {
-            labelKey: `some.scope.fields.contributeContent.label`,
-            scope: "/properties/isViewOnly",
-            type: "Control",
-            options: {
-              control: "hub-field-input-radio",
-              labels: [
-                `{{some.scope.fields.contributeContent.all:translate}}`,
-                `{{some.scope.fields.contributeContent.admins:translate}}`,
-              ],
-            },
+                // rules that pertain to the control as a whole
+                rules: [
+                  {
+                    effect: UiSchemaRuleEffects.RESET,
+                    conditions: [
+                      {
+                        scope: "/properties/access",
+                        schema: { const: "private" },
+                      },
+                    ],
+                  },
+                  {
+                    effect: UiSchemaRuleEffects.RESET,
+                    conditions: [
+                      {
+                        scope: "/properties/leavingDisallowed",
+                        schema: { const: true },
+                      },
+                      {
+                        scope: "/properties/_join",
+                        schema: { const: "auto" },
+                      },
+                    ],
+                  },
+                  {
+                    effect: UiSchemaRuleEffects.RESET,
+                    conditions: [
+                      {
+                        scope: "/properties/isSharedUpdate",
+                        schema: { const: true },
+                      },
+                      {
+                        scope: "/properties/_join",
+                        schema: { const: "auto" },
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                labelKey: `some.scope.fields.hiddenMembers.label`,
+                scope: "/properties/hiddenMembers",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-tile-select",
+                  labels: [
+                    `{{some.scope.fields.hiddenMembers.members.label:translate}}`,
+                    `{{some.scope.fields.hiddenMembers.admins.label:translate}}`,
+                  ],
+                  descriptions: [
+                    `{{some.scope.fields.hiddenMembers.members.description:translate}}`,
+                    `{{some.scope.fields.hiddenMembers.admins.description:translate}}`,
+                  ],
+                },
+              },
+              {
+                labelKey: `some.scope.fields.contributeContent.label`,
+                scope: "/properties/isViewOnly",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-tile-select",
+                  labels: [
+                    `{{some.scope.fields.contributeContent.members.label:translate}}`,
+                    `{{some.scope.fields.contributeContent.admins.label:translate}}`,
+                  ],
+                  descriptions: [
+                    `{{some.scope.fields.contributeContent.members.description:translate}}`,
+                    `{{some.scope.fields.contributeContent.admins.description:translate}}`,
+                  ],
+                },
+              },
+            ],
           },
         ],
       });
@@ -126,9 +426,9 @@ describe("GroupUiSchemaCreate", () => {
       );
 
       expect(defaults).toEqual({
-        access: "org",
+        access: "private",
         autoJoin: false,
-        isSharedUpdate: false,
+        isSharedUpdate: true,
         isInvitationOnly: false,
         hiddenMembers: false,
         isViewOnly: false,
@@ -144,9 +444,9 @@ describe("GroupUiSchemaCreate", () => {
         getMockContextWithPrivilenges(["portal:user:addExternalMembersToGroup"])
       );
       expect(defaults).toEqual({
-        access: "org",
+        access: "private",
         autoJoin: false,
-        isSharedUpdate: false,
+        isSharedUpdate: true,
         isInvitationOnly: false,
         hiddenMembers: false,
         isViewOnly: false,

--- a/packages/common/test/groups/_internal/convertHubGroupToGroup.test.ts
+++ b/packages/common/test/groups/_internal/convertHubGroupToGroup.test.ts
@@ -12,9 +12,10 @@ describe("groups: convertHubGroupToGroup:", () => {
       thumbnail: "group.jpg",
       membershipAccess: "collaborators",
       isSharedUpdate: true,
+      _join: "invite",
     } as unknown as IHubGroup;
   });
-  it("converts an HubGroup to a IGroup", async () => {
+  it("converts an HubGroup with _join === invite to a IGroup", async () => {
     const chk = convertHubGroupToGroup(hubGroup);
     // we convert some props in HubGroup to something else
     // in IGroup, checking them is a good way to
@@ -23,6 +24,32 @@ describe("groups: convertHubGroupToGroup:", () => {
     expect(chk.access).toBe("org");
     expect(chk.membershipAccess).toBe("collaboration");
     expect(chk.capabilities).toBe("updateitemcontrol");
+    expect(chk.isInvitationOnly).toBe(true);
+    expect(chk.autoJoin).toBe(false);
+  });
+  it("converts an HubGroup with _join === request to a IGroup", async () => {
+    const chk = convertHubGroupToGroup({ ...hubGroup, _join: "request" });
+    // we convert some props in HubGroup to something else
+    // in IGroup, checking them is a good way to
+    // varify the HubGroup -> IGroup convertion
+    expect(chk.id).toBe("3ef");
+    expect(chk.access).toBe("org");
+    expect(chk.membershipAccess).toBe("collaboration");
+    expect(chk.capabilities).toBe("updateitemcontrol");
+    expect(chk.isInvitationOnly).toBe(false);
+    expect(chk.autoJoin).toBe(false);
+  });
+  it("converts an HubGroup with _join === auto to a IGroup", async () => {
+    const chk = convertHubGroupToGroup({ ...hubGroup, _join: "auto" });
+    // we convert some props in HubGroup to something else
+    // in IGroup, checking them is a good way to
+    // varify the HubGroup -> IGroup convertion
+    expect(chk.id).toBe("3ef");
+    expect(chk.access).toBe("org");
+    expect(chk.membershipAccess).toBe("collaboration");
+    expect(chk.capabilities).toBe("updateitemcontrol");
+    expect(chk.isInvitationOnly).toBe(false);
+    expect(chk.autoJoin).toBe(true);
   });
   it("clears empty fields", async () => {
     hubGroup.membershipAccess = "anyone";


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Updates to group json schema and create group uiSchema.

1. Closes Issues: [#11368](https://devtopia.esri.com/dc/hub/issues/11368)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
