### PR TITLE
feat(hub-common): add arcgisHubConfig global variable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65003,7 +65003,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.38.0",
+			"version": "15.38.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65032,7 +65032,7 @@
 		},
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
-			"version": "29.6.0",
+			"version": "29.7.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/src/ArcGISContextManager.ts
+++ b/packages/common/src/ArcGISContextManager.ts
@@ -80,8 +80,6 @@ export class ArcGISContextManager {
 
   private _currentUser: IUser;
 
-  private _logLevel: Level = Level.error;
-
   private _serviceStatus: HubServiceStatus;
 
   private _featureFlags: IFeatureFlags = {};
@@ -105,11 +103,10 @@ export class ArcGISContextManager {
     // Having a unique id makes debugging easier
     this.id = new Date().getTime();
 
-    // TODO: remove setLogLevel at next breaking change
+    // TODO: remove all log level logic at next breaking change
     if (opts.logLevel) {
-      this._logLevel = opts.logLevel;
+      Logger.setLogLevel(opts.logLevel);
     }
-    Logger.setLogLevel(this._logLevel);
 
     Logger.debug(`ArcGISContextManager:ctor: Creating ${this.id}`);
 

--- a/packages/common/src/ArcGISContextManager.ts
+++ b/packages/common/src/ArcGISContextManager.ts
@@ -104,10 +104,13 @@ export class ArcGISContextManager {
   private constructor(opts: IArcGISContextManagerOptions) {
     // Having a unique id makes debugging easier
     this.id = new Date().getTime();
+
+    // TODO: remove setLogLevel at next breaking change
     if (opts.logLevel) {
       this._logLevel = opts.logLevel;
     }
     Logger.setLogLevel(this._logLevel);
+
     Logger.debug(`ArcGISContextManager:ctor: Creating ${this.id}`);
 
     if (opts.properties) {

--- a/packages/common/src/types/IArcGISContextManagerOptions.ts
+++ b/packages/common/src/types/IArcGISContextManagerOptions.ts
@@ -54,9 +54,8 @@ export interface IArcGISContextManagerOptions {
   properties?: Record<string, any>;
 
   /**
+   * DEPRECATED: use `globalThis.arcgisHubConfig.logLevel` instead
    * Logging level
-   * off > error > warn > info > debug > all
-   * defaults to 'error'
    */
   logLevel?: Level;
 

--- a/packages/common/src/utils/IHubConfig.ts
+++ b/packages/common/src/utils/IHubConfig.ts
@@ -1,0 +1,25 @@
+import { LogLevel } from "./LogLevel";
+
+/**
+ * Hub.js configuration settings
+ *
+ * You can override the default settings by
+ * initializing the global `arcgisHubConfig` variable
+ * before using any Hub.js functions, for example:
+ * ```js
+ * import { Logger } from '@esri/hub-common';
+ * // configure Hub.js
+ * const logLevel = environment === 'production' ? 'error' : 'debug';
+ * globalThis.arcgisHubConfig = { logLevel };
+ * // then use Hub.js
+ * Logger.info('This message will not log on production');
+ * ```
+ */
+export interface IHubConfig {
+  /**
+   * The global log level for Hub.js
+   *
+   * Available logging levels are specified in the LogLevel type. The default is 'info'.
+   */
+  logLevel?: LogLevel;
+}

--- a/packages/common/src/utils/LogLevel.ts
+++ b/packages/common/src/utils/LogLevel.ts
@@ -1,0 +1,2 @@
+/** The level of console logs that will be issued by Hub.js */
+export type LogLevel = "all" | "debug" | "info" | "warn" | "error" | "off";

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./LogLevel";
 export * from "./asyncForEach";
 export * from "./batch";
 export * from "./encoding";

--- a/packages/common/src/utils/internal/config.ts
+++ b/packages/common/src/utils/internal/config.ts
@@ -1,0 +1,43 @@
+import { IHubConfig } from "../IHubConfig";
+
+// the default settings
+const DEFAULT_CONFIG: IHubConfig = {
+  logLevel: "info",
+};
+
+// the global variable name that consumers use to override the defaults
+const GLOBAL_VARIABLE_NAME = "arcgisHubConfig";
+
+// NOTE: we want to move to a config that is read-only
+// once it has been initialized from the above global variable
+// see https://devtopia.esri.com/dc/hub/issues/10713#issuecomment-5337749
+// but for now we have to support the deprecated Logger.setLogLevel()
+// so we need these temporary functions to get/set config settings
+
+export const _getConfigSetting = (key: keyof IHubConfig) => {
+  const config = {
+    ...DEFAULT_CONFIG,
+    ...(globalThis as any)[GLOBAL_VARIABLE_NAME],
+  } as IHubConfig;
+  return config && config[key];
+};
+
+export const _setConfigSetting = (key: keyof IHubConfig, value: any) => {
+  const config = (globalThis as any)[GLOBAL_VARIABLE_NAME] as IHubConfig;
+  if (!config) {
+    (globalThis as any)[GLOBAL_VARIABLE_NAME] = {};
+  }
+  (globalThis as any)[GLOBAL_VARIABLE_NAME][key] = value;
+};
+
+// TODO: once we remove Logger.setLogLevel() we should
+// replace the above functions with the following:
+
+// merge consumer supplied config (if any) with the defaults
+// const config = {
+//   ...DEFAULT_CONFIG,
+//   ...(globalThis as any)[GLOBAL_VARIABLE_NAME]
+// } as IHubConfig;
+
+// export the settings as immutable consts
+// export const logLevel = config.logLevel;

--- a/packages/common/src/utils/logger.ts
+++ b/packages/common/src/utils/logger.ts
@@ -1,5 +1,8 @@
 /* tslint:disable no-console */
+import { _setConfigSetting, _getConfigSetting } from "./internal/config";
 
+// TODO: stop exporting this at the next breaking change
+// only exporting for backward compatibility
 /**
  * Enum for Logger Levels
  */
@@ -9,12 +12,12 @@ export enum Level {
   info,
   warn,
   error,
-  off
+  off,
 }
 
 /**
  * ```js
- * import { Logger, Level } from '@esri/hub-common'
+ * import { Logger } from '@esri/hub-common'
  * ```
  * Functions share the console interface
  * ```js
@@ -22,7 +25,7 @@ export enum Level {
  * Logger.warn('Watch out!', { threat: 'Charizard' });
  * // etc, etc
  * ```
- * Available logging levels are specified in the Level enum. The hierarchy is as follows:
+ * Available logging levels are specified in the LogLevel type. The hierarchy is as follows:
  * ```
  * off > error > warn > info > debug > all
  * ```
@@ -32,20 +35,17 @@ export enum Level {
  * Logger.info('This message won't log');
  * Logger.error('But this one will!');
  * ```
- * Logger's default level is 'off', so set desired level before use
- * ```js
- * Logger.setLogLevel(Level.all);
- * ```
  */
 export class Logger {
-  private static logLevel = Level.off;
-
+  // TODO: remove this at next breaking change
   /**
+   * DEPRECATED: configure log level with `globalThis.arcgisHubConfig.logLevel` instead
    * Sets the global log level
    * @param {Level} level
    */
   public static setLogLevel(level: Level) {
-    this.logLevel = level;
+    const levelName = Level[level];
+    _setConfigSetting("logLevel", levelName);
   }
 
   /**
@@ -104,6 +104,8 @@ export class Logger {
   }
 
   private static isLevelPermitted(level: Level) {
-    return this.logLevel <= level;
+    const configuredLevel =
+      Level[_getConfigSetting("logLevel") as keyof typeof Level];
+    return configuredLevel <= level;
   }
 }


### PR DESCRIPTION

Issue: https://devtopia.esri.com/dc/hub/issues/10713

affects: @esri/hub-common

1. Description:

Adds `globalThis.arcgisHubConfig` to enable consumers to configure Hub.js before using it. It currently has one setting: `logLevel`, ex:

```js
// in application initialization
const logLevel = isProduction ? 'error' : 'debug'
globalThis.arcgisHubConfig = { logLevel }
// start using Hub.js
```

See https://devtopia.esri.com/dc/hub/issues/10713#issuecomment-5337749 for more details.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
