### PR TITLE
F/11820 pull staged v2 changes

### DIFF
--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -468,7 +468,7 @@ export interface IPost
   postType: PostType;
   channelId?: string;
   channel?: IChannel;
-  parentId?: string;
+  parentId: string | null;
   parent?: IPost | null;
   replies?: IPost[] | IPagedResponse<IPost>;
   replyCount?: number;

--- a/packages/discussions/src/utils/channel-permission.ts
+++ b/packages/discussions/src/utils/channel-permission.ts
@@ -57,7 +57,6 @@ export class ChannelPermission {
   private isChannelAclEmpty: boolean;
   private existingChannel: IChannel;
   private permissionsByCategory: PermissionsByAclCategoryMap;
-  private channelCreator: string;
   private channelOrgId: string;
 
   constructor(channel: IChannel) {
@@ -69,7 +68,6 @@ export class ChannelPermission {
     this.existingChannel = channel;
     this.isChannelAclEmpty = channel.channelAcl.length === 0;
     this.permissionsByCategory = {};
-    this.channelCreator = channel.creator;
     this.channelOrgId = channel.orgId;
 
     channel.channelAcl.forEach((permission) => {
@@ -116,7 +114,6 @@ export class ChannelPermission {
     }
 
     return (
-      user.username === this.channelCreator ||
       this.canSomeUser(ChannelAction.MODERATE_CHANNEL, user) ||
       this.canSomeUserGroup(ChannelAction.MODERATE_CHANNEL, user) ||
       this.canSomeUserOrg(ChannelAction.MODERATE_CHANNEL, user)

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -973,14 +973,14 @@ describe("ChannelPermission class", () => {
         expect(channelPermission.canModerateChannel(user)).toBe(false);
       });
 
-      it("returns true if the user created the channel", async () => {
+      it("returns false if the user created the channel, without acl permissions (V1 change)", async () => {
         const user = buildUser();
         const channelAcl = [] as IChannelAclPermission[];
         const channel = { channelAcl, creator: user.username } as IChannel;
 
         const channelPermission = new ChannelPermission(channel);
 
-        expect(channelPermission.canModerateChannel(user)).toBe(true);
+        expect(channelPermission.canModerateChannel(user)).toBe(false);
       });
     });
 


### PR DESCRIPTION
Issue [11820](https://devtopia.esri.com/dc/hub/issues/11820)

1. Description: Require `parentId` on `IPost`. Channel creator is no longer considered the channel owner

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
