### PR TITLE
feat(hub-common): restrict v2 channel delete to org admins or channel permission OWNER roles

### DIFF
--- a/docs/src/guides/functional/discussions-v2.md
+++ b/docs/src/guides/functional/discussions-v2.md
@@ -433,7 +433,7 @@ In the `@esri/hub-discussions` library, authentication is handled using the fami
 
 A user's access to content stored in the Discussions API is determined by their platform identity -- that is their organization and group memberships and manage roles. As noted above, ArcGIS Online access and permissions are encoded in Channels. Currently, most API methods employ one or many checks comparing Channel specs to the requesting user's identity.
 
-A summary of authorization checks are in the table below (source code: [channels](https://github.com/Esri/hub.js/blob/master/packages/discussions/src/utils/channels/index.ts), [posts](https://github.com/Esri/hub.js/blob/master/packages/discussions/src/utils/channels/index.ts)):
+A summary of authorization checks are in the table below (source code: [channels](https://github.com/Esri/hub.js/blob/master/packages/common/src/discussions/api/utils/channels/index.ts), [posts](https://github.com/Esri/hub.js/blob/master/packages/common/src/discussions/api/utils/posts/index.ts)):
 
 | **Permission** | **Description** |
 | :------------- | :-------------- |

--- a/jasmine.json
+++ b/jasmine.json
@@ -1,6 +1,6 @@
 {
   "spec_dir": "packages",
-  "spec_files": ["**/discussions/api/**/*.test.ts"],
+  "spec_files": ["*/test/**/*.test.ts"],
   "helpers": ["../support/test-helpers.js"],
   "stopSpecOnExpectationFailure": false,
   "random": false

--- a/jasmine.json
+++ b/jasmine.json
@@ -1,6 +1,6 @@
 {
   "spec_dir": "packages",
-  "spec_files": ["*/test/**/*.test.ts"],
+  "spec_files": ["**/discussions/api/**/*.test.ts"],
   "helpers": ["../support/test-helpers.js"],
   "stopSpecOnExpectationFailure": false,
   "random": false

--- a/packages/common/src/discussions/api/utils/channel-permission.ts
+++ b/packages/common/src/discussions/api/utils/channel-permission.ts
@@ -506,9 +506,6 @@ function channelActionLookup(action: ChannelAction): Role[] {
     return [Role.WRITE, Role.READWRITE, Role.MODERATE, Role.MANAGE, Role.OWNER];
   }
 
-  if (action === ChannelAction.READ_POSTS) {
-    return [Role.READ, Role.READWRITE, Role.MODERATE, Role.MANAGE, Role.OWNER];
-  }
   if (action === ChannelAction.MODERATE_CHANNEL) {
     return [Role.MODERATE, Role.MANAGE, Role.OWNER];
   }
@@ -529,4 +526,7 @@ function channelActionLookup(action: ChannelAction): Role[] {
   if (action === ChannelAction.IS_OWNER) {
     return [Role.OWNER];
   }
+
+  // default to read action
+  return [Role.READ, Role.READWRITE, Role.MODERATE, Role.MANAGE, Role.OWNER];
 }

--- a/packages/common/src/discussions/api/utils/channels/can-delete-channel-v2.ts
+++ b/packages/common/src/discussions/api/utils/channels/can-delete-channel-v2.ts
@@ -19,5 +19,5 @@ export function canDeleteChannelV2(
   }
 
   const channelPermission = new ChannelPermission(channel);
-  return channelPermission.canModerateChannel(user as IDiscussionsUser);
+  return channelPermission.canDeleteChannel(user as IDiscussionsUser);
 }

--- a/packages/common/test/discussions/api/utils/channels/can-delete-channel-v2.test.ts
+++ b/packages/common/test/discussions/api/utils/channels/can-delete-channel-v2.test.ts
@@ -1,4 +1,4 @@
-import { IGroup, IUser } from "@esri/arcgis-rest-types";
+import { IUser } from "@esri/arcgis-rest-types";
 import {
   AclCategory,
   IChannel,
@@ -11,22 +11,22 @@ import * as portalPrivModule from "../../../../../src/discussions/api//utils/por
 
 describe("canDeleteChannelV2", () => {
   let hasOrgAdminDeleteRightsSpy: jasmine.Spy;
-  let canModerateChannelSpy: jasmine.Spy;
+  let canDeleteChannelSpy: jasmine.Spy;
 
   beforeAll(() => {
     hasOrgAdminDeleteRightsSpy = spyOn(
       portalPrivModule,
       "hasOrgAdminDeleteRights"
     );
-    canModerateChannelSpy = spyOn(
+    canDeleteChannelSpy = spyOn(
       ChannelPermission.prototype,
-      "canModerateChannel"
+      "canDeleteChannel"
     );
   });
 
   beforeEach(() => {
     hasOrgAdminDeleteRightsSpy.calls.reset();
-    canModerateChannelSpy.calls.reset();
+    canDeleteChannelSpy.calls.reset();
   });
 
   describe("With Org Admin", () => {
@@ -42,7 +42,7 @@ describe("canDeleteChannelV2", () => {
       expect(arg1).toBe(user);
       expect(arg2).toBe(channel.orgId);
 
-      expect(canModerateChannelSpy.calls.count()).toBe(0);
+      expect(canDeleteChannelSpy.calls.count()).toBe(0);
     });
   });
 
@@ -62,7 +62,7 @@ describe("canDeleteChannelV2", () => {
 
     it("return true if channelPermission.canModerateChannel is true", () => {
       hasOrgAdminDeleteRightsSpy.and.callFake(() => false);
-      canModerateChannelSpy.and.callFake(() => true);
+      canDeleteChannelSpy.and.callFake(() => true);
 
       const user = {} as IDiscussionsUser;
       const channel = {
@@ -72,14 +72,14 @@ describe("canDeleteChannelV2", () => {
 
       expect(canDeleteChannelV2(channel, user)).toBe(true);
 
-      expect(canModerateChannelSpy.calls.count()).toBe(1);
-      const [arg1] = canModerateChannelSpy.calls.allArgs()[0]; // args for 1st call
+      expect(canDeleteChannelSpy.calls.count()).toBe(1);
+      const [arg1] = canDeleteChannelSpy.calls.allArgs()[0]; // args for 1st call
       expect(arg1).toBe(user);
     });
 
     it("return false if channelPermission.canModerateChannel is false", () => {
       hasOrgAdminDeleteRightsSpy.and.callFake(() => false);
-      canModerateChannelSpy.and.callFake(() => false);
+      canDeleteChannelSpy.and.callFake(() => false);
 
       const user = {} as IDiscussionsUser;
       const channel = {
@@ -89,14 +89,14 @@ describe("canDeleteChannelV2", () => {
 
       expect(canDeleteChannelV2(channel, user)).toBe(false);
 
-      expect(canModerateChannelSpy.calls.count()).toBe(1);
-      const [arg1] = canModerateChannelSpy.calls.allArgs()[0]; // args for 1st call
+      expect(canDeleteChannelSpy.calls.count()).toBe(1);
+      const [arg1] = canDeleteChannelSpy.calls.allArgs()[0]; // args for 1st call
       expect(arg1).toBe(user);
     });
 
     it("return false if channelPermission.canModerateChannel is false and user is undefined", () => {
       hasOrgAdminDeleteRightsSpy.and.callFake(() => false);
-      canModerateChannelSpy.and.callFake(() => false);
+      canDeleteChannelSpy.and.callFake(() => false);
 
       const user = undefined as unknown as IUser;
       const channel = {
@@ -106,8 +106,8 @@ describe("canDeleteChannelV2", () => {
 
       expect(canDeleteChannelV2(channel, user)).toBe(false);
 
-      expect(canModerateChannelSpy.calls.count()).toBe(1);
-      const [arg1] = canModerateChannelSpy.calls.allArgs()[0]; // args for 1st call
+      expect(canDeleteChannelSpy.calls.count()).toBe(1);
+      const [arg1] = canDeleteChannelSpy.calls.allArgs()[0]; // args for 1st call
       expect(arg1).toEqual({});
     });
   });


### PR DESCRIPTION
Issue [12475](https://devtopia.esri.com/dc/hub/issues/12475)

1. Description: Modify the v2 channel delete permissions check to verify user is org_admin or owner within the defined channelAcl

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
