### PR TITLE
fix: removing extra launch icons on user settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65023,7 +65023,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.17.1",
+			"version": "15.18.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/users/_internal/UserUiSchemaSettings.ts
+++ b/packages/common/src/users/_internal/UserUiSchemaSettings.ts
@@ -26,7 +26,6 @@ export const buildUiSchema = async (
     {
       ariaLabel: `{{${i18nScope}.notice.actions.goToOrg:translate}}`,
       label: `{{${i18nScope}.notice.actions.goToOrg:translate}}`,
-      icon: "launch",
       href: `${context.portalUrl}/home/organization.html?tab=general#settings`,
       target: "_blank",
     },
@@ -69,7 +68,6 @@ export const buildUiSchema = async (
       orgNoticeActions.push({
         ariaLabel: `{{${i18nScope}.notice.actions.${actionLabelKey}:translate}}`,
         label: `{{${i18nScope}.notice.actions.${actionLabelKey}:translate}}`,
-        icon: "launch",
         href: orgUrl,
         target: "_blank",
       });

--- a/packages/common/test/users/_internal/UserUiSchemaSettings.test.ts
+++ b/packages/common/test/users/_internal/UserUiSchemaSettings.test.ts
@@ -107,14 +107,12 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.arcgis.com/home/organization.html?tab=general#settings`,
                       target: "_blank",
                     },
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToCommunityOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToCommunityOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.c.arcgis.com/home/organization.html`,
                       target: "_blank",
                     },
@@ -348,14 +346,12 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.c.arcgis.com/home/organization.html?tab=general#settings`,
                       target: "_blank",
                     },
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToStaffOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToStaffOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.arcgis.com/home/organization.html`,
                       target: "_blank",
                     },
@@ -590,14 +586,12 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.c.arcgis.com/home/organization.html?tab=general#settings`,
                       target: "_blank",
                     },
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToStaffOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToStaffOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.arcgis.com/home/organization.html`,
                       target: "_blank",
                     },
@@ -819,7 +813,6 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.arcgis.com/home/organization.html?tab=general#settings`,
                       target: "_blank",
                     },
@@ -1054,14 +1047,12 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.c.arcgis.com/home/organization.html?tab=general#settings`,
                       target: "_blank",
                     },
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToStaffOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToStaffOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.arcgis.com/home/organization.html`,
                       target: "_blank",
                     },
@@ -1283,7 +1274,6 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.arcgis.com/home/organization.html?tab=general#settings`,
                       target: "_blank",
                     },
@@ -1514,7 +1504,6 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.c.arcgis.com/home/organization.html?tab=general#settings`,
                       target: "_blank",
                     },
@@ -1747,14 +1736,12 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.arcgis.com/home/organization.html?tab=general#settings`,
                       target: "_blank",
                     },
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToCommunityOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToCommunityOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.c.arcgis.com/home/organization.html`,
                       target: "_blank",
                     },
@@ -1982,14 +1969,12 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.arcgis.com/home/organization.html?tab=general#settings`,
                       target: "_blank",
                     },
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToCommunityOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToCommunityOrg:translate}}`,
-                      icon: "launch",
                       href: `https://qaext.c.arcgis.com/home/organization.html`,
                       target: "_blank",
                     },


### PR DESCRIPTION
1. Description: `arcgis-hub-notices` adds launch icons at the end of links by default as requested by design -- so we can remove these pre-pended launch icons that were duplicated

1. Instructions for testing:

**before**
![Screenshot 2024-12-10 at 9 33 19 AM](https://github.com/user-attachments/assets/4410eb42-04de-4dbb-864d-8ffce5efc43d)

**after**
![Screenshot 2024-12-10 at 9 33 09 AM](https://github.com/user-attachments/assets/b4b810ff-5781-4847-9ae3-2bab6fa978d4)



1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/11884

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
