### PR TITLE
F/5799 channel id on post create

### DIFF
--- a/docs/src/guides/functional/discussions.md
+++ b/docs/src/guides/functional/discussions.md
@@ -383,6 +383,6 @@ The Hub Discussions API has only begun to expose the numerous ways users can int
 
 # Useful links
 
-- [Hub Discussions API root](https://hub.arcgis.com/api/discussions/v1)
-- [Hub Discussions API /posts](https://hub.arcgis.com/api/discussions/v1/posts)
-- [Hub Discussions API /channels](https://hub.arcgis.com/api/discussions/v1/channels)
+- [Hub Discussions API root](https://hub.arcgis.com/api/discussions/v2)
+- [Hub Discussions API /posts](https://hub.arcgis.com/api/discussions/v2/posts)
+- [Hub Discussions API /channels](https://hub.arcgis.com/api/discussions/v2/channels)

--- a/docs/src/guides/functional/discussions.md
+++ b/docs/src/guides/functional/discussions.md
@@ -76,36 +76,6 @@ const params: ICreatePost = {
   title: "Question about updating trees dataset",
   body: "We need to add more details about tree planting date.",
   discussion: "hub://dataset/1234",
-  access: "private",
-  groups: ["someGroupId"],
-};
-
-const opts: ICreatePostOptions = { authentication, params };
-
-const myPost = await createPost(opts);
-/*
-myPost = IPost {
-  id: 'abcdefg',
-  ...
-}
-*/
-```
-
-if a channel for `'someGroupId'` doesn't exist and the authenticated user has sufficient permission to create it (i.e. is group manager/owner), then the channel will be created on-the-fly and the post will be joined to it. If the user lacks the ability to create the channel, the API will return an error.
-
-You can also use an existing Channel to share a Post with a pre-defined list of groups and users:
-
-```ts
-import {
-  createPost,
-  ICreateChannelPost,
-  ICreatePostOptions,
-} from "@esri/hub-discussions";
-
-const params: ICreateChannelPost = {
-  title: "Dataset 1234 is so cool",
-  body: "this data ROCKS",
-  discussion: "hub://dataset/1234",
   channelId: "3efabc",
 };
 
@@ -176,17 +146,16 @@ Additionally, a reply post _cannot be more visible_ than the parent post. That i
 ```js
 import {
   createReply,
-  ICreateChannelPost,
-  ICreateReplyOptions,
+  ICreateReplyParams
+  IPostOptions,
 } from "@esri/hub-discussions";
 
-const params: ICreateChannelPost = {
+const data: IPostOptions = {
   body: "I disagree, I do not like this dataset",
   discussion: "hub://dataset/1234",
-  channelId: "3efabc",
 };
 
-const opts: ICreateReplyOptions = { postId: "abcdefg", authentication, params };
+const opts: ICreateReplyParams = { postId: "abcdefg", authentication, data };
 
 const myReply = await createReply(opts);
 /*

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -38,7 +38,7 @@ import { getOrgThumbnailUrl } from "./resources/get-org-thumbnail-url";
 const hubApiEndpoints = {
   domains: "/api/v3/domains",
   search: "/api/v3/datasets",
-  discussions: "/api/discussions/v1",
+  discussions: "/api/discussions/v2",
   ogcRecords: "/api/search/v1",
 };
 

--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -458,25 +458,25 @@ export interface IPost
     Partial<IWithEditor>,
     IWithTimestamps {
   id: string;
-  title: string | null;
-  body: string;
-  status: PostStatus;
   appInfo: string | null; // this is a catch-all field for app-specific information about a post, added for Urban
-  discussion: string | null;
-  geometry: Geometry | null;
-  featureGeometry: Geometry | null;
-  postType: PostType;
-  channelId?: string;
+  body: string;
   channel?: IChannel;
-  parentId: string | null;
+  channelId?: string;
+  discussion: string | null;
+  featureGeometry: Geometry | null;
+  geometry: Geometry | null;
   parent?: IPost | null;
+  parentId: string | null;
+  postType: PostType;
+  reactions?: IReaction[];
   replies?: IPost[] | IPagedResponse<IPost>;
   replyCount?: number;
-  reactions?: IReaction[];
+  status: PostStatus;
+  title: string | null;
 }
 
 /**
- * base parameters for creating a post
+ * parameters for creating a post
  *
  * @export
  * @interface IPostOptions
@@ -503,25 +503,6 @@ export interface ICreatePost extends IPostOptions {
 }
 
 /**
- * dto for creating a post in a unknown or not yet created channel
- *
- * @export
- * @interface ICreateChannelPost
- * @extends {IPostOptions}
- * @extends {ICreateChannel}
- */
-export interface ICreateChannelPost
-  extends IPostOptions,
-    Omit<ICreateChannel, "name" | "channelAclDefinition"> {
-  name?: string;
-  /**
-   * @hidden
-   * set by the API for the v1 -> v2 conversion
-   */
-  channelAclDefinition?: IChannelAclPermissionDefinition[];
-}
-
-/**
  * request options for creating post
  *
  * @export
@@ -529,7 +510,7 @@ export interface ICreateChannelPost
  * @extends {IHubRequestOptions}
  */
 export interface ICreatePostParams extends IDiscussionsRequestOptions {
-  data: ICreatePost | ICreateChannelPost;
+  data: ICreatePost;
   mentionUrl?: string;
 }
 
@@ -843,9 +824,10 @@ export interface ICreateChannel
  * @extends {IWithTimestamps}
  */
 export interface IChannel extends IWithAuthor, IWithEditor, IWithTimestamps {
+  id: string;
   access: SharingAccess | null;
-  allowAsAnonymous: boolean;
   allowAnonymous: boolean | null;
+  allowAsAnonymous: boolean;
   allowedReactions: PostReaction[] | null;
   allowReaction: boolean;
   allowReply: boolean;
@@ -854,7 +836,6 @@ export interface IChannel extends IWithAuthor, IWithEditor, IWithTimestamps {
   defaultPostStatus: PostStatus;
   groups: string[] | null;
   metadata: IChannelMetadata | null;
-  id: string;
   name: string | null;
   orgId: string;
   orgs: string[] | null;

--- a/packages/common/src/discussions/api/utils/request.ts
+++ b/packages/common/src/discussions/api/utils/request.ts
@@ -70,7 +70,7 @@ export function apiRequest<T>(
     // TODO: we _want_ to use getHubApiUrl(),
     // but have to deal w/ the fact that this package overwrites IHubRequestOptions
     host: options.hubApiUrl || "https://hub.arcgis.com",
-    path: "/api/discussions/v1",
+    path: "/api/discussions/v2",
   });
 
   if (options.data) {

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -295,7 +295,7 @@ describe("ArcGISContext:", () => {
       // Hub Urls
       const base = mgr.context.hubUrl;
       expect(mgr.context.discussionsServiceUrl).toBe(
-        `${base}/api/discussions/v1`
+        `${base}/api/discussions/v2`
       );
       expect(mgr.context.hubSearchServiceUrl).toBe(`${base}/api/v3/datasets`);
       expect(mgr.context.domainServiceUrl).toBe(`${base}/api/v3/domains`);
@@ -461,7 +461,7 @@ describe("ArcGISContext:", () => {
       // Hub Urls
       const base = mgr.context.hubUrl;
       expect(mgr.context.discussionsServiceUrl).toBe(
-        `${base}/api/discussions/v1`
+        `${base}/api/discussions/v2`
       );
       expect(mgr.context.hubSearchServiceUrl).toBe(`${base}/api/v3/datasets`);
       expect(mgr.context.domainServiceUrl).toBe(`${base}/api/v3/domains`);

--- a/packages/common/test/discussions/api/request.test.ts
+++ b/packages/common/test/discussions/api/request.test.ts
@@ -66,7 +66,7 @@ describe("authenticateRequest", () => {
 describe("apiRequest", () => {
   const response = { ok: true };
 
-  const hubApiUrl = "https://hub.arcgis.com/api/discussions/v1";
+  const hubApiUrl = "https://hub.arcgis.com/api/discussions/v2";
   const url = "foo";
 
   let expectedOpts: RequestInit;

--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -35,7 +35,6 @@ export {
   IPost,
   IPostOptions,
   ICreatePost,
-  ICreateChannelPost,
   ICreatePostParams,
   ICreateReplyParams,
   IFetchPost,

--- a/packages/discussions/src/utils/request.ts
+++ b/packages/discussions/src/utils/request.ts
@@ -72,7 +72,7 @@ export function apiRequest<T>(
     // TODO: we _want_ to use getHubApiUrl(),
     // but have to deal w/ the fact that this package overwrites IHubRequestOptions
     host: options.hubApiUrl || "https://hub.arcgis.com",
-    path: "/api/discussions/v1",
+    path: "/api/discussions/v2",
   });
 
   if (options.data) {

--- a/packages/discussions/test/posts.test.ts
+++ b/packages/discussions/test/posts.test.ts
@@ -145,53 +145,6 @@ describe("posts", () => {
       .catch(() => fail());
   });
 
-  it("creates post on unknown or non-existent channel", (done) => {
-    const body = {
-      access: SharingAccess.PRIVATE,
-      groups: ["groupId"],
-      body: "foo",
-    };
-
-    const options = { ...baseOpts, data: body };
-    createPost(options)
-      .then(() => {
-        expect(requestSpy.calls.count()).toEqual(1);
-        const [url, opts] = requestSpy.calls.argsFor(0);
-        expect(url).toEqual(`/posts`);
-        expect(opts).toEqual({ ...options, httpMethod: "POST" });
-        done();
-      })
-      .catch(() => fail());
-  });
-
-  it("creates post with mention url on unknown or non-existent channel", (done) => {
-    const body = {
-      access: SharingAccess.PUBLIC,
-      groups: ["foo"],
-      body: "foo",
-    };
-
-    const options = {
-      ...baseOpts,
-      data: body,
-      mentionUrl: "https://some.hub.arcgis.com",
-    };
-    createPost(options)
-      .then(() => {
-        expect(requestSpy.calls.count()).toEqual(1);
-        const [url, opts] = requestSpy.calls.argsFor(0);
-        expect(url).toEqual(`/posts`);
-        expect(opts).toEqual({
-          ...baseOpts,
-          data: body,
-          httpMethod: "POST",
-          headers: { "mention-url": "https://some.hub.arcgis.com" },
-        });
-        done();
-      })
-      .catch(() => fail());
-  });
-
   it("creates post on known channel", (done) => {
     const body = {
       channelId: "abc123",

--- a/packages/discussions/test/request.test.ts
+++ b/packages/discussions/test/request.test.ts
@@ -66,7 +66,7 @@ describe("authenticateRequest", () => {
 describe("apiRequest", () => {
   const response = { ok: true };
 
-  const hubApiUrl = "https://hub.arcgis.com/api/discussions/v1";
+  const hubApiUrl = "https://hub.arcgis.com/api/discussions/v2";
   const url = "foo";
 
   let expectedOpts: RequestInit;


### PR DESCRIPTION
Issue [5779](https://devtopia.esri.com/dc/hub/issues/5779)
Issue [10428](https://devtopia.esri.com/dc/hub/issues/10428)

1. Description: Remove option to include channel parameters in `ICreatePostParams`. Remove `ICreateChannelPost`. Also point discussions requests to v2 of the API (url `/v1` -> `/v2`)

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
