### PR TITLE
fix(hub-discussions): publish after rebase

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -11,6 +11,7 @@
 [coverage-img]: https://codecov.io/gh/Esri/hub.js/branch/master/graph/badge.svg
 [coverage-url]: https://codecov.io/gh/Esri/hub.js
 
+
 # @esri/hub-common
 
 > Common TypeScript types and utility functions for [`@esri/hub.js`](https://github.com/Esri/hub.js).

--- a/packages/discussions/README.md
+++ b/packages/discussions/README.md
@@ -11,6 +11,7 @@
 [coverage-img]: https://codecov.io/gh/Esri/hub.js/branch/master/graph/badge.svg
 [coverage-url]: https://codecov.io/gh/Esri/hub.js
 
+
 # @esri/hub-discussions
 
 > Module to interact with ArcGIS Hub Discussions API in Node.js and modern browsers.


### PR DESCRIPTION
affects: @esri/hub-discussions
affects: @esri/hub-common

1. Description: Force publish after rebase

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
