### PR TITLE
feat(hub-common): ungate Events 3 from alpha orgs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.3.4",
+			"version": "15.3.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/events/_internal/EventBusinessRules.ts
+++ b/packages/common/src/events/_internal/EventBusinessRules.ts
@@ -35,7 +35,7 @@ export const EventPermissionPolicies: IPermissionPolicy[] = [
     licenses: ["hub-premium"],
     // gating
     environments: ["devext", "qaext"],
-    availability: ["alpha"],
+    // availability: ["alpha"],
   },
   {
     permission: "hub:event:create",

--- a/packages/common/src/events/_internal/EventBusinessRules.ts
+++ b/packages/common/src/events/_internal/EventBusinessRules.ts
@@ -19,7 +19,7 @@ export const EventPermissions = [
   "hub:event:workspace:settings",
   "hub:event:workspace:collaborators",
   "hub:event:workspace:manage",
-  "hub:event:workspace:attendees",
+  "hub:event:workspace:registrants",
   "hub:event:workspace:content",
   "hub:event:manage",
 ] as const;
@@ -108,7 +108,7 @@ export const EventPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:event:workspace", "hub:event:edit"],
   },
   {
-    permission: "hub:event:workspace:attendees",
+    permission: "hub:event:workspace:registrants",
     dependencies: ["hub:event:workspace", "hub:event:edit"],
   },
   {


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 11557

1. Description:

1. Instructions for testing:

1. Closes Issues: #[11557](https://devtopia.esri.com/dc/hub/issues/11557)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
