### PR TITLE
Update typedoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Generated TypeDoc site that isn't used
+typedoc
+
 # Logs
 logs
 *.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -65023,7 +65023,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.19.0",
+			"version": "15.22.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,8 +98,8 @@
 				"tslint": "^5.8.0",
 				"tslint-config-prettier": "^1.6.0",
 				"tslint-config-standard": "^6.0.1",
-				"typedoc": "^0.14.2",
-				"typescript": "^3.8.1",
+				"typedoc": "0.23.21",
+				"typescript": "4.9.5",
 				"yo": "^3.1.1"
 			}
 		},
@@ -10390,22 +10390,6 @@
 			"integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
 			"dev": true
 		},
-		"node_modules/@types/handlebars": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
-			"integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
-			"deprecated": "This is a stub types definition. handlebars provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"dependencies": {
-				"handlebars": "*"
-			}
-		},
-		"node_modules/@types/highlight.js": {
-			"version": "9.12.4",
-			"resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.4.tgz",
-			"integrity": "sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==",
-			"dev": true
-		},
 		"node_modules/@types/isomorphic-fetch": {
 			"version": "0.0.34",
 			"resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.34.tgz",
@@ -10428,18 +10412,6 @@
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-			"dev": true
-		},
-		"node_modules/@types/lodash": {
-			"version": "4.14.192",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
-			"integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==",
-			"dev": true
-		},
-		"node_modules/@types/marked": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
-			"integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
 			"dev": true
 		},
 		"node_modules/@types/mime": {
@@ -10522,16 +10494,6 @@
 			"dev": true,
 			"dependencies": {
 				"@types/mime": "*",
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/shelljs": {
-			"version": "0.8.11",
-			"resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.11.tgz",
-			"integrity": "sha512-x9yaMvEh5BEaZKeVQC4vp3l+QoFj3BXcd4aYfuKSzIIyihjdVARAadYy3SMNIz0WCCdS2vB9JL/U6GQk5PaxQw==",
-			"dev": true,
-			"dependencies": {
-				"@types/glob": "*",
 				"@types/node": "*"
 			}
 		},
@@ -25927,19 +25889,6 @@
 				"node": "^12.20.0 || >=14"
 			}
 		},
-		"node_modules/dependency-tree/node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
 		"node_modules/deprecation": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -26130,19 +26079,6 @@
 			},
 			"engines": {
 				"node": "^12.20.0 || ^14.14.0 || >=16.0.0"
-			}
-		},
-		"node_modules/detective-typescript/node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/dev-ip": {
@@ -32799,6 +32735,19 @@
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
+		"node_modules/filing-cabinet/node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -38280,6 +38229,12 @@
 				"json-typescript": "^1.0.0"
 			}
 		},
+		"node_modules/jsonc-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+			"dev": true
+		},
 		"node_modules/jsonfile": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -40408,6 +40363,12 @@
 				"yallist": "^2.1.2"
 			}
 		},
+		"node_modules/lunr": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+			"dev": true
+		},
 		"node_modules/macos-release": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.1.tgz",
@@ -40484,6 +40445,19 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/madge/node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/magic-string": {
@@ -40721,7 +40695,6 @@
 			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
 			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -52376,6 +52349,19 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/precinct/node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
 		"node_modules/precinct/node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -55936,6 +55922,17 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/shellwords-ts/-/shellwords-ts-3.0.1.tgz",
 			"integrity": "sha512-GabK4ApLMqHFRGlpgNqg8dmtHTnYHt0WUUJkIeMd3QaDrUUBEDXHSSNi3I0PzMimg8W+I0EN4TshQxsnHv1cwg=="
+		},
+		"node_modules/shiki": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+			"integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+			"dev": true,
+			"dependencies": {
+				"jsonc-parser": "^3.0.0",
+				"vscode-oniguruma": "^1.6.1",
+				"vscode-textmate": "^6.0.0"
+			}
 		},
 		"node_modules/side-channel": {
 			"version": "1.0.4",
@@ -59687,123 +59684,51 @@
 			}
 		},
 		"node_modules/typedoc": {
-			"version": "0.14.2",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.14.2.tgz",
-			"integrity": "sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==",
+			"version": "0.23.21",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.21.tgz",
+			"integrity": "sha512-VNE9Jv7BgclvyH9moi2mluneSviD43dCE9pY8RWkO88/DrEgJZk9KpUk7WO468c9WWs/+aG6dOnoH7ccjnErhg==",
 			"dev": true,
 			"dependencies": {
-				"@types/fs-extra": "^5.0.3",
-				"@types/handlebars": "^4.0.38",
-				"@types/highlight.js": "^9.12.3",
-				"@types/lodash": "^4.14.110",
-				"@types/marked": "^0.4.0",
-				"@types/minimatch": "3.0.3",
-				"@types/shelljs": "^0.8.0",
-				"fs-extra": "^7.0.0",
-				"handlebars": "^4.0.6",
-				"highlight.js": "^9.13.1",
-				"lodash": "^4.17.10",
-				"marked": "^0.4.0",
-				"minimatch": "^3.0.0",
-				"progress": "^2.0.0",
-				"shelljs": "^0.8.2",
-				"typedoc-default-themes": "^0.5.0",
-				"typescript": "3.2.x"
+				"lunr": "^2.3.9",
+				"marked": "^4.0.19",
+				"minimatch": "^5.1.0",
+				"shiki": "^0.11.1"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
 			},
 			"engines": {
-				"node": ">= 6.0.0"
+				"node": ">= 14.14"
+			},
+			"peerDependencies": {
+				"typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
 			}
 		},
-		"node_modules/typedoc-default-themes": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
-			"integrity": "sha512-7JU1uEDJnc33QJlu5j/UqrLMv2QuGvmElbA1LVnS7WgHq2bOMQpGGki71M1HKeGSReFH04rqfm0swhtfLw7VOQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"node_modules/typedoc/node_modules/fs-extra": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+		"node_modules/typedoc/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
 			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=6 <7 || >=8"
+				"balanced-match": "^1.0.0"
 			}
 		},
-		"node_modules/typedoc/node_modules/jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-			"dev": true,
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/typedoc/node_modules/marked": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-			"integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
-			"dev": true,
-			"bin": {
-				"marked": "bin/marked"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/typedoc/node_modules/shelljs": {
-			"version": "0.8.5",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-			"integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+		"node_modules/typedoc/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
 			"dev": true,
 			"dependencies": {
-				"glob": "^7.0.0",
-				"interpret": "^1.0.0",
-				"rechoir": "^0.6.2"
-			},
-			"bin": {
-				"shjs": "bin/shjs"
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/typedoc/node_modules/typescript": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
-			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
-		"node_modules/typedoc/node_modules/universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4.0.0"
+				"node": ">=10"
 			}
 		},
 		"node_modules/typescript": {
-			"version": "3.9.10",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -60925,6 +60850,18 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/vscode-oniguruma": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+			"dev": true
+		},
+		"node_modules/vscode-textmate": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+			"integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+			"dev": true
 		},
 		"node_modules/walk": {
 			"version": "2.3.15",
@@ -65051,6 +64988,19 @@
 				"@esri/arcgis-rest-types": "^2.15.0 || 3"
 			}
 		},
+		"packages/common/node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
 			"version": "29.4.0",
@@ -65067,6 +65017,19 @@
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
 				"@esri/hub-common": "^15.8.0"
+			}
+		},
+		"packages/discussions/node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
 			}
 		},
 		"packages/downloads": {
@@ -65089,6 +65052,19 @@
 				"@esri/hub-common": "^15.0.0"
 			}
 		},
+		"packages/downloads/node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
 		"packages/events": {
 			"name": "@esri/hub-events",
 			"version": "15.0.0",
@@ -65109,6 +65085,19 @@
 				"@esri/hub-common": "^15.0.0"
 			}
 		},
+		"packages/events/node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
 			"version": "15.0.0",
@@ -65126,6 +65115,19 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/hub-common": "^15.0.0"
+			}
+		},
+		"packages/initiatives/node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
 			}
 		},
 		"packages/search": {
@@ -65150,6 +65152,19 @@
 				"@esri/hub-common": "^15.0.0"
 			}
 		},
+		"packages/search/node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
 			"version": "16.0.0",
@@ -65172,6 +65187,19 @@
 				"@esri/hub-teams": "^15.0.0"
 			}
 		},
+		"packages/sites/node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
 			"version": "15.0.0",
@@ -65192,6 +65220,19 @@
 				"@esri/hub-common": "^15.0.0"
 			}
 		},
+		"packages/surveys/node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
 			"version": "15.0.0",
@@ -65209,6 +65250,19 @@
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
 				"@esri/hub-common": "^15.0.0"
+			}
+		},
+		"packages/teams/node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
 			}
 		}
 	},
@@ -68780,6 +68834,14 @@
 				"jsonapi-typescript": "^0.1.3",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+					"dev": true
+				}
 			}
 		},
 		"@esri/hub-discussions": {
@@ -68789,6 +68851,14 @@
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+					"dev": true
+				}
 			}
 		},
 		"@esri/hub-downloads": {
@@ -68798,6 +68868,14 @@
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+					"dev": true
+				}
 			}
 		},
 		"@esri/hub-events": {
@@ -68806,6 +68884,14 @@
 				"@esri/hub-common": "^15.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+					"dev": true
+				}
 			}
 		},
 		"@esri/hub-initiatives": {
@@ -68815,6 +68901,14 @@
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+					"dev": true
+				}
 			}
 		},
 		"@esri/hub-search": {
@@ -68825,6 +68919,14 @@
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+					"dev": true
+				}
 			}
 		},
 		"@esri/hub-sites": {
@@ -68835,6 +68937,14 @@
 				"@esri/hub-teams": "^15.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+					"dev": true
+				}
 			}
 		},
 		"@esri/hub-surveys": {
@@ -68843,6 +68953,14 @@
 				"@esri/hub-common": "^15.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+					"dev": true
+				}
 			}
 		},
 		"@esri/hub-teams": {
@@ -68851,6 +68969,14 @@
 				"@esri/hub-common": "^15.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+					"dev": true
+				}
 			}
 		},
 		"@evocateur/libnpmaccess": {
@@ -73301,21 +73427,6 @@
 				}
 			}
 		},
-		"@types/handlebars": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
-			"integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
-			"dev": true,
-			"requires": {
-				"handlebars": "*"
-			}
-		},
-		"@types/highlight.js": {
-			"version": "9.12.4",
-			"resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.4.tgz",
-			"integrity": "sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==",
-			"dev": true
-		},
 		"@types/isomorphic-fetch": {
 			"version": "0.0.34",
 			"resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.34.tgz",
@@ -73338,18 +73449,6 @@
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-			"dev": true
-		},
-		"@types/lodash": {
-			"version": "4.14.192",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
-			"integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==",
-			"dev": true
-		},
-		"@types/marked": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
-			"integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
 			"dev": true
 		},
 		"@types/mime": {
@@ -73432,16 +73531,6 @@
 			"dev": true,
 			"requires": {
 				"@types/mime": "*",
-				"@types/node": "*"
-			}
-		},
-		"@types/shelljs": {
-			"version": "0.8.11",
-			"resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.11.tgz",
-			"integrity": "sha512-x9yaMvEh5BEaZKeVQC4vp3l+QoFj3BXcd4aYfuKSzIIyihjdVARAadYy3SMNIz0WCCdS2vB9JL/U6GQk5PaxQw==",
-			"dev": true,
-			"requires": {
-				"@types/glob": "*",
 				"@types/node": "*"
 			}
 		},
@@ -86018,12 +86107,6 @@
 							"dev": true
 						}
 					}
-				},
-				"typescript": {
-					"version": "4.9.5",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-					"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-					"dev": true
 				}
 			}
 		},
@@ -86173,14 +86256,6 @@
 				"ast-module-types": "^4.0.0",
 				"node-source-walk": "^5.0.1",
 				"typescript": "^4.9.5"
-			},
-			"dependencies": {
-				"typescript": {
-					"version": "4.9.5",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-					"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-					"dev": true
-				}
 			}
 		},
 		"dev-ip": {
@@ -91611,6 +91686,12 @@
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 					"dev": true
+				},
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+					"dev": true
 				}
 			}
 		},
@@ -95950,6 +96031,12 @@
 				"json-typescript": "^1.0.0"
 			}
 		},
+		"jsonc-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+			"dev": true
+		},
 		"jsonfile": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -97708,6 +97795,12 @@
 				"yallist": "^2.1.2"
 			}
 		},
+		"lunr": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+			"dev": true
+		},
 		"macos-release": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.1.tgz",
@@ -97759,6 +97852,12 @@
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
 					"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+					"dev": true
+				},
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
 					"dev": true
 				}
 			}
@@ -97965,8 +98064,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
 			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"marked-terminal": {
 			"version": "5.1.1",
@@ -106741,6 +106839,12 @@
 						"lru-cache": "^6.0.0"
 					}
 				},
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+					"dev": true
+				},
 				"yallist": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -109528,6 +109632,17 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/shellwords-ts/-/shellwords-ts-3.0.1.tgz",
 			"integrity": "sha512-GabK4ApLMqHFRGlpgNqg8dmtHTnYHt0WUUJkIeMd3QaDrUUBEDXHSSNi3I0PzMimg8W+I0EN4TshQxsnHv1cwg=="
+		},
+		"shiki": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+			"integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+			"dev": true,
+			"requires": {
+				"jsonc-parser": "^3.0.0",
+				"vscode-oniguruma": "^1.6.1",
+				"vscode-textmate": "^6.0.0"
+			}
 		},
 		"side-channel": {
 			"version": "1.0.4",
@@ -112556,91 +112671,41 @@
 			}
 		},
 		"typedoc": {
-			"version": "0.14.2",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.14.2.tgz",
-			"integrity": "sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==",
+			"version": "0.23.21",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.21.tgz",
+			"integrity": "sha512-VNE9Jv7BgclvyH9moi2mluneSviD43dCE9pY8RWkO88/DrEgJZk9KpUk7WO468c9WWs/+aG6dOnoH7ccjnErhg==",
 			"dev": true,
 			"requires": {
-				"@types/fs-extra": "^5.0.3",
-				"@types/handlebars": "^4.0.38",
-				"@types/highlight.js": "^9.12.3",
-				"@types/lodash": "^4.14.110",
-				"@types/marked": "^0.4.0",
-				"@types/minimatch": "3.0.3",
-				"@types/shelljs": "^0.8.0",
-				"fs-extra": "^7.0.0",
-				"handlebars": "^4.0.6",
-				"highlight.js": "^9.13.1",
-				"lodash": "^4.17.10",
-				"marked": "^0.4.0",
-				"minimatch": "^3.0.0",
-				"progress": "^2.0.0",
-				"shelljs": "^0.8.2",
-				"typedoc-default-themes": "^0.5.0",
-				"typescript": "3.2.x"
+				"lunr": "^2.3.9",
+				"marked": "^4.0.19",
+				"minimatch": "^5.1.0",
+				"shiki": "^0.11.1"
 			},
 			"dependencies": {
-				"fs-extra": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
+						"balanced-match": "^1.0.0"
 					}
 				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+				"minimatch": {
+					"version": "5.1.6",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+					"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.6"
+						"brace-expansion": "^2.0.1"
 					}
-				},
-				"marked": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-					"integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
-					"dev": true
-				},
-				"shelljs": {
-					"version": "0.8.5",
-					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-					"integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.0.0",
-						"interpret": "^1.0.0",
-						"rechoir": "^0.6.2"
-					}
-				},
-				"typescript": {
-					"version": "3.2.4",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
-					"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
-					"dev": true
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-					"dev": true
 				}
 			}
 		},
-		"typedoc-default-themes": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
-			"integrity": "sha512-7JU1uEDJnc33QJlu5j/UqrLMv2QuGvmElbA1LVnS7WgHq2bOMQpGGki71M1HKeGSReFH04rqfm0swhtfLw7VOQ==",
-			"dev": true
-		},
 		"typescript": {
-			"version": "3.9.10",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true
 		},
 		"typescript-memoize": {
@@ -113537,6 +113602,18 @@
 					}
 				}
 			}
+		},
+		"vscode-oniguruma": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+			"dev": true
+		},
+		"vscode-textmate": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+			"integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+			"dev": true
 		},
 		"walk": {
 			"version": "2.3.15",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
 		"y:push": "lerna run y:push",
 		"release:dry": "multi-semantic-release --dry-run --deps.prefix=^ --deps.bump=satisfy --deps.release=inherit --ignore-private-packages --debug",
 		"prerelease": "npm config set workspaces-update false",
-		"release": "multi-semantic-release --deps.prefix=^ --deps.bump=satisfy --deps.release=inherit --ignore-private-packages"
+	"release": "multi-semantic-release --deps.prefix=^ --deps.bump=satisfy --deps.release=inherit --ignore-private-packages",
+		"typedoc": "typedoc --options ./typedoc.json"
 	},
 	"husky": {
 		"hooks": {

--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
 		"tslint": "^5.8.0",
 		"tslint-config-prettier": "^1.6.0",
 		"tslint-config-standard": "^6.0.1",
-		"typedoc": "^0.14.2",
-		"typescript": "^3.8.1",
+		"typedoc": "0.23.21",
+		"typescript": "4.9.5",
 		"yo": "^3.1.1"
 	},
 	"dependencies": {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,20 @@
+{
+  "out": "typedoc",
+  "json": "typedoc/doc.json",
+  "excludeInternal": true,
+  "excludePrivate": true,
+  "excludeExternals": true,
+  "packages": [
+    "./packages/common/",
+    "./packages/discussions/",
+    "./packages/downloads/",
+    "./packages/events/",
+    "./packages/initiatives/",
+    "./packages/search/",
+    "./packages/sites/",
+    "./packages/surveys/",
+    "./packages/teams/"
+  ],
+  "exclude":["**/*test.ts"],
+  "ignoreCompilerErrors": true
+} 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,10 +1,9 @@
 {
   "out": "typedoc",
   "json": "typedoc/doc.json",
-  "excludeInternal": true,
-  "excludePrivate": true,
   "excludeExternals": true,
-  "packages": [
+  "entryPointStrategy": "packages",
+  "entryPoints": [
     "./packages/common/",
     "./packages/discussions/",
     "./packages/downloads/",
@@ -16,5 +15,4 @@
     "./packages/teams/"
   ],
   "exclude":["**/*test.ts"],
-  "ignoreCompilerErrors": true
 } 


### PR DESCRIPTION
1. Description:

This PR updates the versions of Typedoc and Typescript which will be necessary for future projects as well|s to follow ArcGIS REST JS in removing Acetate.

1. Instructions for testing:

Pull changes, then run `npm install`, `npm run build` and `npm run typedoc`. inspect the typedoc site that is generated in the `typedoc` folder.

Typedoc will also denerate many warnings these generall> seem to fall into 2 categories:

* You need to escape curly braces in comment and descriptions https://github.com/TypeStrong/typedoc/issues/1982#issuecomment-1173126752
* There are many referenced types that are not exported from their packages. These should ideally be exported. https://github.com/TypeStrong/typedoc/issues/2703, https://github.com/TypeStrong/typedoc/issues/2703, https://github.com/TypeStrong/typedoc/issues/2703

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
