### PR TITLE
feat(hub-discussions): do not restrict channel creation with org or p…

### DIFF
--- a/jasmine.json
+++ b/jasmine.json
@@ -1,6 +1,6 @@
 {
   "spec_dir": "packages",
-  "spec_files": ["*/test/**/channel-permission.test.ts"],
+  "spec_files": ["*/test/**/*.test.ts"],
   "helpers": ["../support/test-helpers.js"],
   "stopSpecOnExpectationFailure": false,
   "random": false

--- a/jasmine.json
+++ b/jasmine.json
@@ -1,6 +1,6 @@
 {
   "spec_dir": "packages",
-  "spec_files": ["*/test/**/*.test.ts"],
+  "spec_files": ["*/test/**/channel-permission.test.ts"],
   "helpers": ["../support/test-helpers.js"],
   "stopSpecOnExpectationFailure": false,
   "random": false

--- a/packages/discussions/src/utils/channel-permission.ts
+++ b/packages/discussions/src/utils/channel-permission.ts
@@ -330,7 +330,9 @@ export class ChannelPermission {
       return true;
     }
     return (
-      isOrgAdmin(user) || userHasPrivilege(user, "portal:admin:shareToPublic")
+      isOrgAdmin(user) ||
+      userHasPrivilege(user, "portal:admin:shareToPublic") ||
+      userHasPrivilege(user, "portal:user:shareToPublic")
     );
   }
 
@@ -339,7 +341,9 @@ export class ChannelPermission {
       return true;
     }
     return (
-      isOrgAdmin(user) || userHasPrivilege(user, "portal:admin:shareToPublic")
+      isOrgAdmin(user) ||
+      userHasPrivilege(user, "portal:admin:shareToPublic") ||
+      userHasPrivilege(user, "portal:user:shareToPublic")
     );
   }
 
@@ -370,7 +374,9 @@ export class ChannelPermission {
     }
 
     return (
-      (isOrgAdmin(user) || userHasPrivilege(user, "portal:admin:shareToOrg")) &&
+      (isOrgAdmin(user) ||
+        userHasPrivilege(user, "portal:admin:shareToOrg") ||
+        userHasPrivilege(user, "portal:user:shareToOrg")) &&
       this.isEveryPermissionForUserOrg(user.orgId, orgPermissions)
     );
   }

--- a/packages/discussions/src/utils/platform.ts
+++ b/packages/discussions/src/utils/platform.ts
@@ -2,14 +2,16 @@ import { GroupMembership, IGroup, IUser } from "@esri/arcgis-rest-portal";
 import { IChannel, IDiscussionsUser } from "@esri/hub-common";
 
 type Privilege =
-  | "portal:user:createItem"
-  | "portal:user:shareToGroup"
-  | "portal:user:viewOrgItems"
+  | "portal:admin:deleteItems"
   | "portal:admin:shareToOrg"
   | "portal:admin:shareToPublic"
-  | "portal:admin:viewItems"
   | "portal:admin:updateItems"
-  | "portal:admin:deleteItems";
+  | "portal:admin:viewItems"
+  | "portal:user:createItem"
+  | "portal:user:shareToGroup"
+  | "portal:user:shareToOrg"
+  | "portal:user:shareToPublic"
+  | "portal:user:viewOrgItems";
 
 /**
  * Utility that returns reducer function that filters a user's groups

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -545,7 +545,7 @@ describe("ChannelPermission class", () => {
     });
   });
 
-  fdescribe("canCreateChannel", () => {
+  describe("canCreateChannel", () => {
     describe("all permissions cases", () => {
       it("returns false if user not authenticated", () => {
         const user = buildUser({ username: null });

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -545,7 +545,7 @@ describe("ChannelPermission class", () => {
     });
   });
 
-  describe("canCreateChannel", () => {
+  fdescribe("canCreateChannel", () => {
     describe("all permissions cases", () => {
       it("returns false if user not authenticated", () => {
         const user = buildUser({ username: null });
@@ -608,7 +608,19 @@ describe("ChannelPermission class", () => {
         expect(channelPermission.canCreateChannel(user)).toEqual(true);
       });
 
-      it("returns false if user is not org_admin and does not have privilege portal:admin:shareToPublic", () => {
+      it("returns true if user has privilege portal:user:shareToPublic", () => {
+        const user = buildUser({ privileges: ["portal:user:shareToPublic"] });
+        const channelAcl = [
+          { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
+        ] as IChannelAclPermission[];
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+
+        const channelPermission = new ChannelPermission(channel);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(true);
+      });
+
+      it("returns false if user is not org_admin and does not have privileges", () => {
         const user = buildUser();
         const channelAcl = [
           { category: AclCategory.ANONYMOUS_USER, role: Role.READ },
@@ -646,7 +658,19 @@ describe("ChannelPermission class", () => {
         expect(channelPermission.canCreateChannel(user)).toEqual(true);
       });
 
-      it("returns false if user is not org_admin and does not have privilege portal:admin:shareToPublic", () => {
+      it("returns true if user if user has privilege portal:user:shareToPublic", () => {
+        const user = buildUser({ privileges: ["portal:user:shareToPublic"] });
+        const channelAcl = [
+          { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
+        ] as IChannelAclPermission[];
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+
+        const channelPermission = new ChannelPermission(channel);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(true);
+      });
+
+      it("returns false if user is not org_admin and does not privileges", () => {
         const user = buildUser();
         const channelAcl = [
           { category: AclCategory.AUTHENTICATED_USER, role: Role.READ },
@@ -804,6 +828,29 @@ describe("ChannelPermission class", () => {
 
       it("returns true if user if user has privilege portal:admin:shareToOrg and every permission is for the users orgId", () => {
         const user = buildUser({ privileges: ["portal:admin:shareToOrg"] });
+        const channelAcl = [
+          {
+            category: AclCategory.ORG,
+            subCategory: AclSubCategory.ADMIN,
+            key: orgId1,
+            role: Role.OWNER,
+          },
+          {
+            category: AclCategory.ORG,
+            subCategory: AclSubCategory.MEMBER,
+            key: orgId1,
+            role: Role.READ,
+          },
+        ] as IChannelAclPermission[];
+        const channel = { channelAcl, creator: "foo" } as IChannel;
+
+        const channelPermission = new ChannelPermission(channel);
+
+        expect(channelPermission.canCreateChannel(user)).toEqual(true);
+      });
+
+      it("returns true if user if user has privilege portal:user:shareToOrg and every permission is for the users orgId", () => {
+        const user = buildUser({ privileges: ["portal:user:shareToOrg"] });
         const channelAcl = [
           {
             category: AclCategory.ORG,


### PR DESCRIPTION
…ublic permission to only org_ad

affects: @esri/hub-discussions

Issue [11671](https://devtopia.esri.com/dc/hub/issues/11671)

1. Description: Relax validation on channel create:
  - ACL with anonymous or authenticated permissions: allow users with `portal:user:shareToPublic`
  - ACL with org permissions: allow users with `portal:user:shareToOrg`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
