### PR TITLE
feat(hub-common): update discussions interfaces for V2 release

### DIFF
--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -510,7 +510,16 @@ export interface ICreatePost extends IPostOptions {
  * @extends {IPostOptions}
  * @extends {ICreateChannel}
  */
-export interface ICreateChannelPost extends IPostOptions, ICreateChannel {}
+export interface ICreateChannelPost
+  extends IPostOptions,
+    Omit<ICreateChannel, "name" | "channelAclDefinition"> {
+  name?: string;
+  /**
+   * @hidden
+   * set by the API for the v1 -> v2 conversion
+   */
+  channelAclDefinition?: IChannelAclPermissionDefinition[];
+}
 
 /**
  * request options for creating post
@@ -780,7 +789,7 @@ export interface ICreateChannelSettings {
   blockWords?: string[];
   defaultPostStatus?: PostStatus;
   metadata?: IChannelMetadata;
-  name?: string;
+  name: string;
   softDelete?: boolean;
 }
 
@@ -799,15 +808,7 @@ export interface IChannelMetadata {
  * @interface ICreateChannelPermissions
  */
 export interface ICreateChannelPermissions {
-  access?: SharingAccess;
-  allowAnonymous?: boolean;
-  groups?: string[];
-  orgs?: string[];
-  /**
-   * Not available until the V2 Api is released
-   * @hidden
-   */
-  channelAclDefinition?: IChannelAclPermissionDefinition[];
+  channelAclDefinition: IChannelAclPermissionDefinition[];
 }
 
 /**
@@ -817,13 +818,11 @@ export interface ICreateChannelPermissions {
  * @interface IUpdateChannelPermissions
  */
 export interface IUpdateChannelPermissions {
-  access?: SharingAccess;
-  allowAnonymous?: boolean;
-  groups?: string[];
+  channelAclDefinition?: IChannelAclPermissionDefinition[];
 }
 
 /**
- * permissions and settings options for creating a channel
+ * parameters for creating a channel
  *
  * @export
  * @interface ICreateChannel
@@ -844,38 +843,54 @@ export interface ICreateChannel
  * @extends {IWithTimestamps}
  */
 export interface IChannel extends IWithAuthor, IWithEditor, IWithTimestamps {
-  access: SharingAccess;
+  access: SharingAccess | null;
   allowAsAnonymous: boolean;
-  allowAnonymous: boolean;
+  allowAnonymous: boolean | null;
   allowedReactions: PostReaction[] | null;
   allowReaction: boolean;
   allowReply: boolean;
   blockWords: string[] | null;
   channelAcl?: IChannelAclPermission[];
   defaultPostStatus: PostStatus;
-  groups: string[];
+  groups: string[] | null;
   metadata: IChannelMetadata | null;
   id: string;
   name: string | null;
   orgId: string;
-  orgs: string[];
+  orgs: string[] | null;
   posts?: IPost[];
   softDelete: boolean;
 }
 
 /**
- * parameters/options for updating channel settings
+ * parameters for updating a channel
  *
  * @export
  * @interface IUpdateChannel
- * @extends {ICreateChannelSettings}
+ * @extends {IUpdateChannelSettings}
  * @extends {IUpdateChannelPermissions}
- * @extends {Partial<IWithAuthor>}
  */
 export interface IUpdateChannel
-  extends ICreateChannelSettings,
-    IUpdateChannelPermissions,
-    Partial<IWithAuthor> {}
+  extends IUpdateChannelSettings,
+    IUpdateChannelPermissions {}
+
+/**
+ * settings parameters for updating a channel
+ *
+ * @export
+ * @interface IUpdateChannelSettings
+ */
+export interface IUpdateChannelSettings {
+  allowAsAnonymous?: boolean;
+  allowedReactions?: PostReaction[];
+  allowReaction?: boolean;
+  allowReply?: boolean;
+  blockWords?: string[];
+  defaultPostStatus?: PostStatus;
+  metadata?: IChannelMetadata;
+  name?: string;
+  softDelete?: boolean;
+}
 
 /**
  * dto for decorating found channel with relations

--- a/packages/discussions/test/utils/channel-permission.test.ts
+++ b/packages/discussions/test/utils/channel-permission.test.ts
@@ -1827,8 +1827,6 @@ describe("ChannelPermission class", () => {
           const channelPermission = new ChannelPermission(channel);
 
           const updates: IUpdateChannel = {
-            // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-            // @ts-ignore
             channelAclDefinition: buildCompleteAcl(),
           };
 
@@ -1901,8 +1899,6 @@ describe("ChannelPermission class", () => {
           const channelPermission = new ChannelPermission(channel);
 
           const updates: IUpdateChannel = {
-            // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-            // @ts-ignore
             channelAclDefinition: updatedAcl,
           };
 
@@ -1946,8 +1942,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -1979,8 +1973,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2018,8 +2010,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2053,8 +2043,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2086,8 +2074,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2131,8 +2117,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2164,8 +2148,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2203,8 +2185,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2238,8 +2218,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2271,8 +2249,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2316,8 +2292,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2349,8 +2323,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2388,8 +2360,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2423,8 +2393,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2456,8 +2424,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2514,8 +2480,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2579,8 +2543,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2636,8 +2598,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2684,8 +2644,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2749,8 +2707,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2806,8 +2762,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2864,8 +2818,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2929,8 +2881,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -2986,8 +2936,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3034,8 +2982,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3099,8 +3045,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3156,8 +3100,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3201,8 +3143,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3234,8 +3174,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3268,8 +3206,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3303,8 +3239,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3336,8 +3270,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3370,8 +3302,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3415,8 +3345,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3448,8 +3376,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3485,8 +3411,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3520,8 +3444,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3553,8 +3475,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3590,8 +3510,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3635,8 +3553,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3668,8 +3584,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3702,8 +3616,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3737,8 +3649,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3770,8 +3680,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 
@@ -3804,8 +3712,6 @@ describe("ChannelPermission class", () => {
             const channelPermission = new ChannelPermission(channel);
 
             const updates: IUpdateChannel = {
-              // TODO: remove ts-ignore when V2 interfaces are hoisted from service to hub.js
-              // @ts-ignore
               channelAclDefinition: updatedAcl,
             };
 


### PR DESCRIPTION
Issue [10427](https://devtopia.esri.com/dc/hub/issues/10427)

affects: @esri/hub-common

BREAKING CHANGE:
Update interfaces for `IChannel`, `ICreateChannel`, `ICreateChannelSettings`, `ICreateChannelPermissions`, `IUpdateChannel`, `IUpdateChannelSettings`, `IUpdateChannelPermissions`

1. Description: Update the discussions interfaces for creating and updating channels for V2 release. Deprecate legacy channel sharing properties `access`, `groups`, `orgs`, `allowAnonymous` in favor of `channelAcl`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
