### PR TITLE
feat(hub-common): add updated utils for managing and previewing feeds

### DIFF
--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -29,7 +29,6 @@ export const ContentPermissions = [
   "hub:content:manage",
   "hub:content:canRecordDownloadErrors",
   "hub:content:downloads:displayErrors",
-  "temp:hub:content:downloads:unifiedList",
   "hub:content:document:create",
 ] as const;
 
@@ -135,10 +134,6 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:content:downloads:displayErrors",
     availability: ["alpha"],
     environments: ["qaext", "devext"],
-  },
-  {
-    permission: "temp:hub:content:downloads:unifiedList",
-    availability: ["flag"],
   },
   // Specific permission for creating documents
   {

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -46,6 +46,7 @@ export const SitePermissions = [
   "hub:site:workspace:projects",
   "hub:site:workspace:initiatives",
   "hub:site:manage",
+  "temp:hub:site:workspace:feeds",
 ] as const;
 
 /**
@@ -225,6 +226,10 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:site:manage",
     dependencies: ["hub:site:edit"],
+  },
+  {
+    permission: "temp:hub:site:workspace:feeds",
+    availability: ["flag"],
   },
 ];
 

--- a/packages/common/src/sites/feed-configuration.ts
+++ b/packages/common/src/sites/feed-configuration.ts
@@ -1,4 +1,5 @@
 import { IModel } from "../types";
+import { getMajorVersion } from "./feeds/_internal/getMajorVersion";
 
 type FeedFormat = "dcat-us" | "dcat-ap" | "rss";
 
@@ -122,9 +123,4 @@ function setRssConfig(
   }
 
   throw new Error("Unsupported RSS Version");
-}
-
-// TODO: move to internal helper instead
-export function getMajorVersion(version: string) {
-  return version.split(".")[0];
 }

--- a/packages/common/src/sites/feed-configuration.ts
+++ b/packages/common/src/sites/feed-configuration.ts
@@ -4,6 +4,7 @@ import { getMajorVersion } from "./feeds/_internal/getMajorVersion";
 type FeedFormat = "dcat-us" | "dcat-ap" | "rss";
 
 /**
+ * DEPRECATED: This will be removed in the next breaking version. use `getFeedTemplate()` instead
  * Returns feed configuration from a site model
  *
  * @param {IModel} site - site model
@@ -31,6 +32,7 @@ export function getFeedConfiguration(
 }
 
 /**
+ * DEPRECATED: This will be removed in the next breaking version. Use `setFeedTemplate()` instead;
  * Returns feed configuration from a site model
  *
  * @param {IModel} site - site model

--- a/packages/common/src/sites/feed-configuration.ts
+++ b/packages/common/src/sites/feed-configuration.ts
@@ -124,6 +124,7 @@ function setRssConfig(
   throw new Error("Unsupported RSS Version");
 }
 
-function getMajorVersion(version: string) {
+// TODO: move to internal helper instead
+export function getMajorVersion(version: string) {
   return version.split(".")[0];
 }

--- a/packages/common/src/sites/feeds/_internal/defaults.ts
+++ b/packages/common/src/sites/feeds/_internal/defaults.ts
@@ -1,5 +1,8 @@
-import { FeedFormat } from "./types";
+import { FeedFormat } from "../types";
 
+/**
+ * Returns the default templates for each supported major version of each feed format
+ */
 export function getDefaultTemplates(): Record<FeedFormat, Record<string, any>> {
   return {
     "dcat-us": {

--- a/packages/common/src/sites/feeds/_internal/getMajorVersion.ts
+++ b/packages/common/src/sites/feeds/_internal/getMajorVersion.ts
@@ -1,0 +1,10 @@
+/**
+ * @private
+ * Get the major version from a semantic version string
+ *
+ * @param version dot delimited semantic version
+ * @returns the major version of the semantic version
+ */
+export function getMajorVersion(version: string) {
+  return version.split(".")[0];
+}

--- a/packages/common/src/sites/feeds/defaults.ts
+++ b/packages/common/src/sites/feeds/defaults.ts
@@ -1,0 +1,57 @@
+import { FeedFormat } from "./types";
+
+export function getDefaultTemplates(): Record<FeedFormat, Record<string, any>> {
+  return {
+    "dcat-us": {
+      "1": DCAT_US_1X_DEFAULT,
+    },
+    "dcat-ap": {
+      "2": DCAT_AP_2XX_DEFAULT,
+    },
+    rss: {
+      "2": RSS_2X_DEFAULT,
+    },
+  };
+}
+
+const DCAT_US_1X_DEFAULT = {
+  title: "{{name}}",
+  description: "{{description}}",
+  keyword: "{{tags}}",
+  issued: "{{created:toISO}}",
+  modified: "{{modified:toISO}}",
+  publisher: {
+    name: "{{source}}",
+  },
+  contactPoint: {
+    fn: "{{owner}}",
+    hasEmail: "{{orgContactEmail}}",
+  },
+  spatial: "{{extent}}",
+};
+
+const DCAT_AP_2XX_DEFAULT = {
+  "dct:title": "{{name}}",
+  "dct:description": "{{description}}",
+  "dcat:contactPoint": {
+    "vcard:fn": "{{owner}}",
+    "vcard:hasEmail": "{{orgContactEmail}}",
+  },
+};
+
+const RSS_2X_DEFAULT = {
+  channel: {
+    title: "{{name}}",
+    description: "{{searchDescription}}",
+    link: "{{siteUrl}}",
+    language: "{{culture}}",
+    category: "{{categories}}",
+    item: {
+      title: "{{name}}",
+      description: "{{searchDescription}}",
+      author: "{{orgContactEmail}}",
+      category: "{{categories}}",
+      pubDate: "{{created:toUTC}}",
+    },
+  },
+};

--- a/packages/common/src/sites/feeds/getFeedTemplate.ts
+++ b/packages/common/src/sites/feeds/getFeedTemplate.ts
@@ -1,0 +1,33 @@
+import { IModel } from "../../types";
+import { cloneObject } from "../../util";
+import { getFeedConfiguration, getMajorVersion } from "../feed-configuration";
+import { getDefaultTemplates } from "./defaults";
+import { FeedFormat, IFeedsConfiguration } from "./types";
+
+export interface IGetFeedTemplateOptions {
+  feedsConfig: IFeedsConfiguration;
+  format: FeedFormat;
+  version: string;
+}
+
+export function getFeedTemplate(
+  opts: IGetFeedTemplateOptions
+): Record<string, any> {
+  const { feedsConfig, format, version } = opts;
+
+  // TODO: Remove once we have successfully removed the old feed configuration helpers
+  const mockedSite = { data: { feeds: feedsConfig } } as unknown as IModel;
+  const configuredTemplate = getFeedConfiguration(mockedSite, format, version);
+
+  return configuredTemplate || getDefaultTemplate(format, version);
+}
+
+function getDefaultTemplate(
+  format: FeedFormat,
+  version: string
+): Record<string, any> {
+  const majorVersion = getMajorVersion(version);
+  const defaultTemplates = getDefaultTemplates();
+
+  return cloneObject(defaultTemplates[format][majorVersion]);
+}

--- a/packages/common/src/sites/feeds/getFeedTemplate.ts
+++ b/packages/common/src/sites/feeds/getFeedTemplate.ts
@@ -1,7 +1,8 @@
 import { IModel } from "../../types";
 import { cloneObject } from "../../util";
-import { getFeedConfiguration, getMajorVersion } from "../feed-configuration";
-import { getDefaultTemplates } from "./defaults";
+import { getMajorVersion } from "./_internal/getMajorVersion";
+import { getFeedConfiguration } from "../feed-configuration";
+import { getDefaultTemplates } from "./_internal/defaults";
 import { FeedFormat, IFeedsConfiguration } from "./types";
 
 export interface IGetFeedTemplateOptions {
@@ -10,6 +11,14 @@ export interface IGetFeedTemplateOptions {
   version: string;
 }
 
+/**
+ * Get the feed template for a given feed format and version, accounting
+ * for version fallbacks and default templates as necessary.
+ * @param opts.feedConfig - the raw feeds configuration object
+ * @param opts.format - the feed format
+ * @param opts.version - the feed version
+ * @returns a feed template object
+ */
 export function getFeedTemplate(
   opts: IGetFeedTemplateOptions
 ): Record<string, any> {

--- a/packages/common/src/sites/feeds/previewFeed.ts
+++ b/packages/common/src/sites/feeds/previewFeed.ts
@@ -1,0 +1,39 @@
+import { IArcGISContext } from "../../ArcGISContext";
+import { FeedFormat } from "./types";
+
+export interface IPreviewFeedOptions {
+  format: FeedFormat;
+  version: string;
+  previewTemplate: Record<string, any>;
+  previewHubId: string;
+  context: IArcGISContext;
+}
+
+export async function previewFeed(opts: IPreviewFeedOptions): Promise<string> {
+  const { format, version, previewHubId, context } = opts;
+  const stringifiedTemplate = JSON.stringify(opts.previewTemplate);
+
+  const baseUrl = `${context.hubUrl}/api/feed/${format}/${version}`;
+
+  const searchParams = new URLSearchParams();
+  searchParams.set("id", previewHubId);
+  format === "rss"
+    ? searchParams.set("rssConfig", stringifiedTemplate)
+    : searchParams.set("dcatConfig", stringifiedTemplate);
+
+  const response = await fetch(`${baseUrl}?${searchParams.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Failed to preview feed: ${response.statusText}`);
+  }
+
+  let preview: string;
+  if (format === "rss") {
+    const asText = await response.text();
+    preview = decodeURIComponent(asText);
+  } else {
+    const asJson = await response.json();
+    preview = JSON.stringify(asJson, null, 2);
+  }
+
+  return preview;
+}

--- a/packages/common/src/sites/feeds/previewFeed.ts
+++ b/packages/common/src/sites/feeds/previewFeed.ts
@@ -28,9 +28,8 @@ export async function previewFeed(opts: IPreviewFeedOptions): Promise<string> {
   searchParams.set("id", previewHubId);
 
   // The feeds api has different query parameters for rss and dcat feeds
-  format === "rss"
-    ? searchParams.set("rssConfig", stringifiedTemplate)
-    : searchParams.set("dcatConfig", stringifiedTemplate);
+  const isRSS = format === "rss";
+  searchParams.set(isRSS ? "rssConfig" : "dcatConfig", stringifiedTemplate);
 
   const response = await fetch(`${baseUrl}?${searchParams.toString()}`);
   if (!response.ok) {
@@ -38,7 +37,7 @@ export async function previewFeed(opts: IPreviewFeedOptions): Promise<string> {
   }
 
   let preview: string;
-  if (format === "rss") {
+  if (isRSS) {
     // RSS feeds are returned as XML text rather than JSON
     const asText = await response.text();
     preview = decodeURIComponent(asText);

--- a/packages/common/src/sites/feeds/previewFeed.ts
+++ b/packages/common/src/sites/feeds/previewFeed.ts
@@ -9,6 +9,15 @@ export interface IPreviewFeedOptions {
   context: IArcGISContext;
 }
 
+/**
+ * Preview a feed using the provided template and context
+ * @param opts.format - the feed format
+ * @param opts.version - the feed version
+ * @param opts.previewTemplate - the feed template to preview
+ * @param opts.previewHubId - the Hub ID to preview the feed for
+ * @param opts.context - the ArcGIS context
+ * @returns the previewed feed as a string
+ */
 export async function previewFeed(opts: IPreviewFeedOptions): Promise<string> {
   const { format, version, previewHubId, context } = opts;
   const stringifiedTemplate = JSON.stringify(opts.previewTemplate);
@@ -17,6 +26,8 @@ export async function previewFeed(opts: IPreviewFeedOptions): Promise<string> {
 
   const searchParams = new URLSearchParams();
   searchParams.set("id", previewHubId);
+
+  // The feeds api has different query parameters for rss and dcat feeds
   format === "rss"
     ? searchParams.set("rssConfig", stringifiedTemplate)
     : searchParams.set("dcatConfig", stringifiedTemplate);
@@ -28,6 +39,7 @@ export async function previewFeed(opts: IPreviewFeedOptions): Promise<string> {
 
   let preview: string;
   if (format === "rss") {
+    // RSS feeds are returned as XML text rather than JSON
     const asText = await response.text();
     preview = decodeURIComponent(asText);
   } else {

--- a/packages/common/src/sites/feeds/setFeedTemplate.ts
+++ b/packages/common/src/sites/feeds/setFeedTemplate.ts
@@ -10,6 +10,15 @@ export interface ISetFeedTemplateOptions {
   updatedTemplate: Record<string, any>;
 }
 
+/**
+ * Sets the feed template for a given feed format and version. Always use this function
+ * to update feed templates rather than interacting with the feeds configuration object directly.
+ * @param opts.feedsConfig - the raw feeds configuration object
+ * @param opts.format - the feed format
+ * @param opts.version - the feed version
+ * @param opts.updatedTemplate - the updated feed template
+ * @returns a new feeds configuration object with the updated template
+ */
 export function setFeedTemplate(
   opts: ISetFeedTemplateOptions
 ): Record<string, any> {

--- a/packages/common/src/sites/feeds/setFeedTemplate.ts
+++ b/packages/common/src/sites/feeds/setFeedTemplate.ts
@@ -1,0 +1,23 @@
+import { IModel } from "../../types";
+import { cloneObject } from "../../util";
+import { setFeedConfiguration } from "../feed-configuration";
+import { FeedFormat, IFeedsConfiguration } from "./types";
+
+export interface ISetFeedTemplateOptions {
+  feedsConfig: IFeedsConfiguration;
+  format: FeedFormat;
+  version: string;
+  updatedTemplate: Record<string, any>;
+}
+
+export function setFeedTemplate(
+  opts: ISetFeedTemplateOptions
+): Record<string, any> {
+  const { feedsConfig, format, version, updatedTemplate } = opts;
+  const updatedConfig = cloneObject(feedsConfig);
+
+  // TODO: Remove once we have successfully removed the old feed configuration helpers
+  const mockedSite = { data: { feeds: updatedConfig } } as unknown as IModel;
+  setFeedConfiguration(mockedSite, format, version, updatedTemplate);
+  return updatedConfig;
+}

--- a/packages/common/src/sites/feeds/types.ts
+++ b/packages/common/src/sites/feeds/types.ts
@@ -1,6 +1,17 @@
+/**
+ * Represents the feed format types that are supported in Hub
+ */
 export type FeedFormat = "dcat-us" | "dcat-ap" | "rss";
 
+/**
+ * Configuration object for feeds. Stores feed templates for various feed formats and versions
+ * as well as miscellaneous configuration options. Always interact with this object through the
+ * configuration helpers (getFeedTemplate(), setFeedTemplate(), etc.) when possible.
+ */
 export interface IFeedsConfiguration extends IWithFeedTemplatePaths {
+  /**
+   * Whether or not the feeds capability as a whole has been disabled
+   */
   disabled?: boolean;
 }
 
@@ -13,6 +24,23 @@ type FeedTemplatePath =
   | DcatAPTemplatePaths
   | RssTemplatePaths;
 
-type DcatUSTemplatePaths = "dcatUS1X" | "dcatUS11";
-type DcatAPTemplatePaths = "dcatAP2XX" | "dcatAP201";
-type RssTemplatePaths = "rss2";
+type DcatUSTemplatePaths =
+  // Original path for DCAT-US 1.1 configuration. We have an in-memory migration
+  // that automatically migrates this value to an updated path. Some older sites
+  // that haven't been saved in a while will still have this path present.
+  | "dcatUS11"
+  // Updated path for the primary DCAT-US 1.X template. This should be the default
+  // template for all DCAT-US 1.X feeds (unless overriden by a more specific version)
+  | "dcatUS1X";
+
+type DcatAPTemplatePaths =
+  // Original path for DCAT-AP 2.0.1 configuration. We no longer support editing 2.0.1
+  // templates, but we still expose an API endpoint for the 2.0.1 version. We'll
+  // need to keep this value for backwards compatibility.
+  | "dcatAP201"
+  // Updated path for the primary DCAT-AP 2.X template. This should be the default
+  // template for all DCAT-AP 2.X.X feeds (unless overriden by a more specific version).
+  // 2.1.1 is the latest version of 2.X.X as of this writing.
+  | "dcatAP2XX";
+
+type RssTemplatePaths = "rss2"; // Original path for the RSS 2.0 feed

--- a/packages/common/src/sites/feeds/types.ts
+++ b/packages/common/src/sites/feeds/types.ts
@@ -1,0 +1,18 @@
+export type FeedFormat = "dcat-us" | "dcat-ap" | "rss";
+
+export interface IFeedsConfiguration extends IWithFeedTemplatePaths {
+  disabled?: boolean;
+}
+
+type IWithFeedTemplatePaths = Partial<
+  Record<FeedTemplatePath, Record<string, any>>
+>;
+
+type FeedTemplatePath =
+  | DcatUSTemplatePaths
+  | DcatAPTemplatePaths
+  | RssTemplatePaths;
+
+type DcatUSTemplatePaths = "dcatUS1X" | "dcatUS11";
+type DcatAPTemplatePaths = "dcatAP2XX" | "dcatAP201";
+type RssTemplatePaths = "rss2";

--- a/packages/common/src/sites/index.ts
+++ b/packages/common/src/sites/index.ts
@@ -19,6 +19,10 @@ export * from "./themes";
 export * from "./upgrade-site-schema";
 export * from "./feed-configuration";
 export * from "./reharvestSiteCatalog";
+export * from "./feeds/getFeedTemplate";
+export * from "./feeds/setFeedTemplate";
+export * from "./feeds/previewFeed";
+export * from "./feeds/types";
 // No longer exported b/c site app registration is now handled
 // by the domain service due to requirement to send signed HMAC request
 // export * from "./registerSiteAsApplication";

--- a/packages/common/test/sites/feeds/_internal/getMajorVersion.test.ts
+++ b/packages/common/test/sites/feeds/_internal/getMajorVersion.test.ts
@@ -1,0 +1,51 @@
+import { getMajorVersion } from "../../../../src/sites/feeds/_internal/getMajorVersion";
+
+describe("getMajorVersion", () => {
+  it("should return the major version for a standard semantic version", () => {
+    const version = "1.2.3";
+    const result = getMajorVersion(version);
+    expect(result).toBe("1");
+  });
+
+  it("should return the major version for a version with only major and minor", () => {
+    const version = "2.5";
+    const result = getMajorVersion(version);
+    expect(result).toBe("2");
+  });
+
+  it("should return the major version for a version with only major", () => {
+    const version = "3";
+    const result = getMajorVersion(version);
+    expect(result).toBe("3");
+  });
+
+  it("should return the major version for a version with pre-release and build metadata", () => {
+    const version = "4.0.0-alpha+001";
+    const result = getMajorVersion(version);
+    expect(result).toBe("4");
+  });
+
+  it("should return the major version for a version with leading zeros", () => {
+    const version = "05.6.7";
+    const result = getMajorVersion(version);
+    expect(result).toBe("05");
+  });
+
+  it("should return the major version for a version with extra dots", () => {
+    const version = "6.7.8.9";
+    const result = getMajorVersion(version);
+    expect(result).toBe("6");
+  });
+
+  it("should return an empty string for an empty version string", () => {
+    const version = "";
+    const result = getMajorVersion(version);
+    expect(result).toBe("");
+  });
+
+  it("should return the major version for a version with non-numeric characters", () => {
+    const version = "v7.8.9";
+    const result = getMajorVersion(version);
+    expect(result).toBe("v7");
+  });
+});

--- a/packages/common/test/sites/feeds/getFeedTemplate.test.ts
+++ b/packages/common/test/sites/feeds/getFeedTemplate.test.ts
@@ -1,0 +1,40 @@
+import * as legacyFeedsModule from "../../../src/sites/feed-configuration";
+import { getFeedTemplate } from "../../../src/sites/feeds/getFeedTemplate";
+import {
+  FeedFormat,
+  IFeedsConfiguration,
+} from "../../../src/sites/feeds/types";
+describe("getFeedTemplate", () => {
+  let getFeedConfigurationSpy: jasmine.Spy;
+  beforeEach(() => {
+    getFeedConfigurationSpy = spyOn(legacyFeedsModule, "getFeedConfiguration");
+  });
+  it("delegates to getFeedConfiguration to get the configured template", () => {
+    const feedsConfig: IFeedsConfiguration = {};
+    const format: FeedFormat = "dcat-us";
+    const version = "1.1";
+    getFeedConfigurationSpy.and.returnValue({ foo: "bar" });
+    const result = getFeedTemplate({ feedsConfig, format, version });
+    expect(result).toEqual({ foo: "bar" });
+    expect(getFeedConfigurationSpy).toHaveBeenCalledWith(
+      jasmine.objectContaining({ data: { feeds: feedsConfig } }),
+      format,
+      version
+    );
+  });
+  it("gets the default template if no template is configured", () => {
+    const feedsConfig: IFeedsConfiguration = {};
+    const format: FeedFormat = "dcat-ap";
+    const version = "2.1.1";
+    getFeedConfigurationSpy.and.returnValue(undefined);
+    const result = getFeedTemplate({ feedsConfig, format, version });
+    expect(result).toEqual({
+      "dct:title": "{{name}}",
+      "dct:description": "{{description}}",
+      "dcat:contactPoint": {
+        "vcard:fn": "{{owner}}",
+        "vcard:hasEmail": "{{orgContactEmail}}",
+      },
+    });
+  });
+});

--- a/packages/common/test/sites/feeds/previewFeed.test.ts
+++ b/packages/common/test/sites/feeds/previewFeed.test.ts
@@ -1,0 +1,80 @@
+import {
+  previewFeed,
+  IPreviewFeedOptions,
+} from "../../../src/sites/feeds/previewFeed";
+import * as fetchMock from "fetch-mock";
+import { IArcGISContext } from "../../../src/ArcGISContext";
+
+describe("previewFeed", () => {
+  const context = {
+    hubUrl: "https://example.com",
+  } as unknown as IArcGISContext;
+
+  const baseOptions = {
+    previewTemplate: { key: "value" },
+    previewHubId: "hub123",
+    context,
+  } as unknown as IPreviewFeedOptions;
+
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it("should preview an RSS feed", async () => {
+    const options: IPreviewFeedOptions = {
+      ...baseOptions,
+      format: "rss",
+      version: "2.0",
+    };
+    const responseText = "<rss>Sample RSS Feed</rss>";
+    fetchMock.getOnce(
+      "https://example.com/api/feed/rss/2.0?id=hub123&rssConfig=%7B%22key%22%3A%22value%22%7D",
+      {
+        body: responseText,
+        headers: { "Content-Type": "application/xml" },
+      }
+    );
+
+    const result = await previewFeed(options);
+    expect(result).toBe(responseText);
+  });
+
+  it("should preview a DCAT feed", async () => {
+    const options: IPreviewFeedOptions = {
+      ...baseOptions,
+      format: "dcat-us",
+      version: "1.1",
+    };
+    const responseJson = { title: "Sample DCAT Feed" };
+    fetchMock.getOnce(
+      "https://example.com/api/feed/dcat-us/1.1?id=hub123&dcatConfig=%7B%22key%22%3A%22value%22%7D",
+      {
+        body: responseJson,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+
+    const result = await previewFeed(options);
+    expect(result).toBe(JSON.stringify(responseJson, null, 2));
+  });
+
+  it("should throw an error if the response is not ok", async () => {
+    fetchMock.getOnce(
+      "https://example.com/api/feed/dcat-ap/2.1.1?id=hub123&dcatConfig=%7B%22key%22%3A%22value%22%7D",
+      500
+    );
+    try {
+      const options: IPreviewFeedOptions = {
+        ...baseOptions,
+        format: "dcat-ap",
+        version: "2.1.1",
+      };
+      await previewFeed(options);
+      fail("Expected an error to be thrown");
+    } catch (error) {
+      expect(error.message).toBe(
+        "Failed to preview feed: Internal Server Error"
+      );
+    }
+  });
+});

--- a/packages/common/test/sites/feeds/setFeedTemplate.test.ts
+++ b/packages/common/test/sites/feeds/setFeedTemplate.test.ts
@@ -1,0 +1,30 @@
+import * as legacyFeedsModule from "../../../src/sites/feed-configuration";
+import { setFeedTemplate } from "../../../src/sites/feeds/setFeedTemplate";
+import {
+  IFeedsConfiguration,
+  FeedFormat,
+} from "../../../src/sites/feeds/types";
+
+describe("setFeedTemplate", () => {
+  let setFeedConfigurationSpy: jasmine.Spy;
+  beforeEach(() => {
+    setFeedConfigurationSpy = spyOn(
+      legacyFeedsModule,
+      "setFeedConfiguration"
+    ).and.callThrough();
+  });
+  it("delegates to setFeedConfiguration", () => {
+    const feedsConfig: IFeedsConfiguration = {};
+    const format: FeedFormat = "dcat-us";
+    const version = "1.1";
+    const updatedTemplate = { foo: "bar" };
+    const result = setFeedTemplate({
+      feedsConfig,
+      format,
+      version,
+      updatedTemplate,
+    });
+    expect(result).toEqual({ dcatUS1X: { foo: "bar" } });
+    expect(setFeedConfigurationSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Part of https://devtopia.esri.com/dc/hub/issues/11611

Adds new helpers for managing feed configurations, such as
- getFeedTemplate()
- setFeedTemplate()
- previewFeedTemplate()

We want to use these new functions instead of the older `getFeedConfiguration()` and `setFeedConfiguration()` as we are moving more and more towards passing around HubEntity objects instead of IModel objects.

Also note, `getFeedTemplate()` will return the correct default template if none is configured. This was a change from `getFeedConfiguration()`

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
 
