### PR TITLE
feat: deepCatalogContains delegates to deepContains

### DIFF
--- a/packages/common/e2e/catalog-collection-prod.e2e.ts
+++ b/packages/common/e2e/catalog-collection-prod.e2e.ts
@@ -6,7 +6,7 @@ import config from "./helpers/config";
 // Water Resources | 67f5723b1b464ba38be91b91ff3ea442
 // Landbase | 202b983812b44e94be74a4d449841a49
 
-fdescribe("catalog and collection e2e:", () => {
+describe("catalog and collection e2e:", () => {
   let factory: Artifactory;
   const orgName = "hubPremium";
   beforeAll(() => {

--- a/packages/common/e2e/deep-contains.e2e.ts
+++ b/packages/common/e2e/deep-contains.e2e.ts
@@ -24,7 +24,7 @@ import { getProp } from "../src/objects/get-prop";
 //     - Unique Web App: a88285b001574cf3bfc91c4da11391cf
 //     - Common Web App: 63c765456d23439e8faf0e4172fc9b23
 
-describe("deepContains:", () => {
+fdescribe("deepContains:", () => {
   const siteItemId: string = "c84347eb5d0a4a7b84c334fe84a5bbfe";
   const siteAppItemId: string = "7da7ea6055d34afd9125a2ccd63be5e1";
   const projectItemId: string = "9c0ecf87bcc04a1d93dec04b54332458";
@@ -49,6 +49,7 @@ describe("deepContains:", () => {
       };
       const chk = await deepContains(
         siteAppItemId,
+        "item",
         [siteCatalogInfo],
         ctxMgr.context
       );
@@ -63,6 +64,7 @@ describe("deepContains:", () => {
       );
       const chk2 = await deepContains(
         commonAppItemId,
+        "item",
         [siteCatalogInfo],
         ctxMgr.context
       );
@@ -84,6 +86,7 @@ describe("deepContains:", () => {
 
       const chk = await deepContains(
         initiativeAppItemId,
+        "item",
         [initiativeCatalogInfo, siteCatalogInfo],
         ctxMgr.context
       );
@@ -110,7 +113,7 @@ describe("deepContains:", () => {
 
       const chk = await deepContains(
         projectAppItemId,
-
+        "item",
         [projectCatalogInfo, initiativeCatalogInfo, siteCatalogInfo],
         ctxMgr.context
       );
@@ -130,7 +133,7 @@ describe("deepContains:", () => {
       };
       const chk = await deepContains(
         siteAppItemId,
-
+        "item",
         [siteCatalogInfo],
         ctxMgr.context
       );
@@ -153,6 +156,7 @@ describe("deepContains:", () => {
 
       const chk = await deepContains(
         initiativeAppItemId,
+        "item",
         [initiativeCatalogInfo, siteCatalogInfo],
         ctxMgr.context
       );
@@ -183,7 +187,7 @@ describe("deepContains:", () => {
 
       const chk = await deepContains(
         initiativeAppItemId,
-
+        "item",
         [projectCatalogInfo, initiativeCatalogInfo, siteCatalogInfo],
         ctxMgr.context
       );

--- a/packages/common/e2e/hub-sites-contains.e2e.ts
+++ b/packages/common/e2e/hub-sites-contains.e2e.ts
@@ -3,6 +3,7 @@ import config from "./helpers/config";
 import { HubSite } from "../src/sites/HubSite";
 import { IDeepCatalogInfo, IHubCatalog } from "../src/search";
 import { IArcGISContext } from "../src/ArcGISContext";
+import { deepCatalogContains } from "../src/core/deepCatalogContains";
 
 // Fixtures - shared with deep-contains.e2e.ts
 //
@@ -24,7 +25,7 @@ import { IArcGISContext } from "../src/ArcGISContext";
 //     - Unique Web App: a88285b001574cf3bfc91c4da11391cf
 //     - Common Web App: 63c765456d23439e8faf0e4172fc9b23
 
-describe("HubSite.contains:", () => {
+fdescribe("HubSite.contains:", () => {
   const siteItemId: string = "c84347eb5d0a4a7b84c334fe84a5bbfe";
   const siteAppItemId: string = "7da7ea6055d34afd9125a2ccd63be5e1";
   const projectItemId: string = "9c0ecf87bcc04a1d93dec04b54332458";
@@ -47,6 +48,55 @@ describe("HubSite.contains:", () => {
   beforeEach(async () => {
     // re-create site for each test so we can verify the caching works
     siteInstance = await HubSite.fetch(siteItemId, context);
+  });
+
+  fdescribe("deepCatalogContains", () => {
+    it("handles one level deep", async () => {
+      const siteCatalog: IHubCatalog = siteInstance.catalog.toJson();
+      const path = `/initiatives/${initiativeItemId}`;
+      const id = initiativeAppItemId;
+
+      const response = await deepCatalogContains(
+        id,
+        "content",
+        path,
+        context,
+        siteCatalog
+      );
+      expect(response.isContained).toBeTruthy();
+      // tslint:disable-next-line:no-console
+      console.info(
+        `deepCatalogContains: App in Initiative in Site Time: ${response.duration} ms`
+      );
+    });
+    it("handles two levels deep", async () => {
+      const siteCatalog: IHubCatalog = siteInstance.catalog.toJson();
+      const path = `/initiatives/${initiativeItemId}/projects/${projectItemId}`;
+      const id = projectAppItemId;
+
+      const response = await deepCatalogContains(
+        id,
+        "content",
+        path,
+        context,
+        siteCatalog
+      );
+      expect(response.isContained).toBeTruthy();
+      // tslint:disable-next-line:no-console
+      console.info(
+        `deepCatalogContains: App in Project in Initiative in Site Time: ${response.duration} ms`
+      );
+    });
+    fit("handles site in path levels deep", async () => {
+      const path = `/sites/${siteItemId}/initiatives/${initiativeItemId}/projects/${projectItemId}`;
+      const id = projectAppItemId;
+      const response = await deepCatalogContains(id, "content", path, context);
+      expect(response.isContained).toBeTruthy();
+      // tslint:disable-next-line:no-console
+      console.info(
+        `deepCatalogContains: App in Project in Initiative in Site Time: ${response.duration} ms`
+      );
+    });
   });
 
   describe(" passing only id:", () => {

--- a/packages/common/e2e/hub-sites.e2e.ts
+++ b/packages/common/e2e/hub-sites.e2e.ts
@@ -4,9 +4,9 @@ import config from "./helpers/config";
 
 // TODO: RE-WRITE USING HubSite Class
 
-fdescribe("Hub Sites", () => {
+describe("Hub Sites", () => {
   let factory: Artifactory;
-  fdescribe("QAEXT:", () => {
+  describe("QAEXT:", () => {
     beforeAll(() => {
       factory = new Artifactory(config, "qaext");
       jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;

--- a/packages/common/src/core/_internal/deepContains.ts
+++ b/packages/common/src/core/_internal/deepContains.ts
@@ -1,7 +1,102 @@
 import { IArcGISContext } from "../../ArcGISContext";
-import { IContainsResponse, IDeepCatalogInfo } from "../../search";
+import { EntityType, IContainsResponse, IDeepCatalogInfo } from "../../search";
+import { getEntityTypeFromType } from "../../search/_internal/getEntityTypeFromType";
 import { Catalog } from "../../search/Catalog";
 import { asyncForEach } from "../../utils/asyncForEach";
+import { HubEntityType } from "../types/HubEntityType";
+
+const pathMap: Record<string, HubEntityType> = {
+  initiatives: "initiative",
+  projects: "project",
+  content: "content",
+  events: "event",
+  discussions: "discussion",
+  sites: "site",
+  apps: "content",
+  surveys: "content",
+  maps: "content",
+  datasets: "content",
+  pages: "page",
+};
+
+interface IParsedPath {
+  valid: boolean;
+  parts?: string[];
+  reason?: string;
+}
+
+/**
+ * Parse a path string into its parts, and validate that it is a valid path.
+ * @param path
+ * @returns
+ */
+export function parsePath(path: string): IParsedPath {
+  // if the path starts with a /, remove it
+  if (path && path.startsWith("/")) {
+    path = path.slice(1);
+  }
+  // split the path into parts - it will be structured like: /{type}/{id}/{type}/{id}
+  const pathParts = path.split("/");
+
+  const result: IParsedPath = {
+    valid: true,
+    reason: "",
+    parts: pathParts,
+  };
+
+  // if the path is not structured correctly, return false
+  if (pathParts.length % 2 !== 0) {
+    result.valid = false;
+    result.reason = "Path does not contain an even number of parts.";
+  }
+
+  // if the path is > 10 parts, return false
+  if (pathParts.length > 10) {
+    result.valid = false;
+    result.reason = "Path is > 5 entities deep.";
+  }
+
+  // if the path contains invalid types, return false
+  if (result.valid) {
+    const validPaths = Object.keys(pathMap);
+    for (let i = 0; i < pathParts.length; i += 2) {
+      if (!validPaths.includes(pathParts[i])) {
+        result.valid = false;
+        result.reason = `Path contains invalid segment: ${pathParts[i]}.`;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Convert a path string into an array of `IDeepCatalogInfo` objects.
+ * e.g. /initiatives/00a/projects/00b => [{entityType: "item", id: "00a"}, {entityType: "item", id: "00b"}]
+ * @param path
+ * @returns
+ */
+export function pathToCatalogInfo(path: string): IDeepCatalogInfo[] {
+  // validate path, throw if invalid
+  const parsedPath = parsePath(path);
+  if (!parsedPath.valid) {
+    throw new Error(parsedPath.reason);
+  }
+
+  const infos: IDeepCatalogInfo[] = [];
+  for (let i = 0; i < parsedPath.parts.length; i += 2) {
+    const type = pathMap[parsedPath.parts[i]] as HubEntityType;
+    const entityType = getEntityTypeFromType(type);
+    infos.push({
+      entityType,
+      id: parsedPath.parts[i + 1],
+    });
+  }
+
+  // infos are currently in the path order, but we need to reverse them
+  // as we check from the leaf to the root
+  return infos.reverse();
+}
 
 /**
  * Check if a particular entity is contained in a catalog.
@@ -28,6 +123,7 @@ import { asyncForEach } from "../../utils/asyncForEach";
  */
 export async function deepContains(
   identifier: string,
+  entityType: EntityType,
   hierarchy: IDeepCatalogInfo[],
   context: IArcGISContext
 ): Promise<IContainsResponse> {
@@ -43,17 +139,21 @@ export async function deepContains(
     return Promise.resolve(response);
   }
 
-  // get the ids, in order from the hiearchy as that
-  // defines to order we need to check.
-  // remove the last entry b/c that's the top level (usually the site)
-  // and we don't need to check if that's contained in itself.
-  const catalogIds = hierarchy.map((c) => c.id).slice(0, -1);
-  // add the passed in identifier as the first id to check
-  const idsToCheck = [identifier, ...catalogIds];
+  // get the id and targetEntity from each of the entries
+  // in the hiearchy
+  let checks = hierarchy
+    .map((c) => {
+      return { id: c.id, entityType: c.entityType };
+    })
+    .slice(0, -1);
+  // prepend in the thing we are checking for
+  // as this allows catalog.contains to be much more efficient
+  checks = [{ id: identifier, entityType }, ...checks];
 
   // iterate the hierarchy
   await asyncForEach(hierarchy, async (catalogInfo, idx) => {
-    const currentIdentifier = idsToCheck[idx];
+    const currentIdentifier = checks[idx].id;
+    const currentEntityType = checks[idx].entityType;
     // create a catalog instance
     let catalog: Catalog;
     if (catalogInfo.catalog) {
@@ -71,7 +171,7 @@ export async function deepContains(
     };
     // check it
     const check = await catalog.contains(currentIdentifier, {
-      entityType: catalogInfo.entityType,
+      entityType: currentEntityType,
     });
     response.isContained = check.isContained;
   });

--- a/packages/common/src/core/_internal/deepContains.ts
+++ b/packages/common/src/core/_internal/deepContains.ts
@@ -5,6 +5,10 @@ import { Catalog } from "../../search/Catalog";
 import { asyncForEach } from "../../utils/asyncForEach";
 import { HubEntityType } from "../types/HubEntityType";
 
+/**
+ * @internal
+ * Mapping of path segments to entity types.
+ */
 const pathMap: Record<string, HubEntityType> = {
   initiatives: "initiative",
   projects: "project",
@@ -19,6 +23,10 @@ const pathMap: Record<string, HubEntityType> = {
   pages: "page",
 };
 
+/**
+ * @internal
+ * Parsed path object, with validation information.
+ */
 interface IParsedPath {
   valid: boolean;
   parts?: string[];
@@ -99,6 +107,7 @@ export function pathToCatalogInfo(path: string): IDeepCatalogInfo[] {
 }
 
 /**
+ * @internal
  * Check if a particular entity is contained in a catalog.
  *
  * Unlike `Catalog.contains(...)`, this function can checks multiple catalogs to validate

--- a/packages/common/src/core/deepCatalogContains.ts
+++ b/packages/common/src/core/deepCatalogContains.ts
@@ -1,0 +1,53 @@
+import { IArcGISContext } from "../ArcGISContext";
+import { getProp } from "../objects/get-prop";
+import { getEntityTypeFromType } from "../search/_internal/getEntityTypeFromType";
+import { IHubCatalog } from "../search/types/IHubCatalog";
+import { IContainsResponse, IDeepCatalogInfo } from "../search/types/types";
+import { deepContains, pathToCatalogInfo } from "./_internal/deepContains";
+
+import { HubEntityType } from "./types/HubEntityType";
+
+/**
+ * Check that a specific entity is contained within a hierarchy of catalogs
+ * @param identifier id or slug of the entity to check
+ * @param hubEntityType Entity type of the identifier
+ * @param rootCatalog root level catalog to start checking from
+ * @param context
+ * @param path
+ * @returns
+ */
+export async function deepCatalogContains(
+  identifier: string,
+  hubEntityType: HubEntityType,
+  path: string,
+  context: IArcGISContext,
+  rootCatalog?: IHubCatalog
+): Promise<IContainsResponse> {
+  // convert to catalog infos
+  let infos: IDeepCatalogInfo[] = [];
+  try {
+    infos = pathToCatalogInfo(path);
+  } catch (e) {
+    return {
+      identifier,
+      isContained: false,
+      catalogInfo: {},
+      duration: 0,
+      reason: getProp(e, "message") || "An error occurred while parsing path.",
+    };
+  }
+
+  // add the root catalog to the end of the infos as it's the last one to check
+  if (rootCatalog) {
+    infos = [
+      ...infos,
+      {
+        id: "root",
+        entityType: "item",
+        catalog: rootCatalog,
+      },
+    ];
+  }
+  const entityType = getEntityTypeFromType(hubEntityType);
+  return deepContains(identifier, entityType, infos, context);
+}

--- a/packages/common/src/core/index.ts
+++ b/packages/common/src/core/index.ts
@@ -19,3 +19,4 @@ export * from "./getEntityThumbnailUrl";
 // they are not actually exported in the final package.
 // export * from "./updateHubEntity";
 // export * from "./hubHistory";
+// export * from "./deepCatalogContains";

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -55,6 +55,7 @@ export * from "./search/getAddContentConfig";
 export * from "./search/_internal/getCatalogGroups";
 export * from "./search/getPredicateValues";
 export * from "./core/hubHistory";
+export * from "./core/deepCatalogContains";
 
 import OperationStack from "./OperationStack";
 import OperationError from "./OperationError";

--- a/packages/common/src/initiatives/_internal/applyInitiativeMigrations.ts
+++ b/packages/common/src/initiatives/_internal/applyInitiativeMigrations.ts
@@ -66,6 +66,9 @@ function addDefaultCatalog(model: IModel): IModel {
     clone.data.catalog = catalog;
 
     // set the schema version
+    if (!clone.item.properties) {
+      clone.item.properties = {};
+    }
     clone.item.properties.schemaVersion = 1.1;
 
     return clone;

--- a/packages/common/src/search/types/types.ts
+++ b/packages/common/src/search/types/types.ts
@@ -146,6 +146,11 @@ export interface IContainsResponse {
    * How long did it take to check containment?
    */
   duration?: number;
+
+  /**
+   * If the entity is not contained, this will be populated with a reason
+   */
+  reason?: string;
 }
 
 /**

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -283,6 +283,7 @@ export class HubSite
     // delegate to fn
     const response = await deepContains(
       identifier,
+      "item", // NOTE: this is hardcoded for now!
       hierarchyWithSiteCatalog,
       this.context
     );

--- a/packages/common/test/core/_internal/deepContains.test.ts
+++ b/packages/common/test/core/_internal/deepContains.test.ts
@@ -1,4 +1,8 @@
-import { deepContains } from "../../../src/core/_internal/deepContains";
+import {
+  deepContains,
+  parsePath,
+  pathToCatalogInfo,
+} from "../../../src/core/_internal/deepContains";
 import { ArcGISContextManager } from "../../../src/ArcGISContextManager";
 import { MOCK_AUTH } from "../../mocks/mock-auth";
 import {
@@ -33,6 +37,7 @@ describe("deepContains:", () => {
   it("returns false if no hiearchy passed", async () => {
     const response = await deepContains(
       "3ef",
+      "item",
       null as unknown as IDeepCatalogInfo[],
       context
     );
@@ -40,7 +45,7 @@ describe("deepContains:", () => {
     expect(response.isContained).toBe(false);
   });
   it("returns false if hiearchy is empty", async () => {
-    const response = await deepContains("3ef", [], context);
+    const response = await deepContains("3ef", "item", [], context);
     expect(response.identifier).toBe("3ef");
     expect(response.isContained).toBe(false);
   });
@@ -59,6 +64,7 @@ describe("deepContains:", () => {
 
     const response = await deepContains(
       AppItemId,
+      "item",
       [{ id: "00c", entityType: "item" }],
       context
     );
@@ -89,6 +95,7 @@ describe("deepContains:", () => {
 
     const response = await deepContains(
       AppItemId,
+      "item",
       [
         { id: "00c", entityType: "item" },
         { id: "00d", entityType: "item" },
@@ -123,6 +130,7 @@ describe("deepContains:", () => {
 
     const response = await deepContains(
       AppItemId,
+      "item",
       [{ id: "00c", entityType: "item", catalog: createMockCatalog("ff1") }],
       context
     );
@@ -130,6 +138,79 @@ describe("deepContains:", () => {
     expect(response.isContained).toBe(false);
     expect(fetchCatalogSpy).toHaveBeenCalledTimes(0);
     expect(hubSearchSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("parsePath:", () => {
+  // add tests for the parsePath function
+
+  it("path needs even number of parts", () => {
+    const path = "/sites/00b/initiatives";
+
+    const result = parsePath(path);
+    expect(result.valid).toBeFalsy();
+    expect(result.reason).toBe(
+      "Path does not contain an even number of parts."
+    );
+  });
+
+  it("path needs less than 10 parts", () => {
+    const path =
+      "sites/00a/initiatives/00b/projects/00c/content/00d/content/00c/content/00e";
+
+    const result = parsePath(path);
+    expect(result.valid).toBeFalsy();
+    expect(result.reason).toBe("Path is > 5 entities deep.");
+  });
+
+  it("path needs valid paths", () => {
+    const path = "sites/00a/initiatives/00b/projects/00c/wallaby/00d";
+
+    const result = parsePath(path);
+    expect(result.valid).toBeFalsy();
+    expect(result.reason).toBe("Path contains invalid segment: wallaby.");
+  });
+
+  it("good path parses clean", () => {
+    const path = "sites/00a/initiatives/00b/projects/00c";
+    const result = parsePath(path);
+    expect(result.valid).toBeTruthy();
+    expect(result.reason).toBe("");
+    expect(result.parts).toEqual(path.split("/"));
+  });
+});
+
+describe("pathToCatalogInfo:", () => {
+  it("converts a path string into an array of IDeepCatalogInfo objects", () => {
+    const path = "sites/a00a/initiatives/b00b/projects/c00c";
+    const result = pathToCatalogInfo(path);
+    expect(result).toEqual([
+      { entityType: "item", id: "c00c" },
+      { entityType: "item", id: "b00b" },
+      { entityType: "item", id: "a00a" },
+    ]);
+  });
+
+  it("throws an error if there are odd number of parts", () => {
+    const path = "sites/00a/initiatives/00b/projects";
+    expect(() => pathToCatalogInfo(path)).toThrowError(
+      "Path does not contain an even number of parts."
+    );
+  });
+
+  it("throws an error if the path is too deep", () => {
+    const path =
+      "sites/00a/initiatives/00b/projects/00c/content/00d/content/00c/content/00e";
+    expect(() => pathToCatalogInfo(path)).toThrowError(
+      "Path is > 5 entities deep."
+    );
+  });
+
+  it("throws an error if the path contains invalid segments", () => {
+    const path = "sites/00a/initiatives/00b/projects/00c/wallaby/00d";
+    expect(() => pathToCatalogInfo(path)).toThrowError(
+      "Path contains invalid segment: wallaby."
+    );
   });
 });
 

--- a/packages/common/test/core/deepCatalogContains.test.ts
+++ b/packages/common/test/core/deepCatalogContains.test.ts
@@ -1,0 +1,89 @@
+import { deepCatalogContains, IArcGISContext, IHubCatalog } from "../../src";
+import * as DeepContainsModule from "../../src/core/_internal/deepContains";
+
+describe("deepCatalogContains:", () => {
+  it("fails containment if the path is invalid", async () => {
+    const ctx = {} as IArcGISContext;
+    const path = "sites/00a/initiatives/00b/projects";
+    const result = await deepCatalogContains("00c", "content", path, ctx);
+    expect(result.isContained).toBeFalsy();
+    expect(result.reason).toBe(
+      "Path does not contain an even number of parts."
+    );
+  });
+  it("handles random error from pathToCatalog", async () => {
+    spyOn(DeepContainsModule, "pathToCatalogInfo").and.callFake(() => {
+      throw new Error();
+    });
+    const ctx = {} as IArcGISContext;
+    const path = "sites/00a/initiatives/00b/projects";
+    const result = await deepCatalogContains("00c", "content", path, ctx);
+    expect(result.isContained).toBeFalsy();
+    expect(result.reason).toBe("An error occurred while parsing path.");
+  });
+  it("delegates to deepContains", async () => {
+    const spy = spyOn(DeepContainsModule, "deepContains").and.callFake(() => {
+      return Promise.resolve({ isContained: true });
+    });
+
+    const ctx = {} as IArcGISContext;
+
+    const path = "sites/00a/initiatives/00b/projects/00c";
+
+    const result = await deepCatalogContains("ff3", "content", path, ctx);
+
+    expect(result.isContained).toBeTruthy();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // validate the args passed to deepContains
+    const args = spy.calls.mostRecent().args;
+    expect(args[0]).toBe("ff3");
+    expect(args[1]).toBe("item");
+    expect(args[2]).toEqual([
+      { id: "00c", entityType: "item" },
+      { id: "00b", entityType: "item" },
+      { id: "00a", entityType: "item" },
+    ]);
+    expect(args[3]).toBe(ctx);
+  });
+
+  it("includes root Catalog is passed in", async () => {
+    const spy = spyOn(DeepContainsModule, "deepContains").and.callFake(() => {
+      return Promise.resolve({ isContained: true });
+    });
+
+    const ctx = {} as IArcGISContext;
+
+    const rootCatalog: IHubCatalog = {
+      schemaVersion: 1,
+      scopes: {},
+      collections: [],
+    };
+
+    const path = "initiatives/00b/projects/00c";
+
+    const result = await deepCatalogContains(
+      "ff3",
+      "content",
+      path,
+      ctx,
+      rootCatalog
+    );
+
+    expect(result.isContained).toBeTruthy();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // validate the args passed to deepContains
+    const args = spy.calls.mostRecent().args;
+    expect(args[0]).toBe("ff3");
+    expect(args[1]).toBe("item");
+    expect(args[2]).toEqual([
+      { id: "00c", entityType: "item" },
+      { id: "00b", entityType: "item" },
+      { id: "root", entityType: "item", catalog: rootCatalog },
+    ]);
+    expect(args[3]).toBe(ctx);
+  });
+});

--- a/packages/common/test/initiatives/_internal/applyInitiativeMigrations.test.ts
+++ b/packages/common/test/initiatives/_internal/applyInitiativeMigrations.test.ts
@@ -56,7 +56,6 @@ describe("initiative migrations:", () => {
           type: "Hub Initiative",
           owner: "Bob",
           created: 123,
-          properties: {},
         } as unknown as IItem,
         data: {},
       };

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -251,7 +251,7 @@ describe("HubSite Class:", () => {
   describe(" contains:", () => {
     it("checks site catalog by default", async () => {
       const containsSpy = spyOn(ContainsModule, "deepContains").and.callFake(
-        (id: string, h: IDeepCatalogInfo[]) => {
+        (id: string, et: string, h: IDeepCatalogInfo[]) => {
           return Promise.resolve({
             identifier: id,
             isContained: true,
@@ -268,7 +268,7 @@ describe("HubSite Class:", () => {
       );
       const result = await chk.contains("cc0");
       expect(containsSpy).toHaveBeenCalledTimes(1);
-      const hiearchy = containsSpy.calls.argsFor(0)[1];
+      const hiearchy = containsSpy.calls.argsFor(0)[2];
       expect(hiearchy.length).toBe(1);
       expect(hiearchy[0].catalog).toEqual(
         createCatalog("00a"),
@@ -303,7 +303,7 @@ describe("HubSite Class:", () => {
         { id: "4ef", entityType: "item", catalog: createCatalog("00b") },
       ]);
       expect(containsSpy).toHaveBeenCalledTimes(1);
-      const hiearchy = containsSpy.calls.argsFor(0)[1];
+      const hiearchy = containsSpy.calls.argsFor(0)[2];
       expect(hiearchy.length).toBe(2);
       expect(hiearchy[0].catalog).toEqual(
         createCatalog("00b"),
@@ -350,7 +350,7 @@ describe("HubSite Class:", () => {
       await chk.contains("cc1", [{ id: "4ef", entityType: "item" }]);
       expect(containsSpy).toHaveBeenCalledTimes(2);
       // verify first call does not send the 4ef catalog
-      const hiearchy = containsSpy.calls.argsFor(0)[1];
+      const hiearchy = containsSpy.calls.argsFor(0)[2];
       expect(hiearchy.length).toBe(2);
       expect(hiearchy[0].catalog).not.toBeDefined();
       expect(hiearchy[1].catalog).toEqual(
@@ -358,7 +358,7 @@ describe("HubSite Class:", () => {
         "should pass the site catalog"
       );
       // verify second call does send the 4ef catalog
-      const hiearchy2 = containsSpy.calls.argsFor(1)[1];
+      const hiearchy2 = containsSpy.calls.argsFor(1)[2];
       expect(hiearchy2.length).toBe(2);
       expect(hiearchy2[0].catalog).toEqual(
         createCatalog("00b"),


### PR DESCRIPTION
1. Description:

export `deepCatalogContains` which delegates to existing internal `deepContains` after constructing the needed `IDeepCatalogInfo[]`

```
export async function deepCatalogContains(
  identifier: string,  //id of entity to check is contained
  hubEntityType: HubEntityType, // entity type (should be known b/c this will be called by routes)
  path: string, // containment path, will be passed around app as query param
  context: IArcGISContext,
  rootCatalog?: IHubCatalog // typically the catalog for the current site
): Promise<IContainsResponse>
```

1. Instructions for testing:

run unit tests

1. Part of Issues: 111767
 
1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
