### PR TITLE
feat(hub-common): add event scope to catalog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22695,10 +22695,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22713,24 +22712,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22744,10 +22740,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22765,10 +22760,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65023,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.198.1",
+			"version": "14.199.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -83487,8 +83481,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83503,20 +83496,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83530,8 +83520,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83548,8 +83537,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22695,9 +22695,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22712,21 +22713,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22740,9 +22744,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22760,9 +22765,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -83481,7 +83487,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83496,17 +83503,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83520,7 +83530,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83537,7 +83548,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/search/upgradeCatalogSchema.ts
+++ b/packages/common/src/search/upgradeCatalogSchema.ts
@@ -79,6 +79,7 @@ function applyCatalogSchema(original: any): IHubCatalog {
     }
 
     if (groups.length) {
+      // add the group predicate to all the scope queries
       catalog.scopes = Object.entries(catalog.scopes).reduce<ICatalogScope>(
         (acc, entry) => ({
           ...acc,
@@ -95,26 +96,25 @@ function applyCatalogSchema(original: any): IHubCatalog {
     // for org-level home sites (e.g., "my-org.hub.arcgis.com")
     const orgId = getProp(original, "orgId");
     if (orgId) {
+      // add the org ID predicate to all the scope queries
       catalog.scopes = Object.entries(catalog.scopes).reduce<ICatalogScope>(
         (acc, entry) => {
           const entityType: EntityType = entry[0] as EntityType;
           const query: IQuery = entry[1] as IQuery;
-          return ORG_ID_PREDICATE_FNS_BY_ENTITY_TYPE[entityType]
-            ? {
-                ...acc,
-                [entityType]: {
-                  ...query,
-                  filters: [
-                    ...query.filters,
-                    {
-                      operation: "AND",
-                      predicates:
-                        ORG_ID_PREDICATE_FNS_BY_ENTITY_TYPE[entityType](orgId),
-                    },
-                  ],
+          return {
+            ...acc,
+            [entityType]: {
+              ...query,
+              filters: [
+                ...query.filters,
+                {
+                  operation: "AND",
+                  predicates:
+                    ORG_ID_PREDICATE_FNS_BY_ENTITY_TYPE[entityType](orgId),
                 },
-              }
-            : acc;
+              ],
+            },
+          };
         },
         {}
       );

--- a/packages/common/src/search/upgradeCatalogSchema.ts
+++ b/packages/common/src/search/upgradeCatalogSchema.ts
@@ -32,6 +32,8 @@ const ORG_ID_PREDICATE_FNS_BY_ENTITY_TYPE: Partial<
  * @returns
  */
 export function upgradeCatalogSchema(catalog: any): IHubCatalog {
+  /* tslint:disable-next-line */
+  debugger;
   let clone = cloneObject(catalog);
   if (getProp(clone, "schemaVersion") === CATALOG_SCHEMA_VERSION) {
     return clone;

--- a/packages/common/src/search/upgradeCatalogSchema.ts
+++ b/packages/common/src/search/upgradeCatalogSchema.ts
@@ -100,16 +100,18 @@ function applyCatalogSchema(original: any): IHubCatalog {
 
     if (groups.length) {
       // add the group predicate to all the scope queries
-      catalog.scopes = Object.entries(catalog.scopes).reduce<ICatalogScope>(
-        (acc, entry) => ({
-          ...acc,
-          [entry[0] as EntityType]: {
-            ...(entry[1] as IQuery),
-            filters: [{ predicates: [{ group: groups }] }],
-          },
-        }),
-        {}
-      );
+      catalog.scopes = Object.entries(catalog.scopes)
+        .filter(([entityType]) => ["item", "event"].includes(entityType))
+        .reduce<ICatalogScope>(
+          (acc, entry) => ({
+            ...acc,
+            [entry[0] as EntityType]: {
+              ...(entry[1] as IQuery),
+              filters: [{ predicates: [{ group: groups }] }],
+            },
+          }),
+          {}
+        );
     }
 
     // Handle legacy orgId value, which should only be present

--- a/packages/common/src/sites/_internal/applyCatalogStructureMigration.ts
+++ b/packages/common/src/sites/_internal/applyCatalogStructureMigration.ts
@@ -19,6 +19,10 @@ export function applyCatalogStructureMigration(model: IModel): IModel {
   if (!siteCatalog.schemaVersion) {
     const clonedModel = cloneObject(model);
     clonedModel.data.catalog = upgradeCatalogSchema(siteCatalog);
+    // applyCatalogSchema sets the catalog to `Default Catalog` but this fn previously
+    // set it to `Default Site Catalog`. Overriding title to `Default Site Catalog` here
+    // to prevent any potential regressions
+    clonedModel.data.catalog.title = "Default Site Catalog";
     return clonedModel;
   }
   return model;

--- a/packages/common/src/sites/_internal/applyCatalogStructureMigration.ts
+++ b/packages/common/src/sites/_internal/applyCatalogStructureMigration.ts
@@ -1,3 +1,4 @@
+import { getWithDefault } from "../../objects/get-with-default";
 import { IHubCatalog } from "../../search/types/IHubCatalog";
 import { upgradeCatalogSchema } from "../../search/upgradeCatalogSchema";
 import { IModel } from "../../types";
@@ -44,6 +45,7 @@ export function applyCatalogStructureMigration(model: IModel): IModel {
 
   // return model;
   const result = cloneObject(model);
-  result.data.catalog = upgradeCatalogSchema(model.data.catalog || {});
+  const catalog = getWithDefault(model.data, "catalog", {});
+  result.data.catalog = upgradeCatalogSchema(catalog);
   return result;
 }

--- a/packages/common/src/sites/_internal/applyCatalogStructureMigration.ts
+++ b/packages/common/src/sites/_internal/applyCatalogStructureMigration.ts
@@ -1,5 +1,7 @@
 import { IHubCatalog } from "../../search/types/IHubCatalog";
+import { upgradeCatalogSchema } from "../../search/upgradeCatalogSchema";
 import { IModel } from "../../types";
+import { cloneObject } from "../../util";
 
 /**
  * Add the default catalog structure to the Site model
@@ -11,34 +13,37 @@ import { IModel } from "../../types";
  * @returns
  */
 export function applyCatalogStructureMigration(model: IModel): IModel {
-  let siteCatalog = model.data.catalog || {};
-  // This _shouldn't_ happen, but some of our testing sites might have this
-  // migration already persisted in AGO. In that case, we ignore and move on
-  if (!siteCatalog.schemaVersion) {
-    const groups = siteCatalog.groups || [];
-    siteCatalog = {
-      schemaVersion: 1,
-      title: "Default Site Catalog",
-      scopes: {
-        item: {
-          targetEntity: "item",
-          filters: [],
-        },
-      },
-      collections: [],
-    } as IHubCatalog;
+  // let siteCatalog = model.data.catalog || {};
+  // // This _shouldn't_ happen, but some of our testing sites might have this
+  // // migration already persisted in AGO. In that case, we ignore and move on
+  // if (!siteCatalog.schemaVersion) {
+  //   const groups = siteCatalog.groups || [];
+  //   siteCatalog = {
+  //     schemaVersion: 1,
+  //     title: "Default Site Catalog",
+  //     scopes: {
+  //       item: {
+  //         targetEntity: "item",
+  //         filters: [],
+  //       },
+  //     },
+  //     collections: [],
+  //   } as IHubCatalog;
 
-    // groups are used to set the item scope for the whole catalog
-    siteCatalog.scopes.item.filters.push({
-      predicates: [
-        {
-          group: [...groups],
-        },
-      ],
-    });
+  //   // groups are used to set the item scope for the whole catalog
+  //   siteCatalog.scopes.item.filters.push({
+  //     predicates: [
+  //       {
+  //         group: [...groups],
+  //       },
+  //     ],
+  //   });
 
-    model.data.catalog = siteCatalog;
-  }
+  //   model.data.catalog = siteCatalog;
+  // }
 
-  return model;
+  // return model;
+  const result = cloneObject(model);
+  result.data.catalog = upgradeCatalogSchema(model.data.catalog || {});
+  return result;
 }

--- a/packages/common/src/sites/_internal/applyCatalogStructureMigration.ts
+++ b/packages/common/src/sites/_internal/applyCatalogStructureMigration.ts
@@ -1,5 +1,4 @@
 import { getWithDefault } from "../../objects/get-with-default";
-import { IHubCatalog } from "../../search/types/IHubCatalog";
 import { upgradeCatalogSchema } from "../../search/upgradeCatalogSchema";
 import { IModel } from "../../types";
 import { cloneObject } from "../../util";
@@ -14,38 +13,13 @@ import { cloneObject } from "../../util";
  * @returns
  */
 export function applyCatalogStructureMigration(model: IModel): IModel {
-  // let siteCatalog = model.data.catalog || {};
-  // // This _shouldn't_ happen, but some of our testing sites might have this
-  // // migration already persisted in AGO. In that case, we ignore and move on
-  // if (!siteCatalog.schemaVersion) {
-  //   const groups = siteCatalog.groups || [];
-  //   siteCatalog = {
-  //     schemaVersion: 1,
-  //     title: "Default Site Catalog",
-  //     scopes: {
-  //       item: {
-  //         targetEntity: "item",
-  //         filters: [],
-  //       },
-  //     },
-  //     collections: [],
-  //   } as IHubCatalog;
-
-  //   // groups are used to set the item scope for the whole catalog
-  //   siteCatalog.scopes.item.filters.push({
-  //     predicates: [
-  //       {
-  //         group: [...groups],
-  //       },
-  //     ],
-  //   });
-
-  //   model.data.catalog = siteCatalog;
-  // }
-
-  // return model;
-  const result = cloneObject(model);
-  const catalog = getWithDefault(model.data, "catalog", {});
-  result.data.catalog = upgradeCatalogSchema(catalog);
-  return result;
+  const siteCatalog = getWithDefault(model.data, "catalog", {});
+  // This _shouldn't_ happen, but some of our testing sites might have this
+  // migration already persisted in AGO. In that case, we ignore and move on
+  if (!siteCatalog.schemaVersion) {
+    const clonedModel = cloneObject(model);
+    clonedModel.data.catalog = upgradeCatalogSchema(siteCatalog);
+    return clonedModel;
+  }
+  return model;
 }

--- a/packages/common/test/search/upgradeCatalogSchema.test.ts
+++ b/packages/common/test/search/upgradeCatalogSchema.test.ts
@@ -6,6 +6,7 @@ describe("upgradeCatalogSchema", () => {
     expect(chk.title).toBe("Default Catalog");
     expect(chk.scopes).toBeDefined();
     expect(chk.scopes?.item?.filters.length).toBe(0);
+    expect(chk.scopes?.event?.filters.length).toBe(0);
   });
 
   it("returns default catalog if passed empty object", () => {
@@ -13,6 +14,7 @@ describe("upgradeCatalogSchema", () => {
     expect(chk.title).toBe("Default Catalog");
     expect(chk.scopes).toBeDefined();
     expect(chk.scopes?.item?.filters.length).toBe(0);
+    expect(chk.scopes?.event?.filters.length).toBe(0);
   });
 
   it("does not return groups if passed empty array", () => {
@@ -20,6 +22,7 @@ describe("upgradeCatalogSchema", () => {
     expect(chk.title).toBe("Default Catalog");
     expect(chk.scopes).toBeDefined();
     expect(chk.scopes?.item?.filters.length).toBe(0);
+    expect(chk.scopes?.event?.filters.length).toBe(0);
   });
 
   it("returns groups if passed a string", () => {
@@ -28,6 +31,8 @@ describe("upgradeCatalogSchema", () => {
     expect(chk.scopes).toBeDefined();
     expect(chk.scopes?.item?.filters.length).toBe(1);
     expect(chk.scopes?.item?.filters[0].predicates[0].group).toEqual(["3ef"]);
+    expect(chk.scopes?.event?.filters.length).toBe(1);
+    expect(chk.scopes?.event?.filters[0].predicates[0].group).toEqual(["3ef"]);
   });
 
   it("returns groups if passed an array", () => {
@@ -36,6 +41,11 @@ describe("upgradeCatalogSchema", () => {
     expect(chk.scopes).toBeDefined();
     expect(chk.scopes?.item?.filters.length).toBe(1);
     expect(chk.scopes?.item?.filters[0].predicates[0].group).toEqual([
+      "3ef",
+      "bc4",
+    ]);
+    expect(chk.scopes?.event?.filters.length).toBe(1);
+    expect(chk.scopes?.event?.filters[0].predicates[0].group).toEqual([
       "3ef",
       "bc4",
     ]);
@@ -51,6 +61,10 @@ describe("upgradeCatalogSchema", () => {
     expect(chk.scopes?.item?.filters[0].predicates[1].type).toEqual({
       not: ["Code Attachment"],
     });
+    expect(chk.scopes?.event?.filters.length).toBe(1);
+    expect(chk.scopes?.event?.filters[0].operation).toEqual("AND");
+    expect(chk.scopes?.event?.filters[0].predicates[0].orgId).toEqual("a3g");
+    expect(chk.scopes?.event?.filters[0].predicates[1]).toBeUndefined();
   });
 
   it("skips upgrade if on the same version", () => {

--- a/packages/common/test/sites/_internal/applyCatalogStructureMigration.test.ts
+++ b/packages/common/test/sites/_internal/applyCatalogStructureMigration.test.ts
@@ -28,6 +28,18 @@ describe("applyCatalogStructureMigration:", () => {
             },
           ],
         },
+        event: {
+          targetEntity: "event",
+          filters: [
+            {
+              predicates: [
+                {
+                  group: ["00c", "00d"],
+                },
+              ],
+            },
+          ],
+        },
       },
       collections: [],
     });


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 11326

1. Description:

- Adds an `event` scope to catalogs in support of enforcing guards on the events3 view

1. Instructions for testing:

1. Closes Issues: #[11326](https://devtopia.esri.com/dc/hub/issues/11326)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
