### PR TITLE
refactor: import IUser from arcgis-rest-portal instead of -auth

### DIFF
--- a/packages/common/src/content/_internal/computeProps.ts
+++ b/packages/common/src/content/_internal/computeProps.ts
@@ -1,5 +1,5 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
 import { IHubRequestOptions, IModel } from "../../hub-types";
 import { getItemHomeUrl } from "../../urls/get-item-home-url";

--- a/packages/common/src/content/_internal/fetchEditableContentEnrichments.ts
+++ b/packages/common/src/content/_internal/fetchEditableContentEnrichments.ts
@@ -6,7 +6,7 @@ import {
   fetchItemEnrichments,
 } from "../../items/_enrichments";
 import { isService } from "../../resources/is-service";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { IHubRequestOptions } from "../../hub-types";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { fetchItemScheduleEnrichment } from "./fetchItemScheduleEnrichment";

--- a/packages/common/src/content/_internal/fetchItemScheduleEnrichment.ts
+++ b/packages/common/src/content/_internal/fetchItemScheduleEnrichment.ts
@@ -3,7 +3,7 @@ import { IHubSchedule } from "../../core/types/IHubSchedule";
 import { getSchedule, isDownloadSchedulingAvailable } from "../manageSchedule";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IHubRequestOptions } from "../../hub-types";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 /**
  * @private

--- a/packages/common/src/content/_internal/internalContentUtils.ts
+++ b/packages/common/src/content/_internal/internalContentUtils.ts
@@ -46,7 +46,7 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { geojsonToArcGIS } from "@terraformer/arcgis";
 import { Polygon } from "geojson";
 import { getHubApiUrl } from "../../api";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { isSiteType } from "../compose";
 
 /**

--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import {
   IPortal,
   IUserItemOptions,

--- a/packages/common/src/content/manageSchedule.ts
+++ b/packages/common/src/content/manageSchedule.ts
@@ -3,7 +3,7 @@ import { cloneObject } from "../util";
 import { deepEqual } from "../objects/deepEqual";
 import { AccessLevel, IHubEditableContent } from "../core";
 import { getSchedulerApiUrl } from "./_internal/internalContentUtils";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { IHubRequestOptions } from "../hub-types";
 
 // Any code referencing these functions must first pass isDownloadSchedulingAvailable

--- a/packages/common/src/core/_internal/computeItemLinks.ts
+++ b/packages/common/src/core/_internal/computeItemLinks.ts
@@ -1,6 +1,6 @@
 import type { IItem } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemHomeUrl } from "../../urls";
 import { IHubEntityLinks } from "../../core/types";
 import { getItemIdentifier } from "../../items";

--- a/packages/common/src/core/_internal/getAuthedImageUrl.ts
+++ b/packages/common/src/core/_internal/getAuthedImageUrl.ts
@@ -1,4 +1,4 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { cacheBustUrl } from "../../urls/cacheBustUrl";
 

--- a/packages/common/src/core/traits/IWithBannerImage.ts
+++ b/packages/common/src/core/traits/IWithBannerImage.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { IHubImage, IHubImageOptions } from "../types/IHubImage";
 
 /**

--- a/packages/common/src/core/traits/IWithLayout.ts
+++ b/packages/common/src/core/traits/IWithLayout.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IHubLayout } from "../types/IHubLayout";
 

--- a/packages/common/src/discussions/_internal/computeProps.ts
+++ b/packages/common/src/discussions/_internal/computeProps.ts
@@ -1,5 +1,5 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
 import { IModel } from "../../hub-types";
 

--- a/packages/common/src/discussions/api/utils/channels/can-read-channel-v2.ts
+++ b/packages/common/src/discussions/api/utils/channels/can-read-channel-v2.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { IChannel, IDiscussionsUser } from "../../types";
 import { ChannelPermission } from "../channel-permission";
 import { hasOrgAdminViewRights } from "../portal-privilege";

--- a/packages/common/src/discussions/api/utils/channels/can-read-channel.ts
+++ b/packages/common/src/discussions/api/utils/channels/can-read-channel.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { GroupMembership } from "@esri/arcgis-rest-portal";
 import { IChannel, IDiscussionsUser } from "../../types";
 import { reduceByGroupMembership } from "../platform";

--- a/packages/common/src/discussions/api/utils/reactions/can-create-reaction-v2.ts
+++ b/packages/common/src/discussions/api/utils/reactions/can-create-reaction-v2.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { PostReaction, IChannel, IDiscussionsUser } from "../../types";
 import { canReadChannelV2 } from "../channels/can-read-channel-v2";
 

--- a/packages/common/src/discussions/api/utils/reactions/can-create-reaction.ts
+++ b/packages/common/src/discussions/api/utils/reactions/can-create-reaction.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { PostReaction, IChannel, IDiscussionsUser } from "../../types";
 import { canReadChannel } from "../channels/can-read-channel";
 

--- a/packages/common/src/discussions/edit.ts
+++ b/packages/common/src/discussions/edit.ts
@@ -13,7 +13,7 @@ import { getPropertyMap } from "./_internal/getPropertyMap";
 import { computeProps } from "./_internal/computeProps";
 import { DEFAULT_DISCUSSION, DEFAULT_DISCUSSION_MODEL } from "./defaults";
 import { getDefaultEntitySettings } from "./api/settings/getDefaultEntitySettings";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { setDiscussableKeyword } from "./utils";
 import { IHubRequestOptions, IModel } from "../hub-types";
 import { cloneObject } from "../util";

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -14,7 +14,7 @@ import {
 } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IHubGroup } from "../core/types/IHubGroup";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { DEFAULT_GROUP } from "./defaults";
 import { convertHubGroupToGroup } from "./_internal/convertHubGroupToGroup";
 import { convertGroupToHubGroup } from "./_internal/convertGroupToHubGroup";

--- a/packages/common/src/groups/_internal/computeLinks.ts
+++ b/packages/common/src/groups/_internal/computeLinks.ts
@@ -1,6 +1,6 @@
 import type { IGroup } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { IHubEntityLinks } from "../../core/types";
 import { getRelativeWorkspaceUrl } from "../../core/getRelativeWorkspaceUrl";
 import { getGroupHomeUrl } from "../../urls/getGroupHomeUrl";

--- a/packages/common/src/groups/_internal/computeProps.ts
+++ b/packages/common/src/groups/_internal/computeProps.ts
@@ -1,5 +1,5 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 
 import { IHubGroup } from "../../core/types/IHubGroup";
 import type { IGroup } from "@esri/arcgis-rest-portal";

--- a/packages/common/src/groups/_internal/getUniqueGroupTitle.ts
+++ b/packages/common/src/groups/_internal/getUniqueGroupTitle.ts
@@ -1,6 +1,6 @@
 import { IQuery } from "../../search/types";
 import { hubSearch } from "../../search/hubSearch";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 /**
  * @private

--- a/packages/common/src/groups/add-users-workflow/output-processors/_process-secondary-email.ts
+++ b/packages/common/src/groups/add-users-workflow/output-processors/_process-secondary-email.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { _canEmailUser } from "../../add-users-workflow/utils/_can-email-user";
 import { _isOrgAdmin } from "../../add-users-workflow/utils/_is-org-admin";
 import { getProp, getWithDefault } from "../../../objects";

--- a/packages/common/src/groups/add-users-workflow/utils/_can-email-user.ts
+++ b/packages/common/src/groups/add-users-workflow/utils/_can-email-user.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 
 /**
  * @private

--- a/packages/common/src/groups/add-users-workflow/utils/_get-email-users.ts
+++ b/packages/common/src/groups/add-users-workflow/utils/_get-email-users.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { _canEmailUser } from "./_can-email-user";
 import { _getInviteUsers } from "./_get-invite-users";
 
@@ -14,7 +14,7 @@ export function _getEmailUsers(
   includeSelf = false
 ): IUser[] {
   const invitedUsers = _getInviteUsers(users, requestingUser);
-  const emailUsers = invitedUsers.filter(user =>
+  const emailUsers = invitedUsers.filter((user) =>
     _canEmailUser(user, requestingUser)
   );
   if (includeSelf) {

--- a/packages/common/src/groups/add-users-workflow/utils/_get-invite-users.ts
+++ b/packages/common/src/groups/add-users-workflow/utils/_get-invite-users.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { _getAutoAddUsers } from "./_get-auto-add-users";
 
 /**
@@ -12,6 +12,6 @@ export function _getInviteUsers(
 ): IUser[] {
   const autoAddedUsers = _getAutoAddUsers(users, requestingUser);
   return users.filter(
-    user => !autoAddedUsers.some(aau => aau.username === user.username)
+    (user) => !autoAddedUsers.some((aau) => aau.username === user.username)
   );
 }

--- a/packages/common/src/groups/addGroupMembers.ts
+++ b/packages/common/src/groups/addGroupMembers.ts
@@ -3,7 +3,7 @@ import { failSafe } from "../utils";
 import { autoAddUsers } from "./autoAddUsers";
 import { inviteUsers } from "./inviteUsers";
 import { IAddGroupMembersResult, IAddOrInviteMemberResponse } from "./types";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 /**
  * Add or invite N users to a single group.

--- a/packages/common/src/groups/autoAddUsers.ts
+++ b/packages/common/src/groups/autoAddUsers.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import {
   IAddGroupUsersResult,
   IAddGroupUsersOptions,

--- a/packages/common/src/groups/deleteGroupThumbnail.ts
+++ b/packages/common/src/groups/deleteGroupThumbnail.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { request } from "@esri/arcgis-rest-request";
 
 /**

--- a/packages/common/src/groups/emailOrgUsers.ts
+++ b/packages/common/src/groups/emailOrgUsers.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import {
   ICreateOrgNotificationResult,
   ICreateOrgNotificationOptions,

--- a/packages/common/src/groups/inviteUsers.ts
+++ b/packages/common/src/groups/inviteUsers.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import {
   IInviteGroupUsersResult,
   IInviteGroupUsersOptions,

--- a/packages/common/src/groups/setGroupThumbnail.ts
+++ b/packages/common/src/groups/setGroupThumbnail.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { updateGroup } from "@esri/arcgis-rest-portal";
 import HubError from "../HubError";
 

--- a/packages/common/src/hub-types.ts
+++ b/packages/common/src/hub-types.ts
@@ -8,7 +8,7 @@ import type {
   IGeometry,
 } from "@esri/arcgis-rest-types";
 import { IPortal, ISearchResult } from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 
 /**

--- a/packages/common/src/initiative-templates/_internal/computeProps.ts
+++ b/packages/common/src/initiative-templates/_internal/computeProps.ts
@@ -1,4 +1,4 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IHubInitiativeTemplate } from "../../core";
 import { processEntityFeatures } from "../../permissions/_internal/processEntityFeatures";

--- a/packages/common/src/initiative-templates/edit.ts
+++ b/packages/common/src/initiative-templates/edit.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 // Note - we separate these imports so we can cleanly spy on things in tests
 import { createModel, getModel, updateModel } from "../models";

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { editorToEntity } from "../core/schemas/internal/metrics/editorToEntity";
 
 // Note - we separate these imports so we can cleanly spy on things in tests

--- a/packages/common/src/initiatives/_internal/computeProps.ts
+++ b/packages/common/src/initiatives/_internal/computeProps.ts
@@ -1,5 +1,5 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
 
 import { IModel } from "../../hub-types";

--- a/packages/common/src/items/_internal/_prepare-upload-requests.ts
+++ b/packages/common/src/items/_internal/_prepare-upload-requests.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { IBatch } from "../../hub-types";
 
 /**

--- a/packages/common/src/items/_internal/_wait-for-item-ready.ts
+++ b/packages/common/src/items/_internal/_wait-for-item-ready.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import {
   getItemStatus,
   IGetItemStatusResponse,

--- a/packages/common/src/items/create-item-from-file.ts
+++ b/packages/common/src/items/create-item-from-file.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import {
   addItemPart,
   cancelItemUpload,

--- a/packages/common/src/items/create-item-from-url-or-file.ts
+++ b/packages/common/src/items/create-item-from-url-or-file.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import {
   ICreateItemResponse,
   ISharingResponse,

--- a/packages/common/src/items/create-item-from-url.ts
+++ b/packages/common/src/items/create-item-from-url.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { createItem, ICreateItemResponse } from "@esri/arcgis-rest-portal";
 import type { IItemAdd } from "@esri/arcgis-rest-portal";
 

--- a/packages/common/src/items/deleteItemThumbnail.ts
+++ b/packages/common/src/items/deleteItemThumbnail.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { request } from "@esri/arcgis-rest-request";
 
 /**

--- a/packages/common/src/items/fail-safe-update.ts
+++ b/packages/common/src/items/fail-safe-update.ts
@@ -2,7 +2,7 @@ import { IModel } from "../hub-types";
 import { updateItem, IUpdateItemOptions } from "@esri/arcgis-rest-portal";
 import { serializeModel } from "../models/serializeModel";
 import { failSafe } from "../utils";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 /**
  * Update a model's item, wrapped in a failSafe so this will not blow up if

--- a/packages/common/src/items/setItemThumbnail.ts
+++ b/packages/common/src/items/setItemThumbnail.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { updateItem } from "@esri/arcgis-rest-portal";
 import HubError from "../HubError";
 

--- a/packages/common/src/items/uploadImageResource.ts
+++ b/packages/common/src/items/uploadImageResource.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { addItemResource } from "@esri/arcgis-rest-portal";
 import HubError from "../HubError";
 import { getPortalApiUrl } from "../urls";

--- a/packages/common/src/models/index.ts
+++ b/packages/common/src/models/index.ts
@@ -1,6 +1,6 @@
 export * from "./serializeModel";
 
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import {
   createItem,
   FetchReadMethodName,

--- a/packages/common/src/org/fetch.ts
+++ b/packages/common/src/org/fetch.ts
@@ -3,7 +3,7 @@ import { IHubOrganization } from "../core/types/IHubOrganization";
 import { fetchOrg } from "./fetch-org";
 import { IPortal } from "@esri/arcgis-rest-portal";
 import { getOrgThumbnailUrl } from "../resources";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { IHubSearchResult } from "../search/types/IHubSearchResult";
 
 /**

--- a/packages/common/src/org/fetchOrgLimits.ts
+++ b/packages/common/src/org/fetchOrgLimits.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { request } from "@esri/arcgis-rest-request";
 
 export type OrgLimitType =

--- a/packages/common/src/pages/HubPages.ts
+++ b/packages/common/src/pages/HubPages.ts
@@ -20,7 +20,7 @@ import {
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 import { computeProps } from "./_internal/computeProps";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
 import { DEFAULT_PAGE, DEFAULT_PAGE_MODEL } from "./defaults";
 import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";

--- a/packages/common/src/pages/_internal/computeProps.ts
+++ b/packages/common/src/pages/_internal/computeProps.ts
@@ -1,5 +1,5 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
 import { IModel } from "../../hub-types";
 

--- a/packages/common/src/projects/_internal/computeProps.ts
+++ b/packages/common/src/projects/_internal/computeProps.ts
@@ -1,5 +1,5 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
 import { IHubProject } from "../../core";
 import { IModel } from "../../hub-types";

--- a/packages/common/src/projects/edit.ts
+++ b/packages/common/src/projects/edit.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 // Note - we separate these imports so we can cleanly spy on things in tests
 import { createModel, getModel, updateModel } from "../models";

--- a/packages/common/src/resources/doesResourceExist.ts
+++ b/packages/common/src/resources/doesResourceExist.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { getItemResources } from "@esri/arcgis-rest-portal";
 
 /**

--- a/packages/common/src/resources/fetch-and-upload-resource.ts
+++ b/packages/common/src/resources/fetch-and-upload-resource.ts
@@ -1,8 +1,8 @@
 import {
   addItemResource,
-  IItemResourceResponse
+  IItemResourceResponse,
 } from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { fetchImageAsBlob } from "./fetch-image-as-blob";
 
 /**
@@ -24,7 +24,7 @@ export function fetchAndUploadResource(options: {
       owner: options.owner,
       name: options.fileName,
       resource: file,
-      authentication: options.authentication
+      authentication: options.authentication,
     });
   });
 }

--- a/packages/common/src/resources/fetch-and-upload-thumbnail.ts
+++ b/packages/common/src/resources/fetch-and-upload-thumbnail.ts
@@ -1,6 +1,6 @@
 import { fetchImageAsBlob } from "./fetch-image-as-blob";
 import { updateItem } from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 
 /**
  * Fetch image from a url, then upload to an item as it's thumbnail
@@ -15,23 +15,23 @@ export function fetchAndUploadThumbnail(options: {
 }): Promise<any> {
   // first fetch it as a blob...
   return fetchImageAsBlob(options.url)
-    .then(file => {
+    .then((file) => {
       return updateItem({
         item: {
           id: options.id,
-          owner: options.owner
+          owner: options.owner,
         },
         params: {
           fileName: options.fileName,
-          thumbnail: file
+          thumbnail: file,
         },
-        authentication: options.authentication
-      }).catch(_ => {
+        authentication: options.authentication,
+      }).catch((_) => {
         // resolve b/c this is not crtical
         return Promise.resolve();
       });
     })
-    .catch(_ => {
+    .catch((_) => {
       return Promise.resolve();
     });
 }

--- a/packages/common/src/resources/removeResource.ts
+++ b/packages/common/src/resources/removeResource.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { removeItemResource } from "@esri/arcgis-rest-portal";
 import HubError from "../HubError";
 

--- a/packages/common/src/resources/upsertResource.ts
+++ b/packages/common/src/resources/upsertResource.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { addItemResource, updateItemResource } from "@esri/arcgis-rest-portal";
 import HubError from "../HubError";
 import { objectToJsonBlob, stringToBlob, doesResourceExist } from ".";

--- a/packages/common/src/search/types/IHubSearchOptions.ts
+++ b/packages/common/src/search/types/IHubSearchOptions.ts
@@ -1,4 +1,4 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { IHubRequestOptions } from "../../hub-types";
 import { EntityType } from "./IHubCatalog";
 

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { IItem, IUserItemOptions, removeItem } from "@esri/arcgis-rest-portal";
 import { getFamily } from "../content/get-family";
 import { fetchSiteModel } from "./fetchSiteModel";

--- a/packages/common/src/sites/_internal/computeProps.ts
+++ b/packages/common/src/sites/_internal/computeProps.ts
@@ -1,5 +1,5 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { getItemThumbnailUrl } from "../../resources";
 import { IModel } from "../../hub-types";
 import { upgradeCatalogSchema } from "../../search/upgradeCatalogSchema";

--- a/packages/common/src/surveys/_internal/computeProps.ts
+++ b/packages/common/src/surveys/_internal/computeProps.ts
@@ -1,4 +1,4 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { computeItemProps } from "../../core/_internal/computeItemProps";
 import { IHubSurvey } from "../../core/types/IHubSurvey";

--- a/packages/common/src/surveys/edit.ts
+++ b/packages/common/src/surveys/edit.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import {
   IUserItemOptions,
   getItem,

--- a/packages/common/src/templates/edit.ts
+++ b/packages/common/src/templates/edit.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { IHubTemplate, IHubTemplateEditor } from "../core/types/IHubTemplate";
 import { setDiscussableKeyword } from "../discussions";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";

--- a/packages/common/src/types/IArcGISContextManagerOptions.ts
+++ b/packages/common/src/types/IArcGISContextManagerOptions.ts
@@ -1,4 +1,4 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { IPortal } from "@esri/arcgis-rest-portal";
 import type { IUser } from "@esri/arcgis-rest-portal";
 import { IUserResourceToken } from "./IUserResourceToken";

--- a/packages/common/src/types/IArcGISContextOptions.ts
+++ b/packages/common/src/types/IArcGISContextOptions.ts
@@ -1,4 +1,4 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import type { IPortal } from "@esri/arcgis-rest-portal";
 import type { IUser } from "@esri/arcgis-rest-portal";
 import type { IUserResourceToken } from "./IUserResourceToken";

--- a/packages/common/test/content/manageSchedule.test.ts
+++ b/packages/common/test/content/manageSchedule.test.ts
@@ -13,7 +13,7 @@ import { MOCK_HUB_REQOPTS, MOCK_NOAUTH_HUB_REQOPTS } from "../mocks/mock-auth";
 import { IHubEditableContent } from "../../src/core/types/IHubEditableContent";
 import * as fetchMock from "fetch-mock";
 import { getSchedulerApiUrl } from "../../src/content/_internal/internalContentUtils";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 describe("manageSchedule", () => {
   afterEach(() => {

--- a/packages/common/test/discussions/api/utils/channels/index.test.ts
+++ b/packages/common/test/discussions/api/utils/channels/index.test.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import type { IGroup } from "@esri/arcgis-rest-portal";
 import {
   SharingAccess,

--- a/packages/common/test/discussions/api/utils/reactions/can-create-reaction-v2.test.ts
+++ b/packages/common/test/discussions/api/utils/reactions/can-create-reaction-v2.test.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { canCreateReactionV2 } from "../../../../../src/discussions/api//utils/reactions";
 import {
   PostReaction,

--- a/packages/common/test/discussions/api/utils/reactions/can-create-reaction.test.ts
+++ b/packages/common/test/discussions/api/utils/reactions/can-create-reaction.test.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { canCreateReaction } from "../../../../../src/discussions/api//utils/reactions";
 import {
   PostReaction,

--- a/packages/common/test/groups/_internal/getUniqueGroupTitle.test.ts
+++ b/packages/common/test/groups/_internal/getUniqueGroupTitle.test.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { getUniqueGroupTitle } from "../../../src/groups/_internal/getUniqueGroupTitle";
 import * as SearchModule from "../../../src/search/hubSearch";
 

--- a/packages/common/test/items/_prepare-upload-requests.test.ts
+++ b/packages/common/test/items/_prepare-upload-requests.test.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { _prepareUploadRequests } from "../../src/items/_internal/_prepare-upload-requests";
 describe("_prepareUploadRequests", () => {
   if (typeof Blob !== "undefined") {

--- a/packages/common/test/items/_wait-for-item-ready.test.ts
+++ b/packages/common/test/items/_wait-for-item-ready.test.ts
@@ -1,5 +1,5 @@
 import * as portal from "@esri/arcgis-rest-portal";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { _waitForItemReady } from "../../src/items/_internal/_wait-for-item-ready";
 
 describe("_waitForItemReady", () => {

--- a/packages/common/test/items/create-item-from-file.test.ts
+++ b/packages/common/test/items/create-item-from-file.test.ts
@@ -1,7 +1,7 @@
 import { createItemFromFile } from "../../src/items/create-item-from-file";
 import * as portal from "@esri/arcgis-rest-portal";
 import * as _prepareUploadRequestsModule from "../../src/items/_internal/_prepare-upload-requests";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import type { IItemAdd } from "@esri/arcgis-rest-portal";
 
 describe("createItemFromFile", () => {

--- a/packages/common/test/items/create-item-from-url-or-file.test.ts
+++ b/packages/common/test/items/create-item-from-url-or-file.test.ts
@@ -1,4 +1,4 @@
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import type { IGroup, IItemAdd } from "@esri/arcgis-rest-portal";
 import { createItemFromUrlOrFile } from "../../src/items/create-item-from-url-or-file";
 import * as createItemFromFileModule from "../../src/items/create-item-from-file";

--- a/packages/common/test/items/create-item-from-url.test.ts
+++ b/packages/common/test/items/create-item-from-url.test.ts
@@ -1,6 +1,6 @@
 import { createItemFromUrl } from "../../src/items/create-item-from-url";
 import * as portal from "@esri/arcgis-rest-portal";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 describe("createContentWithUrl", () => {
   it("Properly calls createItem", async () => {

--- a/packages/common/test/org/fetchOrgLimits.test.ts
+++ b/packages/common/test/org/fetchOrgLimits.test.ts
@@ -1,7 +1,7 @@
 import * as LimitsModule from "../../src/org/fetchOrgLimits";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as RequestModule from "@esri/arcgis-rest-request";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 describe("fetchOrgLimits module:", () => {
   describe("fetching any limits", () => {

--- a/packages/downloads/src/poll-download-metadata.ts
+++ b/packages/downloads/src/poll-download-metadata.ts
@@ -1,5 +1,5 @@
 import * as EventEmitter from "eventemitter3";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { hubPollDownloadMetadata } from "./hub/hub-poll-download-metadata";
 import { portalPollExportJobStatus } from "./portal/portal-poll-export-job-status";
 import { DownloadFormat } from "./download-format";
@@ -58,7 +58,7 @@ export function pollDownloadMetadata(
     geometry,
     where,
     host,
-    existingFileDate
+    existingFileDate,
   } = params;
 
   if (!target || target === "hub") {
@@ -72,7 +72,7 @@ export function pollDownloadMetadata(
       spatialRefId,
       geometry,
       where,
-      existingFileDate
+      existingFileDate,
     });
   }
 
@@ -87,6 +87,6 @@ export function pollDownloadMetadata(
     eventEmitter,
     pollingInterval,
     geometry,
-    where
+    where,
   });
 }

--- a/packages/downloads/src/portal/portal-get-exports-folder-id.ts
+++ b/packages/downloads/src/portal/portal-get-exports-folder-id.ts
@@ -1,9 +1,9 @@
 import {
   createFolder,
   IAddFolderResponse,
-  getUserContent
+  getUserContent,
 } from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 
 /**
  * @private

--- a/packages/downloads/src/portal/portal-poll-export-job-status.ts
+++ b/packages/downloads/src/portal/portal-poll-export-job-status.ts
@@ -1,10 +1,10 @@
 import {
   getItemStatus,
-  IGetItemStatusResponse
+  IGetItemStatusResponse,
 } from "@esri/arcgis-rest-portal";
 import { DownloadFormat } from "../download-format";
 import * as EventEmitter from "eventemitter3";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { IPoller } from "../poller";
 import { exportSuccessHandler } from "./portal-export-success-handler";
 import { DownloadStatus } from "../download-status";
@@ -45,7 +45,7 @@ class PortalPoller implements IPoller {
       authentication,
       exportCreated,
       eventEmitter,
-      pollingInterval
+      pollingInterval,
     } = params;
 
     this.pollTimer = setInterval(() => {
@@ -53,7 +53,7 @@ class PortalPoller implements IPoller {
         id: downloadId,
         jobId,
         jobType: "export",
-        authentication
+        authentication,
       })
         .then((metadata: IGetItemStatusResponse) => {
           if (metadata.status === "completed") {
@@ -64,7 +64,7 @@ class PortalPoller implements IPoller {
               downloadId,
               spatialRefId,
               exportCreated,
-              eventEmitter
+              eventEmitter,
             }).then(() => {
               this.disablePoll();
             });
@@ -76,9 +76,9 @@ class PortalPoller implements IPoller {
                 error: new Error(metadata.statusMessage),
                 metadata: {
                   status: DownloadStatus.ERROR,
-                  errors: [new Error(metadata.statusMessage)]
-                }
-              }
+                  errors: [new Error(metadata.statusMessage)],
+                },
+              },
             });
             return this.disablePoll();
           }
@@ -90,9 +90,9 @@ class PortalPoller implements IPoller {
                 error,
                 metadata: {
                   status: DownloadStatus.ERROR,
-                  errors: [error]
-                }
-              }
+                  errors: [error],
+                },
+              },
             });
           } else {
             eventEmitter.emit(`${downloadId}PollingError`, {
@@ -100,9 +100,9 @@ class PortalPoller implements IPoller {
                 error,
                 metadata: {
                   status: DownloadStatus.ERROR,
-                  errors: [error]
-                }
-              }
+                  errors: [error],
+                },
+              },
             });
           }
           return this.disablePoll();

--- a/packages/downloads/src/portal/portal-request-download-metadata.ts
+++ b/packages/downloads/src/portal/portal-request-download-metadata.ts
@@ -1,5 +1,5 @@
 import { getItem, IItem, searchItems } from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import {
   getService,
   getLayer,

--- a/packages/downloads/src/request-dataset-export.ts
+++ b/packages/downloads/src/request-dataset-export.ts
@@ -1,4 +1,4 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { hubRequestDatasetExport } from "./hub/hub-request-dataset-export";
 import { portalRequestDatasetExport } from "./portal/portal-request-dataset-export";
 import { DownloadFormat } from "./download-format";
@@ -54,7 +54,7 @@ export function requestDatasetExport(
     where,
     title,
     target,
-    authentication
+    authentication,
   } = params;
 
   if (!target || target === "hub") {
@@ -64,7 +64,7 @@ export function requestDatasetExport(
       format,
       spatialRefId,
       geometry,
-      where
+      where,
     });
   }
 
@@ -74,6 +74,6 @@ export function requestDatasetExport(
     title,
     authentication,
     spatialRefId,
-    where
+    where,
   });
 }

--- a/packages/downloads/src/request-download-metadata.ts
+++ b/packages/downloads/src/request-download-metadata.ts
@@ -3,7 +3,7 @@ import { hubRequestDownloadMetadata } from "./hub/hub-request-download-metadata"
 import { DownloadFormat } from "./download-format";
 import { DownloadTarget } from "./download-target";
 import { DownloadStatuses } from "./download-status";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 
 export interface IDownloadMetadataRequestParams {
   /* API target for downloads: 'hub' (default), 'portal', 'enterprise' */

--- a/packages/events/src/add-users-to-event.ts
+++ b/packages/events/src/add-users-to-event.ts
@@ -1,9 +1,9 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import {
   addUsersToGroup,
   IConsolidatedResult,
   IEmail,
-  IHubRequestOptions
+  IHubRequestOptions,
 } from "@esri/hub-common";
 
 /**

--- a/packages/events/src/register.ts
+++ b/packages/events/src/register.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2019 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import { joinGroup, leaveGroup } from "@esri/arcgis-rest-portal";
 
 export interface IEventRegisterOptions extends IUserRequestOptions {
@@ -29,7 +29,7 @@ export function registerForEvent(
 ): Promise<{ success: boolean; groupId: string }> {
   return joinGroup({
     id: requestOptions.groupId,
-    authentication: requestOptions.authentication
+    authentication: requestOptions.authentication,
   });
 }
 
@@ -52,6 +52,6 @@ export function unregisterForEvent(
 ): Promise<{ success: boolean; groupId: string }> {
   return leaveGroup({
     id: requestOptions.groupId,
-    authentication: requestOptions.authentication
+    authentication: requestOptions.authentication,
   });
 }

--- a/packages/events/src/util.ts
+++ b/packages/events/src/util.ts
@@ -4,7 +4,7 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { searchItems, ISearchResult, IItem } from "@esri/arcgis-rest-portal";
 import { IQueryFeaturesOptions } from "@esri/arcgis-rest-feature-layer";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { getHubApiUrl } from "@esri/hub-common";
 
 /**
@@ -28,7 +28,7 @@ export function getEventServiceUrl(
   orgId: string,
   requestOptions?: IRequestOptions
 ): Promise<string> {
-  return getEventServiceItem(orgId, requestOptions).then(response => {
+  return getEventServiceItem(orgId, requestOptions).then((response) => {
     const host = getHubApiUrl(requestOptions);
 
     // Extract the Event service's view name; the view returned depends
@@ -64,7 +64,7 @@ export function getEventFeatureServiceUrl(
   orgId: string,
   requestOptions?: IRequestOptions
 ): Promise<string> {
-  return getEventServiceItem(orgId, requestOptions).then(response => {
+  return getEventServiceItem(orgId, requestOptions).then((response) => {
     // single-layer service
     let url = `${response.url}/0`;
     // force https
@@ -140,8 +140,8 @@ export function getEventServiceItem(
   return searchItems({
     q: `typekeywords:hubEventsLayer AND orgid:${orgId}`,
     // mixin requestOptions (if present)
-    ...requestOptions
-  }).then(response => {
+    ...requestOptions,
+  }).then((response) => {
     const eventResponse = response as ISearchResult<IItem>;
     if (eventResponse.results && eventResponse.results.length > 0) {
       let result;

--- a/packages/events/test/add-users-to-event.test.ts
+++ b/packages/events/test/add-users-to-event.test.ts
@@ -1,9 +1,9 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import * as commonModule from "@esri/hub-common";
 import {
   IConsolidatedResult,
   IEmail,
-  IHubRequestOptions
+  IHubRequestOptions,
 } from "@esri/hub-common";
 
 import { addUsersToEvent } from "../src/add-users-to-event";
@@ -15,23 +15,23 @@ describe("addUsersToTeam", () => {
     const primaryRO: IHubRequestOptions = {
       isPortal: false,
       hubApiUrl: "a-url",
-      authentication: null
+      authentication: null,
     };
     const email: IEmail = {
       subject: "this is a test",
-      body: "body"
+      body: "body",
     };
     const secondaryRO: IHubRequestOptions = {
       isPortal: false,
       hubApiUrl: "another-url",
-      authentication: null
+      authentication: null,
     };
 
     const expected: IConsolidatedResult = {
       success: true,
       autoAdd: {
-        success: true
-      }
+        success: true,
+      },
     };
 
     const groupSpy = spyOn(commonModule, "addUsersToGroup").and.callFake(() =>

--- a/packages/initiatives/src/follow.ts
+++ b/packages/initiatives/src/follow.ts
@@ -1,10 +1,10 @@
 import { request, IRequestOptions } from "@esri/arcgis-rest-request";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import {
   IUser,
   getUserUrl,
   joinGroup,
-  leaveGroup
+  leaveGroup,
 } from "@esri/arcgis-rest-portal";
 import { IInitiativeModel, getProp, unique } from "@esri/hub-common";
 import { getInitiative } from "./get";
@@ -30,9 +30,9 @@ const currentlyFollowedInitiativesByGroupMembership = (
   user: IUser
 ): string[] => {
   return user.groups
-    .map(group => group.tags)
+    .map((group) => group.tags)
     .reduce((acc, item) => acc.concat(item), [])
-    .filter(tags => tags.indexOf("hubInitiativeFollowers|") === 0)
+    .filter((tags) => tags.indexOf("hubInitiativeFollowers|") === 0)
     .map(initiativeIdFromGroupTag);
 };
 
@@ -62,9 +62,9 @@ export function followInitiative(
 ): Promise<{ success: boolean; username: string }> {
   // we dont call getUser() because the tags are cached and will be mutating
   return request(getUserUrl(requestOptions.authentication), {
-    authentication: requestOptions.authentication
+    authentication: requestOptions.authentication,
   })
-    .then(user => {
+    .then((user) => {
       // don't update if already following
       if (isUserFollowing(user, requestOptions.initiativeId)) {
         return Promise.reject(`user is already following this initiative.`);
@@ -72,16 +72,16 @@ export function followInitiative(
       // if not already following, pass the user on
       return user;
     })
-    .then(user => {
+    .then((user) => {
       return getInitiative(requestOptions.initiativeId, requestOptions).then(
         (initiative: IInitiativeModel) => ({
           user,
           initiative,
-          hasFollowersGroup: false
+          hasFollowersGroup: false,
         })
       );
     })
-    .then(obj => {
+    .then((obj) => {
       // if the initiative has a followersGroupId
       const groupId = getProp(
         obj,
@@ -91,15 +91,15 @@ export function followInitiative(
         // attempt to join it
         return joinGroup({
           id: groupId,
-          authentication: requestOptions.authentication
-        }).then(groupJoinResponse => {
+          authentication: requestOptions.authentication,
+        }).then((groupJoinResponse) => {
           obj.hasFollowersGroup = groupJoinResponse.success;
           return obj;
         });
       }
       return obj;
     })
-    .then(obj => {
+    .then((obj) => {
       if (!obj.hasFollowersGroup) {
         // else add the tag to the user
         const tag = getUserTag(requestOptions.initiativeId);
@@ -108,7 +108,7 @@ export function followInitiative(
 
         return request(getUpdateUrl(requestOptions.authentication), {
           params: { tags },
-          authentication: requestOptions.authentication
+          authentication: requestOptions.authentication,
         });
       }
       // the initiative has a followers group and we successfully joined it
@@ -133,9 +133,9 @@ export function unfollowInitiative(
 ): Promise<{ success: boolean; username: string }> {
   // we dont call getUser() because the tags are cached and will be mutating
   return request(getUserUrl(requestOptions.authentication), {
-    authentication: requestOptions.authentication
+    authentication: requestOptions.authentication,
   })
-    .then(user => {
+    .then((user) => {
       // don't update if not already following
       if (!isUserFollowing(user, requestOptions.initiativeId)) {
         return Promise.reject(`user is not following this initiative.`);
@@ -143,7 +143,7 @@ export function unfollowInitiative(
       // if already following, pass the user on
       return user;
     })
-    .then(user => {
+    .then((user) => {
       const tag = getUserTag(requestOptions.initiativeId);
       const tags = JSON.parse(JSON.stringify(user.tags));
       if (tags.indexOf(tag) > -1) {
@@ -158,17 +158,17 @@ export function unfollowInitiative(
 
         return request(getUpdateUrl(requestOptions.authentication), {
           params: { tags },
-          authentication: requestOptions.authentication
-        }).then(_ => user);
+          authentication: requestOptions.authentication,
+        }).then((_) => user);
       }
       return user;
     })
-    .then(user => {
+    .then((user) => {
       return getInitiative(requestOptions.initiativeId, requestOptions).then(
         (initiative: IInitiativeModel) => ({ user, initiative })
       );
     })
-    .then(obj => {
+    .then((obj) => {
       // if there is an initiative followers group and the user is a member, attempt to leave it
       const groupId = getProp(
         obj,
@@ -182,8 +182,8 @@ export function unfollowInitiative(
       ) {
         return leaveGroup({
           id: groupId,
-          authentication: requestOptions.authentication
-        }).then(groupLeaveResponse => {
+          authentication: requestOptions.authentication,
+        }).then((groupLeaveResponse) => {
           return { success: true, username: obj.user.username };
         });
       }

--- a/packages/initiatives/src/util.ts
+++ b/packages/initiatives/src/util.ts
@@ -1,10 +1,10 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import {
   addItemResource,
-  IItemResourceResponse
+  IItemResourceResponse,
 } from "@esri/arcgis-rest-portal";
 import { getPortalApiUrl } from "@esri/hub-common";
 /**
@@ -31,8 +31,8 @@ export function copyImageResources(
   /* istanbul ignore next blob responses are difficult to make cross platform we will just have to trust the isomorphic fetch will do its job */
   return requestOptions.authentication
     .getToken(itemResourceUrl)
-    .then(token => {
-      const assetPromises = assets.map(assetName => {
+    .then((token) => {
+      const assetPromises = assets.map((assetName) => {
         const sourceUrl = `${itemResourceUrl}/${assetName}?token=${token}`;
         return addImageAsResource(
           targetItemId,
@@ -112,7 +112,7 @@ export function addImageAsResource(
   const fetchOptions: RequestInit = {
     method: "GET",
     // ensures behavior mimics XMLHttpRequest. needed to support sending IWA cookies
-    credentials: "same-origin"
+    credentials: "same-origin",
   };
   return (
     // -------------------------------------------------
@@ -120,16 +120,16 @@ export function addImageAsResource(
     // -------------------------------------------------
 
     fetch(url, fetchOptions)
-      .then(x => {
+      .then((x) => {
         return x.blob();
       })
-      .then(blob => {
+      .then((blob) => {
         return addItemResource({
           id,
           owner,
           name,
           resource: blob,
-          authentication: requestOptions.authentication
+          authentication: requestOptions.authentication,
         }).then((response: IItemResourceResponse) => {
           return response.success;
         });

--- a/packages/search/src/ago/compute-items-facets.ts
+++ b/packages/search/src/ago/compute-items-facets.ts
@@ -1,4 +1,4 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { ISearchParams } from "./params";
 import { getProp } from "@esri/hub-common";
 import {
@@ -6,7 +6,7 @@ import {
   hasApiAgg,
   collectionAgg,
   downloadableAgg,
-  flattenCategories
+  flattenCategories,
 } from "./helpers/aggs";
 import { getItems } from "./get-items";
 
@@ -19,7 +19,7 @@ const customAggsSupportedByAgo = ["hasApi", "collection"];
 const customAggsFunctions: { [key: string]: any } = {
   downloadable: downloadableAgg,
   hasApi: hasApiAgg,
-  collection: collectionAgg
+  collection: collectionAgg,
 };
 
 /**
@@ -49,7 +49,7 @@ export async function computeItemsFacets(
     const paramsCopy = { ...params, ...{ start: 1, num: 100 } };
     paramsCopy.agg = {};
     const response = await getItems(paramsCopy, token, portal, authentication);
-    customAggs.forEach(customAgg => {
+    customAggs.forEach((customAgg) => {
       const rawCounts = customAggsFunctions[customAgg](response);
       facets1 = { ...facets1, ...format(rawCounts) };
     });
@@ -60,7 +60,7 @@ export async function computeItemsFacets(
       formattedAggs[agg.fieldName] = agg.fieldValues.map((fieldVal: any) => {
         return {
           key: fieldVal.value,
-          docCount: fieldVal.count
+          docCount: fieldVal.count,
         };
       });
       return formattedAggs;
@@ -71,7 +71,7 @@ export async function computeItemsFacets(
   customAggs = intersection(aggs, customAggsSupportedByAgo);
   let facets3 = {};
   if (customAggs.length > 0) {
-    customAggs.forEach(customAgg => {
+    customAggs.forEach((customAgg) => {
       const rawCounts = { ...customAggsFunctions[customAgg](agoAggregations) };
       facets3 = { ...facets3, ...format(rawCounts) };
     });
@@ -85,5 +85,5 @@ export async function computeItemsFacets(
 }
 
 function intersection(arr1: any[], arr2: any[]): any[] {
-  return arr1.filter(val => arr2.indexOf(val) !== -1);
+  return arr1.filter((val) => arr2.indexOf(val) !== -1);
 }

--- a/packages/search/src/ago/get-items.ts
+++ b/packages/search/src/ago/get-items.ts
@@ -1,5 +1,5 @@
 import { ISearchParams } from "./params";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { ISearchResult, IItem, searchItems } from "@esri/arcgis-rest-portal";
 import { encodeAgoQuery } from "./encode-ago-query";
 import { getProp, chunkArray } from "@esri/hub-common";

--- a/packages/search/src/ago/search.ts
+++ b/packages/search/src/ago/search.ts
@@ -2,7 +2,7 @@
  * Apache-2.0 */
 
 import { ISearchParams, IHubResults } from "./params";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { computeItemsFacets } from "./compute-items-facets";
 import { agoFormatItemCollection } from "./format-item-collection";
 import { getItems } from "./get-items";

--- a/packages/sites/src/_remove-parent-initiative.ts
+++ b/packages/sites/src/_remove-parent-initiative.ts
@@ -1,5 +1,5 @@
 import { IModel, getProp, _unprotectAndRemoveItem } from "@esri/hub-common";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 /**
  * Remove the parent initiative item, if it exists

--- a/packages/sites/src/_remove-site-groups.ts
+++ b/packages/sites/src/_remove-site-groups.ts
@@ -2,9 +2,9 @@ import {
   IModel,
   maybePush,
   getProp,
-  _unprotectAndRemoveGroup
+  _unprotectAndRemoveGroup,
 } from "@esri/hub-common";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 /**
  * Remove the well-known team groups
@@ -21,12 +21,12 @@ export function _removeSiteGroups(
   const teamsToDelete = [
     "collaborationGroupId",
     "contentGroupId",
-    "followersGroupId"
+    "followersGroupId",
   ].reduce((acc, prop) => {
     return maybePush(getProp(siteModel, `item.properties.${prop}`), acc);
   }, []);
 
-  const promises = teamsToDelete.map(id => {
+  const promises = teamsToDelete.map((id) => {
     const opts = Object.assign({ id }, requestOptions);
     return _unprotectAndRemoveGroup(opts);
   });

--- a/packages/sites/src/layout/remove-unused-resources.ts
+++ b/packages/sites/src/layout/remove-unused-resources.ts
@@ -1,7 +1,7 @@
 import { failSafe } from "@esri/hub-common";
 
 import { IHubRequestOptions } from "@esri/hub-common";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 
 import { getItemResources, removeItemResource } from "@esri/arcgis-rest-portal";
 
@@ -28,7 +28,7 @@ export function removeUnusedResources(
 ) {
   const layoutImageCropIds = _getImageCropIdsFromLayout(layout);
 
-  return getItemResources(id, hubRequestOptions).then(response => {
+  return getItemResources(id, hubRequestOptions).then((response) => {
     const itemResourcesOnAGO = (response.resources || []).map(
       extractResourceProperty
     );
@@ -93,7 +93,7 @@ function removeUnusedResourcesFromAGO(
 ) {
   // failSafe these calls b/c this is not critical
   const failSaveRemoveItemResources = failSafe(removeItemResource, {
-    success: true
+    success: true,
   });
 
   return Promise.all(
@@ -101,7 +101,7 @@ function removeUnusedResourcesFromAGO(
       failSaveRemoveItemResources({
         id,
         resource,
-        authentication
+        authentication,
       })
     )
   );

--- a/packages/sites/src/link-site-and-page.ts
+++ b/packages/sites/src/link-site-and-page.ts
@@ -13,7 +13,7 @@ import {
   deepSet,
 } from "@esri/hub-common";
 import { updateItem } from "@esri/arcgis-rest-portal";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { isSite } from "./is-site";
 
 /**

--- a/packages/sites/src/pages/remove-page.ts
+++ b/packages/sites/src/pages/remove-page.ts
@@ -8,7 +8,7 @@ import {
 } from "@esri/hub-common";
 import { unlinkSiteAndPage } from "../unlink-site-and-page";
 import { removeItem } from "@esri/arcgis-rest-portal";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 /**
  * Remove a Page Item. This deletes the item.

--- a/packages/sites/src/unlink-site-and-page.ts
+++ b/packages/sites/src/unlink-site-and-page.ts
@@ -7,9 +7,9 @@ import {
   getProp,
   failSafeUpdate,
   failSafe,
-  unshareItemFromGroups
+  unshareItemFromGroups,
 } from "@esri/hub-common";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 
 /**
  * Unlink a Page from a Site and vice-versa
@@ -33,14 +33,14 @@ export function unlinkSiteAndPage(unlinkRequestOptions: {
   let pageModel: IModel;
   let siteModel: IModel;
   const requestOptions = {
-    authentication: unlinkRequestOptions.authentication
+    authentication: unlinkRequestOptions.authentication,
   };
   // get the models from the options...
   return Promise.all([
     getModelFromOptions("page", unlinkRequestOptions),
-    getModelFromOptions("site", unlinkRequestOptions)
+    getModelFromOptions("site", unlinkRequestOptions),
   ])
-    .then(models => {
+    .then((models) => {
       [pageModel, siteModel] = models;
       // Handle the site
       if (!siteModel.isMissing) {
@@ -85,7 +85,7 @@ export function unlinkSiteAndPage(unlinkRequestOptions: {
       // return the updated models
       return {
         pageModel,
-        siteModel
+        siteModel,
       };
     });
 }

--- a/packages/sites/test/_remove-parent-initiative.test.ts
+++ b/packages/sites/test/_remove-parent-initiative.test.ts
@@ -1,6 +1,6 @@
 import { _removeParentInitiative } from "../src";
 import * as commonModule from "@esri/hub-common";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 describe("_removeParentInitiative", () => {
   it("removes the groups", async () => {
@@ -12,9 +12,9 @@ describe("_removeParentInitiative", () => {
     const siteModel = {
       item: {
         properties: {
-          parentInitiativeId: "parent"
-        }
-      }
+          parentInitiativeId: "parent",
+        },
+      },
     } as commonModule.IModel;
 
     await _removeParentInitiative(siteModel, {} as IUserRequestOptions);
@@ -32,9 +32,9 @@ describe("_removeParentInitiative", () => {
     const siteModel = {
       item: {
         properties: {
-          parentInitiativeId: null
-        }
-      }
+          parentInitiativeId: null,
+        },
+      },
     } as commonModule.IModel;
 
     await _removeParentInitiative(siteModel, {} as IUserRequestOptions);

--- a/packages/sites/test/_remove-site-groups.test.ts
+++ b/packages/sites/test/_remove-site-groups.test.ts
@@ -1,6 +1,6 @@
 import * as commonModule from "@esri/hub-common";
 import { _removeSiteGroups } from "../src";
-import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
+import type { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 describe("_removeSiteGroups", () => {
   it("removes the groups", async () => {
@@ -13,9 +13,9 @@ describe("_removeSiteGroups", () => {
       item: {
         properties: {
           collaborationGroupId: "abc",
-          contentGroupId: "123"
-        }
-      }
+          contentGroupId: "123",
+        },
+      },
     } as commonModule.IModel;
 
     const res = await _removeSiteGroups(siteModel, {} as IUserRequestOptions);

--- a/packages/surveys/src/sharing/set-access-revertable.ts
+++ b/packages/surveys/src/sharing/set-access-revertable.ts
@@ -2,12 +2,12 @@
  * Apache-2.0 */
 
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { setItemAccess } from "@esri/arcgis-rest-portal";
 import {
   IModel,
   IRevertableTaskResult,
-  runRevertableTask
+  runRevertableTask,
 } from "@esri/hub-common";
 
 /**
@@ -31,8 +31,8 @@ export const setAccessRevertable = (
         id,
         owner,
         access,
-        authentication
-      }).then(result => {
+        authentication,
+      }).then((result) => {
         if (result.notSharedWith.length) {
           throw new Error(`Failed to set item ${id} access to ${access}`);
         }
@@ -44,7 +44,7 @@ export const setAccessRevertable = (
         id,
         owner,
         access: previousAccess,
-        authentication
+        authentication,
       }).catch(() => {})
     /* tslint:enable no-empty */
   );

--- a/packages/surveys/src/sharing/share-with-group-revertable.ts
+++ b/packages/surveys/src/sharing/share-with-group-revertable.ts
@@ -2,7 +2,7 @@
  * Apache-2.0 */
 
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import {
   unshareItemWithGroup,
   shareItemWithGroup,

--- a/packages/surveys/src/sharing/unshare-with-group-revertable.ts
+++ b/packages/surveys/src/sharing/unshare-with-group-revertable.ts
@@ -2,7 +2,7 @@
  * Apache-2.0 */
 
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import {
   unshareItemWithGroup,
   shareItemWithGroup,

--- a/packages/teams/src/add-users-to-team.ts
+++ b/packages/teams/src/add-users-to-team.ts
@@ -1,9 +1,9 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import {
   addUsersToGroup,
   IConsolidatedResult,
   IEmail,
-  IHubRequestOptions
+  IHubRequestOptions,
 } from "@esri/hub-common";
 
 /**

--- a/packages/teams/src/remove-team-from-items.ts
+++ b/packages/teams/src/remove-team-from-items.ts
@@ -1,4 +1,4 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { IUpdateItemResponse, updateItem } from "@esri/arcgis-rest-portal";
 import { cloneObject, IModel, without } from "@esri/hub-common";
 
@@ -29,15 +29,16 @@ export async function removeTeamFromItems(
         teamId
       );
       // Check if the user has access to edit the item. itemControl is only present when the item is directly fetched
-      // 
-      return clonedModel.item.itemControl === "admin" || clonedModel.item.itemControl === "update"
-        // If yes, then update the item
-        ? updateItem({
-          item: clonedModel.item,
-          authentication,
-        })
-        // Otherwise return a 'fail' state for that item specifically
-        : { id: clonedModel.item.id, success: false};
+      //
+      return clonedModel.item.itemControl === "admin" ||
+        clonedModel.item.itemControl === "update"
+        ? // If yes, then update the item
+          updateItem({
+            item: clonedModel.item,
+            authentication,
+          })
+        : // Otherwise return a 'fail' state for that item specifically
+          { id: clonedModel.item.id, success: false };
     })
   );
 }

--- a/packages/teams/src/remove-team.ts
+++ b/packages/teams/src/remove-team.ts
@@ -1,4 +1,4 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import { removeGroup, unprotectGroup } from "@esri/arcgis-rest-portal";
 
 /**
@@ -12,13 +12,13 @@ import { removeGroup, unprotectGroup } from "@esri/arcgis-rest-portal";
 export async function removeTeam(
   id: string,
   authentication: UserSession
-): Promise<{groupId: string; success: boolean}> {
+): Promise<{ groupId: string; success: boolean }> {
   // unprotect the group
   const unprotectResult = await unprotectGroup({ id, authentication });
   // If that succeeded...
   return unprotectResult.success
-    // Remove it.
-    ? removeGroup({ id, authentication })
-    // Otherwise return a fail state
-    : { groupId: id, success: false };
+    ? // Remove it.
+      removeGroup({ id, authentication })
+    : // Otherwise return a fail state
+      { groupId: id, success: false };
 }

--- a/packages/teams/src/update-user-membership.ts
+++ b/packages/teams/src/update-user-membership.ts
@@ -1,4 +1,4 @@
-import { UserSession } from "@esri/arcgis-rest-auth";
+import type { UserSession } from "@esri/arcgis-rest-auth";
 import {
   updateUserMemberships,
   IUpdateGroupUsersResult,

--- a/packages/teams/src/utils/_create-team-group.ts
+++ b/packages/teams/src/utils/_create-team-group.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { IHubRequestOptions } from "@esri/hub-common";
 import { createGroup, protectGroup, IGroup } from "@esri/arcgis-rest-portal";
 import { getUniqueGroupTitle } from "./get-unique-group-title";
@@ -24,29 +24,29 @@ export function _createTeamGroup(
     hubRequestOptions.portalSelf
   );
   return getUniqueGroupTitle(group.title, hubRequestOptions)
-    .then(uniqueTitle => {
+    .then((uniqueTitle) => {
       group.title = uniqueTitle;
       return createGroup({
         group: group as IGroup, // close enough
-        authentication: hubRequestOptions.authentication
+        authentication: hubRequestOptions.authentication,
       });
     })
-    .then(createResponse => {
+    .then((createResponse) => {
       group.id = createResponse.group.id;
       return protectGroup({
         id: group.id,
-        authentication: hubRequestOptions.authentication
+        authentication: hubRequestOptions.authentication,
       });
     })
     .then(() => {
       group.userMembership = {
         username: user.username,
         memberType: "owner",
-        applications: 0
+        applications: 0,
       };
       return group;
     })
-    .catch(ex => {
+    .catch((ex) => {
       throw Error(`Error in team-utils::_createTeamGroup ${ex}`);
     });
 }

--- a/packages/teams/src/utils/can-user-create-team-in-product.ts
+++ b/packages/teams/src/utils/can-user-create-team-in-product.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { hasAllPrivileges } from "./has-all-privileges";
 import { getProp, HubProduct, includes } from "@esri/hub-common";
 import { IGroupTemplate } from "../types";

--- a/packages/teams/src/utils/can-user-create-team.ts
+++ b/packages/teams/src/utils/can-user-create-team.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import {
   IHubRequestOptions,
   getProp,

--- a/packages/teams/src/utils/get-allowed-group-access.ts
+++ b/packages/teams/src/utils/get-allowed-group-access.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { hasAllPrivileges } from "./has-all-privileges";
 import { GROUP_ACCESS_PRIVS } from "./group-access-privs";
 import { AGOAccess } from "../types";

--- a/packages/teams/src/utils/get-user-creatable-teams.ts
+++ b/packages/teams/src/utils/get-user-creatable-teams.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { cloneObject, HubProduct } from "@esri/hub-common";
 import { WELLKNOWNTEAMS } from "../well-known-teams";
 import { canUserCreateTeamInProduct } from "./can-user-create-team-in-product";

--- a/packages/teams/src/utils/has-all-privileges.ts
+++ b/packages/teams/src/utils/has-all-privileges.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 
 /**
  * Does a user have all the privileges in the passed in array
@@ -9,7 +9,7 @@ export function hasAllPrivileges(user: IUser, privileges: string[]) {
   let result = false;
   // ensure we were passed an array...
   if (Array.isArray(privileges)) {
-    result = privileges.every(priv => user.privileges.indexOf(priv) > -1);
+    result = privileges.every((priv) => user.privileges.indexOf(priv) > -1);
   }
   return result;
 }

--- a/packages/teams/src/utils/remove-invalid-privs.ts
+++ b/packages/teams/src/utils/remove-invalid-privs.ts
@@ -1,4 +1,4 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { cloneObject, includes, without } from "@esri/hub-common";
 
 const ALLOWED_SUBSCRIPTION_TYPES = [

--- a/packages/teams/test/add-users-to-team.test.ts
+++ b/packages/teams/test/add-users-to-team.test.ts
@@ -1,9 +1,9 @@
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import * as commonModule from "@esri/hub-common";
 import {
   IConsolidatedResult,
   IEmail,
-  IHubRequestOptions
+  IHubRequestOptions,
 } from "@esri/hub-common";
 
 import { addUsersToTeam } from "../src/add-users-to-team";
@@ -15,23 +15,23 @@ describe("addUsersToTeam", () => {
     const primaryRO: IHubRequestOptions = {
       isPortal: false,
       hubApiUrl: "a-url",
-      authentication: null
+      authentication: null,
     };
     const email: IEmail = {
       subject: "this is a test",
-      body: "body"
+      body: "body",
     };
     const secondaryRO: IHubRequestOptions = {
       isPortal: false,
       hubApiUrl: "another-url",
-      authentication: null
+      authentication: null,
     };
 
     const expected: IConsolidatedResult = {
       success: true,
       autoAdd: {
-        success: true
-      }
+        success: true,
+      },
     };
 
     const groupSpy = spyOn(commonModule, "addUsersToGroup").and.callFake(() =>

--- a/packages/teams/test/utils/_create-team-group.test.ts
+++ b/packages/teams/test/utils/_create-team-group.test.ts
@@ -3,19 +3,19 @@ import * as portalModule from "@esri/arcgis-rest-portal";
 import { IHubRequestOptions, cloneObject } from "@esri/hub-common";
 import { IGroupTemplate } from "../../src/types";
 import { _createTeamGroup } from "../../src/utils/_create-team-group";
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import { IPortal } from "@esri/arcgis-rest-portal";
 
 describe("_createTeamGroup", () => {
   const user = {
     username: "andrew",
-    privileges: ["portal:user:createGroup"]
+    privileges: ["portal:user:createGroup"],
   } as IUser;
   const ro = {
     authentication: { token: "foobar" },
-    portalSelf: ({
-      canSharePublic: true
-    } as unknown) as IPortal
+    portalSelf: {
+      canSharePublic: true,
+    } as unknown as IPortal,
   } as IHubRequestOptions;
 
   it("should create team group correctly", async () => {
@@ -33,7 +33,7 @@ describe("_createTeamGroup", () => {
 
     const groupTemplate = {
       title: "some-group-title",
-      access: "public"
+      access: "public",
     } as IGroupTemplate;
 
     const res = await _createTeamGroup(user, cloneObject(groupTemplate), ro);
@@ -43,7 +43,7 @@ describe("_createTeamGroup", () => {
       {
         username: user.username,
         memberType: "owner",
-        applications: 0
+        applications: 0,
       },
       "attaches group membership"
     );
@@ -93,7 +93,7 @@ describe("_createTeamGroup", () => {
 
     const groupTemplate = {
       title: "some-group-title",
-      access: "public"
+      access: "public",
     } as IGroupTemplate;
 
     try {

--- a/packages/teams/test/utils/_create-team-groups.test.ts
+++ b/packages/teams/test/utils/_create-team-groups.test.ts
@@ -2,7 +2,7 @@ import * as _createTeamModule from "../../src/utils/_create-team-group";
 import { IGroupTemplate } from "../../src/types";
 import { _createTeamGroups } from "../../src/utils/_create-team-groups";
 import { IHubRequestOptions, cloneObject } from "@esri/hub-common";
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 
 const templates: IGroupTemplate[] = [
   {
@@ -14,7 +14,7 @@ const templates: IGroupTemplate[] = [
       requiredPrivs: ["portal:admin:createUpdateCapableGroup"],
       titleI18n: "collaborationTitle",
       descriptionI18n: "collaborationDesc",
-      snippetI18n: "collaborationSnippet"
+      snippetI18n: "collaborationSnippet",
     },
     access: "org",
     autoJoin: false,
@@ -30,8 +30,8 @@ const templates: IGroupTemplate[] = [
       "Hub Initiative Group",
       "Hub Site Group",
       "Hub Core Team Group",
-      "Hub Team Group"
-    ]
+      "Hub Team Group",
+    ],
   },
   {
     config: {
@@ -42,7 +42,7 @@ const templates: IGroupTemplate[] = [
       requiredPrivs: ["portal:user:createGroup"],
       titleI18n: "contentTitle",
       descriptionI18n: "contentDesc",
-      snippetI18n: "contentSnippet"
+      snippetI18n: "contentSnippet",
     },
     access: "public",
     autoJoin: false,
@@ -54,8 +54,8 @@ const templates: IGroupTemplate[] = [
       "Hub Group",
       "Hub Content Group",
       "Hub Site Group",
-      "Hub Initiative Group"
-    ]
+      "Hub Initiative Group",
+    ],
   },
   {
     config: {
@@ -65,7 +65,7 @@ const templates: IGroupTemplate[] = [
       requiredPrivs: ["portal:user:createGroup"],
       titleI18n: "eventTeamTitle",
       descriptionI18n: "eventTeamDesc",
-      snippetI18n: "eventTeamSnippet"
+      snippetI18n: "eventTeamSnippet",
     },
     access: "public",
     autoJoin: true,
@@ -73,8 +73,8 @@ const templates: IGroupTemplate[] = [
     isViewOnly: false,
     sortField: "title",
     sortOrder: "asc",
-    tags: ["Hub Group", "Hub Event Group", "Hub Initiative Group"]
-  }
+    tags: ["Hub Group", "Hub Event Group", "Hub Initiative Group"],
+  },
 ];
 
 const translations = {
@@ -90,17 +90,17 @@ const translations = {
           contentSnippet: "{title} content snippet",
           eventTeamTitle: "{title} eventTeam title",
           eventTeamDesc: "{title} eventTeam desc",
-          eventTeamSnippet: "{title} eventTeam snippet"
-        }
-      }
-    }
-  }
+          eventTeamSnippet: "{title} eventTeam snippet",
+        },
+      },
+    },
+  },
 };
 
 describe("_createTeamGroups", () => {
   it("creates team groups", async () => {
     const ro = {
-      portalSelf: {}
+      portalSelf: {},
     } as IHubRequestOptions;
 
     const createGroupSpy = spyOn(
@@ -144,7 +144,7 @@ describe("_createTeamGroups", () => {
     expect(res.props).toEqual(
       {
         collaborationGroupId: "some-id",
-        contentGroupId: "some-id"
+        contentGroupId: "some-id",
       },
       "returns correct properties hash"
     );
@@ -152,7 +152,7 @@ describe("_createTeamGroups", () => {
 
   it("rejects if error", async () => {
     const ro = {
-      portalSelf: {}
+      portalSelf: {},
     } as IHubRequestOptions;
 
     spyOn(_createTeamModule, "_createTeamGroup").and.returnValue(

--- a/packages/teams/test/utils/can-user-create-team.test.ts
+++ b/packages/teams/test/utils/can-user-create-team.test.ts
@@ -1,6 +1,6 @@
 import { canUserCreateTeam } from "../../src/utils/can-user-create-team";
 import { IHubRequestOptions } from "@esri/hub-common";
-import { IUser } from "@esri/arcgis-rest-auth";
+import type { IUser } from "@esri/arcgis-rest-portal";
 import * as getUserCreatableTeamsModule from "../../src/utils/get-user-creatable-teams";
 
 describe("Name of the group", () => {


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
