### PR TITLE
fix: change export location

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -56,6 +56,8 @@ export * from "./search/searchCatalogs";
 export * from "./search/getAddContentConfig";
 export * from "./search/getCatalogGroups";
 export * from "./search/getPredicateValues";
+export * from "./search/negateGroupPredicates";
+
 export * from "./core/hubHistory";
 export * from "./core/deepCatalogContains";
 export * from "./core/parseContainmentPath";

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -51,12 +51,14 @@ export * from "./core/EntityEditor";
 // Unclear _why_ this needs to be here vs. in search/index.ts
 // but if it's exported there, it's not actually exporeted
 export * from "./search/explainQueryResult";
-export * from "./search/searchEntityCatalogs";
-export * from "./search/searchCatalogs";
 export * from "./search/getAddContentConfig";
 export * from "./search/getCatalogGroups";
 export * from "./search/getPredicateValues";
+export * from "./search/getUserGroupsByMembership";
+export * from "./search/getUserGroupsFromQuery";
 export * from "./search/negateGroupPredicates";
+export * from "./search/searchCatalogs";
+export * from "./search/searchEntityCatalogs";
 
 export * from "./core/hubHistory";
 export * from "./core/deepCatalogContains";

--- a/packages/common/src/search/index.ts
+++ b/packages/common/src/search/index.ts
@@ -3,7 +3,6 @@ export * from "./Collection";
 export * from "./getUserGroupsByMembership";
 export * from "./getUserGroupsFromQuery";
 export * from "./hubSearch";
-export * from "./negateGroupPredicates";
 export * from "./serializeQueryForPortal";
 export * from "./types";
 export * from "./upgradeCatalogSchema";

--- a/packages/common/src/search/index.ts
+++ b/packages/common/src/search/index.ts
@@ -1,7 +1,5 @@
 export * from "./Catalog";
 export * from "./Collection";
-export * from "./getUserGroupsByMembership";
-export * from "./getUserGroupsFromQuery";
 export * from "./hubSearch";
 export * from "./serializeQueryForPortal";
 export * from "./types";


### PR DESCRIPTION
1. Description:

Previous PR resulted in some exports not being "found" when running the stencil spec tests. This just changes their export location form `/search/index.ts` to `/index.ts`

Copying this build into the -ui monorepo resulted in the spec tests all running clean, so... I believe that's the verification we need

1. Instructions for testing:

run tests.

1. Closes Issues: #<number> (if appropriate)

1. [ ] na/ Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
