### PR TITLE
feat: adds domain to site creation uiSchema

### DIFF
--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -438,15 +438,17 @@ export class HubSite
     editor._discussions = this.entity.features["hub:site:feature:discussions"];
 
     // used by the site URL composite field
-    const { url, subdomain, defaultHostname } = editor;
-    editor._urlInfo = {
-      url,
-      subdomain,
-      defaultHostname,
-      // NOTE: once the editor handles custom hostnames,
-      // we'll need to add that here
-      // customHostname
-    };
+    if (!editor._urlInfo) {
+      const { url, subdomain, defaultHostname } = editor;
+      editor._urlInfo = {
+        url,
+        subdomain,
+        defaultHostname,
+        // NOTE: once the editor handles custom hostnames,
+        // we'll need to add that here
+        // customHostname
+      };
+    }
 
     return editor;
   }

--- a/packages/common/src/sites/_internal/SiteSchema.ts
+++ b/packages/common/src/sites/_internal/SiteSchema.ts
@@ -30,6 +30,12 @@ export const getSiteSchema = (siteId: string) =>
       _urlInfo: {
         type: "object",
         isUniqueDomain: { siteId },
+        required: ["subdomain"],
+        properties: {
+          subdomain: {
+            type: "string",
+          },
+        },
       },
     },
   } as IAsyncConfigurationSchema);

--- a/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaCreate.ts
@@ -16,6 +16,10 @@ export const buildUiSchema = async (
   options: Partial<IHubSite>,
   context: IArcGISContext
 ): Promise<IUiSchema> => {
+  // NOTE: if this is not defined on the site then
+  // the component will use the authenticated user's org
+  // which may not be the same as the site's org
+  const orgUrlKey = (options as IHubSite).orgUrlKey;
   return {
     type: "Layout",
     elements: [
@@ -42,6 +46,23 @@ export const buildUiSchema = async (
               keyword: "format",
               icon: true,
               labelKey: `${i18nScope}.fields.name.siteEntityTitleValidatorError`,
+            },
+          ],
+        },
+      },
+      {
+        scope: "/properties/_urlInfo",
+        type: "Control",
+        options: {
+          type: "Control",
+          control: "hub-composite-input-site-url",
+          orgUrlKey,
+          messages: [
+            {
+              type: "ERROR",
+              keyword: "isUniqueDomain",
+              labelKey: `${i18nScope}.fields.siteUrl.isUniqueError`,
+              icon: true,
             },
           ],
         },

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -604,6 +604,23 @@ describe("HubSite Class:", () => {
         expect(enrichEntitySpy).toHaveBeenCalledTimes(1);
         expect(getFollowersGroupSpy).toHaveBeenCalledTimes(1);
       });
+      it("uses _urlInfo if provided", async () => {
+        const site = HubSite.fromJson(
+          {
+            id: "bc3",
+            name: "Test Entity",
+            _urlInfo: {
+              subdomain: "my-subdomain",
+            },
+          },
+          authdCtxMgr.context
+        );
+        getFollowersGroupSpy = spyOn(site, "getFollowersGroup").and.returnValue(
+          Promise.resolve({ typeKeywords: ["cannotDiscuss"] })
+        );
+        const result = await site.toEditor();
+        expect(result._urlInfo.subdomain).toEqual("my-subdomain");
+      });
       describe("entity transforms", () => {
         it("sets the _followers.showFollowAction property based on the presence of the hub:site:feature:follow feature", async () => {
           getFollowersGroupSpy = spyOn(

--- a/packages/common/test/sites/_internal/SiteUiSchemaCreate.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaCreate.test.ts
@@ -3,7 +3,11 @@ import { MOCK_CONTEXT } from "../../mocks/mock-auth";
 
 describe("buildUiSchema: site create", () => {
   it("returns the full site create uiSchema", async () => {
-    const uiSchema = await buildUiSchema("some.scope", {} as any, MOCK_CONTEXT);
+    const uiSchema = await buildUiSchema(
+      "some.scope",
+      { orgUrlKey: "org-url-key" } as any,
+      MOCK_CONTEXT
+    );
     expect(uiSchema).toEqual({
       type: "Layout",
       elements: [
@@ -30,6 +34,23 @@ describe("buildUiSchema: site create", () => {
                 keyword: "format",
                 icon: true,
                 labelKey: `some.scope.fields.name.siteEntityTitleValidatorError`,
+              },
+            ],
+          },
+        },
+        {
+          scope: "/properties/_urlInfo",
+          type: "Control",
+          options: {
+            type: "Control",
+            control: "hub-composite-input-site-url",
+            orgUrlKey: "org-url-key",
+            messages: [
+              {
+                type: "ERROR",
+                keyword: "isUniqueDomain",
+                labelKey: `some.scope.fields.siteUrl.isUniqueError`,
+                icon: true,
               },
             ],
           },


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: add domain to site creation uiSchema

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/11365

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
