### PR TITLE
fix(hub-common): update spatial element from default dcat us template

### DIFF
--- a/packages/common/src/sites/feeds/_internal/defaults.ts
+++ b/packages/common/src/sites/feeds/_internal/defaults.ts
@@ -31,7 +31,6 @@ const DCAT_US_1X_DEFAULT = {
     fn: "{{owner}}",
     hasEmail: "{{orgContactEmail}}",
   },
-  spatial: "{{extent}}",
 };
 
 const DCAT_US_3X_DEFAULT = {

--- a/packages/common/src/sites/feeds/_internal/defaults.ts
+++ b/packages/common/src/sites/feeds/_internal/defaults.ts
@@ -31,6 +31,7 @@ const DCAT_US_1X_DEFAULT = {
     fn: "{{owner}}",
     hasEmail: "{{orgContactEmail}}",
   },
+  spatial: "{{extent:computeSpatialProperty}}",
 };
 
 const DCAT_US_3X_DEFAULT = {

--- a/packages/common/src/sites/feeds/getFeedTemplate.ts
+++ b/packages/common/src/sites/feeds/getFeedTemplate.ts
@@ -58,7 +58,20 @@ function getDcatApConfig(feedsConfig: IFeedsConfiguration, version: string) {
 
 function getDcatUsConfig(feedsConfig: IFeedsConfiguration, version: string) {
   if (getMajorVersion(version) === "1") {
-    return feedsConfig.dcatUS1X || feedsConfig.dcatUS11;
+    const dcatUsConfig = feedsConfig.dcatUS1X || feedsConfig.dcatUS11;
+    // Some sites may have dcat us config with invalid
+    // extent value for spatial property i.e. '{{extent}}'
+    //
+    // Following fixes that by replacing invalid default extent
+    // value to valid one i.e. '{{{extent:computeSpatialProperty}}'
+    if (
+      dcatUsConfig &&
+      typeof dcatUsConfig.spatial === "string" &&
+      dcatUsConfig.spatial.replace(/\s/g, "") === "{{extent}}"
+    ) {
+      dcatUsConfig.spatial = "{{extent:computeSpatialProperty}}";
+    }
+    return dcatUsConfig;
   }
 
   if (getMajorVersion(version) === "3") {

--- a/packages/common/test/sites/feeds/getFeedTemplate.test.ts
+++ b/packages/common/test/sites/feeds/getFeedTemplate.test.ts
@@ -40,6 +40,22 @@ describe("getFeedTemplate", () => {
     const chk = getFeedTemplate({ feedsConfig, format, version });
     expect(chk).toEqual(dcatUsConfig);
   });
+  it("gets DCAT US configuration containing spatial field with valid extent value", async () => {
+    const dcatUsConfig = {
+      title: "{{title}}",
+      spatial: "   {{  extent  }}   ",
+    };
+    const feedsConfig: IFeedsConfiguration = {
+      dcatUS1X: dcatUsConfig,
+    };
+    const format: FeedFormat = "dcat-us";
+    const version = "1.1";
+    const chk = getFeedTemplate({ feedsConfig, format, version });
+    expect(chk).toEqual(dcatUsConfig);
+    expect(chk).toBeDefined();
+    expect(chk.spatial).toEqual("{{extent:computeSpatialProperty}}");
+    expect(chk.title).toEqual("{{title}}");
+  });
   it("throws error if DCAT US version is not supported", async () => {
     const dcatUsConfig = {
       title: "{{title}}",


### PR DESCRIPTION
1. Description: This PR updates `spatial` field of default DCAT US feed template to use default transformer `computeSpatialProperty` with `extent` value. [`computeSpatialProperty`](https://github.com/ArcGIS/hub-feeds-api/blob/main/src/default-feed-templates/dcat-us/template-transforms.js#L164-L189) computes valid value from extent so should be used with `extent` by default.

1. Instructions for testing:

1. Closes Issues: [#12271]( https://devtopia.esri.com/dc/hub/issues/12271)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
