### PR TITLE
fix(hub-common): added sharedToGroups filter for get-events

### DIFF
--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -280,6 +280,10 @@ export type GetEventsParams = {
    * orgId string
    */
   orgId?: string;
+  /**
+   * Comma separated string list of shared groupIds
+   */
+  sharedToGroups?: string;
 };
 
 export interface IRegistrationPermission {


### PR DESCRIPTION
1. Description: sharedToGroups filter added to the get-events-dto

1. Instructions for testing:

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
