### PR TITLE
feat(hub-discussions): channel edit optional update parameter for V2

### DIFF
--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -91,7 +91,7 @@ export enum PostStatus {
 }
 
 /**
- * possible discussionn content types, i.e. a post can be about an item, dataset, or group
+ * possible discussion content types, i.e. a post can be about an item, dataset, or group
  *
  * @export
  * @enum {string}

--- a/packages/discussions/src/utils/channels/can-edit-channel.ts
+++ b/packages/discussions/src/utils/channels/can-edit-channel.ts
@@ -8,7 +8,7 @@ import { hasOrgAdminUpdateRights } from "../portal-privilege";
  * Utility to determine if User has privileges to edit a channel
  * @param channel
  * @param user
- * @param updates - !!! only include for API V2 updates
+ * @param updateData - !!! only include for API V2 updates
  * @returns {boolean}
  */
 export function canEditChannel(

--- a/packages/discussions/src/utils/channels/can-edit-channel.ts
+++ b/packages/discussions/src/utils/channels/can-edit-channel.ts
@@ -1,5 +1,5 @@
 import { IUser } from "@esri/arcgis-rest-types";
-import { IChannel, IDiscussionsUser, SharingAccess } from "../../types";
+import { IChannel, IDiscussionsUser, IUpdateChannel } from "../../types";
 import { ChannelPermission } from "../channel-permission";
 import { isAuthorizedToModifyChannelByLegacyPermissions } from "./is-authorized-to-modify-channel-by-legacy-permissions";
 import { hasOrgAdminUpdateRights } from "../portal-privilege";
@@ -8,11 +8,13 @@ import { hasOrgAdminUpdateRights } from "../portal-privilege";
  * Utility to determine if User has privileges to edit a channel
  * @param channel
  * @param user
+ * @param updates - !!! only include for API V2 updates
  * @returns {boolean}
  */
 export function canEditChannel(
   channel: IChannel,
-  user: IUser | IDiscussionsUser = {}
+  user: IUser | IDiscussionsUser = {},
+  updateData?: IUpdateChannel // !!! only include for API V2 updates
 ): boolean {
   if (hasOrgAdminUpdateRights(user, channel.orgId)) {
     return true;
@@ -20,7 +22,13 @@ export function canEditChannel(
 
   if (channel.channelAcl) {
     const channelPermission = new ChannelPermission(channel);
-    return channelPermission.canModerateChannel(user as IDiscussionsUser);
+    return (
+      channelPermission.canModerateChannel(user as IDiscussionsUser) &&
+      channelPermission.canUpdateProperties(
+        user as IDiscussionsUser,
+        updateData
+      )
+    );
   }
 
   return isAuthorizedToModifyChannelByLegacyPermissions(user, channel);

--- a/packages/discussions/src/utils/channels/can-modify-channel.ts
+++ b/packages/discussions/src/utils/channels/can-modify-channel.ts
@@ -14,7 +14,6 @@ import { isAuthorizedToModifyChannelByLegacyPermissions } from "./is-authorized-
 export function canModifyChannel(
   channel: IChannel,
   user: IUser | IDiscussionsUser = {}
-  // channelUpdates: IUpdateChannel,
 ): boolean {
   if (isOrgAdminInOrg(user, channel.orgId)) {
     return true;
@@ -23,7 +22,6 @@ export function canModifyChannel(
   if (channel.channelAcl) {
     const channelPermission = new ChannelPermission(channel);
     return channelPermission.canModerateChannel(user as IDiscussionsUser);
-    // for V2: && channelPermission.canUpdateProperties(user as IDiscussionsUser, channelUpdates)
   }
 
   return isAuthorizedToModifyChannelByLegacyPermissions(user, channel);

--- a/packages/discussions/src/utils/channels/channel-to-dto-map.ts
+++ b/packages/discussions/src/utils/channels/channel-to-dto-map.ts
@@ -1,0 +1,11 @@
+import { IChannel, IUpdateChannel } from "@esri/hub-common";
+
+// TODO: V2 use IUpdateChannel as param type when hoisted to hub.js from service
+export function dtoToChannel(dto: any): IChannel {
+  const { channelAclDefinition, ...rest } = dto;
+
+  return {
+    ...rest,
+    channelAcl: channelAclDefinition,
+  };
+}

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -1229,6 +1229,21 @@ describe("ChannelPermission class", () => {
 
         expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
       });
+
+      it("returns true if updates undefined, regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowReply: true,
+          channelAcl,
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        expect(channelPermission.canUpdateProperties(user)).toBe(true);
+      });
     });
 
     describe("allowReply", () => {

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -1225,7 +1225,7 @@ describe("ChannelPermission class", () => {
         } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
-        const updates = undefined;
+        const updates: IUpdateChannel = {};
 
         expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
       });

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -1848,16 +1848,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.OWNER }, // will be removed
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -1880,15 +1881,16 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               { category: AclCategory.USER, key: "bbb", role: Role.OWNER }, // added
             ] as IChannelAclPermission[];
 
@@ -1912,21 +1914,23 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               {
+                // added
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "group_id",
                 role: Role.OWNER,
-              }, // added
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -1951,16 +1955,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.OWNER }, // will be removed
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -1983,15 +1988,16 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
               { category: AclCategory.USER, key: "bbb", role: Role.OWNER }, // added
             ] as IChannelAclPermission[];
 
@@ -2027,16 +2033,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.MANAGE }, // will be removed
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2059,15 +2066,16 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               { category: AclCategory.USER, key: "bbb", role: Role.MANAGE }, // added
             ] as IChannelAclPermission[];
 
@@ -2091,21 +2099,23 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               {
+                // added
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "group_id",
                 role: Role.MANAGE,
-              }, // added
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2130,16 +2140,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.MANAGE }, // will be removed
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2162,15 +2173,16 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
               { category: AclCategory.USER, key: "bbb", role: Role.MANAGE }, // added
             ] as IChannelAclPermission[];
 
@@ -2206,16 +2218,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.MODERATE }, // will be removed
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2238,15 +2251,16 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               { category: AclCategory.USER, key: "bbb", role: Role.MODERATE }, // added
             ] as IChannelAclPermission[];
 
@@ -2270,21 +2284,23 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               {
+                // added
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "group_id",
                 role: Role.MODERATE,
-              }, // added
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2309,16 +2325,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.MODERATE }, // will be removed
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2341,15 +2358,16 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
               { category: AclCategory.USER, key: "bbb", role: Role.MODERATE }, // added
             ] as IChannelAclPermission[];
 
@@ -2385,27 +2403,30 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               {
+                // will be removed
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // will be removed
+              },
               {
+                // will be removed
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // will be removed
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2428,45 +2449,49 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               {
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // existing
+              },
               {
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // existing
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               {
+                // no update
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // no update
+              },
               {
+                // no update
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // no update
+              },
               {
+                // added
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.ADMIN,
                 key: "bbb",
                 role: Role.MODERATE,
-              }, // added
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2489,39 +2514,41 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               {
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // existing
+              },
               {
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // existing
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               {
+                // no update
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // no update
+              },
               {
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
-                role: Role.READWRITE,
-              }, // role changed
+                role: Role.READWRITE, // role changed
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2546,27 +2573,30 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               {
+                // will be removed
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // will be removed
+              },
               {
+                // will be removed
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // will be removed
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2589,45 +2619,49 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               {
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // existing
+              },
               {
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // existing
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
               {
+                // no update
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // no update
+              },
               {
+                // no update
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // no update
+              },
               {
+                // added
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.ADMIN,
                 key: "bbb",
                 role: Role.MODERATE,
-              }, // added
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2650,39 +2684,41 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               {
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // existing
+              },
               {
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // existing
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
               {
+                // no update
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // no update
+              },
               {
                 category: AclCategory.ORG,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
-                role: Role.READWRITE,
-              }, // role changed
+                role: Role.READWRITE, // role changed
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2717,27 +2753,30 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               {
+                // will be removed
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // will be removed
+              },
               {
+                // will be removed
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // will be removed
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2760,45 +2799,49 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               {
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // existing
+              },
               {
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // existing
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               {
+                // no update
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // no update
+              },
               {
+                // no update
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // no update
+              },
               {
+                // added
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "bbb",
                 role: Role.MODERATE,
-              }, // added
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2821,39 +2864,41 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               {
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // existing
+              },
               {
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // existing
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               {
+                // no update
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // no update
+              },
               {
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
-                role: Role.READWRITE,
-              }, // role changed
+                role: Role.READWRITE, // role changed
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2878,27 +2923,30 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               {
+                // will be removed
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // will be removed
+              },
               {
+                // will be removed
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // will be removed
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2921,45 +2969,49 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               {
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // existing
+              },
               {
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // existing
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
               {
+                // no update
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // no update
+              },
               {
+                // no update
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // no update
+              },
               {
+                // added
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "bbb",
                 role: Role.MODERATE,
-              }, // added
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -2982,39 +3034,41 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               {
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // existing
+              },
               {
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
                 role: Role.READ,
-              }, // existing
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
               {
+                // no update
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.ADMIN,
                 key: "aaa",
                 role: Role.MODERATE,
-              }, // no update
+              },
               {
                 category: AclCategory.GROUP,
                 subCategory: AclSubCategory.MEMBER,
                 key: "aaa",
-                role: Role.READWRITE,
-              }, // role changed
+                role: Role.READWRITE, // role changed
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -3049,16 +3103,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.READ }, // will be removed
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -3081,15 +3136,16 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.READ }, // added
             ] as IChannelAclPermission[];
 
@@ -3113,16 +3169,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.READ }, // existing
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.READWRITE }, // role changed
             ] as IChannelAclPermission[];
 
@@ -3148,16 +3205,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.READ }, // will be removed
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -3180,15 +3238,16 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.READ }, // added
             ] as IChannelAclPermission[];
 
@@ -3212,16 +3271,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.READ }, // existing
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
               { category: AclCategory.USER, key: "aaa", role: Role.READWRITE }, // role changed
             ] as IChannelAclPermission[];
 
@@ -3257,16 +3317,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               { category: AclCategory.AUTHENTICATED_USER, role: Role.READ }, // will be removed
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -3289,15 +3350,16 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               { category: AclCategory.AUTHENTICATED_USER, role: Role.READ }, // added
             ] as IChannelAclPermission[];
 
@@ -3321,20 +3383,21 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
-              { category: AclCategory.AUTHENTICATED_USER, role: Role.READ }, // existing
+                role: allowedRole, // allows change
+              },
+              { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               {
                 category: AclCategory.AUTHENTICATED_USER,
-                role: Role.READWRITE,
-              }, // role changed
+                role: Role.READWRITE, // role changed
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -3359,16 +3422,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               { category: AclCategory.AUTHENTICATED_USER, role: Role.READ }, // will be removed
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -3391,15 +3455,16 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
               { category: AclCategory.AUTHENTICATED_USER, role: Role.READ }, // added
             ] as IChannelAclPermission[];
 
@@ -3423,20 +3488,21 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               { category: AclCategory.AUTHENTICATED_USER, role: Role.READ }, // existing
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
               {
                 category: AclCategory.AUTHENTICATED_USER,
-                role: Role.READWRITE,
-              }, // role changed
+                role: Role.READWRITE, // role changed
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -3471,16 +3537,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               { category: AclCategory.ANONYMOUS_USER, role: Role.READ }, // will be removed
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -3503,15 +3570,16 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               { category: AclCategory.ANONYMOUS_USER, role: Role.READ }, // added
             ] as IChannelAclPermission[];
 
@@ -3535,16 +3603,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: allowedRole,
-              }, // allows change
+                role: allowedRole, // allows change
+              },
               { category: AclCategory.ANONYMOUS_USER, role: Role.READ }, // existing
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: allowedRole,
-              }, // no update
+              },
               { category: AclCategory.ANONYMOUS_USER, role: Role.READWRITE }, // role changed
             ] as IChannelAclPermission[];
 
@@ -3570,16 +3639,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               { category: AclCategory.ANONYMOUS_USER, role: Role.READ }, // will be removed
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
             ] as IChannelAclPermission[];
 
             const channel = { channelAcl, creator: "foo" } as IChannel;
@@ -3602,15 +3672,16 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
               { category: AclCategory.ANONYMOUS_USER, role: Role.READ }, // added
             ] as IChannelAclPermission[];
 
@@ -3634,16 +3705,17 @@ describe("ChannelPermission class", () => {
               {
                 category: AclCategory.USER,
                 key: user.username,
-                role: notAllowedRole,
-              }, // DOES NOT ALLOW CHANGE
+                role: notAllowedRole, // DOES NOT ALLOW CHANGE
+              },
               { category: AclCategory.ANONYMOUS_USER, role: Role.READ }, // existing
             ] as IChannelAclPermission[];
             const updatedAcl = [
               {
+                // no update
                 category: AclCategory.USER,
                 key: user.username,
                 role: notAllowedRole,
-              }, // no update
+              },
               { category: AclCategory.ANONYMOUS_USER, role: Role.READWRITE }, // role changed
             ] as IChannelAclPermission[];
 

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -6,6 +6,7 @@ import {
   IChannelAclPermission,
   IDiscussionsUser,
   IUpdateChannel,
+  PostReaction,
   PostStatus,
   Role,
 } from "../../src/types";
@@ -1211,7 +1212,47 @@ describe("ChannelPermission class", () => {
   });
 
   describe("canUpdateProperties", () => {
-    describe("update allowReply required role", () => {
+    describe("allowReply", () => {
+      it("returns true if value not changed from existing regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowReply: true,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          allowReply: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if update is undefined regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowReply: true,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          allowReply: undefined,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
       it("returns true if user has a role of moderate", () => {
         const user = buildUser();
         const channelAcl = [
@@ -1222,7 +1263,11 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          allowReply: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1238,7 +1283,11 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          allowReply: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1254,7 +1303,11 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          allowReply: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1274,7 +1327,11 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          allowReply: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1287,7 +1344,47 @@ describe("ChannelPermission class", () => {
       });
     });
 
-    describe("update allowReaction required role", () => {
+    describe("allowReaction", () => {
+      it("returns true if value not changed from existing regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowReaction: true,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          allowReaction: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if update is undefined existing regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowReaction: true,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          allowReaction: undefined,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
       it("returns true if user has a role of moderate", () => {
         const user = buildUser();
         const channelAcl = [
@@ -1298,7 +1395,11 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          allowReaction: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1314,7 +1415,11 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          allowReaction: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1330,7 +1435,11 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          allowReaction: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1350,7 +1459,11 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          allowReaction: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1363,7 +1476,47 @@ describe("ChannelPermission class", () => {
       });
     });
 
-    describe("update allowedReactions required role", () => {
+    describe("allowAsAnonymous", () => {
+      it("returns true if value not changed from existing regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowAsAnonymous: true,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          allowAsAnonymous: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if update is undefined regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowAsAnonymous: true,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          allowAsAnonymous: undefined,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
       it("returns true if user has a role of moderate", () => {
         const user = buildUser();
         const channelAcl = [
@@ -1374,11 +1527,15 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          allowAsAnonymous: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
-          allowedReactions: [],
+          allowAsAnonymous: true,
         };
 
         expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
@@ -1390,11 +1547,15 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          allowAsAnonymous: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
-          allowedReactions: [],
+          allowAsAnonymous: true,
         };
 
         expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
@@ -1406,11 +1567,15 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          allowAsAnonymous: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
-          allowedReactions: [],
+          allowAsAnonymous: true,
         };
 
         expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
@@ -1426,11 +1591,15 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          allowAsAnonymous: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
-          allowedReactions: [],
+          allowAsAnonymous: true,
         };
 
         expect(channelPermission.canUpdateProperties(user, updates)).toBe(
@@ -1439,7 +1608,2103 @@ describe("ChannelPermission class", () => {
       });
     });
 
-    describe("update defaultPostStatus required role", () => {
+    describe("allowedReactions", () => {
+      it("returns true if value not changed from existing regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowedReactions: [PostReaction.THUMBS_UP],
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          allowedReactions: [PostReaction.THUMBS_UP],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if value not changed (just rearranged) from existing regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowedReactions: [PostReaction.THUMBS_UP, PostReaction.LAUGH],
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          allowedReactions: [PostReaction.LAUGH, PostReaction.THUMBS_UP],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of manage and reaction is removed", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowedReactions: [PostReaction.THUMBS_UP, PostReaction.LAUGH],
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          allowedReactions: [PostReaction.THUMBS_UP],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of manage and reaction is added", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowedReactions: [PostReaction.THUMBS_UP],
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          allowedReactions: [PostReaction.THUMBS_UP, PostReaction.LAUGH],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of owner", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.OWNER },
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowedReactions: [PostReaction.THUMBS_UP],
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          allowedReactions: [PostReaction.LAUGH],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns false if user does not have a minimum role of moderate", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.READWRITE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowedReactions: [PostReaction.THUMBS_UP],
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          allowedReactions: [PostReaction.LAUGH],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+          false
+        );
+      });
+    });
+
+    describe("channelAclDefinition", () => {
+      describe("No acl changes", () => {
+        it("should return true if no acl changes, regardless of role", () => {
+          const user = buildUser({ orgId: "aaa", groups: [] });
+          const channelAcl = buildCompleteAcl();
+
+          const channel = { channelAcl, creator: "foo" } as IChannel;
+          const channelPermission = new ChannelPermission(channel);
+
+          const updates: IUpdateChannel = {
+            // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+            // @ts-ignore
+            channelAclDefinition: buildCompleteAcl(),
+          };
+
+          expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+            true
+          );
+        });
+
+        it("should return true if no acl changes, just rearranged, regardless of role", () => {
+          const user = buildUser({ orgId: "aaa", groups: [] });
+          const channelAcl = [
+            { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
+            { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.ADMIN,
+              key: groupId1,
+              role: Role.OWNER,
+            },
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.MEMBER,
+              key: groupId1,
+              role: Role.READ,
+            },
+            {
+              category: AclCategory.ORG,
+              subCategory: AclSubCategory.ADMIN,
+              key: orgId1,
+              role: Role.OWNER,
+            },
+            {
+              category: AclCategory.ORG,
+              subCategory: AclSubCategory.MEMBER,
+              key: orgId1,
+              role: Role.READ,
+            },
+          ];
+
+          const updatedAcl = [
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.MEMBER,
+              key: groupId1,
+              role: Role.READ,
+            },
+            { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
+            {
+              category: AclCategory.GROUP,
+              subCategory: AclSubCategory.ADMIN,
+              key: groupId1,
+              role: Role.OWNER,
+            },
+            {
+              category: AclCategory.ORG,
+              subCategory: AclSubCategory.MEMBER,
+              key: orgId1,
+              role: Role.READ,
+            },
+            {
+              category: AclCategory.ORG,
+              subCategory: AclSubCategory.ADMIN,
+              key: orgId1,
+              role: Role.OWNER,
+            },
+            { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
+          ];
+
+          const channel = { channelAcl, creator: "foo" } as IChannel;
+          const channelPermission = new ChannelPermission(channel);
+
+          const updates: IUpdateChannel = {
+            // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+            // @ts-ignore
+            channelAclDefinition: updatedAcl,
+          };
+
+          expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+            true
+          );
+        });
+      });
+
+      describe("OWNER added or removed", () => {
+        const allowedRoles = [Role.OWNER];
+        const notAllowedRoles = [
+          Role.READ,
+          Role.WRITE,
+          Role.READWRITE,
+          Role.MODERATE,
+          Role.MANAGE,
+        ];
+
+        allowedRoles.forEach((allowedRole) => {
+          it(`should return true if user has role: ${allowedRole} and owner is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              { category: AclCategory.USER, key: "aaa", role: Role.OWNER }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and owner is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              { category: AclCategory.USER, key: "bbb", role: Role.OWNER }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and owner is added in another category`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "group_id",
+                role: Role.OWNER,
+              }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+        });
+
+        notAllowedRoles.forEach((notAllowedRole) => {
+          it(`should return false if user has role: ${notAllowedRole} and owner is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              { category: AclCategory.USER, key: "aaa", role: Role.OWNER }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+
+          it(`should return false if user has role: ${notAllowedRole} and owner is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+              { category: AclCategory.USER, key: "bbb", role: Role.OWNER }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+        });
+      });
+
+      describe("MANAGER added or removed", () => {
+        const allowedRoles = [Role.OWNER, Role.MANAGE];
+        const notAllowedRoles = [
+          Role.READ,
+          Role.WRITE,
+          Role.READWRITE,
+          Role.MODERATE,
+        ];
+
+        allowedRoles.forEach((allowedRole) => {
+          it(`should return true if user has role: ${allowedRole} and manager is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              { category: AclCategory.USER, key: "aaa", role: Role.MANAGE }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and manager is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              { category: AclCategory.USER, key: "bbb", role: Role.MANAGE }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and manager is added in another category`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "group_id",
+                role: Role.MANAGE,
+              }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+        });
+
+        notAllowedRoles.forEach((notAllowedRole) => {
+          it(`should return false if user has role: ${notAllowedRole} and manager is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              { category: AclCategory.USER, key: "aaa", role: Role.MANAGE }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+
+          it(`should return false if user has role: ${notAllowedRole} and manager is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+              { category: AclCategory.USER, key: "bbb", role: Role.MANAGE }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+        });
+      });
+
+      describe("MODERATOR added or removed", () => {
+        const allowedRoles = [Role.OWNER, Role.MANAGE];
+        const notAllowedRoles = [
+          Role.READ,
+          Role.WRITE,
+          Role.READWRITE,
+          Role.MODERATE,
+        ];
+
+        allowedRoles.forEach((allowedRole) => {
+          it(`should return true if user has role: ${allowedRole} and moderator is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              { category: AclCategory.USER, key: "aaa", role: Role.MODERATE }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and moderator is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              { category: AclCategory.USER, key: "bbb", role: Role.MODERATE }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and moderator is added in another category`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "group_id",
+                role: Role.MODERATE,
+              }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+        });
+
+        notAllowedRoles.forEach((notAllowedRole) => {
+          it(`should return false if user has role: ${notAllowedRole} and moderator is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              { category: AclCategory.USER, key: "aaa", role: Role.MODERATE }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+
+          it(`should return false if user has role: ${notAllowedRole} and moderator is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+              { category: AclCategory.USER, key: "bbb", role: Role.MODERATE }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+        });
+      });
+
+      describe("ORG added or removed or updated", () => {
+        const allowedRoles = [Role.OWNER, Role.MANAGE];
+        const notAllowedRoles = [
+          Role.READ,
+          Role.WRITE,
+          Role.READWRITE,
+          Role.MODERATE,
+        ];
+
+        allowedRoles.forEach((allowedRole) => {
+          it(`should return true if user has role: ${allowedRole} and org is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // will be removed
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and org is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // existing
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // no update
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // no update
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: "bbb",
+                role: Role.MODERATE,
+              }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and org role is updated`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // existing
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // no update
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READWRITE,
+              }, // role changed
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+        });
+
+        notAllowedRoles.forEach((notAllowedRole) => {
+          it(`should return false if user has role: ${notAllowedRole} and org is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // will be removed
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+
+          it(`should return false if user has role: ${notAllowedRole} and org is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // existing
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // no update
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // no update
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: "bbb",
+                role: Role.MODERATE,
+              }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+
+          it(`should return false if user has role: ${notAllowedRole} and org role is updated`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // existing
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // no update
+              {
+                category: AclCategory.ORG,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READWRITE,
+              }, // role changed
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+        });
+      });
+
+      describe("GROUP added or removed or updated", () => {
+        const allowedRoles = [Role.OWNER, Role.MANAGE];
+        const notAllowedRoles = [
+          Role.READ,
+          Role.WRITE,
+          Role.READWRITE,
+          Role.MODERATE,
+        ];
+
+        allowedRoles.forEach((allowedRole) => {
+          it(`should return true if user has role: ${allowedRole} and group is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // will be removed
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and GROUP is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // existing
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // no update
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // no update
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "bbb",
+                role: Role.MODERATE,
+              }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and GROUP role is updated`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // existing
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // no update
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READWRITE,
+              }, // role changed
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+        });
+
+        notAllowedRoles.forEach((notAllowedRole) => {
+          it(`should return false if user has role: ${notAllowedRole} and GROUP is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // will be removed
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+
+          it(`should return false if user has role: ${notAllowedRole} and GROUP is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // existing
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // no update
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // no update
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "bbb",
+                role: Role.MODERATE,
+              }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+
+          it(`should return false if user has role: ${notAllowedRole} and GROUP role is updated`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // existing
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READ,
+              }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.ADMIN,
+                key: "aaa",
+                role: Role.MODERATE,
+              }, // no update
+              {
+                category: AclCategory.GROUP,
+                subCategory: AclSubCategory.MEMBER,
+                key: "aaa",
+                role: Role.READWRITE,
+              }, // role changed
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+        });
+      });
+
+      describe("USER added or removed or updated", () => {
+        const allowedRoles = [Role.OWNER, Role.MANAGE];
+        const notAllowedRoles = [
+          Role.READ,
+          Role.WRITE,
+          Role.READWRITE,
+          Role.MODERATE,
+        ];
+
+        allowedRoles.forEach((allowedRole) => {
+          it(`should return true if user has role: ${allowedRole} and USER is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              { category: AclCategory.USER, key: "aaa", role: Role.READ }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and USER is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              { category: AclCategory.USER, key: "aaa", role: Role.READ }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and USER role is updated`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              { category: AclCategory.USER, key: "aaa", role: Role.READ }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              { category: AclCategory.USER, key: "aaa", role: Role.READWRITE }, // role changed
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+        });
+
+        notAllowedRoles.forEach((notAllowedRole) => {
+          it(`should return false if user has role: ${notAllowedRole} and USER is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              { category: AclCategory.USER, key: "aaa", role: Role.READ }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+
+          it(`should return false if user has role: ${notAllowedRole} and USER is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+              { category: AclCategory.USER, key: "aaa", role: Role.READ }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+
+          it(`should return false if user has role: ${notAllowedRole} and USER role is updated`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              { category: AclCategory.USER, key: "aaa", role: Role.READ }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+              { category: AclCategory.USER, key: "aaa", role: Role.READWRITE }, // role changed
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+        });
+      });
+
+      describe("AUTHENTICATED_USER added or removed or updated", () => {
+        const allowedRoles = [Role.OWNER, Role.MANAGE];
+        const notAllowedRoles = [
+          Role.READ,
+          Role.WRITE,
+          Role.READWRITE,
+          Role.MODERATE,
+        ];
+
+        allowedRoles.forEach((allowedRole) => {
+          it(`should return true if user has role: ${allowedRole} and AUTHENTICATED_USER is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              { category: AclCategory.AUTHENTICATED_USER, role: Role.READ }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and AUTHENTICATED_USER is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              { category: AclCategory.AUTHENTICATED_USER, role: Role.READ }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and AUTHENTICATED_USER role is updated`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              { category: AclCategory.AUTHENTICATED_USER, role: Role.READ }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              {
+                category: AclCategory.AUTHENTICATED_USER,
+                role: Role.READWRITE,
+              }, // role changed
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+        });
+
+        notAllowedRoles.forEach((notAllowedRole) => {
+          it(`should return false if user has role: ${notAllowedRole} and AUTHENTICATED_USER is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              { category: AclCategory.AUTHENTICATED_USER, role: Role.READ }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+
+          it(`should return false if user has role: ${notAllowedRole} and AUTHENTICATED_USER is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+              { category: AclCategory.AUTHENTICATED_USER, role: Role.READ }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+
+          it(`should return false if user has role: ${notAllowedRole} and AUTHENTICATED_USER role is updated`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              { category: AclCategory.AUTHENTICATED_USER, role: Role.READ }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+              {
+                category: AclCategory.AUTHENTICATED_USER,
+                role: Role.READWRITE,
+              }, // role changed
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+        });
+      });
+
+      describe("ANONYMOUS_USER added or removed or updated", () => {
+        const allowedRoles = [Role.OWNER, Role.MANAGE];
+        const notAllowedRoles = [
+          Role.READ,
+          Role.WRITE,
+          Role.READWRITE,
+          Role.MODERATE,
+        ];
+
+        allowedRoles.forEach((allowedRole) => {
+          it(`should return true if user has role: ${allowedRole} and ANONYMOUS_USER is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              { category: AclCategory.ANONYMOUS_USER, role: Role.READ }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and ANONYMOUS_USER is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              { category: AclCategory.ANONYMOUS_USER, role: Role.READ }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+
+          it(`should return true if user has role: ${allowedRole} and ANONYMOUS_USER role is updated`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // allows change
+              { category: AclCategory.ANONYMOUS_USER, role: Role.READ }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: allowedRole,
+              }, // no update
+              { category: AclCategory.ANONYMOUS_USER, role: Role.READWRITE }, // role changed
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              true
+            );
+          });
+        });
+
+        notAllowedRoles.forEach((notAllowedRole) => {
+          it(`should return false if user has role: ${notAllowedRole} and ANONYMOUS_USER is removed`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              { category: AclCategory.ANONYMOUS_USER, role: Role.READ }, // will be removed
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+
+          it(`should return false if user has role: ${notAllowedRole} and ANONYMOUS_USER is added`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+              { category: AclCategory.ANONYMOUS_USER, role: Role.READ }, // added
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+
+          it(`should return false if user has role: ${notAllowedRole} and ANONYMOUS_USER role is updated`, () => {
+            const user = buildUser();
+            const channelAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // DOES NOT ALLOW CHANGE
+              { category: AclCategory.ANONYMOUS_USER, role: Role.READ }, // existing
+            ] as IChannelAclPermission[];
+            const updatedAcl = [
+              {
+                category: AclCategory.USER,
+                key: user.username,
+                role: notAllowedRole,
+              }, // no update
+              { category: AclCategory.ANONYMOUS_USER, role: Role.READWRITE }, // role changed
+            ] as IChannelAclPermission[];
+
+            const channel = { channelAcl, creator: "foo" } as IChannel;
+            const channelPermission = new ChannelPermission(channel);
+
+            const updates: IUpdateChannel = {
+              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
+              // @ts-ignore
+              channelAclDefinition: updatedAcl,
+            };
+
+            expect(channelPermission.canUpdateProperties(user, updates)).toBe(
+              false
+            );
+          });
+        });
+      });
+    });
+
+    describe("defaultPostStatus", () => {
+      it("returns true if value not changed regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          defaultPostStatus: PostStatus.APPROVED,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          defaultPostStatus: PostStatus.APPROVED,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if updated is undefined regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          defaultPostStatus: PostStatus.APPROVED,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          defaultPostStatus: undefined,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
       it("returns true if user has a role of moderate", () => {
         const user = buildUser();
         const channelAcl = [
@@ -1450,7 +3715,11 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          defaultPostStatus: PostStatus.PENDING,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1466,7 +3735,11 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          defaultPostStatus: PostStatus.PENDING,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1482,7 +3755,11 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          defaultPostStatus: PostStatus.PENDING,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1502,7 +3779,11 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          defaultPostStatus: PostStatus.PENDING,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1515,8 +3796,48 @@ describe("ChannelPermission class", () => {
       });
     });
 
-    describe("update blockWords required role", () => {
-      it("returns true if user has a role of moderate", () => {
+    describe("blockWords", () => {
+      it("returns true if value not changed from existing regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          blockWords: ["burrito"],
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          blockWords: ["burrito"],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if value not changed (just rearranged) from existing regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          blockWords: ["burrito", "taco"],
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          blockWords: ["taco", "burrito"],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of moderate and blockWord is removed", () => {
         const user = buildUser();
         const channelAcl = [
           {
@@ -1526,11 +3847,39 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          blockWords: ["burrito", "taco"],
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
-          blockWords: [],
+          blockWords: ["burrito"],
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if user has a role of moderate and blockWord is added", () => {
+        const user = buildUser();
+        const channelAcl = [
+          {
+            category: AclCategory.USER,
+            key: user.username,
+            role: Role.MODERATE,
+          },
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          blockWords: ["burrito", "taco"],
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          blockWords: ["burrito", "taco", "flan"],
         };
 
         expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
@@ -1542,11 +3891,15 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          blockWords: ["burrito"],
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
-          blockWords: [],
+          blockWords: ["taco"],
         };
 
         expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
@@ -1558,11 +3911,15 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          blockWords: ["burrito"],
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
-          blockWords: [],
+          blockWords: ["taco"],
         };
 
         expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
@@ -1578,11 +3935,15 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          blockWords: ["burrito"],
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
-          blockWords: [],
+          blockWords: ["taco"],
         };
 
         expect(channelPermission.canUpdateProperties(user, updates)).toBe(
@@ -1591,14 +3952,58 @@ describe("ChannelPermission class", () => {
       });
     });
 
-    describe("update softDelete required role", () => {
+    describe("softDelete", () => {
+      it("returns true if value not changed from existing regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          softDelete: true,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          softDelete: true,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if update is undefined regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          softDelete: true,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          softDelete: undefined,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
       it("returns true if user has a role of manage", () => {
         const user = buildUser();
         const channelAcl = [
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          softDelete: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1614,7 +4019,11 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          softDelete: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1634,7 +4043,11 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          softDelete: false,
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1647,14 +4060,58 @@ describe("ChannelPermission class", () => {
       });
     });
 
-    describe("update name required role", () => {
+    describe("name", () => {
+      it("returns true if value not changed from existing regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          name: "burrito",
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          name: "burrito",
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
+      it("returns true if update is undefined regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          name: "burrito",
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates: IUpdateChannel = {
+          name: undefined,
+        };
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+
       it("returns true if user has a role of manage", () => {
         const user = buildUser();
         const channelAcl = [
           { category: AclCategory.USER, key: user.username, role: Role.MANAGE },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          name: "burrito",
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1670,7 +4127,11 @@ describe("ChannelPermission class", () => {
           { category: AclCategory.USER, key: user.username, role: Role.OWNER },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          name: "burrito",
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1690,7 +4151,11 @@ describe("ChannelPermission class", () => {
           },
         ] as IChannelAclPermission[];
 
-        const channel = { channelAcl, creator: "foo" } as IChannel;
+        const channel = {
+          name: "burrito",
+          channelAcl,
+          creator: "foo",
+        } as IChannel;
         const channelPermission = new ChannelPermission(channel);
 
         const updates: IUpdateChannel = {
@@ -1700,442 +4165,6 @@ describe("ChannelPermission class", () => {
         expect(channelPermission.canUpdateProperties(user, updates)).toBe(
           false
         );
-      });
-    });
-  });
-
-  describe("canPostToChannel", () => {
-    describe("all permission cases", () => {
-      it("returns false if user logged in and channel permissions are empty", async () => {
-        const user = buildUser();
-        const channelAcl = [] as IChannelAclPermission[];
-        const channel = { channelAcl, creator: "foo" } as IChannel;
-
-        const channelPermission = new ChannelPermission(channel);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(false);
-      });
-
-      it("returns false if user not logged in and channel permissions are empty", async () => {
-        const user = buildUser({ username: null });
-        const channelAcl = [] as IChannelAclPermission[];
-        const channel = { channelAcl, creator: "foo" } as IChannel;
-
-        const channelPermission = new ChannelPermission(channel);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(false);
-      });
-    });
-
-    describe("Anonymous User Permissions", () => {
-      it(`returns true if anonymous permission defined and role is allowed`, () => {
-        const user = buildUser({ username: null });
-
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channelAcl = [
-            { category: AclCategory.ANONYMOUS_USER, role: allowedRole },
-          ] as IChannelAclPermission[];
-          const channel = { channelAcl, creator: "foo" } as IChannel;
-
-          const channelPermission = new ChannelPermission(channel);
-
-          expect(channelPermission.canPostToChannel(user)).toBe(true);
-        });
-      });
-
-      it("returns false if anonymous permission defined but role is read", () => {
-        const user = buildUser({ username: null });
-        const channelAcl = [
-          { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
-        ] as IChannelAclPermission[];
-        const channel = { channelAcl, creator: "foo" } as IChannel;
-
-        const channelPermission = new ChannelPermission(channel);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(false);
-      });
-    });
-
-    describe("Authenticated User Permissions", () => {
-      it(`returns true if authenticated permission defined, user logged in, and role is allowed`, async () => {
-        const user = buildUser();
-
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channelAcl = [
-            { category: AclCategory.AUTHENTICATED_USER, role: allowedRole },
-          ] as IChannelAclPermission[];
-          const channel = { channelAcl, creator: "foo" } as IChannel;
-
-          const channelPermission = new ChannelPermission(channel);
-
-          expect(channelPermission.canPostToChannel(user)).toBe(true);
-        });
-      });
-
-      it("returns false if authenticated permission defined, user logged in, and role is read", async () => {
-        const user = buildUser();
-        const channelAcl = [
-          { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
-        ] as IChannelAclPermission[];
-        const channel = { channelAcl, creator: "foo" } as IChannel;
-
-        const channelPermission = new ChannelPermission(channel);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(false);
-      });
-
-      it("returns false if authenticated permission defined and user is not logged in", async () => {
-        const user = buildUser({ username: null });
-        const channelAcl = [
-          { category: AclCategory.AUTHENTICATED_USER, role: Role.READWRITE },
-        ] as IChannelAclPermission[];
-        const channel = { channelAcl, creator: "foo" } as IChannel;
-
-        const channelPermission = new ChannelPermission(channel);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(false);
-      });
-    });
-
-    describe("Group Permissions", () => {
-      it("returns true if user is group member in group permission list and role is allowed", async () => {
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channelAcl = [
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.MEMBER,
-              key: groupId1,
-              role: allowedRole, // members write
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId1,
-              role: Role.READ,
-            },
-          ] as IChannelAclPermission[];
-
-          ALLOWED_GROUP_ROLES.forEach((memberType) => {
-            const user = buildUser({
-              orgId: orgId1,
-              groups: [buildGroup(groupId1, memberType)], // member in groupId1
-            });
-            const channel = { channelAcl, creator: "foo" } as IChannel;
-
-            const channelPermission = new ChannelPermission(channel);
-
-            expect(channelPermission.canPostToChannel(user)).toBe(true);
-          });
-        });
-      });
-
-      it("returns false if user is group member in group permission list and role is NOT allowed", async () => {
-        const user = buildUser(); // member in groupId1
-        const channelAcl = [
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.MEMBER,
-            key: groupId1,
-            role: Role.READ, // members read
-          },
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.ADMIN,
-            key: groupId1,
-            role: Role.READ,
-          },
-        ] as IChannelAclPermission[];
-        const channel = { channelAcl, creator: "foo" } as IChannel;
-
-        const channelPermission = new ChannelPermission(channel);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(false);
-      });
-
-      it("returns false if user is group member in group permission list, role is allowed, but userMemberType is none", async () => {
-        const user = buildUser({
-          groups: [buildGroup(groupId1, "none")], // none in groupId1
-        });
-        const channelAcl = [
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.MEMBER,
-            key: groupId1,
-            role: Role.READWRITE, // members read
-          },
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.ADMIN,
-            key: groupId1,
-            role: Role.READWRITE, // admins read
-          },
-        ] as IChannelAclPermission[];
-        const channel = { channelAcl, creator: "foo" } as IChannel;
-
-        const channelPermission = new ChannelPermission(channel);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(false);
-      });
-
-      it("returns true if user is group owner/admin in group permission list and role is allowed", async () => {
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channelAcl = [
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.MEMBER,
-              key: groupId1,
-              role: Role.READ,
-            },
-            {
-              category: AclCategory.GROUP,
-              subCategory: AclSubCategory.ADMIN,
-              key: groupId1,
-              role: allowedRole, // admins write
-            },
-          ] as IChannelAclPermission[];
-
-          ["owner", "admin"].forEach((memberType) => {
-            const user = buildUser({
-              orgId: orgId1,
-              groups: [buildGroup(groupId1, memberType)], // admin in groupId1
-            });
-            const channel = { channelAcl, creator: "foo" } as IChannel;
-
-            const channelPermission = new ChannelPermission(channel);
-
-            expect(channelPermission.canPostToChannel(user)).toBe(true);
-          });
-        });
-      });
-
-      it("returns false if user is group owner/admin in group permission list and role is NOT allowed", async () => {
-        const user = buildUser(); // admin in groupId2
-        const channelAcl = [
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.MEMBER,
-            key: groupId2,
-            role: Role.READ,
-          },
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.ADMIN,
-            key: groupId2,
-            role: Role.READ, // admins read
-          },
-        ] as IChannelAclPermission[];
-        const channel = { channelAcl, creator: "foo" } as IChannel;
-
-        const channelPermission = new ChannelPermission(channel);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(false);
-      });
-
-      it("returns true if user is group member of at least one group in permissions list that is discussable", async () => {
-        const user = buildUser({
-          orgId: orgId1,
-          groups: [
-            buildGroup(groupId1, "member"), // member in groupId1
-            buildGroup(groupId2, "member", [CANNOT_DISCUSS]), // member in groupId2
-          ],
-        });
-        const channelAcl = [
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.MEMBER,
-            key: groupId1,
-            role: Role.READWRITE, // members write
-          },
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.ADMIN,
-            key: groupId1,
-            role: Role.READ,
-          },
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.MEMBER,
-            key: groupId2,
-            role: Role.READWRITE, // members write, group CANNOT_DISCUSS
-          },
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.ADMIN,
-            key: groupId2,
-            role: Role.READ,
-          },
-        ] as IChannelAclPermission[];
-        const channel = { channelAcl, creator: "foo" } as IChannel;
-
-        const channelPermission = new ChannelPermission(channel);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(true);
-      });
-
-      it("returns false if user is group member in permissions list but the group is not discussable", async () => {
-        const user = buildUser({
-          orgId: orgId1,
-          groups: [
-            buildGroup(groupId1, "member", [CANNOT_DISCUSS]), // member in groupId1
-          ],
-        });
-        const channelAcl = [
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.MEMBER,
-            key: groupId1,
-            role: Role.READWRITE, // members write
-          },
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.ADMIN,
-            key: groupId1,
-            role: Role.READ,
-          },
-        ] as IChannelAclPermission[];
-        const channel = { channelAcl, creator: "foo" } as IChannel;
-
-        const channelPermission = new ChannelPermission(channel);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(false);
-      });
-
-      it("returns false if user is group admin but group is not in permissions list", async () => {
-        const user = buildUser({
-          orgId: orgId1,
-          groups: [
-            buildGroup("unknownGroupId", "admin"), // admin in unknownGroupId
-          ],
-        });
-        const channelAcl = [
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.MEMBER,
-            key: groupId1,
-            role: Role.READWRITE, // members write
-          },
-          {
-            category: AclCategory.GROUP,
-            subCategory: AclSubCategory.ADMIN,
-            key: groupId1,
-            role: Role.READWRITE, // admin write
-          },
-        ] as IChannelAclPermission[];
-        const channel = { channelAcl, creator: "foo" } as IChannel;
-
-        const channelPermission = new ChannelPermission(channel);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(false);
-      });
-    });
-
-    describe("Org Permissions", () => {
-      it("returns true if user is org member in permissions list and member role is allowed", async () => {
-        const user = buildUser();
-
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channelAcl = [
-            {
-              category: AclCategory.ORG,
-              subCategory: AclSubCategory.MEMBER,
-              key: user.orgId,
-              role: allowedRole, // members write
-            },
-            {
-              category: AclCategory.ORG,
-              subCategory: AclSubCategory.ADMIN,
-              key: user.orgId,
-              role: Role.READ, // admin read
-            },
-          ] as IChannelAclPermission[];
-          const channel = { channelAcl, creator: "joker" } as IChannel;
-
-          const channelPermission = new ChannelPermission(channel);
-
-          expect(channelPermission.canPostToChannel(user)).toBe(true);
-        });
-      });
-
-      it("returns true if user is org_admin in permissions list and admin role is allowed", async () => {
-        const user = buildUser({ role: "org_admin" });
-
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channelAcl = [
-            {
-              category: AclCategory.ORG,
-              subCategory: AclSubCategory.MEMBER,
-              key: user.orgId,
-              role: Role.READ, // members read
-            },
-            {
-              category: AclCategory.ORG,
-              subCategory: AclSubCategory.ADMIN,
-              key: user.orgId,
-              role: allowedRole, // admin write
-            },
-          ] as IChannelAclPermission[];
-          const channel = { channelAcl, creator: "foo" } as IChannel;
-
-          const channelPermission = new ChannelPermission(channel);
-
-          expect(channelPermission.canPostToChannel(user)).toBe(true);
-        });
-      });
-
-      it("returns false if user is not in the permissions org", async () => {
-        const user = buildUser({ orgId: "unknownOrgId" });
-        const channelAcl = [
-          {
-            category: AclCategory.ORG,
-            subCategory: AclSubCategory.MEMBER,
-            key: orgId1,
-            role: Role.READ, // members read
-          },
-          {
-            category: AclCategory.ORG,
-            subCategory: AclSubCategory.ADMIN,
-            key: orgId1,
-            role: Role.READWRITE, // admin write
-          },
-        ] as IChannelAclPermission[];
-        const channel = { channelAcl, creator: "foo" } as IChannel;
-
-        const channelPermission = new ChannelPermission(channel);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(false);
-      });
-    });
-
-    describe("User Permissions", () => {
-      it("returns true if user is in permissions list and role is allowed", () => {
-        const user = buildUser();
-
-        ALLOWED_ROLES_FOR_POSTING.forEach((allowedRole) => {
-          const channelAcl = [
-            {
-              category: AclCategory.USER,
-              key: user.username,
-              role: allowedRole,
-            },
-          ] as IChannelAclPermission[];
-          const channel = { channelAcl, creator: "foo" } as IChannel;
-
-          const channelPermission = new ChannelPermission(channel);
-
-          expect(channelPermission.canPostToChannel(user)).toBe(true);
-        });
-      });
-
-      it("returns false if user is in permissions list but role is read", () => {
-        const user = buildUser();
-        const channelAcl = [
-          { category: AclCategory.USER, key: user.username, role: Role.READ },
-        ] as IChannelAclPermission[];
-        const channel = { channelAcl, creator: "foo" } as IChannel;
-
-        const channelPermission = new ChannelPermission(channel);
-
-        expect(channelPermission.canPostToChannel(user)).toBe(false);
       });
     });
   });

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -1212,6 +1212,25 @@ describe("ChannelPermission class", () => {
   });
 
   describe("canUpdateProperties", () => {
+    describe("no updates", () => {
+      it("returns true if no updates, regardless of role", () => {
+        const user = buildUser();
+        const channelAcl = [
+          { category: AclCategory.USER, key: user.username, role: Role.READ }, // bad role for update
+        ] as IChannelAclPermission[];
+
+        const channel = {
+          allowReply: true,
+          channelAcl,
+        } as IChannel;
+        const channelPermission = new ChannelPermission(channel);
+
+        const updates = undefined;
+
+        expect(channelPermission.canUpdateProperties(user, updates)).toBe(true);
+      });
+    });
+
     describe("allowReply", () => {
       it("returns true if value not changed from existing regardless of role", () => {
         const user = buildUser();

--- a/packages/discussions/test/utils/channels/can-edit-channel.test.ts
+++ b/packages/discussions/test/utils/channels/can-edit-channel.test.ts
@@ -14,6 +14,7 @@ import * as portalPrivModule from "../../../src/utils/portal-privilege";
 describe("canEditChannel", () => {
   let hasOrgAdminUpdateRightsSpy: jasmine.Spy;
   let canModerateChannelSpy: jasmine.Spy;
+  let canUpdatePropertiesSpy: jasmine.Spy;
   let isAuthorizedToModifyChannelByLegacyPermissionsSpy: jasmine.Spy;
 
   beforeAll(() => {
@@ -25,6 +26,10 @@ describe("canEditChannel", () => {
       ChannelPermission.prototype,
       "canModerateChannel"
     );
+    canUpdatePropertiesSpy = spyOn(
+      ChannelPermission.prototype,
+      "canUpdateProperties"
+    );
     isAuthorizedToModifyChannelByLegacyPermissionsSpy = spyOn(
       isAuthorizedToModifyChannelByLegacyPermissionsModule,
       "isAuthorizedToModifyChannelByLegacyPermissions"
@@ -35,6 +40,7 @@ describe("canEditChannel", () => {
     hasOrgAdminUpdateRightsSpy.calls.reset();
     isAuthorizedToModifyChannelByLegacyPermissionsSpy.calls.reset();
     canModerateChannelSpy.calls.reset();
+    canUpdatePropertiesSpy.calls.reset();
   });
 
   describe("With Org Admin", () => {
@@ -51,6 +57,7 @@ describe("canEditChannel", () => {
       expect(arg2).toBe(channel.orgId);
 
       expect(canModerateChannelSpy.calls.count()).toBe(0);
+      expect(canUpdatePropertiesSpy.calls.count()).toBe(0);
       expect(
         isAuthorizedToModifyChannelByLegacyPermissionsSpy.calls.count()
       ).toBe(0);
@@ -58,9 +65,10 @@ describe("canEditChannel", () => {
   });
 
   describe("With channelAcl Permissions", () => {
-    it("return true if channelPermission.canModerateChannel is true", () => {
+    it("return true if channelPermission.canModerateChannel and channelPermission.canUpdateProperties is true", () => {
       hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
       canModerateChannelSpy.and.callFake(() => true);
+      canUpdatePropertiesSpy.and.callFake(() => true);
 
       const user = {} as IDiscussionsUser;
       const channel = {
@@ -74,6 +82,10 @@ describe("canEditChannel", () => {
       const [arg1] = canModerateChannelSpy.calls.allArgs()[0]; // args for 1st call
       expect(arg1).toBe(user);
 
+      expect(canUpdatePropertiesSpy.calls.count()).toBe(1);
+      const [arg2] = canUpdatePropertiesSpy.calls.allArgs()[0]; // args for 1st call
+      expect(arg2).toEqual({});
+
       expect(
         isAuthorizedToModifyChannelByLegacyPermissionsSpy.calls.count()
       ).toBe(0);
@@ -82,6 +94,7 @@ describe("canEditChannel", () => {
     it("return false if channelPermission.canModerateChannel is false", () => {
       hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
       canModerateChannelSpy.and.callFake(() => false);
+      canUpdatePropertiesSpy.and.callFake(() => true);
 
       const user = {} as IDiscussionsUser;
       const channel = {
@@ -95,14 +108,17 @@ describe("canEditChannel", () => {
       const [arg1] = canModerateChannelSpy.calls.allArgs()[0]; // args for 1st call
       expect(arg1).toBe(user);
 
+      expect(canUpdatePropertiesSpy.calls.count()).toBe(0);
+
       expect(
         isAuthorizedToModifyChannelByLegacyPermissionsSpy.calls.count()
       ).toBe(0);
     });
 
-    it("return false if channelPermission.canModerateChannel is false and user is undefined", () => {
+    it("return false if channelPermission.canModerateChannel is true and channelPermission.canUpdateProperties is false", () => {
       hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
-      canModerateChannelSpy.and.callFake(() => false);
+      canModerateChannelSpy.and.callFake(() => true);
+      canUpdatePropertiesSpy.and.callFake(() => false);
 
       const user = undefined as unknown as IUser;
       const channel = {
@@ -115,6 +131,10 @@ describe("canEditChannel", () => {
       expect(canModerateChannelSpy.calls.count()).toBe(1);
       const [arg1] = canModerateChannelSpy.calls.allArgs()[0]; // args for 1st call
       expect(arg1).toEqual({});
+
+      expect(canUpdatePropertiesSpy.calls.count()).toBe(1);
+      const [arg2] = canUpdatePropertiesSpy.calls.allArgs()[0]; // args for 1st call
+      expect(arg2).toEqual({});
 
       expect(
         isAuthorizedToModifyChannelByLegacyPermissionsSpy.calls.count()
@@ -134,6 +154,7 @@ describe("canEditChannel", () => {
       expect(canEditChannel(channel, user)).toBe(true);
 
       expect(canModerateChannelSpy.calls.count()).toBe(0);
+      expect(canUpdatePropertiesSpy.calls.count()).toBe(0);
 
       expect(
         isAuthorizedToModifyChannelByLegacyPermissionsSpy.calls.count()
@@ -155,6 +176,7 @@ describe("canEditChannel", () => {
       expect(canEditChannel(channel, user)).toBe(false);
 
       expect(canModerateChannelSpy.calls.count()).toBe(0);
+      expect(canUpdatePropertiesSpy.calls.count()).toBe(0);
 
       expect(
         isAuthorizedToModifyChannelByLegacyPermissionsSpy.calls.count()


### PR DESCRIPTION
affects: @esri/hub-common, @esri/hub-discussions

validate channel property changes based on existing channel channelAcl roles

Issue [8522](https://devtopia.esri.com/dc/hub/issues/8522)
Issue [11010](https://devtopia.esri.com/dc/hub/issues/11010)

1. Description: add optional parameter `updateData` to `canEditChannel` (only used in V2 routes) and additional validation of the changed channel properties based on existing channelAcl roles: https://confluencewikidev.esri.com/pages/viewpage.action?pageId=153747776#Roles&Privileges-ApplicationtoChannels

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
