### PR TITLE
feat(hub-common): add optional includeIdInSlug arg to getItemIdentifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22695,9 +22695,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22712,21 +22713,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22740,9 +22744,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22760,9 +22765,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65017,7 +65023,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.13.2",
+			"version": "15.15.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -83525,7 +83531,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83540,17 +83547,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83564,7 +83574,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83581,7 +83592,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/core/_internal/computeItemLinks.ts
+++ b/packages/common/src/core/_internal/computeItemLinks.ts
@@ -29,10 +29,12 @@ export function computeItemLinks(
     self: getItemHomeUrl(item.id, requestOptions),
     siteRelative: getHubRelativeUrl(
       item.type,
+      // use slug if available, otherwise id
       getItemIdentifier(item),
       item.typeKeywords
     ),
     siteRelativeEntityType: getHubRelativeUrl(item.type),
+    // no SEO for workspace, so we always use id instead of slug
     workspaceRelative: getRelativeWorkspaceUrl(item.type, item.id),
     thumbnail: getItemThumbnailUrl(item, requestOptions, token),
   };

--- a/packages/common/src/items/_internal/slugConverters.ts
+++ b/packages/common/src/items/_internal/slugConverters.ts
@@ -1,3 +1,7 @@
+// TODO: use these const in other utils
+export const SLUG_ORG_SEPARATOR_URI = "::";
+export const SLUG_ORG_SEPARATOR_KEYWORD = "|";
+
 // TODO: work out how to unify content slug fns
 // https: github.com/Esri/hub.js/blob/master/packages/common/src/content/index.ts#L301-L348
 /**
@@ -8,8 +12,8 @@
  */
 
 export function uriSlugToKeywordSlug(slug: string): string {
-  if (slug.indexOf("::") > -1) {
-    slug = slug.replace("::", "|");
+  if (slug.indexOf(SLUG_ORG_SEPARATOR_URI) > -1) {
+    slug = slug.replace(SLUG_ORG_SEPARATOR_URI, SLUG_ORG_SEPARATOR_KEYWORD);
   }
   return slug;
 }
@@ -20,8 +24,8 @@ export function uriSlugToKeywordSlug(slug: string): string {
  */
 
 export function keywordSlugToUriSlug(slug: string): string {
-  if (slug.indexOf("|") > -1) {
-    slug = slug.replace("|", "::");
+  if (slug.indexOf(SLUG_ORG_SEPARATOR_KEYWORD) > -1) {
+    slug = slug.replace(SLUG_ORG_SEPARATOR_KEYWORD, SLUG_ORG_SEPARATOR_URI);
   }
   return slug;
 }

--- a/packages/common/src/items/_internal/slugs.ts
+++ b/packages/common/src/items/_internal/slugs.ts
@@ -1,9 +1,10 @@
 import { isGuid } from "../../utils/is-guid";
+import {
+  SLUG_ORG_SEPARATOR_KEYWORD,
+  SLUG_ORG_SEPARATOR_URI,
+} from "./slugConverters";
 
 const SLUG_ID_SEPARATOR = "~";
-
-// TODO: use this const in other utils
-const SLUG_ORG_KEY_SEPARATOR = "::";
 
 const TYPEKEYWORD_MAX_LENGTH = 256;
 
@@ -72,7 +73,7 @@ export const parseIdentifier = (identifier: string): IParsedIdentifier => {
     let slugParts;
     [slugParts, id] = identifier.split(SLUG_ID_SEPARATOR);
     const match = slugParts.match(
-      new RegExp(`^((.*)${SLUG_ORG_KEY_SEPARATOR})?(.*)$`)
+      new RegExp(`^((.*)${SLUG_ORG_SEPARATOR_URI})?(.*)$`)
     );
     // istanbul ignore next - I think that regex will always match at least the slug
     if (match) {
@@ -85,4 +86,15 @@ export const parseIdentifier = (identifier: string): IParsedIdentifier => {
     slug,
     orgKey,
   };
+};
+
+/**
+ * strip org key prefix from a slug and append an id
+ * @param slug
+ * @param id
+ * @returns
+ */
+export const appendIdToSlug = (slug: string, id: string): string => {
+  const slugWithoutOrgKey = slug.split(SLUG_ORG_SEPARATOR_KEYWORD).pop();
+  return `${slugWithoutOrgKey}${SLUG_ID_SEPARATOR}${id}`;
 };

--- a/packages/common/src/items/getItemIdentifier.ts
+++ b/packages/common/src/items/getItemIdentifier.ts
@@ -1,12 +1,21 @@
 import { IItem } from "@esri/arcgis-rest-portal";
 import { keywordSlugToUriSlug } from "./_internal/slugConverters";
+import { appendIdToSlug } from "./_internal/slugs";
 
 /**
  * Consistent means to get an item's identifier - either the slug or the id
  * @param item
  * @returns
  */
-export function getItemIdentifier(item: IItem): string {
-  const slug = item.properties?.slug;
-  return slug ? keywordSlugToUriSlug(slug) : item.id;
+export function getItemIdentifier(
+  item: IItem,
+  // for backwards compatibility, we do not include the id in the slug by default
+  // once all of the routes have been updated to expect slugs w/ ids, we should always include the id
+  includeIdInSlug = false
+): string {
+  const { id, properties } = item;
+  const slug = properties?.slug;
+  return slug
+    ? keywordSlugToUriSlug(includeIdInSlug ? appendIdToSlug(slug, id) : slug)
+    : id;
 }

--- a/packages/common/src/pages/_internal/computeLinks.ts
+++ b/packages/common/src/pages/_internal/computeLinks.ts
@@ -2,6 +2,8 @@ import { IItem } from "@esri/arcgis-rest-types";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IHubEntityLinks } from "../../core/types";
 import { computeItemLinks } from "../../core/_internal/computeItemLinks";
+import { getHubRelativeUrl } from "../../content/_internal/internalContentUtils";
+import { getItemIdentifier } from "../../items/getItemIdentifier";
 
 /**
  * Compute the links that get appended to a Hub Site
@@ -15,8 +17,18 @@ export function computeLinks(
   requestOptions: IRequestOptions
 ): IHubEntityLinks {
   const links = computeItemLinks(item, requestOptions);
+  // re-compute the site relative link to include the id
+  // NOTE: when we expand this beyond pages we should drop this override
+  // and just pass true to getItemIdentifier in computeItemLinks
+  const siteRelative = getHubRelativeUrl(
+    item.type,
+    getItemIdentifier(item, true),
+    item.typeKeywords
+  );
   return {
     ...links,
+    // add id to site relative link
+    siteRelative,
     // add the layout relative link
     layoutRelative: `/pages/${item.id}/edit`,
   };

--- a/packages/common/test/items/getItemIdentifier.test.ts
+++ b/packages/common/test/items/getItemIdentifier.test.ts
@@ -2,19 +2,20 @@ import { IItem } from "@esri/arcgis-rest-portal";
 import { getItemIdentifier } from "../../src";
 
 describe("getItemIdentifier:", () => {
+  const item = {
+    id: "3ef",
+  } as unknown as IItem;
+  const properties = {
+    slug: "myorg|the-slug",
+  };
+  const itemWithSlug = { ...item, properties };
   it("returns id by default", () => {
-    const item = {
-      id: "3ef",
-    } as unknown as IItem;
     expect(getItemIdentifier(item)).toBe("3ef");
   });
   it("returns slug if defined", () => {
-    const item = {
-      id: "3ef",
-      properties: {
-        slug: "myorg|the-slug",
-      },
-    } as unknown as IItem;
-    expect(getItemIdentifier(item)).toBe("myorg::the-slug");
+    expect(getItemIdentifier(itemWithSlug)).toBe("myorg::the-slug");
+  });
+  it("injects id into slug if requested", () => {
+    expect(getItemIdentifier(itemWithSlug, true)).toBe("the-slug~3ef");
   });
 });


### PR DESCRIPTION
and use it to inject slug into site relative URLs for pages

affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
