### PR TITLE
fix(hub-common): make getUser optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4948,11 +4948,11 @@
 			}
 		},
 		"node_modules/@esri/arcgis-rest-auth": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.6.0.tgz",
-			"integrity": "sha512-rr7Lv9HAmwTI8UnDGQer5mt1S4LlgTKyD9loQ6WqXn/wdo2y29pUVTWafcOejftnidfZxkkKOhZ/eh7YCKGmZg==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.7.0.tgz",
+			"integrity": "sha512-/FovDS6hR+3TPfXOpTOMbAu7vNAOLmIjK/lxt0w0nQd+8Nnx3u91BoGMr9pRBGzAJBJm9/i2yGljbFaNXegusQ==",
 			"dependencies": {
-				"@esri/arcgis-rest-types": "^3.6.0",
+				"@esri/arcgis-rest-types": "^3.7.0",
 				"tslib": "^1.13.0"
 			},
 			"peerDependencies": {
@@ -4960,11 +4960,11 @@
 			}
 		},
 		"node_modules/@esri/arcgis-rest-feature-layer": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.6.0.tgz",
-			"integrity": "sha512-a5BywhJpqzpJIszrXZNDcKdRt9fqGXc/Y60TqS/mVVg0tJIu5Q4VpQQzK4cMkP3D3tFmj7VB2xLBWAzpH7aYVA==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.7.0.tgz",
+			"integrity": "sha512-fS3kG6o7LbxZ4DRLrB1BWOq/lgLlt+ppzTt8ZtNBUI+6r2aWyne3V5Iy2OA0mbji5qOQDCfTt5Bd0CUWSQoQJw==",
 			"dependencies": {
-				"@esri/arcgis-rest-types": "^3.6.0",
+				"@esri/arcgis-rest-types": "^3.7.0",
 				"tslib": "^1.13.0"
 			},
 			"peerDependencies": {
@@ -4986,9 +4986,9 @@
 			}
 		},
 		"node_modules/@esri/arcgis-rest-request": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.6.0.tgz",
-			"integrity": "sha512-JDFx1ZjheFUfW/YXWQ0DwxgIwPdQFBtIl5+Bvee4cyCmhxpO1/b82tv7nOLRMnMYBkC2aKRCgpAwkecaJZDpdw==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.7.0.tgz",
+			"integrity": "sha512-K2cQSzx4roEyMPqvWyc4kjAUjW81Scpue8eHw2+nY/4Ghzl3AhF4eOmHJEcQ9e6ysEGNLrUMwLGibmtBbT8Txw==",
 			"dependencies": {
 				"tslib": "^1.10.0"
 			}
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "14.224.0",
+			"version": "15.3.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65047,32 +65047,32 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "28.5.0",
+			"version": "29.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "^14.0.0"
+				"@esri/hub-common": "^15.0.0"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "14.2.0",
+			"version": "15.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65080,18 +65080,18 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.7.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "^14.0.0"
+				"@esri/hub-common": "^15.0.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "14.0.0",
+			"version": "15.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65100,18 +65100,18 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^14.0.0"
+				"@esri/hub-common": "^15.0.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "14.0.0",
+			"version": "15.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -65119,18 +65119,18 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^14.0.0"
+				"@esri/hub-common": "^15.0.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "14.2.0",
+			"version": "15.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -65141,40 +65141,40 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^14.0.0"
+				"@esri/hub-common": "^15.0.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "15.0.2",
+			"version": "16.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^14.0.0",
-				"@esri/hub-initiatives": "^14.0.0",
-				"@esri/hub-teams": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-initiatives": "^15.0.0",
+				"@esri/hub-teams": "^15.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^14.0.0",
-				"@esri/hub-initiatives": "^14.0.0",
-				"@esri/hub-teams": "^14.0.0"
+				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-initiatives": "^15.0.0",
+				"@esri/hub-teams": "^15.0.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "14.1.1",
+			"version": "15.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65183,18 +65183,18 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^14.0.0"
+				"@esri/hub-common": "^15.0.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "14.1.1",
+			"version": "15.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65202,7 +65202,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^14.0.0"
+				"@esri/hub-common": "^15.0.0"
 			}
 		}
 	},
@@ -68710,20 +68710,20 @@
 			}
 		},
 		"@esri/arcgis-rest-auth": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.6.0.tgz",
-			"integrity": "sha512-rr7Lv9HAmwTI8UnDGQer5mt1S4LlgTKyD9loQ6WqXn/wdo2y29pUVTWafcOejftnidfZxkkKOhZ/eh7YCKGmZg==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.7.0.tgz",
+			"integrity": "sha512-/FovDS6hR+3TPfXOpTOMbAu7vNAOLmIjK/lxt0w0nQd+8Nnx3u91BoGMr9pRBGzAJBJm9/i2yGljbFaNXegusQ==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^3.6.0",
+				"@esri/arcgis-rest-types": "^3.7.0",
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/arcgis-rest-feature-layer": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.6.0.tgz",
-			"integrity": "sha512-a5BywhJpqzpJIszrXZNDcKdRt9fqGXc/Y60TqS/mVVg0tJIu5Q4VpQQzK4cMkP3D3tFmj7VB2xLBWAzpH7aYVA==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.7.0.tgz",
+			"integrity": "sha512-fS3kG6o7LbxZ4DRLrB1BWOq/lgLlt+ppzTt8ZtNBUI+6r2aWyne3V5Iy2OA0mbji5qOQDCfTt5Bd0CUWSQoQJw==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^3.6.0",
+				"@esri/arcgis-rest-types": "^3.7.0",
 				"tslib": "^1.13.0"
 			}
 		},
@@ -68737,9 +68737,9 @@
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.6.0.tgz",
-			"integrity": "sha512-JDFx1ZjheFUfW/YXWQ0DwxgIwPdQFBtIl5+Bvee4cyCmhxpO1/b82tv7nOLRMnMYBkC2aKRCgpAwkecaJZDpdw==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.7.0.tgz",
+			"integrity": "sha512-K2cQSzx4roEyMPqvWyc4kjAUjW81Scpue8eHw2+nY/4Ghzl3AhF4eOmHJEcQ9e6ysEGNLrUMwLGibmtBbT8Txw==",
 			"requires": {
 				"tslib": "^1.10.0"
 			}
@@ -68779,7 +68779,7 @@
 		"@esri/hub-discussions": {
 			"version": "file:packages/discussions",
 			"requires": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68788,7 +68788,7 @@
 		"@esri/hub-downloads": {
 			"version": "file:packages/downloads",
 			"requires": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68797,7 +68797,7 @@
 		"@esri/hub-events": {
 			"version": "file:packages/events",
 			"requires": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68805,7 +68805,7 @@
 		"@esri/hub-initiatives": {
 			"version": "file:packages/initiatives",
 			"requires": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68814,7 +68814,7 @@
 		"@esri/hub-search": {
 			"version": "file:packages/search",
 			"requires": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -68824,9 +68824,9 @@
 		"@esri/hub-sites": {
 			"version": "file:packages/sites",
 			"requires": {
-				"@esri/hub-common": "^14.0.0",
-				"@esri/hub-initiatives": "^14.0.0",
-				"@esri/hub-teams": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-initiatives": "^15.0.0",
+				"@esri/hub-teams": "^15.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68834,7 +68834,7 @@
 		"@esri/hub-surveys": {
 			"version": "file:packages/surveys",
 			"requires": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68842,7 +68842,7 @@
 		"@esri/hub-teams": {
 			"version": "file:packages/teams",
 			"requires": {
-				"@esri/hub-common": "^14.0.0",
+				"@esri/hub-common": "^15.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/common/src/search/_internal/hubEventsHelpers/eventToSearchResult.ts
+++ b/packages/common/src/search/_internal/hubEventsHelpers/eventToSearchResult.ts
@@ -1,4 +1,4 @@
-import { getUser } from "@esri/arcgis-rest-portal";
+import { getUser, IUser } from "@esri/arcgis-rest-portal";
 import { IHubSearchOptions } from "../../types/IHubSearchOptions";
 import { IHubSearchResult } from "../../types/IHubSearchResult";
 import { IEvent } from "../../../events/api/orval/api/orval-events";

--- a/packages/common/src/search/_internal/hubEventsHelpers/eventToSearchResult.ts
+++ b/packages/common/src/search/_internal/hubEventsHelpers/eventToSearchResult.ts
@@ -17,10 +17,13 @@ export async function eventToSearchResult(
   event: IEvent,
   options: IHubSearchOptions
 ): Promise<IHubSearchResult> {
-  const ownerUser = await getUser({
-    username: event.creator.username,
-    ...options.requestOptions,
-  });
+  let ownerUser: IUser;
+  if (options.include?.includes("ownerUser")) {
+    ownerUser = await getUser({
+      username: event.creator.username,
+      ...options.requestOptions,
+    });
+  }
   const result = {
     access: event.access.toLowerCase() as AccessLevel,
     id: event.id,


### PR DESCRIPTION
1. Description: Makes getUser call optional when converting an event to search result to improve loading times.

1. Instructions for testing:

1. Closes Issues: #11752

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
