### PR TITLE
fix(hub-common): fix (| null) types for ISearchPosts

### DIFF
--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -558,34 +558,32 @@ export interface IFetchPost extends Partial<IPagingParams> {
 }
 
 /**
- * dto for querying posts in a single channel
+ * dto for searching posts
  *
  * @export
  * @interface ISearchChannelPosts
- * @extends {Partial<IWithAuthor>}
- * @extends {Partial<IWithEditor>}
  * @extends {Partial<IPagingParams>}
  * @extends {Partial<IWithSorting<PostSort>>}
  * @extends {Partial<IWithTimeQueries>}
  */
 export interface ISearchPosts
-  extends Partial<IWithAuthor>,
-    Partial<IWithEditor>,
-    Partial<IPagingParams>,
+  extends Partial<IPagingParams>,
     Partial<IWithSorting<PostSort>>,
     Partial<IWithTimeQueries> {
-  title?: string;
-  body?: string;
-  discussion?: string;
-  geometry?: Geometry;
-  featureGeometry?: Geometry;
-  parents?: Array<string | null>;
-  status?: PostStatus[];
-  relations?: PostRelation[];
-  groups?: string[];
   access?: SharingAccess[];
+  body?: string;
   channels?: string[];
+  creator?: string | null;
+  discussion?: string;
+  editor?: string | null;
   f?: SearchPostsFormat;
+  featureGeometry?: Geometry;
+  geometry?: Geometry;
+  groups?: string[] | null;
+  parents?: string[] | null;
+  relations?: PostRelation[];
+  status?: PostStatus[];
+  title?: string;
 }
 
 /**


### PR DESCRIPTION
affects: @esri/hub-common

Issue https://devtopia.esri.com/dc/hub/issues/12176

1. Description: For `ISearchPosts`, `creator`, `editor`, `groups`, and `parents` should all include `| null` in the type

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
