### PR TITLE
feat(): add executed query length to search response

### DIFF
--- a/packages/common/src/search/_internal/portalSearchGroups.ts
+++ b/packages/common/src/search/_internal/portalSearchGroups.ts
@@ -11,7 +11,7 @@ import {
   IHubSearchResult,
   IQuery,
 } from "../types";
-import { getNextFunction, getQueryLength } from "../utils";
+import { getNextFunction, getKilobyteSizeOfQuery } from "../utils";
 import { expandPredicate } from "./expandPredicate";
 
 /**
@@ -106,7 +106,7 @@ async function searchPortal(
       resp.total,
       searchPortal
     ),
-    executedQueryLength: getQueryLength(searchOptions.q),
+    executedQuerySize: getKilobyteSizeOfQuery(searchOptions.q),
   };
 }
 

--- a/packages/common/src/search/_internal/portalSearchGroups.ts
+++ b/packages/common/src/search/_internal/portalSearchGroups.ts
@@ -11,7 +11,7 @@ import {
   IHubSearchResult,
   IQuery,
 } from "../types";
-import { getNextFunction } from "../utils";
+import { getNextFunction, getQueryLength } from "../utils";
 import { expandPredicate } from "./expandPredicate";
 
 /**
@@ -106,6 +106,7 @@ async function searchPortal(
       resp.total,
       searchPortal
     ),
+    executedQueryLength: getQueryLength(searchOptions.q),
   };
 }
 

--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -22,6 +22,7 @@ import {
   addDefaultItemSearchPredicates,
   getNextFunction,
   getKilobyteSizeOfQuery,
+  expandPortalQuery,
 } from "../utils";
 import { convertPortalAggregations } from "./portalSearchUtils";
 import { expandPredicate } from "./expandPredicate";
@@ -63,6 +64,9 @@ export function portalSearchItemsAsItems(
 }
 
 /**
+ * DEPRECATED - use expandPortalQuery instead
+ *
+ *
  * @internal
  * Expand an IQuery by applying well-known filters and predicates,
  * and then expanding all the predicates into IMatchOption objects.
@@ -107,7 +111,7 @@ function processSearchParams(options: IHubSearchOptions, query: IQuery) {
     );
   }
 
-  const updatedQuery = expandQuery(query);
+  const updatedQuery = expandPortalQuery(query);
 
   // Serialize the all the groups for portal
   const so = serializeQueryForPortal(updatedQuery);

--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -18,7 +18,11 @@ import {
   IPredicate,
   IQuery,
 } from "../types";
-import { addDefaultItemSearchPredicates, getNextFunction } from "../utils";
+import {
+  addDefaultItemSearchPredicates,
+  getNextFunction,
+  getQueryLength,
+} from "../utils";
 import { convertPortalAggregations } from "./portalSearchUtils";
 import { expandPredicate } from "./expandPredicate";
 import HubError from "../../HubError";
@@ -166,6 +170,7 @@ async function searchPortalAsItem(
       resp.total,
       searchPortalAsItem
     ),
+    executedQueryLength: getQueryLength(searchOptions.q),
   };
 }
 
@@ -209,6 +214,7 @@ async function searchPortalAsHubSearchResult(
       resp.total,
       searchPortalAsHubSearchResult
     ),
+    executedQueryLength: getQueryLength(searchOptions.q),
   };
 }
 

--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -21,7 +21,7 @@ import {
 import {
   addDefaultItemSearchPredicates,
   getNextFunction,
-  getQueryLength,
+  getKilobyteSizeOfQuery,
 } from "../utils";
 import { convertPortalAggregations } from "./portalSearchUtils";
 import { expandPredicate } from "./expandPredicate";
@@ -170,7 +170,7 @@ async function searchPortalAsItem(
       resp.total,
       searchPortalAsItem
     ),
-    executedQueryLength: getQueryLength(searchOptions.q),
+    executedQuerySize: getKilobyteSizeOfQuery(searchOptions.q),
   };
 }
 
@@ -214,7 +214,7 @@ async function searchPortalAsHubSearchResult(
       resp.total,
       searchPortalAsHubSearchResult
     ),
-    executedQueryLength: getQueryLength(searchOptions.q),
+    executedQuerySize: getKilobyteSizeOfQuery(searchOptions.q),
   };
 }
 

--- a/packages/common/src/search/_internal/portalSearchUsers.ts
+++ b/packages/common/src/search/_internal/portalSearchUsers.ts
@@ -19,7 +19,7 @@ import {
 import { getNextFunction } from "../utils";
 import { expandPredicate } from "./expandPredicate";
 import { cloneObject } from "../../util";
-import { getQueryLength } from "../utils";
+import { getKilobyteSizeOfQuery } from "../utils";
 
 function buildSearchOptions(
   query: IQuery,
@@ -204,7 +204,7 @@ async function searchPortal(
       resp.total,
       searchPortal
     ),
-    executedQueryLength: getQueryLength(searchOptions.q),
+    executedQuerySize: getKilobyteSizeOfQuery(searchOptions.q),
   };
 }
 
@@ -234,7 +234,7 @@ async function searchCommunity(
       resp.total,
       searchCommunity
     ),
-    executedQueryLength: getQueryLength(searchOptions.q),
+    executedQuerySize: getKilobyteSizeOfQuery(searchOptions.q),
   };
 }
 

--- a/packages/common/src/search/_internal/portalSearchUsers.ts
+++ b/packages/common/src/search/_internal/portalSearchUsers.ts
@@ -19,6 +19,7 @@ import {
 import { getNextFunction } from "../utils";
 import { expandPredicate } from "./expandPredicate";
 import { cloneObject } from "../../util";
+import { getQueryLength } from "../utils";
 
 function buildSearchOptions(
   query: IQuery,
@@ -203,6 +204,7 @@ async function searchPortal(
       resp.total,
       searchPortal
     ),
+    executedQueryLength: getQueryLength(searchOptions.q),
   };
 }
 
@@ -232,6 +234,7 @@ async function searchCommunity(
       resp.total,
       searchCommunity
     ),
+    executedQueryLength: getQueryLength(searchOptions.q),
   };
 }
 

--- a/packages/common/src/search/explainQueryResult.ts
+++ b/packages/common/src/search/explainQueryResult.ts
@@ -3,6 +3,7 @@ import { IFilter, IPredicate, IQuery } from "./types";
 import { expandQuery } from "./_internal/portalSearchItems";
 import { cloneObject } from "../util";
 import { explainFilter } from "./_internal/explainFilter";
+import { expandPortalQuery } from "./utils";
 
 /**
  * Explanation of why a result matched a query
@@ -123,7 +124,7 @@ export async function explainQueryResult(
   }
 
   // Expand the query so we have a standardized structure to work with
-  const expandedQuery = expandQuery(query);
+  const expandedQuery = expandPortalQuery(query);
 
   // iterate the filters on the query and get explanations for each
   const filterExplanations: IFilterExplanation[] = [];

--- a/packages/common/src/search/types/IHubSearchResponse.ts
+++ b/packages/common/src/search/types/IHubSearchResponse.ts
@@ -1,5 +1,6 @@
 import { IMessage } from "../../types/IMessage";
 import { IHubAggregation } from "./IHubAggregation";
+import { Kilobyte } from "./types";
 
 /**
  * Defines a generic search response interface with parameterized result type
@@ -41,5 +42,5 @@ export interface IHubSearchResponse<T> {
    * The length of the query string that was just executed in the search,
    * measured in kilobytes
    */
-  executedQuerySize?: number;
+  executedQuerySize?: Kilobyte;
 }

--- a/packages/common/src/search/types/IHubSearchResponse.ts
+++ b/packages/common/src/search/types/IHubSearchResponse.ts
@@ -36,4 +36,9 @@ export interface IHubSearchResponse<T> {
    * Array of messages / warnings
    */
   messages?: IMessage[];
+
+  /**
+   * The length of the query string that was just executed in the search
+   */
+  executedQueryLength?: number;
 }

--- a/packages/common/src/search/types/IHubSearchResponse.ts
+++ b/packages/common/src/search/types/IHubSearchResponse.ts
@@ -38,7 +38,8 @@ export interface IHubSearchResponse<T> {
   messages?: IMessage[];
 
   /**
-   * The length of the query string that was just executed in the search
+   * The length of the query string that was just executed in the search,
+   * measured in kilobytes
    */
-  executedQueryLength?: number;
+  executedQuerySize?: number;
 }

--- a/packages/common/src/search/types/types.ts
+++ b/packages/common/src/search/types/types.ts
@@ -176,3 +176,10 @@ export interface ICatalogSearchResponse {
 
 export interface ISearchResponseHash
   extends Record<string, IHubSearchResponse<IHubSearchResult>> {}
+
+/**
+ * Type wrapper for a kilobyte
+ * This is complete syntactic sugar, it makes sizes easier to understand
+ * with units as a type
+ */
+export type Kilobyte = number;

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -31,7 +31,12 @@ import {
   LegacySearchCategory,
 } from "./_internal/commonHelpers/isLegacySearchCategory";
 import { toCollectionKey } from "./_internal/commonHelpers/toCollectionKey";
-import { expandQuery } from "./_internal/portalSearchItems";
+import {
+  applyWellKnownCollectionFilters,
+  applyWellKnownItemPredicates,
+  expandPredicates,
+  expandQuery,
+} from "./_internal/portalSearchItems";
 
 /**
  * Well known APIs
@@ -390,4 +395,19 @@ export function getKilobyteSizeOfQuery(
   const sizeInBytes = encodedString.length;
   const sizeInKB = sizeInBytes / 1024; // Convert bytes to kilobytes
   return sizeInKB;
+}
+
+/**
+ * Expand an item IQuery for portal by applying well-known filters and predicates,
+ * and then expanding all the predicates into IMatchOption objects.
+ * @param query `IQuery` to expand
+ * @returns IQuery
+ */
+export function expandPortalQuery(query: IQuery): IQuery {
+  let updatedQuery = applyWellKnownCollectionFilters(query);
+  // Expand well-known filterGroups
+  // TODO: Should we remove this with the whole idea of collections?
+  updatedQuery = applyWellKnownItemPredicates(updatedQuery);
+  // Expand the individual predicates in each filter
+  return expandPredicates(updatedQuery);
 }

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -8,6 +8,7 @@ import {
   IGroup,
   ISearchGroupUsersOptions,
   ISearchOptions,
+  SearchQueryBuilder,
 } from "@esri/arcgis-rest-portal";
 import { isPageType } from "../content/_internal/internalContentUtils";
 import { IHubSite } from "../core";
@@ -368,4 +369,18 @@ export function addDefaultItemSearchPredicates(query: IQuery): IQuery {
   };
   queryWithDefaultItemPredicates.filters.push(defaultPredicates);
   return queryWithDefaultItemPredicates;
+}
+
+/**
+ * Returns the length in characters of a query string or a SearchQueryBuilder.
+ * This is used to later determine if a query is too large to be sent to the server.
+ * @param query
+ * @returns
+ */
+export function getQueryLength(query: string | SearchQueryBuilder): number {
+  if (typeof query === "string") {
+    return query.length;
+  } else {
+    return query.toParam().length;
+  }
 }

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -372,15 +372,24 @@ export function addDefaultItemSearchPredicates(query: IQuery): IQuery {
 }
 
 /**
- * Returns the length in characters of a query string or a SearchQueryBuilder.
- * This is used to later determine if a query is too large to be sent to the server.
+ * Returns the size in kilobytes of a query string or a SearchQueryBuilder.
+ * This is used to later determine if a query is too large or almost too large to be sent to the server.
  * @param query
  * @returns
  */
-export function getQueryLength(query: string | SearchQueryBuilder): number {
-  if (typeof query === "string") {
-    return query.length;
-  } else {
-    return query.toParam().length;
-  }
+export function getKilobyteSizeOfQuery(
+  query: string | SearchQueryBuilder
+): number {
+  // convert query to string if it isn't already
+  const queryString = typeof query === "string" ? query : query.toParam();
+
+  // make blob of string so we accurately represent string's binary data,
+  // accounting for special characters and encoding
+  const blob = new Blob([queryString]);
+
+  // size of string in bytes
+  const bytes = blob.size;
+
+  // return size of string in kilobytes
+  return bytes / 1024;
 }

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -23,6 +23,7 @@ import {
   IWellKnownApis,
   IApiDefinition,
   NamedApis,
+  Kilobyte,
 } from "./types/types";
 import { WellKnownCollection } from "./wellKnownCatalog";
 import {
@@ -379,7 +380,7 @@ export function addDefaultItemSearchPredicates(query: IQuery): IQuery {
  */
 export function getKilobyteSizeOfQuery(
   query: string | SearchQueryBuilder
-): number {
+): Kilobyte {
   // convert query to string if it isn't already
   const queryString = typeof query === "string" ? query : query.toParam();
 

--- a/packages/common/src/search/utils.ts
+++ b/packages/common/src/search/utils.ts
@@ -384,13 +384,10 @@ export function getKilobyteSizeOfQuery(
   // convert query to string if it isn't already
   const queryString = typeof query === "string" ? query : query.toParam();
 
-  // make blob of string so we accurately represent string's binary data,
-  // accounting for special characters and encoding
-  const blob = new Blob([queryString]);
-
-  // size of string in bytes
-  const bytes = blob.size;
-
-  // return size of string in kilobytes
-  return bytes / 1024;
+  // get the size of the query string using the TextEncoder api
+  const encoder = new TextEncoder();
+  const encodedString = encoder.encode(queryString);
+  const sizeInBytes = encodedString.length;
+  const sizeInKB = sizeInBytes / 1024; // Convert bytes to kilobytes
+  return sizeInKB;
 }

--- a/packages/common/test/search/utils.test.ts
+++ b/packages/common/test/search/utils.test.ts
@@ -489,66 +489,71 @@ describe("Search Utils:", () => {
 
   describe("getKilobyteSizeOfQuery", () => {
     // These tests create a blob
-    if (typeof Blob !== "undefined") {
-      it("returns the size of the query in kilobytes", () => {
-        const query = {
-          targetEntity: "item",
-          filters: [],
-        } as IQuery;
-        const stringQuery = serializeQueryForPortal(query).q;
-        const size = 10;
-        const chk = getKilobyteSizeOfQuery(stringQuery);
-        expect(chk).toEqual(size);
-      });
+    it("returns the size of the query in kilobytes", () => {
+      const query = {
+        targetEntity: "item",
+        filters: [
+          {
+            predicates: [
+              {
+                type: "Web Map",
+                typekeywords: { any: ["my|web|map"] },
+              },
+            ],
+          },
+        ],
+      } as IQuery;
+      const stringQuery = serializeQueryForPortal(query).q;
+      const size = 0.044921875;
+      const chk = getKilobyteSizeOfQuery(stringQuery);
+      expect(chk).toEqual(size);
+    });
 
-      it("returns 0 if the query is empty", () => {
-        const queryString = "";
-        const size = 0;
-        const chk = getKilobyteSizeOfQuery(queryString);
-        expect(chk).toEqual(size);
-      });
+    it("returns 0 if the query is empty", () => {
+      const queryString = "";
+      const size = 0;
+      const chk = getKilobyteSizeOfQuery(queryString);
+      expect(chk).toEqual(size);
+    });
 
-      it("handles special characters in the query", () => {
-        const query = {
-          targetEntity: "item",
-          filters: [
-            {
-              predicates: [
-                {
-                  type: "Web Map",
-                  title: "🚀🚀🚀",
-                },
-              ],
-            },
-          ],
-        } as IQuery;
-        const stringQuery = serializeQueryForPortal(query).q;
-        const size = 14;
-        const chk = getKilobyteSizeOfQuery(stringQuery);
-        expect(chk).toEqual(size);
-      });
+    it("handles special characters in the query", () => {
+      const query = {
+        targetEntity: "item",
+        filters: [
+          {
+            predicates: [
+              {
+                type: "Web Map",
+                title: "🚀🚀🚀",
+              },
+            ],
+          },
+        ],
+      } as IQuery;
+      const stringQuery = serializeQueryForPortal(query).q;
+      const size = 0.0400390625;
+      const chk = getKilobyteSizeOfQuery(stringQuery);
+      expect(chk).toEqual(size);
+    });
 
-      it("handles a SearchQueryBuilder object", () => {
-        const query = new SearchQueryBuilder()
-          .match("Patrick")
-          .in("owner")
-          .and()
-          .startGroup()
-          .match("Web Mapping Application")
-          .in("type")
-          .or()
-          .match("Mobile Application")
-          .in("type")
-          .or()
-          .match("Application")
-          .in("type")
-          .endGroup();
-        const size = 14;
-        const chk = getKilobyteSizeOfQuery(query);
-        expect(chk).toEqual(size);
-      });
-    } else {
-      it("does not test in node", () => true);
-    }
+    it("handles a SearchQueryBuilder object", () => {
+      const query = new SearchQueryBuilder()
+        .match("Patrick")
+        .in("owner")
+        .and()
+        .startGroup()
+        .match("Web Mapping Application")
+        .in("type")
+        .or()
+        .match("Mobile Application")
+        .in("type")
+        .or()
+        .match("Application")
+        .in("type")
+        .endGroup();
+      const size = 0.0966796875;
+      const chk = getKilobyteSizeOfQuery(query);
+      expect(chk).toEqual(size);
+    });
   });
 });


### PR DESCRIPTION
1. Description: Adds an optional `executedQueryLength: Kilobyte (number)` to the `IHubSearchResponse` object to allow for calculating the size of a query. 

1. Instructions for testing:

1. Closes Issues: [#11590](https://zentopia.esri.com/workspaces/sprint-board-60340b9721bc3a4ab6367db5/issues/gh/dc/hub/11590)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
