### PR TITLE
feat(hub-common): change subscription actions to singular action

### DIFF
--- a/packages/common/src/newsletters-scheduler/api/orval/api/orval-newsletters-scheduler.ts
+++ b/packages/common/src/newsletters-scheduler/api/orval/api/orval-newsletters-scheduler.ts
@@ -37,7 +37,7 @@ export enum DeliveryMethod {
   EMAIL = "EMAIL",
 }
 export interface ISubscription {
-  actions: SubscriptionActions[];
+  action: SubscriptionAction;
   active: boolean;
   cadence: Cadence;
   catalog?: ISubscriptionCatalog;
@@ -69,12 +69,12 @@ export enum Cadence {
   WEEKLY = "WEEKLY",
   MONTHLY = "MONTHLY",
 }
-export enum SubscriptionActions {
+export enum SubscriptionAction {
   DISCUSSION_POST_PENDING = "DISCUSSION_POST_PENDING",
 }
 export interface INotify {
-  /** An array of actions representing user selections that further customize the subscription behavior */
-  actions?: SubscriptionActions[];
+  /** Type of action representing user selections that further customize the subscription behavior */
+  action?: SubscriptionAction;
   /** Frequency of the subscription */
   cadence: Cadence;
   /** The AGO id of the entity associated with the subscription */

--- a/packages/common/src/newsletters-scheduler/api/types.ts
+++ b/packages/common/src/newsletters-scheduler/api/types.ts
@@ -8,7 +8,7 @@ export {
   SystemNotificationSpecNames as SchedulerSystemNotificationSpecNames,
   SubscriptionEntityType,
   Cadence as SchedulerCadence,
-  SubscriptionActions,
+  SubscriptionAction as SchedulerSubscriptionAction,
   INotify,
 } from "./orval/api/orval-newsletters-scheduler";
 import { IHubRequestOptions } from "../../types";

--- a/packages/common/src/newsletters/api/orval/api/orval-newsletters.ts
+++ b/packages/common/src/newsletters/api/orval/api/orval-newsletters.ts
@@ -79,8 +79,8 @@ export interface ICreateUser {
 export type IUpdateSubscriptionCatalog = ICreateCatalog | null;
 
 export interface IUpdateSubscription {
-  /** An array of actions representing user selections that further customize the subscription behavior */
-  actions?: SubscriptionActions[];
+  /** Type of action representing user selections that further customize the subscription behavior */
+  action?: SubscriptionAction;
   /** Flag to opt user in or out of subscription */
   active?: boolean;
   /** Frequency of the subscription */
@@ -112,8 +112,8 @@ export type ISubscribeMetadata =
 export type ISubscribeCatalog = ICreateCatalog | null;
 
 export interface ISubscribe {
-  /** An array of actions representing user selections that further customize the subscription behavior */
-  actions?: SubscriptionActions[];
+  /** Type of action representing user selections that further customize the subscription behavior */
+  action?: SubscriptionAction;
   /** ArcGIS Online id for a user. Will always be extracted from the token unless service token is used. */
   agoId?: string;
   /** Frequency of the subscription */
@@ -194,7 +194,7 @@ export enum Cadence {
   MONTHLY = "MONTHLY",
 }
 export interface ISubscription {
-  actions: SubscriptionActions[];
+  action: SubscriptionAction;
   active: boolean;
   cadence: Cadence;
   catalog?: ISubscriptionCatalog;
@@ -218,8 +218,8 @@ export enum SystemNotificationSpecNames {
   DISCUSSION_ON_ENTITY = "DISCUSSION_ON_ENTITY",
 }
 export interface ICreateSubscription {
-  /** An array of actions representing user selections that further customize the subscription behavior */
-  actions?: SubscriptionActions[];
+  /** Type of action representing user selections that further customize the subscription behavior */
+  action?: SubscriptionAction;
   /** Frequency of the subscription */
   cadence: Cadence;
   /** catalog for a subscription */
@@ -344,7 +344,7 @@ export interface ICreateCatalogCollectionQuery {
   targetEntity: EntityType;
 }
 
-export enum SubscriptionActions {
+export enum SubscriptionAction {
   DISCUSSION_POST_PENDING = "DISCUSSION_POST_PENDING",
 }
 export interface ICreateEventMetadata {

--- a/packages/common/src/newsletters/api/types.ts
+++ b/packages/common/src/newsletters/api/types.ts
@@ -9,6 +9,7 @@ export {
   ISubscriptionMetadata,
   IUser,
   SystemNotificationSpecNames,
+  SubscriptionAction,
 } from "./orval/api/orval-newsletters";
 import { IHubRequestOptions } from "../../types";
 import {

--- a/packages/common/test/newsletters-scheduler/api/subscriptions.test.ts
+++ b/packages/common/test/newsletters-scheduler/api/subscriptions.test.ts
@@ -5,7 +5,7 @@ import {
   INotifyParams,
   notify,
   SubscriptionEntityType,
-  SubscriptionActions,
+  SchedulerSubscriptionAction,
 } from "../../../src/newsletters-scheduler";
 import * as authenticateRequestModule from "../../../src/newsletters-scheduler/api/utils/authenticate-request";
 import * as orvalModule from "../../../src/newsletters-scheduler/api/orval/api/orval-newsletters-scheduler";
@@ -32,7 +32,7 @@ describe("Subscriptions", () => {
 
       const options: INotifyParams = {
         data: {
-          actions: [SubscriptionActions.DISCUSSION_POST_PENDING],
+          action: SchedulerSubscriptionAction.DISCUSSION_POST_PENDING,
           cadence: SchedulerCadence.WEEKLY,
           notificationSpecName:
             SchedulerSystemNotificationSpecNames.DISCUSSION_ON_ENTITY,


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
