### PR TITLE
feat(hub-common): add slug to entity edit schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22695,10 +22695,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22713,24 +22712,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22744,10 +22740,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22765,10 +22760,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65023,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.221.0",
+			"version": "14.222.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -83487,8 +83481,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83503,20 +83496,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83530,8 +83520,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83548,8 +83537,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22695,9 +22695,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22712,21 +22713,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22740,9 +22744,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22760,9 +22765,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65017,7 +65023,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.218.0",
+			"version": "14.221.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65047,7 +65053,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "28.4.0",
+			"version": "28.5.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -83481,7 +83487,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83496,17 +83503,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83520,7 +83530,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83537,7 +83548,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.211.0",
+			"version": "14.218.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65047,7 +65047,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "28.3.0",
+			"version": "28.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/src/core/_internal/getEditorSlug.ts
+++ b/packages/common/src/core/_internal/getEditorSlug.ts
@@ -1,0 +1,11 @@
+import { IWithSlug } from "../traits/IWithSlug";
+
+/**
+ * Get the user-editable portion of an entity's slug
+ * @param entity
+ * @returns
+ */
+export const getEditorSlug = (entity: IWithSlug) => {
+  const { slug = "", orgUrlKey } = entity;
+  return slug.replace(`${orgUrlKey}|`, "");
+};

--- a/packages/common/src/core/schemas/internal/addConditionalSlugValidation.ts
+++ b/packages/common/src/core/schemas/internal/addConditionalSlugValidation.ts
@@ -1,0 +1,27 @@
+import { JSONSchema } from "json-schema-typed";
+import { cloneObject } from "../../../util";
+import { HubEntity } from "../../types/HubEntity";
+import { IWithSlug } from "../../traits";
+import { IConfigurationSchema } from "../types";
+import { EditorOptions } from "./EditorOptions";
+
+export const addConditionalSlugValidation = (
+  schema: IConfigurationSchema,
+  options: EditorOptions
+): IConfigurationSchema => {
+  // if schema has slug add conditional validation
+  const _slug = schema.properties?._slug as JSONSchema;
+  if (!_slug) {
+    return schema;
+  }
+  const allOf = cloneObject(schema.allOf) || [];
+  const { pattern } = _slug;
+  const { orgUrlKey } = options as IWithSlug;
+  const { id } = options as HubEntity;
+  allOf.push({
+    // only do async isUniqueSlug check if the slug is valid
+    if: { properties: { _slug: { pattern } } },
+    then: { properties: { _slug: { isUniqueSlug: { id, orgUrlKey } } as any } },
+  });
+  return { ...cloneObject(schema), allOf };
+};

--- a/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
+++ b/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
@@ -1,27 +1,33 @@
 import { JSONSchema } from "json-schema-typed";
+import { TYPEKEYWORD_MAX_LENGTH } from "../../../items/slugs";
 import { cloneObject } from "../../../util";
 import { HubEntity } from "../../types/HubEntity";
 import { IWithSlug } from "../../traits";
 import { IConfigurationSchema } from "../types";
 import { EditorOptions } from "./EditorOptions";
 
-export const addConditionalSlugValidation = (
+export const addDynamicSlugValidation = (
   schema: IConfigurationSchema,
   options: EditorOptions
 ): IConfigurationSchema => {
-  // if schema has slug add conditional validation
-  const _slug = schema.properties?._slug as JSONSchema;
+  const _slug = cloneObject(schema.properties?._slug) as JSONSchema;
   if (!_slug) {
     return schema;
   }
+  // add max length to slug
+  const { orgUrlKey } = options as IWithSlug;
+  _slug.maxLength = TYPEKEYWORD_MAX_LENGTH - (orgUrlKey.length + 1);
+  // add conditional validation to ensure slug is unique
   const allOf = cloneObject(schema.allOf) || [];
   const { pattern } = _slug;
-  const { orgUrlKey } = options as IWithSlug;
   const { id } = options as HubEntity;
   allOf.push({
     // only do async isUniqueSlug check if the slug is valid
     if: { properties: { _slug: { pattern } } },
     then: { properties: { _slug: { isUniqueSlug: { id, orgUrlKey } } as any } },
   });
-  return { ...cloneObject(schema), allOf };
+  const clone = cloneObject(schema);
+  clone.properties._slug = _slug;
+  clone.allOf = allOf;
+  return clone;
 };

--- a/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
+++ b/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
@@ -6,6 +6,13 @@ import { IWithSlug } from "../../traits";
 import { IConfigurationSchema } from "../types";
 import { EditorOptions } from "./EditorOptions";
 
+/**
+ * add slug max length and unique validation to schema
+ * based on the orgUrlKey
+ * @param schema
+ * @param options
+ * @returns
+ */
 export const addDynamicSlugValidation = (
   schema: IConfigurationSchema,
   options: EditorOptions

--- a/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
+++ b/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
@@ -1,5 +1,5 @@
 import { JSONSchema } from "json-schema-typed";
-import { TYPEKEYWORD_MAX_LENGTH } from "../../../items/slugs";
+import { getSlugMaxLength } from "../../../items/_internal/slugs";
 import { cloneObject } from "../../../util";
 import { HubEntity } from "../../types/HubEntity";
 import { IWithSlug } from "../../traits";
@@ -23,7 +23,7 @@ export const addDynamicSlugValidation = (
   }
   // add max length to slug
   const { orgUrlKey } = options as IWithSlug;
-  _slug.maxLength = TYPEKEYWORD_MAX_LENGTH - (orgUrlKey.length + 1);
+  _slug.maxLength = getSlugMaxLength(orgUrlKey);
   // add conditional validation to ensure slug is unique
   const allOf = cloneObject(schema.allOf) || [];
   const { pattern } = _slug;

--- a/packages/common/src/core/schemas/internal/getEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getEditorSchemas.ts
@@ -29,7 +29,7 @@ import { getCardEditorSchemas } from "./getCardEditorSchemas";
 import { SurveyEditorType } from "../../../surveys/_internal/SurveySchema";
 import { EventEditorType } from "../../../events/_internal/EventSchemaCreate";
 import { UserEditorType } from "../../../users/_internal/UserSchema";
-import { addConditionalSlugValidation } from "./addConditionalSlugValidation";
+import { addDynamicSlugValidation } from "./addDynamicSlugValidation";
 
 /**
  * get the editor schema and uiSchema defined for an editor (either an entity or a card).
@@ -461,7 +461,7 @@ export async function getEditorSchemas(
   schema = filterSchemaToUiSchema(schema, uiSchema);
 
   // if schema includes slug, add conditional validation
-  schema = addConditionalSlugValidation(schema, options);
+  schema = addDynamicSlugValidation(schema, options);
 
   return Promise.resolve({ schema, uiSchema, defaults });
 }

--- a/packages/common/src/core/schemas/internal/getEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getEditorSchemas.ts
@@ -29,6 +29,7 @@ import { getCardEditorSchemas } from "./getCardEditorSchemas";
 import { SurveyEditorType } from "../../../surveys/_internal/SurveySchema";
 import { EventEditorType } from "../../../events/_internal/EventSchemaCreate";
 import { UserEditorType } from "../../../users/_internal/UserSchema";
+import { addConditionalSlugValidation } from "./addConditionalSlugValidation";
 
 /**
  * get the editor schema and uiSchema defined for an editor (either an entity or a card).
@@ -458,6 +459,9 @@ export async function getEditorSchemas(
 
   // filter out properties not used in the UI schema
   schema = filterSchemaToUiSchema(schema, uiSchema);
+
+  // if schema includes slug, add conditional validation
+  schema = addConditionalSlugValidation(schema, options);
 
   return Promise.resolve({ schema, uiSchema, defaults });
 }

--- a/packages/common/src/core/schemas/internal/getSlugSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/getSlugSchemaElement.ts
@@ -1,0 +1,29 @@
+import { IUiSchemaElement } from "../types";
+
+export const getSlugSchemaElement = (i18nScope: string): IUiSchemaElement => {
+  return {
+    labelKey: `${i18nScope}.fields.slug.label`,
+    scope: "/properties/_slug",
+    type: "Control",
+    options: {
+      control: "hub-field-input-input",
+      helperText: {
+        labelKey: `${i18nScope}.fields.slug.helperText`,
+      },
+      messages: [
+        {
+          type: "ERROR",
+          keyword: "pattern",
+          icon: true,
+          labelKey: `${i18nScope}.fields.slug.patternError`,
+        },
+        {
+          type: "ERROR",
+          keyword: "isUniqueSlug",
+          icon: true,
+          labelKey: `${i18nScope}.fields.slug.isUniqueError`,
+        },
+      ],
+    },
+  };
+};

--- a/packages/common/src/core/schemas/internal/metrics/editorToEntity.ts
+++ b/packages/common/src/core/schemas/internal/metrics/editorToEntity.ts
@@ -1,0 +1,36 @@
+import { IPortal } from "@esri/arcgis-rest-portal";
+import { cloneObject } from "../../../../util";
+import { IHubItemEntity, IHubItemEntityEditor } from "../../../../core/types";
+import { truncateSlug } from "../../../../items/_internal/slugs";
+
+// NOTE: this is covered by pre-existing tests for project to entity
+/**
+ * extract the common ephemeral properties from the editor
+ * and then clone into an entity that has all common properties
+ * @param editor
+ * @param portal
+ * @returns
+ */
+export function editorToEntity(
+  editor: IHubItemEntityEditor<IHubItemEntity>,
+  portal: IPortal
+): IHubItemEntity {
+  // 1. remove the ephemeral props we graft onto the editor
+  const _slug = editor._slug;
+  delete editor._slug;
+
+  // convert back to an entity. Apply any reverse transforms used in
+  // of the toEditor method
+  const entity = cloneObject(editor) as IHubItemEntity;
+  entity.orgUrlKey = editor.orgUrlKey ? editor.orgUrlKey : portal.urlKey;
+
+  // copy the location extent up one level
+  entity.extent = editor.location?.extent;
+
+  if (_slug) {
+    // ensure the slug is truncated
+    entity.slug = truncateSlug(_slug, entity.orgUrlKey);
+  }
+
+  return entity;
+}

--- a/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
+++ b/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
@@ -1,5 +1,5 @@
 import { HubEntityHero } from "../../../types";
-import { IConfigurationSchema } from "../types";
+import { IAsyncConfigurationSchema } from "../types";
 import {
   ENTITY_ACCESS_SCHEMA,
   ENTITY_CATEGORIES_SCHEMA,
@@ -12,6 +12,7 @@ import {
   ENTITY_SUMMARY_SCHEMA,
   ENTITY_TAGS_SCHEMA,
   ENTITY_TIMELINE_SCHEMA,
+  SLUG_SCHEMA,
 } from "./subschemas";
 
 /**
@@ -19,7 +20,8 @@ import {
  * All item entity schemas should leverage this base schema.
  * Reference the Project or Initiative schemas as an example
  */
-export const HubItemEntitySchema: IConfigurationSchema = {
+export const HubItemEntitySchema: IAsyncConfigurationSchema = {
+  $async: true,
   type: "object",
   required: ["name"],
   properties: {
@@ -79,5 +81,6 @@ export const HubItemEntitySchema: IConfigurationSchema = {
         heroActions: { type: "array" },
       },
     },
+    _slug: SLUG_SCHEMA,
   },
-} as IConfigurationSchema;
+} as IAsyncConfigurationSchema;

--- a/packages/common/src/core/schemas/shared/subschemas.ts
+++ b/packages/common/src/core/schemas/shared/subschemas.ts
@@ -174,5 +174,6 @@ export const PRIVACY_CONFIG_SCHEMA = {
 
 export const SLUG_SCHEMA: JSONSchema = {
   type: "string",
+  /** lower case alpha numeric characters and '-' only */
   pattern: "^[a-z0-9]+(?:-[a-z0-9]+-*)*$",
 };

--- a/packages/common/src/core/schemas/shared/subschemas.ts
+++ b/packages/common/src/core/schemas/shared/subschemas.ts
@@ -171,3 +171,8 @@ export const PRIVACY_CONFIG_SCHEMA = {
     },
   },
 };
+
+export const SLUG_SCHEMA: JSONSchema = {
+  type: "string",
+  pattern: "^[a-z0-9]+(?:-[a-z0-9]+-*)*$",
+};

--- a/packages/common/src/core/types/IHubItemEntity.ts
+++ b/packages/common/src/core/types/IHubItemEntity.ts
@@ -169,4 +169,10 @@ export type IHubItemEntityEditor<T> = Omit<T, "extent"> & {
     membershipAccess?: MembershipAccess;
   };
   _metric?: IMetricEditorValues;
+
+  /**
+   * user editable portion of the slug
+   * (i.e. w/o the orgUrlKey prefix)
+   */
+  _slug?: string;
 };

--- a/packages/common/src/discussions/HubDiscussion.ts
+++ b/packages/common/src/discussions/HubDiscussion.ts
@@ -14,6 +14,9 @@ import { IWithEditorBehavior } from "../core/behaviors/IWithEditorBehavior";
 import { cloneObject } from "../util";
 import { DiscussionEditorType } from "./_internal/DiscussionSchema";
 import { enrichEntity } from "../core/enrichEntity";
+import { getEditorSlug } from "../core/_internal/getEditorSlug";
+import { editorToEntity } from "../core/schemas/internal/metrics/editorToEntity";
+
 /**
  * Hub Discussion Class
  */
@@ -190,6 +193,7 @@ export class HubDiscussion
 
     // 2. Apply transforms to relevant entity values so they
     // can be consumed by the editor
+    editor._slug = getEditorSlug(this.entity);
     return editor;
   }
 
@@ -199,6 +203,7 @@ export class HubDiscussion
    * @returns
    */
   async fromEditor(editor: IHubDiscussionEditor): Promise<IHubDiscussion> {
+    // TODO: move this into a util
     // Setting the thumbnailCache will ensure that
     // the thumbnail is updated on next save
     if (editor._thumbnail) {
@@ -217,15 +222,8 @@ export class HubDiscussion
 
     delete editor._thumbnail;
 
-    // convert back to an entity. Apply any reverse transforms used in
-    // of the toEditor method
-    const entity = cloneObject(editor) as IHubDiscussion;
-
-    // copy the location extent up one level
-    entity.extent = editor.location?.extent;
-
     // Save, which will also create new content if new
-    this.entity = entity;
+    this.entity = editorToEntity(editor, this.context.portal) as IHubDiscussion;
     await this.save();
 
     return this.entity;

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaEdit.ts
@@ -6,6 +6,7 @@ import { getLocationOptions } from "../../core/schemas/internal/getLocationOptio
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
 import { IHubDiscussion } from "../../core/types";
 import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
+import { getSlugSchemaElement } from "../../core/schemas/internal/getSlugSchemaElement";
 
 /**
  * @private
@@ -107,6 +108,7 @@ export const buildUiSchema = async (
         type: "Section",
         labelKey: `${i18nScope}.sections.searchDiscoverability.label`,
         elements: [
+          getSlugSchemaElement(i18nScope),
           {
             labelKey: `${i18nScope}.fields.tags.label`,
             scope: "/properties/tags",

--- a/packages/common/src/discussions/edit.ts
+++ b/packages/common/src/discussions/edit.ts
@@ -2,7 +2,7 @@ import { IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
 import { IHubDiscussion, IHubItemEntity } from "../core/types";
 import { createModel, getModel, updateModel } from "../models";
 import { constructSlug } from "../items/slugs";
-import { ensureUniqueEntitySlug } from "../items/_internal/slugs";
+import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
 import {
   createSetting,
   removeSetting,

--- a/packages/common/src/initiative-templates/HubInitiativeTemplate.ts
+++ b/packages/common/src/initiative-templates/HubInitiativeTemplate.ts
@@ -26,6 +26,7 @@ import {
 } from "./edit";
 import { enrichEntity } from "../core/enrichEntity";
 import { InitiativeTemplateEditorType } from "./_internal/InitiativeTemplateSchema";
+import { getEditorSlug } from "../core/_internal/getEditorSlug";
 
 /**
  * Hub Initiative Template Class
@@ -174,6 +175,9 @@ export class HubInitiativeTemplate
           this.context.hubRequestOptions
         )) as IHubInitiativeTemplateEditor)
       : (cloneObject(this.entity) as IHubInitiativeTemplateEditor);
+
+    // slug life
+    editor._slug = getEditorSlug(this.entity);
 
     // for now, just return
     return editor;

--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
@@ -4,6 +4,7 @@ import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThum
 import { IUiSchema, UiSchemaMessageTypes } from "../../core/schemas/types";
 import { getRecommendedTemplatesCatalog } from "./getRecommendedTemplatesCatalog";
 import { getEntityThumbnailUrl } from "../../core/getEntityThumbnailUrl";
+import { getSlugSchemaElement } from "../../core/schemas/internal/getSlugSchemaElement";
 
 /**
  * @private
@@ -49,6 +50,7 @@ export const buildUiSchema = async (
               ],
             },
           },
+          getSlugSchemaElement(i18nScope),
           {
             type: "Control",
             scope: "/properties/previewUrl",

--- a/packages/common/src/initiative-templates/edit.ts
+++ b/packages/common/src/initiative-templates/edit.ts
@@ -22,7 +22,7 @@ import { getPropertyMap } from "./_internal/getPropertyMap";
 import { cloneObject } from "../util";
 import { setDiscussableKeyword } from "../discussions";
 import { IModel } from "../types";
-import { ensureUniqueEntitySlug } from "../items/_internal/slugs";
+import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
 import { IHubItemEntity } from "../core";
 
 /**

--- a/packages/common/src/initiative-templates/edit.ts
+++ b/packages/common/src/initiative-templates/edit.ts
@@ -24,6 +24,7 @@ import { setDiscussableKeyword } from "../discussions";
 import { IModel } from "../types";
 import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
 import { IHubItemEntity } from "../core";
+import { editorToEntity } from "../core/schemas/internal/metrics/editorToEntity";
 
 /**
  * @private
@@ -82,6 +83,7 @@ export async function createInitiativeTemplate(
 }
 
 /**
+ * DEPRECATED: just use editorToEntity instead
  * Convert an IHubInitiativeTemplateEditor back to an IHubInitiativeTemplate
  * @param editor
  * @param portal
@@ -91,14 +93,7 @@ export function editorToInitiativeTemplate(
   editor: IHubInitiativeTemplateEditor,
   portal: IPortal
 ): IHubInitiativeTemplate {
-  // clone into HubInitiativeTemplate
-  const initiativeTemplate = cloneObject(editor) as IHubInitiativeTemplate;
-  // ensure there's an org url key
-  initiativeTemplate.orgUrlKey = editor.orgUrlKey
-    ? editor.orgUrlKey
-    : portal.urlKey;
-  // return initiatve template
-  return initiativeTemplate;
+  return editorToEntity(editor, portal) as IHubInitiativeTemplate;
 }
 
 /**

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -45,6 +45,7 @@ import { metricToEditor } from "../core/schemas/internal/metrics/metricToEditor"
 import { getGroup } from "@esri/arcgis-rest-portal";
 import { MembershipAccess } from "../core/types";
 import { convertGroupToHubGroup } from "../groups/_internal/convertGroupToHubGroup";
+import { getEditorSlug } from "../core/_internal/getEditorSlug";
 
 /**
  * Hub Initiative Class
@@ -309,6 +310,9 @@ export class HubInitiative
       };
       editor._associations = _associations;
     }
+
+    // 4. slug life
+    editor._slug = getEditorSlug(this.entity);
 
     return editor;
   }

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -57,7 +57,7 @@ import { createId } from "../util";
 import { IArcGISContext } from "../ArcGISContext";
 import { convertHubGroupToGroup } from "../groups/_internal/convertHubGroupToGroup";
 import { IHubGroup } from "../core/types/IHubGroup";
-import { ensureUniqueEntitySlug } from "../items/_internal/slugs";
+import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
 
 /**
  * @private

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -58,6 +58,7 @@ import { IArcGISContext } from "../ArcGISContext";
 import { convertHubGroupToGroup } from "../groups/_internal/convertHubGroupToGroup";
 import { IHubGroup } from "../core/types/IHubGroup";
 import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
+import { truncateSlug } from "../items/_internal/slugs";
 
 /**
  * @private
@@ -121,6 +122,7 @@ export async function editorToInitiative(
 ): Promise<IHubInitiative> {
   const _metric = editor._metric;
   const _associations = editor._associations;
+  const _slug = editor._slug;
 
   // 1. remove the ephemeral props we graft onto the editor
   delete editor._groups;
@@ -129,12 +131,18 @@ export async function editorToInitiative(
   delete editor._metric;
   delete editor._groups;
   delete editor._associations;
+  delete editor._slug;
 
   // 2. clone into a HubInitiative and ensure there's an orgUrlKey
   let initiative = cloneObject(editor) as IHubInitiative;
   initiative.orgUrlKey = editor.orgUrlKey
     ? editor.orgUrlKey
     : context.portal.urlKey;
+
+  // 2.5. slug life
+  if (_slug) {
+    initiative.slug = truncateSlug(_slug, initiative.orgUrlKey);
+  }
 
   // 3. copy the location extent up one level
   initiative.extent = editor.location?.extent;

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -1,4 +1,5 @@
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import { editorToEntity } from "../core/schemas/internal/metrics/editorToEntity";
 
 // Note - we separate these imports so we can cleanly spy on things in tests
 import {
@@ -122,7 +123,6 @@ export async function editorToInitiative(
 ): Promise<IHubInitiative> {
   const _metric = editor._metric;
   const _associations = editor._associations;
-  const _slug = editor._slug;
 
   // 1. remove the ephemeral props we graft onto the editor
   delete editor._groups;
@@ -131,21 +131,9 @@ export async function editorToInitiative(
   delete editor._metric;
   delete editor._groups;
   delete editor._associations;
-  delete editor._slug;
 
-  // 2. clone into a HubInitiative and ensure there's an orgUrlKey
-  let initiative = cloneObject(editor) as IHubInitiative;
-  initiative.orgUrlKey = editor.orgUrlKey
-    ? editor.orgUrlKey
-    : context.portal.urlKey;
-
-  // 2.5. slug life
-  if (_slug) {
-    initiative.slug = truncateSlug(_slug, initiative.orgUrlKey);
-  }
-
-  // 3. copy the location extent up one level
-  initiative.extent = editor.location?.extent;
+  // 2. clone into a HubInitiative and extract common properties
+  let initiative = editorToEntity(editor, context.portal) as IHubInitiative;
 
   // 4. handle configured metric:
   //   a. transform editor values into metric + displayConfig

--- a/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeUiSchemaEdit.ts
@@ -7,6 +7,7 @@ import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThum
 import { IHubInitiative } from "../../core";
 import { getAuthedImageUrl } from "../../core/_internal/getAuthedImageUrl";
 import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
+import { getSlugSchemaElement } from "../../core/schemas/internal/getSlugSchemaElement";
 
 /**
  * @private
@@ -181,6 +182,7 @@ export const buildUiSchema = async (
         type: "Section",
         labelKey: `${i18nScope}.sections.searchDiscoverability.label`,
         elements: [
+          getSlugSchemaElement(i18nScope),
           ...(await fetchCategoriesUiSchemaElement(i18nScope, context)),
           {
             labelKey: `${i18nScope}.fields.tags.label`,

--- a/packages/common/src/items/_internal/ensureUniqueEntitySlug.ts
+++ b/packages/common/src/items/_internal/ensureUniqueEntitySlug.ts
@@ -1,0 +1,17 @@
+import { IHubItemEntity } from "../../core";
+import { IHubRequestOptions } from "../../types";
+import { getUniqueSlug, setSlugKeyword } from "../slugs";
+
+// NOTE: this mutates the entity that is passed in
+export const ensureUniqueEntitySlug = async (
+  entity: IHubItemEntity,
+  requestOptions: IHubRequestOptions
+): Promise<IHubItemEntity> => {
+  // verify that the slug is unique
+  const { id: existingId, slug } = entity;
+  const slugInfo = existingId ? { slug, existingId } : { slug };
+  entity.slug = await getUniqueSlug(slugInfo, requestOptions);
+  // add slug to keywords
+  entity.typeKeywords = setSlugKeyword(entity.typeKeywords, entity.slug);
+  return entity;
+};

--- a/packages/common/src/items/_internal/slugs.ts
+++ b/packages/common/src/items/_internal/slugs.ts
@@ -1,17 +1,42 @@
-import { IHubItemEntity } from "../../core";
-import { IHubRequestOptions } from "../../types";
-import { getUniqueSlug, setSlugKeyword } from "../slugs";
+const TYPEKEYWORD_MAX_LENGTH = 256;
 
-// NOTE: this mutates the entity that is passed in
-export const ensureUniqueEntitySlug = async (
-  entity: IHubItemEntity,
-  requestOptions: IHubRequestOptions
-): Promise<IHubItemEntity> => {
-  // verify that the slug is unique
-  const { id: existingId, slug } = entity;
-  const slugInfo = existingId ? { slug, existingId } : { slug };
-  entity.slug = await getUniqueSlug(slugInfo, requestOptions);
-  // add slug to keywords
-  entity.typeKeywords = setSlugKeyword(entity.typeKeywords, entity.slug);
-  return entity;
-};
+export const TYPEKEYWORD_SLUG_PREFIX = "slug";
+
+/**
+ * truncate a slug, namespaced to an org and accounting for the 256 character limit
+ * of individual typekeywords.
+ *
+ * @param title
+ * @param orgKey
+ * @returns
+ */
+export function truncateSlug(slug: string, orgKey: string, paddingEnd = 0) {
+  // typekeywords have a max length of 256 characters, so we use the slug
+  // format that gets persisted in typekeywords as our basis
+  return (
+    [
+      // add the typekeyword slug prefix
+      TYPEKEYWORD_SLUG_PREFIX,
+      // add the orgKey segment
+      orgKey.toLowerCase(),
+      // add the slugified title segment
+      slug,
+    ]
+      .join("|")
+      .substring(0, TYPEKEYWORD_MAX_LENGTH - paddingEnd)
+      // removing tailing hyphens
+      .replace(/-+$/, "")
+      // remove typekeyword slug prefix, it's re-added in setSlugKeyword
+      .replace(new RegExp(`^${TYPEKEYWORD_SLUG_PREFIX}\\|`), "")
+  );
+}
+
+/**
+ * get the max length of a slug, accounting for the type keyword prefix and orgKey
+ * @param orgKey
+ * @returns
+ */
+export function getSlugMaxLength(orgKey: string) {
+  const prefix = `${TYPEKEYWORD_SLUG_PREFIX}|${orgKey}|`;
+  return TYPEKEYWORD_MAX_LENGTH - prefix.length;
+}

--- a/packages/common/src/items/slugs.ts
+++ b/packages/common/src/items/slugs.ts
@@ -2,11 +2,8 @@ import { getItem, ISearchOptions, searchItems } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IItem } from "@esri/arcgis-rest-types";
 import { slugify } from "../utils";
+import { TYPEKEYWORD_SLUG_PREFIX, truncateSlug } from "./_internal/slugs";
 import { uriSlugToKeywordSlug } from "./_internal/slugConverters";
-
-const TYPEKEYWORD_SLUG_PREFIX = "slug";
-
-export const TYPEKEYWORD_MAX_LENGTH = 256;
 
 /**
  * Create a slug, namespaced to an org and accounting for the 256 character limit
@@ -17,31 +14,15 @@ export const TYPEKEYWORD_MAX_LENGTH = 256;
  * @returns
  */
 export function constructSlug(title: string, orgKey: string) {
-  // typekeywords have a max length of 256 characters, so we use the slug
-  // format that gets persisted in typekeywords as our basis
-  return (
-    [
-      // add the typekeyword slug prefix
-      TYPEKEYWORD_SLUG_PREFIX,
-      // add the orgKey segment
-      orgKey.toLowerCase(),
-      // add the slugified title segment
-      slugify(title),
-    ]
-      .join("|")
-      // allow some padding at the end for incrementing so we don't wind up w/ weird, inconsistent slugs
-      // when the increment goes from single to multiple digits, i.e. avoid producing the following when
-      // deduping:
-      // slug|qa-pre-a-hub|some-really-really-...-really-long
-      // slug|qa-pre-a-hub|some-really-really-...-really-lo-1
-      // slug|qa-pre-a-hub|some-really-really-...-really-l-11
-      // slug|qa-pre-a-hub|some-really-really-...-really-100
-      .substring(0, TYPEKEYWORD_MAX_LENGTH - 4)
-      // removing tailing hyphens
-      .replace(/-+$/, "")
-      // remove typekeyword slug prefix, it's re-added in setSlugKeyword
-      .replace(new RegExp(`^${TYPEKEYWORD_SLUG_PREFIX}\\|`), "")
-  );
+  // allow some padding at the end for incrementing so we don't wind up w/ weird, inconsistent slugs
+  // when the increment goes from single to multiple digits,
+  // avoid producing the following when deduping:
+  // slug|qa-pre-a-hub|some-really-really-...-really-long
+  // slug|qa-pre-a-hub|some-really-really-...-really-lo-1
+  // slug|qa-pre-a-hub|some-really-really-...-really-l-11
+  // slug|qa-pre-a-hub|some-really-really-...-really-100
+  const paddingEnd = 4;
+  return truncateSlug(slugify(title), orgKey, paddingEnd);
 }
 
 /**

--- a/packages/common/src/items/slugs.ts
+++ b/packages/common/src/items/slugs.ts
@@ -6,7 +6,7 @@ import { uriSlugToKeywordSlug } from "./_internal/slugConverters";
 
 const TYPEKEYWORD_SLUG_PREFIX = "slug";
 
-const TYPEKEYWORD_MAX_LENGTH = 256;
+export const TYPEKEYWORD_MAX_LENGTH = 256;
 
 /**
  * Create a slug, namespaced to an org and accounting for the 256 character limit

--- a/packages/common/src/pages/HubPage.ts
+++ b/packages/common/src/pages/HubPage.ts
@@ -22,6 +22,8 @@ import { createPage, deletePage, fetchPage, updatePage } from "./HubPages";
 import { PageEditorType } from "./_internal/PageSchema";
 import { cloneObject } from "../util";
 import { enrichEntity } from "../core/enrichEntity";
+import { getEditorSlug } from "../core/_internal/getEditorSlug";
+import { editorToEntity } from "../core/schemas/internal/metrics/editorToEntity";
 
 /*
   TODO:
@@ -216,6 +218,7 @@ export class HubPage
 
     // 2. Apply transforms to relevant entity values so they
     // can be consumed by the editor
+    editor._slug = getEditorSlug(this.entity);
 
     return editor;
   }
@@ -248,10 +251,7 @@ export class HubPage
 
     // convert back to an entity. Apply any reverse transforms used in
     // of the toEditor method
-    const entity = cloneObject(editor) as IHubPage;
-
-    // copy the location extent up one level
-    entity.extent = editor.location?.extent;
+    const entity = editorToEntity(editor, this.context.portal) as IHubPage;
 
     // create it if it does not yet exist...
     this.entity = entity;

--- a/packages/common/src/pages/HubPages.ts
+++ b/packages/common/src/pages/HubPages.ts
@@ -28,7 +28,7 @@ import { computeProps } from "./_internal/computeProps";
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
 import { DEFAULT_PAGE, DEFAULT_PAGE_MODEL } from "./defaults";
-import { ensureUniqueEntitySlug } from "../items/_internal/slugs";
+import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
 
 /**
  * @private

--- a/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
+++ b/packages/common/src/pages/_internal/PageUiSchemaEdit.ts
@@ -6,6 +6,7 @@ import { getLocationOptions } from "../../core/schemas/internal/getLocationOptio
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
 import { IHubPage } from "../../core/types";
 import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
+import { getSlugSchemaElement } from "../../core/schemas/internal/getSlugSchemaElement";
 
 /**
  * @private
@@ -86,6 +87,7 @@ export const buildUiSchema = async (
             "page",
             context.requestOptions
           ),
+          getSlugSchemaElement(i18nScope),
           {
             labelKey: `${i18nScope}.fields.tags.label`,
             scope: "/properties/tags",

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -41,6 +41,7 @@ import { IMetricDisplayConfig } from "../core/types/Metrics";
 import { upsertResource } from "../resources/upsertResource";
 import { doesResourceExist } from "../resources/doesResourceExist";
 import { removeResource } from "../resources/removeResource";
+import { getEditorSlug } from "../core/_internal/getEditorSlug";
 
 /**
  * Hub Project Class
@@ -211,6 +212,9 @@ export class HubProject
           display.metricId === editorContext.metricId
       ) || {};
     editor._metric = metricToEditor(metric, displayConfig);
+
+    // 4. slug life
+    editor._slug = getEditorSlug(this.entity);
 
     return editor;
   }

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -8,6 +8,7 @@ import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThum
 import { IHubProject } from "../../core/types";
 import { getAuthedImageUrl } from "../../core/_internal/getAuthedImageUrl";
 import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
+import { getSlugSchemaElement } from "../../core/schemas/internal/getSlugSchemaElement";
 
 /**
  * @private
@@ -147,31 +148,7 @@ export const buildUiSchema = async (
         type: "Section",
         labelKey: `${i18nScope}.sections.searchDiscoverability.label`,
         elements: [
-          {
-            labelKey: `${i18nScope}.fields.slug.label`,
-            scope: "/properties/_slug",
-            type: "Control",
-            options: {
-              control: "hub-field-input-input",
-              helperText: {
-                labelKey: `${i18nScope}.fields.slug.helperText`,
-              },
-              messages: [
-                {
-                  type: "ERROR",
-                  keyword: "pattern",
-                  icon: true,
-                  labelKey: `${i18nScope}.fields.slug.patternError`,
-                },
-                {
-                  type: "ERROR",
-                  keyword: "isUniqueSlug",
-                  icon: true,
-                  labelKey: `${i18nScope}.fields.slug.isUniqueError`,
-                },
-              ],
-            },
-          },
+          getSlugSchemaElement(i18nScope),
           {
             labelKey: `${i18nScope}.fields.tags.label`,
             scope: "/properties/tags",

--- a/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
+++ b/packages/common/src/projects/_internal/ProjectUiSchemaEdit.ts
@@ -148,6 +148,31 @@ export const buildUiSchema = async (
         labelKey: `${i18nScope}.sections.searchDiscoverability.label`,
         elements: [
           {
+            labelKey: `${i18nScope}.fields.slug.label`,
+            scope: "/properties/_slug",
+            type: "Control",
+            options: {
+              control: "hub-field-input-input",
+              helperText: {
+                labelKey: `${i18nScope}.fields.slug.helperText`,
+              },
+              messages: [
+                {
+                  type: "ERROR",
+                  keyword: "pattern",
+                  icon: true,
+                  labelKey: `${i18nScope}.fields.slug.patternError`,
+                },
+                {
+                  type: "ERROR",
+                  keyword: "isUniqueSlug",
+                  icon: true,
+                  labelKey: `${i18nScope}.fields.slug.isUniqueError`,
+                },
+              ],
+            },
+          },
+          {
             labelKey: `${i18nScope}.fields.tags.label`,
             scope: "/properties/tags",
             type: "Control",

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -2,7 +2,8 @@ import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 // Note - we separate these imports so we can cleanly spy on things in tests
 import { createModel, getModel, updateModel } from "../models";
-import { constructSlug, getUniqueSlug, setSlugKeyword } from "../items/slugs";
+import { constructSlug } from "../items/slugs";
+import { truncateSlug } from "../items/_internal/slugs";
 import {
   IPortal,
   IUserItemOptions,
@@ -19,7 +20,7 @@ import { IModel } from "../types";
 import { setEntityStatusKeyword } from "../utils/internal/setEntityStatusKeyword";
 import { editorToMetric } from "../core/schemas/internal/metrics/editorToMetric";
 import { setMetricAndDisplay } from "../core/schemas/internal/metrics/setMetricAndDisplay";
-import { ensureUniqueEntitySlug } from "../items/_internal/slugs";
+import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
 
 /**
  * @private
@@ -95,7 +96,7 @@ export function editorToProject(
 
   // 2.5. slug life
   if (_slug) {
-    project.slug = `${project.orgUrlKey}|${_slug}`;
+    project.slug = truncateSlug(_slug, project.orgUrlKey);
   }
 
   // 3. copy the location extent up one level

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -79,6 +79,7 @@ export function editorToProject(
   portal: IPortal
 ): IHubProject {
   const _metric = editor._metric;
+  const _slug = editor._slug;
 
   // 1. remove the ephemeral props we graft onto the editor
   delete editor._groups;
@@ -86,10 +87,16 @@ export function editorToProject(
   delete editor.view?.featuredImage;
   delete editor._metric;
   delete editor._groups;
+  delete editor._slug;
 
   // 2. clone into a HubProject and ensure there's an orgUrlKey
   let project = cloneObject(editor) as IHubProject;
   project.orgUrlKey = editor.orgUrlKey ? editor.orgUrlKey : portal.urlKey;
+
+  // 2.5. slug life
+  if (_slug) {
+    project.slug = `${project.orgUrlKey}|${_slug}`;
+  }
 
   // 3. copy the location extent up one level
   project.extent = editor.location?.extent;

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -21,6 +21,7 @@ import { setEntityStatusKeyword } from "../utils/internal/setEntityStatusKeyword
 import { editorToMetric } from "../core/schemas/internal/metrics/editorToMetric";
 import { setMetricAndDisplay } from "../core/schemas/internal/metrics/setMetricAndDisplay";
 import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
+import { editorToEntity } from "../core/schemas/internal/metrics/editorToEntity";
 
 /**
  * @private
@@ -80,7 +81,6 @@ export function editorToProject(
   portal: IPortal
 ): IHubProject {
   const _metric = editor._metric;
-  const _slug = editor._slug;
 
   // 1. remove the ephemeral props we graft onto the editor
   delete editor._groups;
@@ -88,19 +88,9 @@ export function editorToProject(
   delete editor.view?.featuredImage;
   delete editor._metric;
   delete editor._groups;
-  delete editor._slug;
 
-  // 2. clone into a HubProject and ensure there's an orgUrlKey
-  let project = cloneObject(editor) as IHubProject;
-  project.orgUrlKey = editor.orgUrlKey ? editor.orgUrlKey : portal.urlKey;
-
-  // 2.5. slug life
-  if (_slug) {
-    project.slug = truncateSlug(_slug, project.orgUrlKey);
-  }
-
-  // 3. copy the location extent up one level
-  project.extent = editor.location?.extent;
+  // 2. clone into a HubProject and extract common properties
+  let project = editorToEntity(editor, portal) as IHubProject;
 
   // 4. handle configured metric:
   //   a. transform editor values into metric + displayConfig

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -52,6 +52,8 @@ import {
   SettableAccessLevel,
 } from "../index";
 import { SiteEditorType } from "./_internal/SiteSchema";
+import { getEditorSlug } from "../core/_internal/getEditorSlug";
+import { editorToEntity } from "../core/schemas/internal/metrics/editorToEntity";
 
 /**
  * Hub Site Class
@@ -428,6 +430,8 @@ export class HubSite
       editor
     );
 
+    editor._slug = getEditorSlug(this.entity);
+
     const followersGroup = await this.getFollowersGroup();
     setProp("_followers.isDiscussable", isDiscussable(followersGroup), editor);
 
@@ -490,16 +494,13 @@ export class HubSite
 
     // 2. Convert editor values back to an entity e.g. apply
     // any reverse transforms used in the toEditor method
-    const entity = cloneObject(editor) as IHubSite;
+    const entity = editorToEntity(editor, this.context.portal) as IHubSite;
 
     entity.features = {
       ...entity.features,
       "hub:site:feature:follow": editor._followers?.showFollowAction,
       "hub:site:feature:discussions": editor._discussions,
     };
-
-    // copy the location extent up one level
-    entity.extent = editor.location?.extent;
 
     // site URL info
     const { url, subdomain, defaultHostname } = editor._urlInfo;

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -42,7 +42,7 @@ import { reflectCollectionsToSearchCategories } from "./_internal/reflectCollect
 import { convertCatalogToLegacyFormat } from "./_internal/convertCatalogToLegacyFormat";
 import { convertFeaturesToLegacyCapabilities } from "./_internal/capabilities/convertFeaturesToLegacyCapabilities";
 import { computeLinks } from "./_internal/computeLinks";
-import { ensureUniqueEntitySlug } from "../items/_internal/slugs";
+import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
 import { IHubItemEntity } from "../core";
 export const HUB_SITE_ITEM_TYPE = "Hub Site Application";
 export const ENTERPRISE_SITE_ITEM_TYPE = "Site Application";

--- a/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaEdit.ts
@@ -6,6 +6,7 @@ import { IUiSchema } from "../../core/schemas/types";
 import { getThumbnailUiSchemaElement } from "../../core/schemas/internal/getThumbnailUiSchemaElement";
 import { IHubSite } from "../../core/types";
 import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
+import { getSlugSchemaElement } from "../../core/schemas/internal/getSlugSchemaElement";
 
 /**
  * @private
@@ -86,6 +87,7 @@ export const buildUiSchema = async (
             "site",
             context.requestOptions
           ),
+          getSlugSchemaElement(i18nScope),
           {
             labelKey: `${i18nScope}.fields.tags.label`,
             scope: "/properties/tags",

--- a/packages/common/src/templates/edit.ts
+++ b/packages/common/src/templates/edit.ts
@@ -13,7 +13,7 @@ import {
   IUserItemOptions,
   removeItem,
 } from "@esri/arcgis-rest-portal";
-import { ensureUniqueEntitySlug } from "../items/_internal/slugs";
+import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
 
 /**
  * @private

--- a/packages/common/test/core/schemas/internal/addConditionalSlugValidation.test.ts
+++ b/packages/common/test/core/schemas/internal/addConditionalSlugValidation.test.ts
@@ -1,0 +1,61 @@
+import { addConditionalSlugValidation } from "../../../../src/core/schemas/internal/addConditionalSlugValidation";
+
+describe("addConditionalSlugValidation", () => {
+  it("returns the schema if no slug is present on properties", () => {
+    const schema = {
+      properties: {},
+    };
+    const options = {};
+    const result = addConditionalSlugValidation(schema, options);
+    expect(result).toBe(schema);
+  });
+  it("returns the schema if no properties", () => {
+    const schema = {};
+    const options = {};
+    const result = addConditionalSlugValidation(schema, options);
+    expect(result).toBe(schema);
+  });
+  it("adds the conditional validation", () => {
+    const schema = {
+      properties: {
+        _slug: {
+          pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+        },
+      },
+      // allOf: [],
+    } as any;
+    const options = {
+      orgUrlKey: "orgUrlKey",
+      id: "id",
+    } as any;
+    const result = addConditionalSlugValidation(schema, options);
+    expect(result).toEqual({
+      properties: {
+        _slug: {
+          pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+        },
+      },
+      allOf: [
+        {
+          if: {
+            properties: {
+              _slug: {
+                pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+              },
+            },
+          },
+          then: {
+            properties: {
+              _slug: {
+                isUniqueSlug: {
+                  id: "id",
+                  orgUrlKey: "orgUrlKey",
+                },
+              } as any,
+            },
+          },
+        },
+      ],
+    });
+  });
+});

--- a/packages/common/test/core/schemas/internal/addDynamicSlugValidation.test.ts
+++ b/packages/common/test/core/schemas/internal/addDynamicSlugValidation.test.ts
@@ -1,21 +1,22 @@
-import { addConditionalSlugValidation } from "../../../../src/core/schemas/internal/addConditionalSlugValidation";
+import { addDynamicSlugValidation } from "../../../../src/core/schemas/internal/addDynamicSlugValidation";
+import { TYPEKEYWORD_MAX_LENGTH } from "../../../../src/items/slugs";
 
-describe("addConditionalSlugValidation", () => {
-  it("returns the schema if no slug is present on properties", () => {
+describe("addDynamicSlugValidation", () => {
+  it("returns the original schema if no slug is present on properties", () => {
     const schema = {
       properties: {},
     };
     const options = {};
-    const result = addConditionalSlugValidation(schema, options);
+    const result = addDynamicSlugValidation(schema, options);
     expect(result).toBe(schema);
   });
-  it("returns the schema if no properties", () => {
+  it("returns the original schema if no properties", () => {
     const schema = {};
     const options = {};
-    const result = addConditionalSlugValidation(schema, options);
+    const result = addDynamicSlugValidation(schema, options);
     expect(result).toBe(schema);
   });
-  it("adds the conditional validation", () => {
+  it("adds the dynamic validation", () => {
     const schema = {
       properties: {
         _slug: {
@@ -28,11 +29,12 @@ describe("addConditionalSlugValidation", () => {
       orgUrlKey: "orgUrlKey",
       id: "id",
     } as any;
-    const result = addConditionalSlugValidation(schema, options);
+    const result = addDynamicSlugValidation(schema, options);
     expect(result).toEqual({
       properties: {
         _slug: {
           pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+          maxLength: TYPEKEYWORD_MAX_LENGTH - (options.orgUrlKey.length + 1),
         },
       },
       allOf: [

--- a/packages/common/test/core/schemas/internal/addDynamicSlugValidation.test.ts
+++ b/packages/common/test/core/schemas/internal/addDynamicSlugValidation.test.ts
@@ -1,5 +1,4 @@
 import { addDynamicSlugValidation } from "../../../../src/core/schemas/internal/addDynamicSlugValidation";
-import { TYPEKEYWORD_MAX_LENGTH } from "../../../../src/items/slugs";
 
 describe("addDynamicSlugValidation", () => {
   it("returns the original schema if no slug is present on properties", () => {
@@ -34,7 +33,7 @@ describe("addDynamicSlugValidation", () => {
       properties: {
         _slug: {
           pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
-          maxLength: TYPEKEYWORD_MAX_LENGTH - (options.orgUrlKey.length + 1),
+          maxLength: 256 - ("slug".length + 1) - (options.orgUrlKey.length + 1),
         },
       },
       allOf: [

--- a/packages/common/test/core/schemas/internal/getSlugSchemaElement.test.ts
+++ b/packages/common/test/core/schemas/internal/getSlugSchemaElement.test.ts
@@ -1,0 +1,32 @@
+import { getSlugSchemaElement } from "../../../../src/core/schemas/internal/getSlugSchemaElement";
+
+describe("getSlugSchemaElement", () => {
+  it("returns a slug schema element", () => {
+    const element = getSlugSchemaElement("some.scope");
+    expect(element).toEqual({
+      labelKey: "some.scope.fields.slug.label",
+      scope: "/properties/_slug",
+      type: "Control",
+      options: {
+        control: "hub-field-input-input",
+        helperText: {
+          labelKey: "some.scope.fields.slug.helperText",
+        },
+        messages: [
+          {
+            type: "ERROR",
+            keyword: "pattern",
+            icon: true,
+            labelKey: "some.scope.fields.slug.patternError",
+          },
+          {
+            type: "ERROR",
+            keyword: "isUniqueSlug",
+            icon: true,
+            labelKey: "some.scope.fields.slug.isUniqueError",
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/common/test/discussions/HubDiscussion.test.ts
+++ b/packages/common/test/discussions/HubDiscussion.test.ts
@@ -344,40 +344,6 @@ describe("HubDiscussion Class:", () => {
         // other than via code-coverage
         expect(getProp(result, "_thumbnail")).not.toBeDefined();
       });
-      it("handles extent from location", async () => {
-        const chk = HubDiscussion.fromJson(
-          {
-            id: "bc3",
-            name: "Test Entity",
-            thumbnailUrl: "https://myserver.com/thumbnail.png",
-            extent: [
-              [-1, -1],
-              [1, 1],
-            ],
-          },
-          authdCtxMgr.context
-        );
-        // spy on the instance .save method and retrn void
-        const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
-        // make changes to the editor
-        const editor = await chk.toEditor();
-        editor.name = "new name";
-        editor.location = {
-          extent: [
-            [-2, -2],
-            [2, 2],
-          ],
-          type: "custom",
-        };
-        // call fromEditor
-        const result = await chk.fromEditor(editor);
-        // expect the save method to have been called
-        expect(saveSpy).toHaveBeenCalledTimes(1);
-        expect(result.extent).toEqual([
-          [-2, -2],
-          [2, 2],
-        ]);
-      });
       it("throws if creating", async () => {
         const chk = HubDiscussion.fromJson(
           {

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -5,9 +5,14 @@ import * as getLocationExtentModule from "../../../src/core/schemas/internal/get
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
 import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
+import * as getSlugSchemaElementModule from "../../../src/core/schemas/internal/getSlugSchemaElement";
 
 describe("buildUiSchema: discussion edit", () => {
-  it("returns the full discussion edit uiSchema", async () => {
+  const mockSlugElement = {
+    labelKey: "slug",
+    scope: "/properties/_slug",
+  } as any;
+  beforeEach(() => {
     spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
@@ -25,7 +30,11 @@ describe("buildUiSchema: discussion edit", () => {
     spyOn(getTagItemsModule, "getTagItems").and.returnValue(
       Promise.resolve([])
     );
-
+    spyOn(getSlugSchemaElementModule, "getSlugSchemaElement").and.returnValue(
+      mockSlugElement
+    );
+  });
+  it("returns the full discussion edit uiSchema", async () => {
     const uiSchema = await buildUiSchema(
       "some.scope",
       {
@@ -151,6 +160,7 @@ describe("buildUiSchema: discussion edit", () => {
           type: "Section",
           labelKey: "some.scope.sections.searchDiscoverability.label",
           elements: [
+            mockSlugElement,
             {
               labelKey: "some.scope.fields.tags.label",
               scope: "/properties/tags",
@@ -261,24 +271,6 @@ describe("buildUiSchema: discussion edit", () => {
     });
   });
   it("returns the full discussion edit uiSchema when entity does have a view", async () => {
-    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
-      Promise.resolve([
-        {
-          value: "/categories",
-          label: "/categories",
-        },
-      ])
-    );
-    spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
-      Promise.resolve([])
-    );
-    spyOn(getLocationOptionsModule, "getLocationOptions").and.returnValue(
-      Promise.resolve([])
-    );
-    spyOn(getTagItemsModule, "getTagItems").and.returnValue(
-      Promise.resolve([])
-    );
-
     const uiSchema = await buildUiSchema(
       "some.scope",
       {
@@ -407,6 +399,7 @@ describe("buildUiSchema: discussion edit", () => {
           type: "Section",
           labelKey: "some.scope.sections.searchDiscoverability.label",
           elements: [
+            mockSlugElement,
             {
               labelKey: "some.scope.fields.tags.label",
               scope: "/properties/tags",

--- a/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
@@ -5,13 +5,23 @@ import {
   UiSchemaRuleEffects,
 } from "../../../src/core/schemas/types";
 import * as getRecommendedTemplatesCatalogModule from "../../../src/initiative-templates/_internal/getRecommendedTemplatesCatalog";
+import * as getSlugSchemaElementModule from "../../../src/core/schemas/internal/getSlugSchemaElement";
 
 describe("buildUiSchema: initiative template edit", () => {
-  it("returns the full initiative template edit uiSchema", async () => {
+  const mockSlugElement = {
+    labelKey: "slug",
+    scope: "/properties/_slug",
+  } as any;
+  beforeEach(() => {
     spyOn(
       getRecommendedTemplatesCatalogModule,
       "getRecommendedTemplatesCatalog"
     ).and.returnValue([]);
+    spyOn(getSlugSchemaElementModule, "getSlugSchemaElement").and.returnValue(
+      mockSlugElement
+    );
+  });
+  it("returns the full initiative template edit uiSchema", async () => {
     const uiSchema = await buildUiSchema(
       "some.scope",
       {
@@ -48,6 +58,7 @@ describe("buildUiSchema: initiative template edit", () => {
                 ],
               },
             },
+            mockSlugElement,
             {
               type: "Control",
               scope: "/properties/previewUrl",

--- a/packages/common/test/initiative-templates/edit.test.ts
+++ b/packages/common/test/initiative-templates/edit.test.ts
@@ -5,8 +5,6 @@ import {
   createInitiativeTemplate,
   IHubInitiativeTemplate,
   updateInitiativeTemplate,
-  IHubInitiativeTemplateEditor,
-  editorToInitiativeTemplate,
 } from "../../src";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as portalModule from "@esri/arcgis-rest-portal";
@@ -193,28 +191,6 @@ describe("initiative template edit module:", () => {
       const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
       expect(modelToUpdate.item.description).toBe(it.description);
       expect(modelToUpdate.item.properties.slug).toBe("dcdev-wat-blarg-1");
-    });
-  });
-
-  describe("editor to initiative template", () => {
-    it("basic transform", () => {
-      const editor: IHubInitiativeTemplateEditor = {
-        orgUrlKey: "bar",
-      } as unknown as IHubInitiativeTemplateEditor;
-      const it = editorToInitiativeTemplate(editor, {
-        urlKey: "foo",
-      } as unknown as portalModule.IPortal);
-      expect(it.orgUrlKey).toEqual("bar");
-    });
-
-    it("sparse transform", () => {
-      const editor: IHubInitiativeTemplateEditor =
-        {} as unknown as IHubInitiativeTemplateEditor;
-      const p = editorToInitiativeTemplate(editor, {
-        urlKey: "foo",
-      } as unknown as portalModule.IPortal);
-      expect(p.orgUrlKey).toEqual("foo");
-      expect(p.extent).toBeUndefined();
     });
   });
 });

--- a/packages/common/test/initiatives/HubInitiative.test.ts
+++ b/packages/common/test/initiatives/HubInitiative.test.ts
@@ -534,40 +534,6 @@ describe("HubInitiative Class:", () => {
         // other than via code-coverage
         expect(getProp(result, "_thumbnail")).not.toBeDefined();
       });
-      it("handles extent from location", async () => {
-        const chk = HubInitiative.fromJson(
-          {
-            id: "bc3",
-            name: "Test Entity",
-            thumbnailUrl: "https://myserver.com/thumbnail.png",
-            extent: [
-              [-1, -1],
-              [1, 1],
-            ],
-          },
-          authdCtxMgr.context
-        );
-        // spy on the instance .save method and retrn void
-        const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
-        // make changes to the editor
-        const editor = await chk.toEditor();
-        editor.name = "new name";
-        editor.location = {
-          extent: [
-            [-2, -2],
-            [2, 2],
-          ],
-          type: "custom",
-        };
-        // call fromEditor
-        const result = await chk.fromEditor(editor);
-        // expect the save method to have been called
-        expect(saveSpy).toHaveBeenCalledTimes(1);
-        expect(result.extent).toEqual([
-          [-2, -2],
-          [2, 2],
-        ]);
-      });
       it("handles setting featured image", async () => {
         const chk = HubInitiative.fromJson(
           {

--- a/packages/common/test/initiatives/HubInitiatives.test.ts
+++ b/packages/common/test/initiatives/HubInitiatives.test.ts
@@ -628,42 +628,6 @@ describe("HubInitiatives:", () => {
       expect(res._metric).toBeUndefined();
       expect(res._associations).toBeUndefined();
     });
-    // it("ensures the project has an orgUrlKey", async () => {
-    //   const editor: IHubInitiativeEditor = {
-    //     orgUrlKey: "bar",
-    //   } as unknown as IHubInitiativeEditor;
-
-    //   const res = await editorToInitiative(editor, context);
-
-    //   expect(res.orgUrlKey).toEqual("bar");
-    // });
-    // it("copies the location extent up one level", async () => {
-    //   const editor: IHubInitiativeEditor = {
-    //     location: {
-    //       extent: [
-    //         [1, 2],
-    //         [3, 4],
-    //       ],
-    //     },
-    //   } as unknown as IHubInitiativeEditor;
-
-    //   const res = await editorToInitiative(editor, context);
-
-    //   expect(res.extent).toEqual([
-    //     [1, 2],
-    //     [3, 4],
-    //   ]);
-    // });
-    // it("transforms the slug", async () => {
-    //   const editor: IHubInitiativeEditor = {
-    //     _slug: "updated-slug",
-    //   } as unknown as IHubInitiativeEditor;
-
-    //   const res = await editorToInitiative(editor, context);
-
-    //   expect(res.slug).toEqual("foo|updated-slug");
-    //   expect(res._slug).toBeUndefined();
-    // });
     describe("metrics", () => {
       let mockMetric: IMetric;
       let mockMetricDisplay: IMetricDisplayConfig;

--- a/packages/common/test/initiatives/HubInitiatives.test.ts
+++ b/packages/common/test/initiatives/HubInitiatives.test.ts
@@ -628,42 +628,42 @@ describe("HubInitiatives:", () => {
       expect(res._metric).toBeUndefined();
       expect(res._associations).toBeUndefined();
     });
-    it("ensures the project has an orgUrlKey", async () => {
-      const editor: IHubInitiativeEditor = {
-        orgUrlKey: "bar",
-      } as unknown as IHubInitiativeEditor;
+    // it("ensures the project has an orgUrlKey", async () => {
+    //   const editor: IHubInitiativeEditor = {
+    //     orgUrlKey: "bar",
+    //   } as unknown as IHubInitiativeEditor;
 
-      const res = await editorToInitiative(editor, context);
+    //   const res = await editorToInitiative(editor, context);
 
-      expect(res.orgUrlKey).toEqual("bar");
-    });
-    it("copies the location extent up one level", async () => {
-      const editor: IHubInitiativeEditor = {
-        location: {
-          extent: [
-            [1, 2],
-            [3, 4],
-          ],
-        },
-      } as unknown as IHubInitiativeEditor;
+    //   expect(res.orgUrlKey).toEqual("bar");
+    // });
+    // it("copies the location extent up one level", async () => {
+    //   const editor: IHubInitiativeEditor = {
+    //     location: {
+    //       extent: [
+    //         [1, 2],
+    //         [3, 4],
+    //       ],
+    //     },
+    //   } as unknown as IHubInitiativeEditor;
 
-      const res = await editorToInitiative(editor, context);
+    //   const res = await editorToInitiative(editor, context);
 
-      expect(res.extent).toEqual([
-        [1, 2],
-        [3, 4],
-      ]);
-    });
-    it("transforms the slug", async () => {
-      const editor: IHubInitiativeEditor = {
-        _slug: "updated-slug",
-      } as unknown as IHubInitiativeEditor;
+    //   expect(res.extent).toEqual([
+    //     [1, 2],
+    //     [3, 4],
+    //   ]);
+    // });
+    // it("transforms the slug", async () => {
+    //   const editor: IHubInitiativeEditor = {
+    //     _slug: "updated-slug",
+    //   } as unknown as IHubInitiativeEditor;
 
-      const res = await editorToInitiative(editor, context);
+    //   const res = await editorToInitiative(editor, context);
 
-      expect(res.slug).toEqual("foo|updated-slug");
-      expect(res._slug).toBeUndefined();
-    });
+    //   expect(res.slug).toEqual("foo|updated-slug");
+    //   expect(res._slug).toBeUndefined();
+    // });
     describe("metrics", () => {
       let mockMetric: IMetric;
       let mockMetricDisplay: IMetricDisplayConfig;

--- a/packages/common/test/initiatives/HubInitiatives.test.ts
+++ b/packages/common/test/initiatives/HubInitiatives.test.ts
@@ -601,6 +601,11 @@ describe("HubInitiatives:", () => {
   });
 
   describe("editor to initiative", () => {
+    const context = {
+      portal: {
+        urlKey: "foo",
+      } as unknown as portalModule.IPortal,
+    } as unknown as IArcGISContext;
     it("removes ephemeral props", async () => {
       const editor: IHubInitiativeEditor = {
         _groups: [],
@@ -615,11 +620,7 @@ describe("HubInitiatives:", () => {
         },
       } as unknown as IHubInitiativeEditor;
 
-      const res = await editorToInitiative(editor, {
-        portal: {
-          urlKey: "foo",
-        } as unknown as portalModule.IPortal,
-      } as unknown as IArcGISContext);
+      const res = await editorToInitiative(editor, context);
 
       expect(res._groups).toBeUndefined();
       expect(res._thumbnail).toBeUndefined();
@@ -632,11 +633,7 @@ describe("HubInitiatives:", () => {
         orgUrlKey: "bar",
       } as unknown as IHubInitiativeEditor;
 
-      const res = await editorToInitiative(editor, {
-        portal: {
-          urlKey: "foo",
-        } as unknown as portalModule.IPortal,
-      } as unknown as IArcGISContext);
+      const res = await editorToInitiative(editor, context);
 
       expect(res.orgUrlKey).toEqual("bar");
     });
@@ -650,16 +647,22 @@ describe("HubInitiatives:", () => {
         },
       } as unknown as IHubInitiativeEditor;
 
-      const res = await editorToInitiative(editor, {
-        portal: {
-          urlKey: "foo",
-        } as unknown as portalModule.IPortal,
-      } as unknown as IArcGISContext);
+      const res = await editorToInitiative(editor, context);
 
       expect(res.extent).toEqual([
         [1, 2],
         [3, 4],
       ]);
+    });
+    it("transforms the slug", async () => {
+      const editor: IHubInitiativeEditor = {
+        _slug: "updated-slug",
+      } as unknown as IHubInitiativeEditor;
+
+      const res = await editorToInitiative(editor, context);
+
+      expect(res.slug).toEqual("foo|updated-slug");
+      expect(res._slug).toBeUndefined();
     });
     describe("metrics", () => {
       let mockMetric: IMetric;

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -7,9 +7,14 @@ import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fe
 import * as getFeaturedContentCatalogsModule from "../../../src/core/schemas/internal/getFeaturedContentCatalogs";
 import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
 import * as getAuthedImageUrlModule from "../../../src/core/_internal/getAuthedImageUrl";
+import * as getSlugSchemaElementModule from "../../../src/core/schemas/internal/getSlugSchemaElement";
 
 describe("buildUiSchema: initiative edit", () => {
-  it("returns the full initiative edit uiSchema", async () => {
+  const mockSlugElement = {
+    labelKey: "slug",
+    scope: "/properties/_slug",
+  } as any;
+  beforeEach(() => {
     spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
@@ -17,6 +22,13 @@ describe("buildUiSchema: initiative edit", () => {
           label: "/categories",
         },
       ])
+    );
+    spyOn(
+      getFeaturedContentCatalogsModule,
+      "getFeaturedContentCatalogs"
+    ).and.returnValue({});
+    spyOn(getAuthedImageUrlModule, "getAuthedImageUrl").and.returnValue(
+      "https://some-image-url.com"
     );
     spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
       Promise.resolve([])
@@ -27,14 +39,11 @@ describe("buildUiSchema: initiative edit", () => {
     spyOn(getTagItemsModule, "getTagItems").and.returnValue(
       Promise.resolve([])
     );
-    spyOn(
-      getFeaturedContentCatalogsModule,
-      "getFeaturedContentCatalogs"
-    ).and.returnValue({});
-    spyOn(getAuthedImageUrlModule, "getAuthedImageUrl").and.returnValue(
-      "https://some-image-url.com"
+    spyOn(getSlugSchemaElementModule, "getSlugSchemaElement").and.returnValue(
+      mockSlugElement
     );
-
+  });
+  it("returns the full initiative edit uiSchema", async () => {
     const uiSchema = await buildUiSchema(
       "some.scope",
       {
@@ -193,6 +202,7 @@ describe("buildUiSchema: initiative edit", () => {
           type: "Section",
           labelKey: "some.scope.sections.searchDiscoverability.label",
           elements: [
+            mockSlugElement,
             {
               labelKey: "shared.fields.categories.label",
               scope: "/properties/categories",
@@ -374,31 +384,6 @@ describe("buildUiSchema: initiative edit", () => {
     });
   });
   it("returns the full initiative edit uiSchema with a defined view", async () => {
-    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
-      Promise.resolve([
-        {
-          value: "/categories",
-          label: "/categories",
-        },
-      ])
-    );
-    spyOn(
-      getFeaturedContentCatalogsModule,
-      "getFeaturedContentCatalogs"
-    ).and.returnValue({});
-    spyOn(getAuthedImageUrlModule, "getAuthedImageUrl").and.returnValue(
-      "https://some-image-url.com"
-    );
-    spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
-      Promise.resolve([])
-    );
-    spyOn(getLocationOptionsModule, "getLocationOptions").and.returnValue(
-      Promise.resolve([])
-    );
-    spyOn(getTagItemsModule, "getTagItems").and.returnValue(
-      Promise.resolve([])
-    );
-
     const uiSchema = await buildUiSchema(
       "some.scope",
       {
@@ -560,6 +545,7 @@ describe("buildUiSchema: initiative edit", () => {
           type: "Section",
           labelKey: "some.scope.sections.searchDiscoverability.label",
           elements: [
+            mockSlugElement,
             {
               labelKey: "shared.fields.categories.label",
               scope: "/properties/categories",

--- a/packages/common/test/pages/HubPage.test.ts
+++ b/packages/common/test/pages/HubPage.test.ts
@@ -332,40 +332,6 @@ describe("HubPage Class:", () => {
         // other than via code-coverage
         expect(getProp(result, "_thumbnail")).not.toBeDefined();
       });
-      it("handles extent from location", async () => {
-        const chk = HubPage.fromJson(
-          {
-            id: "bc3",
-            name: "Test Entity",
-            thumbnailUrl: "https://myserver.com/thumbnail.png",
-            extent: [
-              [-1, -1],
-              [1, 1],
-            ],
-          },
-          authdCtxMgr.context
-        );
-        // spy on the instance .save method and retrn void
-        const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
-        // make changes to the editor
-        const editor = await chk.toEditor();
-        editor.name = "new name";
-        editor.location = {
-          extent: [
-            [-2, -2],
-            [2, 2],
-          ],
-          type: "custom",
-        };
-        // call fromEditor
-        const result = await chk.fromEditor(editor);
-        // expect the save method to have been called
-        expect(saveSpy).toHaveBeenCalledTimes(1);
-        expect(result.extent).toEqual([
-          [-2, -2],
-          [2, 2],
-        ]);
-      });
       it("throws if creating", async () => {
         const chk = HubPage.fromJson(
           {

--- a/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
+++ b/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
@@ -5,9 +5,14 @@ import * as getLocationOptionsModule from "../../../src/core/schemas/internal/ge
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
 import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fetchCategoryItems";
 import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
+import * as getSlugSchemaElementModule from "../../../src/core/schemas/internal/getSlugSchemaElement";
 
 describe("buildUiSchema: page edit", () => {
-  it("returns the full page edit uiSchema", async () => {
+  const mockSlugElement = {
+    labelKey: "slug",
+    scope: "/properties/_slug",
+  } as any;
+  beforeEach(() => {
     spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
@@ -25,7 +30,11 @@ describe("buildUiSchema: page edit", () => {
     spyOn(getTagItemsModule, "getTagItems").and.returnValue(
       Promise.resolve([])
     );
-
+    spyOn(getSlugSchemaElementModule, "getSlugSchemaElement").and.returnValue(
+      mockSlugElement
+    );
+  });
+  it("returns the full page edit uiSchema", async () => {
     const uiSchema = await buildUiSchema(
       "some.scope",
       {
@@ -139,6 +148,7 @@ describe("buildUiSchema: page edit", () => {
                 },
               ],
             },
+            mockSlugElement,
             {
               labelKey: "some.scope.fields.tags.label",
               scope: "/properties/tags",

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -160,6 +160,31 @@ describe("buildUiSchema: project edit", () => {
           labelKey: "some.scope.sections.searchDiscoverability.label",
           elements: [
             {
+              labelKey: "some.scope.fields.slug.label",
+              scope: "/properties/_slug",
+              type: "Control",
+              options: {
+                control: "hub-field-input-input",
+                helperText: {
+                  labelKey: "some.scope.fields.slug.helperText",
+                },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "pattern",
+                    icon: true,
+                    labelKey: "some.scope.fields.slug.patternError",
+                  },
+                  {
+                    type: "ERROR",
+                    keyword: "isUniqueSlug",
+                    icon: true,
+                    labelKey: "some.scope.fields.slug.isUniqueError",
+                  },
+                ],
+              },
+            },
+            {
               labelKey: "some.scope.fields.tags.label",
               scope: "/properties/tags",
               type: "Control",
@@ -561,6 +586,31 @@ describe("buildUiSchema: project edit", () => {
           type: "Section",
           labelKey: "some.scope.sections.searchDiscoverability.label",
           elements: [
+            {
+              labelKey: "some.scope.fields.slug.label",
+              scope: "/properties/_slug",
+              type: "Control",
+              options: {
+                control: "hub-field-input-input",
+                helperText: {
+                  labelKey: "some.scope.fields.slug.helperText",
+                },
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "pattern",
+                    icon: true,
+                    labelKey: "some.scope.fields.slug.patternError",
+                  },
+                  {
+                    type: "ERROR",
+                    keyword: "isUniqueSlug",
+                    icon: true,
+                    labelKey: "some.scope.fields.slug.isUniqueError",
+                  },
+                ],
+              },
+            },
             {
               labelKey: "some.scope.fields.tags.label",
               scope: "/properties/tags",

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -7,9 +7,14 @@ import * as getLocationExtentModule from "../../../src/core/schemas/internal/get
 import * as getLocationOptionsModule from "../../../src/core/schemas/internal/getLocationOptions";
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
 import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
+import * as getSlugSchemaElementModule from "../../../src/core/schemas/internal/getSlugSchemaElement";
 
 describe("buildUiSchema: project edit", () => {
-  it("returns the full project edit uiSchema", async () => {
+  const mockSlugElement = {
+    labelKey: "slug",
+    scope: "/properties/_slug",
+  } as any;
+  beforeEach(() => {
     spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
@@ -34,7 +39,11 @@ describe("buildUiSchema: project edit", () => {
     spyOn(getTagItemsModule, "getTagItems").and.returnValue(
       Promise.resolve([])
     );
-
+    spyOn(getSlugSchemaElementModule, "getSlugSchemaElement").and.returnValue(
+      mockSlugElement
+    );
+  });
+  it("returns the full project edit uiSchema", async () => {
     const uiSchema = await buildUiSchema(
       "some.scope",
       {
@@ -159,31 +168,7 @@ describe("buildUiSchema: project edit", () => {
           type: "Section",
           labelKey: "some.scope.sections.searchDiscoverability.label",
           elements: [
-            {
-              labelKey: "some.scope.fields.slug.label",
-              scope: "/properties/_slug",
-              type: "Control",
-              options: {
-                control: "hub-field-input-input",
-                helperText: {
-                  labelKey: "some.scope.fields.slug.helperText",
-                },
-                messages: [
-                  {
-                    type: "ERROR",
-                    keyword: "pattern",
-                    icon: true,
-                    labelKey: "some.scope.fields.slug.patternError",
-                  },
-                  {
-                    type: "ERROR",
-                    keyword: "isUniqueSlug",
-                    icon: true,
-                    labelKey: "some.scope.fields.slug.isUniqueError",
-                  },
-                ],
-              },
-            },
+            mockSlugElement,
             {
               labelKey: "some.scope.fields.tags.label",
               scope: "/properties/tags",
@@ -434,31 +419,6 @@ describe("buildUiSchema: project edit", () => {
     });
   });
   it("returns the full project edit uiSchema with a defined view", async () => {
-    spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
-      Promise.resolve([
-        {
-          value: "/categories",
-          label: "/categories",
-        },
-      ])
-    );
-    spyOn(
-      getFeaturedContentCatalogsModule,
-      "getFeaturedContentCatalogs"
-    ).and.returnValue({});
-    spyOn(getAuthedImageUrlModule, "getAuthedImageUrl").and.returnValue(
-      "https://some-image-url.com"
-    );
-    spyOn(getLocationExtentModule, "getLocationExtent").and.returnValue(
-      Promise.resolve([])
-    );
-    spyOn(getLocationOptionsModule, "getLocationOptions").and.returnValue(
-      Promise.resolve([])
-    );
-    spyOn(getTagItemsModule, "getTagItems").and.returnValue(
-      Promise.resolve([])
-    );
-
     const uiSchema = await buildUiSchema(
       "some.scope",
       {
@@ -586,31 +546,7 @@ describe("buildUiSchema: project edit", () => {
           type: "Section",
           labelKey: "some.scope.sections.searchDiscoverability.label",
           elements: [
-            {
-              labelKey: "some.scope.fields.slug.label",
-              scope: "/properties/_slug",
-              type: "Control",
-              options: {
-                control: "hub-field-input-input",
-                helperText: {
-                  labelKey: "some.scope.fields.slug.helperText",
-                },
-                messages: [
-                  {
-                    type: "ERROR",
-                    keyword: "pattern",
-                    icon: true,
-                    labelKey: "some.scope.fields.slug.patternError",
-                  },
-                  {
-                    type: "ERROR",
-                    keyword: "isUniqueSlug",
-                    icon: true,
-                    labelKey: "some.scope.fields.slug.isUniqueError",
-                  },
-                ],
-              },
-            },
+            mockSlugElement,
             {
               labelKey: "some.scope.fields.tags.label",
               scope: "/properties/tags",

--- a/packages/common/test/projects/edit.test.ts
+++ b/packages/common/test/projects/edit.test.ts
@@ -208,6 +208,7 @@ describe("project edit module:", () => {
           id: "123",
           cardTitle: "foo",
         },
+        _slug: "new-slug",
       } as unknown as IHubProjectEditor;
 
       const res = editorToProject(editor, {
@@ -218,6 +219,8 @@ describe("project edit module:", () => {
       expect(res._thumbnail).toBeUndefined();
       expect(getProp(res, "view.featuredImage")).toBeUndefined();
       expect(res._metric).toBeUndefined();
+      expect(res._slug).toBeUndefined();
+      expect(res.slug).toEqual("foo|new-slug");
     });
     it("ensures the project has an orgUrlKey", () => {
       const editor: IHubProjectEditor = {

--- a/packages/common/test/projects/edit.test.ts
+++ b/packages/common/test/projects/edit.test.ts
@@ -199,6 +199,9 @@ describe("project edit module:", () => {
     });
   });
   describe("editor to project", () => {
+    const portal = {
+      urlKey: "foo",
+    } as unknown as portalModule.IPortal;
     it("removes ephemeral props", () => {
       const editor: IHubProjectEditor = {
         _groups: [],
@@ -211,25 +214,19 @@ describe("project edit module:", () => {
         _slug: "new-slug",
       } as unknown as IHubProjectEditor;
 
-      const res = editorToProject(editor, {
-        urlKey: "foo",
-      } as unknown as portalModule.IPortal);
+      const res = editorToProject(editor, portal);
 
       expect(res._groups).toBeUndefined();
       expect(res._thumbnail).toBeUndefined();
       expect(getProp(res, "view.featuredImage")).toBeUndefined();
       expect(res._metric).toBeUndefined();
-      expect(res._slug).toBeUndefined();
-      expect(res.slug).toEqual("foo|new-slug");
     });
     it("ensures the project has an orgUrlKey", () => {
       const editor: IHubProjectEditor = {
         orgUrlKey: "bar",
       } as unknown as IHubProjectEditor;
 
-      const res = editorToProject(editor, {
-        urlKey: "foo",
-      } as unknown as portalModule.IPortal);
+      const res = editorToProject(editor, portal);
 
       expect(res.orgUrlKey).toEqual("bar");
     });
@@ -243,14 +240,22 @@ describe("project edit module:", () => {
         },
       } as unknown as IHubProjectEditor;
 
-      const res = editorToProject(editor, {
-        urlKey: "foo",
-      } as unknown as portalModule.IPortal);
+      const res = editorToProject(editor, portal);
 
       expect(res.extent).toEqual([
         [1, 2],
         [3, 4],
       ]);
+    });
+    it("transforms the slug", async () => {
+      const editor: IHubProjectEditor = {
+        _slug: "updated-slug",
+      } as unknown as IHubProjectEditor;
+
+      const res = await editorToProject(editor, portal);
+
+      expect(res.slug).toEqual("foo|updated-slug");
+      expect(res._slug).toBeUndefined();
     });
     describe("metrics", () => {
       let mockMetric: IMetric;

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -783,51 +783,6 @@ describe("HubSite Class:", () => {
           expect(setFollowersGroupIsDiscussableSpy).toHaveBeenCalledTimes(1);
         });
       });
-      it("handles extent from location", async () => {
-        const _chk = HubSite.fromJson(
-          {
-            id: "bc3",
-            name: "Test Entity",
-            thumbnailUrl: "https://myserver.com/thumbnail.png",
-            extent: [
-              [-1, -1],
-              [1, 1],
-            ],
-          },
-          authdCtxMgr.context
-        );
-        // spy on the instance .save method and retrn void
-        const saveSpy = spyOn(_chk, "save").and.returnValue(Promise.resolve());
-        const _getFollowersGroupSpy = spyOn(
-          _chk,
-          "getFollowersGroup"
-        ).and.callFake(() => {
-          return Promise.resolve({
-            id: "followers00c",
-            typeKeywords: [],
-          });
-        });
-        // make changes to the editor
-        const editor = await _chk.toEditor();
-        editor.name = "new name";
-        (editor._followers as any).isDiscussable = undefined;
-        editor.location = {
-          extent: [
-            [-2, -2],
-            [2, 2],
-          ],
-          type: "custom",
-        };
-        // call fromEditor
-        const result = await _chk.fromEditor(editor);
-        // expect the save method to have been called
-        expect(saveSpy).toHaveBeenCalledTimes(1);
-        expect(result.extent).toEqual([
-          [-2, -2],
-          [2, 2],
-        ]);
-        expect(_getFollowersGroupSpy).toHaveBeenCalledTimes(1);
-      });
       it("throws if creating", async () => {
         const _chk = HubSite.fromJson(
           {

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -549,7 +549,7 @@ describe("HubSites:", () => {
         return Promise.resolve(newModel);
       });
       ensureUniqueEntitySlugSpy = spyOn(
-        require("../../src/items/_internal/slugs"),
+        require("../../src/items/_internal/ensureUniqueEntitySlug"),
         "ensureUniqueEntitySlug"
       ).and.callFake((site: commonModule.IHubSite) => {
         return Promise.resolve(site);

--- a/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
@@ -5,9 +5,14 @@ import * as getLocationOptionsModule from "../../../src/core/schemas/internal/ge
 import * as getTagItemsModule from "../../../src/core/schemas/internal/getTagItems";
 import * as fetchCategoryItemsModule from "../../../src/core/schemas/internal/fetchCategoryItems";
 import { UiSchemaRuleEffects } from "../../../src/core/schemas/types";
+import * as getSlugSchemaElementModule from "../../../src/core/schemas/internal/getSlugSchemaElement";
 
 describe("buildUiSchema: site edit", () => {
-  it("returns the full site edit uiSchema", async () => {
+  const mockSlugElement = {
+    labelKey: "slug",
+    scope: "/properties/_slug",
+  } as any;
+  beforeEach(() => {
     spyOn(fetchCategoryItemsModule, "fetchCategoryItems").and.returnValue(
       Promise.resolve([
         {
@@ -25,7 +30,11 @@ describe("buildUiSchema: site edit", () => {
     spyOn(getTagItemsModule, "getTagItems").and.returnValue(
       Promise.resolve([])
     );
-
+    spyOn(getSlugSchemaElementModule, "getSlugSchemaElement").and.returnValue(
+      mockSlugElement
+    );
+  });
+  it("returns the full site edit uiSchema", async () => {
     const uiSchema = await buildUiSchema(
       "some.scope",
       {
@@ -139,6 +148,7 @@ describe("buildUiSchema: site edit", () => {
                 },
               ],
             },
+            mockSlugElement,
             {
               labelKey: "some.scope.fields.tags.label",
               scope: "/properties/tags",


### PR DESCRIPTION
1. Description:

Add slug to the edit schema for:
- discussions
- initiatives
- initiative templates
- pages
- projects
- sites

1. Instructions for testing:

1. Closes Issues: [9597](https://devtopia.esri.com/dc/hub/issues/9597)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
