### PR TITLE
fix(): add required type to IChangeEventDetail

### DIFF
--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -186,6 +186,9 @@ export interface IChangeEventDetail {
     [key: string]: any;
   };
   schema?: IConfigurationSchema;
+  /**
+   * The currently required properties in the schema
+   */
   required?: string[];
 }
 

--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -189,7 +189,7 @@ export interface IChangeEventDetail {
   /**
    * The currently required properties in the schema
    */
-  required?: string[];
+  required?: Set<string>;
 }
 
 export interface IUiSchemaElement {

--- a/packages/common/src/core/schemas/types.ts
+++ b/packages/common/src/core/schemas/types.ts
@@ -186,6 +186,7 @@ export interface IChangeEventDetail {
     [key: string]: any;
   };
   schema?: IConfigurationSchema;
+  required?: string[];
 }
 
 export interface IUiSchemaElement {

--- a/packages/common/src/sites/_internal/SiteUiSchemaSettings.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaSettings.ts
@@ -26,7 +26,7 @@ export const buildUiSchema = async (
         labelKey: `${i18nScope}.sections.siteUrl.label`,
         options: {
           requiredHelperText: {
-            labelKey: `${i18nScope}.shared.sections.defaultRequiredHelperText`,
+            labelKey: `${i18nScope}.sections.defaultRequiredHelperText`,
           },
         },
         elements: [

--- a/packages/common/src/sites/_internal/SiteUiSchemaSettings.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaSettings.ts
@@ -32,6 +32,9 @@ export const buildUiSchema = async (
               type: "Control",
               control: "hub-composite-input-site-url",
               orgUrlKey,
+              requiredHelperText: {
+                labelKey: `${i18nScope}.shared.sections.defaultRequiredHelperText`,
+              },
               messages: [
                 {
                   type: "ERROR",

--- a/packages/common/src/sites/_internal/SiteUiSchemaSettings.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaSettings.ts
@@ -24,6 +24,11 @@ export const buildUiSchema = async (
       {
         type: "Section",
         labelKey: `${i18nScope}.sections.siteUrl.label`,
+        options: {
+          requiredHelperText: {
+            labelKey: `${i18nScope}.shared.sections.defaultRequiredHelperText`,
+          },
+        },
         elements: [
           {
             scope: "/properties/_urlInfo",
@@ -32,9 +37,6 @@ export const buildUiSchema = async (
               type: "Control",
               control: "hub-composite-input-site-url",
               orgUrlKey,
-              requiredHelperText: {
-                labelKey: `${i18nScope}.shared.sections.defaultRequiredHelperText`,
-              },
               messages: [
                 {
                   type: "ERROR",

--- a/packages/common/test/sites/_internal/SiteuUiSchemaSettings.test.ts
+++ b/packages/common/test/sites/_internal/SiteuUiSchemaSettings.test.ts
@@ -22,6 +22,9 @@ describe("buildUiSchema: site settings", () => {
               type: "Control",
               options: {
                 type: "Control",
+                requiredHelperText: {
+                  labelKey: `${i18nScope}.shared.sections.defaultRequiredHelperText`,
+                },
                 control: "hub-composite-input-site-url",
                 orgUrlKey,
                 messages: [

--- a/packages/common/test/sites/_internal/SiteuUiSchemaSettings.test.ts
+++ b/packages/common/test/sites/_internal/SiteuUiSchemaSettings.test.ts
@@ -16,15 +16,17 @@ describe("buildUiSchema: site settings", () => {
         {
           type: "Section",
           labelKey: `${i18nScope}.sections.siteUrl.label`,
+          options: {
+            requiredHelperText: {
+              labelKey: `${i18nScope}.shared.sections.defaultRequiredHelperText`,
+            },
+          },
           elements: [
             {
               scope: "/properties/_urlInfo",
               type: "Control",
               options: {
                 type: "Control",
-                requiredHelperText: {
-                  labelKey: `${i18nScope}.shared.sections.defaultRequiredHelperText`,
-                },
                 control: "hub-composite-input-site-url",
                 orgUrlKey,
                 messages: [

--- a/packages/common/test/sites/_internal/SiteuUiSchemaSettings.test.ts
+++ b/packages/common/test/sites/_internal/SiteuUiSchemaSettings.test.ts
@@ -18,7 +18,7 @@ describe("buildUiSchema: site settings", () => {
           labelKey: `${i18nScope}.sections.siteUrl.label`,
           options: {
             requiredHelperText: {
-              labelKey: `${i18nScope}.shared.sections.defaultRequiredHelperText`,
+              labelKey: `${i18nScope}.sections.defaultRequiredHelperText`,
             },
           },
           elements: [


### PR DESCRIPTION
1. Description:
Updates the `IChangeEventDetail` type to have `required: Set<string>` on it, meaning the currently required properties in the editor.

1. Instructions for testing:

1. Closes Issues: [#11605](https://zentopia.esri.com/workspaces/sprint-board-60340b9721bc3a4ab6367db5/issues/gh/dc/hub/11605)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
