### PR TITLE
fix: update permissions for user event and discussion pane

### DIFF
--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -137,11 +137,9 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     // When enabled, the manage links will take the user the org home site
-    // Reverting to devext but likely remove and always load workspaces
-    // on the "current site"
     permission: "hub:feature:workspace:org",
     availability: ["alpha"],
-    environments: ["devext"],
+    environments: ["devext", "qaext"],
   },
   {
     // when enabled keyboard shortcuts will be available

--- a/packages/common/src/search/types/types.ts
+++ b/packages/common/src/search/types/types.ts
@@ -29,7 +29,8 @@ export type SortOption =
   | "joined"
   | "memberType"
   | "firstName"
-  | "lastName";
+  | "lastName"
+  | "startDate";
 
 /**
  * Defines a span of time by specifying a `from` and `to` Date

--- a/packages/common/src/users/_internal/UserBusinessRules.ts
+++ b/packages/common/src/users/_internal/UserBusinessRules.ts
@@ -15,6 +15,8 @@ export const UserPermissions = [
   "hub:user:workspace:settings",
   "hub:user:workspace:content",
   "hub:user:workspace:groups",
+  "hub:user:workspace:events",
+  "hub:user:workspace:discussions",
   "hub:user:workspace:shared-with-me",
   "hub:user:manage",
 ] as const;
@@ -62,6 +64,17 @@ export const UserPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:user:workspace:groups",
+    dependencies: ["hub:user:workspace", "hub:user:owner"],
+  },
+  {
+    permission: "hub:user:workspace:events",
+    services: ["events"],
+    dependencies: ["hub:user:workspace", "hub:user:owner"],
+  },
+  {
+    permission: "hub:user:workspace:discussions",
+    availability: ["alpha"],
+    services: ["discussions"],
     dependencies: ["hub:user:workspace", "hub:user:owner"],
   },
   {


### PR DESCRIPTION
1. Description:

- add `"hub:user:workspace:events"` and `"hub:user:workspace:discussions"`
- re-enabled "workspace on org url" for QA Alpha orgs
- add `startDate` to `SortOptions`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
