### PR TITLE
feat(hub-common): change content settings schema's extract toggle to be a tile select

### DIFF
--- a/packages/common/src/content/_internal/ContentSchema.ts
+++ b/packages/common/src/content/_internal/ContentSchema.ts
@@ -20,6 +20,7 @@ export const ContentSchema: IConfigurationSchema = {
     },
     serverExtractCapability: {
       type: "boolean",
+      enum: [true, false],
     },
     schedule: {
       type: "object",

--- a/packages/common/src/content/_internal/getDownloadsSection.ts
+++ b/packages/common/src/content/_internal/getDownloadsSection.ts
@@ -24,9 +24,9 @@ export function getDownloadsSection(
 ): IUiSchemaElement {
   const downloadSectionElements: IUiSchemaElement[] = [];
 
-  if (shouldShowExtractToggleElement(entity)) {
-    const extractToggleElement = getExtractToggleElement(i18nScope);
-    downloadSectionElements.push(extractToggleElement);
+  if (shouldShowDownloadSystemElement(entity)) {
+    const downloadSystemElement = getDownloadSystemElement(i18nScope);
+    downloadSectionElements.push(downloadSystemElement);
   }
 
   const downloadFormatsElement = getDownloadFormatsElement(i18nScope, entity);
@@ -41,15 +41,15 @@ export function getDownloadsSection(
 }
 
 /**
- * NOTE: we only show the extract toggle for main entities of a hosted feature service
+ * NOTE: we only show the download system toggle for main entities of a hosted feature service
  * since we can guarantee that the user will have the necessary permissions to enable
  * extract capabilities on the service.
  */
-function shouldShowExtractToggleElement(entity: IHubEditableContent): boolean {
+function shouldShowDownloadSystemElement(entity: IHubEditableContent): boolean {
   return isHostedFeatureServiceMainEntity(entity);
 }
 
-function getExtractToggleElement(i18nScope: string): IUiSchemaElement {
+function getDownloadSystemElement(i18nScope: string): IUiSchemaElement {
   return {
     labelKey: `${i18nScope}.fields.serverExtractCapability.label`,
     scope: "/properties/serverExtractCapability",
@@ -57,12 +57,12 @@ function getExtractToggleElement(i18nScope: string): IUiSchemaElement {
     options: {
       control: "hub-field-input-tile-select",
       labels: [
-        `{{${i18nScope}.fields.serverExtractCapability.exportDataSetting.label:translate}}`, // TODO: Translate
-        `{{${i18nScope}.fields.serverExtractCapability.defaultDownloadsSystem.label:translate}}`, // TODO: Translate
+        `{{${i18nScope}.fields.serverExtractCapability.exportDataSetting.label:translate}}`,
+        `{{${i18nScope}.fields.serverExtractCapability.defaultDownloadsSystem.label:translate}}`,
       ],
       descriptions: [
-        `{{${i18nScope}.fields.serverExtractCapability.exportDataSetting.description:translate}}`, // TODO: Translate
-        `{{${i18nScope}.fields.serverExtractCapability.defaultDownloadsSystem.description:translate}}`, // TODO: Translate
+        `{{${i18nScope}.fields.serverExtractCapability.exportDataSetting.description:translate}}`,
+        `{{${i18nScope}.fields.serverExtractCapability.defaultDownloadsSystem.description:translate}}`,
       ],
       layout: "vertical",
       messages: [
@@ -114,7 +114,7 @@ function getDownloadFormatsElement(
   // Product has asked that if the extract capability toggle is present, we should disable
   // the download formats control when the toggle is off. We hope this will encourage more
   // users to opt into the hosted downloads experience.
-  if (shouldShowExtractToggleElement(entity)) {
+  if (shouldShowDownloadSystemElement(entity)) {
     result.rules.push({
       effect: UiSchemaRuleEffects.DISABLE,
       conditions: [

--- a/packages/common/src/content/_internal/getDownloadsSection.ts
+++ b/packages/common/src/content/_internal/getDownloadsSection.ts
@@ -55,9 +55,16 @@ function getExtractToggleElement(i18nScope: string): IUiSchemaElement {
     scope: "/properties/serverExtractCapability",
     type: "Control",
     options: {
-      helperText: {
-        labelKey: `${i18nScope}.fields.serverExtractCapability.helperText`,
-      },
+      control: "hub-field-input-tile-select",
+      labels: [
+        `{{${i18nScope}.fields.serverExtractCapability.exportDataSetting.label:translate}}`, // TODO: Translate
+        `{{${i18nScope}.fields.serverExtractCapability.defaultDownloadsSystem.label:translate}}`, // TODO: Translate
+      ],
+      descriptions: [
+        `{{${i18nScope}.fields.serverExtractCapability.exportDataSetting.description:translate}}`, // TODO: Translate
+        `{{${i18nScope}.fields.serverExtractCapability.defaultDownloadsSystem.description:translate}}`, // TODO: Translate
+      ],
+      layout: "vertical",
       messages: [
         {
           type: UiSchemaMessageTypes.custom,

--- a/packages/common/test/content/_internal/ContentUiSchemaSettings.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaSettings.test.ts
@@ -36,10 +36,16 @@ describe("buildUiSchema: content settings", () => {
               scope: "/properties/serverExtractCapability",
               type: "Control",
               options: {
-                helperText: {
-                  labelKey:
-                    "some.scope.fields.serverExtractCapability.helperText",
-                },
+                control: "hub-field-input-tile-select",
+                labels: [
+                  `{{some.scope.fields.serverExtractCapability.exportDataSetting.label:translate}}`,
+                  `{{some.scope.fields.serverExtractCapability.defaultDownloadsSystem.label:translate}}`,
+                ],
+                descriptions: [
+                  `{{some.scope.fields.serverExtractCapability.exportDataSetting.description:translate}}`,
+                  `{{some.scope.fields.serverExtractCapability.defaultDownloadsSystem.description:translate}}`,
+                ],
+                layout: "vertical",
                 messages: [
                   {
                     type: "CUSTOM",

--- a/packages/common/test/content/_internal/getDownloadsSection.test.ts
+++ b/packages/common/test/content/_internal/getDownloadsSection.test.ts
@@ -21,9 +21,16 @@ describe("getDownloadsSection", () => {
           scope: "/properties/serverExtractCapability",
           type: "Control",
           options: {
-            helperText: {
-              labelKey: "some.scope.fields.serverExtractCapability.helperText",
-            },
+            control: "hub-field-input-tile-select",
+            labels: [
+              `{{some.scope.fields.serverExtractCapability.exportDataSetting.label:translate}}`,
+              `{{some.scope.fields.serverExtractCapability.defaultDownloadsSystem.label:translate}}`,
+            ],
+            descriptions: [
+              `{{some.scope.fields.serverExtractCapability.exportDataSetting.description:translate}}`,
+              `{{some.scope.fields.serverExtractCapability.defaultDownloadsSystem.description:translate}}`,
+            ],
+            layout: "vertical",
             messages: [
               {
                 type: "CUSTOM",


### PR DESCRIPTION
1. Description:

Part of https://devtopia.esri.com/dc/hub/issues/11504

Changes the "extract" toggle in the content settings schema to be a "download system" tile select

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
