### PR TITLE
fix: update schemas to require catalog scope

### DIFF
--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -105,6 +105,7 @@ export const FilterSchema: IConfigurationSchema = {
     predicates: {
       type: "array",
       items: PredicateSchema,
+      minItems: 1,
     },
   },
 };

--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -104,12 +104,6 @@ export const FilterSchema: IConfigurationSchema = {
     },
     predicates: {
       type: "array",
-      // TODO: uncomment this once site catalogs have been migrated
-      // to the new catalog structure. This is too difficult to work
-      // around for now, and isn't currently doing much in the UI.
-      // Eventually, we'll want to use this to render an error message
-      // if a predicate hasn't been fully configured
-      // minItems: 1,
       items: PredicateSchema,
     },
   },
@@ -127,6 +121,7 @@ export const QuerySchema: IConfigurationSchema = {
     filters: {
       type: "array",
       items: FilterSchema,
+      minItems: 1,
     },
   },
 };


### PR DESCRIPTION
[12620](https://devtopia.esri.com/dc/hub/issues/12620)

### Description
Update catalog schemas to require at least 1 filter and predicate

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.