### PR TITLE
feat(hub-common): replace temporary workspace feeds permission with hub:site:workspace:feeds

### DIFF
--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -46,7 +46,7 @@ export const SitePermissions = [
   "hub:site:workspace:projects",
   "hub:site:workspace:initiatives",
   "hub:site:manage",
-  "temp:hub:site:workspace:feeds",
+  "hub:site:workspace:feeds",
 ] as const;
 
 /**
@@ -228,8 +228,9 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:site:edit"],
   },
   {
-    permission: "temp:hub:site:workspace:feeds",
-    availability: ["flag"],
+    permission: "hub:site:workspace:feeds",
+    dependencies: ["hub:site:workspace", "hub:site:edit"],
+    environments: ["devext", "qaext", "production"],
   },
 ];
 


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Part of https://devtopia.esri.com/dc/hub/issues/11047
DO NOT MERGE until the functionality this ungates has been verified

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
