### PR TITLE
fix: export _get-sharing-eligible-models

### DIFF
--- a/packages/sites/src/index.ts
+++ b/packages/sites/src/index.ts
@@ -44,6 +44,7 @@ export * from "./get-data-for-site-item";
 export * from "./is-site";
 export * from "./get-members";
 export * from "./interpolate-site";
+export * from "./_get-sharing-eligible-models"; // exporting because we need to use the _getSharingEligibleModels fn to share eligible models to groups in the solutions-service
 
 // Re-exports to avoid breaking changes
 export {


### PR DESCRIPTION

affects: @esri/hub-sites

1. Description:

Export `_get-sharing-eligible-models` so we can use `_getSharingEligibleModels` in solutions service

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
