### PR TITLE
feat(hub-common): add content home url util

### DIFF
--- a/packages/common/src/urls/getContentHomeUrl.ts
+++ b/packages/common/src/urls/getContentHomeUrl.ts
@@ -1,0 +1,11 @@
+import { IPortal } from "@esri/arcgis-rest-portal/dist/esm/util/get-portal";
+import { IHubRequestOptions } from "../types";
+import { IRequestOptions } from "@esri/arcgis-rest-request/dist/esm/utils/IRequestOptions";
+import { getPortalUrl } from "./get-portal-url";
+
+export function getContentHomeUrl(
+  portalUrlOrObject?: string | IPortal | IHubRequestOptions | IRequestOptions
+): string {
+  const portalUrl = getPortalUrl(portalUrlOrObject);
+  return `${portalUrl}/home/content.html`;
+}

--- a/packages/common/src/urls/getContentHomeUrl.ts
+++ b/packages/common/src/urls/getContentHomeUrl.ts
@@ -3,6 +3,11 @@ import { IHubRequestOptions } from "../types";
 import { IRequestOptions } from "@esri/arcgis-rest-request/dist/esm/utils/IRequestOptions";
 import { getPortalUrl } from "./get-portal-url";
 
+/**
+ * Computes a URL to the "Content" tab in the AGO Home app for a given portal URL string, IPortal, IHubRequestOptions or IRequestOptions object
+ * @param portalUrlOrObject a portal URL string, IPortal, IHubRequestOptions or IRequestOptions object
+ * @returns a URL string for the AGO Home for the given portalUrlOrObject parameter
+ */
 export function getContentHomeUrl(
   portalUrlOrObject?: string | IPortal | IHubRequestOptions | IRequestOptions
 ): string {

--- a/packages/common/src/urls/index.ts
+++ b/packages/common/src/urls/index.ts
@@ -16,6 +16,7 @@ export * from "./get-item-data-url";
 export * from "./convert-urls-to-anchor-tags";
 export * from "./getHubApiFromPortalUrl";
 export * from "./getPortalBaseFromOrgUrl";
+export * from "./getContentHomeUrl";
 export * from "./getGroupHomeUrl";
 export * from "./getUserHomeUrl";
 export * from "./get-campaign-url";

--- a/packages/common/test/urls/getContentHomeUrl.test.ts
+++ b/packages/common/test/urls/getContentHomeUrl.test.ts
@@ -1,0 +1,8 @@
+import { getContentHomeUrl } from "../../src/urls/getContentHomeUrl";
+
+describe("getContentHomeUrl", () => {
+  it("returns content home url", () => {
+    const result = getContentHomeUrl("https://portal.com");
+    expect(result).toEqual("https://portal.com/home/content.html");
+  });
+});

--- a/packages/common/test/urls/getContentHomeUrl.test.ts
+++ b/packages/common/test/urls/getContentHomeUrl.test.ts
@@ -1,8 +1,48 @@
 import { getContentHomeUrl } from "../../src/urls/getContentHomeUrl";
+import * as getPortalUrlModule from "../../src/urls/get-portal-url";
+import { IPortal } from "@esri/arcgis-rest-portal";
+import { IHubRequestOptions } from "../../src/types";
+import { IRequestOptions } from "@esri/arcgis-rest-request";
 
-describe("getContentHomeUrl", () => {
-  it("returns content home url", () => {
-    const result = getContentHomeUrl("https://portal.com");
-    expect(result).toEqual("https://portal.com/home/content.html");
+fdescribe("getContentHomeUrl", () => {
+  const portalUrl = "https://portal.com";
+  const portal: IPortal = {
+    id: "31c",
+    isPortal: false,
+    name: "My portal",
+  };
+  const requestOptions: IRequestOptions = {
+    params: { f: "json" },
+  };
+  const hubRequestOptions: IHubRequestOptions = {
+    isPortal: false,
+  };
+  const inputs = [
+    ["an undefined value"],
+    ["a string", `${portalUrl}/sharing/rest`],
+    ["an IPortal object", portal],
+    ["an IRequestOptions object", requestOptions],
+    ["an IHubRequestOptions object", hubRequestOptions],
+  ];
+  let getPortalUrlStub: jasmine.Spy;
+
+  beforeEach(() => {
+    getPortalUrlStub = spyOn(
+      getPortalUrlModule,
+      "getPortalUrl"
+    ).and.returnValue(portalUrl);
+  });
+
+  afterEach(() => {
+    getPortalUrlStub.calls.reset();
+  });
+
+  inputs.forEach(([label, value]) => {
+    it(`returns the AGO content home URL for ${label}`, () => {
+      const result = getContentHomeUrl(value);
+      expect(result).toEqual(`${portalUrl}/home/content.html`);
+      expect(getPortalUrlStub).toHaveBeenCalledTimes(1);
+      expect(getPortalUrlStub).toHaveBeenCalledWith(value);
+    });
   });
 });

--- a/packages/common/test/urls/getContentHomeUrl.test.ts
+++ b/packages/common/test/urls/getContentHomeUrl.test.ts
@@ -4,7 +4,7 @@ import { IPortal } from "@esri/arcgis-rest-portal";
 import { IHubRequestOptions } from "../../src/types";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 
-fdescribe("getContentHomeUrl", () => {
+describe("getContentHomeUrl", () => {
   const portalUrl = "https://portal.com";
   const portal: IPortal = {
     id: "31c",


### PR DESCRIPTION
1. Description: Adds content home url util.

1. Instructions for testing:

1. Closes Issues: #11979

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
