### PR TITLE
fix: add minProperties validation to catalog schemas

### DIFF
--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -92,11 +92,13 @@ export const GalleryDisplayConfigSchema: IConfigurationSchema = {
 /** JSON schema for an IPredicate */
 export const PredicateSchema: IConfigurationSchema = {
   type: "object",
+  minProperties: 1,
 };
 
 /** JSON schema for an IFilter */
 export const FilterSchema: IConfigurationSchema = {
   type: "object",
+  minProperties: 1,
   properties: {
     operation: {
       type: "string",


### PR DESCRIPTION
[12620](https://devtopia.esri.com/dc/hub/issues/12620)

adds `minProperties` to the `FilterSchema` and `PredicateSchema` for accurate validation in the UI:

- `minProperties` on the `PredicateSchema` provides validation against a config like:
  ```ts
  {
    scopes: {
      [targetEntity]: {
        filters: [ { predicates: [ {} ] } ]
      }
    }
  }
  ```

- `minProperties` on the `FilterSchema` provides validation against a config like: 
  ```ts
  {
    scopes: {
      [targetEntity]: {
        filters: [ {} ]
      }
    }
  }
  ```

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.