### PR TITLE
feat(hub-discussions): added enum and parameter for downloading posts as csv

### DIFF
--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -182,6 +182,15 @@ export enum CommonSort {
 }
 
 /**
+ * @export
+ * @enum {string}
+ */
+export enum SearchPostsFormat {
+  CSV = "CSV",
+  JSON = "JSON",
+}
+
+/**
  * creator property
  *
  * @export
@@ -576,6 +585,7 @@ export interface ISearchPosts
   groups?: string[];
   access?: SharingAccess[];
   channels?: string[];
+  f?: SearchPostsFormat;
 }
 
 /**

--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -186,8 +186,8 @@ export enum CommonSort {
  * @enum {string}
  */
 export enum SearchPostsFormat {
-  CSV = "CSV",
-  JSON = "JSON",
+  CSV = "csv",
+  JSON = "json",
 }
 
 /**

--- a/packages/discussions/src/types.ts
+++ b/packages/discussions/src/types.ts
@@ -11,6 +11,7 @@ export {
   ReactionRelation,
   ChannelFilter,
   CommonSort,
+  SearchPostsFormat,
   IWithAuthor,
   IWithEditor,
   IWithSorting,


### PR DESCRIPTION
Related Issue: [11813](https://zentopia.esri.com/workspaces/sprint-board-60340b9721bc3a4ab6367db5/issues/gh/dc/hub/11813)

1. Description: Added `f` query parameter to `ISearchPosts` and  `SearchPostsFormat` enum for its type.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
