### PR TITLE
fix: small fixes for breadcrumbs and deep containment checks

### DIFF
--- a/packages/common/src/core/_internal/deepContains.ts
+++ b/packages/common/src/core/_internal/deepContains.ts
@@ -4,79 +4,7 @@ import { getEntityTypeFromType } from "../../search/_internal/getEntityTypeFromT
 import { Catalog } from "../../search/Catalog";
 import { asyncForEach } from "../../utils/asyncForEach";
 import { HubEntityType } from "../types/HubEntityType";
-
-/**
- * @internal
- * Mapping of path segments to entity types.
- */
-const pathMap: Record<string, HubEntityType> = {
-  initiatives: "initiative",
-  projects: "project",
-  content: "content",
-  events: "event",
-  discussions: "discussion",
-  sites: "site",
-  apps: "content",
-  surveys: "content",
-  maps: "content",
-  datasets: "content",
-  pages: "page",
-};
-
-/**
- * @internal
- * Parsed path object, with validation information.
- */
-interface IParsedPath {
-  valid: boolean;
-  parts?: string[];
-  reason?: string;
-}
-
-/**
- * Parse a path string into its parts, and validate that it is a valid path.
- * @param path
- * @returns
- */
-export function parsePath(path: string): IParsedPath {
-  // if the path starts with a /, remove it
-  if (path && path.startsWith("/")) {
-    path = path.slice(1);
-  }
-  // split the path into parts - it will be structured like: /{type}/{id}/{type}/{id}
-  const pathParts = path.split("/");
-
-  const result: IParsedPath = {
-    valid: true,
-    reason: "",
-    parts: pathParts,
-  };
-
-  // if the path is not structured correctly, return false
-  if (pathParts.length % 2 !== 0) {
-    result.valid = false;
-    result.reason = "Path does not contain an even number of parts.";
-  }
-
-  // if the path is > 10 parts, return false
-  if (pathParts.length > 10) {
-    result.valid = false;
-    result.reason = "Path is > 5 entities deep.";
-  }
-
-  // if the path contains invalid types, return false
-  if (result.valid) {
-    const validPaths = Object.keys(pathMap);
-    for (let i = 0; i < pathParts.length; i += 2) {
-      if (!validPaths.includes(pathParts[i])) {
-        result.valid = false;
-        result.reason = `Path contains invalid segment: ${pathParts[i]}.`;
-      }
-    }
-  }
-
-  return result;
-}
+import { parseContainmentPath, pathMap } from "../parseContainmentPath";
 
 /**
  * Convert a path string into an array of `IDeepCatalogInfo` objects.
@@ -86,7 +14,7 @@ export function parsePath(path: string): IParsedPath {
  */
 export function pathToCatalogInfo(path: string): IDeepCatalogInfo[] {
   // validate path, throw if invalid
-  const parsedPath = parsePath(path);
+  const parsedPath = parseContainmentPath(path);
   if (!parsedPath.valid) {
     throw new Error(parsedPath.reason);
   }

--- a/packages/common/src/core/index.ts
+++ b/packages/common/src/core/index.ts
@@ -14,7 +14,6 @@ export * from "./shareEntityWithGroups";
 export * from "./unshareEntityWithGroups";
 export * from "./getEntityGroups";
 export * from "./getEntityThumbnailUrl";
-export * from "./parseContainmentPath";
 
 // For sme reason, if these are exported here,
 // they are not actually exported in the final package.

--- a/packages/common/src/core/index.ts
+++ b/packages/common/src/core/index.ts
@@ -14,6 +14,7 @@ export * from "./shareEntityWithGroups";
 export * from "./unshareEntityWithGroups";
 export * from "./getEntityGroups";
 export * from "./getEntityThumbnailUrl";
+export * from "./parseContainmentPath";
 
 // For sme reason, if these are exported here,
 // they are not actually exported in the final package.

--- a/packages/common/src/core/parseContainmentPath.ts
+++ b/packages/common/src/core/parseContainmentPath.ts
@@ -1,0 +1,75 @@
+import { HubEntityType } from "./types/HubEntityType";
+
+/**
+ * @internal
+ * Mapping of path segments to entity types.
+ */
+export const pathMap: Record<string, HubEntityType> = {
+  initiatives: "initiative",
+  projects: "project",
+  content: "content",
+  events: "event",
+  discussions: "discussion",
+  sites: "site",
+  apps: "content",
+  surveys: "content",
+  maps: "content",
+  datasets: "content",
+  pages: "page",
+};
+
+/**
+ * @internal
+ * Parsed path object, with validation information.
+ */
+export interface IParsedPath {
+  valid: boolean;
+  parts?: string[];
+  reason?: string;
+}
+
+/**
+ * Parse a path string into its parts, and validate that it is a valid path.
+ * @param path
+ * @returns
+ */
+
+export function parseContainmentPath(path: string): IParsedPath {
+  // if the path starts with a /, remove it
+  if (path && path.startsWith("/")) {
+    path = path.slice(1);
+  }
+  // split the path into parts - it will be structured like: /{type}/{id}/{type}/{id}
+  const pathParts = path.split("/");
+
+  const result: IParsedPath = {
+    valid: true,
+    reason: "",
+    parts: pathParts,
+  };
+
+  // if the path is not structured correctly, return false
+  if (pathParts.length % 2 !== 0) {
+    result.valid = false;
+    result.reason = "Path does not contain an even number of parts.";
+  }
+
+  // if the path is > 10 parts, return false
+  if (pathParts.length > 10) {
+    result.valid = false;
+    result.reason = "Path is > 5 entities deep.";
+  }
+
+  // if the path contains invalid types, return false
+  if (result.valid) {
+    const validPaths = Object.keys(pathMap);
+    for (let i = 0; i < pathParts.length; i += 2) {
+      if (!validPaths.includes(pathParts[i])) {
+        result.valid = false;
+        result.reason = `Path contains invalid segment: ${pathParts[i]}.`;
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -56,6 +56,7 @@ export * from "./search/_internal/getCatalogGroups";
 export * from "./search/getPredicateValues";
 export * from "./core/hubHistory";
 export * from "./core/deepCatalogContains";
+export * from "./core/parseContainmentPath";
 
 import OperationStack from "./OperationStack";
 import OperationError from "./OperationError";

--- a/packages/common/src/initiatives/_internal/getPropertyMap.ts
+++ b/packages/common/src/initiatives/_internal/getPropertyMap.ts
@@ -14,6 +14,7 @@ export function getPropertyMap(): IPropertyMap[] {
   // Type specific mappings
   map.push({ entityKey: "status", storeKey: "data.status" });
   map.push({ entityKey: "catalog", storeKey: "data.catalog" });
+  map.push({ entityKey: "catalogs", storeKey: "data.catalogs" });
   map.push({ entityKey: "permissions", storeKey: "data.permissions" });
 
   map.push({ entityKey: "contacts", storeKey: "data.contacts" });

--- a/packages/common/src/search/Catalog.ts
+++ b/packages/common/src/search/Catalog.ts
@@ -118,7 +118,7 @@ export class Catalog implements IHubCatalog {
    * Return an array of the entity types available in this Catalog
    */
   get availableScopes(): EntityType[] {
-    return Object.keys(this.scopes || {}) as unknown as EntityType[];
+    return Object.keys(this.scopes) as unknown as EntityType[];
   }
 
   /**

--- a/packages/common/test/core/_internal/deepContains.test.ts
+++ b/packages/common/test/core/_internal/deepContains.test.ts
@@ -1,6 +1,5 @@
 import {
   deepContains,
-  parsePath,
   pathToCatalogInfo,
 } from "../../../src/core/_internal/deepContains";
 import { ArcGISContextManager } from "../../../src/ArcGISContextManager";
@@ -163,45 +162,6 @@ describe("deepContains:", () => {
     expect(response.reason).toContain("not contained in catalog");
     expect(fetchCatalogSpy).toHaveBeenCalledTimes(0);
     expect(hubSearchSpy).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("parsePath:", () => {
-  // add tests for the parsePath function
-
-  it("path needs even number of parts", () => {
-    const path = "/sites/00b/initiatives";
-
-    const result = parsePath(path);
-    expect(result.valid).toBeFalsy();
-    expect(result.reason).toBe(
-      "Path does not contain an even number of parts."
-    );
-  });
-
-  it("path needs less than 10 parts", () => {
-    const path =
-      "sites/00a/initiatives/00b/projects/00c/content/00d/content/00c/content/00e";
-
-    const result = parsePath(path);
-    expect(result.valid).toBeFalsy();
-    expect(result.reason).toBe("Path is > 5 entities deep.");
-  });
-
-  it("path needs valid paths", () => {
-    const path = "sites/00a/initiatives/00b/projects/00c/wallaby/00d";
-
-    const result = parsePath(path);
-    expect(result.valid).toBeFalsy();
-    expect(result.reason).toBe("Path contains invalid segment: wallaby.");
-  });
-
-  it("good path parses clean", () => {
-    const path = "sites/00a/initiatives/00b/projects/00c";
-    const result = parsePath(path);
-    expect(result.valid).toBeTruthy();
-    expect(result.reason).toBe("");
-    expect(result.parts).toEqual(path.split("/"));
   });
 });
 

--- a/packages/common/test/core/parseContainmentPath.test.ts
+++ b/packages/common/test/core/parseContainmentPath.test.ts
@@ -1,0 +1,38 @@
+import { parseContainmentPath } from "../../src";
+
+describe("parseContainmentPath:", () => {
+  it("path needs even number of parts", () => {
+    const path = "/sites/00b/initiatives";
+
+    const result = parseContainmentPath(path);
+    expect(result.valid).toBeFalsy();
+    expect(result.reason).toBe(
+      "Path does not contain an even number of parts."
+    );
+  });
+
+  it("path needs less than 10 parts", () => {
+    const path =
+      "sites/00a/initiatives/00b/projects/00c/content/00d/content/00c/content/00e";
+
+    const result = parseContainmentPath(path);
+    expect(result.valid).toBeFalsy();
+    expect(result.reason).toBe("Path is > 5 entities deep.");
+  });
+
+  it("path needs valid paths", () => {
+    const path = "sites/00a/initiatives/00b/projects/00c/wallaby/00d";
+
+    const result = parseContainmentPath(path);
+    expect(result.valid).toBeFalsy();
+    expect(result.reason).toBe("Path contains invalid segment: wallaby.");
+  });
+
+  it("good path parses clean", () => {
+    const path = "sites/00a/initiatives/00b/projects/00c";
+    const result = parseContainmentPath(path);
+    expect(result.valid).toBeTruthy();
+    expect(result.reason).toBe("");
+    expect(result.parts).toEqual(path.split("/"));
+  });
+});


### PR DESCRIPTION
1. Description:

Four things:
- export `parseContainmentPath` from the library to apps can use it
- fix `Catalog.scopes` to return `{}` instead of `undefined` if `.scopes` is 🥁 `undefined`
- if present, `data.catalogs` should flow through to `IHubInitiative.catalogs`
- update `Catalog.contains` to handle cases where there is no `scope` for the targetEntity, and instead execute queries for all collections.

1. Instructions for testing: run tests

1. Connected to #11176

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
