### PR TITLE
fix(hub-common): update "hub:site:workspace:catalog:events" permission to include license checks

### DIFF
--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -177,7 +177,7 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:site:workspace:catalog:events",
-    dependencies: ["hub:site:workspace:catalog"],
+    dependencies: ["hub:site:workspace:catalog", "hub:event"],
   },
   {
     permission: "hub:site:workspace:pages",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Tightens up licensing restrictions for editing the event scope for site catalogs

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
