### PR TITLE
poc(): add discussions to projects and initiatives? 

### DIFF
--- a/packages/common/src/core/schemas/internal/getEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getEditorSchemas.ts
@@ -140,6 +140,8 @@ export async function getEditorSchemas(
           import("../../../projects/_internal/ProjectUiSchemaCreate"),
         "hub:project:create2": () =>
           import("../../../projects/_internal/ProjectUiSchemaCreate2"),
+        "hub:project:discussions": () =>
+          import("../../../projects/_internal/ProjectUiSchemaDiscussions"),
         "hub:project:metrics": () => import("./metrics/ProjectUiSchemaMetrics"),
         "hub:project:settings": () =>
           import("../../../projects/_internal/ProjectUiSchemaSettings"),

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -30,6 +30,7 @@ export const ProjectPermissions = [
   "hub:project:workspace:overview",
   "hub:project:workspace:dashboard",
   "hub:project:workspace:details",
+  "hub:project:workspace:discussions",
   "hub:project:workspace:initiatives",
   "hub:project:workspace:settings",
   "hub:project:workspace:collaborators",
@@ -132,6 +133,10 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:project:workspace:details",
+    dependencies: ["hub:project:workspace", "hub:project:edit"],
+  },
+  {
+    permission: "hub:project:workspace:discussions",
     dependencies: ["hub:project:workspace", "hub:project:edit"],
   },
   {

--- a/packages/common/src/projects/_internal/ProjectUiSchemaDiscussions.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaDiscussions.ts
@@ -1,0 +1,44 @@
+import { IArcGISContext } from "../../ArcGISContext";
+import { IUiSchema } from "../../core/schemas/types";
+import { EntityEditorOptions } from "../../core/schemas/internal/EditorOptions";
+
+/**
+ * @private
+ * settings uiSchema for Hub Discussions - this
+ * defines how the schema properties should be
+ * rendered in the Discussions settings experience
+ */
+export const buildUiSchema = async (
+  i18nScope: string,
+  options: EntityEditorOptions,
+  context: IArcGISContext
+): Promise<IUiSchema> => {
+  return {
+    type: "Layout",
+    elements: [
+      {
+        type: "Section",
+        labelKey: `${i18nScope}.sections.discussions.label`,
+        elements: [
+          {
+            labelKey: `${i18nScope}.fields.discussable.label`,
+            scope: "/properties/isDiscussable",
+            type: "Control",
+            options: {
+              control: "hub-field-input-radio",
+              labels: [
+                `{{${i18nScope}.fields.discussable.enabled.label:translate}}`,
+                `{{${i18nScope}.fields.discussable.disabled.label:translate}}`,
+              ],
+              descriptions: [
+                `{{${i18nScope}.fields.discussable.enabled.description:translate}}`,
+                `{{${i18nScope}.fields.discussable.disabled.description:translate}}`,
+              ],
+              icons: ["speech-bubbles", "circle-disallowed"],
+            },
+          },
+        ],
+      },
+    ],
+  };
+};


### PR DESCRIPTION
Prototype -- adding discussions to projects. 

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
