### PR TITLE
Force publish 2/5

### DIFF
--- a/packages/common/src/events/api/events.ts
+++ b/packages/common/src/events/api/events.ts
@@ -35,6 +35,7 @@ export async function createEvent(
  * get events
  * @deprecated use searchEvents instead
  *
+ *
  * @param {IGetEventsParams} options
  * @return {Promise<IPagedEventResponse>}
  */

--- a/packages/common/test/discussions/api/discussions-api-request.test.ts
+++ b/packages/common/test/discussions/api/discussions-api-request.test.ts
@@ -261,7 +261,7 @@ describe("apiRequest", () => {
 
     const [calledUrl, calledOpts] = fetchMock.calls()[0];
     expect(calledUrl).toEqual(
-      "https://hub.arcgis.com/api/discussions/v1/posts/search"
+      "https://hub.arcgis.com/api/discussions/v2/posts/search"
     );
     expect(calledOpts).toEqual(expectedOpts);
   });
@@ -312,7 +312,7 @@ describe("apiRequest", () => {
 
     const [calledUrl, calledOpts] = fetchMock.calls()[0];
     expect(calledUrl).toEqual(
-      "https://hub.arcgis.com/api/discussions/v1/posts/search"
+      "https://hub.arcgis.com/api/discussions/v2/posts/search"
     );
     expect(calledOpts).toEqual(expectedOpts);
   });

--- a/packages/discussions/src/posts/posts.ts
+++ b/packages/discussions/src/posts/posts.ts
@@ -21,6 +21,7 @@ import {
 /**
  * search posts
  *
+ *
  * @export
  * @param {ISearchPostsParams} options
  * @return {*}  {Promise<IPagedResponse<IPost>>}


### PR DESCRIPTION
1. Description: Force `next` version and publish after rebase

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
