### PR TITLE
chore(hub-common): remove use of UserSession in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65009,7 +65009,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.42.0",
+			"version": "15.43.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -833,9 +833,11 @@ describe("ArcGISContext:", () => {
         }
       );
       // flex case where auth does not have clientId
-      const MOCK_AUTH_NO_CLIENTID = new authModule.UserSession({
+      const token = "fake-token";
+      const MOCK_AUTH_NO_CLIENTID = {
+        getToken: () => Promise.resolve(token),
         redirectUri: "https://example-app.com/redirect-uri",
-        token: "fake-token",
+        token,
         tokenExpires: TOMORROW,
         refreshToken: "refreshToken",
         refreshTokenExpires: TOMORROW,
@@ -843,7 +845,7 @@ describe("ArcGISContext:", () => {
         username: "casey",
         password: "123456",
         portal: "https://myorg.maps.arcgis.com/sharing/rest",
-      });
+      } as any;
 
       await ArcGISContextManager.create({
         authentication: MOCK_AUTH_NO_CLIENTID,

--- a/packages/common/test/content/edit.test.ts
+++ b/packages/common/test/content/edit.test.ts
@@ -11,10 +11,9 @@ import {
   updateContent,
 } from "../../src/content/edit";
 import { cloneObject } from "../../src/util";
-import { UserSession } from "@esri/arcgis-rest-auth";
 
 const GUID = "9b77674e43cf4bbd9ecad5189b3f1fdc";
-const myMockAuth = new UserSession({
+const myMockAuth = {
   clientId: "clientId",
   redirectUri: "https://example-app.com/redirect-uri",
   token: "fake-token",
@@ -25,7 +24,7 @@ const myMockAuth = new UserSession({
   username: "casey",
   password: "123456",
   portal: MOCK_HUB_REQOPTS.hubApiUrl,
-});
+} as any;
 
 describe("content editing:", () => {
   beforeAll(() => {

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -10,7 +10,6 @@ import {
   IQuery,
 } from "../../../src";
 
-import { UserSession } from "@esri/arcgis-rest-auth";
 import {
   formatPredicate,
   formatFilterBlock,
@@ -405,7 +404,7 @@ describe("hubSearchItems Module |", () => {
           requestOptions: {
             authentication: {
               token: "abc",
-            } as UserSession,
+            } as any,
           },
         };
 
@@ -427,7 +426,7 @@ describe("hubSearchItems Module |", () => {
           requestOptions: {
             authentication: {
               token: "abc",
-            } as UserSession,
+            } as any,
           },
           num: 9,
         };
@@ -450,7 +449,7 @@ describe("hubSearchItems Module |", () => {
           requestOptions: {
             authentication: {
               token: "abc",
-            } as UserSession,
+            } as any,
           },
           num: 9,
           start: 10,
@@ -474,7 +473,7 @@ describe("hubSearchItems Module |", () => {
           requestOptions: {
             authentication: {
               token: "abc",
-            } as UserSession,
+            } as any,
           },
           num: 9,
           start: 10,
@@ -501,7 +500,7 @@ describe("hubSearchItems Module |", () => {
           requestOptions: {
             authentication: {
               token: "abc",
-            } as UserSession,
+            } as any,
           },
           num: 9,
           start: 10,
@@ -591,7 +590,7 @@ describe("hubSearchItems Module |", () => {
           requestOptions: {
             authentication: {
               token: "abc",
-            } as UserSession,
+            } as any,
           },
         };
         const opendataQuery = cloneObject(baseQuery);

--- a/packages/common/test/sites/test-helpers.test.ts
+++ b/packages/common/test/sites/test-helpers.test.ts
@@ -1,4 +1,4 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
+import { get } from "fetch-mock";
 import { IHubRequestOptions } from "../../src";
 
 export function expectAllCalled(spys: jasmine.Spy[], expect: any) {
@@ -25,10 +25,12 @@ export const getTomorrow = function () {
 
 export const TOMORROW = getTomorrow();
 
-export const MOCK_USER_SESSION = new UserSession({
+const token = "fake-token";
+export const MOCK_USER_SESSION = {
   clientId: "clientId",
+  getToken: () => Promise.resolve(token),
   redirectUri: "https://example-app.com/redirect-uri",
-  token: "fake-token",
+  token,
   tokenExpires: TOMORROW,
   refreshToken: "refreshToken",
   refreshTokenExpires: TOMORROW,
@@ -36,7 +38,7 @@ export const MOCK_USER_SESSION = new UserSession({
   username: "luke",
   password: "teHf0rc3",
   portal: "https://myorg.maps.arcgis.com/sharing/rest",
-});
+} as any;
 
 export const MOCK_HUB_REQOPTS = {
   authentication: MOCK_USER_SESSION,
@@ -49,10 +51,11 @@ export const MOCK_HUB_REQOPTS = {
   hubApiUrl: "https://hubqa.arcgis.com",
 } as unknown as IHubRequestOptions;
 
-export const MOCK_PORTAL_USER_SESSION = new UserSession({
+export const MOCK_PORTAL_USER_SESSION = {
   clientId: "clientId",
+  getToken: () => Promise.resolve(token),
   redirectUri: "https://example-app.com/redirect-uri",
-  token: "fake-token",
+  token,
   tokenExpires: TOMORROW,
   refreshToken: "refreshToken",
   refreshTokenExpires: TOMORROW,
@@ -60,7 +63,7 @@ export const MOCK_PORTAL_USER_SESSION = new UserSession({
   username: "luke",
   password: "teHf0rc3",
   portal: "https://myportal.foo.com/instancename/sharing/rest",
-});
+} as any;
 
 export const MOCK_PORTAL_REQOPTS = {
   authentication: MOCK_PORTAL_USER_SESSION,

--- a/packages/downloads/test/poll-download-metadata.test.ts
+++ b/packages/downloads/test/poll-download-metadata.test.ts
@@ -1,11 +1,10 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
 import { pollDownloadMetadata } from "../src/poll-download-metadata";
 import * as hubPoller from "../src/hub/hub-poll-download-metadata";
 import * as portalPoller from "../src/portal/portal-poll-export-job-status";
 import * as EventEmitter from "eventemitter3";
 
 describe("pollDownloadMetadata", () => {
-  it("handle hub polling", async done => {
+  it("handle hub polling", async (done) => {
     try {
       const mockEventEmitter = new EventEmitter();
       spyOn(mockEventEmitter, "emit");
@@ -23,7 +22,7 @@ describe("pollDownloadMetadata", () => {
         format: "CSV",
         downloadId: "download-id",
         eventEmitter: mockEventEmitter,
-        pollingInterval: 10
+        pollingInterval: 10,
       });
 
       expect(hubPoller.hubPollDownloadMetadata as any).toHaveBeenCalledTimes(1);
@@ -40,8 +39,8 @@ describe("pollDownloadMetadata", () => {
           spatialRefId: "4326",
           geometry: undefined,
           where: undefined,
-          existingFileDate: undefined
-        }
+          existingFileDate: undefined,
+        },
       ]);
     } catch (err) {
       expect(err).toBeUndefined();
@@ -50,14 +49,14 @@ describe("pollDownloadMetadata", () => {
     }
   });
 
-  it("handle portal download", async done => {
-    const authentication = new UserSession({
+  it("handle portal download", async (done) => {
+    const authentication = {
       username: "portal-user",
       portal: "http://portal.com/sharing/rest",
-      token: "123"
-    });
+      token: "123",
+    } as any;
     authentication.getToken = () =>
-      new Promise(resolve => {
+      new Promise((resolve) => {
         resolve("123");
       });
 
@@ -81,7 +80,7 @@ describe("pollDownloadMetadata", () => {
         exportCreated: 1000,
         eventEmitter: mockEventEmitter,
         pollingInterval: 10,
-        authentication
+        authentication,
       });
 
       expect(
@@ -101,8 +100,8 @@ describe("pollDownloadMetadata", () => {
           authentication,
           exportCreated: 1000,
           geometry: undefined,
-          where: undefined
-        }
+          where: undefined,
+        },
       ]);
     } catch (err) {
       expect(err).toBeUndefined();
@@ -111,14 +110,14 @@ describe("pollDownloadMetadata", () => {
     }
   });
 
-  it("handle enterprise download", async done => {
-    const authentication = new UserSession({
+  it("handle enterprise download", async (done) => {
+    const authentication = {
       username: "portal-user",
       portal: "http://portal.com/sharing/rest",
-      token: "123"
-    });
+      token: "123",
+    } as any;
     authentication.getToken = () =>
-      new Promise(resolve => {
+      new Promise((resolve) => {
         resolve("123");
       });
 
@@ -142,7 +141,7 @@ describe("pollDownloadMetadata", () => {
         exportCreated: 1000,
         eventEmitter: mockEventEmitter,
         pollingInterval: 10,
-        authentication
+        authentication,
       });
 
       expect(
@@ -162,8 +161,8 @@ describe("pollDownloadMetadata", () => {
           authentication,
           exportCreated: 1000,
           geometry: undefined,
-          where: undefined
-        }
+          where: undefined,
+        },
       ]);
     } catch (err) {
       expect(err).toBeUndefined();

--- a/packages/downloads/test/portal/portal-export-success-handler.test.ts
+++ b/packages/downloads/test/portal/portal-export-success-handler.test.ts
@@ -1,11 +1,10 @@
 import * as portal from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
 import * as folderHelper from "../../src/portal/portal-get-exports-folder-id";
 import { exportSuccessHandler } from "../../src/portal/portal-export-success-handler";
 import * as EventEmitter from "eventemitter3";
 
 function delay(milliseconds: number) {
-  return new Promise(resolve => setTimeout(resolve, milliseconds));
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 class RestJsError extends Error {
@@ -18,18 +17,18 @@ class RestJsError extends Error {
 }
 
 describe("portalPollExportJobStatus", () => {
-  const authentication = new UserSession({
+  const authentication = {
     username: "portal-user",
     portal: "http://portal.com/sharing/rest",
-    token: "123"
-  });
+    token: "123",
+  } as any;
   authentication.getToken = () =>
-    new Promise(resolve => {
+    new Promise((resolve) => {
       resolve("123");
     });
 
   describe("export-completed handling errors", () => {
-    it("updateItem failure", async done => {
+    it("updateItem failure", async (done) => {
       try {
         spyOn(portal, "updateItem").and.callFake(async () => {
           return Promise.reject(new Error("5xx"));
@@ -45,7 +44,7 @@ describe("portalPollExportJobStatus", () => {
           datasetId: "abcdef0123456789abcdef0123456789_0",
           authentication,
           exportCreated: 1000,
-          eventEmitter: mockEventEmitter
+          eventEmitter: mockEventEmitter,
         });
         throw new Error("should have errored");
       } catch (err) {
@@ -56,23 +55,23 @@ describe("portalPollExportJobStatus", () => {
           {
             item: {
               id: "download-id",
-              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`
+              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`,
             },
-            authentication
-          }
+            authentication,
+          },
         ]);
         expect(portal.removeItem).toHaveBeenCalledTimes(1);
         expect((portal.removeItem as any).calls.first().args).toEqual([
           {
             id: "download-id",
-            authentication
-          }
+            authentication,
+          },
         ]);
         done();
       }
     });
 
-    it("setItemAccess failure", async done => {
+    it("setItemAccess failure", async (done) => {
       try {
         spyOn(portal, "updateItem").and.callFake(async () => {
           return Promise.resolve();
@@ -93,7 +92,7 @@ describe("portalPollExportJobStatus", () => {
           datasetId: "abcdef0123456789abcdef0123456789_0",
           authentication,
           exportCreated: 1000,
-          eventEmitter: mockEventEmitter
+          eventEmitter: mockEventEmitter,
         });
         throw new Error("should have errored");
       } catch (err) {
@@ -103,32 +102,32 @@ describe("portalPollExportJobStatus", () => {
           {
             item: {
               id: "download-id",
-              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`
+              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`,
             },
-            authentication
-          }
+            authentication,
+          },
         ]);
         expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
         expect((portal.setItemAccess as any).calls.first().args).toEqual([
           {
             id: "download-id",
             authentication,
-            access: "private"
-          }
+            access: "private",
+          },
         ]);
         expect(portal.removeItem).toHaveBeenCalledTimes(1);
         expect((portal.removeItem as any).calls.first().args).toEqual([
           {
             id: "download-id",
-            authentication
-          }
+            authentication,
+          },
         ]);
       } finally {
         done();
       }
     });
 
-    it("getExportsFolderId failure", async done => {
+    it("getExportsFolderId failure", async (done) => {
       try {
         spyOn(portal, "updateItem").and.callFake(async () => {
           return Promise.resolve();
@@ -153,7 +152,7 @@ describe("portalPollExportJobStatus", () => {
           datasetId: "abcdef0123456789abcdef0123456789_0",
           authentication,
           exportCreated: 1000,
-          eventEmitter: mockEventEmitter
+          eventEmitter: mockEventEmitter,
         });
         throw new Error("should have errored");
       } catch (err) {
@@ -163,18 +162,18 @@ describe("portalPollExportJobStatus", () => {
           {
             item: {
               id: "download-id",
-              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`
+              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`,
             },
-            authentication
-          }
+            authentication,
+          },
         ]);
         expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
         expect((portal.setItemAccess as any).calls.first().args).toEqual([
           {
             id: "download-id",
             authentication,
-            access: "private"
-          }
+            access: "private",
+          },
         ]);
         expect(folderHelper.getExportsFolderId).toHaveBeenCalledTimes(1);
         expect(
@@ -184,15 +183,15 @@ describe("portalPollExportJobStatus", () => {
         expect((portal.removeItem as any).calls.first().args).toEqual([
           {
             id: "download-id",
-            authentication
-          }
+            authentication,
+          },
         ]);
       } finally {
         done();
       }
     });
 
-    it("moveItem failure", async done => {
+    it("moveItem failure", async (done) => {
       try {
         spyOn(portal, "updateItem").and.callFake(async () => {
           return Promise.resolve();
@@ -221,7 +220,7 @@ describe("portalPollExportJobStatus", () => {
           datasetId: "abcdef0123456789abcdef0123456789_0",
           authentication,
           exportCreated: 1000,
-          eventEmitter: mockEventEmitter
+          eventEmitter: mockEventEmitter,
         });
         throw new Error("should have errored");
       } catch (err) {
@@ -231,18 +230,18 @@ describe("portalPollExportJobStatus", () => {
           {
             item: {
               id: "download-id",
-              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`
+              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`,
             },
-            authentication
-          }
+            authentication,
+          },
         ]);
         expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
         expect((portal.setItemAccess as any).calls.first().args).toEqual([
           {
             id: "download-id",
             authentication,
-            access: "private"
-          }
+            access: "private",
+          },
         ]);
         expect(folderHelper.getExportsFolderId).toHaveBeenCalledTimes(1);
         expect(
@@ -253,15 +252,15 @@ describe("portalPollExportJobStatus", () => {
           {
             itemId: "download-id",
             folderId: "export-folder-id",
-            authentication
-          }
+            authentication,
+          },
         ]);
         expect(portal.removeItem).toHaveBeenCalledTimes(1);
         expect((portal.removeItem as any).calls.first().args).toEqual([
           {
             id: "download-id",
-            authentication
-          }
+            authentication,
+          },
         ]);
       } finally {
         done();
@@ -270,7 +269,7 @@ describe("portalPollExportJobStatus", () => {
   });
 
   describe("exported-completed, successful handling", () => {
-    it("succeeds without moving download", async done => {
+    it("succeeds without moving download", async (done) => {
       try {
         spyOn(portal, "updateItem").and.callFake(async () => {
           return Promise.resolve();
@@ -299,7 +298,7 @@ describe("portalPollExportJobStatus", () => {
           datasetId: "abcdef0123456789abcdef0123456789_0",
           authentication,
           exportCreated: 1000,
-          eventEmitter: mockEventEmitter
+          eventEmitter: mockEventEmitter,
         });
 
         await delay(100);
@@ -308,18 +307,18 @@ describe("portalPollExportJobStatus", () => {
           {
             item: {
               id: "download-id",
-              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`
+              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:undefined`,
             },
-            authentication
-          }
+            authentication,
+          },
         ]);
         expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
         expect((portal.setItemAccess as any).calls.first().args).toEqual([
           {
             id: "download-id",
             authentication,
-            access: "private"
-          }
+            access: "private",
+          },
         ]);
         expect(folderHelper.getExportsFolderId).toHaveBeenCalledTimes(1);
         expect(
@@ -330,8 +329,8 @@ describe("portalPollExportJobStatus", () => {
           {
             itemId: "download-id",
             folderId: "export-folder-id",
-            authentication
-          }
+            authentication,
+          },
         ]);
         expect(portal.removeItem).toHaveBeenCalledTimes(0);
         expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
@@ -340,8 +339,8 @@ describe("portalPollExportJobStatus", () => {
         );
         const {
           detail: {
-            metadata: { downloadId, status, downloadUrl, lastModified }
-          }
+            metadata: { downloadId, status, downloadUrl, lastModified },
+          },
         } = (mockEventEmitter.emit as any).calls.first().args[1];
         expect(downloadId).toEqual("download-id");
         expect(status).toEqual("ready");
@@ -360,17 +359,17 @@ describe("portalPollExportJobStatus", () => {
       }
     });
 
-    it("succeeds with spatialRefId", async done => {
+    it("succeeds with spatialRefId", async (done) => {
       try {
         spyOn(portal, "getItemStatus").and.returnValues(
           new Promise((resolve, reject) => {
             resolve({
-              status: "progress"
+              status: "progress",
             });
           }),
           new Promise((resolve, reject) => {
             resolve({
-              status: "completed"
+              status: "completed",
             });
           })
         );
@@ -403,7 +402,7 @@ describe("portalPollExportJobStatus", () => {
           authentication,
           exportCreated: 1000,
           eventEmitter: mockEventEmitter,
-          spatialRefId: "3857"
+          spatialRefId: "3857",
         });
 
         await delay(100);
@@ -412,18 +411,18 @@ describe("portalPollExportJobStatus", () => {
           {
             item: {
               id: "download-id",
-              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:3857`
+              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:00,modified:1000,spatialRefId:3857`,
             },
-            authentication
-          }
+            authentication,
+          },
         ]);
         expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
         expect((portal.setItemAccess as any).calls.first().args).toEqual([
           {
             id: "download-id",
             authentication,
-            access: "private"
-          }
+            access: "private",
+          },
         ]);
         expect(folderHelper.getExportsFolderId).toHaveBeenCalledTimes(1);
         expect(
@@ -434,8 +433,8 @@ describe("portalPollExportJobStatus", () => {
           {
             itemId: "download-id",
             folderId: "export-folder-id",
-            authentication
-          }
+            authentication,
+          },
         ]);
         expect(portal.removeItem).toHaveBeenCalledTimes(0);
         expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
@@ -444,8 +443,8 @@ describe("portalPollExportJobStatus", () => {
         );
         const {
           detail: {
-            metadata: { downloadId, status, downloadUrl, lastModified }
-          }
+            metadata: { downloadId, status, downloadUrl, lastModified },
+          },
         } = (mockEventEmitter.emit as any).calls.first().args[1];
         expect(downloadId).toEqual("download-id");
         expect(status).toEqual("ready");
@@ -464,17 +463,17 @@ describe("portalPollExportJobStatus", () => {
       }
     });
 
-    it("succeeds with multilayer dataset", async done => {
+    it("succeeds with multilayer dataset", async (done) => {
       try {
         spyOn(portal, "getItemStatus").and.returnValues(
           new Promise((resolve, reject) => {
             resolve({
-              status: "progress"
+              status: "progress",
             });
           }),
           new Promise((resolve, reject) => {
             resolve({
-              status: "completed"
+              status: "completed",
             });
           })
         );
@@ -506,7 +505,7 @@ describe("portalPollExportJobStatus", () => {
           datasetId: "abcdef0123456789abcdef0123456789",
           authentication,
           exportCreated: 1000,
-          eventEmitter: mockEventEmitter
+          eventEmitter: mockEventEmitter,
         });
 
         await delay(100);
@@ -515,18 +514,18 @@ describe("portalPollExportJobStatus", () => {
           {
             item: {
               id: "download-id",
-              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:null,modified:1000,spatialRefId:undefined`
+              typekeywords: `exportItem:abcdef0123456789abcdef0123456789,exportLayer:null,modified:1000,spatialRefId:undefined`,
             },
-            authentication
-          }
+            authentication,
+          },
         ]);
         expect(portal.setItemAccess).toHaveBeenCalledTimes(1);
         expect((portal.setItemAccess as any).calls.first().args).toEqual([
           {
             id: "download-id",
             authentication,
-            access: "private"
-          }
+            access: "private",
+          },
         ]);
         expect(folderHelper.getExportsFolderId).toHaveBeenCalledTimes(1);
         expect(
@@ -537,8 +536,8 @@ describe("portalPollExportJobStatus", () => {
           {
             itemId: "download-id",
             folderId: "export-folder-id",
-            authentication
-          }
+            authentication,
+          },
         ]);
         expect(portal.removeItem).toHaveBeenCalledTimes(0);
         expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
@@ -547,8 +546,8 @@ describe("portalPollExportJobStatus", () => {
         );
         const {
           detail: {
-            metadata: { downloadId, status, downloadUrl, lastModified }
-          }
+            metadata: { downloadId, status, downloadUrl, lastModified },
+          },
         } = (mockEventEmitter.emit as any).calls.first().args[1];
         expect(downloadId).toEqual("download-id");
         expect(status).toEqual("ready");

--- a/packages/downloads/test/portal/portal-get-exports-folder-id.test.ts
+++ b/packages/downloads/test/portal/portal-get-exports-folder-id.test.ts
@@ -1,19 +1,18 @@
 import * as portal from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
 import { getExportsFolderId } from "../../src/portal/portal-get-exports-folder-id";
 
 describe("portalPollExportJobStatus", () => {
-  const authentication = new UserSession({
+  const authentication = {
     username: "portal-user",
     portal: "http://portal.com/sharing/rest",
-    token: "123"
-  });
+    token: "123",
+  } as any;
   authentication.getToken = () =>
-    new Promise(resolve => {
+    new Promise((resolve) => {
       resolve("123");
     });
 
-  it("userContent failure", async done => {
+  it("userContent failure", async (done) => {
     try {
       spyOn(portal, "getUserContent").and.callFake(async () => {
         return Promise.reject(new Error("5xx"));
@@ -25,14 +24,14 @@ describe("portalPollExportJobStatus", () => {
       expect(err.message).toEqual("5xx");
       expect(portal.getUserContent).toHaveBeenCalledTimes(1);
       expect((portal.getUserContent as any).calls.first().args).toEqual([
-        { authentication }
+        { authentication },
       ]);
     } finally {
       done();
     }
   });
 
-  it("createFolder failure", async done => {
+  it("createFolder failure", async (done) => {
     try {
       spyOn(portal, "getUserContent").and.callFake(async () => {
         return Promise.resolve({ folders: [] });
@@ -52,21 +51,21 @@ describe("portalPollExportJobStatus", () => {
       expect(err.message).toEqual("5xx");
       expect(portal.getUserContent).toHaveBeenCalledTimes(1);
       expect((portal.getUserContent as any).calls.first().args).toEqual([
-        { authentication }
+        { authentication },
       ]);
       expect(portal.createFolder).toHaveBeenCalledTimes(1);
       expect((portal.createFolder as any).calls.first().args).toEqual([
         {
           title: "item-exports",
-          authentication
-        }
+          authentication,
+        },
       ]);
     } finally {
       done();
     }
   });
 
-  it("succeeds without existing exports folder", async done => {
+  it("succeeds without existing exports folder", async (done) => {
     try {
       spyOn(portal, "getUserContent").and.callFake(async () => {
         return Promise.resolve({ folders: [] });
@@ -80,14 +79,14 @@ describe("portalPollExportJobStatus", () => {
       expect(result).toBe("export-folder-id");
       expect(portal.getUserContent).toHaveBeenCalledTimes(1);
       expect((portal.getUserContent as any).calls.first().args).toEqual([
-        { authentication }
+        { authentication },
       ]);
       expect(portal.createFolder).toHaveBeenCalledTimes(1);
       expect((portal.createFolder as any).calls.first().args).toEqual([
         {
           title: "item-exports",
-          authentication
-        }
+          authentication,
+        },
       ]);
     } catch (err) {
       expect(err).toEqual(undefined);
@@ -96,7 +95,7 @@ describe("portalPollExportJobStatus", () => {
     }
   });
 
-  it("succeeds with existing exports folder", async done => {
+  it("succeeds with existing exports folder", async (done) => {
     try {
       spyOn(portal, "getUserContent").and.returnValue(
         new Promise((resolve, reject) => {
@@ -104,9 +103,9 @@ describe("portalPollExportJobStatus", () => {
             folders: [
               {
                 id: "export-folder-id",
-                title: "item-exports"
-              }
-            ]
+                title: "item-exports",
+              },
+            ],
           });
         })
       );
@@ -118,7 +117,7 @@ describe("portalPollExportJobStatus", () => {
 
       expect(portal.getUserContent).toHaveBeenCalledTimes(1);
       expect((portal.getUserContent as any).calls.first().args).toEqual([
-        { authentication }
+        { authentication },
       ]);
       expect(portal.createFolder).toHaveBeenCalledTimes(0);
     } catch (err) {

--- a/packages/downloads/test/portal/portal-poll-export-job-status.test.ts
+++ b/packages/downloads/test/portal/portal-poll-export-job-status.test.ts
@@ -1,30 +1,29 @@
 import * as portal from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
 import { portalPollExportJobStatus } from "../../src/portal/portal-poll-export-job-status";
 import * as EventEmitter from "eventemitter3";
 import * as exportHelper from "../../src/portal/portal-export-success-handler";
 import ExportCompletionError from "../../src/portal/portal-export-completion-error";
 function delay(milliseconds: number) {
-  return new Promise(resolve => setTimeout(resolve, milliseconds));
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 describe("portalPollExportJobStatus", () => {
-  const authentication = new UserSession({
+  const authentication = {
     username: "portal-user",
     portal: "http://portal.com/sharing/rest",
-    token: "123"
-  });
+    token: "123",
+  } as any;
   authentication.getToken = () =>
-    new Promise(resolve => {
+    new Promise((resolve) => {
       resolve("123");
     });
 
-  it("handle export failure", async done => {
+  it("handle export failure", async (done) => {
     try {
       spyOn(portal, "getItemStatus").and.callFake(async () => {
         return Promise.resolve({
           status: "failed",
-          statusMessage: "Export failed"
+          statusMessage: "Export failed",
         });
       });
 
@@ -38,7 +37,7 @@ describe("portalPollExportJobStatus", () => {
         authentication,
         exportCreated: 1000,
         pollingInterval: 10,
-        eventEmitter: mockEventEmitter
+        eventEmitter: mockEventEmitter,
       });
       expect(poller.pollTimer !== null).toEqual(true);
       await delay(100);
@@ -48,8 +47,8 @@ describe("portalPollExportJobStatus", () => {
           id: "download-id",
           jobId: "test-id",
           jobType: "export",
-          authentication
-        }
+          authentication,
+        },
       ]);
       expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
       expect((mockEventEmitter.emit as any).calls.first().args).toEqual([
@@ -57,9 +56,9 @@ describe("portalPollExportJobStatus", () => {
         {
           detail: {
             error: new Error("Export failed"),
-            metadata: { status: "error", errors: [new Error("Export failed")] }
-          }
-        }
+            metadata: { status: "error", errors: [new Error("Export failed")] },
+          },
+        },
       ]);
       expect(poller.pollTimer === null).toEqual(true);
     } catch (err) {
@@ -69,7 +68,7 @@ describe("portalPollExportJobStatus", () => {
     }
   });
 
-  it("handle polling error", async done => {
+  it("handle polling error", async (done) => {
     try {
       spyOn(portal, "getItemStatus").and.callFake(async () => {
         return Promise.reject(new Error("Not Found"));
@@ -85,7 +84,7 @@ describe("portalPollExportJobStatus", () => {
         authentication,
         exportCreated: 1000,
         pollingInterval: 10,
-        eventEmitter: mockEventEmitter
+        eventEmitter: mockEventEmitter,
       });
 
       expect(poller.pollTimer !== null).toEqual(true);
@@ -96,8 +95,8 @@ describe("portalPollExportJobStatus", () => {
           id: "download-id",
           jobId: "test-id",
           jobType: "export",
-          authentication
-        }
+          authentication,
+        },
       ]);
       expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
       expect((mockEventEmitter.emit as any).calls.first().args).toEqual([
@@ -105,9 +104,9 @@ describe("portalPollExportJobStatus", () => {
         {
           detail: {
             error: new Error("Not Found"),
-            metadata: { status: "error", errors: [new Error("Not Found")] }
-          }
-        }
+            metadata: { status: "error", errors: [new Error("Not Found")] },
+          },
+        },
       ]);
       expect(poller.pollTimer === null).toEqual(true);
     } catch (err) {
@@ -117,7 +116,7 @@ describe("portalPollExportJobStatus", () => {
     }
   });
 
-  it("handle job incomplete", async done => {
+  it("handle job incomplete", async (done) => {
     try {
       spyOn(portal, "getItemStatus").and.callFake(async () => {
         return Promise.resolve({ status: "in progress" });
@@ -133,7 +132,7 @@ describe("portalPollExportJobStatus", () => {
         authentication,
         exportCreated: 1000,
         pollingInterval: 10,
-        eventEmitter: mockEventEmitter
+        eventEmitter: mockEventEmitter,
       });
 
       expect(poller.pollTimer !== null).toEqual(true);
@@ -144,8 +143,8 @@ describe("portalPollExportJobStatus", () => {
           id: "download-id",
           jobId: "test-id",
           jobType: "export",
-          authentication
-        }
+          authentication,
+        },
       ]);
       expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(0);
       expect(poller.pollTimer === null).toEqual(false);
@@ -158,7 +157,7 @@ describe("portalPollExportJobStatus", () => {
     }
   });
 
-  it("exportSuccessHandler other failure", async done => {
+  it("exportSuccessHandler other failure", async (done) => {
     try {
       spyOn(portal, "getItemStatus").and.callFake(async () => {
         return Promise.resolve({ status: "completed" });
@@ -180,7 +179,7 @@ describe("portalPollExportJobStatus", () => {
         authentication,
         exportCreated: 1000,
         pollingInterval: 10,
-        eventEmitter: mockEventEmitter
+        eventEmitter: mockEventEmitter,
       });
       expect(poller.pollTimer !== null).toEqual(true);
       await delay(100);
@@ -190,8 +189,8 @@ describe("portalPollExportJobStatus", () => {
           id: "download-id",
           jobId: "test-id",
           jobType: "export",
-          authentication
-        }
+          authentication,
+        },
       ]);
       expect(exportHelper.exportSuccessHandler).toHaveBeenCalledTimes(1);
       expect(
@@ -204,8 +203,8 @@ describe("portalPollExportJobStatus", () => {
           exportCreated: 1000,
           format: "CSV",
           spatialRefId: undefined,
-          eventEmitter: mockEventEmitter
-        }
+          eventEmitter: mockEventEmitter,
+        },
       ]);
 
       expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
@@ -214,9 +213,9 @@ describe("portalPollExportJobStatus", () => {
         {
           detail: {
             error: new Error("5xx"),
-            metadata: { status: "error", errors: [new Error("5xx")] }
-          }
-        }
+            metadata: { status: "error", errors: [new Error("5xx")] },
+          },
+        },
       ]);
       expect(poller.pollTimer === null).toEqual(true);
     } catch (err) {
@@ -226,7 +225,7 @@ describe("portalPollExportJobStatus", () => {
     }
   });
 
-  it("exportSuccessHandler other failure", async done => {
+  it("exportSuccessHandler other failure", async (done) => {
     try {
       spyOn(portal, "getItemStatus").and.callFake(async () => {
         return Promise.resolve({ status: "completed" });
@@ -249,7 +248,7 @@ describe("portalPollExportJobStatus", () => {
         authentication,
         exportCreated: 1000,
         pollingInterval: 10,
-        eventEmitter: mockEventEmitter
+        eventEmitter: mockEventEmitter,
       });
       expect(poller.pollTimer !== null).toEqual(true);
       await delay(100);
@@ -259,8 +258,8 @@ describe("portalPollExportJobStatus", () => {
           id: "download-id",
           jobId: "test-id",
           jobType: "export",
-          authentication
-        }
+          authentication,
+        },
       ]);
       expect(exportHelper.exportSuccessHandler).toHaveBeenCalledTimes(1);
       expect(
@@ -273,8 +272,8 @@ describe("portalPollExportJobStatus", () => {
           exportCreated: 1000,
           format: "CSV",
           spatialRefId: undefined,
-          eventEmitter: mockEventEmitter
-        }
+          eventEmitter: mockEventEmitter,
+        },
       ]);
       expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
       expect((mockEventEmitter.emit as any).calls.first().args).toEqual([
@@ -282,9 +281,9 @@ describe("portalPollExportJobStatus", () => {
         {
           detail: {
             error: new Error("5xx"),
-            metadata: { status: "error", errors: [new Error("5xx")] }
-          }
-        }
+            metadata: { status: "error", errors: [new Error("5xx")] },
+          },
+        },
       ]);
       expect(poller.pollTimer === null).toEqual(true);
     } catch (err) {
@@ -294,7 +293,7 @@ describe("portalPollExportJobStatus", () => {
     }
   });
 
-  it("exportSuccessHandler success", async done => {
+  it("exportSuccessHandler success", async (done) => {
     try {
       spyOn(portal, "getItemStatus").and.callFake(async () => {
         return Promise.resolve({ status: "completed" });
@@ -315,7 +314,7 @@ describe("portalPollExportJobStatus", () => {
         authentication,
         exportCreated: 1000,
         pollingInterval: 10,
-        eventEmitter: mockEventEmitter
+        eventEmitter: mockEventEmitter,
       });
       expect(poller.pollTimer !== null).toEqual(true);
       await delay(100);
@@ -325,8 +324,8 @@ describe("portalPollExportJobStatus", () => {
           id: "download-id",
           jobId: "test-id",
           jobType: "export",
-          authentication
-        }
+          authentication,
+        },
       ]);
       expect(mockEventEmitter.emit as any).toHaveBeenCalledTimes(1);
       expect(poller.pollTimer === null).toEqual(true);

--- a/packages/downloads/test/portal/portal-request-dataset-export.test.ts
+++ b/packages/downloads/test/portal/portal-request-dataset-export.test.ts
@@ -1,19 +1,18 @@
 import * as portal from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
 import { portalRequestDatasetExport } from "../../src/portal/portal-request-dataset-export";
 
-const authentication = new UserSession({
+const authentication = {
   username: "portal-user",
   portal: "http://portal.com/sharing/rest",
-  token: "123"
-});
+  token: "123",
+} as any;
 authentication.getToken = () =>
-  new Promise(resolve => {
+  new Promise((resolve) => {
     resolve("123");
   });
 
 describe("portalRequestDatasetExport", () => {
-  it("exportItem fails", async done => {
+  it("exportItem fails", async (done) => {
     try {
       spyOn(portal, "exportItem").and.returnValue(
         new Promise((resolve, reject) => {
@@ -25,7 +24,7 @@ describe("portalRequestDatasetExport", () => {
         datasetId: "abcdef0123456789abcdef0123456789_0",
         format: "CSV",
         authentication,
-        title: "test-export"
+        title: "test-export",
       });
       expect(result).toBeUndefined();
     } catch (err) {
@@ -37,22 +36,22 @@ describe("portalRequestDatasetExport", () => {
           exportFormat: "CSV",
           exportParameters: { layers: [Object({ id: 0, where: undefined })] },
           title: "test-export",
-          authentication
-        }
+          authentication,
+        },
       ]);
     } finally {
       done();
     }
   });
 
-  it("succeeds", async done => {
+  it("succeeds", async (done) => {
     try {
       spyOn(portal, "exportItem").and.returnValue(
         new Promise((resolve, reject) => {
           resolve({
             size: 1000,
             jobId: "job-id",
-            exportItemId: "abcdef"
+            exportItemId: "abcdef",
           });
         })
       );
@@ -61,7 +60,7 @@ describe("portalRequestDatasetExport", () => {
         datasetId: "abcdef0123456789abcdef0123456789_0",
         format: "CSV",
         authentication,
-        title: "test-export"
+        title: "test-export",
       });
       expect(portal.exportItem).toHaveBeenCalledTimes(1);
       expect((portal.exportItem as any).calls.first().args).toEqual([
@@ -70,8 +69,8 @@ describe("portalRequestDatasetExport", () => {
           exportFormat: "CSV",
           exportParameters: { layers: [Object({ id: 0, where: undefined })] },
           title: "test-export",
-          authentication
-        }
+          authentication,
+        },
       ]);
       expect(result).toBeDefined();
       expect(result.downloadId).toEqual("abcdef");
@@ -85,14 +84,14 @@ describe("portalRequestDatasetExport", () => {
     }
   });
 
-  it("succeeds, dataset has no layer id", async done => {
+  it("succeeds, dataset has no layer id", async (done) => {
     try {
       spyOn(portal, "exportItem").and.returnValue(
         new Promise((resolve, reject) => {
           resolve({
             size: 1000,
             jobId: "job-id",
-            exportItemId: "abcdef"
+            exportItemId: "abcdef",
           });
         })
       );
@@ -101,7 +100,7 @@ describe("portalRequestDatasetExport", () => {
         datasetId: "abcdef0123456789abcdef0123456789",
         format: "CSV",
         authentication,
-        title: "test-export"
+        title: "test-export",
       });
       expect(portal.exportItem).toHaveBeenCalledTimes(1);
       expect((portal.exportItem as any).calls.first().args).toEqual([
@@ -110,8 +109,8 @@ describe("portalRequestDatasetExport", () => {
           exportFormat: "CSV",
           exportParameters: {},
           title: "test-export",
-          authentication
-        }
+          authentication,
+        },
       ]);
       expect(result).toBeDefined();
       expect(result.downloadId).toEqual("abcdef");
@@ -125,101 +124,14 @@ describe("portalRequestDatasetExport", () => {
     }
   });
 
-  it("succeeds, uses single layer and spatialRefId", async done => {
+  it("succeeds, uses single layer and spatialRefId", async (done) => {
     try {
       spyOn(portal, "exportItem").and.returnValue(
         new Promise((resolve, reject) => {
           resolve({
             size: 1000,
             jobId: "job-id",
-            exportItemId: "abcdef"
-          });
-        })
-      );
-
-      const result = await portalRequestDatasetExport({
-        datasetId: "abcdef0123456789abcdef0123456789_0",
-        format: "CSV",
-        authentication,
-        spatialRefId: "4326",
-        title: "test-export"
-      });
-      expect(portal.exportItem).toHaveBeenCalledTimes(1);
-      expect((portal.exportItem as any).calls.first().args).toEqual([
-        {
-          id: "abcdef0123456789abcdef0123456789",
-          exportFormat: "CSV",
-          exportParameters: {
-            layers: [Object({ id: 0, where: undefined })],
-            targetSR: { wkid: 4326 }
-          },
-          title: "test-export",
-          authentication
-        }
-      ]);
-      expect(result).toBeDefined();
-      expect(result.downloadId).toEqual("abcdef");
-      expect(result.jobId).toEqual("job-id");
-      expect(result.size).toEqual(1000);
-      expect(typeof result.exportCreated === "number").toEqual(true);
-    } catch (err) {
-      expect(err).toBeUndefined();
-    } finally {
-      done();
-    }
-  });
-
-  it("succeeds, uses no layers and spatialRefId", async done => {
-    try {
-      spyOn(portal, "exportItem").and.returnValue(
-        new Promise((resolve, reject) => {
-          resolve({
-            size: 1000,
-            jobId: "job-id",
-            exportItemId: "abcdef"
-          });
-        })
-      );
-
-      const result = await portalRequestDatasetExport({
-        datasetId: "abcdef0123456789abcdef0123456789",
-        format: "CSV",
-        authentication,
-        spatialRefId: "4326",
-        title: "test-export"
-      });
-      expect(portal.exportItem).toHaveBeenCalledTimes(1);
-      expect((portal.exportItem as any).calls.first().args).toEqual([
-        {
-          id: "abcdef0123456789abcdef0123456789",
-          exportFormat: "CSV",
-          exportParameters: {
-            targetSR: { wkid: 4326 }
-          },
-          title: "test-export",
-          authentication
-        }
-      ]);
-      expect(result).toBeDefined();
-      expect(result.downloadId).toEqual("abcdef");
-      expect(result.jobId).toEqual("job-id");
-      expect(result.size).toEqual(1000);
-      expect(typeof result.exportCreated === "number").toEqual(true);
-    } catch (err) {
-      expect(err).toBeUndefined();
-    } finally {
-      done();
-    }
-  });
-
-  it("succeeds, uses where", async done => {
-    try {
-      spyOn(portal, "exportItem").and.returnValue(
-        new Promise((resolve, reject) => {
-          resolve({
-            size: 1000,
-            jobId: "job-id",
-            exportItemId: "abcdef"
+            exportItemId: "abcdef",
           });
         })
       );
@@ -230,7 +142,94 @@ describe("portalRequestDatasetExport", () => {
         authentication,
         spatialRefId: "4326",
         title: "test-export",
-        where: "1=1"
+      });
+      expect(portal.exportItem).toHaveBeenCalledTimes(1);
+      expect((portal.exportItem as any).calls.first().args).toEqual([
+        {
+          id: "abcdef0123456789abcdef0123456789",
+          exportFormat: "CSV",
+          exportParameters: {
+            layers: [Object({ id: 0, where: undefined })],
+            targetSR: { wkid: 4326 },
+          },
+          title: "test-export",
+          authentication,
+        },
+      ]);
+      expect(result).toBeDefined();
+      expect(result.downloadId).toEqual("abcdef");
+      expect(result.jobId).toEqual("job-id");
+      expect(result.size).toEqual(1000);
+      expect(typeof result.exportCreated === "number").toEqual(true);
+    } catch (err) {
+      expect(err).toBeUndefined();
+    } finally {
+      done();
+    }
+  });
+
+  it("succeeds, uses no layers and spatialRefId", async (done) => {
+    try {
+      spyOn(portal, "exportItem").and.returnValue(
+        new Promise((resolve, reject) => {
+          resolve({
+            size: 1000,
+            jobId: "job-id",
+            exportItemId: "abcdef",
+          });
+        })
+      );
+
+      const result = await portalRequestDatasetExport({
+        datasetId: "abcdef0123456789abcdef0123456789",
+        format: "CSV",
+        authentication,
+        spatialRefId: "4326",
+        title: "test-export",
+      });
+      expect(portal.exportItem).toHaveBeenCalledTimes(1);
+      expect((portal.exportItem as any).calls.first().args).toEqual([
+        {
+          id: "abcdef0123456789abcdef0123456789",
+          exportFormat: "CSV",
+          exportParameters: {
+            targetSR: { wkid: 4326 },
+          },
+          title: "test-export",
+          authentication,
+        },
+      ]);
+      expect(result).toBeDefined();
+      expect(result.downloadId).toEqual("abcdef");
+      expect(result.jobId).toEqual("job-id");
+      expect(result.size).toEqual(1000);
+      expect(typeof result.exportCreated === "number").toEqual(true);
+    } catch (err) {
+      expect(err).toBeUndefined();
+    } finally {
+      done();
+    }
+  });
+
+  it("succeeds, uses where", async (done) => {
+    try {
+      spyOn(portal, "exportItem").and.returnValue(
+        new Promise((resolve, reject) => {
+          resolve({
+            size: 1000,
+            jobId: "job-id",
+            exportItemId: "abcdef",
+          });
+        })
+      );
+
+      const result = await portalRequestDatasetExport({
+        datasetId: "abcdef0123456789abcdef0123456789_0",
+        format: "CSV",
+        authentication,
+        spatialRefId: "4326",
+        title: "test-export",
+        where: "1=1",
       });
       expect(portal.exportItem).toHaveBeenCalledTimes(1);
       expect((portal.exportItem as any).calls.first().args).toEqual([
@@ -239,11 +238,11 @@ describe("portalRequestDatasetExport", () => {
           exportFormat: "CSV",
           exportParameters: {
             layers: [Object({ id: 0, where: "1=1" })],
-            targetSR: { wkid: 4326 }
+            targetSR: { wkid: 4326 },
           },
           title: "test-export",
-          authentication
-        }
+          authentication,
+        },
       ]);
       expect(result).toBeDefined();
       expect(result.downloadId).toEqual("abcdef");

--- a/packages/downloads/test/portal/portal-request-download-metadata.test.ts
+++ b/packages/downloads/test/portal/portal-request-download-metadata.test.ts
@@ -1,7 +1,6 @@
 import * as fetchMock from "fetch-mock";
 import * as portalModule from "@esri/arcgis-rest-portal";
 import * as featureLayer from "@esri/arcgis-rest-feature-layer";
-import { UserSession } from "@esri/arcgis-rest-auth";
 import { portalRequestDownloadMetadata } from "../../src/portal/portal-request-download-metadata";
 import { ArcGISAuthError } from "@esri/arcgis-rest-request";
 
@@ -14,7 +13,7 @@ function buildAuth({
   portal?: string;
   token: string;
 }) {
-  const authentication = new UserSession({ username, portal, token });
+  const authentication = { username, portal, token } as any;
   authentication.getToken = () =>
     new Promise((resolve) => {
       resolve(token);
@@ -31,7 +30,7 @@ describe("portalRequestDownloadMetadata", () => {
   });
   afterEach(() => fetchMock.restore());
 
-  describe('failed service requests', () => {
+  describe("failed service requests", () => {
     // See https://github.com/Esri/arcgis-rest-js/issues/920 for context
     it("retries failed service requests without token if they threw auth error", async () => {
       const featureServiceResponse = { layers: [{ id: 0 }] };
@@ -84,7 +83,9 @@ describe("portalRequestDownloadMetadata", () => {
       expect(mockAuthErrorForServiceCall.retry).toHaveBeenCalled();
       expect(mockAuthErrorForLayerCall.retry).toHaveBeenCalled();
 
-      const getSessionFunc = (mockAuthErrorForServiceCall.retry as jasmine.Spy).calls.argsFor(0)[0];
+      const getSessionFunc = (
+        mockAuthErrorForServiceCall.retry as jasmine.Spy
+      ).calls.argsFor(0)[0];
       expect(await getSessionFunc()).toBeNull();
     });
 
@@ -97,11 +98,15 @@ describe("portalRequestDownloadMetadata", () => {
           modified: new Date(1593450876).getTime(),
           url: "http://feature-service.com/FeatureServer",
         })
-        );
+      );
 
-        spyOn(featureLayer, "getService").and.callFake(() => Promise.reject(new NotAnAuthError()));
+      spyOn(featureLayer, "getService").and.callFake(() =>
+        Promise.reject(new NotAnAuthError())
+      );
 
-        spyOn(featureLayer, "getLayer").and.callFake(() => Promise.reject(new NotAnAuthError()));
+      spyOn(featureLayer, "getLayer").and.callFake(() =>
+        Promise.reject(new NotAnAuthError())
+      );
 
       try {
         await portalRequestDownloadMetadata({
@@ -110,7 +115,7 @@ describe("portalRequestDownloadMetadata", () => {
           authentication,
         });
 
-        fail('should reject!');
+        fail("should reject!");
       } catch (err) {
         expect(err).toEqual(jasmine.any(NotAnAuthError));
       }

--- a/packages/downloads/test/request-dataset-export.test.ts
+++ b/packages/downloads/test/request-dataset-export.test.ts
@@ -1,16 +1,15 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
 import { requestDatasetExport } from "../src/request-dataset-export";
 import * as hubExport from "../src/hub/hub-request-dataset-export";
 import * as portalExport from "../src/portal/portal-request-dataset-export";
 
 describe("requestDownloadMetadata", () => {
-  it("handle hub export", async done => {
+  it("handle hub export", async (done) => {
     try {
       spyOn(hubExport, "hubRequestDatasetExport").and.returnValue(
         new Promise((resolve, reject) => {
           resolve({
             downloadId:
-              "abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined"
+              "abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined",
           });
         })
       );
@@ -19,7 +18,7 @@ describe("requestDownloadMetadata", () => {
         host: "http://hub.com/",
         datasetId: "abcdef0123456789abcdef0123456789_0",
         spatialRefId: "4326",
-        format: "CSV"
+        format: "CSV",
       });
 
       expect(hubExport.hubRequestDatasetExport).toHaveBeenCalledTimes(1);
@@ -32,13 +31,13 @@ describe("requestDownloadMetadata", () => {
           format: "CSV",
           spatialRefId: "4326",
           geometry: undefined,
-          where: undefined
-        }
+          where: undefined,
+        },
       ]);
 
       expect(result).toEqual({
         downloadId:
-          "abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined"
+          "abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined",
       });
     } catch (err) {
       expect(err).toBeUndefined();
@@ -47,7 +46,7 @@ describe("requestDownloadMetadata", () => {
     }
   });
 
-  it("handle portal export", async done => {
+  it("handle portal export", async (done) => {
     try {
       spyOn(portalExport, "portalRequestDatasetExport").and.returnValue(
         new Promise((resolve, reject) => {
@@ -55,18 +54,18 @@ describe("requestDownloadMetadata", () => {
             size: 1000,
             jobId: "job-id",
             downloadId: "abcdef",
-            exportCreated: Date.now()
+            exportCreated: Date.now(),
           });
         })
       );
 
-      const authentication = new UserSession({
+      const authentication = {
         username: "portal-user",
         portal: "http://portal.com/sharing/rest",
-        token: "123"
-      });
+        token: "123",
+      } as any;
       authentication.getToken = () =>
-        new Promise(resolve => {
+        new Promise((resolve) => {
           resolve("123");
         });
 
@@ -76,7 +75,7 @@ describe("requestDownloadMetadata", () => {
         authentication,
         title: "test-export",
         target: "portal",
-        spatialRefId: "2227"
+        spatialRefId: "2227",
       });
 
       expect(portalExport.portalRequestDatasetExport).toHaveBeenCalledTimes(1);
@@ -89,8 +88,8 @@ describe("requestDownloadMetadata", () => {
           title: "test-export",
           authentication,
           spatialRefId: "2227",
-          where: undefined
-        }
+          where: undefined,
+        },
       ]);
       expect(result).toBeDefined();
       expect(result.downloadId).toEqual("abcdef");
@@ -104,7 +103,7 @@ describe("requestDownloadMetadata", () => {
     }
   });
 
-  it("handle enterprise export", async done => {
+  it("handle enterprise export", async (done) => {
     try {
       spyOn(portalExport, "portalRequestDatasetExport").and.returnValue(
         new Promise((resolve, reject) => {
@@ -112,18 +111,18 @@ describe("requestDownloadMetadata", () => {
             size: 1000,
             jobId: "job-id",
             downloadId: "abcdef",
-            exportCreated: Date.now()
+            exportCreated: Date.now(),
           });
         })
       );
 
-      const authentication = new UserSession({
+      const authentication = {
         username: "portal-user",
         portal: "http://portal.com/sharing/rest",
-        token: "123"
-      });
+        token: "123",
+      } as any;
       authentication.getToken = () =>
-        new Promise(resolve => {
+        new Promise((resolve) => {
           resolve("123");
         });
 
@@ -133,7 +132,7 @@ describe("requestDownloadMetadata", () => {
         authentication,
         title: "test-export",
         target: "enterprise",
-        spatialRefId: "2227"
+        spatialRefId: "2227",
       });
 
       expect(portalExport.portalRequestDatasetExport).toHaveBeenCalledTimes(1);
@@ -146,8 +145,8 @@ describe("requestDownloadMetadata", () => {
           title: "test-export",
           authentication,
           spatialRefId: "2227",
-          where: undefined
-        }
+          where: undefined,
+        },
       ]);
       expect(result).toBeDefined();
       expect(result.downloadId).toEqual("abcdef");

--- a/packages/downloads/test/request-download-metadata.test.ts
+++ b/packages/downloads/test/request-download-metadata.test.ts
@@ -1,5 +1,4 @@
 import * as fetchMock from "fetch-mock";
-import { UserSession } from "@esri/arcgis-rest-auth";
 import { requestDownloadMetadata } from "../src/request-download-metadata";
 
 describe("requestDownloadMetadata", () => {
@@ -74,11 +73,11 @@ describe("requestDownloadMetadata", () => {
 
   it("handle portal download", async (done) => {
     const host = `http://portal.com`;
-    const authentication = new UserSession({
+    const authentication = {
       username: "portal-user",
       portal: `${host}/sharing/rest`,
       token: "123",
-    });
+    } as any;
     authentication.getToken = () =>
       new Promise((resolve) => {
         resolve("123");
@@ -146,11 +145,11 @@ describe("requestDownloadMetadata", () => {
 
   it("handle enterprise download", async (done) => {
     const host = "https://my-enterprise-box.portal.com";
-    const authentication = new UserSession({
+    const authentication = {
       username: "portal-user",
       portal: `${host}/sharing/rest`,
       token: "123",
-    });
+    } as any;
     authentication.getToken = () =>
       new Promise((resolve) => {
         resolve("123");

--- a/packages/events/test/register.test.ts
+++ b/packages/events/test/register.test.ts
@@ -2,10 +2,9 @@
  * Apache-2.0 */
 
 import { registerForEvent, unregisterForEvent } from "../src/register";
-import { UserSession } from "@esri/arcgis-rest-auth";
 import * as groups from "@esri/arcgis-rest-portal";
 
-export const TOMORROW = (function() {
+export const TOMORROW = (function () {
   const now = new Date();
   now.setDate(now.getDate() + 1);
   return now;
@@ -13,7 +12,7 @@ export const TOMORROW = (function() {
 
 describe("register/unregister methods", () => {
   const MOCK_REQOPTS = {
-    authentication: new UserSession({
+    authentication: {
       clientId: "clientId",
       redirectUri: "https://example-app.com/redirect-uri",
       token: "fake-token",
@@ -23,13 +22,13 @@ describe("register/unregister methods", () => {
       refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
-      portal: "https://myorg.maps.arcgis.com/sharing/rest"
-    })
+      portal: "https://myorg.maps.arcgis.com/sharing/rest",
+    } as any,
   };
 
-  it("should help a user register for an event", done => {
+  it("should help a user register for an event", (done) => {
     const joinGroupParamsSpy = spyOn(groups, "joinGroup").and.returnValue(
-      new Promise(resolve => {
+      new Promise((resolve) => {
         resolve({ success: true, groupId: "5bc" });
       })
     );
@@ -44,14 +43,14 @@ describe("register/unregister methods", () => {
         expect(opts.authentication).toBe(MOCK_REQOPTS.authentication);
         done();
       })
-      .catch(e => {
+      .catch((e) => {
         fail(e);
       });
   });
 
-  it("should help a user unregister for an event.", done => {
+  it("should help a user unregister for an event.", (done) => {
     const leaveGroupParamsSpy = spyOn(groups, "leaveGroup").and.returnValue(
-      new Promise(resolve => {
+      new Promise((resolve) => {
         resolve({ success: true, groupId: "5bc" });
       })
     );
@@ -66,7 +65,7 @@ describe("register/unregister methods", () => {
         expect(opts.authentication).toBe(MOCK_REQOPTS.authentication);
         done();
       })
-      .catch(e => {
+      .catch((e) => {
         fail(e);
       });
   });

--- a/packages/events/test/util.test.ts
+++ b/packages/events/test/util.test.ts
@@ -1,31 +1,30 @@
 import {
   getEventServiceUrl,
   getEventFeatureServiceUrl,
-  getEventQueryFromType
+  getEventQueryFromType,
 } from "../src/util";
 import {
   adminEventSearchResponse,
   orgEventSearchResponse,
   publicEventSearchResponse,
-  emptyEventSearchResponse
+  emptyEventSearchResponse,
 } from "./mocks/ago_search";
 import * as portal from "@esri/arcgis-rest-portal";
 
 import { ISearchOptions } from "@esri/arcgis-rest-portal";
 import { IQueryFeaturesOptions } from "@esri/arcgis-rest-feature-layer";
-import { UserSession } from "@esri/arcgis-rest-auth";
 
 describe("getEventServiceUrl", () => {
-  it("should return admin event service url", done => {
+  it("should return admin event service url", (done) => {
     // stub searchItems
     const paramsSpy = spyOn(portal, "searchItems").and.returnValue(
-      new Promise(resolve => {
+      new Promise((resolve) => {
         resolve(adminEventSearchResponse);
       })
     );
 
     getEventServiceUrl("5bc")
-      .then(result => {
+      .then((result) => {
         expect(paramsSpy.calls.count()).toEqual(1);
         const opts = paramsSpy.calls.argsFor(0)[0] as ISearchOptions;
         expect(opts.q).toContain("typekeywords:hubEventsLayer AND orgid:5bc");
@@ -37,16 +36,16 @@ describe("getEventServiceUrl", () => {
       .catch(() => fail());
   });
 
-  it("should return org event service url", done => {
+  it("should return org event service url", (done) => {
     // stub searchItems
     const paramsSpy = spyOn(portal, "searchItems").and.returnValue(
-      new Promise(resolve => {
+      new Promise((resolve) => {
         resolve(orgEventSearchResponse);
       })
     );
 
     getEventServiceUrl("5bc")
-      .then(result => {
+      .then((result) => {
         expect(paramsSpy.calls.count()).toEqual(1);
         const opts = paramsSpy.calls.argsFor(0)[0] as ISearchOptions;
         expect(opts.q).toContain("typekeywords:hubEventsLayer AND orgid:5bc");
@@ -58,16 +57,16 @@ describe("getEventServiceUrl", () => {
       .catch(() => fail());
   });
 
-  it("should return the public event service url", done => {
+  it("should return the public event service url", (done) => {
     // stub searchItems
     const paramsSpy = spyOn(portal, "searchItems").and.returnValue(
-      new Promise(resolve => {
+      new Promise((resolve) => {
         resolve(publicEventSearchResponse);
       })
     );
 
     getEventServiceUrl("5bc")
-      .then(result => {
+      .then((result) => {
         expect(paramsSpy.calls.count()).toEqual(1);
         const opts = paramsSpy.calls.argsFor(0)[0] as ISearchOptions;
         expect(opts.q).toContain("typekeywords:hubEventsLayer AND orgid:5bc");
@@ -79,15 +78,15 @@ describe("getEventServiceUrl", () => {
       .catch(() => fail());
   });
 
-  it("should throw if no event layer is found", done => {
+  it("should throw if no event layer is found", (done) => {
     // stub searchItems
     const paramsSpy = spyOn(portal, "searchItems").and.returnValue(
-      new Promise(resolve => {
+      new Promise((resolve) => {
         resolve(emptyEventSearchResponse);
       })
     );
 
-    getEventServiceUrl("v8b").catch(error => {
+    getEventServiceUrl("v8b").catch((error) => {
       expect(paramsSpy.calls.count()).toEqual(1);
       const opts = paramsSpy.calls.argsFor(0)[0] as ISearchOptions;
       expect(opts.q).toContain("typekeywords:hubEventsLayer AND orgid:v8b");
@@ -100,16 +99,16 @@ describe("getEventServiceUrl", () => {
 });
 
 describe("getEventFeatureServiceUrl", () => {
-  it("should return admin event service url", done => {
+  it("should return admin event service url", (done) => {
     // stub searchItems
     const paramsSpy = spyOn(portal, "searchItems").and.returnValue(
-      new Promise(resolve => {
+      new Promise((resolve) => {
         resolve(adminEventSearchResponse);
       })
     );
 
     getEventFeatureServiceUrl("5bc")
-      .then(result => {
+      .then((result) => {
         expect(paramsSpy.calls.count()).toEqual(1);
         const opts = paramsSpy.calls.argsFor(0)[0] as ISearchOptions;
         expect(opts.q).toContain("typekeywords:hubEventsLayer AND orgid:5bc");
@@ -121,16 +120,16 @@ describe("getEventFeatureServiceUrl", () => {
       .catch(() => fail());
   });
 
-  it("should return org event service url", done => {
+  it("should return org event service url", (done) => {
     // stub searchItems
     const paramsSpy = spyOn(portal, "searchItems").and.returnValue(
-      new Promise(resolve => {
+      new Promise((resolve) => {
         resolve(orgEventSearchResponse);
       })
     );
 
     getEventFeatureServiceUrl("5bc")
-      .then(result => {
+      .then((result) => {
         expect(paramsSpy.calls.count()).toEqual(1);
         const opts = paramsSpy.calls.argsFor(0)[0] as ISearchOptions;
         expect(opts.q).toContain("typekeywords:hubEventsLayer AND orgid:5bc");
@@ -142,16 +141,16 @@ describe("getEventFeatureServiceUrl", () => {
       .catch(() => fail());
   });
 
-  it("should return the public event service url", done => {
+  it("should return the public event service url", (done) => {
     // stub searchItems
     const paramsSpy = spyOn(portal, "searchItems").and.returnValue(
-      new Promise(resolve => {
+      new Promise((resolve) => {
         resolve(publicEventSearchResponse);
       })
     );
 
     getEventFeatureServiceUrl("5bc")
-      .then(result => {
+      .then((result) => {
         expect(paramsSpy.calls.count()).toEqual(1);
         const opts = paramsSpy.calls.argsFor(0)[0] as ISearchOptions;
         expect(opts.q).toContain("typekeywords:hubEventsLayer AND orgid:5bc");
@@ -163,15 +162,15 @@ describe("getEventFeatureServiceUrl", () => {
       .catch(() => fail());
   });
 
-  it("should throw if no event layer is found", done => {
+  it("should throw if no event layer is found", (done) => {
     // stub searchItems
     const paramsSpy = spyOn(portal, "searchItems").and.returnValue(
-      new Promise(resolve => {
+      new Promise((resolve) => {
         resolve(emptyEventSearchResponse);
       })
     );
 
-    getEventFeatureServiceUrl("v8b").catch(error => {
+    getEventFeatureServiceUrl("v8b").catch((error) => {
       expect(paramsSpy.calls.count()).toEqual(1);
       const opts = paramsSpy.calls.argsFor(0)[0] as ISearchOptions;
       expect(opts.q).toContain("typekeywords:hubEventsLayer AND orgid:v8b");
@@ -184,13 +183,13 @@ describe("getEventFeatureServiceUrl", () => {
 });
 
 describe("getEventQueryFromType", () => {
-  const authentication = new UserSession({
-    username: "vader"
-  });
+  const authentication = {
+    username: "vader",
+  } as any;
 
   it("should return the event where clause for 'upcoming' type", () => {
     const requestOptions = {
-      outFields: "*"
+      outFields: "*",
     } as IQueryFeaturesOptions;
     const newRequestOptions = getEventQueryFromType("upcoming", requestOptions);
     expect(newRequestOptions.where).toEqual(
@@ -202,7 +201,7 @@ describe("getEventQueryFromType", () => {
   it("should return the modified event where clause for 'upcoming' type and orderByFields is not set", () => {
     const requestOptions = {
       where: "1=1",
-      outFields: "*"
+      outFields: "*",
     } as IQueryFeaturesOptions;
 
     const newRequestOptions = getEventQueryFromType("upcoming", requestOptions);
@@ -215,7 +214,7 @@ describe("getEventQueryFromType", () => {
   it("should return the modified event where clause for 'upcoming' type and orderByFields is set", () => {
     const requestOptions = {
       outFields: "*",
-      orderByFields: "startDate ASC"
+      orderByFields: "startDate ASC",
     } as IQueryFeaturesOptions;
     const newRequestOptions = getEventQueryFromType("upcoming", requestOptions);
     expect(newRequestOptions.where).toEqual(
@@ -228,7 +227,7 @@ describe("getEventQueryFromType", () => {
 
   it("should return the event where clause for 'past' type", () => {
     const requestOptions = {
-      outFields: "*"
+      outFields: "*",
     } as IQueryFeaturesOptions;
     const newRequestOptions = getEventQueryFromType("past", requestOptions);
     expect(newRequestOptions.where).toEqual(
@@ -240,7 +239,7 @@ describe("getEventQueryFromType", () => {
   it("should return the modified event where clause for 'past' type and orderByFields is not set", () => {
     const requestOptions = {
       where: "1=1",
-      outFields: "*"
+      outFields: "*",
     } as IQueryFeaturesOptions;
     const newRequestOptions = getEventQueryFromType("past", requestOptions);
     expect(newRequestOptions.where).toContain(
@@ -253,7 +252,7 @@ describe("getEventQueryFromType", () => {
   it("should return the modified event where clause for 'past' type and orderByFields is set", () => {
     const requestOptions = {
       outFields: "*",
-      orderByFields: "startDate ASC"
+      orderByFields: "startDate ASC",
     } as IQueryFeaturesOptions;
     const newRequestOptions = getEventQueryFromType("past", requestOptions);
     expect(newRequestOptions.where).toEqual(
@@ -266,7 +265,7 @@ describe("getEventQueryFromType", () => {
 
   it("should return the event where clause for 'cancelled' type", () => {
     const requestOptions = {
-      outFields: "*"
+      outFields: "*",
     } as IQueryFeaturesOptions;
     const newRequestOptions = getEventQueryFromType(
       "cancelled",
@@ -281,7 +280,7 @@ describe("getEventQueryFromType", () => {
   it("should return the modified event where clause for 'cancelled' type and orderByFields is not set", () => {
     const requestOptions = {
       where: "1=1",
-      outFields: "*"
+      outFields: "*",
     } as IQueryFeaturesOptions;
     const newRequestOptions = getEventQueryFromType(
       "cancelled",
@@ -296,7 +295,7 @@ describe("getEventQueryFromType", () => {
   it("should return the modified event where clause for 'cancelled' type and orderByFields is set", () => {
     const requestOptions = {
       outFields: "*",
-      orderByFields: "startDate ASC"
+      orderByFields: "startDate ASC",
     } as IQueryFeaturesOptions;
     const newRequestOptions = getEventQueryFromType(
       "cancelled",
@@ -312,11 +311,11 @@ describe("getEventQueryFromType", () => {
 
   it("should return the event where clause for 'draft' type", () => {
     const requestOptions = {
-      outFields: "*"
+      outFields: "*",
     } as IQueryFeaturesOptions;
     requestOptions.authentication = authentication;
     const newRequestOptions = getEventQueryFromType("draft", requestOptions);
-    const user = (requestOptions.authentication as UserSession).username;
+    const user = (requestOptions.authentication as any).username;
     expect(newRequestOptions.where).toEqual(
       `Creator = '${user}' AND status = 'draft'`
     );
@@ -325,7 +324,7 @@ describe("getEventQueryFromType", () => {
 
   it("should return the event where clause for 'draft' type when no user is set", () => {
     const requestOptions = {
-      outFields: "*"
+      outFields: "*",
     } as IQueryFeaturesOptions;
     const newRequestOptions = getEventQueryFromType("draft", requestOptions);
     expect(newRequestOptions.where).toEqual(
@@ -337,11 +336,11 @@ describe("getEventQueryFromType", () => {
   it("should return the modified event where clause for 'draft' type and orderByFields is not set", () => {
     const requestOptions = {
       where: "1=1",
-      outFields: "*"
+      outFields: "*",
     } as IQueryFeaturesOptions;
     requestOptions.authentication = authentication;
     const newRequestOptions = getEventQueryFromType("draft", requestOptions);
-    const user = (requestOptions.authentication as UserSession).username;
+    const user = (requestOptions.authentication as any).username;
     expect(newRequestOptions.where).toContain(
       `AND Creator = '${user}' AND status = 'draft'`
     );
@@ -351,11 +350,11 @@ describe("getEventQueryFromType", () => {
   it("should return the modified event where clause for 'draft' type and orderByFields is set", () => {
     const requestOptions = {
       outFields: "*",
-      orderByFields: "startDate ASC"
+      orderByFields: "startDate ASC",
     } as IQueryFeaturesOptions;
     requestOptions.authentication = authentication;
     const newRequestOptions = getEventQueryFromType("draft", requestOptions);
-    const user = (requestOptions.authentication as UserSession).username;
+    const user = (requestOptions.authentication as any).username;
     expect(newRequestOptions.where).toEqual(
       `Creator = '${user}' AND status = 'draft'`
     );

--- a/packages/sites/test/_update-pages.test.ts
+++ b/packages/sites/test/_update-pages.test.ts
@@ -8,31 +8,33 @@ describe("_updatePages", () => {
     fetchMock
       .post(`glob:*/ef1/update*`, {
         status: 200,
-        body: JSON.stringify({ success: true, id: "3ef" })
+        body: JSON.stringify({ success: true, id: "3ef" }),
       })
       .post(`glob:*/ef2/update*`, {
         status: 200,
-        body: JSON.stringify({ success: true, id: "3ef" })
+        body: JSON.stringify({ success: true, id: "3ef" }),
       });
 
-    const site = ({
+    const site = {
       item: {
         id: "bc3",
-        type: "Hub Site Application"
+        type: "Hub Site Application",
       },
       key: "bleep-boop",
-      data: {}
-    } as unknown) as IModel;
-    const models = ([
+      data: {},
+    } as unknown as IModel;
+    // NOTE: owner is needed b/c mock authentication lacks the getUser method
+    const owner = "owner";
+    const models = [
       {
-        item: { id: "ef1", type: "Hub Page" },
-        data: { values: { sites: [] } }
+        item: { id: "ef1", owner, type: "Hub Page" },
+        data: { values: { sites: [] } },
       },
       {
-        item: { id: "ef2", type: "Hub Page" },
-        data: { values: { sites: [{ id: "other", title: "other" }] } }
-      }
-    ] as unknown) as IModelTemplate[];
+        item: { id: "ef2", owner, type: "Hub Page" },
+        data: { values: { sites: [{ id: "other", title: "other" }] } },
+      },
+    ] as unknown as IModelTemplate[];
 
     const results = await _updatePages(site, models, MOCK_HUB_REQOPTS);
 
@@ -40,21 +42,21 @@ describe("_updatePages", () => {
     expect(fetchMock.called()).toBeTruthy("fetch should be intercepted");
   });
   it("_updatePages returns not promises if no Page", async () => {
-    const site = ({
+    const site = {
       item: {
         id: "bc3",
-        type: "Hub Site Application"
+        type: "Hub Site Application",
       },
       key: "bleep-boop",
-      data: {}
-    } as unknown) as IModel;
-    const models = ([
+      data: {},
+    } as unknown as IModel;
+    const models = [
       { item: { id: "ef1", type: "Web Map" }, data: { values: { sites: [] } } },
       {
         item: { id: "ef2", type: "Web Map" },
-        data: { values: { sites: [{ id: "other", title: "other" }] } }
-      }
-    ] as unknown) as IModelTemplate[];
+        data: { values: { sites: [{ id: "other", title: "other" }] } },
+      },
+    ] as unknown as IModelTemplate[];
 
     const results = await _updatePages(site, models, MOCK_HUB_REQOPTS);
 

--- a/packages/sites/test/get-members.test.ts
+++ b/packages/sites/test/get-members.test.ts
@@ -1,5 +1,4 @@
 import { getMembers } from "../src/get-members";
-import { UserSession } from "@esri/arcgis-rest-auth";
 import { IUser } from "@esri/arcgis-rest-types";
 import * as hubCommon from "@esri/hub-common";
 import * as restPortal from "@esri/arcgis-rest-portal";
@@ -20,12 +19,12 @@ describe("getMembers", function () {
     return now;
   })();
 
-  const MOCK_USER_SESSION = new UserSession({
+  const MOCK_USER_SESSION = {
     username: "mockUsername",
     password: "mockPassword",
     token: "mock-token",
     tokenExpires: TOMORROW,
-  });
+  } as any;
 
   const MOCK_MEMBERS = [
     { username: "mockUsername1" } as IUser,

--- a/packages/sites/test/layout/remove-unused-resources.test.ts
+++ b/packages/sites/test/layout/remove-unused-resources.test.ts
@@ -1,21 +1,19 @@
 import * as portalModule from "@esri/arcgis-rest-portal";
 import { IHubRequestOptions } from "@esri/hub-common";
 
-import { UserSession } from "@esri/arcgis-rest-auth";
-
 import { removeUnusedResources } from "../../src/layout";
 import * as _getImageCropIdsFromLayout from "../../src/layout/_get-image-crop-ids-from-layout";
 
 import { ISection } from "../../src/layout/types";
 
-describe("removeUnusedResources", function() {
-  const mockUserSession = new UserSession({
+describe("removeUnusedResources", function () {
+  const mockUserSession = {
     username: "vader",
     password: "123456",
     token: "fake-token",
     tokenExpires: new Date(),
-    portal: "https://vader.maps.arcgis.com/sharing/rest"
-  });
+    portal: "https://vader.maps.arcgis.com/sharing/rest",
+  } as any;
 
   const hubRequestOptions: IHubRequestOptions = {
     isPortal: false,
@@ -24,12 +22,12 @@ describe("removeUnusedResources", function() {
       id: "",
       name: "",
       isPortal: true,
-      portalHostname: "portal-hostname"
+      portalHostname: "portal-hostname",
     },
-    authentication: mockUserSession
+    authentication: mockUserSession,
   };
 
-  it("all cards in all row in section should should have dependencies extracted", async function() {
+  it("all cards in all row in section should should have dependencies extracted", async function () {
     spyOn(
       _getImageCropIdsFromLayout,
       "_getImageCropIdsFromLayout"
@@ -42,15 +40,15 @@ describe("removeUnusedResources", function() {
       Promise.resolve({
         resources: [
           {
-            resource: "hub-image-card-crop-cropId 2.png"
+            resource: "hub-image-card-crop-cropId 2.png",
           },
           {
-            resource: "hub-image-card-crop-cropId 3.png"
+            resource: "hub-image-card-crop-cropId 3.png",
           },
           {
-            resource: "hub-image-card-crop-cropId 4.png"
-          }
-        ]
+            resource: "hub-image-card-crop-cropId 4.png",
+          },
+        ],
       })
     );
 
@@ -63,7 +61,7 @@ describe("removeUnusedResources", function() {
     );
 
     const layout = {
-      sections: [] as ISection[]
+      sections: [] as ISection[],
     };
 
     const res = await removeUnusedResources(
@@ -78,21 +76,21 @@ describe("removeUnusedResources", function() {
     expect(removeItemResourceSpy).toHaveBeenCalledWith({
       id: "id value",
       resource: "hub-image-card-crop-cropId 2.png",
-      authentication: mockUserSession
+      authentication: mockUserSession,
     });
     expect(removeItemResourceSpy).toHaveBeenCalledWith({
       id: "id value",
       resource: "hub-image-card-crop-cropId 4.png",
-      authentication: mockUserSession
+      authentication: mockUserSession,
     });
 
     expect(res).toEqual([
       "removed hub-image-card-crop-cropId 2.png",
-      "removed hub-image-card-crop-cropId 4.png"
+      "removed hub-image-card-crop-cropId 4.png",
     ]);
   });
 
-  it("layout with 0 cropIds should remove all ", async function() {
+  it("layout with 0 cropIds should remove all ", async function () {
     spyOn(
       _getImageCropIdsFromLayout,
       "_getImageCropIdsFromLayout"
@@ -105,15 +103,15 @@ describe("removeUnusedResources", function() {
       Promise.resolve({
         resources: [
           {
-            resource: "hub-image-card-crop-cropId 1.png"
+            resource: "hub-image-card-crop-cropId 1.png",
           },
           {
-            resource: "hub-image-card-crop-cropId 2.png"
+            resource: "hub-image-card-crop-cropId 2.png",
           },
           {
-            resource: "hub-image-card-crop-cropId 3.png"
-          }
-        ]
+            resource: "hub-image-card-crop-cropId 3.png",
+          },
+        ],
       })
     );
 
@@ -127,7 +125,7 @@ describe("removeUnusedResources", function() {
     );
 
     const layout = {
-      sections: [] as ISection[]
+      sections: [] as ISection[],
     };
 
     const res = await removeUnusedResources(
@@ -143,11 +141,11 @@ describe("removeUnusedResources", function() {
     expect(res).toEqual([
       "removed hub-image-card-crop-cropId 1.png",
       "removed hub-image-card-crop-cropId 2.png",
-      "removed hub-image-card-crop-cropId 3.png"
+      "removed hub-image-card-crop-cropId 3.png",
     ]);
   });
 
-  it("layout containing 0 imageCropIds should remove all resources that start with 'hub-image-card-crop-'", async function() {
+  it("layout containing 0 imageCropIds should remove all resources that start with 'hub-image-card-crop-'", async function () {
     spyOn(
       _getImageCropIdsFromLayout,
       "_getImageCropIdsFromLayout"
@@ -160,18 +158,18 @@ describe("removeUnusedResources", function() {
       Promise.resolve({
         resources: [
           {
-            resource: "hub-image-card-crop-1"
+            resource: "hub-image-card-crop-1",
           },
           {
-            resource: "hub-image-card-crop-2"
+            resource: "hub-image-card-crop-2",
           },
           {
-            resource: "non hub-image-card-crop-3"
+            resource: "non hub-image-card-crop-3",
           },
           {
-            resource: "hub-image-card-crop-4"
-          }
-        ]
+            resource: "hub-image-card-crop-4",
+          },
+        ],
       })
     );
 
@@ -185,7 +183,7 @@ describe("removeUnusedResources", function() {
     );
 
     const layout = {
-      sections: [] as ISection[]
+      sections: [] as ISection[],
     };
 
     const res = await removeUnusedResources(
@@ -200,27 +198,27 @@ describe("removeUnusedResources", function() {
     expect(removeItemResourceSpy).toHaveBeenCalledWith({
       id: "id value",
       resource: "hub-image-card-crop-1",
-      authentication: mockUserSession
+      authentication: mockUserSession,
     });
     expect(removeItemResourceSpy).toHaveBeenCalledWith({
       id: "id value",
       resource: "hub-image-card-crop-2",
-      authentication: mockUserSession
+      authentication: mockUserSession,
     });
     expect(removeItemResourceSpy).toHaveBeenCalledWith({
       id: "id value",
       resource: "hub-image-card-crop-4",
-      authentication: mockUserSession
+      authentication: mockUserSession,
     });
 
     expect(res).toEqual([
       "removed hub-image-card-crop-1",
       "removed hub-image-card-crop-2",
-      "removed hub-image-card-crop-4"
+      "removed hub-image-card-crop-4",
     ]);
   });
 
-  it("getItemResources returning 0 resources should not call removeItemResource at all", async function() {
+  it("getItemResources returning 0 resources should not call removeItemResource at all", async function () {
     spyOn(
       _getImageCropIdsFromLayout,
       "_getImageCropIdsFromLayout"
@@ -234,7 +232,7 @@ describe("removeUnusedResources", function() {
     const removeItemResourceSpy = spyOn(portalModule, "removeItemResource");
 
     const layout = {
-      sections: [] as ISection[]
+      sections: [] as ISection[],
     };
 
     const res = await removeUnusedResources(
@@ -250,13 +248,13 @@ describe("removeUnusedResources", function() {
     expect(res).toEqual([]);
   });
 
-  it("getItemResources throwing error should rethrow it", async function() {
+  it("getItemResources throwing error should rethrow it", async function () {
     spyOn(portalModule, "getItemResources").and.throwError(
       "getItemResources threw an error for some reason"
     );
 
     const layout = {
-      sections: [] as ISection[]
+      sections: [] as ISection[],
     };
 
     expect(() =>

--- a/packages/sites/test/link-site-and-page.test.ts
+++ b/packages/sites/test/link-site-and-page.test.ts
@@ -1,43 +1,42 @@
 import { linkSiteAndPage } from "../src";
 import * as commonModule from "@esri/hub-common";
 import * as portalModule from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
 import * as fetchMock from "fetch-mock";
 import { cloneObject } from "@esri/hub-common";
 
 function resetSpys(...args: jasmine.Spy[]) {
-  args.forEach(spy => spy.calls.reset());
+  args.forEach((spy) => spy.calls.reset());
 }
 
 describe("linkSiteAndPage", () => {
-  const siteModel = ({
+  const siteModel = {
     item: {
       id: "bazsite",
       type: "Hub Site Application",
       typeKeywords: [],
       properties: {
         collaborationGroupId: "collab-id",
-        contentGroupId: "content-id"
-      }
+        contentGroupId: "content-id",
+      },
     },
     data: {
       values: {
-        pages: [{ id: "foopage" }, { id: "bazpage" }]
-      }
-    }
-  } as unknown) as commonModule.IModel;
+        pages: [{ id: "foopage" }, { id: "bazpage" }],
+      },
+    },
+  } as unknown as commonModule.IModel;
 
-  const pageModel = ({
+  const pageModel = {
     item: {
       id: "barpage",
-      type: "Hub Page"
+      type: "Hub Page",
     },
     data: {
       values: {
-        sites: [{ id: "foosite" }, { id: "barsite" }]
-      }
-    }
-  } as unknown) as commonModule.IModel;
+        sites: [{ id: "foosite" }, { id: "barsite" }],
+      },
+    },
+  } as unknown as commonModule.IModel;
 
   let shareSpy: jasmine.Spy;
   let updateSpy: jasmine.Spy;
@@ -56,7 +55,7 @@ describe("linkSiteAndPage", () => {
     await linkSiteAndPage({
       siteModel: cloneObject(siteModel),
       pageModel: cloneObject(pageModel),
-      authentication: {} as UserSession
+      authentication: {} as any,
     });
 
     expect(updateSpy).toHaveBeenCalledTimes(2);
@@ -65,14 +64,14 @@ describe("linkSiteAndPage", () => {
     const serializedPage = updateSpy.calls.argsFor(0)[0].item;
     const updatePageModel = {
       item: serializedPage,
-      data: JSON.parse(serializedPage.text)
+      data: JSON.parse(serializedPage.text),
     };
     expect(updatePageModel.data.values.sites).toContain({ id: "bazsite" });
 
     const serializedSite = updateSpy.calls.argsFor(1)[0].item;
     const updateSiteModel = {
       item: serializedSite,
-      data: JSON.parse(serializedSite.text)
+      data: JSON.parse(serializedSite.text),
     };
     expect(updateSiteModel.data.values.pages.map((p: any) => p.id)).toContain(
       "barpage"
@@ -95,7 +94,7 @@ describe("linkSiteAndPage", () => {
     await linkSiteAndPage({
       siteModel: oldSite,
       pageModel: cloneObject(pageModel),
-      authentication: {} as UserSession
+      authentication: {} as any,
     });
 
     expect(updateSpy).toHaveBeenCalledTimes(2);
@@ -113,7 +112,7 @@ describe("linkSiteAndPage", () => {
     await linkSiteAndPage({
       siteModel: site,
       pageModel: page,
-      authentication: {} as UserSession
+      authentication: {} as any,
     });
 
     expect(updateSpy).toHaveBeenCalledTimes(2);
@@ -136,7 +135,7 @@ describe("linkSiteAndPage", () => {
     await linkSiteAndPage({
       siteModel: site,
       pageModel: page,
-      authentication: {} as UserSession
+      authentication: {} as any,
     });
 
     expect(updateSpy).not.toHaveBeenCalled();
@@ -151,16 +150,16 @@ describe("linkSiteAndPage", () => {
   it("rejects if one or both are non-existant", async () => {
     fetchMock.mock("*", 404); // make all model requests fail
 
-    const fakeSession = ({
-      getToken: () => Promise.resolve("token")
-    } as unknown) as UserSession;
+    const fakeSession = {
+      getToken: () => Promise.resolve("token"),
+    } as unknown as any;
 
     // Non-existant site
     try {
       await linkSiteAndPage({
         siteId: "no-exist",
         pageModel: cloneObject(pageModel),
-        authentication: fakeSession
+        authentication: fakeSession,
       });
       fail("should reject");
     } catch (err) {
@@ -175,7 +174,7 @@ describe("linkSiteAndPage", () => {
       await linkSiteAndPage({
         siteModel: cloneObject(siteModel),
         pageId: "no-exist",
-        authentication: fakeSession
+        authentication: fakeSession,
       });
       fail("should reject");
     } catch (err) {
@@ -190,7 +189,7 @@ describe("linkSiteAndPage", () => {
       await linkSiteAndPage({
         siteId: "no-exist",
         pageId: "no-exist",
-        authentication: fakeSession
+        authentication: fakeSession,
       });
       fail("should reject");
     } catch (err) {
@@ -208,7 +207,7 @@ describe("linkSiteAndPage", () => {
     await linkSiteAndPage({
       siteModel: cloneObject(siteModel),
       pageModel: notPage,
-      authentication: {} as UserSession
+      authentication: {} as any,
     });
 
     expect(updateSpy).not.toHaveBeenCalled();

--- a/packages/sites/test/test-helpers.test.ts
+++ b/packages/sites/test/test-helpers.test.ts
@@ -1,4 +1,3 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
 import { IHubRequestOptions } from "@esri/hub-common";
 
 export function expectAllCalled(spys: jasmine.Spy[], expect: any) {
@@ -17,7 +16,7 @@ export function expectAll(
   args.forEach(assertFunc);
 }
 
-export const getTomorrow = function() {
+export const getTomorrow = function () {
   const now = new Date();
   now.setDate(now.getDate() + 1);
   return now;
@@ -25,49 +24,53 @@ export const getTomorrow = function() {
 
 export const TOMORROW = getTomorrow();
 
-export const MOCK_USER_SESSION = new UserSession({
+const token = "fake-token";
+
+export const MOCK_USER_SESSION = {
   clientId: "clientId",
+  getToken: () => Promise.resolve(token),
   redirectUri: "https://example-app.com/redirect-uri",
-  token: "fake-token",
+  token,
   tokenExpires: TOMORROW,
   refreshToken: "refreshToken",
   refreshTokenExpires: TOMORROW,
   refreshTokenTTL: 1440,
   username: "luke",
   password: "teHf0rc3",
-  portal: "https://myorg.maps.arcgis.com/sharing/rest"
-});
+  portal: "https://myorg.maps.arcgis.com/sharing/rest",
+} as any;
 
-export const MOCK_HUB_REQOPTS = ({
+export const MOCK_HUB_REQOPTS = {
   authentication: MOCK_USER_SESSION,
   portalSelf: {
     id: "orgIdFromPortalSelf",
     name: "my spiffy org",
-    urlKey: "org"
+    urlKey: "org",
   },
   isPortal: false,
-  hubApiUrl: "https://hubqa.arcgis.com"
-} as unknown) as IHubRequestOptions;
+  hubApiUrl: "https://hubqa.arcgis.com",
+} as unknown as IHubRequestOptions;
 
-export const MOCK_PORTAL_USER_SESSION = new UserSession({
+export const MOCK_PORTAL_USER_SESSION = {
   clientId: "clientId",
+  getToken: () => Promise.resolve(token),
   redirectUri: "https://example-app.com/redirect-uri",
-  token: "fake-token",
+  token,
   tokenExpires: TOMORROW,
   refreshToken: "refreshToken",
   refreshTokenExpires: TOMORROW,
   refreshTokenTTL: 1440,
   username: "luke",
   password: "teHf0rc3",
-  portal: "https://myportal.foo.com/instancename/sharing/rest"
-});
+  portal: "https://myportal.foo.com/instancename/sharing/rest",
+} as any;
 
-export const MOCK_PORTAL_REQOPTS = ({
+export const MOCK_PORTAL_REQOPTS = {
   authentication: MOCK_PORTAL_USER_SESSION,
   portalSelf: {
     id: "orgIdFromPortalSelf",
     name: "my spiffy portal",
-    urlKey: "portalOrg"
+    urlKey: "portalOrg",
   },
-  isPortal: true
-} as unknown) as IHubRequestOptions;
+  isPortal: true,
+} as unknown as IHubRequestOptions;

--- a/packages/sites/test/unlink-site-and-page.test.ts
+++ b/packages/sites/test/unlink-site-and-page.test.ts
@@ -1,38 +1,37 @@
 import { unlinkSiteAndPage } from "../src";
 import * as commonModule from "@esri/hub-common";
 import * as fetchMock from "fetch-mock";
-import { UserSession } from "@esri/arcgis-rest-auth";
 
 function resetSpys(...args: jasmine.Spy[]) {
-  args.forEach(spy => spy.calls.reset());
+  args.forEach((spy) => spy.calls.reset());
 }
 
 describe("unlinkSiteAndPage", () => {
-  const siteModel = ({
+  const siteModel = {
     item: {
       id: "bazsite",
       properties: {
         collaborationGroupId: "collab-id",
-        contentGroupId: "content-id"
-      }
+        contentGroupId: "content-id",
+      },
     },
     data: {
       values: {
-        pages: [{ id: "foopage" }, { id: "barpage" }, { id: "bazpage" }]
-      }
-    }
-  } as unknown) as commonModule.IModel;
+        pages: [{ id: "foopage" }, { id: "barpage" }, { id: "bazpage" }],
+      },
+    },
+  } as unknown as commonModule.IModel;
 
-  const pageModel = ({
+  const pageModel = {
     item: {
-      id: "barpage"
+      id: "barpage",
     },
     data: {
       values: {
-        sites: [{ id: "foosite" }, { id: "barsite" }, { id: "bazsite" }]
-      }
-    }
-  } as unknown) as commonModule.IModel;
+        sites: [{ id: "foosite" }, { id: "barsite" }, { id: "bazsite" }],
+      },
+    },
+  } as unknown as commonModule.IModel;
 
   it("removes site and page from corresponding item arrays and unshares site with site groups", async () => {
     const updateSpy = spyOn(commonModule, "failSafeUpdate").and.callFake(
@@ -47,7 +46,7 @@ describe("unlinkSiteAndPage", () => {
     await unlinkSiteAndPage({
       siteModel,
       pageModel,
-      authentication: {} as UserSession
+      authentication: {} as any,
     });
 
     expect(updateSpy).toHaveBeenCalledTimes(2);
@@ -77,15 +76,15 @@ describe("unlinkSiteAndPage", () => {
       "unshareItemFromGroups"
     ).and.returnValue(Promise.resolve({}));
 
-    const fakeSession = ({
-      getToken: () => Promise.resolve("token")
-    } as unknown) as UserSession;
+    const fakeSession = {
+      getToken: () => Promise.resolve("token"),
+    } as unknown as any;
 
     // Non-existant site
     await unlinkSiteAndPage({
       siteId: "no-exist",
       pageModel,
-      authentication: fakeSession
+      authentication: fakeSession,
     });
     expect(updateSpy).toHaveBeenCalledTimes(1);
     expect(unshareSpy.calls.argsFor(0)[1]).toEqual(
@@ -98,7 +97,7 @@ describe("unlinkSiteAndPage", () => {
     await unlinkSiteAndPage({
       siteModel,
       pageId: "no-exist",
-      authentication: fakeSession
+      authentication: fakeSession,
     });
     expect(updateSpy).toHaveBeenCalledTimes(1);
     expect(unshareSpy).not.toHaveBeenCalled();
@@ -108,7 +107,7 @@ describe("unlinkSiteAndPage", () => {
     await unlinkSiteAndPage({
       siteId: "no-exist",
       pageId: "no-exist",
-      authentication: fakeSession
+      authentication: fakeSession,
     });
     expect(updateSpy).not.toHaveBeenCalled();
     expect(unshareSpy).not.toHaveBeenCalled();

--- a/packages/teams/test/create-hub-team.test.ts
+++ b/packages/teams/test/create-hub-team.test.ts
@@ -1,7 +1,6 @@
 import * as createGroupsModule from "../src/utils/_create-team-groups";
 import * as commonModule from "@esri/hub-common";
 import { IHubRequestOptions } from "@esri/hub-common";
-import { UserSession } from "@esri/arcgis-rest-auth";
 
 import { createHubTeam } from "../src/create-hub-team";
 import { HubTeamType, IGroupTemplate } from "../src/types";
@@ -31,7 +30,7 @@ describe("createHubTeam", () => {
         type: "In House",
       },
     },
-    authentication: {} as UserSession,
+    authentication: {} as any,
   } as IHubRequestOptions;
 
   it("creates a hub team", async () => {

--- a/packages/teams/test/create-hub-teams.test.ts
+++ b/packages/teams/test/create-hub-teams.test.ts
@@ -1,5 +1,4 @@
 import * as commonModule from "@esri/hub-common";
-import { UserSession } from "@esri/arcgis-rest-auth";
 import { IGroup } from "@esri/arcgis-rest-types";
 import * as _createTeamGroupsModule from "../src/utils/_create-team-groups";
 import { createHubTeams } from "../src/create-hub-teams";
@@ -30,7 +29,7 @@ describe("createHubTeams", () => {
         type: "In House",
       },
     },
-    authentication: {} as UserSession,
+    authentication: {} as any,
   } as commonModule.IHubRequestOptions;
 
   it("creates the correct hub teams", async () => {

--- a/packages/teams/test/remove-team-from-items.test.ts
+++ b/packages/teams/test/remove-team-from-items.test.ts
@@ -1,5 +1,4 @@
 import * as restPortalModule from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
 import { IModel } from "@esri/hub-common";
 import { removeTeamFromItems } from "../src/remove-team-from-items";
 
@@ -9,12 +8,12 @@ const TOMORROW = (function () {
   return now;
 })();
 
-const MOCK_USER_SESSION = new UserSession({
+const MOCK_USER_SESSION = {
   username: "casey",
   password: "123456",
   token: "fake-token",
   tokenExpires: TOMORROW,
-});
+} as any;
 
 describe("remove-team-from-items", function () {
   const firstModel: IModel = {

--- a/packages/teams/test/remove-team.test.ts
+++ b/packages/teams/test/remove-team.test.ts
@@ -1,5 +1,4 @@
 import * as restPortalModule from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
 import { removeTeam } from "../src/remove-team";
 
 const TOMORROW = (function () {
@@ -8,12 +7,12 @@ const TOMORROW = (function () {
   return now;
 })();
 
-const MOCK_USER_SESSION = new UserSession({
+const MOCK_USER_SESSION = {
   username: "casey",
   password: "123456",
   token: "fake-token",
   tokenExpires: TOMORROW,
-});
+} as any;
 
 describe("remove-team", function () {
   let unprotectGroupSpy: jasmine.Spy;

--- a/packages/teams/test/update-user-membership.test.ts
+++ b/packages/teams/test/update-user-membership.test.ts
@@ -1,6 +1,5 @@
 import { updateUserMembership } from "../src/update-user-membership";
 import * as restPortalModule from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
 
 const TOMORROW = (function () {
   const now = new Date();
@@ -8,12 +7,12 @@ const TOMORROW = (function () {
   return now;
 })();
 
-const MOCK_USER_SESSION = new UserSession({
+const MOCK_USER_SESSION = {
   username: "casey",
   password: "123456",
   token: "fake-token",
   tokenExpires: TOMORROW,
-});
+} as any;
 
 describe("update-user-membership", function () {
   let updateMembershipSpy: jasmine.Spy;

--- a/packages/teams/test/utils/can-user-create-team.test.ts
+++ b/packages/teams/test/utils/can-user-create-team.test.ts
@@ -1,6 +1,6 @@
 import { canUserCreateTeam } from "../../src/utils/can-user-create-team";
 import { IHubRequestOptions } from "@esri/hub-common";
-import { IUser, UserSession } from "@esri/arcgis-rest-auth";
+import { IUser } from "@esri/arcgis-rest-auth";
 import * as getUserCreatableTeamsModule from "../../src/utils/get-user-creatable-teams";
 
 describe("Name of the group", () => {
@@ -9,8 +9,8 @@ describe("Name of the group", () => {
       portalSelf: {
         id: "some-id",
         isPortal: false,
-        name: "some name"
-      }
+        name: "some name",
+      },
     } as IHubRequestOptions;
 
     const spy = spyOn(
@@ -19,7 +19,7 @@ describe("Name of the group", () => {
     ).and.returnValue([{ config: { type: "core" } }]);
 
     const user = {
-      groups: new Array(600).fill("grp")
+      groups: new Array(600).fill("grp"),
     } as IUser;
 
     expect(canUserCreateTeam(user, "followers", ro)).toBeFalsy();
@@ -35,10 +35,10 @@ describe("Name of the group", () => {
         isPortal: false,
         name: "some name",
         subscriptionInfo: {
-          type: "In House"
-        }
+          type: "In House",
+        },
       },
-      authentication: {} as UserSession
+      authentication: {} as any,
     } as IHubRequestOptions;
 
     const spy = spyOn(

--- a/packages/teams/test/utils/get-team-by-id.test.ts
+++ b/packages/teams/test/utils/get-team-by-id.test.ts
@@ -1,20 +1,19 @@
 import * as portalModule from "@esri/arcgis-rest-portal";
 import { getTeamById } from "../../src/utils/get-team-by-id";
 import { IHubRequestOptions } from "@esri/hub-common";
-import { UserSession } from "@esri/arcgis-rest-auth";
 
 describe("getTeamById", () => {
-  const authentication = new UserSession({
+  const authentication = {
     username: "portal-user",
     portal: "http://portal.com/sharing/rest",
-    token: "123"
-  });
+    token: "123",
+  } as any;
   authentication.getToken = () =>
-    new Promise(resolve => {
+    new Promise((resolve) => {
       resolve("123");
     });
   const ro = {
-    authentication
+    authentication,
   } as IHubRequestOptions;
 
   it("should call with the right group id", async () => {
@@ -38,7 +37,7 @@ describe("getTeamById", () => {
       Promise.resolve({})
     );
     const unAuthRo = {
-      portal: "https://foo.com"
+      portal: "https://foo.com",
     } as IHubRequestOptions;
     const res = await getTeamById(groupId, unAuthRo);
 

--- a/packages/teams/test/utils/get-team-members.test.ts
+++ b/packages/teams/test/utils/get-team-members.test.ts
@@ -1,20 +1,19 @@
 import * as portalModule from "@esri/arcgis-rest-portal";
 import { getTeamMembers } from "../../src/utils/get-team-members";
 import { IHubRequestOptions } from "@esri/hub-common";
-import { UserSession } from "@esri/arcgis-rest-auth";
 
 describe("getTeamMembers", () => {
-  const authentication = new UserSession({
+  const authentication = {
     username: "portal-user",
     portal: "http://portal.com/sharing/rest",
-    token: "123"
-  });
+    token: "123",
+  } as any;
   authentication.getToken = () =>
-    new Promise(resolve => {
+    new Promise((resolve) => {
       resolve("123");
     });
   const ro = {
-    authentication
+    authentication,
   } as IHubRequestOptions;
 
   it("should call with the right group id", async () => {

--- a/packages/teams/test/utils/search-team-members.test.ts
+++ b/packages/teams/test/utils/search-team-members.test.ts
@@ -1,20 +1,19 @@
 import * as portalModule from "@esri/arcgis-rest-portal";
 import { searchTeamMembers } from "../../src/utils/search-team-members";
 import { IHubRequestOptions } from "@esri/hub-common";
-import { UserSession } from "@esri/arcgis-rest-auth";
 
 describe("searchTeamMembers", () => {
-  const authentication = new UserSession({
+  const authentication = {
     username: "portal-user",
     portal: "http://portal.com/sharing/rest",
-    token: "123"
-  });
+    token: "123",
+  } as any;
   authentication.getToken = () =>
-    new Promise(resolve => {
+    new Promise((resolve) => {
       resolve("123");
     });
   const ro = {
-    authentication
+    authentication,
   } as IHubRequestOptions;
 
   it("should call with the right group id", async () => {


### PR DESCRIPTION
1. Description:

Removes all use of `UserSession` (except one test that mocks the static `UserSession.completeOAuth2`) from tests.

This will make the transition to REST JS 4 easier.

1. Instructions for testing:

If build passes, merge.

1. addresses Issues: #<number> (if appropriate)

https://devtopia.esri.com/dc/hub/issues/10768

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

n/a

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
n/a