### PR TITLE
fix(): removed unused layout options in catalog schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5016,10 +5016,6 @@
 			"resolved": "packages/common",
 			"link": true
 		},
-		"node_modules/@esri/hub-discussions": {
-			"resolved": "packages/discussions",
-			"link": true
-		},
 		"node_modules/@esri/hub-downloads": {
 			"resolved": "packages/downloads",
 			"link": true
@@ -65003,7 +64999,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.45.0",
+			"version": "16.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65033,6 +65029,7 @@
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
 			"version": "29.7.0",
+			"extraneous": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65050,14 +65047,14 @@
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "15.0.1",
+			"version": "16.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65065,18 +65062,18 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.7.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^16.0.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "15.0.1",
+			"version": "16.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65084,18 +65081,18 @@
 				"@esri/arcgis-rest-feature-layer": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^16.0.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "15.0.1",
+			"version": "16.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -65103,18 +65100,18 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^16.0.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "15.0.0",
+			"version": "16.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -65124,20 +65121,20 @@
 				"@esri/arcgis-rest-feature-layer": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^16.0.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "16.0.2",
+			"version": "17.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
-				"@esri/hub-initiatives": "^15.0.0",
-				"@esri/hub-teams": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
+				"@esri/hub-initiatives": "^16.0.0",
+				"@esri/hub-teams": "^16.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65145,19 +65142,19 @@
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/hub-common": "^16.0.0",
-				"@esri/hub-initiatives": "^15.0.0",
-				"@esri/hub-teams": "^15.0.0"
+				"@esri/hub-initiatives": "^16.0.0",
+				"@esri/hub-teams": "^16.0.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "15.0.1",
+			"version": "16.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65165,25 +65162,25 @@
 				"@esri/arcgis-rest-feature-layer": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^16.0.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "15.0.1",
+			"version": "16.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^16.0.0"
 			}
 		}
 	},
@@ -68756,19 +68753,10 @@
 				"typescript": "^3.8.1"
 			}
 		},
-		"@esri/hub-discussions": {
-			"version": "file:packages/discussions",
-			"requires": {
-				"@esri/hub-common": "^15.38.0",
-				"@types/geojson": "^7946.0.7",
-				"tslib": "^1.13.0",
-				"typescript": "^3.8.1"
-			}
-		},
 		"@esri/hub-downloads": {
 			"version": "file:packages/downloads",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68777,7 +68765,7 @@
 		"@esri/hub-events": {
 			"version": "file:packages/events",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68785,7 +68773,7 @@
 		"@esri/hub-initiatives": {
 			"version": "file:packages/initiatives",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68794,7 +68782,7 @@
 		"@esri/hub-search": {
 			"version": "file:packages/search",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -68804,9 +68792,9 @@
 		"@esri/hub-sites": {
 			"version": "file:packages/sites",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
-				"@esri/hub-initiatives": "^15.0.0",
-				"@esri/hub-teams": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
+				"@esri/hub-initiatives": "^16.0.0",
+				"@esri/hub-teams": "^16.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68814,7 +68802,7 @@
 		"@esri/hub-surveys": {
 			"version": "file:packages/surveys",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68822,7 +68810,7 @@
 		"@esri/hub-teams": {
 			"version": "file:packages/teams",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -12,15 +12,7 @@ export const GalleryDisplayConfigSchema: IConfigurationSchema = {
     hidden: { type: "boolean", default: false },
     layout: {
       type: "string",
-      enum: [
-        "list",
-        "grid",
-        "grid-filled",
-        "table",
-        "map",
-        "compact",
-        "calendar",
-      ],
+      enum: ["list", "grid", "table", "map", "compact"],
       default: "list",
     },
     cardTitleTag: {


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 12775

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
