### PR TITLE
feat(hub-common): add hub:feature:catalogs:edit:advanced permission for controlling catalog editing

### DIFF
--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -167,6 +167,19 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     environments: ["qaext"],
     availability: ["alpha"],
   },
+  // TODO: Remove this permission once all catalog configuration features are supported by sites
+  {
+    permission: "hub:feature:catalogs:edit:advanced",
+    dependencies: ["hub:feature:catalogs"],
+    entityEdit: true,
+    assertions: [
+      {
+        property: "entity:type",
+        type: "neq",
+        value: "Hub Site Application",
+      },
+    ],
+  },
   {
     // Enable inline-workspace for Entity Views
     // limited to devext alpha so we have to pass as a flag to enable

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -29,6 +29,8 @@ const SystemPermissions = [
   "hub:feature:newentityview",
   "hub:feature:history",
   "hub:feature:catalogs",
+  /** remove once sites support all catalog configuration features */
+  "hub:feature:catalogs:edit:advanced",
   "hub:feature:inline-workspace",
   "hub:feature:pagescatalog",
   "hub:license:hub-premium",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Part of https://devtopia.esri.com/dc/hub/issues/12248, adds a permission that limits advanced catalog configuration for sites.

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
 
