### PR TITLE
fix(hub-common): adjust discussions apiRequest response for text from…

### DIFF
--- a/packages/common/src/discussions/api/utils/request.ts
+++ b/packages/common/src/discussions/api/utils/request.ts
@@ -86,7 +86,7 @@ export function apiRequest<T>(
   // this currently only applies to the search post route. we should rework things in the future such that we don't need
   // to do this sort of evaluation in common logic.
   const isCSV =
-    route === "/posts" &&
+    ["/posts", "/posts/search"].includes(route) &&
     (options.data?.f === SearchPostsFormat.CSV ||
       headers.get("Accept") === "text/csv");
 

--- a/packages/common/test/discussions/api/discussions-api-request.test.ts
+++ b/packages/common/test/discussions/api/discussions-api-request.test.ts
@@ -196,7 +196,7 @@ describe("apiRequest", () => {
     expect(calledOpts).toEqual(expectedOpts);
   });
 
-  it(`cleans up baseUrl and enpoint`, async () => {
+  it(`cleans up baseUrl and endpoint`, async () => {
     const options = { ...opts, hubApiUrl: `${hubApiUrl}/` };
     const result = await utils.apiRequest(
       `/${url}`,
@@ -224,7 +224,7 @@ describe("apiRequest", () => {
     expect(calledOpts).toEqual(expectedOpts);
   });
 
-  it("resolves plain-text when f=csv for search posts route", async () => {
+  it("resolves plain-text when f=csv for GET search posts route", async () => {
     url = "/posts";
     const options = {
       data: {
@@ -243,7 +243,30 @@ describe("apiRequest", () => {
     expect(calledOpts).toEqual(expectedOpts);
   });
 
-  it('resolves plain-text when HTTP "Accept" header has a value of "text/csv" for search posts route', async () => {
+  it("resolves plain-text when f=csv for POST search posts route", async () => {
+    url = "/posts/search";
+    const options = {
+      data: {
+        f: SearchPostsFormat.CSV,
+      },
+      httpMethod: "POST",
+    } as IDiscussionsRequestOptions;
+    expectedOpts.method = "POST";
+    expectedOpts.body = JSON.stringify({
+      f: SearchPostsFormat.CSV,
+    });
+    const result = await utils.apiRequest(url, options);
+
+    expect(result).toEqual(JSON.stringify(response));
+
+    const [calledUrl, calledOpts] = fetchMock.calls()[0];
+    expect(calledUrl).toEqual(
+      "https://hub.arcgis.com/api/discussions/v1/posts/search"
+    );
+    expect(calledOpts).toEqual(expectedOpts);
+  });
+
+  it('resolves plain-text when HTTP "Accept" header has a value of "text/csv" for GET search posts route', async () => {
     url = "/posts";
     const options = {
       headers: {
@@ -264,6 +287,32 @@ describe("apiRequest", () => {
     const [calledUrl, calledOpts] = fetchMock.calls()[0];
     expect(calledUrl).toEqual(
       "https://hub.arcgis.com/api/discussions/v1/posts"
+    );
+    expect(calledOpts).toEqual(expectedOpts);
+  });
+
+  it('resolves plain-text when HTTP "Accept" header has a value of "text/csv" for POST search posts route', async () => {
+    url = "/posts/search";
+    const options = {
+      headers: {
+        Accept: "text/csv",
+      },
+      httpMethod: "POST",
+    } as IDiscussionsRequestOptions;
+    expectedOpts.method = "POST";
+    const result = await utils.apiRequest(url, options);
+    const expectedHeaders = new Headers(expectedOpts.headers);
+    expectedHeaders.set("accept", "text/csv");
+    expectedOpts = {
+      ...expectedOpts,
+      headers: expectedHeaders,
+    };
+
+    expect(result).toEqual(JSON.stringify(response));
+
+    const [calledUrl, calledOpts] = fetchMock.calls()[0];
+    expect(calledUrl).toEqual(
+      "https://hub.arcgis.com/api/discussions/v1/posts/search"
     );
     expect(calledOpts).toEqual(expectedOpts);
   });


### PR DESCRIPTION
… new search posts route

affects: @esri/hub-common

1. Description: update the hub-common discussions `apiRequest` function to correctly parse a test response from either the GET /posts route or the POST /posts/search route

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
