### PR TITLE
feat: add logic/permissions to enable site catalog config in new UI

### DIFF
--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -17,7 +17,12 @@ export const FilterSchema: IConfigurationSchema = {
     },
     predicates: {
       type: "array",
-      minItems: 1,
+      // TODO: uncomment this once site catalogs have been migrated
+      // to the new catalog structure. This is too difficult to work
+      // around for now, and isn't currently doing much in the UI.
+      // Eventually, we'll want to use this to render an error message
+      // if a predicate hasn't been fully configured
+      // minItems: 1,
       items: PredicateSchema,
     },
   },

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -173,10 +173,11 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     environments: ["qaext"],
     availability: ["alpha"],
   },
+  // gates advanced editing (e.g. adding new collections, adding
+  // additional scope filters, etc.) for site entities
   // TODO: Remove this permission once all catalog configuration features are supported by sites
   {
     permission: "hub:feature:catalogs:edit:advanced",
-    dependencies: ["hub:feature:catalogs"],
     entityEdit: true,
     assertions: [
       {

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -167,8 +167,10 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:project:workspace:metrics",
     dependencies: ["hub:project:workspace", "hub:project:edit"],
   },
+  // DEPRECATED - use hub:project:workspace:catalog instead
+  // TODO: remove in next breaking change
   {
-    permission: "hub:project:workspace:catalogs", // TODO: remove plural permission
+    permission: "hub:project:workspace:catalogs",
     dependencies: [
       "hub:project:workspace",
       "hub:feature:catalogs",

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -36,6 +36,9 @@ export const SitePermissions = [
   "hub:site:workspace:settings",
   "hub:site:workspace:collaborators",
   "hub:site:workspace:content",
+  "hub:site:workspace:catalog",
+  "hub:site:workspace:catalog:content",
+  "hub:site:workspace:catalog:events",
   "hub:site:workspace:metrics",
   "hub:site:workspace:followers",
   "hub:site:workspace:followers:member",
@@ -152,9 +155,27 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:site:workspace:collaborators",
     dependencies: ["hub:site:workspace", "hub:site:edit"],
   },
+  // DEPRECATED - use hub:site:workspace:catalog instead
+  // TODO: remove in next breaking change
   {
     permission: "hub:site:workspace:content",
     dependencies: ["hub:site:workspace", "hub:site:edit"],
+  },
+  {
+    permission: "hub:site:workspace:catalog",
+    dependencies: [
+      "hub:site:workspace",
+      "hub:feature:catalogs",
+      "hub:site:edit",
+    ],
+  },
+  {
+    permission: "hub:site:workspace:catalog:content",
+    dependencies: ["hub:site:workspace:catalog"],
+  },
+  {
+    permission: "hub:site:workspace:catalog:events",
+    dependencies: ["hub:site:workspace:catalog"],
   },
   {
     permission: "hub:site:workspace:pages",

--- a/packages/common/src/sites/_internal/applyDefaultCollectionMigration.ts
+++ b/packages/common/src/sites/_internal/applyDefaultCollectionMigration.ts
@@ -4,6 +4,17 @@ import { WellKnownCollection } from "../../search/wellKnownCatalog";
 import { IModel } from "../../types";
 import { SearchCategories } from "./types";
 
+export const defaultSiteCollectionKeys: WellKnownCollection[] = [
+  // TODO: add 'all' as a wellknown collection and figure out the
+  // ramifications of doing so across the app. (or create a new
+  // type that includes 'all')
+  "all" as any,
+  "dataset",
+  "document",
+  "site",
+  "appAndMap",
+];
+
 /**
  * In-Memory migration that adds default collections to site models that have the
  * new catalog structure. These default collections will have the same names and
@@ -24,17 +35,7 @@ import { SearchCategories } from "./types";
  * to the catalog
  */
 export function applyDefaultCollectionMigration(model: IModel): IModel {
-  const baseCollectionKeys: WellKnownCollection[] = [
-    // TODO: add 'all' as a wellknown collection and figure out the
-    // ramifications of doing so across the app. (or create a new
-    // type that includes 'all')
-    "all" as any,
-    "dataset",
-    "document",
-    "site",
-    "appAndMap",
-  ];
-  const baseCollectionMap = baseCollectionKeys.reduce((map, key) => {
+  const baseCollectionMap = defaultSiteCollectionKeys.reduce((map, key) => {
     map[key] = {
       // We chose to leave the label as "null" for a couple of reasons. First off,
       // the default collection names are supposed to be translated and we don't

--- a/packages/common/src/sites/_internal/applyDefaultCollectionMigration.ts
+++ b/packages/common/src/sites/_internal/applyDefaultCollectionMigration.ts
@@ -3,17 +3,7 @@ import { IHubCollectionPersistance } from "../../search/types/IHubCatalog";
 import { WellKnownCollection } from "../../search/wellKnownCatalog";
 import { IModel } from "../../types";
 import { SearchCategories } from "./types";
-
-export const defaultSiteCollectionKeys: WellKnownCollection[] = [
-  // TODO: add 'all' as a wellknown collection and figure out the
-  // ramifications of doing so across the app. (or create a new
-  // type that includes 'all')
-  "all" as any,
-  "dataset",
-  "document",
-  "site",
-  "appAndMap",
-];
+import { defaultSiteCollectionKeys } from "../defaultSiteCollectionKeys";
 
 /**
  * In-Memory migration that adds default collections to site models that have the

--- a/packages/common/src/sites/defaultSiteCollectionKeys.ts
+++ b/packages/common/src/sites/defaultSiteCollectionKeys.ts
@@ -1,0 +1,12 @@
+import { WellKnownCollection } from "../search/wellKnownCatalog";
+
+export const defaultSiteCollectionKeys: WellKnownCollection[] = [
+  // TODO: add 'all' as a wellknown collection and figure out the
+  // ramifications of doing so across the app. (or create a new
+  // type that includes 'all')
+  "all" as any,
+  "dataset",
+  "document",
+  "site",
+  "appAndMap",
+];

--- a/packages/common/src/sites/index.ts
+++ b/packages/common/src/sites/index.ts
@@ -27,3 +27,6 @@ export * from "./feeds/types";
 // by the domain service due to requirement to send signed HMAC request
 // export * from "./registerSiteAsApplication";
 export * from "./get-catalog-from-site-model";
+// Exporting these keys to access in the catalog builder so
+// we can apply translated labels to default site collections
+export { defaultSiteCollectionKeys } from "./_internal/applyDefaultCollectionMigration";

--- a/packages/common/src/sites/index.ts
+++ b/packages/common/src/sites/index.ts
@@ -29,4 +29,4 @@ export * from "./feeds/types";
 export * from "./get-catalog-from-site-model";
 // Exporting these keys to access in the catalog builder so
 // we can apply translated labels to default site collections
-export { defaultSiteCollectionKeys } from "./_internal/applyDefaultCollectionMigration";
+export { defaultSiteCollectionKeys } from "./defaultSiteCollectionKeys";


### PR DESCRIPTION
[12246](https://devtopia.esri.com/dc/hub/issues/12246)

### Description 
- add/update permissions for site catalogs
- export default site collection keys to be used by catalog builder
- temporarily remove `minItems` requirement in filters schema

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages 
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.