### PR TITLE
feat: hub page layoutRelative and workspaceRelative links

### DIFF
--- a/packages/common/src/pages/HubPages.ts
+++ b/packages/common/src/pages/HubPages.ts
@@ -1,15 +1,10 @@
 import { getFamily } from "../content/get-family";
-import {
-  deriveLocationFromItem,
-  getHubRelativeUrl,
-} from "../content/_internal/internalContentUtils";
+import { deriveLocationFromItem } from "../content/_internal/internalContentUtils";
 import { fetchItemEnrichments } from "../items/_enrichments";
 import { getProp } from "../objects";
-import { getItemThumbnailUrl } from "../resources";
 import { IHubSearchResult } from "../search";
 import { parseInclude } from "../search/_internal/parseInclude";
 import { IHubRequestOptions, IModel } from "../types";
-import { getItemHomeUrl } from "../urls";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { getItem, IItem } from "@esri/arcgis-rest-portal";
 import { cloneObject, unique } from "../util";
@@ -29,6 +24,7 @@ import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
 import { DEFAULT_PAGE, DEFAULT_PAGE_MODEL } from "./defaults";
 import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
+import { computeLinks } from "./_internal/computeLinks";
 
 /**
  * @private
@@ -232,14 +228,8 @@ export async function enrichPageSearchResult(
     result[spec.prop] = getProp(enriched, spec.path);
   });
 
-  // Handle Links
-  result.links.thumbnail = getItemThumbnailUrl(item, requestOptions);
-  result.links.self = getItemHomeUrl(result.id, requestOptions);
-  result.links.siteRelative = getHubRelativeUrl(
-    result.type,
-    result.id,
-    item.typeKeywords
-  );
+  // Handle links
+  result.links = computeLinks(item, requestOptions);
 
   return result;
 }

--- a/packages/common/src/pages/_internal/computeLinks.ts
+++ b/packages/common/src/pages/_internal/computeLinks.ts
@@ -6,6 +6,7 @@ import { getItemIdentifier } from "../../items";
 import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
 import { getItemThumbnailUrl } from "../../resources/get-item-thumbnail-url";
 import { getHubRelativeUrl } from "../../content/_internal/internalContentUtils";
+import { getItemHomeUrl } from "../../urls";
 
 /**
  * Compute the links that get appended to a Hub Site
@@ -25,10 +26,10 @@ export function computeLinks(
   }
 
   return {
-    self: item.url,
+    self: getItemHomeUrl(item.id, requestOptions),
     siteRelative: getHubRelativeUrl(item.type, item.id, item.typeKeywords),
-    siteRelativeEntityType: getHubRelativeUrl(item.type),
-    layoutRelative: "/edit",
+    siteRelativeEntityType: getHubRelativeUrl("page"),
+    layoutRelative: `/pages/${item.id}/edit`,
     workspaceRelative: getRelativeWorkspaceUrl(item.type, item.id),
     thumbnail: getItemThumbnailUrl(item, requestOptions, token),
   };

--- a/packages/common/src/pages/_internal/computeProps.ts
+++ b/packages/common/src/pages/_internal/computeProps.ts
@@ -10,6 +10,7 @@ import { IHubPage } from "../../core/types/IHubPage";
 import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
 import { computeItemProps } from "../../core/_internal/computeItemProps";
 import { getHubRelativeUrl } from "../../content/_internal/internalContentUtils";
+import { computeLinks } from "./computeLinks";
 
 /**
  * Given a model and a page, set various computed properties that can't be directly mapped
@@ -35,14 +36,7 @@ export function computeProps(
   const thumbnailUrl = getItemThumbnailUrl(model.item, requestOptions, token);
   // TODO: Remove this once opendata-ui starts using `links.thumbnail` instead
   page.thumbnailUrl = thumbnailUrl;
-  page.links = {
-    self: getItemHomeUrl(page.id, requestOptions),
-    siteRelative: `/pages/${page.id}`,
-    siteRelativeEntityType: getHubRelativeUrl("page"),
-    workspaceRelative: getRelativeWorkspaceUrl("page", page.id),
-    layoutRelative: `/pages/${page.id}/edit`,
-    thumbnail: thumbnailUrl,
-  };
+  page.links = computeLinks(model.item, requestOptions);
 
   /**
    * Features that can be disabled by the entity owner

--- a/packages/common/test/pages/_internal/computeProps.test.ts
+++ b/packages/common/test/pages/_internal/computeProps.test.ts
@@ -31,6 +31,7 @@ describe("Pages: computeProps:", () => {
         item: {
           created: new Date().getTime(),
           modified: new Date().getTime(),
+          type: "Hub Page",
         },
         data: {},
       } as IModel;


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: hub page entities and search results now have links.workspaceRelative and links.layoutRelative; hub site entities and search results have correct workspaceRelative link.

1. Instructions for testing:

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/11674, https://devtopia.esri.com/dc/hub/issues/11874

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
