### PR TITLE
feat(hub-common): update organization entity and search results to ha…

### DIFF
--- a/packages/common/src/core/types/IHubCardViewModel.ts
+++ b/packages/common/src/core/types/IHubCardViewModel.ts
@@ -60,6 +60,7 @@ export interface ICardActionLink {
   showLabel?: boolean;
   icon?: string;
   buttonStyle?: "outline" | "outline-fill" | "solid" | "transparent";
+  buttonKind?: "brand" | "danger" | "inverse" | "neutral";
   disabled?: boolean;
   tooltip?: string;
 }

--- a/packages/common/src/org/fetch.ts
+++ b/packages/common/src/org/fetch.ts
@@ -26,13 +26,12 @@ export async function fetchOrganization(
 }
 
 /**
- * Convert an IHubOrganization to an IHubSearchResult
- * @param org
+ * Convert an IPortal to an IHubSearchResult
+ * @param portal
  * @returns
  */
-export function organizationToSearchResult(
-  org: IHubOrganization
-): IHubSearchResult {
+export function portalToSearchResult(portal: IPortal): IHubSearchResult {
+  const org = portalToOrganization(portal);
   // simple transform
   return {
     id: org.id,
@@ -52,6 +51,7 @@ export function organizationToSearchResult(
     access: org.access,
     tags: org.tags,
     typeKeywords: org.typeKeywords,
+    links: org.links,
   };
 }
 
@@ -86,6 +86,10 @@ export function portalToOrganization(
     thumbnail: portal.thumbnail,
     thumbnailUrl: getOrgThumbnailUrl(portal, token),
     url: portalUrl,
+    links: {
+      self: portalUrl,
+      thumbnail: getOrgThumbnailUrl(portal, token),
+    },
     // Props needed to be a HubEntity, but which don't apply to a portal
     typeKeywords: [],
     tags: [],

--- a/packages/common/src/search/_internal/portalFetchOrgs.ts
+++ b/packages/common/src/search/_internal/portalFetchOrgs.ts
@@ -1,5 +1,5 @@
-import { IHubOrganization } from "../../core";
-import { fetchOrg, organizationToSearchResult } from "../../org";
+import { IPortal } from "@esri/arcgis-rest-portal";
+import { fetchOrg, portalToSearchResult } from "../../org";
 import { failSafe } from "../../utils";
 import { batch } from "../../utils/batch";
 import { getPredicateValues } from "../getPredicateValues";
@@ -35,14 +35,14 @@ export async function portalFetchOrgs(
     return failSafeFetchOrg(id, options.requestOptions);
   };
   // fetch the orgs and remove any nulls from the failsafe
-  const results = (
-    (await batch(ids, fetchOrgFn, 8)) as IHubOrganization[]
-  ).filter((org) => org !== null);
+  const results = ((await batch(ids, fetchOrgFn, 8)) as IPortal[]).filter(
+    (org) => org !== null
+  );
   // convert to a search result
   return {
     total: results.length,
     hasNext: false,
     next: null,
-    results: results.map((org) => organizationToSearchResult(org)),
+    results: results.map((org) => portalToSearchResult(org)),
   };
 }

--- a/packages/common/test/org/fetch.test.ts
+++ b/packages/common/test/org/fetch.test.ts
@@ -3,49 +3,39 @@ import {
   cloneObject,
   fetchOrganization,
   IHubOrganization,
-  organizationToSearchResult,
+  portalToSearchResult,
 } from "../../src";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 
 describe("HubOrganizations", () => {
   describe("convert to searchResult", () => {
     it("converts", () => {
-      const org: IHubOrganization = {
-        id: "123",
-        orgId: "123",
-        access: "public",
-        name: "name",
-        summary: "summary",
-        description: "description",
+      const result = portalToSearchResult(PORTAL);
+      expect(result).toEqual({
+        id: "Xj56SBi2udA78cC9",
+        title: "QA Premium Alpha Hub",
+        name: "QA Premium Alpha Hub",
+        url: "https://qa-pre-a-hub.mapsqa.arcgis.com",
         type: "Organization",
+        family: "organization",
         source: "portal",
-        createdDate: new Date(),
+        createdDate: new Date(PORTAL.created),
         createdDateSource: "portal",
-        updatedDate: new Date(),
+        updatedDate: new Date(PORTAL.modified),
         updatedDateSource: "portal",
-        thumbnail: "thumbnail",
-        url: "url",
-        thumbnailUrl: "thumbnailUrl",
-        portal: {} as IPortal,
-        tags: ["tag"],
-        typeKeywords: ["typeKeyword"],
-      };
-      const result = organizationToSearchResult(org);
-      expect(result.id).toBe(org.id);
-      expect(result.title).toBe(org.name);
-      expect(result.name).toBe(org.name);
-      expect(result.url).toBe(org.url);
-      expect(result.type).toBe("Organization");
-      expect(result.family).toBe("organization");
-      expect(result.source).toBe("portal");
-      expect(result.createdDate).toBe(org.createdDate);
-      expect(result.createdDateSource).toBe(org.createdDateSource);
-      expect(result.updatedDate).toBe(org.updatedDate);
-      expect(result.updatedDateSource).toBe(org.updatedDateSource);
-      expect(result.thumbnailUrl).toBe(org.thumbnailUrl);
-      expect(result.thumbnail).toBe(org.thumbnail);
-      expect(result.description).toBe(org.description);
-      expect(result.access).toBe(org.access);
+        thumbnailUrl:
+          "https://qa-pre-a-hub.mapsqa.arcgis.com/sharing/rest/portals/Xj56SBi2udA78cC9/resources/thumbnail1707251441205.png",
+        thumbnail: "thumbnail1707251441205.png",
+        description: "<br>",
+        access: "public",
+        tags: [],
+        typeKeywords: [],
+        links: {
+          self: "https://qa-pre-a-hub.mapsqa.arcgis.com",
+          thumbnail:
+            "https://qa-pre-a-hub.mapsqa.arcgis.com/sharing/rest/portals/Xj56SBi2udA78cC9/resources/thumbnail1707251441205.png",
+        },
+      });
     });
   });
   describe("fetchOrganization", () => {


### PR DESCRIPTION
…ve links

affects: @esri/hub-common

1. Description:

- Adds `links` prop to organization entity & search results so card title links work
- Adds additional `buttonKind` prop to `ICardActionLink` so action link buttons `kind` property can be changed

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. x ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
