### PR TITLE
feat(hub-common): add new v2 discussions interfaces and functions

### DIFF
--- a/packages/common/src/discussions/api/channels/channels.ts
+++ b/packages/common/src/discussions/api/channels/channels.ts
@@ -2,12 +2,7 @@ import {
   discussionsApiRequest,
   discussionsApiRequestV2,
 } from "../discussions-api-request";
-import {
-  IChannel,
-  IChannelV2,
-  IPagedResponse,
-  ISearchChannelsParams,
-} from "../types";
+import { IChannel, IPagedResponse, ISearchChannelsParams } from "../types";
 
 /**
  * Search for Channels in the Discussions API.  Channels define the capabilities,
@@ -30,11 +25,11 @@ export function searchChannels(
  *
  * @export
  * @param {ISearchChannelsParams} options
- * @return {*}  {Promise<IPagedResponse<IChannelV2>>}
+ * @return {*}  {Promise<IPagedResponse<IChannel>>}
  */
 export function searchChannelsV2(
   options: ISearchChannelsParams
-): Promise<IPagedResponse<IChannelV2>> {
+): Promise<IPagedResponse<IChannel>> {
   options.httpMethod = "GET";
   return discussionsApiRequestV2(`/channels`, options);
 }

--- a/packages/common/src/discussions/api/channels/channels.ts
+++ b/packages/common/src/discussions/api/channels/channels.ts
@@ -1,5 +1,13 @@
-import { discussionsApiRequest } from "../discussions-api-request";
-import { IChannel, IPagedResponse, ISearchChannelsParams } from "../types";
+import {
+  discussionsApiRequest,
+  discussionsApiRequestV2,
+} from "../discussions-api-request";
+import {
+  IChannel,
+  IChannelV2,
+  IPagedResponse,
+  ISearchChannelsParams,
+} from "../types";
 
 /**
  * Search for Channels in the Discussions API.  Channels define the capabilities,
@@ -14,4 +22,19 @@ export function searchChannels(
 ): Promise<IPagedResponse<IChannel>> {
   options.httpMethod = "GET";
   return discussionsApiRequest(`/channels`, options);
+}
+
+/**
+ * Search for Channels in the Discussions API.  Channels define the capabilities,
+ * permissions, and configuration for Discussion posts.
+ *
+ * @export
+ * @param {ISearchChannelsParams} options
+ * @return {*}  {Promise<IPagedResponse<IChannelV2>>}
+ */
+export function searchChannelsV2(
+  options: ISearchChannelsParams
+): Promise<IPagedResponse<IChannelV2>> {
+  options.httpMethod = "GET";
+  return discussionsApiRequestV2(`/channels`, options);
 }

--- a/packages/common/src/discussions/api/discussions-api-request.ts
+++ b/packages/common/src/discussions/api/discussions-api-request.ts
@@ -19,6 +19,28 @@ export function discussionsApiRequest<T>(
   options: IDiscussionsRequestOptions
 ): Promise<T> {
   return authenticateRequest(options).then((token) => {
-    return apiRequest(url, options, token);
+    return apiRequest(url, options, "v1", token);
+  });
+}
+
+/**
+ * method that authenticates and makes requests to Discussions API v2
+ *
+ * @export
+ * @template T
+ * @param {string} url
+ * @param {IDiscussionsRequestOptions} options
+ * @return {*}  {Promise<T>}
+ */
+// NOTE: feasibly this could be replaced with @esi/hub-common hubApiRequest,
+// if that method didn't prepend `/api/v3` to the supplied path. Additionally,
+// there is the difference that hubApiRequest sets Authorization header without `Bearer`
+// https://github.com/Esri/hub.js/blob/f35b1a0a868916bd07e1dfd84cb084bc2c876267/packages/common/src/request.ts#L62
+export function discussionsApiRequestV2<T>(
+  url: string,
+  options: IDiscussionsRequestOptions
+): Promise<T> {
+  return authenticateRequest(options).then((token) => {
+    return apiRequest(url, options, "v2", token);
   });
 }

--- a/packages/common/src/discussions/api/settings/settings.ts
+++ b/packages/common/src/discussions/api/settings/settings.ts
@@ -1,4 +1,7 @@
-import { discussionsApiRequest } from "../discussions-api-request";
+import {
+  discussionsApiRequest,
+  discussionsApiRequestV2,
+} from "../discussions-api-request";
 import {
   ICreateSettingParams,
   IEntitySetting,
@@ -62,4 +65,60 @@ export function removeSetting(
 ): Promise<IRemoveSettingResponse> {
   options.httpMethod = "DELETE";
   return discussionsApiRequest(`/settings/${options.id}`, options);
+}
+
+/**
+ * create setting V2
+ *
+ * @export
+ * @param {ICreateSettingParams} options
+ * @return {*} {Promise<IEntitySetting>}
+ */
+export function createSettingV2(
+  options: ICreateSettingParams
+): Promise<IEntitySetting> {
+  options.httpMethod = "POST";
+  return discussionsApiRequestV2(`/settings`, options);
+}
+
+/**
+ * fetch setting V2
+ *
+ * @export
+ * @param {IFetchSettingParams} options
+ * @return {*} {Promise<IEntitySetting>}
+ */
+export function fetchSettingV2(
+  options: IFetchSettingParams
+): Promise<IEntitySetting> {
+  options.httpMethod = "GET";
+  return discussionsApiRequestV2(`/settings/${options.id}`, options);
+}
+
+/**
+ * update setting V2
+ *
+ * @export
+ * @param {IUpdateSettingParams} options
+ * @return {*} {Promise<IEntitySetting>}
+ */
+export function updateSettingV2(
+  options: IUpdateSettingParams
+): Promise<IEntitySetting> {
+  options.httpMethod = "PATCH";
+  return discussionsApiRequestV2(`/settings/${options.id}`, options);
+}
+
+/**
+ * remove setting
+ *
+ * @export
+ * @param {IRemoveSettingParams} options
+ * @return {*} {Promise<IRemoveSettingResponse>}
+ */
+export function removeSettingV2(
+  options: IRemoveSettingParams
+): Promise<IRemoveSettingResponse> {
+  options.httpMethod = "DELETE";
+  return discussionsApiRequestV2(`/settings/${options.id}`, options);
 }

--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -485,37 +485,6 @@ export interface IPost
 }
 
 /**
- * representation of v2 post from service
- *
- * @export
- * @interface IPostV2
- * @extends {IWithAuthor}
- * @extends {IWithEditor}
- * @extends {IWithTimestamps}
- */
-export interface IPostV2
-  extends Partial<IWithAuthor>,
-    Partial<IWithEditor>,
-    IWithTimestamps {
-  id: string;
-  title: string | null;
-  body: string;
-  status: PostStatus;
-  appInfo: string | null; // this is a catch-all field for app-specific information about a post, added for Urban
-  discussion: string | null;
-  geometry: Geometry | null;
-  featureGeometry: Geometry | null;
-  postType: PostType;
-  channelId: string;
-  channel?: IChannelV2;
-  parentId: string | null;
-  parent?: IPostV2 | null;
-  replies?: IPostV2[] | IPagedResponse<IPostV2>;
-  replyCount?: number;
-  reactions?: IReaction[];
-}
-
-/**
  * base parameters for creating a post
  *
  * @export
@@ -965,8 +934,14 @@ export interface ICreateChannelV2
  */
 export interface IChannel extends IWithAuthor, IWithEditor, IWithTimestamps {
   id: string;
-  access: SharingAccess;
-  allowAnonymous: boolean;
+  /** deprecated V1 permissions field, use channelAcl */
+  access: SharingAccess | null;
+  /** deprecated V1 permissions field, use channelAcl */
+  allowAnonymous: boolean | null;
+  /** deprecated V1 permissions field, use channelAcl */
+  groups: string[] | null;
+  /** deprecated V1 permissions field, use channelAcl */
+  orgs: string[] | null;
   allowAsAnonymous: boolean;
   allowedReactions: PostReaction[] | null;
   allowPost: boolean;
@@ -975,38 +950,10 @@ export interface IChannel extends IWithAuthor, IWithEditor, IWithTimestamps {
   blockWords: string[] | null;
   channelAcl?: IChannelAclPermission[];
   defaultPostStatus: PostStatus;
-  groups: string[];
   metadata: IChannelMetadata | null;
   name: string | null;
   orgId: string;
-  orgs: string[];
   posts?: IPost[];
-  softDelete: boolean;
-}
-
-/**
- * representation of V2 channel from service
- *
- * @export
- * @interface IChannelV2
- * @extends {IWithAuthor}
- * @extends {IWithEditor}
- * @extends {IWithTimestamps}
- */
-export interface IChannelV2 extends IWithAuthor, IWithEditor, IWithTimestamps {
-  id: string;
-  allowAsAnonymous: boolean;
-  allowedReactions: PostReaction[] | null;
-  allowPost: boolean;
-  allowReaction: boolean;
-  allowReply: boolean;
-  blockWords: string[] | null;
-  channelAcl?: IChannelAclPermission[];
-  defaultPostStatus: PostStatus;
-  metadata: IChannelMetadata | null;
-  name: string | null;
-  orgId: string;
-  posts?: IPostV2[];
   softDelete: boolean;
 }
 

--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -874,7 +874,7 @@ export interface ICreateChannelPermissions {
  * @interface ICreateChannelPermissionsV2
  */
 export interface ICreateChannelPermissionsV2 {
-  channelAclDefinition?: IChannelAclPermissionDefinition[];
+  channelAclDefinition: IChannelAclPermissionDefinition[];
 }
 
 /**

--- a/packages/common/src/discussions/api/utils/request.ts
+++ b/packages/common/src/discussions/api/utils/request.ts
@@ -45,11 +45,13 @@ export function authenticateRequest(
  * @param {string} route
  * @param {IDiscussionsRequestOptions} options
  * @param {string} [token]
+ * @param {string} [version]
  * @return {*}  {Promise<T>}
  */
 export function apiRequest<T>(
   route: string,
   options: IDiscussionsRequestOptions,
+  version: "v1" | "v2",
   token?: string
 ): Promise<T> {
   let routeWithParams = route;
@@ -71,7 +73,7 @@ export function apiRequest<T>(
     // TODO: we _want_ to use getHubApiUrl(),
     // but have to deal w/ the fact that this package overwrites IHubRequestOptions
     host: options.hubApiUrl || "https://hub.arcgis.com",
-    path: "/api/discussions/v1",
+    path: `/api/discussions/${version}`,
   });
 
   if (options.data) {

--- a/packages/common/test/discussions/api/channels.test.ts
+++ b/packages/common/test/discussions/api/channels.test.ts
@@ -2,11 +2,15 @@ import {
   IDiscussionsRequestOptions,
   SharingAccess,
 } from "../../../src/discussions/api/types";
-import { searchChannels } from "../../../src/discussions/api/channels";
+import {
+  searchChannels,
+  searchChannelsV2,
+} from "../../../src/discussions/api/channels";
 import * as req from "../../../src/discussions/api/discussions-api-request";
 
 describe("channels", () => {
   let requestSpy: any;
+  let requestSpyV2: any;
   const response = new Response("ok", { status: 200 });
   const baseOpts: IDiscussionsRequestOptions = {
     hubApiUrl: "https://hub.arcgis.com/api",
@@ -17,9 +21,12 @@ describe("channels", () => {
     requestSpy = spyOn(req, "discussionsApiRequest").and.returnValue(
       Promise.resolve(response)
     );
+    requestSpyV2 = spyOn(req, "discussionsApiRequestV2").and.returnValue(
+      Promise.resolve(response)
+    );
   });
 
-  it("queries channels", (done) => {
+  it("searchChannels", (done) => {
     const query = {
       access: [SharingAccess.PUBLIC],
       groups: ["foo"],
@@ -30,6 +37,24 @@ describe("channels", () => {
       .then(() => {
         expect(requestSpy.calls.count()).toEqual(1);
         const [url, opts] = requestSpy.calls.argsFor(0);
+        expect(url).toEqual(`/channels`);
+        expect(opts).toEqual({ ...options, httpMethod: "GET" });
+        done();
+      })
+      .catch(() => fail());
+  });
+
+  it("searchChannelsV2", (done) => {
+    const query = {
+      access: [SharingAccess.PUBLIC],
+      groups: ["foo"],
+    };
+
+    const options = { ...baseOpts, data: query };
+    searchChannelsV2(options)
+      .then(() => {
+        expect(requestSpyV2.calls.count()).toEqual(1);
+        const [url, opts] = requestSpyV2.calls.argsFor(0);
         expect(url).toEqual(`/channels`);
         expect(opts).toEqual({ ...options, httpMethod: "GET" });
         done();

--- a/packages/common/test/discussions/api/discussions-api-request.test.ts
+++ b/packages/common/test/discussions/api/discussions-api-request.test.ts
@@ -230,8 +230,8 @@ describe("apiRequest", () => {
     expect(calledOpts).toEqual(expectedOpts);
   });
 
-  it(`cleans up baseUrl and endpoint`, async () => {
-    const options = { ...opts, hubApiUrlV2: `${hubApiUrlV2}/` };
+  it(`cleans up baseUrl and endpoint (for V2)`, async () => {
+    const options = { ...opts, hubApiUrl: `${hubApiUrlV2}/` };
     const result = await utils.apiRequest(
       `/${url}`,
       options as IDiscussionsRequestOptions,
@@ -245,7 +245,22 @@ describe("apiRequest", () => {
     expect(calledOpts).toEqual(expectedOpts);
   });
 
-  it(`uses default hubApiUrlV2 if none provided`, async () => {
+  it(`cleans up baseUrl and endpoint (for V1)`, async () => {
+    const options = { ...opts, hubApiUrl: `${hubApiUrlV1}/` };
+    const result = await utils.apiRequest(
+      `/${url}`,
+      options as IDiscussionsRequestOptions,
+      "v1"
+    );
+
+    expect(result).toEqual(response);
+
+    const [calledUrl, calledOpts] = fetchMock.calls()[0];
+    expect(calledUrl).toEqual([hubApiUrlV1, url].join("/"));
+    expect(calledOpts).toEqual(expectedOpts);
+  });
+
+  it(`uses default hubApiUrlV2 (for v2) if none provided`, async () => {
     const options = {};
     const result = await utils.apiRequest(
       url,
@@ -257,6 +272,21 @@ describe("apiRequest", () => {
 
     const [calledUrl, calledOpts] = fetchMock.calls()[0];
     expect(calledUrl).toEqual([hubApiUrlV2, url].join("/"));
+    expect(calledOpts).toEqual(expectedOpts);
+  });
+
+  it(`uses default hubApiUrl (for v1) if none provided`, async () => {
+    const options = {};
+    const result = await utils.apiRequest(
+      url,
+      options as IDiscussionsRequestOptions,
+      "v1"
+    );
+
+    expect(result).toEqual(response);
+
+    const [calledUrl, calledOpts] = fetchMock.calls()[0];
+    expect(calledUrl).toEqual([hubApiUrlV1, url].join("/"));
     expect(calledOpts).toEqual(expectedOpts);
   });
 

--- a/packages/common/test/discussions/api/settings.test.ts
+++ b/packages/common/test/discussions/api/settings.test.ts
@@ -2,10 +2,14 @@ import * as req from "../../../src/discussions/api/discussions-api-request";
 import { Geometry } from "geojson";
 import {
   createSetting,
+  createSettingV2,
   fetchSetting,
+  fetchSettingV2,
   getDefaultEntitySettings,
   removeSetting,
+  removeSettingV2,
   updateSetting,
+  updateSettingV2,
 } from "../../../src/discussions/api/settings";
 import {
   EntitySettingType,
@@ -20,6 +24,7 @@ import {
 
 describe("settings", () => {
   let requestSpy: any;
+  let requestSpyV2: any;
   const response = new Response("ok", { status: 200 });
   const baseOpts: IDiscussionsRequestOptions = {
     hubApiUrl: "https://hub.arcgis.com/api",
@@ -41,6 +46,9 @@ describe("settings", () => {
 
   beforeEach(() => {
     requestSpy = spyOn(req, "discussionsApiRequest").and.returnValue(
+      Promise.resolve(response)
+    );
+    requestSpyV2 = spyOn(req, "discussionsApiRequestV2").and.returnValue(
       Promise.resolve(response)
     );
   });
@@ -114,6 +122,75 @@ describe("settings", () => {
     expect(opts).toEqual({ ...options, httpMethod: "DELETE" });
   });
 
+  it("createSettingV2", async () => {
+    const body: ICreateSetting = {
+      id: "uuidv4",
+      type: EntitySettingType.CONTENT,
+      settings: {
+        discussions: {
+          allowedChannelIds: ["aaa"],
+          allowedLocations: [polygon],
+        },
+      },
+    };
+    const options: ICreateSettingParams = { ...baseOpts, data: body };
+
+    await createSettingV2(options);
+
+    expect(requestSpyV2.calls.count()).toEqual(1);
+    const [url, opts] = requestSpyV2.calls.argsFor(0);
+    expect(url).toEqual(`/settings`);
+    expect(opts).toEqual({ ...options, httpMethod: "POST" });
+  });
+
+  it("fetchSettingV2", async () => {
+    const id = "uuidv4";
+    const options: IFetchSettingParams = { ...baseOpts, id };
+
+    await fetchSettingV2(options);
+
+    expect(requestSpyV2.calls.count()).toEqual(1);
+    const [url, opts] = requestSpyV2.calls.argsFor(0);
+    expect(url).toEqual(`/settings/${id}`);
+    expect(opts).toEqual({ ...options, httpMethod: "GET" });
+  });
+
+  it("updateSettingV2", async () => {
+    const id = "uuidv4";
+    const body: IUpdateSetting = {
+      settings: {
+        discussions: {
+          allowedChannelIds: ["aaa"],
+          allowedLocations: [polygon],
+        },
+      },
+    };
+    const options: IUpdateSettingParams = {
+      ...baseOpts,
+      id,
+      data: body,
+    };
+
+    await updateSettingV2(options);
+
+    expect(requestSpyV2.calls.count()).toEqual(1);
+    const [url, opts] = requestSpyV2.calls.argsFor(0);
+    expect(url).toEqual(`/settings/${id}`);
+    expect(opts).toEqual({ ...options, httpMethod: "PATCH" });
+  });
+
+  it("removeSettingV2", async () => {
+    const id = "uuidv4";
+    const options: IRemoveSettingParams = { ...baseOpts, id };
+
+    await removeSettingV2(options);
+
+    expect(requestSpyV2.calls.count()).toEqual(1);
+    const [url, opts] = requestSpyV2.calls.argsFor(0);
+    expect(url).toEqual(`/settings/${id}`);
+    expect(opts).toEqual({ ...options, httpMethod: "DELETE" });
+  });
+
   describe("getDefaultEntitySettings", () => {
     it("returns default entity settings", () => {
       const result = getDefaultEntitySettings("discussion");
@@ -131,7 +208,7 @@ describe("settings", () => {
     it("throws error if entity type not valid", () => {
       try {
         getDefaultEntitySettings("org");
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).toBe("no default entity settings defined for org");
       }
     });

--- a/packages/common/test/discussions/api/settings.test.ts
+++ b/packages/common/test/discussions/api/settings.test.ts
@@ -208,7 +208,7 @@ describe("settings", () => {
     it("throws error if entity type not valid", () => {
       try {
         getDefaultEntitySettings("org");
-      } catch (e: any) {
+      } catch (e) {
         expect(e.message).toBe("no default entity settings defined for org");
       }
     });


### PR DESCRIPTION
affects: @esri/hub-common

Issue [12460](https://devtopia.esri.com/dc/hub/issues/12460)

`hub-common` (all non-breaking changes):
Added types:
  - `ICreateChannelParamsV2`
  - `ICreateChannelPermissionsV2`
  - `ICreateChannelSettingsV2`
  - `ICreateChannelV2`
  - `IUpdateChannelParamsV2`
  - `IUpdateChannelPermissionsV2`
  - `IUpdateChannelSettingsV2`
  - `IUpdateChannelV2`
  - `ICreatePostParamsV2`

Added route functions:
  - `discussionsApiRequestV2` // called only within V2 route functions
  - `searchChannelsV2`
  - `createSettingV2`
  - `fetchSettingV2`
  - `updateSettingV2`
  - `removeSettingV2`
Modified functions:
  - `apiRequest` // called from discussionsApiRequestV2, discussionsApiRequest. Version passed as an argument

---

1. Description: Completely separate discussions V1 and V2 interfaces and route functions/permissions utils in a non-breaking manner so `hub-common` can be published.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
