### PR TITLE
fix: update correct schemas for catalog editing

### DIFF
--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -51,30 +51,6 @@ export const CollectionSchema: IConfigurationSchema = {
   },
 };
 
-/** JSON schema for an IHubCatalog */
-export const CatalogSchema: IConfigurationSchema = {
-  type: "object",
-  properties: {
-    title: {
-      type: "string",
-    },
-    scopes: {
-      type: "object",
-      properties: targetEntities.reduce(
-        (acc: Record<EntityType, any>, targetEntity: EntityType) => {
-          acc[targetEntity] = QuerySchema;
-          return acc;
-        },
-        {} as Record<EntityType, any>
-      ),
-    },
-    collections: {
-      type: "array",
-      items: CollectionSchema,
-    },
-  },
-};
-
 /**
  * JSON schema for the appearance of a gallery display
  * This can be for a catalog, a collection, a gallery card, etc
@@ -118,6 +94,31 @@ export const GalleryDisplayConfigSchema: IConfigurationSchema = {
   },
 };
 
+/** JSON schema for an IHubCatalog */
+export const CatalogSchema: IConfigurationSchema = {
+  type: "object",
+  properties: {
+    title: {
+      type: "string",
+    },
+    scopes: {
+      type: "object",
+      properties: targetEntities.reduce(
+        (acc: Record<EntityType, any>, targetEntity: EntityType) => {
+          acc[targetEntity] = QuerySchema;
+          return acc;
+        },
+        {} as Record<EntityType, any>
+      ),
+    },
+    collections: {
+      type: "array",
+      items: CollectionSchema,
+    },
+    displayConfig: GalleryDisplayConfigSchema,
+  },
+};
+
 /**
  * JSON schema for the appearance of an IHubCollection
  */
@@ -125,19 +126,5 @@ export const CollectionAppearanceSchema: IConfigurationSchema = {
   type: "object",
   properties: {
     displayConfig: GalleryDisplayConfigSchema,
-  },
-};
-
-/**
- * JSON schema for the appearance of a catalog
- */
-export const CatalogAppearanceSchema: IConfigurationSchema = {
-  type: "object",
-  properties: {
-    displayConfig: GalleryDisplayConfigSchema,
-    collections: {
-      type: "array",
-      items: CollectionAppearanceSchema,
-    },
   },
 };


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Updates the catalog schemas to include appearance settings.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
