### PR TITLE
feat: user overview resources

### DIFF
--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -43,6 +43,20 @@ const hubApiEndpoints = {
 };
 
 /**
+ * Per-environment Group Ids that contain documents/links to
+ * Hub Resources (help docs, blog posts etc)
+ */
+const HUB_RESOURE_GROUPS: Record<HubEnvironment, string[]> = {
+  qaext: [
+    "da45c26e67764c79840928cd8d05561a", // owner: dcadminqa
+  ],
+  devext: [], // EMPTY
+  production: ["e3db35f7de63451f8243415445694761"],
+  enterprise: [], // EMPTY
+  "enterprise-k8s": [], // EMPTY
+};
+
+/**
  * Defines the properties of the ArcGISContext.
  * Typically components or functions will get an instance
  * of `ArcGISContext` from `ArcGISContetManager`.
@@ -262,6 +276,14 @@ export interface IArcGISContext {
    * Is the current user an org admin and not in a custom role?
    */
   isOrgAdmin: boolean;
+
+  /**
+   * Groups that contain Hub Resources (linkable documents etc)
+   * that are tagged to appear in different areas of the appliation.
+   * Default platform groups are defined per-environment in the
+   * "HUB_RESOURE_GROUPS" const..
+   */
+  resourceGroupIDs: string[];
 
   /**
    * Return the token for a given app, if defined
@@ -920,6 +942,15 @@ export class ArcGISContext implements IArcGISContext {
    */
   public get history(): IHubHistory {
     return this._userHubSettings.history || ({ entries: [] } as IHubHistory);
+  }
+
+  /**
+   * Return an array of GroupIds, per-environment, that contain
+   * Hub Resources (linkable documents etc) that are tagged to appear
+   * in different areas of the appliation.
+   */
+  public get resourceGroupIDs(): string[] {
+    return HUB_RESOURE_GROUPS[this.environment];
   }
 
   /**

--- a/packages/common/src/search/_internal/portalSearchGroups.ts
+++ b/packages/common/src/search/_internal/portalSearchGroups.ts
@@ -47,6 +47,7 @@ export async function portalSearchGroups(
     "sortOrder",
     "include",
     "start",
+    "httpMethod",
     "requestOptions",
   ];
   // copy the props over

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -313,6 +313,7 @@ describe("ArcGISContext:", () => {
       expect(mgr.context.orgThumbnailUrl).toBeNull();
       expect(mgr.context.survey123Url).toEqual("https://survey123.arcgis.com");
       expect(mgr.context.isOrgAdmin).toBeFalsy();
+      expect(mgr.context.resourceGroupIDs).toBeDefined();
     });
     it("verify alpha and beta orgs", async () => {
       const mgr = await ArcGISContextManager.create({


### PR DESCRIPTION
1. Description:

- Add `context.resourceGroupIds` pre-populated with group id's for PROD and QA
- Ensure `IHubSearchOptions.httpMethod` is respected in `portalSearchGroups` function

1. Instructions for testing: run tests

1. Related to Issues: #11602

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
