### PR TITLE
fix: add maxItems to ENTITY_CATEGORIES_SCHEMA

### DIFF
--- a/packages/common/src/core/schemas/shared/subschemas.ts
+++ b/packages/common/src/core/schemas/shared/subschemas.ts
@@ -42,6 +42,7 @@ export const ENTITY_CATEGORIES_SCHEMA: JSONSchema = {
   items: {
     type: "string",
   },
+  maxItems: 20,
 };
 
 export const ENTITY_IS_DISCUSSABLE_SCHEMA = {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: add maxItems to ENTITY_CATEGORIES_SCHEMA

1. Instructions for testing:

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/12257

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
