### PR TITLE
feat(hub-common): implement getCatalogFromModel()

### DIFF
--- a/packages/common/src/sites/_internal/computeProps.ts
+++ b/packages/common/src/sites/_internal/computeProps.ts
@@ -9,6 +9,7 @@ import { SiteDefaultFeatures } from "./SiteBusinessRules";
 import { IHubSite } from "../../core/types/IHubSite";
 import { computeItemProps } from "../../core/_internal/computeItemProps";
 import { computeLinks } from "./computeLinks";
+import { getCatalogFromSiteModel } from "../get-catalog-from-site-model";
 
 /**
  * Given a model and a site, set various computed properties that can't be directly mapped
@@ -43,6 +44,8 @@ export function computeProps(
     model.data.settings?.features || {},
     SiteDefaultFeatures
   );
+
+  site.catalog = getCatalogFromSiteModel(model);
 
   // Perform schema upgrades on the new catalog structure
   site.catalog = upgradeCatalogSchema(site.catalog);

--- a/packages/common/src/sites/get-catalog-from-site-model.ts
+++ b/packages/common/src/sites/get-catalog-from-site-model.ts
@@ -1,0 +1,58 @@
+import { getWithDefault } from "../objects/get-with-default";
+import {
+  getWellknownCollections,
+  IHubCatalog,
+  IHubCollection,
+} from "../search";
+import { IModel } from "../types";
+import { capitalize, cloneObject } from "../util";
+import { applyCatalogStructureMigration } from "./_internal/applyCatalogStructureMigration";
+import { applyDefaultCollectionMigration } from "./_internal/applyDefaultCollectionMigration";
+
+/**
+ * Get IHubCatalog from site model
+ * @param {IModel} model
+ */
+export function getCatalogFromSiteModel(model: IModel): IHubCatalog {
+  // catalogV2 contains site's IHubCatalog
+  if (model.data.catalogV2) {
+    return model.data.catalogV2;
+  }
+
+  // migrate legacy catalog to IHubCatalog
+  let migrated = cloneObject(model);
+  migrated = applyCatalogStructureMigration(migrated);
+  migrated = applyDefaultCollectionMigration(migrated);
+  migrated = applyDefaultCollectionValues(migrated);
+
+  return migrated.data.catalog;
+}
+
+/**
+ * Default collection values like `scope.filter` and `label`
+ * is required for Hub OGC Search service. This applies
+ * default collection values required for search.
+ *
+ */
+function applyDefaultCollectionValues(model: IModel): IModel {
+  const collections: IHubCollection[] = getWithDefault(
+    model.data,
+    "catalog.collections",
+    []
+  );
+  const wellKnownCollections = getWellknownCollections("", "item");
+
+  collections.forEach((collection: IHubCollection) => {
+    const wellKnownCollection = wellKnownCollections.find(
+      (c: IHubCollection) => c.key === collection.key
+    );
+    if (wellKnownCollection) {
+      collection.scope.filters = wellKnownCollection.scope.filters;
+    }
+    collection.label =
+      collection.key === "appAndMap"
+        ? "App and Map"
+        : capitalize(collection.key);
+  });
+  return model;
+}

--- a/packages/common/test/sites/get-catalog-from-site-model.ts
+++ b/packages/common/test/sites/get-catalog-from-site-model.ts
@@ -1,0 +1,51 @@
+import { IHubCatalog } from "../../src";
+import { getCatalogFromSiteModel } from "../../src/sites/get-catalog-from-site-model";
+import { IModel } from "../../src/types";
+
+describe("getCatalogFromSiteModel", () => {
+  it("gets updated catalog from legacy catalog", async () => {
+    const model = {
+      data: {
+        catalog: { groups: ["00c", "00d"] },
+        values: {},
+      },
+    } as unknown as IModel;
+
+    const chk = getCatalogFromSiteModel(model);
+
+    // check for collection
+    expect(chk.collections?.map((c) => c.key)).toEqual([
+      "all",
+      "site",
+      "dataset",
+      "document",
+      "appAndMap",
+    ]);
+  });
+
+  it("gets IHubCatalog from legacy catalog", async () => {
+    const catalogV2 = {
+      schemaVersion: 1,
+      title: "Default Site Catalog",
+      scopes: {
+        item: {
+          targetEntity: "item",
+          filters: [],
+        },
+      },
+      collections: [],
+    } as unknown as IHubCatalog;
+
+    const model = {
+      data: {
+        catalogV2,
+        values: {},
+      },
+    } as unknown as IModel;
+
+    const chk = getCatalogFromSiteModel(model);
+
+    // check for collection
+    expect(chk).toEqual(catalogV2);
+  });
+});


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
