### PR TITLE
fix: revert "refactor: minimize use of rest-types package"

### DIFF
--- a/packages/common/e2e/helpers/metric-fixtures-crud.ts
+++ b/packages/common/e2e/helpers/metric-fixtures-crud.ts
@@ -1,5 +1,5 @@
 import { createGroup, removeGroup } from "@esri/arcgis-rest-portal";
-import { IGroup, IGroupAdd } from "@esri/arcgis-rest-portal";
+import { IGroup, IGroupAdd } from "@esri/arcgis-rest-types";
 import {
   IArcGISContext,
   HubInitiative,

--- a/packages/common/src/access/can-edit-event.ts
+++ b/packages/common/src/access/can-edit-event.ts
@@ -1,4 +1,4 @@
-import { IItem, IUser } from "@esri/arcgis-rest-portal";
+import { IItem, IUser } from "@esri/arcgis-rest-types";
 import { IInitiativeModel } from "../types";
 import { getProp } from "../objects";
 import { findBy } from "../util";

--- a/packages/common/src/access/can-edit-item.ts
+++ b/packages/common/src/access/can-edit-item.ts
@@ -1,4 +1,4 @@
-import { IItem, IUser, IGroup } from "@esri/arcgis-rest-portal";
+import { IItem, IUser, IGroup } from "@esri/arcgis-rest-types";
 import { isUpdateGroup, includes } from "../utils";
 import { getProp } from "../objects";
 import { hasBasePriv } from "./has-base-priv";
@@ -25,7 +25,7 @@ export function canEditItem(item: IItem, user: IUser): boolean {
   } else if (hasPriv) {
     const itemGroups = [
       ...(getProp(item, "groupIds") || []),
-      getProp(item, "properties.collaborationGroupId"),
+      getProp(item, "properties.collaborationGroupId")
     ];
     const isGroupEditable = (group: IGroup): boolean =>
       isUpdateGroup(group) && includes(itemGroups, group.id);

--- a/packages/common/src/access/can-edit-site-content.ts
+++ b/packages/common/src/access/can-edit-site-content.ts
@@ -1,4 +1,4 @@
-import { IItem, IUser } from "@esri/arcgis-rest-portal";
+import { IItem, IUser } from "@esri/arcgis-rest-types";
 import { includes } from "../utils";
 import { getProp } from "../objects";
 import { hasBasePriv } from "./has-base-priv";
@@ -9,7 +9,7 @@ export const REQUIRED_PRIVS = [
   "portal:user:createItem",
   "portal:user:shareToGroup",
   "portal:user:viewOrgGroups",
-  "portal:user:viewOrgItems",
+  "portal:user:viewOrgItems"
 ];
 
 /**
@@ -32,9 +32,7 @@ export function canEditSiteContent(item: IItem, user: IUser): boolean {
     const sameOrg = !!userOrgId && userOrgId === itemOrgId;
     if (sameOrg) {
       const privileges = user.privileges || [];
-      res = REQUIRED_PRIVS.every((privilege) =>
-        includes(privileges, privilege)
-      );
+      res = REQUIRED_PRIVS.every(privilege => includes(privileges, privilege));
     }
   }
   return res;

--- a/packages/common/src/access/can-edit-site.ts
+++ b/packages/common/src/access/can-edit-site.ts
@@ -1,4 +1,4 @@
-import { IItem, IUser } from "@esri/arcgis-rest-portal";
+import { IItem, IUser } from "@esri/arcgis-rest-types";
 import { getProp } from "../objects";
 import { hasBasePriv } from "./has-base-priv";
 import { canEditItem } from "./can-edit-item";

--- a/packages/common/src/access/has-base-priv.ts
+++ b/packages/common/src/access/has-base-priv.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { includes } from "../utils";
 
 /**

--- a/packages/common/src/associations/internal/getIdsFromAssociationGroups.ts
+++ b/packages/common/src/associations/internal/getIdsFromAssociationGroups.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import { HubEntityType } from "../../core";
 
 /**

--- a/packages/common/src/categories.ts
+++ b/packages/common/src/categories.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { collections } from "./collections";
 
 const {

--- a/packages/common/src/content/_internal/internalContentUtils.ts
+++ b/packages/common/src/content/_internal/internalContentUtils.ts
@@ -10,11 +10,11 @@
  */
 import { parseServiceUrl } from "@esri/arcgis-rest-feature-layer";
 import { IItem, IPortal } from "@esri/arcgis-rest-portal";
-import { IUser } from "@esri/arcgis-rest-portal";
 import {
   IExtent,
   ILayerDefinition,
   ISpatialReference,
+  IUser,
 } from "@esri/arcgis-rest-types";
 import {
   IGeometryInstance,

--- a/packages/common/src/content/search.ts
+++ b/packages/common/src/content/search.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { fetchItemEnrichments } from "../items/_enrichments";
 import { getProp } from "../objects";
 import { getItemThumbnailUrl } from "../resources";

--- a/packages/common/src/core/_internal/computeItemLinks.ts
+++ b/packages/common/src/core/_internal/computeItemLinks.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemHomeUrl } from "../../urls";

--- a/packages/common/src/core/_internal/computeItemProps.ts
+++ b/packages/common/src/core/_internal/computeItemProps.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IHubItemEntity } from "../types";
 import { deriveLocationFromItem } from "../../content/_internal/internalContentUtils";
 import { isDiscussable } from "../../discussions";

--- a/packages/common/src/core/behaviors/IWithFollowersBehavior.ts
+++ b/packages/common/src/core/behaviors/IWithFollowersBehavior.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import { SettableAccessLevel } from "../types";
 
 /**

--- a/packages/common/src/core/enrichEntity.ts
+++ b/packages/common/src/core/enrichEntity.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import { HubEntity } from "./types";
 import { IHubRequestOptions } from "../types";
 import { mapBy } from "../utils";

--- a/packages/common/src/core/schemas/internal/follow/FollowCardUiSchema.ts
+++ b/packages/common/src/core/schemas/internal/follow/FollowCardUiSchema.ts
@@ -6,7 +6,7 @@ import {
   WellKnownCollection,
   getWellKnownCatalog,
 } from "../../../../search/wellKnownCatalog";
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { IHubCatalog } from "../../../../search/types/IHubCatalog";
 
 // Get the catalogs for the entity gallery picker

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -2,7 +2,7 @@ import { extentToBBox, orgExtent as orgExtent } from "../../../extent";
 import { IHubRequestOptions } from "../../../types";
 import { getTypeFromEntity } from "../../getTypeFromEntity";
 import { IHubLocation, IHubLocationOption } from "../../types/IHubLocation";
-import { IExtent } from "@esri/arcgis-rest-feature-layer";
+import { IExtent } from "@esri/arcgis-rest-types";
 
 /**
  * Construct the dynamic location picker options with the entity's

--- a/packages/common/src/core/types/IHubEditableContent.ts
+++ b/packages/common/src/core/types/IHubEditableContent.ts
@@ -1,4 +1,4 @@
-import { IFeatureServiceDefinition } from "@esri/arcgis-rest-feature-layer";
+import { IFeatureServiceDefinition } from "@esri/arcgis-rest-types";
 import { IWithPermissions, IWithSlug } from "../traits/index";
 import { IHubAdditionalResource } from "./IHubAdditionalResource";
 import { IHubItemEntity, IHubItemEntityEditor } from "./IHubItemEntity";

--- a/packages/common/src/core/types/IHubLocation.ts
+++ b/packages/common/src/core/types/IHubLocation.ts
@@ -1,7 +1,7 @@
 import { ISpatialReference } from "@esri/arcgis-rest-types";
 import { IHubLocationType } from "./types";
 import { HubEntityType } from "./HubEntityType";
-import { IGeometryInstance } from "./IGeometryInstance";
+import { IGeometryInstance } from "../..";
 
 /**
  * A location associated with an item and stored as a json resource.

--- a/packages/common/src/core/types/Metrics.ts
+++ b/packages/common/src/core/types/Metrics.ts
@@ -1,6 +1,5 @@
 import { IQuery } from "../../search/types/IHubCatalog";
-import { IField } from "@esri/arcgis-rest-feature-layer";
-import { FieldType } from "@esri/arcgis-rest-types";
+import { FieldType, IField } from "@esri/arcgis-rest-types";
 import { IReference } from "./IReference";
 import { IGeometryInstance, ServiceAggregation } from "../../core/types";
 

--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -2,7 +2,7 @@ import {
   IPagingParams,
   IPagedResponse as IRestPagedResponse,
   IUser,
-} from "@esri/arcgis-rest-portal";
+} from "@esri/arcgis-rest-types";
 import { Geometry, Polygon } from "geojson";
 import { IHubRequestOptions } from "../../types";
 

--- a/packages/common/src/discussions/utils.ts
+++ b/packages/common/src/discussions/utils.ts
@@ -1,4 +1,4 @@
-import { IGroup, IItem } from "@esri/arcgis-rest-portal";
+import { IGroup, IItem } from "@esri/arcgis-rest-types";
 import { IHubContent, IHubItemEntity } from "../core";
 import { CANNOT_DISCUSS } from "./constants";
 import {

--- a/packages/common/src/downloads/_internal/file-url-fetchers/fetchExportImageDownloadFile.ts
+++ b/packages/common/src/downloads/_internal/file-url-fetchers/fetchExportImageDownloadFile.ts
@@ -1,4 +1,4 @@
-import { IExtent } from "@esri/arcgis-rest-feature-layer";
+import { IExtent } from "@esri/arcgis-rest-types";
 import { request } from "@esri/arcgis-rest-request";
 import {
   DownloadOperationStatus,

--- a/packages/common/src/downloads/build-existing-exports-portal-query.ts
+++ b/packages/common/src/downloads/build-existing-exports-portal-query.ts
@@ -1,5 +1,5 @@
 import { SearchQueryBuilder } from "@esri/arcgis-rest-portal";
-import { ISpatialReference } from "@esri/arcgis-rest-feature-layer";
+import { ISpatialReference } from "@esri/arcgis-rest-types";
 import { btoa } from "abab";
 import { flattenArray } from "../util";
 import { PORTAL_EXPORT_TYPES } from "./types";

--- a/packages/common/src/events/HubEvent.ts
+++ b/packages/common/src/events/HubEvent.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import { HubItemEntity } from "../core/HubItemEntity";
 import { IHubEventEditor, IHubEvent } from "../core/types/IHubEvent";
 import { IWithEditorBehavior } from "../core/behaviors";

--- a/packages/common/src/extent.ts
+++ b/packages/common/src/extent.ts
@@ -1,9 +1,8 @@
-import { IExtent } from "@esri/arcgis-rest-feature-layer";
+import { IExtent, IPoint, IPolygon, Position } from "@esri/arcgis-rest-types";
 import { IHubRequestOptions, BBox } from "./types";
 import { getProp } from "./objects";
 import { IRequestOptions, request } from "@esri/arcgis-rest-request";
 import { Polygon } from "geojson";
-import { IPoint, IPolygon, Position } from "@esri/arcgis-rest-types";
 
 /**
  * Turns an bounding box coordinate array into an extent object

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import { fetchGroupEnrichments } from "./_internal/enrichments";
 import { getProp, setProp } from "../objects";
 import { parseInclude } from "../search/_internal/parseInclude";

--- a/packages/common/src/groups/_internal/computeLinks.ts
+++ b/packages/common/src/groups/_internal/computeLinks.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { IHubEntityLinks } from "../../core/types";

--- a/packages/common/src/groups/_internal/computeProps.ts
+++ b/packages/common/src/groups/_internal/computeProps.ts
@@ -2,7 +2,7 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { UserSession } from "@esri/arcgis-rest-auth";
 
 import { IHubGroup } from "../../core/types/IHubGroup";
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import { isDiscussable } from "../../discussions";
 import { getGroupThumbnailUrl } from "../../search/utils";
 import { computeLinks } from "./computeLinks";

--- a/packages/common/src/groups/_internal/convertGroupToHubGroup.ts
+++ b/packages/common/src/groups/_internal/convertGroupToHubGroup.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import { PropertyMapper } from "../../core/_internal/PropertyMapper";
 import { IHubGroup } from "../../core/types/IHubGroup";
 import { computeProps } from "./computeProps";

--- a/packages/common/src/groups/_internal/convertHubGroupToGroup.ts
+++ b/packages/common/src/groups/_internal/convertHubGroupToGroup.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import { PropertyMapper } from "../../core/_internal/PropertyMapper";
 import { IHubGroup } from "../../core/types/IHubGroup";
 import { getPropertyMap } from "./getPropertyMap";

--- a/packages/common/src/groups/addGroupMembers.ts
+++ b/packages/common/src/groups/addGroupMembers.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { failSafe } from "../utils";
 import { autoAddUsers } from "./autoAddUsers";
 import { inviteUsers } from "./inviteUsers";

--- a/packages/common/src/groups/defaults.ts
+++ b/packages/common/src/groups/defaults.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import { IHubGroup } from "../core/types/IHubGroup";
 
 export const HUB_GROUP_TYPE = "Hub Group";

--- a/packages/common/src/groups/isOpenDataGroup.ts
+++ b/packages/common/src/groups/isOpenDataGroup.ts
@@ -1,3 +1,3 @@
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 
 export const isOpenDataGroup = (group: IGroup) => !!group.isOpenData;

--- a/packages/common/src/initiative-templates/_internal/computeLinks.ts
+++ b/packages/common/src/initiative-templates/_internal/computeLinks.ts
@@ -1,5 +1,5 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IHubEntityLinks } from "../../core";
 import { computeItemLinks } from "../../core/_internal/computeItemLinks";
 

--- a/packages/common/src/initiative-templates/_internal/getRecommendedTemplatesCatalog.ts
+++ b/packages/common/src/initiative-templates/_internal/getRecommendedTemplatesCatalog.ts
@@ -3,7 +3,7 @@ import {
   getWellKnownCatalog,
   WellKnownCatalog,
 } from "../../search/wellKnownCatalog";
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 
 export const getRecommendedTemplatesCatalog = (
   user: IUser,

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -36,7 +36,7 @@ import {
 } from "../core";
 import { IEditorConfig } from "../core/schemas/types";
 import { enrichEntity } from "../core/enrichEntity";
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import { getProp, getWithDefault } from "../objects";
 import { upsertResource } from "../resources/upsertResource";
 import { doesResourceExist } from "../resources/doesResourceExist";

--- a/packages/common/src/initiatives/_internal/computeLinks.ts
+++ b/packages/common/src/initiatives/_internal/computeLinks.ts
@@ -1,6 +1,6 @@
 import { computeItemLinks } from "../../core/_internal/computeItemLinks";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IHubEntityLinks } from "../../core";
 
 /**

--- a/packages/common/src/items/apply-properties-to-items.ts
+++ b/packages/common/src/items/apply-properties-to-items.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 
 /**
  * Apply a hash of properties to an array of items.

--- a/packages/common/src/items/create-item-from-file.ts
+++ b/packages/common/src/items/create-item-from-file.ts
@@ -6,7 +6,7 @@ import {
   createItem,
   ICreateItemResponse,
 } from "@esri/arcgis-rest-portal";
-import { IItemAdd } from "@esri/arcgis-rest-portal";
+import { IItemAdd } from "@esri/arcgis-rest-types";
 import { isBBox, bboxToString } from "../extent";
 import { batch } from "../utils";
 import { _prepareUploadRequests } from "./_internal/_prepare-upload-requests";

--- a/packages/common/src/items/create-item-from-url-or-file.ts
+++ b/packages/common/src/items/create-item-from-url-or-file.ts
@@ -5,7 +5,7 @@ import {
   setItemAccess,
   shareItemWithGroup,
 } from "@esri/arcgis-rest-portal";
-import { IGroup, IItemAdd } from "@esri/arcgis-rest-portal";
+import { IGroup, IItemAdd } from "@esri/arcgis-rest-types";
 import { failSafe, isUpdateGroup } from "../utils";
 import { createItemFromFile } from "./create-item-from-file";
 import { createItemFromUrl } from "./create-item-from-url";

--- a/packages/common/src/items/create-item-from-url.ts
+++ b/packages/common/src/items/create-item-from-url.ts
@@ -1,6 +1,6 @@
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { createItem, ICreateItemResponse } from "@esri/arcgis-rest-portal";
-import { IItemAdd } from "@esri/arcgis-rest-portal";
+import { IItemAdd } from "@esri/arcgis-rest-types";
 
 /**
  * Create AGO item from a URL

--- a/packages/common/src/items/is-services-directory-disabled.ts
+++ b/packages/common/src/items/is-services-directory-disabled.ts
@@ -1,7 +1,7 @@
 import { parseServiceUrl } from "@esri/arcgis-rest-feature-layer";
 import { getItem } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 
 /**
  * Checks if a server's services directory is disabled. Consider hoisting this to RESTJS

--- a/packages/common/src/items/normalize-solution-template-item.ts
+++ b/packages/common/src/items/normalize-solution-template-item.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IItemTemplate } from "../types";
 import { cloneObject } from "../util";
 
@@ -28,7 +28,7 @@ export const itemPropsNotInTemplates = [
   "appCategories",
   "industries",
   "languages",
-  "largeThumbnail",
+  "largeThumbnail"
 ];
 
 /**
@@ -39,7 +39,7 @@ export const itemPropsNotInTemplates = [
 export function normalizeSolutionTemplateItem(item: IItem): IItemTemplate {
   const template = cloneObject(item) as IItemTemplate;
 
-  itemPropsNotInTemplates.forEach((prop) => {
+  itemPropsNotInTemplates.forEach(prop => {
     delete template[prop];
   });
 

--- a/packages/common/src/items/slugs.ts
+++ b/packages/common/src/items/slugs.ts
@@ -1,6 +1,6 @@
 import { getItem, ISearchOptions, searchItems } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { slugify } from "../utils";
 import { TYPEKEYWORD_SLUG_PREFIX, truncateSlug } from "./_internal/slugs";
 import { uriSlugToKeywordSlug } from "./_internal/slugConverters";

--- a/packages/common/src/metrics/resolveMetric.ts
+++ b/packages/common/src/metrics/resolveMetric.ts
@@ -9,13 +9,12 @@ import {
   MetricSource,
 } from "../core/types/Metrics";
 import { queryFeatures } from "@esri/arcgis-rest-feature-layer";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem, IStatisticDefinition } from "@esri/arcgis-rest-types";
 import { getProp } from "../objects/get-prop";
 import { IPredicate, IQuery } from "../search/types/IHubCatalog";
 import { combineQueries } from "../search/_internal/combineQueries";
 import { IHubSearchOptions } from "../search/types/IHubSearchOptions";
 import { portalSearchItemsAsItems } from "../search/_internal/portalSearchItems";
-import { IStatisticDefinition } from "@esri/arcgis-rest-types";
 
 /**
  * Resolve a Metric into an array of `IMetricFeature` objects.

--- a/packages/common/src/models/serializeModel.ts
+++ b/packages/common/src/models/serializeModel.ts
@@ -1,6 +1,6 @@
 import { IModel } from "../types";
 import { cloneObject } from "../util";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 
 interface ISerializedModel extends IItem {
   text: string;

--- a/packages/common/src/pages/_internal/computeLinks.ts
+++ b/packages/common/src/pages/_internal/computeLinks.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IHubEntityLinks } from "../../core/types";
 import { computeItemLinks } from "../../core/_internal/computeItemLinks";

--- a/packages/common/src/projects/HubProject.ts
+++ b/packages/common/src/projects/HubProject.ts
@@ -35,7 +35,7 @@ import { createProject, editorToProject, updateProject } from "./edit";
 import { ProjectEditorType } from "./_internal/ProjectSchema";
 import { enrichEntity } from "../core/enrichEntity";
 import { getProp, getWithDefault } from "../objects";
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import { metricToEditor } from "../metrics/metricToEditor";
 import { IMetricDisplayConfig } from "../core/types/Metrics";
 import { upsertResource } from "../resources/upsertResource";

--- a/packages/common/src/projects/_internal/computeLinks.ts
+++ b/packages/common/src/projects/_internal/computeLinks.ts
@@ -1,6 +1,6 @@
 import { computeItemLinks } from "../../core/_internal/computeItemLinks";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IHubEntityLinks } from "../../core";
 
 /**

--- a/packages/common/src/resources/_internal/_validate-url-helpers.ts
+++ b/packages/common/src/resources/_internal/_validate-url-helpers.ts
@@ -2,7 +2,7 @@ import {
   IExtent,
   IFeatureServiceDefinition,
   ILayerDefinition,
-} from "@esri/arcgis-rest-feature-layer";
+} from "@esri/arcgis-rest-types";
 import { ItemType } from "../../types";
 import { Logger } from "../../utils";
 

--- a/packages/common/src/resources/get-item-assets.ts
+++ b/packages/common/src/resources/get-item-assets.ts
@@ -1,5 +1,5 @@
 import { IHubRequestOptions, ITemplateAsset } from "../types";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { getPortalApiUrl } from "../urls";
 import { getItemThumbnailUrl } from "./get-item-thumbnail-url";
 import { getItemResources } from "@esri/arcgis-rest-portal";
@@ -23,17 +23,17 @@ export function getItemAssets(
     assets.push({
       name: item.thumbnail,
       url: thumbnailUrl,
-      type: "thumbnail",
+      type: "thumbnail"
     });
   }
   // get all the other resources
   // TODO: see how this works w/ folders
-  return getItemResources(item.id, hubRequestOptions).then((response) => {
+  return getItemResources(item.id, hubRequestOptions).then(response => {
     const resourceAssets = response.resources.map((e: any) => {
       return {
         name: e.resource,
         type: "resource",
-        url: `${itemUrl}/resources/${e.resource}`,
+        url: `${itemUrl}/resources/${e.resource}`
       };
     });
     return assets.concat(resourceAssets);

--- a/packages/common/src/resources/get-item-thumbnail-url.ts
+++ b/packages/common/src/resources/get-item-thumbnail-url.ts
@@ -1,5 +1,5 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IPortal } from "@esri/arcgis-rest-portal";
 import { IHubRequestOptions } from "../types";
 import { getItemApiUrl } from "../urls/get-item-api-url";

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/ogcItemToSearchResult.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IHubRequestOptions } from "../../../types";
 import { IHubSearchResult } from "../../types/IHubSearchResult";
 import { itemToSearchResult } from "../portalSearchItems";

--- a/packages/common/src/search/_internal/portalSearchGroups.ts
+++ b/packages/common/src/search/_internal/portalSearchGroups.ts
@@ -1,5 +1,5 @@
 import { ISearchOptions, searchGroups } from "@esri/arcgis-rest-portal";
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 
 import { enrichGroupSearchResult } from "../../groups/HubGroups";
 import HubError from "../../HubError";

--- a/packages/common/src/search/_internal/portalSearchUsers.ts
+++ b/packages/common/src/search/_internal/portalSearchUsers.ts
@@ -5,7 +5,7 @@ import {
   searchUsers,
   searchCommunityUsers as _searchCommunityUsers,
 } from "@esri/arcgis-rest-portal";
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { enrichUserSearchResult } from "../../users";
 import { serializeQueryForPortal } from "../serializeQueryForPortal";
 import HubError from "../../HubError";

--- a/packages/common/src/search/getUserGroupsByMembership.ts
+++ b/packages/common/src/search/getUserGroupsByMembership.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { IGroupsByMembership } from "./types/IGroupsByMembership";
 
 /**

--- a/packages/common/src/search/getUserGroupsFromQuery.ts
+++ b/packages/common/src/search/getUserGroupsFromQuery.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { getPredicateValues } from "./getPredicateValues";
 import { IGroupsByMembership } from "./types/IGroupsByMembership";
 import { IQuery } from "./types/IHubCatalog";

--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { getFamilyTypes } from "../content/get-family";
 import { HubFamily } from "../types";
 import { EntityType, IFilter, IHubCatalog, IHubCollection } from "./types";

--- a/packages/common/src/sites/_internal/computeLinks.ts
+++ b/packages/common/src/sites/_internal/computeLinks.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IHubEntityLinks } from "../../core/types";
 import { getHubRelativeUrl } from "../../content/_internal/internalContentUtils";

--- a/packages/common/src/surveys/fetch.ts
+++ b/packages/common/src/surveys/fetch.ts
@@ -1,5 +1,5 @@
 import { getItem } from "@esri/arcgis-rest-portal";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IHubSurvey } from "../core/types/IHubSurvey";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
 import { computeProps } from "./_internal/computeProps";

--- a/packages/common/src/surveys/utils/is-draft.ts
+++ b/packages/common/src/surveys/utils/is-draft.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 
 /**
  * Determines if a given Form item is a draft

--- a/packages/common/src/surveys/utils/is-fieldworker-view.ts
+++ b/packages/common/src/surveys/utils/is-fieldworker-view.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 
 /**
  * Determines if the provided Feature Service item is a

--- a/packages/common/src/surveys/utils/is-survey123-connect.ts
+++ b/packages/common/src/surveys/utils/is-survey123-connect.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 
 /**
  * Returns true if the given Form item is a Survey123 Connect

--- a/packages/common/src/surveys/utils/should-display-map.ts
+++ b/packages/common/src/surveys/utils/should-display-map.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { MAP_SURVEY_TYPEKEYWORD } from "../constants";
 
 /**

--- a/packages/common/src/templates/_internal/computeLinks.ts
+++ b/packages/common/src/templates/_internal/computeLinks.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IHubEntityLinks } from "../../core/types";
 import { computeItemLinks } from "../../core/_internal/computeItemLinks";

--- a/packages/common/src/templates/utils.ts
+++ b/packages/common/src/templates/utils.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { dasherize } from "../utils";
 import { capitalize } from "../util";
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,12 +1,17 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IItem, IUser, IGroup } from "@esri/arcgis-rest-portal";
+import {
+  IItem,
+  IUser,
+  IGroup,
+  IPolygon,
+  ISpatialReference,
+  IGeometry,
+} from "@esri/arcgis-rest-types";
 import { IPortal, ISearchResult } from "@esri/arcgis-rest-portal";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IGeometry } from "@esri/arcgis-rest-feature-layer";
-import { IPolygon, ISpatialReference } from "@esri/arcgis-rest-types";
 
 /**
  * Generic Model, used with all items that have a json

--- a/packages/common/src/users/HubUsers.ts
+++ b/packages/common/src/users/HubUsers.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { getUser } from "@esri/arcgis-rest-portal";
 import { fetchUserEnrichments } from "./_internal/enrichments";
 import { SettableAccessLevel } from "../core/types";

--- a/packages/common/src/users/_internal/computeProps.ts
+++ b/packages/common/src/users/_internal/computeProps.ts
@@ -1,5 +1,5 @@
 import { getPortalUrl, getSelf } from "@esri/arcgis-rest-portal";
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { IRequestOptions, request } from "@esri/arcgis-rest-request";
 import { IArcGISContext } from "../../ArcGISContext";
 import { IHubUser } from "../../core/types";

--- a/packages/common/src/utils/is-update-group.ts
+++ b/packages/common/src/utils/is-update-group.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 
 /**
  * Determines if a given IGroup is an update group

--- a/packages/common/test/content/fixtures.ts
+++ b/packages/common/test/content/fixtures.ts
@@ -1,5 +1,5 @@
 import { IItem } from "@esri/arcgis-rest-portal";
-import { IFeatureServiceDefinition } from "@esri/arcgis-rest-feature-layer";
+import { IFeatureServiceDefinition } from "@esri/arcgis-rest-types";
 
 export const HOSTED_FEATURE_SERVICE_GUID = "A1295DEF67814571B99EDDEA65748143";
 export const HOSTED_FEATURE_SERVICE_URL =

--- a/packages/common/test/core/_internal/computeBaseProps.tests.ts
+++ b/packages/common/test/core/_internal/computeBaseProps.tests.ts
@@ -1,5 +1,5 @@
 import { computeItemProps } from "../../../src/core/_internal/computeItemProps";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IHubItemEntity } from "../../../src";
 import * as internalContentUtils from "../../../src/content/_internal/internalContentUtils";
 

--- a/packages/common/test/initiative-templates/fixtures.ts
+++ b/packages/common/test/initiative-templates/fixtures.ts
@@ -1,5 +1,5 @@
 import { IPortal } from "@esri/arcgis-rest-portal";
-import { IItem, IUser } from "@esri/arcgis-rest-portal";
+import { IItem, IUser } from "@esri/arcgis-rest-types";
 import {
   ArcGISContext,
   IHubCatalog,

--- a/packages/common/test/initiatives/fixtures.ts
+++ b/packages/common/test/initiatives/fixtures.ts
@@ -1,4 +1,4 @@
-import { IItem, IUser } from "@esri/arcgis-rest-portal";
+import { IItem, IUser } from "@esri/arcgis-rest-types";
 import {
   ArcGISContext,
   HubEntityStatus,

--- a/packages/common/test/projects/fixtures.ts
+++ b/packages/common/test/projects/fixtures.ts
@@ -1,4 +1,4 @@
-import { IItem, IUser } from "@esri/arcgis-rest-portal";
+import { IItem, IUser } from "@esri/arcgis-rest-types";
 import {
   ArcGISContext,
   HubEntityStatus,

--- a/packages/common/test/templates/fixtures.ts
+++ b/packages/common/test/templates/fixtures.ts
@@ -1,4 +1,4 @@
-import { IItem, IUser } from "@esri/arcgis-rest-portal";
+import { IItem, IUser } from "@esri/arcgis-rest-types";
 import { IHubCatalog, IHubSearchResult } from "../../src/search/types";
 import { IModel } from "../../src/types";
 import { IHubTemplate } from "../../src/core/types/IHubTemplate";

--- a/packages/common/test/test-helpers/fake-user.ts
+++ b/packages/common/test/test-helpers/fake-user.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 
 export const mockUser = {
   username: "vader",

--- a/packages/common/test/users/fixtures.ts
+++ b/packages/common/test/users/fixtures.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { ArcGISContext, IHubSearchResult } from "../../src";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import { IPortal } from "@esri/arcgis-rest-portal";

--- a/packages/discussions/src/utils/channel-permission.ts
+++ b/packages/discussions/src/utils/channel-permission.ts
@@ -1,4 +1,4 @@
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import {
   AclCategory,
   AclSubCategory,

--- a/packages/discussions/src/utils/channels/can-create-channel.ts
+++ b/packages/discussions/src/utils/channels/can-create-channel.ts
@@ -1,4 +1,4 @@
-import { IGroup, IUser } from "@esri/arcgis-rest-portal";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser, SharingAccess } from "../../types";
 import { CANNOT_DISCUSS } from "../constants";
 import { isOrgAdmin } from "../platform";

--- a/packages/discussions/src/utils/channels/can-delete-channel.ts
+++ b/packages/discussions/src/utils/channels/can-delete-channel.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser } from "../../types";
 import { isAuthorizedToModifyChannelByLegacyPermissions } from "./is-authorized-to-modify-channel-by-legacy-permissions";
 import { hasOrgAdminDeleteRights } from "../portal-privilege";

--- a/packages/discussions/src/utils/channels/can-edit-channel.ts
+++ b/packages/discussions/src/utils/channels/can-edit-channel.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser } from "../../types";
 import { isAuthorizedToModifyChannelByLegacyPermissions } from "./is-authorized-to-modify-channel-by-legacy-permissions";
 import { hasOrgAdminUpdateRights } from "../portal-privilege";

--- a/packages/discussions/src/utils/channels/can-modify-channel.ts
+++ b/packages/discussions/src/utils/channels/can-modify-channel.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser } from "../../types";
 import { isOrgAdminInOrg } from "../platform";
 import { isAuthorizedToModifyChannelByLegacyPermissions } from "./is-authorized-to-modify-channel-by-legacy-permissions";

--- a/packages/discussions/src/utils/channels/can-post-to-channel.ts
+++ b/packages/discussions/src/utils/channels/can-post-to-channel.ts
@@ -1,4 +1,4 @@
-import { IGroup, IUser } from "@esri/arcgis-rest-portal";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser, SharingAccess } from "../../types";
 import { CANNOT_DISCUSS } from "../constants";
 import { hasOrgAdminUpdateRights } from "../portal-privilege";

--- a/packages/discussions/src/utils/channels/is-authorized-to-modify-channel-by-legacy-permissions.ts
+++ b/packages/discussions/src/utils/channels/is-authorized-to-modify-channel-by-legacy-permissions.ts
@@ -1,4 +1,4 @@
-import { IGroup, IUser } from "@esri/arcgis-rest-portal";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser, SharingAccess } from "@esri/hub-common";
 import { isOrgAdmin } from "../platform";
 

--- a/packages/discussions/src/utils/portal-privilege.ts
+++ b/packages/discussions/src/utils/portal-privilege.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { IDiscussionsUser } from "@esri/hub-common";
 import { isOrgAdminInOrg, isUserInOrg, userHasPrivileges } from "./platform";
 

--- a/packages/discussions/src/utils/posts/can-create-post.ts
+++ b/packages/discussions/src/utils/posts/can-create-post.ts
@@ -1,4 +1,4 @@
-import { IGroup, IUser } from "@esri/arcgis-rest-portal";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser, SharingAccess } from "../../types";
 import { CANNOT_DISCUSS } from "../constants";
 import { hasOrgAdminUpdateRights } from "../portal-privilege";

--- a/packages/discussions/src/utils/posts/can-create-reply.ts
+++ b/packages/discussions/src/utils/posts/can-create-reply.ts
@@ -1,4 +1,4 @@
-import { IGroup, IUser } from "@esri/arcgis-rest-portal";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser, SharingAccess } from "../../types";
 import { CANNOT_DISCUSS } from "../constants";
 import { hasOrgAdminUpdateRights } from "../portal-privilege";

--- a/packages/discussions/src/utils/posts/can-delete-post.ts
+++ b/packages/discussions/src/utils/posts/can-delete-post.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser, IPost } from "../../types";
 import { ChannelPermission } from "../channel-permission";
 import { hasOrgAdminUpdateRights } from "../portal-privilege";

--- a/packages/discussions/src/utils/posts/can-edit-post-status.ts
+++ b/packages/discussions/src/utils/posts/can-edit-post-status.ts
@@ -1,4 +1,4 @@
-import { IGroup, IUser } from "@esri/arcgis-rest-portal";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser, SharingAccess } from "../../types";
 import { isOrgAdmin } from "../platform";
 import { hasOrgAdminUpdateRights } from "../portal-privilege";

--- a/packages/discussions/src/utils/posts/can-edit-post.ts
+++ b/packages/discussions/src/utils/posts/can-edit-post.ts
@@ -1,4 +1,4 @@
-import { IGroup, IUser } from "@esri/arcgis-rest-portal";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
 import { IChannel, IDiscussionsUser, IPost, SharingAccess } from "../../types";
 import { CANNOT_DISCUSS } from "../constants";
 import { ChannelPermission } from "../channel-permission";

--- a/packages/downloads/src/portal/utils.ts
+++ b/packages/downloads/src/portal/utils.ts
@@ -3,7 +3,7 @@ import { DownloadFormat } from "../download-format";
 import { DownloadTarget } from "../download-target";
 
 const DOWNLOADS_LOCK_MS = 10 * 60 * 1000;
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 
 /**
  * @private

--- a/packages/events/src/search.ts
+++ b/packages/events/src/search.ts
@@ -4,7 +4,7 @@
 import {
   IQueryFeaturesOptions,
   queryFeatures,
-  IQueryFeaturesResponse,
+  IQueryFeaturesResponse
 } from "@esri/arcgis-rest-feature-layer";
 
 import { ISearchOptions, searchItems } from "@esri/arcgis-rest-portal";
@@ -58,21 +58,21 @@ export function searchEvents(
 ): Promise<{ data: IEventResourceObject[]; included: IEventResourceObject[] }> {
   const queryOptions: IQueryFeaturesOptions = {
     returnGeometry: true,
-    ...requestOptions,
+    ...requestOptions
   };
 
-  return queryFeatures(queryOptions).then((response) => {
+  return queryFeatures(queryOptions).then(response => {
     if ((response as IQueryFeaturesResponse).features.length <= 0) {
       return {
         data: [] as IEventResourceObject[],
-        included: [] as IEventResourceObject[],
+        included: [] as IEventResourceObject[]
       };
     }
     // if authentication is passed, get a reference to the token to tack onto image urls
     if (queryOptions.authentication) {
       return queryOptions.authentication
         .getToken(queryOptions.url)
-        .then((token) => {
+        .then(token => {
           return buildEventResponse(
             (response as IQueryFeaturesResponse).features,
             queryOptions.url,
@@ -102,14 +102,16 @@ function buildEventResponse(
   const cacheBust = new Date().getTime();
   let siteSearchQuery = "";
 
-  features.forEach(function (event) {
+  features.forEach(function(event) {
     const attributes = event.attributes;
     const geometry = event.geometry;
     let imageUrl = null;
     if (attributes.imageAttributes) {
       const imageAttributes = JSON.parse(attributes.imageAttributes);
       if (imageAttributes.crop) {
-        imageUrl = `${url}/${attributes.OBJECTID}/attachments/${imageAttributes.crop}?v=${cacheBust}`;
+        imageUrl = `${url}/${attributes.OBJECTID}/attachments/${
+          imageAttributes.crop
+        }?v=${cacheBust}`;
         if (token) {
           imageUrl += `&token=${token}`;
         }
@@ -120,7 +122,7 @@ function buildEventResponse(
       type: "events",
       imageUrl,
       attributes,
-      geometry,
+      geometry
     });
     const currentEventSiteId = attributes.siteId;
     if (
@@ -138,16 +140,16 @@ function buildEventResponse(
   // search for site items and include those in the response
   const searchRequestOptions = requestOptions as ISearchOptions;
   searchRequestOptions.q = siteSearchQuery;
-  return searchItems(searchRequestOptions).then(function (siteInfo) {
-    siteInfo.results.forEach((siteItem) => {
+  return searchItems(searchRequestOptions).then(function(siteInfo) {
+    siteInfo.results.forEach(siteItem => {
       included.push({
         id: siteItem.id,
         type: `sites`,
         // passing along all the site item information would be overkill
         attributes: {
           id: siteItem.id,
-          url: siteItem.url,
-        },
+          url: siteItem.url
+        }
       });
     });
 

--- a/packages/events/test/mocks/event_search.ts
+++ b/packages/events/test/mocks/event_search.ts
@@ -2,21 +2,21 @@
  * Apache-2.0 */
 
 import { IEventResourceObject } from "../../src/search";
-import { IGeometry, IField } from "@esri/arcgis-rest-types";
+import { IGeometry, IItem, IField } from "@esri/arcgis-rest-types";
 import { IQueryFeaturesResponse } from "@esri/arcgis-rest-feature-layer";
-import { IItem, ISearchResult } from "@esri/arcgis-rest-portal";
+import { ISearchResult } from "@esri/arcgis-rest-portal";
 
 export const eventQueryResponseEmpty = {
   objectIdFieldName: "OBJECTID",
   uniqueIdField: {
     name: "OBJECTID",
-    isSystemMaintained: true,
+    isSystemMaintained: true
   },
   globalIdFieldName: "",
   geometryType: "esriGeometryPoint",
   spatialReference: {
     wkid: 4326,
-    latestWkid: 4326,
+    latestWkid: 4326
   },
   fields: [
     {
@@ -24,7 +24,7 @@ export const eventQueryResponseEmpty = {
       type: "esriFieldTypeOID",
       alias: "OBJECTID",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "title",
@@ -32,7 +32,7 @@ export const eventQueryResponseEmpty = {
       alias: "title",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "location",
@@ -40,7 +40,7 @@ export const eventQueryResponseEmpty = {
       alias: "location",
       length: 2000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "description",
@@ -48,7 +48,7 @@ export const eventQueryResponseEmpty = {
       alias: "description",
       length: 4000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "startDate",
@@ -56,7 +56,7 @@ export const eventQueryResponseEmpty = {
       alias: "startDate",
       length: 0,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "endDate",
@@ -64,7 +64,7 @@ export const eventQueryResponseEmpty = {
       alias: "endDate",
       length: 0,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "organizerId",
@@ -72,7 +72,7 @@ export const eventQueryResponseEmpty = {
       alias: "organizerId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "organizerName",
@@ -80,7 +80,7 @@ export const eventQueryResponseEmpty = {
       alias: "organizerName",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "organizerEmail",
@@ -88,7 +88,7 @@ export const eventQueryResponseEmpty = {
       alias: "organizerEmail",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "url",
@@ -96,7 +96,7 @@ export const eventQueryResponseEmpty = {
       alias: "url",
       length: 2000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "pageId",
@@ -104,21 +104,21 @@ export const eventQueryResponseEmpty = {
       alias: "pageId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "capacity",
       type: "esriFieldTypeInteger",
       alias: "capacity",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "attendance",
       type: "esriFieldTypeInteger",
       alias: "attendance",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "status",
@@ -126,14 +126,14 @@ export const eventQueryResponseEmpty = {
       alias: "status",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "isCancelled",
       type: "esriFieldTypeInteger",
       alias: "isCancelled",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "groupId",
@@ -141,7 +141,7 @@ export const eventQueryResponseEmpty = {
       alias: "groupId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "siteId",
@@ -149,7 +149,7 @@ export const eventQueryResponseEmpty = {
       alias: "siteId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "initiativeId",
@@ -157,7 +157,7 @@ export const eventQueryResponseEmpty = {
       alias: "initiativeId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "surveyId",
@@ -165,7 +165,7 @@ export const eventQueryResponseEmpty = {
       alias: "surveyId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "CreationDate",
@@ -173,7 +173,7 @@ export const eventQueryResponseEmpty = {
       alias: "CreationDate",
       length: 8,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "Creator",
@@ -181,7 +181,7 @@ export const eventQueryResponseEmpty = {
       alias: "Creator",
       length: 50,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "EditDate",
@@ -189,7 +189,7 @@ export const eventQueryResponseEmpty = {
       alias: "EditDate",
       length: 8,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "Editor",
@@ -197,14 +197,14 @@ export const eventQueryResponseEmpty = {
       alias: "Editor",
       length: 50,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "schemaVersion",
       type: "esriFieldTypeDouble",
       alias: "schemaVersion",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "organizers",
@@ -212,7 +212,7 @@ export const eventQueryResponseEmpty = {
       alias: "organizers",
       length: 4000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "sponsors",
@@ -220,7 +220,7 @@ export const eventQueryResponseEmpty = {
       alias: "sponsors",
       length: 4000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "onlineLocation",
@@ -228,7 +228,7 @@ export const eventQueryResponseEmpty = {
       alias: "onlineLocation",
       length: 2000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "venue",
@@ -236,7 +236,7 @@ export const eventQueryResponseEmpty = {
       alias: "venue",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "address1",
@@ -244,7 +244,7 @@ export const eventQueryResponseEmpty = {
       alias: "address1",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "address2",
@@ -252,14 +252,14 @@ export const eventQueryResponseEmpty = {
       alias: "address2",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "isAllDay",
       type: "esriFieldTypeInteger",
       alias: "isAllDay",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "timeZone",
@@ -267,7 +267,7 @@ export const eventQueryResponseEmpty = {
       alias: "timeZone",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "appIds",
@@ -275,7 +275,7 @@ export const eventQueryResponseEmpty = {
       alias: "appIds",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "imageAttributes",
@@ -283,7 +283,7 @@ export const eventQueryResponseEmpty = {
       alias: "imageAttributes",
       length: 4000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "videoUrl",
@@ -291,10 +291,10 @@ export const eventQueryResponseEmpty = {
       alias: "videoUrl",
       length: 2000,
       domain: null,
-      defaultValue: null,
-    },
+      defaultValue: null
+    }
   ] as IField[],
-  features: [] as any,
+  features: [] as any
 };
 
 export const eventQueryResponse: IQueryFeaturesResponse = {
@@ -303,7 +303,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
   geometryType: "esriGeometryPoint",
   spatialReference: {
     wkid: 4326,
-    latestWkid: 4326,
+    latestWkid: 4326
   },
   fields: [
     {
@@ -311,7 +311,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       type: "esriFieldTypeOID",
       alias: "OBJECTID",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "title",
@@ -319,7 +319,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "title",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "location",
@@ -327,7 +327,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "location",
       length: 2000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "description",
@@ -335,7 +335,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "description",
       length: 4000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "startDate",
@@ -343,7 +343,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "startDate",
       length: 0,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "endDate",
@@ -351,7 +351,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "endDate",
       length: 0,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "organizerId",
@@ -359,7 +359,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "organizerId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "organizerName",
@@ -367,7 +367,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "organizerName",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "organizerEmail",
@@ -375,7 +375,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "organizerEmail",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "url",
@@ -383,7 +383,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "url",
       length: 2000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "pageId",
@@ -391,21 +391,21 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "pageId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "capacity",
       type: "esriFieldTypeInteger",
       alias: "capacity",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "attendance",
       type: "esriFieldTypeInteger",
       alias: "attendance",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "status",
@@ -413,14 +413,14 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "status",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "isCancelled",
       type: "esriFieldTypeInteger",
       alias: "isCancelled",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "groupId",
@@ -428,7 +428,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "groupId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "siteId",
@@ -436,7 +436,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "siteId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "initiativeId",
@@ -444,7 +444,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "initiativeId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "surveyId",
@@ -452,7 +452,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "surveyId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "CreationDate",
@@ -460,7 +460,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "CreationDate",
       length: 8,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "Creator",
@@ -468,7 +468,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "Creator",
       length: 50,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "EditDate",
@@ -476,7 +476,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "EditDate",
       length: 8,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "Editor",
@@ -484,14 +484,14 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "Editor",
       length: 50,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "schemaVersion",
       type: "esriFieldTypeDouble",
       alias: "schemaVersion",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "organizers",
@@ -499,7 +499,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "organizers",
       length: 4000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "sponsors",
@@ -507,7 +507,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "sponsors",
       length: 4000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "onlineLocation",
@@ -515,7 +515,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "onlineLocation",
       length: 2000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "venue",
@@ -523,7 +523,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "venue",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "address1",
@@ -531,7 +531,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "address1",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "address2",
@@ -539,14 +539,14 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "address2",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "isAllDay",
       type: "esriFieldTypeInteger",
       alias: "isAllDay",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "timeZone",
@@ -554,7 +554,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "timeZone",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "appIds",
@@ -562,7 +562,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "appIds",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "imageAttributes",
@@ -570,7 +570,7 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "imageAttributes",
       length: 4000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "videoUrl",
@@ -578,8 +578,8 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
       alias: "videoUrl",
       length: 2000,
       domain: null,
-      defaultValue: null,
-    },
+      defaultValue: null
+    }
   ],
   features: [
     {
@@ -618,12 +618,12 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
         timeZone: null,
         appIds: null,
         imageAttributes: null,
-        videoUrl: null,
+        videoUrl: null
       },
       geometry: {
         x: -74.310680054965559,
-        y: 40.723010058860787,
-      } as IGeometry,
+        y: 40.723010058860787
+      } as IGeometry
     },
     {
       attributes: {
@@ -663,12 +663,12 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
         appIds: null,
         imageAttributes:
           '{"raw":251,"crop":252,"props":{"transformAxis":"x","position":{"x":0,"y":0},"scale":{"current":0,"original":0},"container":{"width":858,"height":429,"left":54,"top":27},"natural":{"width":700,"height":700},"output":{"width":750,"height":375},"version":2,"rendered":{"width":858,"height":858}}}',
-        videoUrl: null,
+        videoUrl: null
       },
       geometry: {
         x: -77.036430054965564,
-        y: 38.897929948352669,
-      } as IGeometry,
+        y: 38.897929948352669
+      } as IGeometry
     },
     {
       attributes: {
@@ -707,14 +707,14 @@ export const eventQueryResponse: IQueryFeaturesResponse = {
         appIds: null,
         imageAttributes:
           '{"raw":251,"props":{"transformAxis":"x","position":{"x":0,"y":0},"scale":{"current":0,"original":0},"container":{"width":858,"height":429,"left":54,"top":27},"natural":{"width":700,"height":700},"output":{"width":750,"height":375},"version":2,"rendered":{"width":858,"height":858}}}',
-        videoUrl: "",
+        videoUrl: ""
       },
       geometry: {
         x: -77.071490000576887,
-        y: 38.895170069969296,
-      } as IGeometry,
-    },
-  ],
+        y: 38.895170069969296
+      } as IGeometry
+    }
+  ]
 };
 
 export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
@@ -723,7 +723,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
   geometryType: "esriGeometryPoint",
   spatialReference: {
     wkid: 4326,
-    latestWkid: 4326,
+    latestWkid: 4326
   },
   fields: [
     {
@@ -731,7 +731,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       type: "esriFieldTypeOID",
       alias: "OBJECTID",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "title",
@@ -739,7 +739,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "title",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "location",
@@ -747,7 +747,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "location",
       length: 2000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "description",
@@ -755,7 +755,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "description",
       length: 4000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "startDate",
@@ -763,7 +763,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "startDate",
       length: 0,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "endDate",
@@ -771,7 +771,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "endDate",
       length: 0,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "organizerId",
@@ -779,7 +779,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "organizerId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "organizerName",
@@ -787,7 +787,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "organizerName",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "organizerEmail",
@@ -795,7 +795,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "organizerEmail",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "url",
@@ -803,7 +803,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "url",
       length: 2000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "pageId",
@@ -811,21 +811,21 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "pageId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "capacity",
       type: "esriFieldTypeInteger",
       alias: "capacity",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "attendance",
       type: "esriFieldTypeInteger",
       alias: "attendance",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "status",
@@ -833,14 +833,14 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "status",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "isCancelled",
       type: "esriFieldTypeInteger",
       alias: "isCancelled",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "groupId",
@@ -848,7 +848,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "groupId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "siteId",
@@ -856,7 +856,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "siteId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "initiativeId",
@@ -864,7 +864,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "initiativeId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "surveyId",
@@ -872,7 +872,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "surveyId",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "CreationDate",
@@ -880,7 +880,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "CreationDate",
       length: 8,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "Creator",
@@ -888,7 +888,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "Creator",
       length: 50,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "EditDate",
@@ -896,7 +896,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "EditDate",
       length: 8,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "Editor",
@@ -904,14 +904,14 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "Editor",
       length: 50,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "schemaVersion",
       type: "esriFieldTypeDouble",
       alias: "schemaVersion",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "organizers",
@@ -919,7 +919,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "organizers",
       length: 4000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "sponsors",
@@ -927,7 +927,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "sponsors",
       length: 4000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "onlineLocation",
@@ -935,7 +935,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "onlineLocation",
       length: 2000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "venue",
@@ -943,7 +943,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "venue",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "address1",
@@ -951,7 +951,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "address1",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "address2",
@@ -959,14 +959,14 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "address2",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "isAllDay",
       type: "esriFieldTypeInteger",
       alias: "isAllDay",
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "timeZone",
@@ -974,7 +974,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "timeZone",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "appIds",
@@ -982,7 +982,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "appIds",
       length: 256,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "imageAttributes",
@@ -990,7 +990,7 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "imageAttributes",
       length: 4000,
       domain: null,
-      defaultValue: null,
+      defaultValue: null
     },
     {
       name: "videoUrl",
@@ -998,8 +998,8 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
       alias: "videoUrl",
       length: 2000,
       domain: null,
-      defaultValue: null,
-    },
+      defaultValue: null
+    }
   ],
   features: [
     {
@@ -1038,14 +1038,14 @@ export const eventQueryResponseWithoutSiteId: IQueryFeaturesResponse = {
         timeZone: null,
         appIds: null,
         imageAttributes: null,
-        videoUrl: null,
+        videoUrl: null
       },
       geometry: {
         x: -74.310680054965559,
-        y: 40.723010058860787,
-      } as IGeometry,
-    },
-  ],
+        y: 40.723010058860787
+      } as IGeometry
+    }
+  ]
 };
 
 export const siteResponse71a58 = {
@@ -1068,7 +1068,7 @@ export const siteResponse71a58 = {
     "Online Map",
     "OpenData",
     "Web Map",
-    "Registered App",
+    "Registered App"
   ],
   description:
     "DO NOT DELETE OR MODIFY THIS ITEM. This item is managed by the ArcGIS Hub application. To make changes to this site, please visit https://hub.arcgis.com/admin/",
@@ -1099,7 +1099,7 @@ export const siteResponse71a58 = {
   avgRating: 0,
   numViews: 8916,
   scoreCompleteness: 73,
-  groupDesignations: null,
+  groupDesignations: null
 } as IItem;
 
 export const siteResponse7c395 = {
@@ -1122,7 +1122,7 @@ export const siteResponse7c395 = {
     "Online Map",
     "OpenData",
     "Web Map",
-    "Registered App",
+    "Registered App"
   ],
   description:
     "DO NOT DELETE OR MODIFY THIS ITEM. This item is managed by the ArcGIS Hub application. To make changes to this site, please visit https://hub.arcgis.com/admin/",
@@ -1153,7 +1153,7 @@ export const siteResponse7c395 = {
   avgRating: 0,
   numViews: 8916,
   scoreCompleteness: 73,
-  groupDesignations: null,
+  groupDesignations: null
 } as IItem;
 
 export const siteSearchResponse = {
@@ -1162,7 +1162,7 @@ export const siteSearchResponse = {
   start: 1,
   num: 1,
   nextStart: 2,
-  results: [siteResponse71a58, siteResponse7c395],
+  results: [siteResponse71a58, siteResponse7c395]
 } as ISearchResult<IItem>;
 
 const cacheBust = new Date().getTime();
@@ -1172,9 +1172,9 @@ const data = [
     type: "events",
     attributes: {
       imageUrl: null,
-      ...eventQueryResponse.features[0].attributes,
+      ...eventQueryResponse.features[0].attributes
     },
-    geometry: eventQueryResponse.features[0].geometry,
+    geometry: eventQueryResponse.features[0].geometry
   },
   {
     id: 6,
@@ -1184,19 +1184,19 @@ const data = [
         `https://hub.arcgis.com/api/v3/events/5bc/Hub Events (public)/FeatureServer/0/6/attachments/252?v=` +
         { cacheBust } +
         `&token=FAKE-TOKEN`,
-      ...eventQueryResponse.features[1].attributes,
+      ...eventQueryResponse.features[1].attributes
     },
-    geometry: eventQueryResponse.features[1].geometry,
+    geometry: eventQueryResponse.features[1].geometry
   },
   {
     id: 7,
     type: "events",
     attributes: {
       imageUrl: null,
-      ...eventQueryResponse.features[2].attributes,
+      ...eventQueryResponse.features[2].attributes
     },
-    geometry: eventQueryResponse.features[2].geometry,
-  },
+    geometry: eventQueryResponse.features[2].geometry
+  }
 ] as IEventResourceObject[];
 const dataWithoutSiteId = [
   {
@@ -1204,14 +1204,14 @@ const dataWithoutSiteId = [
     type: "events",
     attributes: {
       imageUrl: null,
-      ...eventQueryResponseWithoutSiteId.features[0].attributes,
+      ...eventQueryResponseWithoutSiteId.features[0].attributes
     },
-    geometry: eventQueryResponseWithoutSiteId.features[0].geometry,
-  },
+    geometry: eventQueryResponseWithoutSiteId.features[0].geometry
+  }
 ] as IEventResourceObject[];
 export const eventResponseEmpty = {
   data: [] as IEventResourceObject[],
-  included: [] as IEventResourceObject[],
+  included: [] as IEventResourceObject[]
 };
 
 export const eventResponse = {
@@ -1222,21 +1222,21 @@ export const eventResponse = {
       type: "sites",
       attributes: {
         id: siteResponse71a58.id,
-        url: siteResponse71a58.url,
-      },
+        url: siteResponse71a58.url
+      }
     },
     {
       id: siteResponse7c395.id,
       type: "sites",
       attributes: {
         id: siteResponse7c395.id,
-        url: siteResponse7c395.url,
-      },
-    },
-  ] as IEventResourceObject[],
+        url: siteResponse7c395.url
+      }
+    }
+  ] as IEventResourceObject[]
 };
 
 export const eventResponseWithoutSiteId = {
   data: dataWithoutSiteId,
-  included: [] as IEventResourceObject[],
+  included: [] as IEventResourceObject[]
 };

--- a/packages/sites/src/convert-site-to-template.ts
+++ b/packages/sites/src/convert-site-to-template.ts
@@ -11,7 +11,7 @@ import {
   getItemAssets,
 } from "@esri/hub-common";
 import { getSiteItemType } from "./get-site-item-type";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { SITE_SCHEMA_VERSION } from "./site-schema-version";
 import { convertLayoutToTemplate } from "./layout";
 import { getSiteDependencies } from "./get-site-dependencies";

--- a/packages/sites/src/get-data-for-site-item.ts
+++ b/packages/sites/src/get-data-for-site-item.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { IHubRequestOptions, upgradeSiteSchema } from "@esri/hub-common";
 import { getItemData } from "@esri/arcgis-rest-portal";
 

--- a/packages/sites/src/get-members.ts
+++ b/packages/sites/src/get-members.ts
@@ -1,6 +1,6 @@
 import { getUser } from "@esri/arcgis-rest-portal";
 import { request } from "@esri/arcgis-rest-request";
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import {
   IHubRequestOptions,
   getPortalUrl,

--- a/packages/sites/src/get-site-edit-url.ts
+++ b/packages/sites/src/get-site-edit-url.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 
 /**
  * Get the correct url used to edit the site

--- a/packages/sites/src/pages/convert-page-to-template.ts
+++ b/packages/sites/src/pages/convert-page-to-template.ts
@@ -12,7 +12,7 @@ import {
 import { getPageItemType } from "./get-page-item-type";
 import { convertLayoutToTemplate } from "../layout";
 import { getSiteDependencies } from "../get-site-dependencies";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { DRAFT_RESOURCE_REGEX } from "../drafts/_draft-resource-regex";
 
 /**

--- a/packages/sites/src/pages/get-page-edit-url.ts
+++ b/packages/sites/src/pages/get-page-edit-url.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 
 /**
  * Get the correct url used to edit the page

--- a/packages/surveys/src/sharing/share-with-group-revertable.ts
+++ b/packages/surveys/src/sharing/share-with-group-revertable.ts
@@ -5,14 +5,14 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import {
   unshareItemWithGroup,
-  shareItemWithGroup,
+  shareItemWithGroup
 } from "@esri/arcgis-rest-portal";
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import {
   IModel,
   IRevertableTaskResult,
   runRevertableTask,
-  isUpdateGroup,
+  isUpdateGroup
 } from "@esri/hub-common";
 
 /**
@@ -38,8 +38,8 @@ export const shareWithGroupRevertable = (
         owner,
         groupId,
         confirmItemControl: isUpdateGroup(group),
-        authentication,
-      }).then((result) => {
+        authentication
+      }).then(result => {
         if (result.notSharedWith.length) {
           throw new Error(`Failed to share item ${id} to group ${groupId}`);
         }
@@ -51,7 +51,7 @@ export const shareWithGroupRevertable = (
         id,
         owner,
         groupId,
-        authentication,
+        authentication
       }).catch(() => {})
     /* tslint:enable no-empty */
   );

--- a/packages/surveys/src/sharing/unshare-with-group-revertable.ts
+++ b/packages/surveys/src/sharing/unshare-with-group-revertable.ts
@@ -5,14 +5,14 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import {
   unshareItemWithGroup,
-  shareItemWithGroup,
+  shareItemWithGroup
 } from "@esri/arcgis-rest-portal";
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 import {
   IModel,
   IRevertableTaskResult,
   runRevertableTask,
-  isUpdateGroup,
+  isUpdateGroup
 } from "@esri/hub-common";
 
 /**
@@ -37,8 +37,8 @@ export const unshareWithGroupRevertable = (
         id,
         owner,
         groupId,
-        authentication,
-      }).then((result) => {
+        authentication
+      }).then(result => {
         if (result.notUnsharedFrom.length) {
           throw new Error(`Failed to unshare item ${id} from group ${groupId}`);
         }
@@ -51,7 +51,7 @@ export const unshareWithGroupRevertable = (
         owner,
         groupId,
         confirmItemControl: isUpdateGroup(group),
-        authentication,
+        authentication
       }).catch(() => {})
     /* tslint:enable no-empty */
   );

--- a/packages/surveys/src/types.ts
+++ b/packages/surveys/src/types.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 
 /*
  * possible values of formItem.properties.settings.resultsAvailability,

--- a/packages/surveys/src/utils/is-published.ts
+++ b/packages/surveys/src/utils/is-published.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 import { isDraft } from "@esri/hub-common";
 
 /**

--- a/packages/teams/src/create-hub-team.ts
+++ b/packages/teams/src/create-hub-team.ts
@@ -10,7 +10,7 @@ import {
 } from "@esri/hub-common";
 import { getUserCreatableTeams } from "./utils/get-user-creatable-teams";
 import { _createTeamGroups } from "./utils/_create-team-groups";
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 
 /**
  * Create a single Team, using the same logic as creating multiple Teams.

--- a/packages/teams/src/create-hub-teams.ts
+++ b/packages/teams/src/create-hub-teams.ts
@@ -9,7 +9,7 @@ import {
 import { getUserCreatableTeams } from "./utils/get-user-creatable-teams";
 import { _createTeamGroups } from "./utils/_create-team-groups";
 import { HubTeamType } from "./types";
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 
 /**
  * Create all the groups (aka Teams) required for a Site or Initiative

--- a/packages/teams/src/types.ts
+++ b/packages/teams/src/types.ts
@@ -2,7 +2,7 @@ import {
   ArcGISRequestError,
   IAuthenticationManager,
 } from "@esri/arcgis-rest-request";
-import { IGroup, IUser } from "@esri/arcgis-rest-portal";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
 import { IEmail } from "@esri/hub-common";
 
 export type AGOAccess = "public" | "org" | "private";
@@ -17,7 +17,7 @@ export type HubProduct = "basic" | "premium" | "portal";
 
 // This type just says that whatever string is used as a
 // TeamType must exist in TEAMTYPES
-export type HubTeamType = (typeof TEAMTYPES)[number];
+export type HubTeamType = typeof TEAMTYPES[number];
 
 /**
  * Group Template

--- a/packages/teams/src/update-team.ts
+++ b/packages/teams/src/update-team.ts
@@ -1,6 +1,6 @@
 import { updateGroup } from "@esri/arcgis-rest-portal";
 import { IAuthenticationManager } from "@esri/arcgis-rest-request";
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 
 /**
  * Updates a group. Wrapper around updateGroup from arcgis-rest-portal

--- a/packages/teams/src/utils/_create-team-groups.ts
+++ b/packages/teams/src/utils/_create-team-groups.ts
@@ -2,7 +2,7 @@ import { IGroupTemplate } from "../types";
 import { IHubRequestOptions } from "@esri/hub-common";
 import { _translateTeamTemplate } from "./_translate-team-template";
 import { _createTeamGroup } from "./_create-team-group";
-import { IGroup } from "@esri/arcgis-rest-portal";
+import { IGroup } from "@esri/arcgis-rest-types";
 
 /**
  * Internal: Actually create the team groups
@@ -18,12 +18,12 @@ export function _createTeamGroups(
   hubRequestOptions: IHubRequestOptions
 ): Promise<{ props: any; groups: IGroup[] }> {
   // now translate the templates...
-  const translatedTemplates = groupTemplates.map((tmpl) => {
+  const translatedTemplates = groupTemplates.map(tmpl => {
     return _translateTeamTemplate(tmpl, title, translations);
   });
   // now we actually create the groups... obvs async...
   return Promise.all(
-    translatedTemplates.map((grpTmpl) => {
+    translatedTemplates.map(grpTmpl => {
       return _createTeamGroup(
         hubRequestOptions.portalSelf.user,
         grpTmpl,
@@ -31,28 +31,31 @@ export function _createTeamGroups(
       );
     })
   )
-    .then((groups) => {
+    .then(groups => {
       // hoist out the id's into a structure that has the groupnameProperty: id
-      const props = groups.reduce((acc, grp) => {
-        // assign to the property, if one is specified
-        if (grp.config.propertyName) {
-          acc[grp.config.propertyName] = grp.id;
-        }
-        return acc;
-      }, {} as any);
+      const props = groups.reduce(
+        (acc, grp) => {
+          // assign to the property, if one is specified
+          if (grp.config.propertyName) {
+            acc[grp.config.propertyName] = grp.id;
+          }
+          return acc;
+        },
+        {} as any
+      );
 
       // remove config node
-      groups.forEach((g) => delete g.config);
+      groups.forEach(g => delete g.config);
 
       // construct the return the hash...
       // props: the props which can be spread into the item.properties hash..
       // groups: the array of groups that were created
       return {
         props,
-        groups: groups as IGroup[],
+        groups: groups as IGroup[]
       };
     })
-    .catch((ex) => {
+    .catch(ex => {
       throw Error(`Error in team-utils::_createTeamGroups ${ex}`);
     });
 }

--- a/packages/teams/src/utils/apply-priv-prop-values-to-template.ts
+++ b/packages/teams/src/utils/apply-priv-prop-values-to-template.ts
@@ -1,5 +1,5 @@
 import { IGroupTemplate } from "../types";
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { cloneObject, getWithDefault, includes } from "@esri/hub-common";
 
 /**

--- a/packages/teams/src/utils/can-edit-team.ts
+++ b/packages/teams/src/utils/can-edit-team.ts
@@ -1,4 +1,4 @@
-import { IGroup, IUser } from "@esri/arcgis-rest-portal";
+import { IGroup, IUser } from "@esri/arcgis-rest-types";
 
 /**
  * Checks if user has access to edit a team

--- a/packages/teams/src/utils/get-team-status.ts
+++ b/packages/teams/src/utils/get-team-status.ts
@@ -1,4 +1,4 @@
-import { IItem, IUser } from "@esri/arcgis-rest-portal";
+import { IItem, IUser } from "@esri/arcgis-rest-types";
 import { getProp, IHubRequestOptions } from "@esri/hub-common";
 import { getTeamById } from "./get-team-by-id";
 import { ITeamStatus } from "../types";

--- a/packages/teams/src/utils/process-auto-add-users.ts
+++ b/packages/teams/src/utils/process-auto-add-users.ts
@@ -1,5 +1,5 @@
 import { ArcGISRequestError } from "@esri/arcgis-rest-request";
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { autoAddUsers, getProp } from "@esri/hub-common";
 import { IAddOrInviteContext, IAddOrInviteResponse } from "../types";
 import { autoAddUsersAsAdmins } from "./auto-add-users-as-admins";

--- a/packages/teams/src/utils/process-email-users.ts
+++ b/packages/teams/src/utils/process-email-users.ts
@@ -1,5 +1,5 @@
 import { ArcGISRequestError } from "@esri/arcgis-rest-request";
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { getProp, emailOrgUsers } from "@esri/hub-common";
 import { IAddOrInviteContext, IAddOrInviteResponse } from "../types";
 

--- a/packages/teams/src/utils/process-invite-users.ts
+++ b/packages/teams/src/utils/process-invite-users.ts
@@ -1,5 +1,5 @@
 import { ArcGISRequestError } from "@esri/arcgis-rest-request";
-import { IUser } from "@esri/arcgis-rest-portal";
+import { IUser } from "@esri/arcgis-rest-types";
 import { getProp, inviteUsers } from "@esri/hub-common";
 import { IAddOrInviteContext, IAddOrInviteResponse } from "../types";
 

--- a/packages/teams/src/utils/search-team-content.ts
+++ b/packages/teams/src/utils/search-team-content.ts
@@ -1,9 +1,9 @@
 import {
   searchGroupContent,
   ISearchResult,
-  ISearchGroupContentOptions,
+  ISearchGroupContentOptions
 } from "@esri/arcgis-rest-portal";
-import { IItem } from "@esri/arcgis-rest-portal";
+import { IItem } from "@esri/arcgis-rest-types";
 /**
  * Get the content of a team
  * @param {ISearchGroupContentOptions} searchOptions


### PR DESCRIPTION
Reverts Esri/hub.js#1809

This is being reverted due to breaking issues in ci / running hub-components from either #1808 or #1809, they went out together.