### PR TITLE
feat: prescribe order of add content config items

### DIFF
--- a/packages/common/src/search/_internal/getWorkflowForType.ts
+++ b/packages/common/src/search/_internal/getWorkflowForType.ts
@@ -1,7 +1,6 @@
 import { IArcGISContext } from "../../ArcGISContext";
 import { checkPermission } from "../../permissions/checkPermission";
 import { Permission } from "../../permissions/types/Permission";
-import { cloneObject } from "../../util";
 import { EntityType } from "../types/IHubCatalog";
 
 /**
@@ -106,17 +105,29 @@ export function getDefaultCreateableTypes(
   context: IArcGISContext,
   limitTo: EntityType[] = []
 ): string[] {
-  const itemCreateableTypes = ["Hub Project", "Hub Initiative", "Discussion"];
+  // NOTE: AT prescribed the order: Discussion Board, Event, Project, Initiative, Group, Site Page | Hub Page, Site Application | Hub Site Application
+  const prescribedOrder = [
+    "Discussion",
+    "Event",
+    "Hub Project",
+    "Hub Initiative",
+    "Group",
+    "Hub Page",
+    "Site Page",
+    "Hub Site Application",
+    "Site Application",
+  ];
+  const itemCreateableTypes = ["Discussion", "Hub Project", "Hub Initiative"];
   // If the user has the hub:license:enterprise-sites permission
   // they are on Enterprise and the types are "site applications" and "site pages"
   if (checkPermission("hub:environment:enterprise", context).access) {
-    itemCreateableTypes.push("Site Application");
     itemCreateableTypes.push("Site Page");
+    itemCreateableTypes.push("Site Application");
   } else {
     // Otherwise we infer they are running on AGO, and can
     // the types are "hub site applications" and "hub pages"
-    itemCreateableTypes.push("Hub Site Application");
     itemCreateableTypes.push("Hub Page");
+    itemCreateableTypes.push("Hub Site Application");
   }
 
   const eventCreateableTypes = ["Event"];
@@ -140,6 +151,12 @@ export function getDefaultCreateableTypes(
       ...groupCreateableTypes,
     ];
   }
+
+  response = response.sort((a, b) => {
+    const aIdx = prescribedOrder.indexOf(a);
+    const bIdx = prescribedOrder.indexOf(b);
+    return aIdx - bIdx;
+  });
 
   return response;
 }

--- a/packages/common/test/search/_internal/getWorkflowForType.test.ts
+++ b/packages/common/test/search/_internal/getWorkflowForType.test.ts
@@ -63,13 +63,13 @@ describe("getDefaultCreateableTypes:", () => {
     const chk = getDefaultCreateableTypes(premiumUserCtxMgr.context);
     expect(chk.length).toBe(7);
     [
+      "Discussion",
+      "Event",
       "Hub Project",
       "Hub Initiative",
-      "Discussion",
-      "Hub Site Application",
-      "Hub Page",
-      "Event",
       "Group",
+      "Hub Page",
+      "Hub Site Application",
     ].forEach((type) => {
       expect(chk).toContain(type);
     });
@@ -86,11 +86,11 @@ describe("getDefaultCreateableTypes:", () => {
     const chk = getDefaultCreateableTypes(premiumUserCtxMgr.context, ["item"]);
     expect(chk.length).toBe(5);
     [
+      "Discussion",
       "Hub Project",
       "Hub Initiative",
-      "Discussion",
-      "Hub Site Application",
       "Hub Page",
+      "Hub Site Application",
     ].forEach((type) => {
       expect(chk).toContain(type);
     });
@@ -116,12 +116,12 @@ describe("getDefaultCreateableTypes:", () => {
     ]);
     expect(chk.length).toBe(6);
     [
+      "Discussion",
+      "Event",
       "Hub Project",
       "Hub Initiative",
-      "Discussion",
-      "Hub Site Application",
       "Hub Page",
-      "Event",
+      "Hub Site Application",
     ].forEach((type) => {
       expect(chk).toContain(type);
     });

--- a/packages/common/test/search/getAddContentConfig.test.ts
+++ b/packages/common/test/search/getAddContentConfig.test.ts
@@ -1,7 +1,6 @@
 import { IGroup } from "@esri/arcgis-rest-types";
 import {
   ArcGISContextManager,
-  getProp,
   getAddContentConfig,
   IQuery,
   getPredicateValues,
@@ -146,12 +145,12 @@ describe("getAddContentConfig:", () => {
       expect(chk.existing).toBeDefined();
       expect(chk.create?.types.length).toBeGreaterThan(0);
       [
+        "Discussion",
+        "Event",
         "Hub Project",
         "Hub Initiative",
-        "Discussion",
-        "Hub Site Application",
         "Hub Page",
-        "Event",
+        "Hub Site Application",
       ].forEach((t) => {
         expect(chk.create?.types).toContain(t);
       });
@@ -192,11 +191,11 @@ describe("getAddContentConfig:", () => {
         expect(chk.upload).toBeNull();
         expect(chk.existing).toBeDefined();
         [
+          "Discussion",
           "Hub Project",
           "Hub Initiative",
           "Hub Page",
           "Hub Site Application",
-          "Discussion",
         ].forEach((t) => {
           expect(chk.create?.types).toContain(t);
         });
@@ -678,11 +677,11 @@ describe("getAddContentConfig:", () => {
           const chk = getAddContentConfig(ctxMgr.context, query);
           expect(chk).toBeDefined();
           expect(chk.create?.types.length).toEqual(2);
-          expect(chk.create?.types).toEqual(["Site Application", "Site Page"]);
+          expect(chk.create?.types).toEqual(["Site Page", "Site Application"]);
           expect(chk.existing?.types.length).toEqual(2);
           expect(chk.existing?.types).toEqual([
-            "Site Application",
             "Site Page",
+            "Site Application",
           ]);
         });
       });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: [11507](https://devtopia.esri.com/dc/hub/issues/11507) prescribes the order of the create content menu items.

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
