### PR TITLE
feat(hub-common): add fetchItem and call it from fetchPage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22695,10 +22695,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22713,24 +22712,21 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22744,10 +22740,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22765,10 +22760,9 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65023,7 +65017,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.13.0",
+			"version": "15.13.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -83531,8 +83525,7 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83547,20 +83540,17 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"dev": true,
-							"peer": true,
+							"extraneous": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83574,8 +83564,7 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83592,8 +83581,7 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"dev": true,
-							"peer": true
+							"extraneous": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/items/_internal/slugs.ts
+++ b/packages/common/src/items/_internal/slugs.ts
@@ -1,3 +1,10 @@
+import { isGuid } from "../../utils/is-guid";
+
+const SLUG_ID_SEPARATOR = "~";
+
+// TODO: use this const in other utils
+const SLUG_ORG_KEY_SEPARATOR = "::";
+
 const TYPEKEYWORD_MAX_LENGTH = 256;
 
 export const TYPEKEYWORD_SLUG_PREFIX = "slug";
@@ -40,3 +47,42 @@ export function getSlugMaxLength(orgKey: string) {
   const prefix = `${TYPEKEYWORD_SLUG_PREFIX}|${orgKey}|`;
   return TYPEKEYWORD_MAX_LENGTH - prefix.length;
 }
+
+export interface IParsedIdentifier {
+  /* ArcGIS Online item Id */
+  id?: string;
+  /* slug (without org prefix) */
+  slug?: string;
+  /* org key */
+  orgKey?: string;
+}
+
+/**
+ * parse out the item's id, slug, and org key out of an identifier
+ * @param identifier
+ * @returns
+ */
+export const parseIdentifier = (identifier: string): IParsedIdentifier => {
+  let orgKey;
+  let slug;
+  // if identifier is a guid, we just return that as the id below
+  let id = isGuid(identifier) && identifier;
+  if (!id) {
+    // otherwise try parsing id, slug, and org key from the identifier
+    let slugParts;
+    [slugParts, id] = identifier.split(SLUG_ID_SEPARATOR);
+    const match = slugParts.match(
+      new RegExp(`^((.*)${SLUG_ORG_KEY_SEPARATOR})?(.*)$`)
+    );
+    // istanbul ignore next - I think that regex will always match at least the slug
+    if (match) {
+      orgKey = match[2];
+      slug = match[3];
+    }
+  }
+  return {
+    id,
+    slug,
+    orgKey,
+  };
+};

--- a/packages/common/src/items/fetch.ts
+++ b/packages/common/src/items/fetch.ts
@@ -1,0 +1,38 @@
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { IItem, getItem } from "@esri/arcgis-rest-portal";
+import { addContextToSlug } from "../content";
+import { findItemsBySlug } from "./slugs";
+import { uriSlugToKeywordSlug } from "./_internal/slugConverters";
+import { parseIdentifier } from "./_internal/slugs";
+
+/**
+ * Fetch an item by its identifier
+ * @param identifier item id or slug, which may or may not include the org key
+ * @param requestOptions
+ */
+export function fetchItem(
+  identifier: string,
+  requestOptions: IRequestOptions
+): Promise<IItem> {
+  const { id, slug, orgKey } = parseIdentifier(identifier);
+  if (id) {
+    // use the id to fetch the item
+    return getItem(id, requestOptions);
+  }
+  // we'll have to look up by slug
+  // first, ensure the slug has the org key
+  // TODO: fallback to site org key if none parsed from slug
+  const fullyQualifiedSlug = addContextToSlug(slug, orgKey);
+  const slugKeyword = uriSlugToKeywordSlug(fullyQualifiedSlug);
+  return findItemsBySlug({ slug: slugKeyword }, requestOptions).then(
+    (results) => {
+      if (results.length) {
+        // search results only include a subset of properties of the item, so
+        // issue a subsequent call to getItem to get the full item details
+        return getItem(results[0].id, requestOptions);
+      } else {
+        return null;
+      }
+    }
+  );
+}

--- a/packages/common/src/items/fetch.ts
+++ b/packages/common/src/items/fetch.ts
@@ -5,6 +5,15 @@ import { findItemsBySlug } from "./slugs";
 import { uriSlugToKeywordSlug } from "./_internal/slugConverters";
 import { parseIdentifier } from "./_internal/slugs";
 
+export interface IFetchItemOptions extends IRequestOptions {
+  /**
+   * Org key of the site for which this item is being fetched.
+   * This is used as a fallback when looking up by a slug
+   * that is missing the org key prefix.
+   */
+  siteOrgKey?: string;
+}
+
 /**
  * Fetch an item by its identifier
  * @param identifier item id or slug, which may or may not include the org key
@@ -12,7 +21,7 @@ import { parseIdentifier } from "./_internal/slugs";
  */
 export function fetchItem(
   identifier: string,
-  requestOptions: IRequestOptions
+  requestOptions: IFetchItemOptions
 ): Promise<IItem> {
   const { id, slug, orgKey } = parseIdentifier(identifier);
   if (id) {
@@ -21,8 +30,10 @@ export function fetchItem(
   }
   // we'll have to look up by slug
   // first, ensure the slug has the org key
-  // TODO: fallback to site org key if none parsed from slug
-  const fullyQualifiedSlug = addContextToSlug(slug, orgKey);
+  const fullyQualifiedSlug = addContextToSlug(
+    slug,
+    orgKey || requestOptions.siteOrgKey
+  );
   const slugKeyword = uriSlugToKeywordSlug(fullyQualifiedSlug);
   return findItemsBySlug({ slug: slugKeyword }, requestOptions).then(
     (results) => {

--- a/packages/common/src/items/index.ts
+++ b/packages/common/src/items/index.ts
@@ -26,6 +26,7 @@ export * from "./getItemIdentifier";
 export * from "./deleteItemThumbnail";
 export * from "./deleteItemThumbnail";
 export * from "./follow";
+export * from "./fetch";
 // No longer exported as the only App Hub needed this for was a Site
 // and that registration is now done in the domain service with a
 // signed HMAC request.

--- a/packages/common/src/pages/HubPages.ts
+++ b/packages/common/src/pages/HubPages.ts
@@ -25,7 +25,7 @@ import { IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
 import { DEFAULT_PAGE, DEFAULT_PAGE_MODEL } from "./defaults";
 import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
 import { computeLinks } from "./_internal/computeLinks";
-import { fetchItem } from "../items/fetch";
+import { IFetchItemOptions, fetchItem } from "../items/fetch";
 
 /**
  * @private
@@ -107,7 +107,7 @@ export async function updatePage(
  */
 export async function fetchPage(
   identifier: string,
-  requestOptions: IRequestOptions
+  requestOptions: IFetchItemOptions
 ): Promise<IHubPage> {
   const item = await fetchItem(identifier, requestOptions);
   return item ? convertItemToPage(item, requestOptions) : null;

--- a/packages/common/src/pages/HubPages.ts
+++ b/packages/common/src/pages/HubPages.ts
@@ -6,10 +6,10 @@ import { IHubSearchResult } from "../search";
 import { parseInclude } from "../search/_internal/parseInclude";
 import { IHubRequestOptions, IModel } from "../types";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { getItem, IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-portal";
 import { cloneObject, unique } from "../util";
-import { mapBy, isGuid } from "../utils";
-import { constructSlug, getItemBySlug } from "../items/slugs";
+import { mapBy } from "../utils";
+import { constructSlug } from "../items/slugs";
 import { IHubItemEntity, IHubPage } from "../core";
 import {
   createModel,
@@ -25,6 +25,7 @@ import { IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
 import { DEFAULT_PAGE, DEFAULT_PAGE_MODEL } from "./defaults";
 import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
 import { computeLinks } from "./_internal/computeLinks";
+import { fetchItem } from "../items/fetch";
 
 /**
  * @private
@@ -108,17 +109,8 @@ export async function fetchPage(
   identifier: string,
   requestOptions: IRequestOptions
 ): Promise<IHubPage> {
-  let getPrms;
-  if (isGuid(identifier)) {
-    // get item by id
-    getPrms = getItem(identifier, requestOptions);
-  } else {
-    getPrms = getItemBySlug(identifier, requestOptions);
-  }
-  return getPrms.then((item) => {
-    if (!item) return null;
-    return convertItemToPage(item, requestOptions);
-  });
+  const item = await fetchItem(identifier, requestOptions);
+  return item ? convertItemToPage(item, requestOptions) : null;
 }
 
 /**

--- a/packages/common/src/pages/_internal/computeProps.ts
+++ b/packages/common/src/pages/_internal/computeProps.ts
@@ -26,6 +26,7 @@ export function computeProps(
   requestOptions: IRequestOptions
 ): IHubPage {
   let token: string;
+  // istanbul ignore next - this logic is covered elsewhere and should be refactored into a shared util
   if (requestOptions.authentication) {
     const session: UserSession = requestOptions.authentication as UserSession;
     token = session.token;

--- a/packages/common/test/items/_internal/slug.test.ts
+++ b/packages/common/test/items/_internal/slug.test.ts
@@ -1,0 +1,47 @@
+import { parseIdentifier } from "../../../src/items/_internal/slugs";
+
+describe("item _internal slug", () => {
+  const guidId = "67be0486253a423891042361843d1b0a";
+  describe("parseIdentifier", () => {
+    it("only returns an id when identifier is a guid", () => {
+      const identifier = guidId;
+      expect(parseIdentifier(identifier)).toEqual({
+        id: guidId,
+        orgKey: undefined,
+        slug: undefined,
+      });
+    });
+    it("parses an identifier with an id and an org key", () => {
+      const identifier = `some-org::some-slug~${guidId}`;
+      expect(parseIdentifier(identifier)).toEqual({
+        id: guidId,
+        orgKey: "some-org",
+        slug: "some-slug",
+      });
+    });
+    it("parses an identifier with no id", () => {
+      const identifier = "some-org::some-slug";
+      expect(parseIdentifier(identifier)).toEqual({
+        id: undefined,
+        orgKey: "some-org",
+        slug: "some-slug",
+      });
+    });
+    it("parses an identifier with no id and no org key", () => {
+      const identifier = "some-slug";
+      expect(parseIdentifier(identifier)).toEqual({
+        id: undefined,
+        orgKey: undefined,
+        slug: "some-slug",
+      });
+    });
+    it("handles an empty string", () => {
+      const identifier = "";
+      expect(parseIdentifier(identifier)).toEqual({
+        id: undefined,
+        orgKey: undefined,
+        slug: "",
+      });
+    });
+  });
+});

--- a/packages/common/test/items/fetch.test.ts
+++ b/packages/common/test/items/fetch.test.ts
@@ -6,8 +6,10 @@ import { MOCK_AUTH } from "../groups/add-users-workflow/fixtures";
 
 describe("fetchItem", () => {
   const authentication = MOCK_AUTH;
+  const siteOrgKey = "site-org";
   const requestOptions = {
     authentication,
+    siteOrgKey,
   };
   it("calls getItem with id when identifier is or contains an id", async () => {
     const identifier = "67be0486253a423891042361843d1b0a";
@@ -48,6 +50,34 @@ describe("fetchItem", () => {
         orgKey,
       };
       const slugInfo = { slug: `${orgKey}|${slug}` };
+      const parseIdentifierSpy = spyOn(
+        _internalSlugModule,
+        "parseIdentifier"
+      ).and.returnValue(parsedIdentifier);
+      const findItemsBySlugSpy = spyOn(
+        slugModule,
+        "findItemsBySlug"
+      ).and.returnValue(Promise.resolve([searchResult]));
+      const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
+        Promise.resolve(item)
+      );
+
+      const result = await fetchItem(identifier, requestOptions);
+
+      expect(result).toBe(item);
+      expect(parseIdentifierSpy.calls.count()).toBe(1);
+      expect(parseIdentifierSpy).toHaveBeenCalledWith(identifier);
+      expect(findItemsBySlugSpy.calls.count()).toBe(1);
+      expect(findItemsBySlugSpy).toHaveBeenCalledWith(slugInfo, requestOptions);
+      expect(getItemSpy.calls.count()).toBe(1);
+      expect(getItemSpy).toHaveBeenCalledWith(searchResult.id, requestOptions);
+    });
+    it('falls back to "siteOrgKey" when org key is missing from slug', async () => {
+      const identifier = slug;
+      const parsedIdentifier = {
+        slug,
+      };
+      const slugInfo = { slug: `${siteOrgKey}|${slug}` };
       const parseIdentifierSpy = spyOn(
         _internalSlugModule,
         "parseIdentifier"

--- a/packages/common/test/items/fetch.test.ts
+++ b/packages/common/test/items/fetch.test.ts
@@ -1,0 +1,102 @@
+import * as portalModule from "@esri/arcgis-rest-portal";
+import * as slugModule from "../../src/items/slugs";
+import * as _internalSlugModule from "../../src/items/_internal/slugs";
+import { fetchItem } from "../../src/items/fetch";
+import { MOCK_AUTH } from "../groups/add-users-workflow/fixtures";
+
+describe("fetchItem", () => {
+  const authentication = MOCK_AUTH;
+  const requestOptions = {
+    authentication,
+  };
+  it("calls getItem with id when identifier is or contains an id", async () => {
+    const identifier = "67be0486253a423891042361843d1b0a";
+    const id = identifier;
+    const parsedIdentifier = {
+      id,
+    };
+    const item = {
+      id,
+    } as any as portalModule.IItem;
+    const parseIdentifierSpy = spyOn(
+      _internalSlugModule,
+      "parseIdentifier"
+    ).and.returnValue(parsedIdentifier);
+    const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
+      Promise.resolve(item)
+    );
+
+    const result = await fetchItem(identifier, requestOptions);
+
+    expect(result).toBe(item);
+    expect(parseIdentifierSpy.calls.count()).toBe(1);
+    expect(parseIdentifierSpy).toHaveBeenCalledWith(identifier);
+    expect(getItemSpy.calls.count()).toBe(1);
+    expect(getItemSpy).toHaveBeenCalledWith(identifier, requestOptions);
+  });
+  describe("when identifier is a slug w/ no id", () => {
+    const slug = "some-slug";
+    const orgKey = "some-org";
+    const searchResult = {
+      id: "3ef",
+    };
+    const item = searchResult as any as portalModule.IItem;
+    it("returns first item found by slug w/ org key", async () => {
+      const identifier = `${orgKey}::${slug}`;
+      const parsedIdentifier = {
+        slug,
+        orgKey,
+      };
+      const slugInfo = { slug: `${orgKey}|${slug}` };
+      const parseIdentifierSpy = spyOn(
+        _internalSlugModule,
+        "parseIdentifier"
+      ).and.returnValue(parsedIdentifier);
+      const findItemsBySlugSpy = spyOn(
+        slugModule,
+        "findItemsBySlug"
+      ).and.returnValue(Promise.resolve([searchResult]));
+      const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
+        Promise.resolve(item)
+      );
+
+      const result = await fetchItem(identifier, requestOptions);
+
+      expect(result).toBe(item);
+      expect(parseIdentifierSpy.calls.count()).toBe(1);
+      expect(parseIdentifierSpy).toHaveBeenCalledWith(identifier);
+      expect(findItemsBySlugSpy.calls.count()).toBe(1);
+      expect(findItemsBySlugSpy).toHaveBeenCalledWith(slugInfo, requestOptions);
+      expect(getItemSpy.calls.count()).toBe(1);
+      expect(getItemSpy).toHaveBeenCalledWith(searchResult.id, requestOptions);
+    });
+    it("returns null if no item found by slug", async () => {
+      const identifier = `${orgKey}::${slug}`;
+      const parsedIdentifier = {
+        slug,
+        orgKey,
+      };
+      const slugInfo = { slug: `${orgKey}|${slug}` };
+      const parseIdentifierSpy = spyOn(
+        _internalSlugModule,
+        "parseIdentifier"
+      ).and.returnValue(parsedIdentifier);
+      const findItemsBySlugSpy = spyOn(
+        slugModule,
+        "findItemsBySlug"
+      ).and.returnValue(Promise.resolve([]));
+      const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
+        Promise.resolve(item)
+      );
+
+      const result = await fetchItem(identifier, requestOptions);
+
+      expect(result).toBeNull();
+      expect(parseIdentifierSpy.calls.count()).toBe(1);
+      expect(parseIdentifierSpy).toHaveBeenCalledWith(identifier);
+      expect(findItemsBySlugSpy.calls.count()).toBe(1);
+      expect(findItemsBySlugSpy).toHaveBeenCalledWith(slugInfo, requestOptions);
+      expect(getItemSpy.calls.count()).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
1. Description:

- adds `fetchItem()` which:
  - uses a new internal `parseIdentifier()` to parse the id or slug out of the identifier
  - allows callers to pass in the site's org key as a fallback for slugs w/o an org key prefix
  - encapsulates the logic for calling the appropriate function to fetch via id or slug
- `fetchPage()` now defers to `fetchItem()` to handle all the above (we will do the same for other item-backed entities in a future PR)

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
