### PR TITLE
[DNM] feat: add a notice for Browser template in site creation workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.211.0",
+			"version": "14.221.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65047,7 +65047,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "28.3.0",
+			"version": "28.5.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
@@ -40,6 +40,30 @@ export const buildUiSchema = async (
           ],
         },
       },
+      {
+        type: "Notice",
+        options: {
+          notice: {
+            configuration: {
+              id: "use-template-notice",
+              noticeType: "notice",
+              closable: false,
+              kind: "info",
+              scale: "m",
+              "data-autoclose": true,
+            },
+            message: `{{${i18nScope}.fields.browseTemplate.message:translate}}`,
+            autoShow: true,
+            actions: [
+              {
+                label: `{{${i18nScope}.fields.browseTemplate.action:translate}}`,
+                href: `${context.hubHomeUrl}/edit/new/browse?source=org`,
+                target: "_blank",
+              },
+            ],
+          },
+        },
+      },
     ],
   };
 };


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
