### PR TITLE
feat(hub-common): reenable additional info

### DIFF
--- a/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/events/EventGalleryCardUiSchema.ts
@@ -370,16 +370,15 @@ export async function buildUiSchema(
                   },
                 },
               },
-              // TODO: Re-add this once https://github.com/Esri/calcite-design-system/issues/10152 & https://github.com/Esri/calcite-design-system/issues/6059 are resolved
-              // {
-              //   label: `{{${i18nScope}.appearance.showAdditionalInfo.label:translate}}`,
-              //   scope: "/properties/showAdditionalInfo",
-              //   type: "Control",
-              //   options: {
-              //     control: "hub-field-input-switch",
-              //     layout: "inline-space-between",
-              //   },
-              // },
+              {
+                label: `{{${i18nScope}.appearance.showAdditionalInfo.label:translate}}`,
+                scope: "/properties/showAdditionalInfo",
+                type: "Control",
+                options: {
+                  control: "hub-field-input-switch",
+                  layout: "inline-space-between",
+                },
+              },
               {
                 label: `{{${i18nScope}.appearance.layout.label:translate}}`,
                 options: {

--- a/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
+++ b/packages/common/test/core/schemas/internal/events/EventGalleryCardUiSchema.test.ts
@@ -379,17 +379,16 @@ describe("EventGalleryCardUiSchema", () => {
                       enum: { i18nScope: "some.scope.appearance.shadow" },
                     },
                   },
-                  // TODO: Re-add this once https://github.com/Esri/calcite-design-system/issues/10152 & https://github.com/Esri/calcite-design-system/issues/6059 are resolved
-                  // {
-                  //   label:
-                  //     "{{some.scope.appearance.showAdditionalInfo.label:translate}}",
-                  //   scope: "/properties/showAdditionalInfo",
-                  //   type: "Control",
-                  //   options: {
-                  //     control: "hub-field-input-switch",
-                  //     layout: "inline-space-between",
-                  //   },
-                  // },
+                  {
+                    label:
+                      "{{some.scope.appearance.showAdditionalInfo.label:translate}}",
+                    scope: "/properties/showAdditionalInfo",
+                    type: "Control",
+                    options: {
+                      control: "hub-field-input-switch",
+                      layout: "inline-space-between",
+                    },
+                  },
                   {
                     label: `{{some.scope.appearance.layout.label:translate}}`,
                     options: {


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #11537

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
