### PR TITLE
fix(hub-common): fix package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22695,9 +22695,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22712,21 +22713,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22740,9 +22744,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22760,9 +22765,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -65017,7 +65023,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.25.1",
+			"version": "15.22.0-next.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65047,32 +65053,32 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "29.4.1",
+			"version": "29.5.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.16.0",
+				"@esri/hub-common": "^15.22.0-next.1",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "^15.8.0"
+				"@esri/hub-common": "^15.22.0-next.1"
 			}
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "15.0.0",
+			"version": "15.1.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.22.0-next.1",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65080,18 +65086,18 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.7.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^15.22.0-next.1"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "15.0.0",
+			"version": "15.1.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.29.0-next.1",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65100,18 +65106,42 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^15.29.0-next.1"
+			}
+		},
+		"packages/events/node_modules/@esri/hub-common": {
+			"version": "15.31.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-15.31.1.tgz",
+			"integrity": "sha512-hX4mWkeXxxncR2aJP16L3PJWZHZ8scs5dFt2UC4qAncU9mi+K0z6BZBc7VNnv4OPD8ag88uDC+hT4S2B6IZYEQ==",
+			"dev": true,
+			"dependencies": {
+				"@terraformer/arcgis": "^2.1.2",
+				"abab": "^2.0.5",
+				"adlib": "^3.0.8",
+				"ajv": "^6.12.6",
+				"fast-xml-parser": "^3.21.0",
+				"json-schema-typed": "^7.0.3",
+				"jsonapi-typescript": "^0.1.3",
+				"tslib": "^1.13.0"
+			},
+			"peerDependencies": {
+				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
+				"@esri/arcgis-rest-feature-layer": "^3.2.0",
+				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
+				"@esri/arcgis-rest-request": "^2.14.0 || 3",
+				"@esri/arcgis-rest-service-admin": "^3.6.0",
+				"@esri/arcgis-rest-types": "^2.15.0 || 3"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "15.0.0",
+			"version": "15.1.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.22.0-next.1",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -65119,18 +65149,18 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^15.22.0-next.1"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "15.0.0",
+			"version": "15.1.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.22.0-next.1",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -65141,40 +65171,64 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^15.22.0-next.1"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "16.0.1",
+			"version": "16.1.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
-				"@esri/hub-initiatives": "^15.0.0",
-				"@esri/hub-teams": "^15.0.0",
+				"@esri/hub-common": "^15.22.0-next.1",
+				"@esri/hub-initiatives": "^15.1.0-next.1",
+				"@esri/hub-teams": "^15.1.0-next.1",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0",
-				"@esri/hub-initiatives": "^15.0.0",
-				"@esri/hub-teams": "^15.0.0"
+				"@esri/hub-common": "^15.22.0-next.1",
+				"@esri/hub-initiatives": "^15.1.0-next.1",
+				"@esri/hub-teams": "^15.1.0-next.1"
+			}
+		},
+		"packages/sites/node_modules/@esri/hub-common": {
+			"version": "15.31.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-15.31.1.tgz",
+			"integrity": "sha512-hX4mWkeXxxncR2aJP16L3PJWZHZ8scs5dFt2UC4qAncU9mi+K0z6BZBc7VNnv4OPD8ag88uDC+hT4S2B6IZYEQ==",
+			"dev": true,
+			"dependencies": {
+				"@terraformer/arcgis": "^2.1.2",
+				"abab": "^2.0.5",
+				"adlib": "^3.0.8",
+				"ajv": "^6.12.6",
+				"fast-xml-parser": "^3.21.0",
+				"json-schema-typed": "^7.0.3",
+				"jsonapi-typescript": "^0.1.3",
+				"tslib": "^1.13.0"
+			},
+			"peerDependencies": {
+				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
+				"@esri/arcgis-rest-feature-layer": "^3.2.0",
+				"@esri/arcgis-rest-portal": "^2.18.0 || 3",
+				"@esri/arcgis-rest-request": "^2.14.0 || 3",
+				"@esri/arcgis-rest-service-admin": "^3.6.0",
+				"@esri/arcgis-rest-types": "^2.15.0 || 3"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "15.0.0",
+			"version": "15.1.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.22.0-next.1",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65183,18 +65237,18 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^15.22.0-next.1"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "15.0.0",
+			"version": "15.1.0-next.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.22.0-next.1",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65202,7 +65256,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^15.22.0-next.1"
 			}
 		}
 	},
@@ -68779,7 +68833,7 @@
 		"@esri/hub-discussions": {
 			"version": "file:packages/discussions",
 			"requires": {
-				"@esri/hub-common": "^15.16.0",
+				"@esri/hub-common": "^15.22.0-next.1",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68788,7 +68842,7 @@
 		"@esri/hub-downloads": {
 			"version": "file:packages/downloads",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.22.0-next.1",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68797,15 +68851,33 @@
 		"@esri/hub-events": {
 			"version": "file:packages/events",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.29.0-next.1",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
+			},
+			"dependencies": {
+				"@esri/hub-common": {
+					"version": "15.31.1",
+					"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-15.31.1.tgz",
+					"integrity": "sha512-hX4mWkeXxxncR2aJP16L3PJWZHZ8scs5dFt2UC4qAncU9mi+K0z6BZBc7VNnv4OPD8ag88uDC+hT4S2B6IZYEQ==",
+					"dev": true,
+					"requires": {
+						"@terraformer/arcgis": "^2.1.2",
+						"abab": "^2.0.5",
+						"adlib": "^3.0.8",
+						"ajv": "^6.12.6",
+						"fast-xml-parser": "^3.21.0",
+						"json-schema-typed": "^7.0.3",
+						"jsonapi-typescript": "^0.1.3",
+						"tslib": "^1.13.0"
+					}
+				}
 			}
 		},
 		"@esri/hub-initiatives": {
 			"version": "file:packages/initiatives",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.22.0-next.1",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68814,7 +68886,7 @@
 		"@esri/hub-search": {
 			"version": "file:packages/search",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.22.0-next.1",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -68824,17 +68896,35 @@
 		"@esri/hub-sites": {
 			"version": "file:packages/sites",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
-				"@esri/hub-initiatives": "^15.0.0",
-				"@esri/hub-teams": "^15.0.0",
+				"@esri/hub-common": "^15.22.0-next.1",
+				"@esri/hub-initiatives": "^15.1.0-next.1",
+				"@esri/hub-teams": "^15.1.0-next.1",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
+			},
+			"dependencies": {
+				"@esri/hub-common": {
+					"version": "15.31.1",
+					"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-15.31.1.tgz",
+					"integrity": "sha512-hX4mWkeXxxncR2aJP16L3PJWZHZ8scs5dFt2UC4qAncU9mi+K0z6BZBc7VNnv4OPD8ag88uDC+hT4S2B6IZYEQ==",
+					"dev": true,
+					"requires": {
+						"@terraformer/arcgis": "^2.1.2",
+						"abab": "^2.0.5",
+						"adlib": "^3.0.8",
+						"ajv": "^6.12.6",
+						"fast-xml-parser": "^3.21.0",
+						"json-schema-typed": "^7.0.3",
+						"jsonapi-typescript": "^0.1.3",
+						"tslib": "^1.13.0"
+					}
+				}
 			}
 		},
 		"@esri/hub-surveys": {
 			"version": "file:packages/surveys",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.22.0-next.1",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68842,7 +68932,7 @@
 		"@esri/hub-teams": {
 			"version": "file:packages/teams",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.22.0-next.1",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -83481,7 +83571,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83496,17 +83587,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83520,7 +83614,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83537,7 +83632,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -504,7 +504,7 @@ export interface IPostOptions {
 }
 
 /**
- * dto for creating a post
+ * dto for creating a post in a channel
  *
  * @export
  * @interface ICreatePost


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Fix package-lock after rebase

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
