### PR TITLE
feat(hub-common): add allowPost to IChannel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65017,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.13.2",
+			"version": "15.16.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65053,7 +65053,7 @@
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.8.0",
+				"@esri/hub-common": "^15.16.0",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
@@ -65061,31 +65061,6 @@
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
 				"@esri/hub-common": "^15.8.0"
-			}
-		},
-		"packages/discussions/node_modules/@esri/hub-common": {
-			"version": "15.8.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-15.8.0.tgz",
-			"integrity": "sha512-ogwgQvXa08AY0stRcXVmkhTR7h4nOrizg+TZt+ttzFsSfX0phaMkRedeppbCkMBMs9BmfaVK65tZg5nGf7HaSw==",
-			"dev": true,
-			"dependencies": {
-				"@terraformer/arcgis": "^2.1.2",
-				"@types/arcgis-js-api": "~4.28.0",
-				"abab": "^2.0.5",
-				"adlib": "^3.0.8",
-				"ajv": "^6.12.6",
-				"fast-xml-parser": "^3.21.0",
-				"json-schema-typed": "^7.0.3",
-				"jsonapi-typescript": "^0.1.3",
-				"tslib": "^1.13.0"
-			},
-			"peerDependencies": {
-				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
-				"@esri/arcgis-rest-feature-layer": "^3.2.0",
-				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
-				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/arcgis-rest-service-admin": "^3.6.0",
-				"@esri/arcgis-rest-types": "^2.15.0 || 3"
 			}
 		},
 		"packages/downloads": {
@@ -68804,29 +68779,10 @@
 		"@esri/hub-discussions": {
 			"version": "file:packages/discussions",
 			"requires": {
-				"@esri/hub-common": "^15.8.0",
+				"@esri/hub-common": "^15.16.0",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
-			},
-			"dependencies": {
-				"@esri/hub-common": {
-					"version": "15.8.0",
-					"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-15.8.0.tgz",
-					"integrity": "sha512-ogwgQvXa08AY0stRcXVmkhTR7h4nOrizg+TZt+ttzFsSfX0phaMkRedeppbCkMBMs9BmfaVK65tZg5nGf7HaSw==",
-					"dev": true,
-					"requires": {
-						"@terraformer/arcgis": "^2.1.2",
-						"@types/arcgis-js-api": "~4.28.0",
-						"abab": "^2.0.5",
-						"adlib": "^3.0.8",
-						"ajv": "^6.12.6",
-						"fast-xml-parser": "^3.21.0",
-						"json-schema-typed": "^7.0.3",
-						"jsonapi-typescript": "^0.1.3",
-						"tslib": "^1.13.0"
-					}
-				}
 			}
 		},
 		"@esri/hub-downloads": {

--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -866,9 +866,10 @@ export interface ICreateChannel
  * @extends {IWithTimestamps}
  */
 export interface IChannel extends IWithAuthor, IWithEditor, IWithTimestamps {
+  id: string;
   access: SharingAccess;
-  allowAsAnonymous: boolean;
   allowAnonymous: boolean;
+  allowAsAnonymous: boolean;
   allowedReactions: PostReaction[] | null;
   allowPost: boolean;
   allowReaction: boolean;
@@ -878,7 +879,6 @@ export interface IChannel extends IWithAuthor, IWithEditor, IWithTimestamps {
   defaultPostStatus: PostStatus;
   groups: string[];
   metadata: IChannelMetadata | null;
-  id: string;
   name: string | null;
   orgId: string;
   orgs: string[];

--- a/packages/discussions/package.json
+++ b/packages/discussions/package.json
@@ -16,7 +16,7 @@
     "@esri/hub-common": "^15.8.0"
   },
   "devDependencies": {
-    "@esri/hub-common": "^15.8.0",
+    "@esri/hub-common": "^15.16.0",
     "@types/geojson": "^7946.0.7",
     "typescript": "^3.8.1"
   },

--- a/packages/discussions/src/utils/posts/can-create-post.ts
+++ b/packages/discussions/src/utils/posts/can-create-post.ts
@@ -13,19 +13,22 @@ type ILegacyChannelPermissions = Pick<
 
 /**
  * Utility to determine if User has privileges to create a post in a channel
- * @deprecated use `canCreatePost` or 'canCreateReply` instead
  * @param channel
  * @param user
  * @returns {boolean}
  */
-export function canPostToChannel(
+export function canCreatePost(
   channel: IChannel,
   user: IUser | IDiscussionsUser = {}
 ): boolean {
-  const { access, groups, orgs, allowAnonymous } = channel;
+  const { access, groups, orgs, allowAnonymous, allowPost } = channel;
 
   if (hasOrgAdminUpdateRights(user, channel.orgId)) {
     return true;
+  }
+
+  if (!allowPost) {
+    return false;
   }
 
   if (channel.channelAcl) {

--- a/packages/discussions/src/utils/posts/can-create-reply.ts
+++ b/packages/discussions/src/utils/posts/can-create-reply.ts
@@ -12,7 +12,7 @@ type ILegacyChannelPermissions = Pick<
 >;
 
 /**
- * Utility to determine if User has privileges to create a post in a channel
+ * Utility to determine if User has privileges to create a reply in a channel
  * @param channel
  * @param user
  * @returns {boolean}

--- a/packages/discussions/src/utils/posts/can-create-reply.ts
+++ b/packages/discussions/src/utils/posts/can-create-reply.ts
@@ -13,19 +13,22 @@ type ILegacyChannelPermissions = Pick<
 
 /**
  * Utility to determine if User has privileges to create a post in a channel
- * @deprecated use `canCreatePost` or 'canCreateReply` instead
  * @param channel
  * @param user
  * @returns {boolean}
  */
-export function canPostToChannel(
+export function canCreateReply(
   channel: IChannel,
   user: IUser | IDiscussionsUser = {}
 ): boolean {
-  const { access, groups, orgs, allowAnonymous } = channel;
+  const { access, groups, orgs, allowAnonymous, allowReply } = channel;
 
   if (hasOrgAdminUpdateRights(user, channel.orgId)) {
     return true;
+  }
+
+  if (!allowReply) {
+    return false;
   }
 
   if (channel.channelAcl) {

--- a/packages/discussions/src/utils/posts/can-edit-post.ts
+++ b/packages/discussions/src/utils/posts/can-edit-post.ts
@@ -37,10 +37,16 @@ export function canEditPost(
   channel: IChannel
 ): boolean {
   const { access, groups, orgs, allowAnonymous } = channel;
+
   if (channel.channelAcl) {
+    const canReplyOrPost = post.parentId
+      ? channel.allowReply
+      : channel.allowPost;
     const channelPermission = new ChannelPermission(channel);
     return (
-      isPostCreator(post, user) && channelPermission.canPostToChannel(user)
+      isPostCreator(post, user) &&
+      canReplyOrPost &&
+      channelPermission.canPostToChannel(user)
     );
   }
 

--- a/packages/discussions/src/utils/posts/index.ts
+++ b/packages/discussions/src/utils/posts/index.ts
@@ -1,3 +1,5 @@
+export { canCreatePost } from "./can-create-post";
+export { canCreateReply } from "./can-create-reply";
 export { canDeletePost } from "./can-delete-post";
 export { canModifyPostStatus, canEditPostStatus } from "./can-edit-post-status";
 export { canModifyPost, canEditPost } from "./can-edit-post";

--- a/packages/discussions/src/utils/reactions/can-create-reaction.ts
+++ b/packages/discussions/src/utils/reactions/can-create-reaction.ts
@@ -27,11 +27,13 @@ function channelAllowsReaction(
   value: PostReaction
 ): boolean {
   const { allowReaction, allowedReactions } = channel;
-  if (allowReaction) {
-    if (allowedReactions) {
-      return allowedReactions.includes(value);
-    }
-    return true;
+  if (!allowReaction) {
+    return false;
   }
-  return false;
+
+  if (allowedReactions) {
+    return allowedReactions.includes(value);
+  }
+
+  return true;
 }

--- a/packages/discussions/test/utils/posts/can-create-post.test.ts
+++ b/packages/discussions/test/utils/posts/can-create-post.test.ts
@@ -1,0 +1,327 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import {
+  AclCategory,
+  IChannel,
+  IDiscussionsUser,
+  Role,
+} from "../../../src/types";
+import { ChannelPermission } from "../../../src/utils/channel-permission";
+import { canCreatePost } from "../../../src/utils/posts/can-create-post";
+import * as portalPrivModule from "../../../src/utils/portal-privilege";
+
+const orgId1 = "3ef";
+const groupId1 = "aaa";
+const groupId2 = "bbb";
+
+function buildUser(overrides = {}) {
+  const defaultUser = {
+    username: "john",
+    orgId: orgId1,
+    role: "org_user",
+    groups: [buildGroup(groupId1, "member"), buildGroup(groupId2, "admin")],
+  };
+
+  return { ...defaultUser, ...overrides } as IDiscussionsUser;
+}
+
+function buildGroup(id: string, memberType: string, typeKeywords?: string[]) {
+  return {
+    id,
+    userMembership: { memberType },
+    typeKeywords,
+  } as any as IGroup;
+}
+
+describe("canCreatePost", () => {
+  let canPostToChannelSpy: jasmine.Spy;
+  let hasOrgAdminUpdateRightsSpy: jasmine.Spy;
+
+  beforeAll(() => {
+    hasOrgAdminUpdateRightsSpy = spyOn(
+      portalPrivModule,
+      "hasOrgAdminUpdateRights"
+    );
+    canPostToChannelSpy = spyOn(
+      ChannelPermission.prototype,
+      "canPostToChannel"
+    );
+  });
+
+  beforeEach(() => {
+    hasOrgAdminUpdateRightsSpy.calls.reset();
+    canPostToChannelSpy.calls.reset();
+  });
+
+  describe("With Org Admin", () => {
+    it("return true if hasOrgAdminUpdateRights returns true", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => true);
+      canPostToChannelSpy.and.callFake(() => false); // bypass permissions check
+
+      const user = {} as IDiscussionsUser;
+      const channel = { orgId: "aaa", allowPost: false } as IChannel; // bypass channel setting check
+
+      expect(canCreatePost(channel, user)).toBe(true);
+
+      expect(hasOrgAdminUpdateRightsSpy.calls.count()).toBe(1);
+      const [arg1, arg2] = hasOrgAdminUpdateRightsSpy.calls.allArgs()[0]; // args for 1st call
+      expect(arg1).toBe(user);
+      expect(arg2).toBe(channel.orgId);
+
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+  });
+
+  describe("with channelAcl", () => {
+    it("return true if channelPermission.canPostToChannel is true", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      canPostToChannelSpy.and.callFake(() => true);
+
+      const user = buildUser();
+      const channel = {
+        allowPost: true,
+        channelAcl: [{ category: AclCategory.ANONYMOUS_USER, role: Role.READ }],
+      } as IChannel;
+
+      expect(canCreatePost(channel, user)).toBe(true);
+
+      expect(hasOrgAdminUpdateRightsSpy.calls.count()).toBe(1);
+
+      expect(canPostToChannelSpy.calls.count()).toBe(1);
+      const [arg] = canPostToChannelSpy.calls.allArgs()[0]; // arg for 1st call
+      expect(arg).toBe(user);
+    });
+
+    it("return false if channelPermission.canPostToChannel is false", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      canPostToChannelSpy.and.callFake(() => false);
+
+      const user = buildUser();
+      const channel = {
+        allowPost: true,
+        channelAcl: [{ category: AclCategory.ANONYMOUS_USER, role: Role.READ }],
+      } as IChannel;
+
+      expect(canCreatePost(channel, user)).toBe(false);
+
+      expect(hasOrgAdminUpdateRightsSpy.calls.count()).toBe(1);
+
+      expect(canPostToChannelSpy.calls.count()).toBe(1);
+      const [arg] = canPostToChannelSpy.calls.allArgs()[0]; // arg for 1st call
+      expect(arg).toBe(user);
+    });
+
+    it("return false if channel.allowPost is false", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      canPostToChannelSpy.and.callFake(() => true);
+
+      const user = buildUser();
+      const channel = {
+        allowPost: false,
+        channelAcl: [{ category: AclCategory.ANONYMOUS_USER, role: Role.READ }],
+      } as IChannel;
+
+      expect(canCreatePost(channel, user)).toBe(false);
+
+      expect(hasOrgAdminUpdateRightsSpy.calls.count()).toBe(1);
+
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+  });
+
+  describe("with legacy permissions", () => {
+    it("returns true if undefined user attempts to create post in allowAnonymous === true channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const channel = {
+        allowPost: true,
+        allowAnonymous: true,
+      } as IChannel;
+
+      expect(canCreatePost(channel)).toBe(true);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns true if anonymous user attempts to create post in allowAnonymous === true channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = { username: null };
+      const channel = {
+        allowPost: true,
+        allowAnonymous: true,
+      } as IChannel;
+
+      expect(canCreatePost(channel, user)).toBe(true);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if anonymous user attempts to create post in allowAnonymous === false channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = { username: null };
+      const channel = {
+        allowPost: true,
+        allowAnonymous: false,
+      } as IChannel;
+
+      expect(canCreatePost(channel, user)).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns true if authenticated user attempts to create post in public-access channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = { username: "Slughorn" };
+      const channel = {
+        allowPost: true,
+        access: "public",
+        allowAnonymous: false,
+      } as IChannel;
+
+      expect(canCreatePost(channel, user)).toBe(true);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns true if group authorized user attempts to create post in private-access channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        groups: [
+          {
+            id: "abc",
+            userMembership: { memberType: "member" },
+            typeKeywords: [],
+          },
+        ],
+      } as any;
+      const channel = {
+        allowPost: true,
+        access: "private",
+        allowAnonymous: false,
+        groups: ["abc"],
+      } as any;
+
+      expect(canCreatePost(channel, user)).toBe(true);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns true if a group authorized user attempts to create post in private-access channel, but at least one group is NOT marked cannotDiscuss", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        groups: [
+          {
+            id: "abc",
+            userMembership: { memberType: "member" },
+            typeKeywords: ["cannotDiscuss"],
+          },
+          {
+            id: "xyz",
+            userMembership: { memberType: "member" },
+            typeKeywords: [],
+          },
+        ],
+      } as any;
+      const channel = {
+        allowPost: true,
+        access: "private",
+        allowAnonymous: false,
+        groups: ["abc", "xyz"],
+      } as any;
+
+      expect(canCreatePost(channel, user)).toBe(true);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if group authorized user attempts to create post in private-access channel, but the only group is marked cannotDiscuss", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        groups: [
+          {
+            id: "abc",
+            userMembership: { memberType: "member" },
+            typeKeywords: ["cannotDiscuss"],
+          },
+        ],
+      } as any;
+      const channel = {
+        allowPost: true,
+        access: "private",
+        allowAnonymous: false,
+        groups: ["abc"],
+      } as any;
+
+      expect(canCreatePost(channel, user)).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if group unauthorized user attempts to create post in private-access channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        groups: [
+          {
+            id: "abc",
+            userMembership: { memberType: "member" },
+            typeKeywords: [],
+          },
+        ],
+        typeKeywords: [],
+      } as any;
+      const channel = {
+        allowPost: true,
+        access: "private",
+        allowAnonymous: false,
+        groups: ["xyz"],
+      } as any;
+
+      expect(canCreatePost(channel, user)).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("handles missing user/channel groups", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+      } as any;
+      const channel = {
+        allowPost: true,
+        access: "private",
+        allowAnonymous: false,
+      } as any;
+
+      expect(canCreatePost(channel, user)).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns true if org authorized user attempts to create post in org-access channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        orgId: "abc",
+      } as any;
+      const channel = {
+        allowPost: true,
+        access: "org",
+        allowAnonymous: false,
+        orgs: ["abc"],
+      } as any;
+
+      expect(canCreatePost(channel, user)).toBe(true);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if unknown access value", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        orgId: "abc",
+      } as any;
+      const channel = {
+        allowPost: true,
+        access: "foo",
+        allowAnonymous: false,
+        orgs: ["abc"],
+      } as any;
+
+      expect(canCreatePost(channel, user)).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+  });
+});

--- a/packages/discussions/test/utils/posts/can-create-reply.test.ts
+++ b/packages/discussions/test/utils/posts/can-create-reply.test.ts
@@ -1,0 +1,327 @@
+import { IGroup } from "@esri/arcgis-rest-types";
+import {
+  AclCategory,
+  IChannel,
+  IDiscussionsUser,
+  Role,
+} from "../../../src/types";
+import { ChannelPermission } from "../../../src/utils/channel-permission";
+import { canCreateReply } from "../../../src/utils/posts/can-create-reply";
+import * as portalPrivModule from "../../../src/utils/portal-privilege";
+
+const orgId1 = "3ef";
+const groupId1 = "aaa";
+const groupId2 = "bbb";
+
+function buildUser(overrides = {}) {
+  const defaultUser = {
+    username: "john",
+    orgId: orgId1,
+    role: "org_user",
+    groups: [buildGroup(groupId1, "member"), buildGroup(groupId2, "admin")],
+  };
+
+  return { ...defaultUser, ...overrides } as IDiscussionsUser;
+}
+
+function buildGroup(id: string, memberType: string, typeKeywords?: string[]) {
+  return {
+    id,
+    userMembership: { memberType },
+    typeKeywords,
+  } as any as IGroup;
+}
+
+describe("canCreateReply", () => {
+  let canPostToChannelSpy: jasmine.Spy;
+  let hasOrgAdminUpdateRightsSpy: jasmine.Spy;
+
+  beforeAll(() => {
+    hasOrgAdminUpdateRightsSpy = spyOn(
+      portalPrivModule,
+      "hasOrgAdminUpdateRights"
+    );
+    canPostToChannelSpy = spyOn(
+      ChannelPermission.prototype,
+      "canPostToChannel"
+    );
+  });
+
+  beforeEach(() => {
+    hasOrgAdminUpdateRightsSpy.calls.reset();
+    canPostToChannelSpy.calls.reset();
+  });
+
+  describe("With Org Admin", () => {
+    it("return true if hasOrgAdminUpdateRights returns true", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => true);
+      canPostToChannelSpy.and.callFake(() => false); // bypass permissions check
+
+      const user = {} as IDiscussionsUser;
+      const channel = { orgId: "aaa", allowReply: false } as IChannel; // bypass channel setting check
+
+      expect(canCreateReply(channel, user)).toBe(true);
+
+      expect(hasOrgAdminUpdateRightsSpy.calls.count()).toBe(1);
+      const [arg1, arg2] = hasOrgAdminUpdateRightsSpy.calls.allArgs()[0]; // args for 1st call
+      expect(arg1).toBe(user);
+      expect(arg2).toBe(channel.orgId);
+
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+  });
+
+  describe("with channelAcl", () => {
+    it("return true if channelPermission.canPostToChannel is true", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      canPostToChannelSpy.and.callFake(() => true);
+
+      const user = buildUser();
+      const channel = {
+        allowReply: true,
+        channelAcl: [{ category: AclCategory.ANONYMOUS_USER, role: Role.READ }],
+      } as IChannel;
+
+      expect(canCreateReply(channel, user)).toBe(true);
+
+      expect(hasOrgAdminUpdateRightsSpy.calls.count()).toBe(1);
+
+      expect(canPostToChannelSpy.calls.count()).toBe(1);
+      const [arg] = canPostToChannelSpy.calls.allArgs()[0]; // arg for 1st call
+      expect(arg).toBe(user);
+    });
+
+    it("return false if channelPermission.canPostToChannel is false", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      canPostToChannelSpy.and.callFake(() => false);
+
+      const user = buildUser();
+      const channel = {
+        allowReply: true,
+        channelAcl: [{ category: AclCategory.ANONYMOUS_USER, role: Role.READ }],
+      } as IChannel;
+
+      expect(canCreateReply(channel, user)).toBe(false);
+
+      expect(hasOrgAdminUpdateRightsSpy.calls.count()).toBe(1);
+
+      expect(canPostToChannelSpy.calls.count()).toBe(1);
+      const [arg] = canPostToChannelSpy.calls.allArgs()[0]; // arg for 1st call
+      expect(arg).toBe(user);
+    });
+
+    it("return false if channel.allowReply is false", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      canPostToChannelSpy.and.callFake(() => true);
+
+      const user = buildUser();
+      const channel = {
+        allowReply: false,
+        channelAcl: [{ category: AclCategory.ANONYMOUS_USER, role: Role.READ }],
+      } as IChannel;
+
+      expect(canCreateReply(channel, user)).toBe(false);
+
+      expect(hasOrgAdminUpdateRightsSpy.calls.count()).toBe(1);
+
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+  });
+
+  describe("with legacy permissions", () => {
+    it("returns true if undefined user attempts to create post in allowAnonymous === true channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const channel = {
+        allowReply: true,
+        allowAnonymous: true,
+      } as IChannel;
+
+      expect(canCreateReply(channel)).toBe(true);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns true if anonymous user attempts to create post in allowAnonymous === true channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = { username: null };
+      const channel = {
+        allowReply: true,
+        allowAnonymous: true,
+      } as IChannel;
+
+      expect(canCreateReply(channel, user)).toBe(true);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if anonymous user attempts to create post in allowAnonymous === false channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = { username: null };
+      const channel = {
+        allowReply: true,
+        allowAnonymous: false,
+      } as IChannel;
+
+      expect(canCreateReply(channel, user)).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns true if authenticated user attempts to create post in public-access channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = { username: "Slughorn" };
+      const channel = {
+        allowReply: true,
+        access: "public",
+        allowAnonymous: false,
+      } as IChannel;
+
+      expect(canCreateReply(channel, user)).toBe(true);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns true if group authorized user attempts to create post in private-access channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        groups: [
+          {
+            id: "abc",
+            userMembership: { memberType: "member" },
+            typeKeywords: [],
+          },
+        ],
+      } as any;
+      const channel = {
+        allowReply: true,
+        access: "private",
+        allowAnonymous: false,
+        groups: ["abc"],
+      } as any;
+
+      expect(canCreateReply(channel, user)).toBe(true);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns true if a group authorized user attempts to create post in private-access channel, but at least one group is NOT marked cannotDiscuss", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        groups: [
+          {
+            id: "abc",
+            userMembership: { memberType: "member" },
+            typeKeywords: ["cannotDiscuss"],
+          },
+          {
+            id: "xyz",
+            userMembership: { memberType: "member" },
+            typeKeywords: [],
+          },
+        ],
+      } as any;
+      const channel = {
+        allowReply: true,
+        access: "private",
+        allowAnonymous: false,
+        groups: ["abc", "xyz"],
+      } as any;
+
+      expect(canCreateReply(channel, user)).toBe(true);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if group authorized user attempts to create post in private-access channel, but the only group is marked cannotDiscuss", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        groups: [
+          {
+            id: "abc",
+            userMembership: { memberType: "member" },
+            typeKeywords: ["cannotDiscuss"],
+          },
+        ],
+      } as any;
+      const channel = {
+        allowReply: true,
+        access: "private",
+        allowAnonymous: false,
+        groups: ["abc"],
+      } as any;
+
+      expect(canCreateReply(channel, user)).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if group unauthorized user attempts to create post in private-access channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        groups: [
+          {
+            id: "abc",
+            userMembership: { memberType: "member" },
+            typeKeywords: [],
+          },
+        ],
+        typeKeywords: [],
+      } as any;
+      const channel = {
+        allowReply: true,
+        access: "private",
+        allowAnonymous: false,
+        groups: ["xyz"],
+      } as any;
+
+      expect(canCreateReply(channel, user)).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("handles missing user/channel groups", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+      } as any;
+      const channel = {
+        allowReply: true,
+        access: "private",
+        allowAnonymous: false,
+      } as any;
+
+      expect(canCreateReply(channel, user)).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns true if org authorized user attempts to create post in org-access channel", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        orgId: "abc",
+      } as any;
+      const channel = {
+        allowReply: true,
+        access: "org",
+        allowAnonymous: false,
+        orgs: ["abc"],
+      } as any;
+
+      expect(canCreateReply(channel, user)).toBe(true);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if unknown access value", () => {
+      hasOrgAdminUpdateRightsSpy.and.callFake(() => false);
+      const user: IDiscussionsUser = {
+        username: "Slughorn",
+        orgId: "abc",
+      } as any;
+      const channel = {
+        allowReply: true,
+        access: "foo",
+        allowAnonymous: false,
+        orgs: ["abc"],
+      } as any;
+
+      expect(canCreateReply(channel, user)).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+  });
+});

--- a/packages/discussions/test/utils/posts/can-edit-post.test.ts
+++ b/packages/discussions/test/utils/posts/can-edit-post.test.ts
@@ -13,7 +13,10 @@ describe("canModifyPost", () => {
   it("returns false if the user did not create the post", () => {
     const post = { id: "postId", creator: "john" } as IPost;
     const user = { username: "notJohn" } as IDiscussionsUser;
-    const channel = { access: SharingAccess.PUBLIC } as IChannel;
+    const channel = {
+      allowPost: true,
+      access: SharingAccess.PUBLIC,
+    } as IChannel;
 
     const result = canModifyPost(post, user, channel);
     expect(result).toBe(false);
@@ -22,7 +25,10 @@ describe("canModifyPost", () => {
   it("returns false if the user is not logged in", () => {
     const post = { id: "postId" } as IPost; // asAnonymous post
     const user = {} as IDiscussionsUser;
-    const channel = { access: SharingAccess.PUBLIC } as IChannel;
+    const channel = {
+      allowPost: true,
+      access: SharingAccess.PUBLIC,
+    } as IChannel;
 
     const result = canModifyPost(post, user, channel);
     expect(result).toBe(false);
@@ -31,7 +37,10 @@ describe("canModifyPost", () => {
   it("returns false if the user undefined", () => {
     const post = { id: "postId" } as IPost; // asAnonymous post
     const user = undefined as unknown as IDiscussionsUser;
-    const channel = { access: SharingAccess.PUBLIC } as IChannel;
+    const channel = {
+      allowPost: true,
+      access: SharingAccess.PUBLIC,
+    } as IChannel;
 
     const result = canModifyPost(post, user, channel);
     expect(result).toBe(false);
@@ -44,7 +53,7 @@ describe("canModifyPost", () => {
     ).and.returnValue(false);
     const post = { id: "postId", creator: "john" } as IPost;
     const user = { username: "john" } as IDiscussionsUser;
-    const channel = { channelAcl: [] } as unknown as IChannel;
+    const channel = { allowPost: true, channelAcl: [] } as unknown as IChannel;
 
     const result = canModifyPost(post, user, channel);
     expect(result).toBe(false);
@@ -57,7 +66,7 @@ describe("canModifyPost", () => {
     ).and.returnValue(true);
     const post = { id: "postId", creator: "john" } as IPost;
     const user = { username: "john" } as IDiscussionsUser;
-    const channel = { channelAcl: [] } as unknown as IChannel;
+    const channel = { allowPost: true, channelAcl: [] } as unknown as IChannel;
 
     const result = canModifyPost(post, user, channel);
     expect(result).toBe(true);
@@ -68,7 +77,10 @@ describe("canModifyPost", () => {
       it("returns true if user is creator", () => {
         const post = { id: "postId", creator: "john" } as IPost;
         const user = { username: "john" } as IDiscussionsUser;
-        const channel = { access: SharingAccess.PUBLIC } as IChannel;
+        const channel = {
+          allowPost: true,
+          access: SharingAccess.PUBLIC,
+        } as IChannel;
 
         const result = canModifyPost(post, user, channel);
         expect(result).toBe(true);
@@ -83,6 +95,7 @@ describe("canModifyPost", () => {
           groups: [{ id: "bbb" }],
         } as IDiscussionsUser;
         const channel = {
+          allowPost: true,
           access: SharingAccess.PRIVATE,
           groups: ["bbb"],
         } as IChannel;
@@ -100,6 +113,7 @@ describe("canModifyPost", () => {
           ] as any as IGroup[],
         } as IDiscussionsUser;
         const channel = {
+          allowPost: true,
           access: SharingAccess.PRIVATE,
           groups: ["bbb"],
         } as IChannel;
@@ -115,6 +129,7 @@ describe("canModifyPost", () => {
           groups: [{ id: "bbb" }],
         } as IDiscussionsUser;
         const channel = {
+          allowPost: true,
           access: SharingAccess.PRIVATE,
           groups: ["zzz"],
         } as IChannel; // user's group not included
@@ -129,6 +144,7 @@ describe("canModifyPost", () => {
           username: "john",
         } as IDiscussionsUser;
         const channel = {
+          allowPost: true,
           access: SharingAccess.PRIVATE,
         } as IChannel;
 
@@ -145,6 +161,7 @@ describe("canModifyPost", () => {
           groups: [{ id: "bbb" }],
         } as IDiscussionsUser;
         const channel = {
+          allowPost: true,
           access: SharingAccess.ORG,
           groups: ["bbb"],
           orgs: ["zzz"], // not user's org
@@ -164,6 +181,7 @@ describe("canModifyPost", () => {
           orgs: ["zzz"], // not user's org
         } as IDiscussionsUser;
         const channel = {
+          allowPost: true,
           access: SharingAccess.ORG,
           groups: ["bbb"],
         } as IChannel;
@@ -179,6 +197,7 @@ describe("canModifyPost", () => {
           groups: [{ id: "bbb" }],
         } as IDiscussionsUser;
         const channel = {
+          allowPost: true,
           access: SharingAccess.ORG,
           groups: ["zzz"], // user's group not included
         } as IChannel;
@@ -193,6 +212,7 @@ describe("canModifyPost", () => {
           username: "john",
         } as IDiscussionsUser;
         const channel = {
+          allowPost: true,
           access: SharingAccess.ORG,
         } as IChannel;
 
@@ -207,6 +227,7 @@ describe("canModifyPost", () => {
           orgId: "ccc",
         } as IDiscussionsUser;
         const channel = {
+          allowPost: true,
           access: SharingAccess.ORG,
           orgs: ["ccc"],
         } as IChannel;
@@ -222,6 +243,7 @@ describe("canModifyPost", () => {
           orgId: "ccc",
         } as IDiscussionsUser;
         const channel = {
+          allowPost: true,
           access: SharingAccess.ORG,
           orgs: ["zzz"], // user's org not included
         } as IChannel;
@@ -234,57 +256,195 @@ describe("canModifyPost", () => {
 });
 
 describe("canEditPost", () => {
-  it("returns false if the user did not create the post", () => {
-    const post = { id: "postId", creator: "john" } as IPost;
-    const user = { username: "notJohn" } as IDiscussionsUser;
-    const channel = { access: SharingAccess.PUBLIC } as IChannel;
+  let canPostToChannelSpy: jasmine.Spy;
 
-    const result = canEditPost(post, user, channel);
-    expect(result).toBe(false);
-  });
-
-  it("returns false if the user is not logged in", () => {
-    const post = { id: "postId" } as IPost; // asAnonymous post
-    const user = {} as IDiscussionsUser;
-    const channel = { access: SharingAccess.PUBLIC } as IChannel;
-
-    const result = canEditPost(post, user, channel);
-    expect(result).toBe(false);
-  });
-
-  it("returns false if the user undefined", () => {
-    const post = { id: "postId" } as IPost; // asAnonymous post
-    const user = undefined as unknown as IDiscussionsUser;
-    const channel = { access: SharingAccess.PUBLIC } as IChannel;
-
-    const result = canEditPost(post, user, channel);
-    expect(result).toBe(false);
-  });
-
-  it("returns false if the user created the post but can longer write to channel", () => {
-    const canModerateChannelSpy = spyOn(
+  beforeAll(() => {
+    canPostToChannelSpy = spyOn(
       ChannelPermission.prototype,
       "canPostToChannel"
-    ).and.returnValue(false);
-    const post = { id: "postId", creator: "john" } as IPost;
-    const user = { username: "john" } as IDiscussionsUser;
-    const channel = { channelAcl: [] } as unknown as IChannel;
-
-    const result = canEditPost(post, user, channel);
-    expect(result).toBe(false);
+    );
   });
 
-  it("returns true if the user created the post and can still write to channel", () => {
-    const canModerateChannelSpy = spyOn(
-      ChannelPermission.prototype,
-      "canPostToChannel"
-    ).and.returnValue(true);
-    const post = { id: "postId", creator: "john" } as IPost;
-    const user = { username: "john" } as IDiscussionsUser;
-    const channel = { channelAcl: [] } as unknown as IChannel;
+  beforeEach(() => {
+    canPostToChannelSpy.calls.reset();
+  });
 
-    const result = canEditPost(post, user, channel);
-    expect(result).toBe(true);
+  describe("POST", () => {
+    it("returns false if the user did not create the post", () => {
+      const post = { id: "postId", creator: "john" } as IPost;
+      const user = { username: "notJohn" } as IDiscussionsUser;
+      const channel = {
+        allowPost: true,
+        channelAcl: [],
+      } as unknown as IChannel;
+
+      const result = canEditPost(post, user, channel);
+      expect(result).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if the user is not logged in", () => {
+      const post = { id: "postId" } as IPost; // asAnonymous post
+      const user = {} as IDiscussionsUser;
+      const channel = {
+        allowPost: true,
+        channelAcl: [],
+      } as unknown as IChannel;
+
+      const result = canEditPost(post, user, channel);
+      expect(result).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if the user undefined", () => {
+      const post = { id: "postId" } as IPost; // asAnonymous post
+      const user = undefined as unknown as IDiscussionsUser;
+      const channel = {
+        allowPost: true,
+        channelAcl: [],
+      } as unknown as IChannel;
+
+      const result = canEditPost(post, user, channel);
+      expect(result).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if channel.allowPost is false", () => {
+      canPostToChannelSpy.and.callFake(() => true); // bypass permissions check
+      const post = { id: "postId", creator: "john" } as IPost;
+      const user = { username: "john" } as IDiscussionsUser;
+      const channel = {
+        allowPost: false,
+        channelAcl: [],
+      } as unknown as IChannel;
+
+      const result = canEditPost(post, user, channel);
+      expect(result).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if the user created the post but can longer write to channel", () => {
+      canPostToChannelSpy.and.callFake(() => false);
+      const post = { id: "postId", creator: "john" } as IPost;
+      const user = { username: "john" } as IDiscussionsUser;
+      const channel = {
+        allowPost: true,
+        channelAcl: [],
+      } as unknown as IChannel;
+
+      const result = canEditPost(post, user, channel);
+      expect(result).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(1);
+      const [arg] = canPostToChannelSpy.calls.allArgs()[0]; // arg for 1st call
+      expect(arg).toBe(user);
+    });
+
+    it("returns true if the user created the post and can still write to channel", () => {
+      canPostToChannelSpy.and.callFake(() => true);
+      const post = { id: "postId", creator: "john" } as IPost;
+      const user = { username: "john" } as IDiscussionsUser;
+      const channel = {
+        allowPost: true,
+        channelAcl: [],
+      } as unknown as IChannel;
+
+      const result = canEditPost(post, user, channel);
+      expect(result).toBe(true);
+
+      expect(canPostToChannelSpy.calls.count()).toBe(1);
+      const [arg] = canPostToChannelSpy.calls.allArgs()[0]; // arg for 1st call
+      expect(arg).toBe(user);
+    });
+  });
+
+  describe("REPLY", () => {
+    it("returns false if the user did not create the reply", () => {
+      const post = { id: "postId", creator: "john", parentId: "aaa" } as IPost;
+      const user = { username: "notJohn" } as IDiscussionsUser;
+      const channel = {
+        allowReply: true,
+        channelAcl: [],
+      } as unknown as IChannel;
+
+      const result = canEditPost(post, user, channel);
+      expect(result).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if the user is not logged in", () => {
+      const post = { id: "postId", parentId: "aaa" } as IPost; // asAnonymous post
+      const user = {} as IDiscussionsUser;
+      const channel = {
+        allowReply: true,
+        channelAcl: [],
+      } as unknown as IChannel;
+
+      const result = canEditPost(post, user, channel);
+      expect(result).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if the user undefined", () => {
+      const post = { id: "postId", parentId: "aaa" } as IPost; // asAnonymous post
+      const user = undefined as unknown as IDiscussionsUser;
+      const channel = {
+        allowReply: true,
+        channelAcl: [],
+      } as unknown as IChannel;
+
+      const result = canEditPost(post, user, channel);
+      expect(result).toBe(false);
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false channel.allowReply is false", () => {
+      canPostToChannelSpy.and.callFake(() => true); // bypass permissions check
+      const post = { id: "postId", creator: "john", parentId: "aaa" } as IPost;
+      const user = { username: "john" } as IDiscussionsUser;
+      const channel = {
+        allowReply: false,
+        channelAcl: [],
+      } as unknown as IChannel;
+
+      const result = canEditPost(post, user, channel);
+      expect(result).toBe(false);
+
+      expect(canPostToChannelSpy.calls.count()).toBe(0);
+    });
+
+    it("returns false if the user created the post but can longer write to channel", () => {
+      canPostToChannelSpy.and.callFake(() => false);
+      const post = { id: "postId", creator: "john", parentId: "aaa" } as IPost;
+      const user = { username: "john" } as IDiscussionsUser;
+      const channel = {
+        allowReply: true,
+        channelAcl: [],
+      } as unknown as IChannel;
+
+      const result = canEditPost(post, user, channel);
+      expect(result).toBe(false);
+
+      expect(canPostToChannelSpy.calls.count()).toBe(1);
+      const [arg] = canPostToChannelSpy.calls.allArgs()[0]; // arg for 1st call
+      expect(arg).toBe(user);
+    });
+
+    it("returns true if the user created the post and can still write to channel", () => {
+      canPostToChannelSpy.and.callFake(() => true);
+      const post = { id: "postId", creator: "john", parentId: "aaa" } as IPost;
+      const user = { username: "john" } as IDiscussionsUser;
+      const channel = {
+        allowReply: true,
+        channelAcl: [],
+      } as unknown as IChannel;
+
+      const result = canEditPost(post, user, channel);
+      expect(result).toBe(true);
+
+      expect(canPostToChannelSpy.calls.count()).toBe(1);
+      const [arg] = canPostToChannelSpy.calls.allArgs()[0]; // arg for 1st call
+      expect(arg).toBe(user);
+    });
   });
 
   describe("Legacy Permissions", () => {


### PR DESCRIPTION
affects: @esri/hub-discussions

1. Description: Add new util functions `canCreatePost` and `canCreateReply`. Modify the `canEditPost` util function to also check channel properties `allowPost` or `allowReply`, dependent on whether the post is a post or a reply (has a `parentId`)

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
