### PR TITLE
fix(): add catalog permission

### DIFF
--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -38,7 +38,8 @@ export const InitiativePermissions = [
   "hub:initiative:workspace:content",
   "hub:initiative:workspace:events",
   "hub:initiative:workspace:metrics",
-  "hub:initiative:workspace:catalogs",
+  "hub:initiative:workspace:catalogs", // deprecated -- should be removed
+  "hub:initiative:workspace:catalog",
   "hub:initiative:workspace:associationGroup:create",
   "hub:initiative:manage",
 ] as const;
@@ -187,7 +188,15 @@ export const InitiativePermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:initiative:workspace", "hub:initiative:edit"],
   },
   {
-    permission: "hub:initiative:workspace:catalogs",
+    permission: "hub:initiative:workspace:catalogs", // TODO: remove plural permission
+    dependencies: [
+      "hub:initiative:workspace",
+      "hub:feature:catalogs",
+      "hub:initiative:edit",
+    ],
+  },
+  {
+    permission: "hub:initiative:workspace:catalog",
     dependencies: [
       "hub:initiative:workspace",
       "hub:feature:catalogs",

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -36,7 +36,8 @@ export const ProjectPermissions = [
   "hub:project:workspace:content",
   "hub:project:workspace:events",
   "hub:project:workspace:metrics",
-  "hub:project:workspace:catalogs",
+  "hub:project:workspace:catalogs", // deprecated - should be removed
+  "hub:project:workspace:catalog",
   "hub:project:manage",
 ] as const;
 
@@ -167,7 +168,15 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:project:workspace", "hub:project:edit"],
   },
   {
-    permission: "hub:project:workspace:catalogs",
+    permission: "hub:project:workspace:catalogs", // TODO: remove plural permission
+    dependencies: [
+      "hub:project:workspace",
+      "hub:feature:catalogs",
+      "hub:project:edit",
+    ],
+  },
+  {
+    permission: "hub:project:workspace:catalog",
     dependencies: [
       "hub:project:workspace",
       "hub:feature:catalogs",


### PR DESCRIPTION
1. Description:
Adds the singular catalog permission to projects and initiatives, so that we can later remove the plural catalogs permission after switching the ui over to use the singular permission. 

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
