### PR TITLE
fix: add format for subdomain field

### DIFF
--- a/packages/common/src/sites/_internal/SiteSchema.ts
+++ b/packages/common/src/sites/_internal/SiteSchema.ts
@@ -34,6 +34,7 @@ export const getSiteSchema = (siteId: string) =>
         properties: {
           subdomain: {
             type: "string",
+            format: "slug" as any,
           },
         },
       },


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Adds format to subdomain of site schema.

1. Closes Issues: [#<number> (if appropriate)](https://devtopia.esri.com/dc/hub/issues/11365)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
