### PR TITLE
feat: add inline-workspace flag; limit workspace:org to devext

### DIFF
--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -147,9 +147,11 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     // When enabled, the manage links will take the user the org home site
+    // Reverting to devext but likely remove and always load workspaces
+    // on the "current site"
     permission: "hub:feature:workspace:org",
     availability: ["alpha"],
-    environments: ["qaext"],
+    environments: ["devext"],
   },
   {
     // DEPRECATED: This permission has been replaced by hub:feature:workspace:org,
@@ -157,7 +159,7 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     // When enabled, the edit & manage links will take the user to umbrella
     permission: "hub:feature:workspace:umbrella",
     availability: ["alpha"],
-    environments: ["qaext"],
+    environments: ["devext"],
   },
   {
     // when enabled keyboard shortcuts will be available
@@ -183,6 +185,13 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     // Enables catalog configuration and viewing
     permission: "hub:feature:catalogs",
     environments: ["qaext"],
+    availability: ["alpha"],
+  },
+  {
+    // Enable inline-workspace for Entity Views
+    // limited to devext alpha so we have to pass as a flag to enable
+    permission: "hub:feature:inline-workspace",
+    environments: ["devext"],
     availability: ["alpha"],
   },
   // NOTE: only use this permission if necessary. Use the licenses check on a permission to check license when able instead of a separate permission.

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -35,6 +35,7 @@ const SystemPermissions = [
   "hub:feature:newentityview",
   "hub:feature:history",
   "hub:feature:catalogs",
+  "hub:feature:inline-workspace",
   "hub:license:hub-premium",
   "hub:license:hub-basic",
   "hub:license:enterprise-sites",


### PR DESCRIPTION
1. Description:

- Limit `hub:feature:workspace:org` to devext so it's no longer the default in our alpha orgs (where we do most dev/test)
- add `hub:feature:inline-workspace` permission, limit to devext so we have to pass `?pe=hub:feature:inline-workspace`

1. Instructions for testing:

1. Part of Issues: #11691

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
