### PR TITLE
fix: add displayConfig to CollectionSchema

### DIFF
--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -12,7 +12,15 @@ export const GalleryDisplayConfigSchema: IConfigurationSchema = {
     hidden: { type: "boolean", default: false },
     layout: {
       type: "string",
-      enum: ["list", "grid", "table", "map", "compact"],
+      enum: [
+        "list",
+        "grid",
+        "grid-filled",
+        "table",
+        "map",
+        "compact",
+        "calendar",
+      ],
       default: "list",
     },
     cardTitleTag: {

--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -2,6 +2,85 @@ import { EntityType, targetEntities } from "../../../search/types/IHubCatalog";
 import { IConfigurationSchema } from "../types";
 import { CARD_TITLE_TAGS, CORNERS, DROP_SHADOWS } from "./enums";
 
+/**
+ * JSON schema for the appearance of a gallery display
+ * This can be for a catalog, a collection, a gallery card, etc
+ */
+export const GalleryDisplayConfigSchema: IConfigurationSchema = {
+  type: "object",
+  properties: {
+    hidden: { type: "boolean", default: false },
+    layout: {
+      type: "string",
+      enum: ["list", "grid", "table", "map", "compact"],
+      default: "list",
+    },
+    cardTitleTag: {
+      type: "string",
+      enum: Object.keys(CARD_TITLE_TAGS),
+      default: CARD_TITLE_TAGS.h3,
+    },
+    showThumbnail: {
+      type: "string",
+      enum: ["show", "hide", "grid"],
+      default: "show",
+    },
+    corners: {
+      type: "string",
+      enum: Object.keys(CORNERS),
+      default: CORNERS.square,
+    },
+    shadow: {
+      type: "string",
+      enum: Object.keys(DROP_SHADOWS),
+      default: DROP_SHADOWS.none,
+    },
+    showLinkButton: { type: "boolean", default: false },
+    linkButtonStyle: {
+      type: "string",
+      enum: ["outline", "outline-filled"],
+      default: "outline-filled",
+    },
+    linkButtonText: { type: "string", default: "Explore" },
+    sort: {
+      type: "string",
+      enum: ["relevance", "title", "created", "modified"],
+      default: "relevance",
+    },
+    filters: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          key: {
+            type: "string",
+            enum: [
+              "location",
+              "type",
+              "source",
+              "event-occurrence",
+              "event-from",
+              "event-attendance",
+              "tags",
+              "categories",
+              "license",
+              "modified",
+              "access",
+              "group-role",
+              "group-type",
+              "group-access",
+              "event-access",
+              "event-date",
+            ],
+          },
+          hidden: { type: "boolean" },
+          label: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
 /** JSON schema for an IPredicate */
 export const PredicateSchema: IConfigurationSchema = {
   type: "object",
@@ -53,52 +132,7 @@ export const CollectionSchema: IConfigurationSchema = {
       type: "string",
     },
     scope: QuerySchema,
-    displayConfig: {
-      type: "object",
-    },
-  },
-};
-
-/**
- * JSON schema for the appearance of a gallery display
- * This can be for a catalog, a collection, a gallery card, etc
- */
-export const GalleryDisplayConfigSchema: IConfigurationSchema = {
-  type: "object",
-  properties: {
-    hidden: { type: "boolean", default: false },
-    layout: {
-      type: "string",
-      enum: ["list", "grid", "table", "map", "compact"],
-      default: "list",
-    },
-    cardTitleTag: {
-      type: "string",
-      enum: Object.keys(CARD_TITLE_TAGS),
-      default: CARD_TITLE_TAGS.h3,
-    },
-    showThumbnail: {
-      type: "string",
-      enum: ["show", "hide", "grid"],
-      default: "show",
-    },
-    corners: {
-      type: "string",
-      enum: Object.keys(CORNERS),
-      default: CORNERS.square,
-    },
-    shadow: {
-      type: "string",
-      enum: Object.keys(DROP_SHADOWS),
-      default: DROP_SHADOWS.none,
-    },
-    showLinkButton: { type: "boolean", default: false },
-    linkButtonStyle: {
-      type: "string",
-      enum: ["outline", "outline-filled"],
-      default: "outline-filled",
-    },
-    linkButtonText: { type: "string", default: "Explore" },
+    displayConfig: GalleryDisplayConfigSchema,
   },
 };
 
@@ -123,16 +157,6 @@ export const CatalogSchema: IConfigurationSchema = {
       type: "array",
       items: CollectionSchema,
     },
-    displayConfig: GalleryDisplayConfigSchema,
-  },
-};
-
-/**
- * JSON schema for the appearance of an IHubCollection
- */
-export const CollectionAppearanceSchema: IConfigurationSchema = {
-  type: "object",
-  properties: {
     displayConfig: GalleryDisplayConfigSchema,
   },
 };

--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -157,6 +157,15 @@ export const CatalogSchema: IConfigurationSchema = {
       type: "array",
       items: CollectionSchema,
     },
-    displayConfig: GalleryDisplayConfigSchema,
+    displayConfig: {
+      type: "object",
+      properties: targetEntities.reduce(
+        (acc: Record<EntityType, any>, targetEntity: EntityType) => {
+          acc[targetEntity] = GalleryDisplayConfigSchema;
+          return acc;
+        },
+        {} as Record<EntityType, any>
+      ),
+    },
   },
 };

--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -53,6 +53,9 @@ export const CollectionSchema: IConfigurationSchema = {
       type: "string",
     },
     scope: QuerySchema,
+    displayConfig: {
+      type: "object",
+    },
   },
 };
 

--- a/packages/common/src/search/Catalog.ts
+++ b/packages/common/src/search/Catalog.ts
@@ -22,7 +22,7 @@ import {
   IQuery,
   IFilter,
   IHubCollection,
-  IGalleryDisplayConfig,
+  ICatalogDisplayConfig,
 } from "./types";
 import { upgradeCatalogSchema } from "./upgradeCatalogSchema";
 
@@ -132,7 +132,7 @@ export class Catalog implements IHubCatalog {
   /**
    * Return the display configuration for the gallery
    */
-  get displayConfig(): IGalleryDisplayConfig {
+  get displayConfig(): ICatalogDisplayConfig {
     return this._catalog.displayConfig;
   }
 

--- a/packages/common/src/search/types/IHubCatalog.ts
+++ b/packages/common/src/search/types/IHubCatalog.ts
@@ -44,11 +44,13 @@ export interface IHubCatalog {
   /**
    * Optional display configuration to control a catalog's appearance in the UI
    */
-  displayConfig?: Partial<Record<EntityType, IGalleryDisplayConfig>>;
+  displayConfig?: ICatalogDisplayConfig;
 }
 
 export interface ICatalogScope extends Partial<Record<EntityType, IQuery>> {}
 
+export interface ICatalogDisplayConfig
+  extends Partial<Record<EntityType, IGalleryDisplayConfig>> {}
 export interface IHubCollection {
   /**
    * String to show in the UI. translated.

--- a/packages/common/src/search/types/IHubCatalog.ts
+++ b/packages/common/src/search/types/IHubCatalog.ts
@@ -44,7 +44,7 @@ export interface IHubCatalog {
   /**
    * Optional display configuration to control a catalog's appearance in the UI
    */
-  displayConfig?: IGalleryDisplayConfig;
+  displayConfig?: Partial<Record<EntityType, IGalleryDisplayConfig>>;
 }
 
 export interface ICatalogScope extends Partial<Record<EntityType, IQuery>> {}

--- a/packages/common/test/search/Catalog.test.ts
+++ b/packages/common/test/search/Catalog.test.ts
@@ -97,14 +97,16 @@ const catalogJson: IHubCatalog = {
     },
   ],
   displayConfig: {
-    hidden: false,
-    showThumbnail: "show",
-    showLinkButton: true,
-    linkButtonStyle: "outline",
-    linkButtonText: "Explore",
-    corners: CORNERS.square,
-    shadow: DROP_SHADOWS.none,
-    layout: "list",
+    item: {
+      hidden: false,
+      showThumbnail: "show",
+      showLinkButton: true,
+      linkButtonStyle: "outline",
+      linkButtonText: "Explore",
+      corners: CORNERS.square,
+      shadow: DROP_SHADOWS.none,
+      layout: "list",
+    },
   },
 };
 
@@ -168,9 +170,7 @@ describe("Catalog Class:", () => {
       instance.title = "Changed Title";
       expect(instance.title).toBe("Changed Title");
       expect(instance.availableScopes).toEqual(["item", "group", "user"]);
-      expect(instance.displayConfig).toEqual(
-        catalogJson.displayConfig as IGalleryDisplayConfig
-      );
+      expect(instance.displayConfig).toEqual(catalogJson.displayConfig);
     });
     it("allows null scopes", () => {
       const instance = Catalog.fromJson(cloneObject(noScopeCatalog), context);


### PR DESCRIPTION
[12663](https://devtopia.esri.com/dc/hub/issues/12663)

### Description
- adds `sort` and `filters` to the `GalleryDisplayConfigSchema`
- adds `displayConfig` to `CollectionSchema`
- fix catalog `displayConfig` interface and schema
  - Note: it appears that at some point (presumably, when the UI got refactored), we started persisting the top-level catalog `displayConfig` by `targetEntity`. This was never updated in the interface or schema.

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.