### PR TITLE
fix(hub-common): rename hub:event:workspace:attendees permission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22695,10 +22695,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22713,24 +22712,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22744,10 +22740,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22765,10 +22760,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65023,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.9.0",
+			"version": "15.12.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65053,7 +65047,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "29.2.1",
+			"version": "29.3.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -83531,8 +83525,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83547,20 +83540,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83574,8 +83564,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83592,8 +83581,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/core/schemas/internal/getEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getEditorSchemas.ts
@@ -363,7 +363,7 @@ export async function getEditorSchemas(
           import("../../../events/_internal/EventSchemaCreate"),
         "hub:event:edit": () =>
           import("../../../events/_internal/EventSchemaEdit"),
-        "hub:event:attendees": () =>
+        "hub:event:registrants": () =>
           import("../../../events/_internal/EventSchemaAttendeesSettings"),
       }[type as EventEditorType]();
       const eventUiSchemaModule = await {
@@ -371,7 +371,7 @@ export async function getEditorSchemas(
           import("../../../events/_internal/EventUiSchemaCreate"),
         "hub:event:edit": () =>
           import("../../../events/_internal/EventUiSchemaEdit"),
-        "hub:event:attendees": () =>
+        "hub:event:registrants": () =>
           import("../../../events/_internal/EventUiSchemaAttendeesSettings"),
       }[type as EventEditorType]();
       schema = eventSchemaModule.buildSchema();

--- a/packages/common/src/events/_internal/EventBusinessRules.ts
+++ b/packages/common/src/events/_internal/EventBusinessRules.ts
@@ -35,8 +35,7 @@ export const EventPermissionPolicies: IPermissionPolicy[] = [
     licenses: ["hub-premium"],
     // gating
     environments: ["devext", "qaext"],
-    // TODO: temp, uncomment this until we're ready to release Events 3
-    // availability: ["alpha"],
+    availability: ["alpha"],
   },
   {
     permission: "hub:event:create",

--- a/packages/common/src/events/_internal/EventBusinessRules.ts
+++ b/packages/common/src/events/_internal/EventBusinessRules.ts
@@ -19,7 +19,7 @@ export const EventPermissions = [
   "hub:event:workspace:settings",
   "hub:event:workspace:collaborators",
   "hub:event:workspace:manage",
-  "hub:event:workspace:attendees",
+  "hub:event:workspace:registrants",
   "hub:event:workspace:content",
   "hub:event:manage",
 ] as const;
@@ -108,7 +108,7 @@ export const EventPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:event:workspace", "hub:event:edit"],
   },
   {
-    permission: "hub:event:workspace:attendees",
+    permission: "hub:event:workspace:registrants",
     dependencies: ["hub:event:workspace", "hub:event:edit"],
   },
   {

--- a/packages/common/src/events/_internal/EventBusinessRules.ts
+++ b/packages/common/src/events/_internal/EventBusinessRules.ts
@@ -35,7 +35,8 @@ export const EventPermissionPolicies: IPermissionPolicy[] = [
     licenses: ["hub-premium"],
     // gating
     environments: ["devext", "qaext"],
-    availability: ["alpha"],
+    // TODO: temp, uncomment this until we're ready to release Events 3
+    // availability: ["alpha"],
   },
   {
     permission: "hub:event:create",

--- a/packages/common/src/events/_internal/EventSchemaCreate.ts
+++ b/packages/common/src/events/_internal/EventSchemaCreate.ts
@@ -11,7 +11,7 @@ export type EventEditorType = (typeof EventEditorTypes)[number];
 export const EventEditorTypes = [
   "hub:event:create",
   "hub:event:edit",
-  "hub:event:attendees",
+  "hub:event:registrants",
 ] as const;
 
 /**


### PR DESCRIPTION
1. Description:
* Renames `hub:event:workspace:attendees` permission to `hub:event:workspace:registrants`
* Renames `hub:event:attendees` schema to `hub:event:registrants`

1. Instructions for testing:

1. Closes Issues: #[11557](https://devtopia.esri.com/dc/hub/issues/11557)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
