### PR TITLE
fix(): expose editor to metric functions

### DIFF
--- a/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
@@ -9,10 +9,12 @@ import { EntityEditorOptions } from "../EditorOptions";
 import {
   SHOW_FOR_STATIC_RULE_ENTITY,
   SHOW_FOR_DYNAMIC_RULE_ENTITY,
-  SHOW_FOR_SHARING_RULE_ENTITY,
   SHOW_FOR_STATIC_AND_STRING_RULE_ENTITY,
   SHOW_FOR_STATIC_AND_NUMBER_RULE_ENTITY,
   SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY,
+  RESET_FOR_NOT_STRING_RULE_ENTITY,
+  RESET_FOR_NOT_NUMBER_RULE_ENTITY,
+  RESET_FOR_NOT_DATE_RULE_ENTITY,
 } from "./rules";
 
 /**
@@ -105,10 +107,12 @@ export const buildUiSchema = async (
             labelKey: "shared.fields.metrics.value.label",
             scope: "/properties/_metric/properties/value",
             type: "Control",
-            rule: SHOW_FOR_STATIC_AND_STRING_RULE_ENTITY,
+            rules: [
+              SHOW_FOR_STATIC_AND_STRING_RULE_ENTITY,
+              RESET_FOR_NOT_STRING_RULE_ENTITY,
+            ],
             options: {
               control: "hub-field-input-input",
-              clearOnHidden: true,
               messages: [
                 {
                   type: "ERROR",
@@ -123,11 +127,13 @@ export const buildUiSchema = async (
             labelKey: "shared.fields.metrics.value.label",
             scope: "/properties/_metric/properties/value",
             type: "Control",
-            rule: SHOW_FOR_STATIC_AND_NUMBER_RULE_ENTITY,
+            rules: [
+              SHOW_FOR_STATIC_AND_NUMBER_RULE_ENTITY,
+              RESET_FOR_NOT_NUMBER_RULE_ENTITY,
+            ],
             options: {
               control: "hub-field-input-input",
               type: "number",
-              clearOnHidden: true,
               messages: [
                 {
                   type: "ERROR",
@@ -142,10 +148,12 @@ export const buildUiSchema = async (
             labelKey: "shared.fields.metrics.value.label",
             scope: "/properties/_metric/properties/value",
             type: "Control",
-            rule: SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY,
+            rules: [
+              SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY,
+              RESET_FOR_NOT_DATE_RULE_ENTITY,
+            ],
             options: {
               control: "hub-field-input-date",
-              clearOnHidden: true,
               messages: [
                 {
                   type: "ERROR",

--- a/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/InitiativeUiSchemaMetrics.ts
@@ -12,9 +12,6 @@ import {
   SHOW_FOR_STATIC_AND_STRING_RULE_ENTITY,
   SHOW_FOR_STATIC_AND_NUMBER_RULE_ENTITY,
   SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY,
-  RESET_FOR_NOT_STRING_RULE_ENTITY,
-  RESET_FOR_NOT_NUMBER_RULE_ENTITY,
-  RESET_FOR_NOT_DATE_RULE_ENTITY,
 } from "./rules";
 
 /**
@@ -107,12 +104,10 @@ export const buildUiSchema = async (
             labelKey: "shared.fields.metrics.value.label",
             scope: "/properties/_metric/properties/value",
             type: "Control",
-            rules: [
-              SHOW_FOR_STATIC_AND_STRING_RULE_ENTITY,
-              RESET_FOR_NOT_STRING_RULE_ENTITY,
-            ],
+            rules: [SHOW_FOR_STATIC_AND_STRING_RULE_ENTITY],
             options: {
               control: "hub-field-input-input",
+              clearOnHidden: true,
               messages: [
                 {
                   type: "ERROR",
@@ -127,13 +122,11 @@ export const buildUiSchema = async (
             labelKey: "shared.fields.metrics.value.label",
             scope: "/properties/_metric/properties/value",
             type: "Control",
-            rules: [
-              SHOW_FOR_STATIC_AND_NUMBER_RULE_ENTITY,
-              RESET_FOR_NOT_NUMBER_RULE_ENTITY,
-            ],
+            rules: [SHOW_FOR_STATIC_AND_NUMBER_RULE_ENTITY],
             options: {
               control: "hub-field-input-input",
               type: "number",
+              clearOnHidden: true,
               messages: [
                 {
                   type: "ERROR",
@@ -148,12 +141,10 @@ export const buildUiSchema = async (
             labelKey: "shared.fields.metrics.value.label",
             scope: "/properties/_metric/properties/value",
             type: "Control",
-            rules: [
-              SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY,
-              RESET_FOR_NOT_DATE_RULE_ENTITY,
-            ],
+            rules: [SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY],
             options: {
               control: "hub-field-input-date",
+              clearOnHidden: true,
               messages: [
                 {
                   type: "ERROR",

--- a/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
@@ -12,9 +12,6 @@ import {
   SHOW_FOR_STATIC_AND_STRING_RULE_ENTITY,
   SHOW_FOR_STATIC_AND_NUMBER_RULE_ENTITY,
   SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY,
-  RESET_FOR_NOT_STRING_RULE_ENTITY,
-  RESET_FOR_NOT_NUMBER_RULE_ENTITY,
-  RESET_FOR_NOT_DATE_RULE_ENTITY,
 } from "./rules";
 
 /**
@@ -103,12 +100,10 @@ export const buildUiSchema = async (
             labelKey: "shared.fields.metrics.value.label",
             scope: "/properties/_metric/properties/value",
             type: "Control",
-            rules: [
-              SHOW_FOR_STATIC_AND_STRING_RULE_ENTITY,
-              RESET_FOR_NOT_STRING_RULE_ENTITY,
-            ],
+            rules: [SHOW_FOR_STATIC_AND_STRING_RULE_ENTITY],
             options: {
               control: "hub-field-input-input",
+              clearOnHidden: true,
               messages: [
                 {
                   type: "ERROR",
@@ -123,12 +118,10 @@ export const buildUiSchema = async (
             labelKey: "shared.fields.metrics.value.label",
             scope: "/properties/_metric/properties/value",
             type: "Control",
-            rules: [
-              SHOW_FOR_STATIC_AND_NUMBER_RULE_ENTITY,
-              RESET_FOR_NOT_NUMBER_RULE_ENTITY,
-            ],
+            rules: [SHOW_FOR_STATIC_AND_NUMBER_RULE_ENTITY],
             options: {
               control: "hub-field-input-input",
+              clearOnHidden: true,
               type: "number",
               messages: [
                 {
@@ -144,12 +137,10 @@ export const buildUiSchema = async (
             labelKey: "shared.fields.metrics.value.label",
             scope: "/properties/_metric/properties/value",
             type: "Control",
-            rules: [
-              SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY,
-              RESET_FOR_NOT_DATE_RULE_ENTITY,
-            ],
+            rules: [SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY],
             options: {
               control: "hub-field-input-date",
+              clearOnHidden: true,
               messages: [
                 {
                   type: "ERROR",

--- a/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
+++ b/packages/common/src/core/schemas/internal/metrics/ProjectUiSchemaMetrics.ts
@@ -12,6 +12,9 @@ import {
   SHOW_FOR_STATIC_AND_STRING_RULE_ENTITY,
   SHOW_FOR_STATIC_AND_NUMBER_RULE_ENTITY,
   SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY,
+  RESET_FOR_NOT_STRING_RULE_ENTITY,
+  RESET_FOR_NOT_NUMBER_RULE_ENTITY,
+  RESET_FOR_NOT_DATE_RULE_ENTITY,
 } from "./rules";
 
 /**
@@ -100,10 +103,12 @@ export const buildUiSchema = async (
             labelKey: "shared.fields.metrics.value.label",
             scope: "/properties/_metric/properties/value",
             type: "Control",
-            rule: SHOW_FOR_STATIC_AND_STRING_RULE_ENTITY,
+            rules: [
+              SHOW_FOR_STATIC_AND_STRING_RULE_ENTITY,
+              RESET_FOR_NOT_STRING_RULE_ENTITY,
+            ],
             options: {
               control: "hub-field-input-input",
-              clearOnHidden: true,
               messages: [
                 {
                   type: "ERROR",
@@ -118,11 +123,13 @@ export const buildUiSchema = async (
             labelKey: "shared.fields.metrics.value.label",
             scope: "/properties/_metric/properties/value",
             type: "Control",
-            rule: SHOW_FOR_STATIC_AND_NUMBER_RULE_ENTITY,
+            rules: [
+              SHOW_FOR_STATIC_AND_NUMBER_RULE_ENTITY,
+              RESET_FOR_NOT_NUMBER_RULE_ENTITY,
+            ],
             options: {
               control: "hub-field-input-input",
               type: "number",
-              clearOnHidden: true,
               messages: [
                 {
                   type: "ERROR",
@@ -137,10 +144,12 @@ export const buildUiSchema = async (
             labelKey: "shared.fields.metrics.value.label",
             scope: "/properties/_metric/properties/value",
             type: "Control",
-            rule: SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY,
+            rules: [
+              SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY,
+              RESET_FOR_NOT_DATE_RULE_ENTITY,
+            ],
             options: {
               control: "hub-field-input-date",
-              clearOnHidden: true,
               messages: [
                 {
                   type: "ERROR",

--- a/packages/common/src/core/schemas/internal/metrics/rules.ts
+++ b/packages/common/src/core/schemas/internal/metrics/rules.ts
@@ -67,6 +67,60 @@ export const SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY: IUiSchemaRule = {
   effect: UiSchemaRuleEffects.SHOW,
 };
 
+/** Resets the field if value type is no longer a string */
+export const RESET_FOR_NOT_STRING_RULE_ENTITY: IUiSchemaRule = {
+  condition: {
+    schema: {
+      type: "object",
+      properties: {
+        _metric: {
+          type: "object",
+          properties: {
+            valueType: { not: { const: "string" } },
+          },
+        },
+      },
+    },
+  },
+  effect: UiSchemaRuleEffects.RESET,
+};
+
+/** Resets the field if value type is no longer a number */
+export const RESET_FOR_NOT_NUMBER_RULE_ENTITY: IUiSchemaRule = {
+  condition: {
+    schema: {
+      type: "object",
+      properties: {
+        _metric: {
+          type: "object",
+          properties: {
+            valueType: { not: { const: "number" } },
+          },
+        },
+      },
+    },
+  },
+  effect: UiSchemaRuleEffects.RESET,
+};
+
+/** Resets the field if value type is no longer a date */
+export const RESET_FOR_NOT_DATE_RULE_ENTITY: IUiSchemaRule = {
+  condition: {
+    schema: {
+      type: "object",
+      properties: {
+        _metric: {
+          type: "object",
+          properties: {
+            valueType: { not: { const: "date" } },
+          },
+        },
+      },
+    },
+  },
+  effect: UiSchemaRuleEffects.RESET,
+};
+
 /** Show if the type is set to dynamic */
 export const SHOW_FOR_DYNAMIC_RULE_ENTITY: IUiSchemaRule = {
   condition: {

--- a/packages/common/src/core/schemas/internal/metrics/rules.ts
+++ b/packages/common/src/core/schemas/internal/metrics/rules.ts
@@ -67,60 +67,6 @@ export const SHOW_FOR_STATIC_AND_DATE_RULE_ENTITY: IUiSchemaRule = {
   effect: UiSchemaRuleEffects.SHOW,
 };
 
-/** Resets the field if value type is no longer a string */
-export const RESET_FOR_NOT_STRING_RULE_ENTITY: IUiSchemaRule = {
-  condition: {
-    schema: {
-      type: "object",
-      properties: {
-        _metric: {
-          type: "object",
-          properties: {
-            valueType: { not: { const: "string" } },
-          },
-        },
-      },
-    },
-  },
-  effect: UiSchemaRuleEffects.RESET,
-};
-
-/** Resets the field if value type is no longer a number */
-export const RESET_FOR_NOT_NUMBER_RULE_ENTITY: IUiSchemaRule = {
-  condition: {
-    schema: {
-      type: "object",
-      properties: {
-        _metric: {
-          type: "object",
-          properties: {
-            valueType: { not: { const: "number" } },
-          },
-        },
-      },
-    },
-  },
-  effect: UiSchemaRuleEffects.RESET,
-};
-
-/** Resets the field if value type is no longer a date */
-export const RESET_FOR_NOT_DATE_RULE_ENTITY: IUiSchemaRule = {
-  condition: {
-    schema: {
-      type: "object",
-      properties: {
-        _metric: {
-          type: "object",
-          properties: {
-            valueType: { not: { const: "date" } },
-          },
-        },
-      },
-    },
-  },
-  effect: UiSchemaRuleEffects.RESET,
-};
-
 /** Show if the type is set to dynamic */
 export const SHOW_FOR_DYNAMIC_RULE_ENTITY: IUiSchemaRule = {
   condition: {

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -41,7 +41,7 @@ import { getProp, getWithDefault } from "../objects";
 import { upsertResource } from "../resources/upsertResource";
 import { doesResourceExist } from "../resources/doesResourceExist";
 import { removeResource } from "../resources/removeResource";
-import { metricToEditor } from "../core/schemas/internal/metrics/metricToEditor";
+import { metricToEditor } from "../metrics/metricToEditor";
 import { getGroup } from "@esri/arcgis-rest-portal";
 import { MembershipAccess } from "../core/types";
 import { convertGroupToHubGroup } from "../groups/_internal/convertGroupToHubGroup";

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -48,7 +48,7 @@ import { negateGroupPredicates } from "../search/_internal/negateGroupPredicates
 import { computeLinks } from "./_internal/computeLinks";
 import { deriveLocationFromItem } from "../content/_internal/internalContentUtils";
 import { setEntityStatusKeyword } from "../utils/internal/setEntityStatusKeyword";
-import { editorToMetric } from "../core/schemas/internal/metrics/editorToMetric";
+import { editorToMetric } from "../metrics/editorToMetric";
 import { setMetricAndDisplay } from "../core/schemas/internal/metrics/setMetricAndDisplay";
 import { createId } from "../util";
 import { IArcGISContext } from "../ArcGISContext";

--- a/packages/common/src/metrics/editorToMetric.ts
+++ b/packages/common/src/metrics/editorToMetric.ts
@@ -1,4 +1,4 @@
-import { isNil } from "../../../../util";
+import { isNil } from "../util";
 import {
   IMetric,
   IMetricDisplayConfig,
@@ -8,8 +8,8 @@ import {
   IExpression,
   IMetricEditorValues,
   MetricVisibility,
-} from "../../../types/Metrics";
-import { ServiceAggregation } from "../../../../core/types/DynamicValues";
+} from "../core/types/Metrics";
+import { ServiceAggregation } from "../core/types/DynamicValues";
 
 /**
  * Transforms the IConfigurationValues into an object with IMetric and IMetricDisplayConfig to be saved on an entity or rendered in the ui.

--- a/packages/common/src/metrics/index.ts
+++ b/packages/common/src/metrics/index.ts
@@ -1,3 +1,4 @@
 export * from "./getEntityMetrics";
 export * from "./resolveMetric";
 export * from "./aggregateMetrics";
+export * from "./editorToMetric";

--- a/packages/common/src/metrics/metricToEditor.ts
+++ b/packages/common/src/metrics/metricToEditor.ts
@@ -5,7 +5,7 @@ import {
   IServiceQueryMetricSource,
   IStaticValueMetricSource,
   MetricSource,
-} from "../../../types/Metrics";
+} from "../core/types/Metrics";
 
 /**
  * Util to convert a metric into editor values consumable by the configuration editor

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -36,7 +36,7 @@ import { ProjectEditorType } from "./_internal/ProjectSchema";
 import { enrichEntity } from "../core/enrichEntity";
 import { getProp, getWithDefault } from "../objects";
 import { IGroup } from "@esri/arcgis-rest-types";
-import { metricToEditor } from "../core/schemas/internal/metrics/metricToEditor";
+import { metricToEditor } from "../metrics/metricToEditor";
 import { IMetricDisplayConfig } from "../core/types/Metrics";
 import { upsertResource } from "../resources/upsertResource";
 import { doesResourceExist } from "../resources/doesResourceExist";

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -18,7 +18,7 @@ import { camelize, cloneObject, createId } from "../util";
 import { setDiscussableKeyword } from "../discussions";
 import { IModel } from "../types";
 import { setEntityStatusKeyword } from "../utils/internal/setEntityStatusKeyword";
-import { editorToMetric } from "../core/schemas/internal/metrics/editorToMetric";
+import { editorToMetric } from "../metrics/editorToMetric";
 import { setMetricAndDisplay } from "../core/schemas/internal/metrics/setMetricAndDisplay";
 import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
 import { editorToEntity } from "../core/schemas/internal/metrics/editorToEntity";

--- a/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
@@ -111,26 +111,10 @@ describe("ProjectUiSchemaMetrics", () => {
                     },
                     effect: UiSchemaRuleEffects.SHOW,
                   },
-                  {
-                    condition: {
-                      schema: {
-                        type: "object",
-                        properties: {
-                          _metric: {
-                            type: "object",
-                            properties: {
-                              type: { const: "static" },
-                              valueType: { not: { const: "string" } },
-                            },
-                          },
-                        },
-                      },
-                    },
-                    effect: UiSchemaRuleEffects.RESET,
-                  },
                 ],
                 options: {
                   control: "hub-field-input-input",
+                  clearOnHidden: true,
                   messages: [
                     {
                       type: "ERROR",
@@ -163,27 +147,11 @@ describe("ProjectUiSchemaMetrics", () => {
                     },
                     effect: UiSchemaRuleEffects.SHOW,
                   },
-                  {
-                    condition: {
-                      schema: {
-                        type: "object",
-                        properties: {
-                          _metric: {
-                            type: "object",
-                            properties: {
-                              type: { const: "static" },
-                              valueType: { not: { const: "number" } },
-                            },
-                          },
-                        },
-                      },
-                    },
-                    effect: UiSchemaRuleEffects.RESET,
-                  },
                 ],
                 options: {
                   control: "hub-field-input-input",
                   type: "number",
+                  clearOnHidden: true,
                   messages: [
                     {
                       type: "ERROR",
@@ -216,25 +184,10 @@ describe("ProjectUiSchemaMetrics", () => {
                     },
                     effect: UiSchemaRuleEffects.SHOW,
                   },
-                  {
-                    condition: {
-                      schema: {
-                        type: "object",
-                        properties: {
-                          _metric: {
-                            type: "object",
-                            properties: {
-                              valueType: { not: { const: "date" } },
-                            },
-                          },
-                        },
-                      },
-                    },
-                    effect: UiSchemaRuleEffects.RESET,
-                  },
                 ],
                 options: {
                   control: "hub-field-input-date",
+                  clearOnHidden: true,
                   messages: [
                     {
                       type: "ERROR",

--- a/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
+++ b/packages/common/test/core/schemas/internal/metrics/ProjectUiSchemaMetrics.test.ts
@@ -93,26 +93,44 @@ describe("ProjectUiSchemaMetrics", () => {
                 labelKey: `shared.fields.metrics.value.label`,
                 scope: "/properties/_metric/properties/value",
                 type: "Control",
-                rule: {
-                  condition: {
-                    schema: {
-                      type: "object",
-                      properties: {
-                        _metric: {
-                          type: "object",
-                          properties: {
-                            type: { const: "static" },
-                            valueType: { const: "string" },
+                rules: [
+                  {
+                    condition: {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          _metric: {
+                            type: "object",
+                            properties: {
+                              type: { const: "static" },
+                              valueType: { const: "string" },
+                            },
                           },
                         },
                       },
                     },
+                    effect: UiSchemaRuleEffects.SHOW,
                   },
-                  effect: UiSchemaRuleEffects.SHOW,
-                },
+                  {
+                    condition: {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          _metric: {
+                            type: "object",
+                            properties: {
+                              type: { const: "static" },
+                              valueType: { not: { const: "string" } },
+                            },
+                          },
+                        },
+                      },
+                    },
+                    effect: UiSchemaRuleEffects.RESET,
+                  },
+                ],
                 options: {
                   control: "hub-field-input-input",
-                  clearOnHidden: true,
                   messages: [
                     {
                       type: "ERROR",
@@ -127,27 +145,45 @@ describe("ProjectUiSchemaMetrics", () => {
                 labelKey: `shared.fields.metrics.value.label`,
                 scope: "/properties/_metric/properties/value",
                 type: "Control",
-                rule: {
-                  condition: {
-                    schema: {
-                      type: "object",
-                      properties: {
-                        _metric: {
-                          type: "object",
-                          properties: {
-                            type: { const: "static" },
-                            valueType: { const: "number" },
+                rules: [
+                  {
+                    condition: {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          _metric: {
+                            type: "object",
+                            properties: {
+                              type: { const: "static" },
+                              valueType: { const: "number" },
+                            },
                           },
                         },
                       },
                     },
+                    effect: UiSchemaRuleEffects.SHOW,
                   },
-                  effect: UiSchemaRuleEffects.SHOW,
-                },
+                  {
+                    condition: {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          _metric: {
+                            type: "object",
+                            properties: {
+                              type: { const: "static" },
+                              valueType: { not: { const: "number" } },
+                            },
+                          },
+                        },
+                      },
+                    },
+                    effect: UiSchemaRuleEffects.RESET,
+                  },
+                ],
                 options: {
                   control: "hub-field-input-input",
                   type: "number",
-                  clearOnHidden: true,
                   messages: [
                     {
                       type: "ERROR",
@@ -162,26 +198,43 @@ describe("ProjectUiSchemaMetrics", () => {
                 labelKey: `shared.fields.metrics.value.label`,
                 scope: "/properties/_metric/properties/value",
                 type: "Control",
-                rule: {
-                  condition: {
-                    schema: {
-                      type: "object",
-                      properties: {
-                        _metric: {
-                          type: "object",
-                          properties: {
-                            type: { const: "static" },
-                            valueType: { const: "date" },
+                rules: [
+                  {
+                    condition: {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          _metric: {
+                            type: "object",
+                            properties: {
+                              type: { const: "static" },
+                              valueType: { const: "date" },
+                            },
                           },
                         },
                       },
                     },
+                    effect: UiSchemaRuleEffects.SHOW,
                   },
-                  effect: UiSchemaRuleEffects.SHOW,
-                },
+                  {
+                    condition: {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          _metric: {
+                            type: "object",
+                            properties: {
+                              valueType: { not: { const: "date" } },
+                            },
+                          },
+                        },
+                      },
+                    },
+                    effect: UiSchemaRuleEffects.RESET,
+                  },
+                ],
                 options: {
                   control: "hub-field-input-date",
-                  clearOnHidden: true,
                   messages: [
                     {
                       type: "ERROR",

--- a/packages/common/test/initiatives/HubInitiative.test.ts
+++ b/packages/common/test/initiatives/HubInitiative.test.ts
@@ -12,7 +12,7 @@ import * as EnrichEntityModule from "../../src/core/enrichEntity";
 import * as upsertResourceModule from "../../src/resources/upsertResource";
 import * as doesResourceExistModule from "../../src/resources/doesResourceExist";
 import * as removeResourceModule from "../../src/resources/removeResource";
-import * as metricToEditorModule from "../../src/core/schemas/internal/metrics/metricToEditor";
+import * as metricToEditorModule from "../../src/metrics/metricToEditor";
 import * as restPortalModule from "@esri/arcgis-rest-portal";
 import { HubItemEntity } from "../../src/core/HubItemEntity";
 import { initContextManager } from "../templates/fixtures";

--- a/packages/common/test/initiatives/HubInitiatives.test.ts
+++ b/packages/common/test/initiatives/HubInitiatives.test.ts
@@ -28,7 +28,7 @@ import {
   getProp,
 } from "../../src";
 import { IArcGISContext } from "../../src/ArcGISContext";
-import * as editorToMetricModule from "../../src/core/schemas/internal/metrics/editorToMetric";
+import * as editorToMetricModule from "../../src/metrics/editorToMetric";
 import * as setMetricAndDisplayModule from "../../src/core/schemas/internal/metrics/setMetricAndDisplay";
 
 const GUID = "9b77674e43cf4bbd9ecad5189b3f1fdc";

--- a/packages/common/test/metrics/editorToMetric.test.ts
+++ b/packages/common/test/metrics/editorToMetric.test.ts
@@ -5,15 +5,15 @@ import {
   IServiceQueryMetricSource,
   IStaticValueMetricSource,
   MetricVisibility,
-} from "../../../../../src/core/types/Metrics";
-import * as EditorToMetric from "../../../../../src/core/schemas/internal/metrics/editorToMetric";
+} from "../../src/core/types/Metrics";
+import * as EditorToMetric from "../../src/metrics/editorToMetric";
 
 import {
   MOCK_DATE_FIELD,
   MOCK_ID_FIELD,
   MOCK_NUMERIC_FIELD,
   MOCK_STRING_FIELD,
-} from "./fixtures";
+} from "../core/schemas/internal/metrics/fixtures";
 import { FieldType } from "@esri/arcgis-rest-types";
 
 describe("editorToMetric", () => {

--- a/packages/common/test/metrics/metricToEditor.test.ts
+++ b/packages/common/test/metrics/metricToEditor.test.ts
@@ -2,8 +2,8 @@ import {
   IMetric,
   IMetricDisplayConfig,
   MetricSource,
-} from "../../../../../src/core/types/Metrics";
-import { metricToEditor } from "../../../../../src/core/schemas/internal/metrics/metricToEditor";
+} from "../../src/core/types/Metrics";
+import { metricToEditor } from "../../src/metrics/metricToEditor";
 
 describe("metricToEditor", () => {
   it("converts a service-query metric correctly", () => {

--- a/packages/common/test/projects/edit.test.ts
+++ b/packages/common/test/projects/edit.test.ts
@@ -17,7 +17,7 @@ import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as portalModule from "@esri/arcgis-rest-portal";
 import * as slugUtils from "../../src/items/slugs";
 import * as modelUtils from "../../src/models";
-import * as editorToMetricModule from "../../src/core/schemas/internal/metrics/editorToMetric";
+import * as editorToMetricModule from "../../src/metrics/editorToMetric";
 import * as setMetricAndDisplayModule from "../../src/core/schemas/internal/metrics/setMetricAndDisplay";
 import * as utilModule from "../../src/util";
 


### PR DESCRIPTION
1. Description: Exposes the `editorToMetric` and `metricToEditor` functions for usage in front end with preview metric. 

1. Instructions for testing:

1. Closes Issues: [#11855](https://zentopia.esri.com/workspaces/sprint-board-60340b9721bc3a4ab6367db5/issues/gh/dc/hub/11855)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
