### PR TITLE
fix: ensure site created via HubSite class has correct catalog format

### DIFF
--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -292,6 +292,7 @@ export function migrateToCollectionKey(
  * @param scope Catalog scope to search through
  * @returns The first predicate with a `group` field (if present)
  */
+// istanbul ignore next
 export function getScopeGroupPredicate(scope: IQuery): IPredicate {
   /* tslint:disable no-console */
   console.warn(

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -292,7 +292,7 @@ export function migrateToCollectionKey(
  * @param scope Catalog scope to search through
  * @returns The first predicate with a `group` field (if present)
  */
-// istanbul ignore next
+// istanbul ignore next -- deprecated function
 export function getScopeGroupPredicate(scope: IQuery): IPredicate {
   /* tslint:disable no-console */
   console.warn(

--- a/packages/common/src/sites/_internal/_ensureLegacySiteCatalog.ts
+++ b/packages/common/src/sites/_internal/_ensureLegacySiteCatalog.ts
@@ -1,0 +1,24 @@
+import { getProp } from "../../objects/get-prop";
+import { IModel } from "../../types";
+import { catalogToLegacy } from "./convertCatalogToLegacyFormat";
+
+/**
+ * On the off chance that sites get stored with a IHubCatalog in their
+ * data.json, we will convert them back to the legacy format on load.
+ * @param model
+ * @returns
+ */
+export function _ensureLegacySiteCatalog(model: IModel): IModel {
+  // Only apply to 1.8 or below.
+  if (getProp(model, "item.properties.schemaVersion") > 1.8) return model;
+  const catalog = model.data.catalog || {};
+  if (!catalog.groups) {
+    const legacy = catalogToLegacy(catalog);
+    if (legacy.groups.length) {
+      model.data.catalog = legacy;
+    } else {
+      model.data.catalog = { groups: [] };
+    }
+  }
+  return model;
+}

--- a/packages/common/src/sites/_internal/convertCatalogToLegacyFormat.ts
+++ b/packages/common/src/sites/_internal/convertCatalogToLegacyFormat.ts
@@ -1,6 +1,6 @@
-import { getProp } from "../../objects";
+import { getWithDefault } from "../../objects/get-with-default";
 import { IHubCatalog } from "../../search/types/IHubCatalog";
-import { getScopeGroupPredicate } from "../../search/utils";
+import { getGroupPredicate } from "../../search/utils";
 import { IModel } from "../../types";
 import { cloneObject } from "../../util";
 
@@ -42,14 +42,12 @@ export function catalogToLegacy(catalog: IHubCatalog): Record<string, any> {
   };
 
   if (catalog.scopes?.item) {
-    const groupPredicate = getScopeGroupPredicate(catalog.scopes.item);
+    const groupPredicate = getGroupPredicate(catalog.scopes.item);
     if (groupPredicate) {
-      const groupIds = Array.isArray(groupPredicate.group)
-        ? groupPredicate.group
-        : [groupPredicate.group];
-      legacyCatalog.groups = groupIds;
+      // using getWithDefault to side-step test coverage for a condition
+      // we can't replicate in a typed environment
+      legacyCatalog.groups = getWithDefault(groupPredicate, "group.any", []);
     }
   }
-
   return legacyCatalog;
 }

--- a/packages/common/src/sites/upgrade-site-schema.ts
+++ b/packages/common/src/sites/upgrade-site-schema.ts
@@ -14,6 +14,7 @@ import { migrateBadBasemap } from "./_internal/migrateBadBasemap";
 import { ensureBaseTelemetry } from "./_internal/ensureBaseTelemetry";
 import { migrateWebMappingApplicationSites } from "./_internal/migrateWebMappingApplicationSites";
 import { _migrateLinkUnderlinesCapability } from "./_internal/_migrate-link-underlines-capability";
+import { _ensureLegacySiteCatalog } from "./_internal/_ensureLegacySiteCatalog";
 
 /**
  * Upgrades the schema upgrades
@@ -43,5 +44,7 @@ export function upgradeSiteSchema(model: IModel) {
   model = ensureBaseTelemetry(model);
   model = migrateWebMappingApplicationSites(model);
   model = _migrateLinkUnderlinesCapability(model);
+  // This will only make changes to sites with schemaVersion 1.5 or lower
+  model = _ensureLegacySiteCatalog(model);
   return model;
 }

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -597,6 +597,24 @@ describe("HubSites:", () => {
           theme: {
             fake: "theme",
           },
+          catalog: {
+            schemaVersion: 1,
+            title: "Default Site Catalog",
+            scopes: {
+              item: {
+                targetEntity: "item",
+                filters: [
+                  {
+                    predicates: [
+                      {
+                        group: ["9001"],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
           defaultExtent: {
             xmax: 10,
             ymax: 10,
@@ -638,6 +656,7 @@ describe("HubSites:", () => {
 
         const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
         expect(modelToUpdate.data.values.clientId).toBe("FAKE_CLIENT_KEY");
+        expect(modelToUpdate.data.catalog.groups).toContain("9001");
         expect(chk.name).toBe("Special Site");
         expect(chk.url).toBe("https://site.myorg.com");
         expect(chk.culture).toBe("fr-ca");

--- a/packages/common/test/sites/_internal/_ensureLegacySiteCatalog.test.ts
+++ b/packages/common/test/sites/_internal/_ensureLegacySiteCatalog.test.ts
@@ -1,0 +1,81 @@
+import { _ensureLegacySiteCatalog } from "../../../src/sites/_internal/_ensureLegacySiteCatalog";
+import { IModel } from "../../../src/types";
+
+describe("_ensureLegacySiteCatalog:", () => {
+  it("skips if model > 1.8", () => {
+    const model = {
+      item: {
+        properties: {
+          schemaVersion: 1.9,
+        },
+      },
+      data: {
+        catalog: {
+          groups: [],
+        },
+      },
+    } as unknown as IModel;
+    const chk = _ensureLegacySiteCatalog(model);
+    expect(chk).toBe(model);
+  });
+  it("skips if model has legacy format", () => {
+    const model = {
+      item: {
+        properties: {
+          schemaVersion: 1.8,
+        },
+      },
+      data: {
+        catalog: {
+          groups: [],
+        },
+      },
+    } as unknown as IModel;
+    const chk = _ensureLegacySiteCatalog(model);
+    expect(chk).toBe(model);
+  });
+  it("return legacy format if catalog not defined", () => {
+    const model = {
+      item: {
+        properties: {
+          schemaVersion: 1.8,
+        },
+      },
+      data: {},
+    } as unknown as IModel;
+
+    const chk = _ensureLegacySiteCatalog(model);
+    expect(chk.data?.catalog?.groups).toEqual([]);
+  });
+  it("converts to legacy format if present", () => {
+    const model = {
+      item: {
+        properties: {
+          schemaVersion: 1.8,
+        },
+      },
+      data: {
+        catalog: {
+          schemaVersion: 1,
+          scopes: {
+            item: {
+              targetEntity: "item",
+              filters: [
+                {
+                  predicates: [
+                    {
+                      group: ["9001"],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    } as unknown as IModel;
+
+    const chk = _ensureLegacySiteCatalog(model);
+    expect(chk.data?.catalog?.groups).toEqual(["9001"]);
+  });
+});

--- a/packages/common/test/sites/_internal/convertCatalogToLegacyFormat.test.ts
+++ b/packages/common/test/sites/_internal/convertCatalogToLegacyFormat.test.ts
@@ -1,104 +1,143 @@
 import { IItem } from "@esri/arcgis-rest-portal";
-import { convertCatalogToLegacyFormat } from "../../../src/sites/_internal/convertCatalogToLegacyFormat";
+import {
+  convertCatalogToLegacyFormat,
+  catalogToLegacy,
+} from "../../../src/sites/_internal/convertCatalogToLegacyFormat";
 import { IModel } from "../../../src/types";
+import { IHubCatalog } from "../../../src";
 
-describe("convertCatalogToLegacyFormat", () => {
-  it("leaves the old catalog untouched if no group predicate is present", () => {
-    const modelToUpdate = {
-      item: {} as IItem,
-      data: {
-        catalog: {
-          scopes: {
-            item: {
-              targetEntity: "item",
-              filters: [
-                {
-                  predicates: [
-                    {
-                      type: "Feature Service",
-                    },
-                  ],
-                },
-              ],
-            },
+describe("utils:", () => {
+  describe("catalogToLegacy:", () => {
+    it("only makes changes if catalog has item scope", () => {
+      const catalog: IHubCatalog = {
+        schemaVersion: 1,
+        scopes: {
+          event: {
+            targetEntity: "event",
+            filters: [
+              {
+                predicates: [
+                  {
+                    type: "Event",
+                  },
+                ],
+              },
+            ],
           },
         },
-      },
-    } as IModel;
-    const currentModel = {
-      item: {} as IItem,
-      data: {
-        catalog: { groups: ["00c", "00d"] },
-      },
-    } as IModel;
-    const chk = convertCatalogToLegacyFormat(modelToUpdate, currentModel);
+      };
 
-    expect(chk.data.catalog).toEqual({ groups: ["00c", "00d"] });
+      const chk = catalogToLegacy(catalog);
+      expect(chk).toEqual({ groups: [] });
+    });
+    it("works with scopeless catalog", () => {
+      const catalog: IHubCatalog = {
+        schemaVersion: 1,
+        collections: [],
+      };
+
+      const chk = catalogToLegacy(catalog);
+      expect(chk).toEqual({ groups: [] });
+    });
   });
-
-  it("converts the catalog if the group predicate has a single id", () => {
-    const modelToUpdate = {
-      item: {} as IItem,
-      data: {
-        catalog: {
-          scopes: {
-            item: {
-              targetEntity: "item",
-              filters: [
-                {
-                  predicates: [
-                    {
-                      group: "9001",
-                    },
-                  ],
-                },
-              ],
+  describe("convertCatalogToLegacyFormat", () => {
+    it("leaves the old catalog untouched if no group predicate is present", () => {
+      const modelToUpdate = {
+        item: {} as IItem,
+        data: {
+          catalog: {
+            scopes: {
+              item: {
+                targetEntity: "item",
+                filters: [
+                  {
+                    predicates: [
+                      {
+                        type: "Feature Service",
+                      },
+                    ],
+                  },
+                ],
+              },
             },
           },
         },
-      },
-    } as IModel;
-    const currentModel = {
-      item: {} as IItem,
-      data: {
-        catalog: { groups: ["00c", "00d"] },
-      },
-    } as IModel;
-    const chk = convertCatalogToLegacyFormat(modelToUpdate, currentModel);
+      } as IModel;
+      const currentModel = {
+        item: {} as IItem,
+        data: {
+          catalog: { groups: ["00c", "00d"] },
+        },
+      } as IModel;
+      const chk = convertCatalogToLegacyFormat(modelToUpdate, currentModel);
 
-    expect(chk.data.catalog).toEqual({ groups: ["9001"] });
-  });
+      expect(chk.data?.catalog).toEqual({ groups: ["00c", "00d"] });
+    });
 
-  it("converts the catalog if the group predicate has multiple ids", () => {
-    const modelToUpdate = {
-      item: {} as IItem,
-      data: {
-        catalog: {
-          scopes: {
-            item: {
-              targetEntity: "item",
-              filters: [
-                {
-                  predicates: [
-                    {
-                      group: ["9001", "1006"],
-                    },
-                  ],
-                },
-              ],
+    it("converts the catalog if the group predicate has a single id", () => {
+      const modelToUpdate = {
+        item: {} as IItem,
+        data: {
+          catalog: {
+            scopes: {
+              item: {
+                targetEntity: "item",
+                filters: [
+                  {
+                    predicates: [
+                      {
+                        group: "9001",
+                      },
+                    ],
+                  },
+                ],
+              },
             },
           },
         },
-      },
-    } as IModel;
-    const currentModel = {
-      item: {} as IItem,
-      data: {
-        catalog: { groups: ["00c", "00d"] },
-      },
-    } as IModel;
-    const chk = convertCatalogToLegacyFormat(modelToUpdate, currentModel);
+      } as IModel;
+      const currentModel = {
+        item: {} as IItem,
+        data: {
+          catalog: { groups: ["00c", "00d"] },
+        },
+      } as IModel;
+      const chk = convertCatalogToLegacyFormat(modelToUpdate, currentModel);
 
-    expect(chk.data.catalog).toEqual({ groups: ["9001", "1006"] });
+      expect(chk.data?.catalog).toEqual({ groups: ["9001"] });
+    });
+
+    it("converts the catalog if the group predicate has multiple ids", () => {
+      const modelToUpdate = {
+        item: {} as IItem,
+        data: {
+          catalog: {
+            scopes: {
+              item: {
+                targetEntity: "item",
+                filters: [
+                  {
+                    predicates: [
+                      {
+                        group: ["9001", "1006"],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      } as IModel;
+      const currentModel = {
+        item: {} as IItem,
+        data: {
+          catalog: { groups: ["00c", "00d"] },
+        },
+      } as IModel;
+      const chk = convertCatalogToLegacyFormat(modelToUpdate, currentModel);
+
+      expect(chk.data?.catalog).toEqual({ groups: ["9001", "1006"] });
+    });
   });
 });

--- a/packages/common/test/sites/upgrade-site-schema.test.ts
+++ b/packages/common/test/sites/upgrade-site-schema.test.ts
@@ -11,6 +11,7 @@ import * as _migrateTelemetryConfig from "../../src/sites/_internal/_migrate-tel
 import * as _migrateLinkUnderlinesCapability from "../../src/sites/_internal/_migrate-link-underlines-capability";
 import * as migrateBadBasemapModule from "../../src/sites/_internal/migrateBadBasemap";
 import * as ensureBaseTelemetry from "../../src/sites/_internal/ensureBaseTelemetry";
+import * as _ensureLegacySiteCatalog from "../../src/sites/_internal/_ensureLegacySiteCatalog";
 import { IModel } from "../../src";
 import { SITE_SCHEMA_VERSION } from "../../src/sites/site-schema-version";
 import { expectAllCalled, expectAll } from "./test-helpers.test";
@@ -28,6 +29,7 @@ describe("upgradeSiteSchema", () => {
   let migrateLinkUnderlinesCapabilitySpy: jasmine.Spy;
   let migrateBadBasemapSpy: jasmine.Spy;
   let ensureBaseTelemetrySpy: jasmine.Spy;
+  let ensureLegacySiteCatalog: jasmine.Spy;
   beforeEach(() => {
     applySpy = spyOn(_applySiteSchemaModule, "_applySiteSchema").and.callFake(
       (model: IModel) => model
@@ -75,6 +77,10 @@ describe("upgradeSiteSchema", () => {
     ensureBaseTelemetrySpy = spyOn(
       ensureBaseTelemetry,
       "ensureBaseTelemetry"
+    ).and.callFake((model: IModel) => model);
+    ensureLegacySiteCatalog = spyOn(
+      _ensureLegacySiteCatalog,
+      "_ensureLegacySiteCatalog"
     ).and.callFake((model: IModel) => model);
   });
 


### PR DESCRIPTION
1. Description:

When a Site was created via the HubSite class (via the `arcgis-hub-add-content` component), the item that was created had `.catalog` as an `IHubCatalog` _not_ the legacy format. This was due to small deviation between `.fromEditor(..)` and `.create(..)` logic. The fix was to ensure that we apply the same "migration" back to the legacy catalog in the "create" workflow that's applied in the "save" workflow.

1. Instructions for testing: run tests

1. Closes Issues: Bug found by Tom

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
