### PR TITLE
feat: showInfoBanner for user org settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22695,10 +22695,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22713,24 +22712,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22744,10 +22740,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22765,10 +22760,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65023,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.199.0",
+			"version": "14.204.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -83487,8 +83481,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83503,20 +83496,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83530,8 +83520,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83548,8 +83537,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/users/HubUser.ts
+++ b/packages/common/src/users/HubUser.ts
@@ -8,6 +8,7 @@ import { cloneObject } from "../util";
 import { UserEditorType } from "./_internal/UserSchema";
 import { DEFAULT_USER } from "./defaults";
 import { updateCommunityOrgSettings } from "../utils/internal/updateCommunityOrgSettings";
+import { updatePortalOrgSettings } from "../utils/internal/updatePortalOrgSettings";
 
 export class HubUser implements IWithEditorBehavior {
   protected context: IArcGISContext;
@@ -92,7 +93,15 @@ export class HubUser implements IWithEditorBehavior {
     }
 
     // 3. update portal settings
-    // TODO in later story
+    // User is org admin, we have org settings to send, and we have a banner to show
+    if (
+      this.context.isOrgAdmin &&
+      this.entity.hubOrgSettings &&
+      this.entity.hubOrgSettings.hasOwnProperty("showInformationalBanner")
+    ) {
+      // update the portal settings
+      await updatePortalOrgSettings(this.entity.hubOrgSettings, this.context);
+    }
 
     return;
   }

--- a/packages/common/src/users/_internal/UserUiSchemaSettings.ts
+++ b/packages/common/src/users/_internal/UserUiSchemaSettings.ts
@@ -125,6 +125,26 @@ export const buildUiSchema = async (
           },
           {
             type: "Section",
+            labelKey: `${i18nScope}.sections.orgSettings.siteDefaults.label`,
+            elements: [
+              {
+                type: "Control",
+                scope:
+                  "/properties/hubOrgSettings/properties/showInformationalBanner",
+                labelKey: `${i18nScope}.fields.infoBanner.label`,
+                options: {
+                  type: "Control",
+                  control: "hub-field-input-switch",
+                  layout: "inline-space-between",
+                  helperText: {
+                    labelKey: `${i18nScope}.fields.infoBanner.helperText`,
+                  },
+                },
+              },
+            ],
+          },
+          {
+            type: "Section",
             labelKey: `${i18nScope}.sections.orgSettings.signinSettings.label`,
             rules: [
               {

--- a/packages/common/src/utils/internal/updateCommunityOrgSettings.ts
+++ b/packages/common/src/utils/internal/updateCommunityOrgSettings.ts
@@ -1,4 +1,3 @@
-import { _isOrgAdmin } from "../..";
 import { IArcGISContext } from "../../ArcGISContext";
 import { IHubUserOrgSettings } from "../../core/types/IHubUser";
 import { request } from "@esri/arcgis-rest-request";

--- a/packages/common/src/utils/internal/updateCommunityOrgSettings.ts
+++ b/packages/common/src/utils/internal/updateCommunityOrgSettings.ts
@@ -1,4 +1,4 @@
-import { _isOrgAdmin, getPortalUrl } from "../..";
+import { _isOrgAdmin } from "../..";
 import { IArcGISContext } from "../../ArcGISContext";
 import { IHubUserOrgSettings } from "../../core/types/IHubUser";
 import { request } from "@esri/arcgis-rest-request";

--- a/packages/common/src/utils/internal/updatePortalOrgSettings.ts
+++ b/packages/common/src/utils/internal/updatePortalOrgSettings.ts
@@ -1,0 +1,39 @@
+import { _isOrgAdmin } from "../..";
+import { IArcGISContext } from "../../ArcGISContext";
+import { IHubUserOrgSettings } from "../../core/types/IHubUser";
+import { request } from "@esri/arcgis-rest-request";
+
+/**
+ * Function to update a user's community org settings. Expects the user to be an org admin in the current community org.
+ * @param settings
+ */
+export async function updatePortalOrgSettings(
+  settings: IHubUserOrgSettings,
+  context: IArcGISContext
+) {
+  // check that user is authed
+  if (!context.currentUser) {
+    throw new Error("User is not authenticated");
+  }
+
+  // check that user is in community org and is org admin
+  if (!context.isOrgAdmin) {
+    throw new Error("User is not an org admin in the current community org");
+  }
+
+  // grab settings
+  const { showInformationalBanner } = settings;
+
+  // build the url
+  const urlPath = "/sharing/rest/portals/self/setSigninSettings?f=json";
+  const url = `${context.portalUrl}${urlPath}`;
+
+  // send the request to update
+  return request(url, {
+    httpMethod: "POST",
+    params: {
+      showInformationalBanner,
+      token: context.hubRequestOptions.authentication.token,
+    },
+  });
+}

--- a/packages/common/src/utils/internal/updatePortalOrgSettings.ts
+++ b/packages/common/src/utils/internal/updatePortalOrgSettings.ts
@@ -4,7 +4,8 @@ import { IHubUserOrgSettings } from "../../core/types/IHubUser";
 import { request } from "@esri/arcgis-rest-request";
 
 /**
- * Function to update a user's community org settings. Expects the user to be an org admin in the current community org.
+ * Function to update a user's org settings. Expects the user to be an org admin in the current org.
+ * Currently only updates whether to show the informational banner.
  * @param settings
  */
 export async function updatePortalOrgSettings(
@@ -16,9 +17,9 @@ export async function updatePortalOrgSettings(
     throw new Error("User is not authenticated");
   }
 
-  // check that user is in community org and is org admin
+  // check that user is org admin
   if (!context.isOrgAdmin) {
-    throw new Error("User is not an org admin in the current community org");
+    throw new Error("User is not an org admin in the current org");
   }
 
   // grab and clone portalProperties

--- a/packages/common/src/utils/internal/updatePortalOrgSettings.ts
+++ b/packages/common/src/utils/internal/updatePortalOrgSettings.ts
@@ -1,7 +1,7 @@
-import { _isOrgAdmin, cloneObject } from "../..";
 import { IArcGISContext } from "../../ArcGISContext";
 import { IHubUserOrgSettings } from "../../core/types/IHubUser";
 import { request } from "@esri/arcgis-rest-request";
+import { cloneObject } from "../../util";
 
 /**
  * Function to update a user's org settings. Expects the user to be an org admin in the current org.

--- a/packages/common/src/utils/internal/updatePortalOrgSettings.ts
+++ b/packages/common/src/utils/internal/updatePortalOrgSettings.ts
@@ -1,4 +1,4 @@
-import { _isOrgAdmin } from "../..";
+import { _isOrgAdmin, cloneObject } from "../..";
 import { IArcGISContext } from "../../ArcGISContext";
 import { IHubUserOrgSettings } from "../../core/types/IHubUser";
 import { request } from "@esri/arcgis-rest-request";
@@ -21,18 +21,22 @@ export async function updatePortalOrgSettings(
     throw new Error("User is not an org admin in the current community org");
   }
 
+  // grab and clone portalProperties
+  const portalProperties = cloneObject(context.portal.portalProperties);
   // grab settings
   const { showInformationalBanner } = settings;
+  // update infoBanner value in portalProperties
+  portalProperties.hub.settings.informationalBanner = showInformationalBanner;
 
   // build the url
-  const urlPath = "/sharing/rest/portals/self/setSigninSettings?f=json";
+  const urlPath = `/sharing/rest/portals/self/update?f=json`;
   const url = `${context.portalUrl}${urlPath}`;
 
   // send the request to update
   return request(url, {
     httpMethod: "POST",
     params: {
-      showInformationalBanner,
+      portalProperties: JSON.stringify(portalProperties),
       token: context.hubRequestOptions.authentication.token,
     },
   });

--- a/packages/common/test/users/HubUser.test.ts
+++ b/packages/common/test/users/HubUser.test.ts
@@ -4,10 +4,10 @@ import { HubUser } from "../../src/users/HubUser";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import { mergeObjects } from "../../src/objects/merge-objects";
 import * as EditConfigModule from "../../src/core/schemas/getEditorConfig";
-import * as HubUsersModule from "../../src/users/HubUsers";
 import * as EnrichEntityModule from "../../src/core/enrichEntity";
 import { IHubUser } from "../../src/core/types/IHubUser";
 import * as UpdateCommunityOrgSettingsModule from "../../src/utils/internal/updateCommunityOrgSettings";
+import * as UpdatePortalOrgSettingsModule from "../../src/utils/internal/updatePortalOrgSettings";
 
 const initContextManager = async (opts = {}) => {
   const defaults = {
@@ -143,9 +143,16 @@ describe("HubUser Class:", () => {
         return Promise.resolve();
       });
 
-      const updateCommunityOrgSettings = spyOn(
+      const updateCommunityOrgSettingsSpy = spyOn(
         UpdateCommunityOrgSettingsModule,
         "updateCommunityOrgSettings"
+      ).and.callFake(async () => {
+        return Promise.resolve();
+      });
+
+      const updatePortalOrgSettingsSpy = spyOn(
+        UpdatePortalOrgSettingsModule,
+        "updatePortalOrgSettings"
       ).and.callFake(async () => {
         return Promise.resolve();
       });
@@ -155,7 +162,8 @@ describe("HubUser Class:", () => {
 
       expect(updateUserHubSettingsSpy).toHaveBeenCalledTimes(1);
       expect(updateUserHubSettingsSpy).toHaveBeenCalledWith(user.settings);
-      expect(updateCommunityOrgSettings).toHaveBeenCalledTimes(0);
+      expect(updateCommunityOrgSettingsSpy).toHaveBeenCalledTimes(0);
+      expect(updatePortalOrgSettingsSpy).toHaveBeenCalledTimes(0);
     });
     it("saves hub org settings if we are in a community org and user is admin", async () => {
       const user = {
@@ -167,6 +175,7 @@ describe("HubUser Class:", () => {
           termsAndConditions: "testTerms",
           enableSignupText: true,
           enableTermsAndConditions: true,
+          showInformationalBanner: true,
         },
       } as unknown as IHubUser;
 
@@ -177,9 +186,16 @@ describe("HubUser Class:", () => {
         return Promise.resolve();
       });
 
-      const updateCommunityOrgSettings = spyOn(
+      const updateCommunityOrgSettingsSpy = spyOn(
         UpdateCommunityOrgSettingsModule,
         "updateCommunityOrgSettings"
+      ).and.callFake(async () => {
+        return Promise.resolve();
+      });
+
+      const updatePortalOrgSettingsSpy = spyOn(
+        UpdatePortalOrgSettingsModule,
+        "updatePortalOrgSettings"
       ).and.callFake(async () => {
         return Promise.resolve();
       });
@@ -193,12 +209,21 @@ describe("HubUser Class:", () => {
 
       expect(updateUserHubSettingsSpy).toHaveBeenCalledTimes(1);
       expect(updateUserHubSettingsSpy).toHaveBeenCalledWith(user.settings);
-      expect(updateCommunityOrgSettings).toHaveBeenCalledTimes(1);
-      expect(updateCommunityOrgSettings).toHaveBeenCalledWith(
+      expect(updateCommunityOrgSettingsSpy).toHaveBeenCalledTimes(1);
+      expect(updateCommunityOrgSettingsSpy).toHaveBeenCalledWith(
         {
           signupText: "testSignup",
           termsAndConditions: "testTerms",
         },
+        {
+          ...authdCtxMgr.context,
+          isCommunityOrg: true,
+          isOrgAdmin: true,
+        }
+      );
+      expect(updatePortalOrgSettingsSpy).toHaveBeenCalledTimes(1);
+      expect(updatePortalOrgSettingsSpy).toHaveBeenCalledWith(
+        user.hubOrgSettings,
         {
           ...authdCtxMgr.context,
           isCommunityOrg: true,
@@ -216,6 +241,7 @@ describe("HubUser Class:", () => {
           enableTermsAndConditions: false,
           signupText: "test",
           termsAndConditions: "test",
+          showInformationalBanner: true,
         },
       } as unknown as IHubUser;
 
@@ -226,9 +252,16 @@ describe("HubUser Class:", () => {
         return Promise.resolve();
       });
 
-      const updateCommunityOrgSettings = spyOn(
+      const updateCommunityOrgSettingsSpy = spyOn(
         UpdateCommunityOrgSettingsModule,
         "updateCommunityOrgSettings"
+      ).and.callFake(async () => {
+        return Promise.resolve();
+      });
+
+      const updatePortalOrgSettingsSpy = spyOn(
+        UpdatePortalOrgSettingsModule,
+        "updatePortalOrgSettings"
       ).and.callFake(async () => {
         return Promise.resolve();
       });
@@ -242,12 +275,21 @@ describe("HubUser Class:", () => {
 
       expect(updateUserHubSettingsSpy).toHaveBeenCalledTimes(1);
       expect(updateUserHubSettingsSpy).toHaveBeenCalledWith(user.settings);
-      expect(updateCommunityOrgSettings).toHaveBeenCalledTimes(1);
-      expect(updateCommunityOrgSettings).toHaveBeenCalledWith(
+      expect(updateCommunityOrgSettingsSpy).toHaveBeenCalledTimes(1);
+      expect(updateCommunityOrgSettingsSpy).toHaveBeenCalledWith(
         {
           signupText: "",
           termsAndConditions: "",
         },
+        {
+          ...authdCtxMgr.context,
+          isCommunityOrg: true,
+          isOrgAdmin: true,
+        }
+      );
+      expect(updatePortalOrgSettingsSpy).toHaveBeenCalledTimes(1);
+      expect(updatePortalOrgSettingsSpy).toHaveBeenCalledWith(
+        user.hubOrgSettings,
         {
           ...authdCtxMgr.context,
           isCommunityOrg: true,
@@ -265,6 +307,7 @@ describe("HubUser Class:", () => {
           enableTermsAndConditions: true,
           signupText: "",
           termsAndConditions: "",
+          showInformationalBanner: true,
         },
       } as unknown as IHubUser;
 
@@ -275,9 +318,16 @@ describe("HubUser Class:", () => {
         return Promise.resolve();
       });
 
-      const updateCommunityOrgSettings = spyOn(
+      const updateCommunityOrgSettingsSpy = spyOn(
         UpdateCommunityOrgSettingsModule,
         "updateCommunityOrgSettings"
+      ).and.callFake(async () => {
+        return Promise.resolve();
+      });
+
+      const updatePortalOrgSettingsSpy = spyOn(
+        UpdatePortalOrgSettingsModule,
+        "updatePortalOrgSettings"
       ).and.callFake(async () => {
         return Promise.resolve();
       });
@@ -291,8 +341,8 @@ describe("HubUser Class:", () => {
 
       expect(updateUserHubSettingsSpy).toHaveBeenCalledTimes(1);
       expect(updateUserHubSettingsSpy).toHaveBeenCalledWith(user.settings);
-      expect(updateCommunityOrgSettings).toHaveBeenCalledTimes(1);
-      expect(updateCommunityOrgSettings).toHaveBeenCalledWith(
+      expect(updateCommunityOrgSettingsSpy).toHaveBeenCalledTimes(1);
+      expect(updateCommunityOrgSettingsSpy).toHaveBeenCalledWith(
         {
           signupText: "",
           termsAndConditions: "",
@@ -303,13 +353,26 @@ describe("HubUser Class:", () => {
           isOrgAdmin: true,
         }
       );
+      expect(updatePortalOrgSettingsSpy).toHaveBeenCalledTimes(1);
+      expect(updatePortalOrgSettingsSpy).toHaveBeenCalledWith(
+        user.hubOrgSettings,
+        {
+          ...authdCtxMgr.context,
+          isCommunityOrg: true,
+          isOrgAdmin: true,
+        }
+      );
     });
-    it("doesn't call updateCommunityOrgSettings if not in a community org", async () => {
+    it("doesn't call updateCommunityOrgSettings, but does call updatePortalOrgSettings if not in a community org, but org admin", async () => {
       const user = {
         id: "123",
         name: "Paige",
         settings: { schemaVersion: 1, preview: { workspace: false } },
-        hubOrgSettings: { schemaVersion: 1, preview: { workspace: false } },
+        hubOrgSettings: {
+          schemaVersion: 1,
+          preview: { workspace: false },
+          showInformationalBanner: true,
+        },
       } as unknown as IHubUser;
 
       const updateUserHubSettingsSpy = spyOn(
@@ -319,9 +382,16 @@ describe("HubUser Class:", () => {
         return Promise.resolve();
       });
 
-      const updateCommunityOrgSettings = spyOn(
+      const updateCommunityOrgSettingsSpy = spyOn(
         UpdateCommunityOrgSettingsModule,
         "updateCommunityOrgSettings"
+      ).and.callFake(async () => {
+        return Promise.resolve();
+      });
+
+      const updatePortalOrgSettingsSpy = spyOn(
+        UpdatePortalOrgSettingsModule,
+        "updatePortalOrgSettings"
       ).and.callFake(async () => {
         return Promise.resolve();
       });
@@ -329,14 +399,24 @@ describe("HubUser Class:", () => {
       const chk = HubUser.fromJson(user, {
         ...authdCtxMgr.context,
         isCommunityOrg: false,
+        isOrgAdmin: true,
       });
       await chk.save();
 
       expect(updateUserHubSettingsSpy).toHaveBeenCalledTimes(1);
       expect(updateUserHubSettingsSpy).toHaveBeenCalledWith(user.settings);
-      expect(updateCommunityOrgSettings).toHaveBeenCalledTimes(0);
+      expect(updateCommunityOrgSettingsSpy).toHaveBeenCalledTimes(0);
+      expect(updatePortalOrgSettingsSpy).toHaveBeenCalledTimes(1);
+      expect(updatePortalOrgSettingsSpy).toHaveBeenCalledWith(
+        user.hubOrgSettings,
+        {
+          ...authdCtxMgr.context,
+          isCommunityOrg: false,
+          isOrgAdmin: true,
+        }
+      );
     });
-    it("doesn't call updateCommunityOrgSettings if user is not an org admin", async () => {
+    it("doesn't call updateCommunityOrgSettings or updatePortalOrgSettings if user is not an org admin", async () => {
       const user = {
         id: "123",
         name: "Paige",
@@ -351,9 +431,16 @@ describe("HubUser Class:", () => {
         return Promise.resolve();
       });
 
-      const updateCommunityOrgSettings = spyOn(
+      const updateCommunityOrgSettingsSpy = spyOn(
         UpdateCommunityOrgSettingsModule,
         "updateCommunityOrgSettings"
+      ).and.callFake(async () => {
+        return Promise.resolve();
+      });
+
+      const updatePortalOrgSettingsSpy = spyOn(
+        UpdatePortalOrgSettingsModule,
+        "updatePortalOrgSettings"
       ).and.callFake(async () => {
         return Promise.resolve();
       });
@@ -367,7 +454,8 @@ describe("HubUser Class:", () => {
 
       expect(updateUserHubSettingsSpy).toHaveBeenCalledTimes(1);
       expect(updateUserHubSettingsSpy).toHaveBeenCalledWith(user.settings);
-      expect(updateCommunityOrgSettings).toHaveBeenCalledTimes(0);
+      expect(updateCommunityOrgSettingsSpy).toHaveBeenCalledTimes(0);
+      expect(updatePortalOrgSettingsSpy).toHaveBeenCalledTimes(0);
     });
     it("throws an error if destroyed", async () => {
       const chk = HubUser.fromJson(

--- a/packages/common/test/users/_internal/UserUiSchemaSettings.test.ts
+++ b/packages/common/test/users/_internal/UserUiSchemaSettings.test.ts
@@ -106,6 +106,26 @@ describe("UserUiSchemaSettings:", () => {
             },
             {
               type: "Section",
+              labelKey: "some.scope.sections.orgSettings.siteDefaults.label",
+              elements: [
+                {
+                  type: "Control",
+                  scope:
+                    "/properties/hubOrgSettings/properties/showInformationalBanner",
+                  labelKey: "some.scope.fields.infoBanner.label",
+                  options: {
+                    type: "Control",
+                    control: "hub-field-input-switch",
+                    layout: "inline-space-between",
+                    helperText: {
+                      labelKey: "some.scope.fields.infoBanner.helperText",
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              type: "Section",
               labelKey: "some.scope.sections.orgSettings.signinSettings.label",
               rules: [
                 {
@@ -289,6 +309,26 @@ describe("UserUiSchemaSettings:", () => {
                   ],
                 },
               },
+            },
+            {
+              type: "Section",
+              labelKey: "some.scope.sections.orgSettings.siteDefaults.label",
+              elements: [
+                {
+                  type: "Control",
+                  scope:
+                    "/properties/hubOrgSettings/properties/showInformationalBanner",
+                  labelKey: "some.scope.fields.infoBanner.label",
+                  options: {
+                    type: "Control",
+                    control: "hub-field-input-switch",
+                    layout: "inline-space-between",
+                    helperText: {
+                      labelKey: "some.scope.fields.infoBanner.helperText",
+                    },
+                  },
+                },
+              ],
             },
             {
               type: "Section",
@@ -479,6 +519,26 @@ describe("UserUiSchemaSettings:", () => {
             },
             {
               type: "Section",
+              labelKey: "some.scope.sections.orgSettings.siteDefaults.label",
+              elements: [
+                {
+                  type: "Control",
+                  scope:
+                    "/properties/hubOrgSettings/properties/showInformationalBanner",
+                  labelKey: "some.scope.fields.infoBanner.label",
+                  options: {
+                    type: "Control",
+                    control: "hub-field-input-switch",
+                    layout: "inline-space-between",
+                    helperText: {
+                      labelKey: "some.scope.fields.infoBanner.helperText",
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              type: "Section",
               labelKey: "some.scope.sections.orgSettings.signinSettings.label",
               rules: [
                 {
@@ -643,6 +703,26 @@ describe("UserUiSchemaSettings:", () => {
                   ],
                 },
               },
+            },
+            {
+              type: "Section",
+              labelKey: "some.scope.sections.orgSettings.siteDefaults.label",
+              elements: [
+                {
+                  type: "Control",
+                  scope:
+                    "/properties/hubOrgSettings/properties/showInformationalBanner",
+                  labelKey: "some.scope.fields.infoBanner.label",
+                  options: {
+                    type: "Control",
+                    control: "hub-field-input-switch",
+                    layout: "inline-space-between",
+                    helperText: {
+                      labelKey: "some.scope.fields.infoBanner.helperText",
+                    },
+                  },
+                },
+              ],
             },
             {
               type: "Section",
@@ -833,6 +913,26 @@ describe("UserUiSchemaSettings:", () => {
             },
             {
               type: "Section",
+              labelKey: "some.scope.sections.orgSettings.siteDefaults.label",
+              elements: [
+                {
+                  type: "Control",
+                  scope:
+                    "/properties/hubOrgSettings/properties/showInformationalBanner",
+                  labelKey: "some.scope.fields.infoBanner.label",
+                  options: {
+                    type: "Control",
+                    control: "hub-field-input-switch",
+                    layout: "inline-space-between",
+                    helperText: {
+                      labelKey: "some.scope.fields.infoBanner.helperText",
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              type: "Section",
               labelKey: "some.scope.sections.orgSettings.signinSettings.label",
               rules: [
                 {
@@ -997,6 +1097,26 @@ describe("UserUiSchemaSettings:", () => {
                   ],
                 },
               },
+            },
+            {
+              type: "Section",
+              labelKey: "some.scope.sections.orgSettings.siteDefaults.label",
+              elements: [
+                {
+                  type: "Control",
+                  scope:
+                    "/properties/hubOrgSettings/properties/showInformationalBanner",
+                  labelKey: "some.scope.fields.infoBanner.label",
+                  options: {
+                    type: "Control",
+                    control: "hub-field-input-switch",
+                    layout: "inline-space-between",
+                    helperText: {
+                      labelKey: "some.scope.fields.infoBanner.helperText",
+                    },
+                  },
+                },
+              ],
             },
             {
               type: "Section",
@@ -1173,6 +1293,26 @@ describe("UserUiSchemaSettings:", () => {
                   ],
                 },
               },
+            },
+            {
+              type: "Section",
+              labelKey: "some.scope.sections.orgSettings.siteDefaults.label",
+              elements: [
+                {
+                  type: "Control",
+                  scope:
+                    "/properties/hubOrgSettings/properties/showInformationalBanner",
+                  labelKey: "some.scope.fields.infoBanner.label",
+                  options: {
+                    type: "Control",
+                    control: "hub-field-input-switch",
+                    layout: "inline-space-between",
+                    helperText: {
+                      labelKey: "some.scope.fields.infoBanner.helperText",
+                    },
+                  },
+                },
+              ],
             },
             {
               type: "Section",

--- a/packages/common/test/utils/internal/updatePortalOrgSettings.test.ts
+++ b/packages/common/test/utils/internal/updatePortalOrgSettings.test.ts
@@ -1,0 +1,76 @@
+import * as requestModule from "@esri/arcgis-rest-request";
+import { updatePortalOrgSettings } from "../../../src/utils/internal/updatePortalOrgSettings";
+import { IArcGISContext } from "../../../src/ArcGISContext";
+
+describe("updatePortalOrgSettings", () => {
+  it("throws an error if there is no current user on the context object", async () => {
+    const settings = {};
+    const context: IArcGISContext = {} as IArcGISContext;
+    try {
+      await updatePortalOrgSettings(settings, context);
+    } catch (error) {
+      expect(error).toEqual(new Error("User is not authenticated"));
+    }
+  });
+
+  it("throws an error if the user is not an org admin in the current org", async () => {
+    const settings = {};
+    const context: IArcGISContext = {
+      currentUser: {},
+      isOrgAdmin: false,
+      isCommunityOrg: true,
+    } as unknown as IArcGISContext;
+    try {
+      await updatePortalOrgSettings(settings, context);
+    } catch (error) {
+      expect(error).toEqual(
+        new Error("User is not an org admin in the current org")
+      );
+    }
+  });
+
+  it("sends a request to the right url w/ showInformationalBanner", () => {
+    const settings = {
+      showInformationalBanner: true,
+    };
+    const context: IArcGISContext = {
+      isOrgAdmin: true,
+      currentUser: {},
+      portalUrl: "https://www.community-org.hubqa.arcgis.com",
+      hubRequestOptions: {
+        authentication: {
+          token: "token",
+        },
+      },
+      portal: {
+        portalProperties: {
+          hub: {
+            settings: {
+              informationalBanner: false,
+            },
+          },
+        },
+      },
+    } as unknown as IArcGISContext;
+    const requestSpy = spyOn(requestModule, "request").and.returnValue(
+      Promise.resolve()
+    );
+    updatePortalOrgSettings(settings, context);
+    expect(requestSpy).toHaveBeenCalledWith(
+      "https://www.community-org.hubqa.arcgis.com/sharing/rest/portals/self/update?f=json",
+      {
+        httpMethod: "POST",
+        params: {
+          portalProperties: JSON.stringify({
+            hub: {
+              settings: {
+                informationalBanner: true,
+              },
+            },
+          }),
+          token: "token",
+        },
+      }
+    );
+  });
+});


### PR DESCRIPTION
1. Description: Adds a showInfoBanner section to User Org Settings. Also adds the save logic.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
