### PR TITLE
fix(hub-discussions): use POST /posts/search to search and export posts

### DIFF
--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -558,34 +558,32 @@ export interface IFetchPost extends Partial<IPagingParams> {
 }
 
 /**
- * dto for querying posts in a single channel
+ * dto for searching posts
  *
  * @export
  * @interface ISearchChannelPosts
- * @extends {Partial<IWithAuthor>}
- * @extends {Partial<IWithEditor>}
  * @extends {Partial<IPagingParams>}
  * @extends {Partial<IWithSorting<PostSort>>}
  * @extends {Partial<IWithTimeQueries>}
  */
 export interface ISearchPosts
-  extends Partial<IWithAuthor>,
-    Partial<IWithEditor>,
-    Partial<IPagingParams>,
+  extends Partial<IPagingParams>,
     Partial<IWithSorting<PostSort>>,
     Partial<IWithTimeQueries> {
-  title?: string;
-  body?: string;
-  discussion?: string;
-  geometry?: Geometry;
-  featureGeometry?: Geometry;
-  parents?: Array<string | null>;
-  status?: PostStatus[];
-  relations?: PostRelation[];
-  groups?: string[];
   access?: SharingAccess[];
+  body?: string;
   channels?: string[];
+  creator?: string | null;
+  discussion?: string | null;
+  editor?: string | null;
   f?: SearchPostsFormat;
+  featureGeometry?: Geometry;
+  geometry?: Geometry;
+  groups?: string[] | null;
+  parents?: string[] | null;
+  relations?: PostRelation[];
+  status?: PostStatus[];
+  title?: string;
 }
 
 /**

--- a/packages/discussions/src/posts/posts.ts
+++ b/packages/discussions/src/posts/posts.ts
@@ -18,21 +18,6 @@ import {
   IPagedResponse,
 } from "../types";
 
-const stringifySearchParams = (data: ISearchPosts): any => {
-  // need to serialize geometry and featureGeometry since this
-  // is a GET request. we should consider requiring this to be
-  // a base64 string to safeguard against large geometries that
-  // will exceed URL character limits
-  const paramsToStringify = ["geometry", "featureGeometry"];
-  return Object.entries(data ?? {}).reduce(
-    (acc, [key, val]) => ({
-      ...acc,
-      [key]: paramsToStringify.includes(key) ? JSON.stringify(val) : val,
-    }),
-    {}
-  );
-};
-
 /**
  * search posts
  *
@@ -43,12 +28,13 @@ const stringifySearchParams = (data: ISearchPosts): any => {
 export function searchPosts(
   options: ISearchPostsParams
 ): Promise<IPagedResponse<IPost>> {
-  const url = `/posts`;
-  const data = stringifySearchParams(options.data);
+  const url = `/posts/search`;
   return discussionsApiRequest<IPagedResponse<IPost>>(url, {
     ...options,
-    data,
-    httpMethod: "GET",
+    data: {
+      ...options.data,
+    },
+    httpMethod: "POST",
   });
 }
 
@@ -60,15 +46,14 @@ export function searchPosts(
  * @return {*}  {Promise<string>}
  */
 export function exportPosts(options: IExportPostsParams): Promise<string> {
-  const url = `/posts`;
-  const data = stringifySearchParams(options.data);
+  const url = `/posts/search`;
   return discussionsApiRequest<string>(url, {
     ...options,
     data: {
-      ...data,
+      ...options.data,
       f: SearchPostsFormat.CSV,
     },
-    httpMethod: "GET",
+    httpMethod: "POST",
   });
 }
 

--- a/packages/discussions/test/posts.test.ts
+++ b/packages/discussions/test/posts.test.ts
@@ -41,11 +41,11 @@ describe("posts", () => {
       .then(() => {
         expect(requestSpy.calls.count()).toEqual(1);
         const [url, opts] = requestSpy.calls.argsFor(0);
-        expect(url).toEqual(`/posts`);
+        expect(url).toEqual(`/posts/search`);
         expect(opts).toEqual({
           ...options,
           data: {},
-          httpMethod: "GET",
+          httpMethod: "POST",
         });
         done();
       })
@@ -63,8 +63,8 @@ describe("posts", () => {
       .then(() => {
         expect(requestSpy.calls.count()).toEqual(1);
         const [url, opts] = requestSpy.calls.argsFor(0);
-        expect(url).toEqual(`/posts`);
-        expect(opts).toEqual({ ...options, httpMethod: "GET" });
+        expect(url).toEqual(`/posts/search`);
+        expect(opts).toEqual({ ...options, httpMethod: "POST" });
         done();
       })
       .catch(() => fail());
@@ -94,13 +94,10 @@ describe("posts", () => {
       .then(() => {
         expect(requestSpy.calls.count()).toEqual(1);
         const [url, opts] = requestSpy.calls.argsFor(0);
-        expect(url).toEqual(`/posts`);
+        expect(url).toEqual(`/posts/search`);
         expect(opts).toEqual({
-          ...{
-            ...options,
-            data: { ...query, geometry: JSON.stringify(query.geometry) },
-          },
-          httpMethod: "GET",
+          ...options,
+          httpMethod: "POST",
         });
         done();
       })
@@ -131,16 +128,10 @@ describe("posts", () => {
       .then(() => {
         expect(requestSpy.calls.count()).toEqual(1);
         const [url, opts] = requestSpy.calls.argsFor(0);
-        expect(url).toEqual(`/posts`);
+        expect(url).toEqual(`/posts/search`);
         expect(opts).toEqual({
-          ...{
-            ...options,
-            data: {
-              ...query,
-              featureGeometry: JSON.stringify(query.featureGeometry),
-            },
-          },
-          httpMethod: "GET",
+          ...options,
+          httpMethod: "POST",
         });
         done();
       })
@@ -158,14 +149,14 @@ describe("posts", () => {
       .then(() => {
         expect(requestSpy.calls.count()).toEqual(1);
         const [url, opts] = requestSpy.calls.argsFor(0);
-        expect(url).toEqual(`/posts`);
+        expect(url).toEqual(`/posts/search`);
         expect(opts).toEqual({
           ...options,
           data: {
             ...options.data,
             f: SearchPostsFormat.CSV,
           },
-          httpMethod: "GET",
+          httpMethod: "POST",
         });
         done();
       })


### PR DESCRIPTION
affects: @esri/hub-discussions
affects: @esri/hub-common

Issue: https://devtopia.esri.com/dc/hub/issues/12176

1. Description: The discussions API added a new route `POST /posts/search`. Use this route for searching and downloading posts. Since this route accepts a POST body, `geometry` and `featureGeometry` parameters no longer to be stringified

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
