### PR TITLE
feat(hub-common): hubSearchEvents switch to new POST events search route

### DIFF
--- a/packages/common/src/search/_internal/hubEventsHelpers/getUniquePredicateValuesByKey.ts
+++ b/packages/common/src/search/_internal/hubEventsHelpers/getUniquePredicateValuesByKey.ts
@@ -1,21 +1,10 @@
 import { unique } from "../../../util";
 import { IFilter } from "../../types/IHubCatalog";
+import { getPredicateValuesByKey } from "./getPredicateValuesByKey";
 
 export const getUniquePredicateValuesByKey = <T>(
   filters: IFilter[],
   predicateKey: string
 ): T[] => {
-  const toPredicateValuesByKey = (a1: T[], filter: IFilter): T[] =>
-    filter.predicates.reduce<T[]>(
-      (a2, predicate) =>
-        Object.entries(predicate).reduce(
-          (a3, [key, val]) =>
-            key === predicateKey
-              ? [...a3, ...(Array.isArray(val) ? val : [val])]
-              : a3,
-          a2
-        ),
-      a1
-    );
-  return filters.reduce<T[]>(toPredicateValuesByKey, []).filter(unique);
+  return getPredicateValuesByKey<T>(filters, predicateKey).filter(unique);
 };

--- a/packages/common/src/search/_internal/hubEventsHelpers/getUniquePredicateValuesByKey.ts
+++ b/packages/common/src/search/_internal/hubEventsHelpers/getUniquePredicateValuesByKey.ts
@@ -1,0 +1,21 @@
+import { unique } from "../../../util";
+import { IFilter } from "../../types/IHubCatalog";
+
+export const getUniquePredicateValuesByKey = <T>(
+  filters: IFilter[],
+  predicateKey: string
+): T[] => {
+  const toPredicateValuesByKey = (a1: T[], filter: IFilter): T[] =>
+    filter.predicates.reduce<T[]>(
+      (a2, predicate) =>
+        Object.entries(predicate).reduce(
+          (a3, [key, val]) =>
+            key === predicateKey
+              ? [...a3, ...(Array.isArray(val) ? val : [val])]
+              : a3,
+          a2
+        ),
+      a1
+    );
+  return filters.reduce<T[]>(toPredicateValuesByKey, []).filter(unique);
+};

--- a/packages/common/src/search/_internal/hubEventsHelpers/processFilters.ts
+++ b/packages/common/src/search/_internal/hubEventsHelpers/processFilters.ts
@@ -40,14 +40,14 @@ export async function processFilters(
     filters,
     "entityType"
   );
-  if (entityTypes?.length) {
+  if (entityTypes.length) {
     processedFilters.entityTypes = toEnums(
       entityTypes,
       EventAssociationEntityType
     );
   }
   const eventIds = getUniquePredicateValuesByKey<string>(filters, "id");
-  if (eventIds?.length) {
+  if (eventIds.length) {
     processedFilters.eventIds = eventIds;
   }
   const term = getPredicateValuesByKey<string>(filters, "term");
@@ -62,17 +62,17 @@ export async function processFilters(
     filters,
     "categories"
   );
-  if (categories?.length) {
+  if (categories.length) {
     processedFilters.categories = categories;
   }
   const tags = getUniquePredicateValuesByKey<string>(filters, "tags");
-  if (tags?.length) {
+  if (tags.length) {
     processedFilters.tags = tags;
   }
   const groupIds = getUniquePredicateValuesByKey<string>(filters, "group");
   // if a group was provided, we prioritize that over individual readGroupId or editGroupId
   // filters to prevent collisions
-  if (groupIds?.length) {
+  if (groupIds.length) {
     // We are explicitly sending groupIds to sharedToGroups
     processedFilters.sharedToGroups = groupIds;
   } else {
@@ -81,14 +81,14 @@ export async function processFilters(
       filters,
       "readGroupId"
     );
-    if (readGroupIds?.length) {
+    if (readGroupIds.length) {
       processedFilters.readGroups = readGroupIds;
     }
     const editGroupIds = getUniquePredicateValuesByKey<string>(
       filters,
       "editGroupId"
     );
-    if (editGroupIds?.length) {
+    if (editGroupIds.length) {
       processedFilters.editGroups = editGroupIds;
     }
   }
@@ -127,35 +127,33 @@ export async function processFilters(
       filters,
       "notReadGroupId"
     );
-    if (notReadGroupIds?.length) {
+    if (notReadGroupIds.length) {
       processedFilters.withoutReadGroups = notReadGroupIds;
     }
     const notEditGroupIds = getUniquePredicateValuesByKey<string>(
       filters,
       "notEditGroupId"
     );
-    if (notEditGroupIds?.length) {
+    if (notEditGroupIds.length) {
       processedFilters.withoutEditGroups = notEditGroupIds;
     }
   }
-  // todo: <enums or strings?> (API is upper casing each value in the array, but throws off the typing here)
   const attendanceType = getUniquePredicateValuesByKey<string>(
     filters,
     "attendanceType"
   );
-  if (attendanceType?.length) {
+  if (attendanceType.length) {
     processedFilters.attendanceTypes = toEnums(
       attendanceType,
       EventAttendanceType
     );
   }
   const createdByIds = getUniquePredicateValuesByKey<string>(filters, "owner");
-  if (createdByIds?.length) {
+  if (createdByIds.length) {
     processedFilters.createdByIds = createdByIds;
   }
-  // todo: <enums or strings?> (API is upper casing each value in the array, but throws off the typing here)
   const status = getUniquePredicateValuesByKey<string>(filters, "status");
-  processedFilters.status = status?.length
+  processedFilters.status = status.length
     ? toEnums(status, EventStatus)
     : [EventStatus.PLANNED, EventStatus.CANCELED];
 

--- a/packages/common/src/search/_internal/hubEventsHelpers/processFilters.ts
+++ b/packages/common/src/search/_internal/hubEventsHelpers/processFilters.ts
@@ -12,6 +12,7 @@ import { IDateRange } from "../../types/types";
 import { searchGroups } from "@esri/arcgis-rest-portal";
 import { IHubRequestOptions } from "../../../types";
 import { isUpdateGroup } from "../../../utils/is-update-group";
+import { toEnums } from "./toEnumConverters";
 
 /**
  * Builds a Partial<ISearchEvents> given an Array of IFilter objects
@@ -23,10 +24,9 @@ export async function processFilters(
   requestOptions: IHubRequestOptions
 ): Promise<Partial<ISearchEvents>> {
   const processedFilters: Partial<ISearchEvents> = {};
-  // todo: <enums or strings?> (API is upper casing each value in the array, but throws off the typing here)
-  const access = getUniquePredicateValuesByKey<EventAccess>(filters, "access");
-  if (access?.length) {
-    processedFilters.access = access;
+  const access = getUniquePredicateValuesByKey<string>(filters, "access");
+  if (access.length) {
+    processedFilters.access = toEnums(access, EventAccess);
   }
   const canEdit = getPredicateValuesByKey<boolean>(filters, "canEdit");
   if (canEdit.length) {
@@ -36,13 +36,15 @@ export async function processFilters(
   if (entityIds?.length) {
     processedFilters.entityIds = entityIds;
   }
-  // todo: <enums or strings?> (NO API conversion here)
-  const entityTypes = getUniquePredicateValuesByKey<EventAssociationEntityType>(
+  const entityTypes = getUniquePredicateValuesByKey<string>(
     filters,
     "entityType"
   );
   if (entityTypes?.length) {
-    processedFilters.entityTypes = entityTypes;
+    processedFilters.entityTypes = toEnums(
+      entityTypes,
+      EventAssociationEntityType
+    );
   }
   const eventIds = getUniquePredicateValuesByKey<string>(filters, "id");
   if (eventIds?.length) {
@@ -137,21 +139,24 @@ export async function processFilters(
     }
   }
   // todo: <enums or strings?> (API is upper casing each value in the array, but throws off the typing here)
-  const attendanceType = getUniquePredicateValuesByKey<EventAttendanceType>(
+  const attendanceType = getUniquePredicateValuesByKey<string>(
     filters,
     "attendanceType"
   );
   if (attendanceType?.length) {
-    processedFilters.attendanceTypes = attendanceType;
+    processedFilters.attendanceTypes = toEnums(
+      attendanceType,
+      EventAttendanceType
+    );
   }
   const createdByIds = getUniquePredicateValuesByKey<string>(filters, "owner");
   if (createdByIds?.length) {
     processedFilters.createdByIds = createdByIds;
   }
   // todo: <enums or strings?> (API is upper casing each value in the array, but throws off the typing here)
-  const status = getUniquePredicateValuesByKey<EventStatus>(filters, "status");
+  const status = getUniquePredicateValuesByKey<string>(filters, "status");
   processedFilters.status = status?.length
-    ? status
+    ? toEnums(status, EventStatus)
     : [EventStatus.PLANNED, EventStatus.CANCELED];
 
   const startDateRange = getPredicateValuesByKey<IDateRange<string | number>>(

--- a/packages/common/src/search/_internal/hubEventsHelpers/processFilters.ts
+++ b/packages/common/src/search/_internal/hubEventsHelpers/processFilters.ts
@@ -33,7 +33,7 @@ export async function processFilters(
     processedFilters.canEdit = canEdit[0];
   }
   const entityIds = getUniquePredicateValuesByKey<string>(filters, "entityId");
-  if (entityIds?.length) {
+  if (entityIds.length) {
     processedFilters.entityIds = entityIds;
   }
   const entityTypes = getUniquePredicateValuesByKey<string>(

--- a/packages/common/src/search/_internal/hubEventsHelpers/processOptions.ts
+++ b/packages/common/src/search/_internal/hubEventsHelpers/processOptions.ts
@@ -1,24 +1,24 @@
 import { IHubSearchOptions } from "../../types/IHubSearchOptions";
 import {
   EventSort,
-  GetEventsParams,
+  ISearchEvents,
   EventSortOrder,
 } from "../../../events/api/orval/api/orval-events";
 
 /**
- * Builds a Partial<GetEventsParams> for the given IHubSearchOptions
+ * Builds a Partial<ISearchEvents> for the given IHubSearchOptions
  * @param options An IHubSearchOptions object
- * @returns a Partial<GetEventsParams> for the given IHubSearchOptions
+ * @returns a Partial<ISearchEvents> for the given IHubSearchOptions
  */
 export function processOptions(
   options: IHubSearchOptions
-): Partial<GetEventsParams> {
-  const processedOptions: Partial<GetEventsParams> = {};
+): Partial<ISearchEvents> {
+  const processedOptions: Partial<ISearchEvents> = {};
   if (options.num > 0) {
-    processedOptions.num = options.num.toString();
+    processedOptions.num = options.num;
   }
   if (options.start > 1) {
-    processedOptions.start = options.start.toString();
+    processedOptions.start = options.start;
   }
   if (options.sortField === "modified") {
     processedOptions.sortBy = EventSort.updatedAt;

--- a/packages/common/src/search/_internal/hubEventsHelpers/toEnumConverters.ts
+++ b/packages/common/src/search/_internal/hubEventsHelpers/toEnumConverters.ts
@@ -1,0 +1,22 @@
+/**
+ * Converts a string to an enum value
+ *
+ * strings not in the enum will be returned as the original string
+ */
+export function toEnum<T>(value: string, enumType: T): T[keyof T] {
+  return (
+    (enumType as any)[value] ||
+    (enumType as any)[value.toUpperCase()] ||
+    (enumType as any)[value.toLowerCase()] ||
+    value
+  );
+}
+
+/**
+ * Converts an array of strings to an array of enum values
+ *
+ * strings not in the enum will be returned as the original string
+ */
+export function toEnums<T>(values: string[], enumType: T): Array<T[keyof T]> {
+  return values.map((value) => toEnum<T>(value, enumType));
+}

--- a/packages/common/src/search/_internal/hubSearchEvents.ts
+++ b/packages/common/src/search/_internal/hubSearchEvents.ts
@@ -20,7 +20,6 @@ import { processFilters } from "./hubEventsHelpers/processFilters";
  *   - entityId: string | string[];
  *   - entityType: string | string[];
  *   - id: string | string[];
- *   - userId: string;
  *   - term: string;
  *   - categories: string | string[];
  *   - tags: string | string[];

--- a/packages/common/src/search/_internal/hubSearchEvents.ts
+++ b/packages/common/src/search/_internal/hubSearchEvents.ts
@@ -2,8 +2,12 @@ import { IQuery } from "../types/IHubCatalog";
 import { IHubSearchOptions } from "../types/IHubSearchOptions";
 import { IHubSearchResponse } from "../types/IHubSearchResponse";
 import { IHubSearchResult } from "../types/IHubSearchResult";
-import { getEvents } from "../../events/api/events";
-import { GetEventsParams } from "../../events/api/orval/api/orval-events";
+import { searchEvents } from "../../events/api/events";
+import {
+  GetEventsInclude,
+  GetEventsParams,
+  ISearchEvents,
+} from "../../events/api/orval/api/orval-events";
 import { eventToSearchResult } from "./hubEventsHelpers/eventToSearchResult";
 import { processOptions } from "./hubEventsHelpers/processOptions";
 import { processFilters } from "./hubEventsHelpers/processFilters";
@@ -11,7 +15,7 @@ import { processFilters } from "./hubEventsHelpers/processFilters";
 /**
  * Searches for events against the Events 3 API using the given `query` and `options`.
  * Currently supported filters include:
- *   - access: 'public' | 'private' | 'org' | Array<'public' | 'org' | 'access'>;
+ *   - access: 'public' | 'private' | 'org' | Array<'public' | 'org' | 'private'>;
  *   - canEdit: boolean
  *   - entityId: string | string[];
  *   - entityType: string | string[];
@@ -54,12 +58,12 @@ export async function hubSearchEvents(
     options.requestOptions
   );
   const processedOptions = processOptions(options);
-  const data: GetEventsParams = {
+  const data: ISearchEvents = {
     ...processedFilters,
     ...processedOptions,
-    include: "creator,location",
+    include: [GetEventsInclude.creator, GetEventsInclude.location],
   };
-  const { items, nextStart, total } = await getEvents({
+  const { items, nextStart, total } = await searchEvents({
     ...options.requestOptions,
     data,
   });

--- a/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
+++ b/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
@@ -1,4 +1,10 @@
 import { IHubRequestOptions } from "../../../../src";
+import {
+  EventAccess,
+  EventAssociationEntityType,
+  EventAttendanceType,
+  EventStatus,
+} from "../../../../src/events/api";
 import { processFilters } from "../../../../src/search/_internal/hubEventsHelpers/processFilters";
 import * as arcgisRestPortal from "@esri/arcgis-rest-portal";
 
@@ -83,30 +89,37 @@ describe("processFilters", () => {
       );
       expect(result.access).toBeUndefined();
     });
-    it("should consolidate values from multiple filters & predicates", async () => {
+    it("should consolidate and unique values from multiple filters & predicates", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
-                access: "public",
+                access: EventAccess.PUBLIC,
+              },
+              {
+                access: EventAccess.ORG,
               },
             ],
           },
           {
             predicates: [
               {
-                access: "org",
+                access: EventAccess.ORG,
               },
               {
-                access: ["private"],
+                access: [EventAccess.PRIVATE],
               },
             ],
           },
         ],
         hubRequestOptions
       );
-      expect(result.access).toEqual("public,org,private");
+      expect(result.access).toEqual([
+        EventAccess.PUBLIC,
+        EventAccess.ORG,
+        EventAccess.PRIVATE,
+      ]);
     });
   });
   describe("canEdit", () => {
@@ -140,7 +153,7 @@ describe("processFilters", () => {
         ],
         hubRequestOptions
       );
-      expect(result.canEdit).toEqual("true");
+      expect(result.canEdit).toEqual(true);
     });
   });
   describe("entityId", () => {
@@ -151,13 +164,16 @@ describe("processFilters", () => {
       );
       expect(result.entityIds).toBeUndefined();
     });
-    it("should consolidate values from multiple filters & predicates", async () => {
+    it("should consolidate and unique values from multiple filters & predicates", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
                 entityId: "abc",
+              },
+              {
+                entityId: "def",
               },
             ],
           },
@@ -174,7 +190,7 @@ describe("processFilters", () => {
         ],
         hubRequestOptions
       );
-      expect(result.entityIds).toEqual("abc,def,ghi");
+      expect(result.entityIds).toEqual(["abc", "def", "ghi"]);
     });
   });
   describe("entityType", () => {
@@ -185,30 +201,37 @@ describe("processFilters", () => {
       );
       expect(result.entityTypes).toBeUndefined();
     });
-    it("should consolidate values from multiple filters & predicates", async () => {
+    it("should consolidate and unique values from multiple filters & predicates", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
-                entityType: "abc",
+                entityType: EventAssociationEntityType.Hub_Site_Application,
+              },
+              {
+                entityType: EventAssociationEntityType.Hub_Initiative,
               },
             ],
           },
           {
             predicates: [
               {
-                entityType: "def",
+                entityType: EventAssociationEntityType.Hub_Initiative,
               },
               {
-                entityType: ["ghi"],
+                entityType: [EventAssociationEntityType.Hub_Project],
               },
             ],
           },
         ],
         hubRequestOptions
       );
-      expect(result.entityTypes).toEqual("abc,def,ghi");
+      expect(result.entityTypes).toEqual([
+        EventAssociationEntityType.Hub_Site_Application,
+        EventAssociationEntityType.Hub_Initiative,
+        EventAssociationEntityType.Hub_Project,
+      ]);
     });
   });
   describe("id", () => {
@@ -219,13 +242,16 @@ describe("processFilters", () => {
       );
       expect(result.eventIds).toBeUndefined();
     });
-    it("should consolidate values from multiple filters & predicates", async () => {
+    it("should consolidate and unique values from multiple filters & predicates", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
                 id: "abc",
+              },
+              {
+                id: "def",
               },
             ],
           },
@@ -242,7 +268,7 @@ describe("processFilters", () => {
         ],
         hubRequestOptions
       );
-      expect(result.eventIds).toEqual("abc,def,ghi");
+      expect(result.eventIds).toEqual(["abc", "def", "ghi"]);
     });
   });
   describe("term", () => {
@@ -321,13 +347,16 @@ describe("processFilters", () => {
       );
       expect(result.categories).toBeUndefined();
     });
-    it("should consolidate values from multiple filters & predicates", async () => {
+    it("should consolidate and unique values from multiple filters & predicates", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
                 categories: "abc",
+              },
+              {
+                categories: "def",
               },
             ],
           },
@@ -344,7 +373,7 @@ describe("processFilters", () => {
         ],
         hubRequestOptions
       );
-      expect(result.categories).toEqual("abc,def,ghi");
+      expect(result.categories).toEqual(["abc", "def", "ghi"]);
     });
   });
   describe("tags", () => {
@@ -355,13 +384,16 @@ describe("processFilters", () => {
       );
       expect(result.tags).toBeUndefined();
     });
-    it("should consolidate values from multiple filters & predicates", async () => {
+    it("should consolidate and unique values from multiple filters & predicates", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
                 tags: "abc",
+              },
+              {
+                tags: "def",
               },
             ],
           },
@@ -378,7 +410,7 @@ describe("processFilters", () => {
         ],
         hubRequestOptions
       );
-      expect(result.tags).toEqual("abc,def,ghi");
+      expect(result.tags).toEqual(["abc", "def", "ghi"]);
     });
   });
   describe("attendanceType", () => {
@@ -389,30 +421,36 @@ describe("processFilters", () => {
       );
       expect(result.attendanceTypes).toBeUndefined();
     });
-    it("should consolidate values from multiple filters & predicates", async () => {
+    it("should consolidate and unique values from multiple filters & predicates", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
-                attendanceType: "abc",
+                attendanceType: EventAttendanceType.VIRTUAL,
+              },
+              {
+                attendanceType: EventAttendanceType.IN_PERSON,
               },
             ],
           },
           {
             predicates: [
               {
-                attendanceType: "def",
+                attendanceType: EventAttendanceType.VIRTUAL,
               },
               {
-                attendanceType: ["ghi"],
+                attendanceType: [EventAttendanceType.IN_PERSON],
               },
             ],
           },
         ],
         hubRequestOptions
       );
-      expect(result.attendanceTypes).toEqual("abc,def,ghi");
+      expect(result.attendanceTypes).toEqual([
+        EventAttendanceType.VIRTUAL,
+        EventAttendanceType.IN_PERSON,
+      ]);
     });
   });
   describe("owner", () => {
@@ -423,13 +461,16 @@ describe("processFilters", () => {
       );
       expect(result.createdByIds).toBeUndefined();
     });
-    it("should consolidate values from multiple filters & predicates", async () => {
+    it("should consolidate and unique values from multiple filters & predicates", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
                 owner: "abc",
+              },
+              {
+                owner: "def",
               },
             ],
           },
@@ -446,7 +487,7 @@ describe("processFilters", () => {
         ],
         hubRequestOptions
       );
-      expect(result.createdByIds).toEqual("abc,def,ghi");
+      expect(result.createdByIds).toEqual(["abc", "def", "ghi"]);
     });
   });
   describe("status", () => {
@@ -455,32 +496,42 @@ describe("processFilters", () => {
         [{ predicates: [] }],
         hubRequestOptions
       );
-      expect(result.status).toEqual("planned,canceled");
+      expect(result.status).toEqual([
+        EventStatus.PLANNED,
+        EventStatus.CANCELED,
+      ]);
     });
-    it("should consolidate values from multiple filters & predicates", async () => {
+    it("should consolidate and unique values from multiple filters & predicates", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
-                status: "planned",
+                status: EventStatus.PLANNED,
+              },
+              {
+                status: EventStatus.CANCELED,
               },
             ],
           },
           {
             predicates: [
               {
-                status: "canceled",
+                status: EventStatus.CANCELED,
               },
               {
-                status: ["removed"],
+                status: [EventStatus.REMOVED],
               },
             ],
           },
         ],
         hubRequestOptions
       );
-      expect(result.status).toEqual("planned,canceled,removed");
+      expect(result.status).toEqual([
+        EventStatus.PLANNED,
+        EventStatus.CANCELED,
+        EventStatus.REMOVED,
+      ]);
     });
   });
   describe("group", () => {
@@ -491,13 +542,16 @@ describe("processFilters", () => {
       );
       expect(result.sharedToGroups).toBeUndefined();
     });
-    it("should return returnToGroups if group has been supplied", async () => {
+    it("should return and unique sharedToGroups if group has been supplied", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
                 group: editGroup1.id,
+              },
+              {
+                group: readGroup1.id,
               },
             ],
           },
@@ -511,9 +565,11 @@ describe("processFilters", () => {
         ],
         hubRequestOptions
       );
-      expect(result.sharedToGroups).toEqual(
-        [editGroup1.id, readGroup1.id, editGroup2.id].join(",")
-      );
+      expect(result.sharedToGroups).toEqual([
+        editGroup1.id,
+        readGroup1.id,
+        editGroup2.id,
+      ]);
     });
   });
   describe("notGroup", () => {
@@ -525,7 +581,7 @@ describe("processFilters", () => {
       expect(result.withoutReadGroups).toBeUndefined();
       expect(result.withoutEditGroups).toBeUndefined();
     });
-    it("should return readGroups and editGroups", async () => {
+    it("should return and unique withoutReadGroups and withoutEditGroups", async () => {
       const searchGroupsSpy = spyOn(
         arcgisRestPortal,
         "searchGroups"
@@ -538,6 +594,9 @@ describe("processFilters", () => {
             predicates: [
               {
                 notGroup: editGroup1.id,
+              },
+              {
+                notGroup: readGroup1.id,
               },
             ],
           },
@@ -557,10 +616,8 @@ describe("processFilters", () => {
         num: 3,
         ...hubRequestOptions,
       });
-      expect(result.withoutReadGroups).toEqual(readGroup1.id);
-      expect(result.withoutEditGroups).toEqual(
-        [editGroup1.id, editGroup2.id].join(",")
-      );
+      expect(result.withoutReadGroups).toEqual([readGroup1.id]);
+      expect(result.withoutEditGroups).toEqual([editGroup1.id, editGroup2.id]);
     });
     it("should filter out inaccessible groups", async () => {
       const searchGroupsSpy = spyOn(
@@ -631,10 +688,8 @@ describe("processFilters", () => {
         num: 3,
         ...hubRequestOptions,
       });
-      expect(result.withoutReadGroups).toEqual(readGroup1.id);
-      expect(result.withoutEditGroups).toEqual(
-        [editGroup1.id, editGroup2.id].join(",")
-      );
+      expect(result.withoutReadGroups).toEqual([readGroup1.id]);
+      expect(result.withoutEditGroups).toEqual([editGroup1.id, editGroup2.id]);
     });
   });
   describe("readGroupId", () => {
@@ -645,13 +700,16 @@ describe("processFilters", () => {
       );
       expect(result.readGroups).toBeUndefined();
     });
-    it("should consolidate values from multiple filters & predicates", async () => {
+    it("should consolidate and unique values from multiple filters & predicates", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
                 readGroupId: readGroup1.id,
+              },
+              {
+                readGroupId: readGroup2.id,
               },
             ],
           },
@@ -665,9 +723,7 @@ describe("processFilters", () => {
         ],
         hubRequestOptions
       );
-      expect(result.readGroups).toEqual(
-        [readGroup1.id, readGroup2.id].join(",")
-      );
+      expect(result.readGroups).toEqual([readGroup1.id, readGroup2.id]);
     });
   });
   describe("notReadGroupId", () => {
@@ -678,13 +734,16 @@ describe("processFilters", () => {
       );
       expect(result.withoutReadGroups).toBeUndefined();
     });
-    it("should consolidate values from multiple filters & predicates", async () => {
+    it("should consolidate and unique values from multiple filters & predicates", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
                 notReadGroupId: readGroup1.id,
+              },
+              {
+                notReadGroupId: readGroup2.id,
               },
             ],
           },
@@ -698,9 +757,7 @@ describe("processFilters", () => {
         ],
         hubRequestOptions
       );
-      expect(result.withoutReadGroups).toEqual(
-        [readGroup1.id, readGroup2.id].join(",")
-      );
+      expect(result.withoutReadGroups).toEqual([readGroup1.id, readGroup2.id]);
     });
   });
   describe("editGroupId", () => {
@@ -711,13 +768,16 @@ describe("processFilters", () => {
       );
       expect(result.editGroups).toBeUndefined();
     });
-    it("should consolidate values from multiple filters & predicates", async () => {
+    it("should consolidate and unique values from multiple filters & predicates", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
                 editGroupId: editGroup1.id,
+              },
+              {
+                editGroupId: editGroup2.id,
               },
             ],
           },
@@ -731,9 +791,7 @@ describe("processFilters", () => {
         ],
         hubRequestOptions
       );
-      expect(result.editGroups).toEqual(
-        [editGroup1.id, editGroup2.id].join(",")
-      );
+      expect(result.editGroups).toEqual([editGroup1.id, editGroup2.id]);
     });
   });
   describe("notEditGroupId", () => {
@@ -744,13 +802,16 @@ describe("processFilters", () => {
       );
       expect(result.withoutEditGroups).toBeUndefined();
     });
-    it("should consolidate values from multiple filters & predicates", async () => {
+    it("should consolidate and unique values from multiple filters & predicates", async () => {
       const result = await processFilters(
         [
           {
             predicates: [
               {
                 notEditGroupId: editGroup1.id,
+              },
+              {
+                notEditGroupId: editGroup2.id,
               },
             ],
           },
@@ -764,9 +825,7 @@ describe("processFilters", () => {
         ],
         hubRequestOptions
       );
-      expect(result.withoutEditGroups).toEqual(
-        [editGroup1.id, editGroup2.id].join(",")
-      );
+      expect(result.withoutEditGroups).toEqual([editGroup1.id, editGroup2.id]);
     });
   });
   describe("startDateRange", () => {

--- a/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
+++ b/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
@@ -95,20 +95,20 @@ describe("processFilters", () => {
           {
             predicates: [
               {
-                access: EventAccess.PUBLIC,
+                access: "public",
               },
               {
-                access: EventAccess.ORG,
+                access: "org",
               },
             ],
           },
           {
             predicates: [
               {
-                access: EventAccess.ORG,
+                access: "org",
               },
               {
-                access: [EventAccess.PRIVATE],
+                access: "private",
               },
             ],
           },
@@ -130,7 +130,7 @@ describe("processFilters", () => {
       );
       expect(result.canEdit).toBeUndefined();
     });
-    it("should use the first value and coerce to a string", async () => {
+    it("should use the first value", async () => {
       const result = await processFilters(
         [
           {
@@ -207,20 +207,20 @@ describe("processFilters", () => {
           {
             predicates: [
               {
-                entityType: EventAssociationEntityType.Hub_Site_Application,
+                entityType: "Hub Site Application",
               },
               {
-                entityType: EventAssociationEntityType.Hub_Initiative,
+                entityType: "Hub Initiative",
               },
             ],
           },
           {
             predicates: [
               {
-                entityType: EventAssociationEntityType.Hub_Initiative,
+                entityType: "Hub Initiative",
               },
               {
-                entityType: [EventAssociationEntityType.Hub_Project],
+                entityType: ["Hub Project"],
               },
             ],
           },
@@ -427,20 +427,20 @@ describe("processFilters", () => {
           {
             predicates: [
               {
-                attendanceType: EventAttendanceType.VIRTUAL,
+                attendanceType: "virtual",
               },
               {
-                attendanceType: EventAttendanceType.IN_PERSON,
+                attendanceType: "in_person",
               },
             ],
           },
           {
             predicates: [
               {
-                attendanceType: EventAttendanceType.VIRTUAL,
+                attendanceType: "virtual",
               },
               {
-                attendanceType: [EventAttendanceType.IN_PERSON],
+                attendanceType: ["in_person"],
               },
             ],
           },
@@ -507,20 +507,20 @@ describe("processFilters", () => {
           {
             predicates: [
               {
-                status: EventStatus.PLANNED,
+                status: "planned",
               },
               {
-                status: EventStatus.CANCELED,
+                status: "canceled",
               },
             ],
           },
           {
             predicates: [
               {
-                status: EventStatus.CANCELED,
+                status: "canceled",
               },
               {
-                status: [EventStatus.REMOVED],
+                status: ["removed"],
               },
             ],
           },

--- a/packages/common/test/search/_internal/hubEventsHelpers/processOptions.test.ts
+++ b/packages/common/test/search/_internal/hubEventsHelpers/processOptions.test.ts
@@ -11,7 +11,7 @@ describe("processOptions", () => {
       sortOrder: EventSortOrder.asc,
     });
     expect(processOptions({ num: 2 })).toEqual({
-      num: "2",
+      num: 2,
       sortOrder: EventSortOrder.asc,
     });
   });
@@ -21,7 +21,7 @@ describe("processOptions", () => {
       sortOrder: EventSortOrder.asc,
     });
     expect(processOptions({ start: 2 })).toEqual({
-      start: "2",
+      start: 2,
       sortOrder: EventSortOrder.asc,
     });
   });

--- a/packages/common/test/search/_internal/hubEventsHelpers/toEnumConverters.test.ts
+++ b/packages/common/test/search/_internal/hubEventsHelpers/toEnumConverters.test.ts
@@ -1,0 +1,49 @@
+import {
+  EventAccess,
+  EventAssociationEntityType,
+  EventSortOrder,
+} from "../../../../src/events/api";
+import {
+  toEnum,
+  toEnums,
+} from "../../../../src/search/_internal/hubEventsHelpers/toEnumConverters";
+
+describe("toEnumConverters", () => {
+  describe("toEnum", () => {
+    it("should convert a string to a mixed case enum", () => {
+      expect(
+        toEnum("Hub Site Application", EventAssociationEntityType)
+      ).toEqual(EventAssociationEntityType.Hub_Site_Application);
+    });
+
+    it("should convert a string to a lowercase enum regardless of case", () => {
+      expect(toEnum("asc", EventSortOrder)).toEqual(EventSortOrder.asc);
+      expect(toEnum("ASC", EventSortOrder)).toEqual(EventSortOrder.asc);
+    });
+
+    it("should convert a string to an uppercase enum regardless of case", () => {
+      expect(toEnum("private", EventAccess)).toEqual(EventAccess.PRIVATE);
+      expect(toEnum("PRIVATE", EventAccess)).toEqual(EventAccess.PRIVATE);
+    });
+
+    it("should return original value if string is not a key in the enum", () => {
+      expect(toEnum("unknown", EventAccess)).toEqual("unknown");
+    });
+  });
+
+  describe("toEnums", () => {
+    it("should convert an array of strings to an array of enums", () => {
+      expect(toEnums(["PUBLIC", "ORG"], EventAccess)).toEqual([
+        EventAccess.PUBLIC,
+        EventAccess.ORG,
+      ]);
+    });
+    it("should not change original values if string is not a key in the enum", () => {
+      expect(toEnums(["PUBLIC", "ORG", "unknown"], EventAccess)).toEqual([
+        EventAccess.PUBLIC,
+        EventAccess.ORG,
+        "unknown" as EventAccess,
+      ]);
+    });
+  });
+});

--- a/packages/common/test/search/_internal/hubSearchEvents.test.ts
+++ b/packages/common/test/search/_internal/hubSearchEvents.test.ts
@@ -7,7 +7,7 @@ import {
   EventAccess,
   EventAttendanceType,
   EventStatus,
-  GetEventsParams,
+  ISearchEvents,
   IEvent,
   IPagedEventResponse,
   IUser,
@@ -205,21 +205,21 @@ describe("hubSearchEvents", () => {
   } as unknown as IHubSearchOptions;
   const processedFilters = {
     processedFilters: true,
-  } as unknown as Partial<GetEventsParams>;
+  } as unknown as Partial<ISearchEvents>;
   const processedOptions = {
     processedOptions: true,
-  } as unknown as Partial<GetEventsParams>;
+  } as unknown as Partial<ISearchEvents>;
   const processedOptions2 = {
     processedOptions: true,
     start: PAGE_1.nextStart,
-  } as unknown as Partial<GetEventsParams>;
-  let getEventsSpy: jasmine.Spy;
+  } as unknown as Partial<ISearchEvents>;
+  let searchEventsSpy: jasmine.Spy;
   let processFiltersSpy: jasmine.Spy;
   let processOptionsSpy: jasmine.Spy;
   let eventToSearchResultSpy: jasmine.Spy;
 
   beforeEach(() => {
-    getEventsSpy = spyOn(eventsModule, "getEvents").and.returnValues(
+    searchEventsSpy = spyOn(eventsModule, "searchEvents").and.returnValues(
       Promise.resolve(PAGE_1),
       Promise.resolve(PAGE_2)
     );
@@ -247,13 +247,13 @@ describe("hubSearchEvents", () => {
     });
     expect(processOptionsSpy).toHaveBeenCalledTimes(1);
     expect(processOptionsSpy).toHaveBeenCalledWith(options);
-    expect(getEventsSpy).toHaveBeenCalledTimes(1);
-    expect(getEventsSpy).toHaveBeenCalledWith({
+    expect(searchEventsSpy).toHaveBeenCalledTimes(1);
+    expect(searchEventsSpy).toHaveBeenCalledWith({
       ...options.requestOptions,
       data: {
         ...processedFilters,
         ...processedOptions,
-        include: "creator,location",
+        include: ["creator", "location"],
       },
     });
     expect(eventToSearchResultSpy).toHaveBeenCalledTimes(2);
@@ -290,19 +290,19 @@ describe("hubSearchEvents", () => {
       [options2],
       "processOptionsSpy.calls.argsFor(1)"
     );
-    expect(getEventsSpy).toHaveBeenCalledTimes(2);
-    expect(getEventsSpy.calls.argsFor(1)).toEqual(
+    expect(searchEventsSpy).toHaveBeenCalledTimes(2);
+    expect(searchEventsSpy.calls.argsFor(1)).toEqual(
       [
         {
           ...options2.requestOptions,
           data: {
             ...processedFilters,
             ...processedOptions2,
-            include: "creator,location",
+            include: ["creator", "location"],
           },
         },
       ],
-      "getEventsSpy.calls.argsFor(1)"
+      "searchEventsSpy.calls.argsFor(1)"
     );
     expect(eventToSearchResultSpy).toHaveBeenCalledTimes(3);
     expect(eventToSearchResultSpy.calls.argsFor(2)).toEqual(
@@ -324,7 +324,7 @@ describe("hubSearchEvents", () => {
       await results2.next();
       fail("did not reject");
     } catch (e) {
-      expect(e.message).toEqual(
+      expect((e as Error).message).toEqual(
         "No more hub events for the given query and options"
       );
     }


### PR DESCRIPTION
affects: @esri/hub-common

https://devtopia.esri.com/dc/hub/issues/12274

1. Description: In `hubSearchEvents`, swap `getEvents` with `searchEvents`. This function points to the new POST /events/search route. Update the process filter and options functions for the new interface (remove parsing to string)

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
