### PR TITLE
feat(hub-common): support flatten and fields predicates in hubSearch()

### DIFF
--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getFieldsQueryParam.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getFieldsQueryParam.ts
@@ -1,0 +1,16 @@
+import { IQuery } from "../../types/IHubCatalog";
+import { getTopLevelPredicate } from "../commonHelpers/getTopLevelPredicate";
+
+/**
+ * @private
+ * Extracts the fields value that the search should be filtered by.
+ * Also validates that the fields predicate is not combined in some
+ * invalid way with other predicates.
+ *
+ * @param query query to extract the fields predicate from
+ * @returns the fields value to filter by
+ */
+export function getFieldsQueryParam(query: IQuery): string {
+  const fieldsPredicate = getTopLevelPredicate("fields", query.filters);
+  return fieldsPredicate?.fields;
+}

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getFilterQueryParam.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getFilterQueryParam.ts
@@ -21,7 +21,9 @@ export function formatFilterBlock(filter: IFilter) {
 export function formatPredicate(predicate: IPredicate) {
   const formatted = Object.entries(predicate)
     // Remove predicates that use `term` (handled in `getQQueryParam`),
-    // `bbox` (handled in `getBboxQueryParam) or have undefined entries
+    // `bbox` (handled in `getBboxQueryParam),
+    // `fields` (handled in `getFieldsQueryParam)
+    // `flatten` (handled in `getFlattenQueryParam) or have undefined entries
     .filter(
       ([field, value]) =>
         field !== "term" &&

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getFilterQueryParam.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getFilterQueryParam.ts
@@ -24,7 +24,11 @@ export function formatPredicate(predicate: IPredicate) {
     // `bbox` (handled in `getBboxQueryParam) or have undefined entries
     .filter(
       ([field, value]) =>
-        field !== "term" && field !== "bbox" && !isNilOrEmptyString(value)
+        field !== "term" &&
+        field !== "bbox" &&
+        field !== "fields" &&
+        field !== "flatten" &&
+        !isNilOrEmptyString(value)
     )
     // Create sections for each field
     .reduce((acc, [field, value]) => {

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getFlattenQueryParam.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getFlattenQueryParam.ts
@@ -1,0 +1,16 @@
+import { IQuery } from "../../types/IHubCatalog";
+import { getTopLevelPredicate } from "../commonHelpers/getTopLevelPredicate";
+
+/**
+ * @private
+ * Extracts the flatten value that the search should be filtered by.
+ * Also validates that the flatten predicate is not combined in some
+ * invalid way with other predicates.
+ *
+ * @param query query to extract the flatten predicate from
+ * @returns the flatten value to filter by
+ */
+export function getFlattenQueryParam(query: IQuery): boolean {
+  const flattenPredicate = getTopLevelPredicate("flatten", query.filters);
+  return flattenPredicate?.flatten;
+}

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcItemQueryParams.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcItemQueryParams.ts
@@ -2,7 +2,9 @@ import { getProp } from "../../../objects/get-prop";
 import { IQuery } from "../../types/IHubCatalog";
 import { IHubSearchOptions } from "../../types/IHubSearchOptions";
 import { getBboxQueryParam } from "./getBboxQueryParam";
+import { getFieldsQueryParam } from "./getFieldsQueryParam";
 import { getFilterQueryParam } from "./getFilterQueryParam";
+import { getFlattenQueryParam } from "./getFlattenQueryParam";
 import { getQQueryParam } from "./getQQueryParam";
 import { getSortByQueryParam } from "./getSortByQueryParam";
 
@@ -14,6 +16,8 @@ export interface IOgcItemQueryParams {
   q?: string;
   sortBy?: string;
   bbox?: string;
+  fields?: string;
+  flatten?: boolean;
 }
 
 /**
@@ -37,6 +41,8 @@ export function getOgcItemQueryParams(
   const q = getQQueryParam(query);
   const sortBy = getSortByQueryParam(options);
   const bbox = getBboxQueryParam(query);
+  const flatten = getFlattenQueryParam(query);
+  const fields = getFieldsQueryParam(query);
 
   return {
     filter,
@@ -46,5 +52,7 @@ export function getOgcItemQueryParams(
     q,
     sortBy,
     bbox,
+    flatten,
+    fields,
   };
 }

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -526,6 +526,45 @@ describe("hubSearchItems Module |", () => {
         } as IOgcItemQueryParams;
         expect(result).toEqual(expected);
       });
+
+      it("handles query, auth, limit, startindex, q, flatten, fields and sortBy", () => {
+        const options: IHubSearchOptions = {
+          requestOptions: {
+            authentication: {
+              token: "abc",
+            } as any,
+          },
+          num: 9,
+          start: 10,
+          sortField: "title",
+          sortOrder: "asc",
+        };
+
+        const termQuery: IQuery = cloneObject(query);
+        termQuery.filters.push({
+          operation: "AND",
+          predicates: [
+            { term: "term1" },
+            { bbox: "1,2,3,4" },
+            { flatten: true },
+            { fields: "id, slugs" },
+          ],
+        });
+
+        const result = getOgcItemQueryParams(termQuery, options);
+        const expected = {
+          filter: "((type=typeA))",
+          token: "abc",
+          limit: 9,
+          startindex: 10,
+          q: "term1",
+          sortBy: "properties.title",
+          bbox: "1,2,3,4",
+          flatten: true,
+          fields: "id, slugs",
+        } as IOgcItemQueryParams;
+        expect(result).toEqual(expected);
+      });
     });
 
     describe("getQueryString", () => {

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -395,6 +395,8 @@ describe("hubSearchItems Module |", () => {
           q: undefined,
           sortBy: undefined,
           bbox: undefined,
+          flatten: undefined,
+          fields: undefined,
         } as IOgcItemQueryParams;
         expect(result).toEqual(expected);
       });
@@ -417,6 +419,8 @@ describe("hubSearchItems Module |", () => {
           q: undefined,
           sortBy: undefined,
           bbox: undefined,
+          flatten: undefined,
+          fields: undefined,
         } as IOgcItemQueryParams;
         expect(result).toEqual(expected);
       });
@@ -440,6 +444,8 @@ describe("hubSearchItems Module |", () => {
           q: undefined,
           sortBy: undefined,
           bbox: undefined,
+          flatten: undefined,
+          fields: undefined,
         } as IOgcItemQueryParams;
         expect(result).toEqual(expected);
       });
@@ -464,6 +470,8 @@ describe("hubSearchItems Module |", () => {
           q: undefined,
           sortBy: undefined,
           bbox: undefined,
+          flatten: undefined,
+          fields: undefined,
         } as IOgcItemQueryParams;
         expect(result).toEqual(expected);
       });
@@ -491,6 +499,8 @@ describe("hubSearchItems Module |", () => {
           q: "term1",
           sortBy: undefined,
           bbox: undefined,
+          flatten: undefined,
+          fields: undefined,
         } as IOgcItemQueryParams;
         expect(result).toEqual(expected);
       });
@@ -523,6 +533,8 @@ describe("hubSearchItems Module |", () => {
           q: "term1",
           sortBy: "properties.title",
           bbox: "1,2,3,4",
+          flatten: undefined,
+          fields: undefined,
         } as IOgcItemQueryParams;
         expect(result).toEqual(expected);
       });


### PR DESCRIPTION
1. Description: This PR adds `flatten` and `fields` as valid OGC query params in hubSearch(). OGC Search API supports `flatten` query param to include layers items in result and `fields` query param to include only specific fields in response.


1. Instructions for testing:

1. Closes Issues: [#12300 ](https://devtopia.esri.com/dc/hub/issues/12300)


1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
