### PR TITLE
fix: fix peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65003,7 +65003,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.41.0",
+			"version": "15.41.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65038,14 +65038,14 @@
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.38.0",
+				"@esri/hub-common": "^15.41.3",
 				"@types/geojson": "^7946.0.7",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.14.0 || 3",
 				"@esri/arcgis-rest-request": "^2.14.0 || 3",
-				"@esri/hub-common": "^15.38.0"
+				"@esri/hub-common": "^15.41.3"
 			}
 		},
 		"packages/downloads": {
@@ -65057,7 +65057,7 @@
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65065,7 +65065,7 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.7.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^15.41.3"
 			}
 		},
 		"packages/events": {
@@ -65076,7 +65076,7 @@
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65085,7 +65085,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^15.41.3"
 			}
 		},
 		"packages/initiatives": {
@@ -65096,7 +65096,7 @@
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -65104,7 +65104,7 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^15.41.3"
 			}
 		},
 		"packages/search": {
@@ -65115,7 +65115,7 @@
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -65126,7 +65126,7 @@
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^15.41.3"
 			}
 		},
 		"packages/sites": {
@@ -65137,18 +65137,18 @@
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
-				"@esri/hub-initiatives": "^15.0.0",
-				"@esri/hub-teams": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
+				"@esri/hub-initiatives": "^15.0.1",
+				"@esri/hub-teams": "^15.0.1",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0",
-				"@esri/hub-initiatives": "^15.0.0",
-				"@esri/hub-teams": "^15.0.0"
+				"@esri/hub-common": "^15.41.3",
+				"@esri/hub-initiatives": "^15.0.1",
+				"@esri/hub-teams": "^15.0.1"
 			}
 		},
 		"packages/surveys": {
@@ -65159,7 +65159,7 @@
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65168,7 +65168,7 @@
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^15.41.3"
 			}
 		},
 		"packages/teams": {
@@ -65179,7 +65179,7 @@
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65187,7 +65187,7 @@
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/arcgis-rest-types": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^15.41.3"
 			}
 		}
 	},
@@ -68763,7 +68763,7 @@
 		"@esri/hub-discussions": {
 			"version": "file:packages/discussions",
 			"requires": {
-				"@esri/hub-common": "^15.38.0",
+				"@esri/hub-common": "^15.41.3",
 				"@types/geojson": "^7946.0.7",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68772,7 +68772,7 @@
 		"@esri/hub-downloads": {
 			"version": "file:packages/downloads",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68781,7 +68781,7 @@
 		"@esri/hub-events": {
 			"version": "file:packages/events",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68789,7 +68789,7 @@
 		"@esri/hub-initiatives": {
 			"version": "file:packages/initiatives",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68798,7 +68798,7 @@
 		"@esri/hub-search": {
 			"version": "file:packages/search",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -68808,9 +68808,9 @@
 		"@esri/hub-sites": {
 			"version": "file:packages/sites",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
-				"@esri/hub-initiatives": "^15.0.0",
-				"@esri/hub-teams": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
+				"@esri/hub-initiatives": "^15.0.1",
+				"@esri/hub-teams": "^15.0.1",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68818,7 +68818,7 @@
 		"@esri/hub-surveys": {
 			"version": "file:packages/surveys",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68826,7 +68826,7 @@
 		"@esri/hub-teams": {
 			"version": "file:packages/teams",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^15.41.3",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/discussions/package.json
+++ b/packages/discussions/package.json
@@ -13,10 +13,10 @@
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.14.0 || 3",
     "@esri/arcgis-rest-request": "^2.14.0 || 3",
-    "@esri/hub-common": "^15.38.0"
+    "@esri/hub-common": "^15.41.3"
   },
   "devDependencies": {
-    "@esri/hub-common": "^15.38.0",
+    "@esri/hub-common": "^15.41.3",
     "@types/geojson": "^7946.0.7",
     "typescript": "^3.8.1"
   },

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -16,10 +16,10 @@
     "@esri/arcgis-rest-feature-layer": "^3.1.0",
     "@esri/arcgis-rest-portal": "^3.7.0",
     "@esri/arcgis-rest-request": "^3.1.0",
-    "@esri/hub-common": "^15.0.0"
+    "@esri/hub-common": "^15.41.3"
   },
   "devDependencies": {
-    "@esri/hub-common": "^15.0.0",
+    "@esri/hub-common": "^15.41.3",
     "typescript": "^3.8.1"
   },
   "files": [

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -16,10 +16,10 @@
     "@esri/arcgis-rest-portal": "^2.15.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "^15.0.0"
+    "@esri/hub-common": "^15.41.3"
   },
   "devDependencies": {
-    "@esri/hub-common": "^15.0.0",
+    "@esri/hub-common": "^15.41.3",
     "typescript": "^3.8.1"
   },
   "files": [

--- a/packages/initiatives/package.json
+++ b/packages/initiatives/package.json
@@ -14,10 +14,10 @@
     "@esri/arcgis-rest-auth": "^2.13.0 || 3",
     "@esri/arcgis-rest-portal": "^2.13.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
-    "@esri/hub-common": "^15.0.0"
+    "@esri/hub-common": "^15.41.3"
   },
   "devDependencies": {
-    "@esri/hub-common": "^15.0.0",
+    "@esri/hub-common": "^15.41.3",
     "blob": "0.0.4",
     "typescript": "^3.8.1"
   },

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -16,10 +16,10 @@
     "@esri/arcgis-rest-portal": "^2.6.1 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "^15.0.0"
+    "@esri/hub-common": "^15.41.3"
   },
   "devDependencies": {
-    "@esri/hub-common": "^15.0.0",
+    "@esri/hub-common": "^15.41.3",
     "@types/faker": "^5.1.5",
     "faker": "^5.1.0",
     "typescript": "^3.8.1"

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -14,14 +14,14 @@
     "@esri/arcgis-rest-auth": "^2.13.0 || 3",
     "@esri/arcgis-rest-portal": "^2.19.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
-    "@esri/hub-common": "^15.0.0",
-    "@esri/hub-initiatives": "^15.0.0",
-    "@esri/hub-teams": "^15.0.0"
+    "@esri/hub-common": "^15.41.3",
+    "@esri/hub-initiatives": "^15.0.1",
+    "@esri/hub-teams": "^15.0.1"
   },
   "devDependencies": {
-    "@esri/hub-common": "^15.0.0",
-    "@esri/hub-initiatives": "^15.0.0",
-    "@esri/hub-teams": "^15.0.0",
+    "@esri/hub-common": "^15.41.3",
+    "@esri/hub-initiatives": "^15.0.1",
+    "@esri/hub-teams": "^15.0.1",
     "typescript": "^3.8.1"
   },
   "files": [

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -16,10 +16,10 @@
     "@esri/arcgis-rest-portal": "^2.13.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "^15.0.0"
+    "@esri/hub-common": "^15.41.3"
   },
   "devDependencies": {
-    "@esri/hub-common": "^15.0.0",
+    "@esri/hub-common": "^15.41.3",
     "typescript": "^3.8.1"
   },
   "files": [

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -15,10 +15,10 @@
     "@esri/arcgis-rest-portal": "^2.15.0 || 3",
     "@esri/arcgis-rest-request": "^2.13.0 || 3",
     "@esri/arcgis-rest-types": "^2.13.0 || 3",
-    "@esri/hub-common": "^15.0.0"
+    "@esri/hub-common": "^15.41.3"
   },
   "devDependencies": {
-    "@esri/hub-common": "^15.0.0",
+    "@esri/hub-common": "^15.41.3",
     "typescript": "^3.8.1"
   },
   "files": [


### PR DESCRIPTION
affects: @esri/hub-discussions, @esri/hub-downloads, @esri/hub-events, @esri/hub-initiatives, @esri/hub-search, @esri/hub-sites, @esri/hub-surveys, @esri/hub-teams

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
