### PR TITLE
fix(hub-common): add trackCacheUpdate by default when polling download API

### DIFF
--- a/packages/common/src/downloads/_internal/file-url-fetchers/fetchHubApiDownloadFile.ts
+++ b/packages/common/src/downloads/_internal/file-url-fetchers/fetchHubApiDownloadFile.ts
@@ -173,12 +173,10 @@ async function pollDownloadApi(
   progressCallback && progressCallback(operationStatus, progressInPercent);
   await wait(pollInterval);
 
-  let updatedCacheQueryParam: CacheQueryParam;
-  if (cacheQueryParam) {
-    // After an initial request with ?updateCache=true, we need to switch to ?trackCacheUpdate=true.
-    // This enables us to follow the progress of the cache update without causing an infinite update loop.
-    updatedCacheQueryParam = "trackCacheUpdate";
-  }
+  // always have `trackCacheUpdate` present when polling Hub download API
+  // because polling is always done to update cache or create a new cache
+  // if not already present
+  const updatedCacheQueryParam: CacheQueryParam = "trackCacheUpdate";
 
   return pollDownloadApi(
     requestUrl,

--- a/packages/common/test/downloads/_internal/file-url-fetchers/fetchHubApiDownloadFile.test.ts
+++ b/packages/common/test/downloads/_internal/file-url-fetchers/fetchHubApiDownloadFile.test.ts
@@ -61,7 +61,7 @@ describe("fetchHubApiDownloadFile", () => {
   });
   it("throws an ArcgisHubDownloadError if the api returns an error during polling", async () => {
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
       {
         status: 500,
         body: { message: "Special Server Error" },
@@ -107,7 +107,7 @@ describe("fetchHubApiDownloadFile", () => {
   });
   it("polls without a progress callback", async () => {
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
       {
         body: {
           status: "Pending",
@@ -155,7 +155,7 @@ describe("fetchHubApiDownloadFile", () => {
   });
   it("polls with a progress callback", async () => {
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
       {
         body: {
           status: "Pending",
@@ -305,7 +305,7 @@ describe("fetchHubApiDownloadFile", () => {
   });
   it("polls without a progress callback", async () => {
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
       {
         body: {
           status: "Pending",

--- a/packages/common/test/downloads/_internal/file-url-fetchers/fetchHubApiDownloadFile.test.ts
+++ b/packages/common/test/downloads/_internal/file-url-fetchers/fetchHubApiDownloadFile.test.ts
@@ -61,7 +61,7 @@ describe("fetchHubApiDownloadFile", () => {
   });
   it("throws an ArcgisHubDownloadError if the api returns an error during polling", async () => {
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
       {
         status: 500,
         body: { message: "Special Server Error" },
@@ -107,7 +107,7 @@ describe("fetchHubApiDownloadFile", () => {
   });
   it("polls without a progress callback", async () => {
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
       {
         body: {
           status: "Pending",
@@ -115,7 +115,7 @@ describe("fetchHubApiDownloadFile", () => {
       }
     );
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
       {
         body: {
           status: "InProgress",
@@ -126,7 +126,7 @@ describe("fetchHubApiDownloadFile", () => {
       { overwriteRoutes: false }
     );
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
       {
         body: {
           status: "Completed",
@@ -155,7 +155,7 @@ describe("fetchHubApiDownloadFile", () => {
   });
   it("polls with a progress callback", async () => {
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
       {
         body: {
           status: "Pending",
@@ -163,7 +163,7 @@ describe("fetchHubApiDownloadFile", () => {
       }
     );
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
       {
         body: {
           status: "PagingData",
@@ -174,7 +174,7 @@ describe("fetchHubApiDownloadFile", () => {
       { overwriteRoutes: false }
     );
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
       {
         body: {
           status: "Completed",
@@ -305,7 +305,7 @@ describe("fetchHubApiDownloadFile", () => {
   });
   it("polls without a progress callback", async () => {
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
       {
         body: {
           status: "Pending",
@@ -313,7 +313,7 @@ describe("fetchHubApiDownloadFile", () => {
       }
     );
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
       {
         body: {
           status: "InProgress",
@@ -324,7 +324,7 @@ describe("fetchHubApiDownloadFile", () => {
       { overwriteRoutes: false }
     );
     fetchMock.once(
-      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0",
+      "https://hubqa.arcgis.com/api/download/v1/items/123/csv?redirect=false&layers=0&trackCacheUpdate=true",
       {
         body: {
           status: "Completed",


### PR DESCRIPTION
Bug: When there is no cache for a dataset whose service have editor tracking disabled and download is requested. Cache generation process is completed, a notice that "cache may be outdated" is present. This might be confusing to the user because user just finished generated a cache.  The notice is not expected immediately after cache generation.

This fixes the bug by pending `trackCacheUpdate` query params which contains the response to hide notice when download job is complete.

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
