### PR TITLE
feat(hub-common): add feature flag for site pages via catalog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.3.4",
+			"version": "15.3.7",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -174,6 +174,13 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     environments: ["devext"],
     availability: ["alpha"],
   },
+  {
+    // Enable site getting pages from it's catalog
+    // instead of those linked in the site's data
+    permission: "hub:feature:pagescatalog",
+    environments: ["qaext"],
+    availability: ["alpha"],
+  },
   // NOTE: only use this permission if necessary. Use the licenses check on a permission to check license when able instead of a separate permission.
   // checks if using hub-premium
   {

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -30,6 +30,7 @@ const SystemPermissions = [
   "hub:feature:history",
   "hub:feature:catalogs",
   "hub:feature:inline-workspace",
+  "hub:feature:pagescatalog",
   "hub:license:hub-premium",
   "hub:license:hub-basic",
   "hub:license:enterprise-sites",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
