### PR TITLE
fix(hub-common): remove calcite-radio-group

### DIFF
--- a/packages/common/src/content/_internal/ContentUiSchemaDiscussions.ts
+++ b/packages/common/src/content/_internal/ContentUiSchemaDiscussions.ts
@@ -25,7 +25,8 @@ export const buildUiSchema = async (
             scope: "/properties/isDiscussable",
             type: "Control",
             options: {
-              control: "hub-field-input-radio",
+              control: "hub-field-input-tile-select",
+              layout: "horizontal",
               labels: [
                 `{{${i18nScope}.fields.discussable.enabled.label:translate}}`,
                 `{{${i18nScope}.fields.discussable.disabled.label:translate}}`,
@@ -35,6 +36,8 @@ export const buildUiSchema = async (
                 `{{${i18nScope}.fields.discussable.disabled.description:translate}}`,
               ],
               icons: ["speech-bubbles", "circle-disallowed"],
+              type: "radio",
+              styles: { "max-width": "45rem" },
             },
           },
         ],

--- a/packages/common/src/groups/_internal/GroupUiSchemaDiscussions.ts
+++ b/packages/common/src/groups/_internal/GroupUiSchemaDiscussions.ts
@@ -24,7 +24,8 @@ export const buildUiSchema = async (
             scope: "/properties/isDiscussable",
             type: "Control",
             options: {
-              control: "hub-field-input-radio",
+              control: "hub-field-input-tile-select",
+              layout: "horizontal",
               labels: [
                 `{{${i18nScope}.fields.discussable.enabled.label:translate}}`,
                 `{{${i18nScope}.fields.discussable.disabled.label:translate}}`,
@@ -34,6 +35,8 @@ export const buildUiSchema = async (
                 `{{${i18nScope}.fields.discussable.disabled.description:translate}}`,
               ],
               icons: ["speech-bubbles", "circle-disallowed"],
+              type: "radio",
+              styles: { "max-width": "45rem" },
             },
           },
         ],

--- a/packages/common/test/content/_internal/ContentUiSchemaDiscussions.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaDiscussions.test.ts
@@ -16,7 +16,8 @@ describe("buildUiSchema: content discussions", () => {
               scope: "/properties/isDiscussable",
               type: "Control",
               options: {
-                control: "hub-field-input-radio",
+                control: "hub-field-input-tile-select",
+                layout: "horizontal",
                 labels: [
                   "{{some.scope.fields.discussable.enabled.label:translate}}",
                   "{{some.scope.fields.discussable.disabled.label:translate}}",
@@ -26,6 +27,8 @@ describe("buildUiSchema: content discussions", () => {
                   "{{some.scope.fields.discussable.disabled.description:translate}}",
                 ],
                 icons: ["speech-bubbles", "circle-disallowed"],
+                type: "radio",
+                styles: { "max-width": "45rem" },
               },
             },
           ],

--- a/packages/common/test/groups/_internal/GroupUiSchemaDiscussions.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaDiscussions.test.ts
@@ -16,7 +16,8 @@ describe("buildUiSchema: group discussions", () => {
               scope: "/properties/isDiscussable",
               type: "Control",
               options: {
-                control: "hub-field-input-radio",
+                control: "hub-field-input-tile-select",
+                layout: "horizontal",
                 labels: [
                   "{{some.scope.fields.discussable.enabled.label:translate}}",
                   "{{some.scope.fields.discussable.disabled.label:translate}}",
@@ -26,6 +27,8 @@ describe("buildUiSchema: group discussions", () => {
                   "{{some.scope.fields.discussable.disabled.description:translate}}",
                 ],
                 icons: ["speech-bubbles", "circle-disallowed"],
+                type: "radio",
+                styles: { "max-width": "45rem" },
               },
             },
           ],


### PR DESCRIPTION
1. Description: Updates discussions pane to be more a11y-compliant.

1. Instructions for testing:

1. Closes Issues: #11728, #11722

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
