### PR TITLE
fix: add default to filters on queryschema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65003,7 +65003,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.29.0",
+			"version": "15.31.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -35,6 +35,7 @@ export const QuerySchema: IConfigurationSchema = {
     filters: {
       type: "array",
       items: FilterSchema,
+      default: [{ predicates: [] }],
     },
   },
 };


### PR DESCRIPTION
1. Description: Need to provide a default so the configuration editor doesn't strip out the empty predicates array.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
