### PR TITLE
feat: switch scheduler to select format

### DIFF
--- a/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaSettings.ts
@@ -41,7 +41,7 @@ export const buildUiSchema = async (
           type: "Control",
           control: "hub-field-input-scheduler",
           labelKey: "fieldHeader",
-          format: "radio",
+          format: "select",
           inputs: [
             { type: "automatic" },
             { type: "daily" },

--- a/packages/common/test/content/_internal/ContentUiSchemaSettings.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaSettings.test.ts
@@ -136,7 +136,7 @@ describe("buildUiSchema: content settings", () => {
                 type: "Control",
                 control: "hub-field-input-scheduler",
                 labelKey: "fieldHeader",
-                format: "radio",
+                format: "select",
                 inputs: [
                   { type: "automatic" },
                   { type: "daily" },
@@ -234,7 +234,7 @@ describe("buildUiSchema: content settings", () => {
                 type: "Control",
                 control: "hub-field-input-scheduler",
                 labelKey: "fieldHeader",
-                format: "radio",
+                format: "select",
                 inputs: [
                   { type: "automatic" },
                   { type: "daily" },


### PR DESCRIPTION
1. Description: switch scheduler to select format

1. Instructions for testing: copy this to the opendata-ui PR (https://github.com/ArcGIS/opendata-ui/pull/14125)

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/11446

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
