### PR TITLE
fix: account for empty collection filters when merging with scope filters

### DIFF
--- a/packages/common/src/search/Catalog.ts
+++ b/packages/common/src/search/Catalog.ts
@@ -203,7 +203,10 @@ export class Catalog implements IHubCatalog {
       const clone = cloneObject(json);
       const catalogScope = this.getScope(clone.scope.targetEntity);
       if (catalogScope?.filters) {
-        clone.scope.filters = [...clone.scope.filters, ...catalogScope.filters];
+        clone.scope.filters = [
+          ...(clone.scope.filters || []),
+          ...catalogScope.filters,
+        ];
       }
       return clone;
     } else {

--- a/packages/common/test/search/Catalog.test.ts
+++ b/packages/common/test/search/Catalog.test.ts
@@ -271,6 +271,20 @@ describe("Catalog Class:", () => {
       const teamsCollection = instance.getCollection("teams");
       expect(teamsCollection.scope.filters.length).toBe(1);
     });
+    it("get collection works without collection scope filters", () => {
+      const instance = Catalog.fromJson(cloneObject(catalogJson), context);
+      instance.addCollection({
+        key: "documents",
+        label: "Documents",
+        targetEntity: "item",
+        scope: {
+          targetEntity: "item",
+          collection: "document",
+        } as IQuery,
+      });
+      const docCollection = instance.getCollection("documents");
+      expect(docCollection.scope.filters.length).toBe(1);
+    });
   });
   describe("addCollection", () => {
     const newCollection = {


### PR DESCRIPTION
[12246](https://devtopia.esri.com/dc/hub/issues/12246)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.