### PR TITLE
feat(hub-common): add entity discussion settings ui schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5016,10 +5016,6 @@
 			"resolved": "packages/common",
 			"link": true
 		},
-		"node_modules/@esri/hub-discussions": {
-			"resolved": "packages/discussions",
-			"link": true
-		},
 		"node_modules/@esri/hub-downloads": {
 			"resolved": "packages/downloads",
 			"link": true
@@ -65003,7 +64999,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "15.45.0",
+			"version": "16.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -65033,6 +65029,7 @@
 		"packages/discussions": {
 			"name": "@esri/hub-discussions",
 			"version": "29.7.0",
+			"extraneous": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -65050,14 +65047,14 @@
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "15.0.1",
+			"version": "16.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65065,18 +65062,18 @@
 				"@esri/arcgis-rest-feature-layer": "^3.1.0",
 				"@esri/arcgis-rest-portal": "^3.7.0",
 				"@esri/arcgis-rest-request": "^3.1.0",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^16.0.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "15.0.1",
+			"version": "16.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65084,18 +65081,18 @@
 				"@esri/arcgis-rest-feature-layer": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^16.0.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "15.0.1",
+			"version": "16.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
@@ -65103,18 +65100,18 @@
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^16.0.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "15.0.0",
+			"version": "16.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -65124,20 +65121,20 @@
 				"@esri/arcgis-rest-feature-layer": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.6.1 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^16.0.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "16.0.2",
+			"version": "17.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
-				"@esri/hub-initiatives": "^15.0.0",
-				"@esri/hub-teams": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
+				"@esri/hub-initiatives": "^16.0.0",
+				"@esri/hub-teams": "^16.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65145,19 +65142,19 @@
 				"@esri/arcgis-rest-portal": "^2.19.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
 				"@esri/hub-common": "^16.0.0",
-				"@esri/hub-initiatives": "^15.0.0",
-				"@esri/hub-teams": "^15.0.0"
+				"@esri/hub-initiatives": "^16.0.0",
+				"@esri/hub-teams": "^16.0.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "15.0.1",
+			"version": "16.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
@@ -65165,25 +65162,25 @@
 				"@esri/arcgis-rest-feature-layer": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.13.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^16.0.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "15.0.1",
+			"version": "16.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-auth": "^2.13.0 || 3",
 				"@esri/arcgis-rest-portal": "^2.15.0 || 3",
 				"@esri/arcgis-rest-request": "^2.13.0 || 3",
-				"@esri/hub-common": "^15.0.0"
+				"@esri/hub-common": "^16.0.0"
 			}
 		}
 	},
@@ -68756,19 +68753,10 @@
 				"typescript": "^3.8.1"
 			}
 		},
-		"@esri/hub-discussions": {
-			"version": "file:packages/discussions",
-			"requires": {
-				"@esri/hub-common": "^15.38.0",
-				"@types/geojson": "^7946.0.7",
-				"tslib": "^1.13.0",
-				"typescript": "^3.8.1"
-			}
-		},
 		"@esri/hub-downloads": {
 			"version": "file:packages/downloads",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68777,7 +68765,7 @@
 		"@esri/hub-events": {
 			"version": "file:packages/events",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68785,7 +68773,7 @@
 		"@esri/hub-initiatives": {
 			"version": "file:packages/initiatives",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -68794,7 +68782,7 @@
 		"@esri/hub-search": {
 			"version": "file:packages/search",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -68804,9 +68792,9 @@
 		"@esri/hub-sites": {
 			"version": "file:packages/sites",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
-				"@esri/hub-initiatives": "^15.0.0",
-				"@esri/hub-teams": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
+				"@esri/hub-initiatives": "^16.0.0",
+				"@esri/hub-teams": "^16.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68814,7 +68802,7 @@
 		"@esri/hub-surveys": {
 			"version": "file:packages/surveys",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -68822,7 +68810,7 @@
 		"@esri/hub-teams": {
 			"version": "file:packages/teams",
 			"requires": {
-				"@esri/hub-common": "^15.0.0",
+				"@esri/hub-common": "^16.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/common/src/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.ts
+++ b/packages/common/src/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.ts
@@ -1,0 +1,148 @@
+import type { IArcGISContext } from "../../../../types/IArcGISContext";
+import { IUiSchema } from "../../types";
+import { EntityEditorOptions } from "../EditorOptions";
+
+/**
+ * Builds the UI Schema for the "settings => discussions" workspace pane
+ * @param i18nScope the i18n scope for translations
+ * @param options an EntityEditorOptions object
+ * @param context an IArcGISContext object
+ * @returns a promise that resolves a UI Schema object
+ */
+export const buildUiSchema = async (
+  i18nScope: string,
+  options: EntityEditorOptions,
+  context: IArcGISContext
+): Promise<IUiSchema> => {
+  const uiSchema: IUiSchema = {
+    type: "Layout",
+    elements: [
+      {
+        type: "Section",
+        labelKey: "shared.sections.discussionSettings.moderation.label",
+        elements: [
+          {
+            labelKey: "shared.fields.discussable.label",
+            scope: "/properties/isDiscussable",
+            type: "Control",
+            options: {
+              control: "hub-field-input-tile-select",
+              labels: [
+                "{{shared.fields.discussable.enabled.label:translate}}",
+                `{{${i18nScope}.fields.discussable.disabled.label:translate}}`,
+              ],
+              descriptions: [
+                "{{shared.fields.discussable.disabled.label:translate}}",
+                `{{${i18nScope}.fields.discussable.disabled.description:translate}}`,
+              ],
+              icons: ["speech-bubbles", "circle-disallowed"],
+              layout: "horizontal",
+              styles: { "max-width": "45rem" },
+              type: "radio",
+            },
+          },
+        ],
+      },
+    ],
+  };
+  // if (context.hubLicense === "hub-premium") {
+  //   uiSchema.elements[0].elements.push({
+  //     labelKey: "shared.fields.allowedChannelIds.label",
+  //     scope: "/properties/discussionSettings/properties/allowedChannelIds",
+  //     type: "Control",
+  //     options: {
+  //       control: "hub-field-input-gallery-picker",
+  //       targetEntity: "channel",
+  //       showSelection: false,
+  //       showAllCollectionFacet: false,
+  //       canReorder: false,
+  //       catalogs: [
+  //         {
+  //           schemaVersion: 1,
+  //           title:
+  //             "{{shared.fields.allowedChannelIds.catalog.title:translate}}",
+  //           scopes: {},
+  //           collections: [
+  //             {
+  //               label:
+  //                 "{{shared.fields.allowedChannelIds.catalog.title:translate}}",
+  //               key: "channels",
+  //               targetEntity: "channel",
+  //               scope: {
+  //                 targetEntity: "channel",
+  //                 filters: [],
+  //                 collection: "channel",
+  //               },
+  //               include: ["groups"],
+  //             },
+  //           ],
+  //         },
+  //       ],
+  //       facets: [
+  //         {
+  //           label:
+  //             "{{shared.fields.allowedChannelIds.facets.access.label:translate}}",
+  //           key: "access",
+  //           display: "multi-select",
+  //           operation: "OR",
+  //           options: [
+  //             {
+  //               label:
+  //                 "{{shared.fields.allowedChannelIds.facets.access.options.public.label:translate}}",
+  //               key: "public",
+  //               selected: false,
+  //               predicates: [
+  //                 {
+  //                   access: "public",
+  //                 },
+  //               ],
+  //             },
+  //             {
+  //               label:
+  //                 "{{shared.fields.allowedChannelIds.facets.access.options.org.label:translate}}",
+  //               key: "organization",
+  //               selected: false,
+  //               predicates: [
+  //                 {
+  //                   access: "org",
+  //                 },
+  //               ],
+  //             },
+  //             {
+  //               label:
+  //                 "{{shared.fields.allowedChannelIds.facets.access.options.private.label:translate}}",
+  //               key: "private",
+  //               selected: false,
+  //               predicates: [
+  //                 {
+  //                   access: "private",
+  //                 },
+  //               ],
+  //             },
+  //           ],
+  //         },
+  //         {
+  //           label:
+  //             "{{shared.fields.allowedChannelIds.facets.groups.label:translate}}",
+  //           key: "groups",
+  //           display: "multi-select",
+  //           operation: "OR",
+  //           options: context.currentUser.groups.map((group) => ({
+  //             label: group.title,
+  //             key: group.title,
+  //             selected: false,
+  //             predicates: [
+  //               {
+  //                 groups: group.id,
+  //               },
+  //             ],
+  //           })),
+  //         },
+  //       ],
+  //       include: "groups",
+  //       reorderable: false,
+  //     },
+  //   });
+  // }
+  return uiSchema;
+};

--- a/packages/common/src/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.ts
+++ b/packages/common/src/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.ts
@@ -140,7 +140,7 @@ export const buildUiSchema = async (
   //         },
   //       ],
   //       include: "groups",
-  //       reorderable: false,
+  //       canReorder: false,
   //     },
   //   });
   // }

--- a/packages/common/src/core/schemas/internal/getEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getEditorSchemas.ts
@@ -108,6 +108,10 @@ export async function getEditorSchemas(
           import("../../../discussions/_internal/DiscussionUiSchemaCreate"),
         "hub:discussion:settings": () =>
           import("../../../discussions/_internal/DiscussionUiSchemaSettings"),
+        "hub:discussion:settings:discussions": () =>
+          import(
+            "../../../core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings"
+          ),
       }[type as DiscussionEditorType]();
       uiSchema = await discussionModule.buildUiSchema(
         i18nScope,

--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -18,8 +18,10 @@ export const DiscussionPermissions = [
   "hub:discussion:workspace:details",
   "hub:discussion:workspace:settings",
   "hub:discussion:workspace:collaborators",
+  // TODO: remove `hub:discussion:workspace:discussion` when we deprecate the discussion board participation workspace pane
   "hub:discussion:workspace:discussion",
   "hub:discussion:workspace:metrics",
+  "hub:discussion:workspace:settings:discussions",
   "hub:discussion:manage",
   "temp:hub:discussion:create",
 ] as const;
@@ -51,14 +53,12 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
     authenticated: true,
     dependencies: ["hub:discussion"],
     entityEdit: true,
-    licenses: ["hub-premium"],
   },
   {
     permission: "hub:discussion:delete",
     authenticated: true,
     dependencies: ["hub:discussion"],
     entityDelete: true,
-    licenses: ["hub-premium"],
   },
   {
     permission: "hub:discussion:owner",
@@ -105,12 +105,34 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
     dependencies: ["hub:discussion:edit"],
   },
   {
+    permission: "hub:discussion:workspace:settings:discussions",
+    dependencies: ["hub:discussion:edit"],
+    // TODO: remove the following `environments` and `availability` properties when we're ready to cut over to V2 discussions API
+    // environments: ["devext", "qaext"],
+    // availability: ["alpha"],
+  },
+  {
     permission: "hub:discussion:workspace:collaborators",
     dependencies: ["hub:discussion:edit"],
   },
+  // TODO: remove the following IPermissionPolicy when we're ready to cut over to V2 discussions API
   {
     permission: "hub:discussion:workspace:discussion",
     dependencies: ["hub:discussion:edit"],
+    assertions: [
+      {
+        property: "context:isAlphaOrg",
+        type: "eq",
+        value: false,
+        conditions: [
+          {
+            property: "context:environment",
+            type: "included-in",
+            value: ["devext", "qaext"],
+          },
+        ],
+      },
+    ],
   },
   {
     permission: "hub:discussion:workspace:metrics",

--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -107,32 +107,15 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:discussion:workspace:settings:discussions",
     dependencies: ["hub:discussion:edit"],
-    // TODO: remove the following `environments` and `availability` properties when we're ready to cut over to V2 discussions API
-    // environments: ["devext", "qaext"],
-    // availability: ["alpha"],
   },
   {
     permission: "hub:discussion:workspace:collaborators",
     dependencies: ["hub:discussion:edit"],
   },
-  // TODO: remove the following IPermissionPolicy when we're ready to cut over to V2 discussions API
   {
+    // TODO: remove this IPermissionPolicy when we deprecate the discussion board participation workspace pane
     permission: "hub:discussion:workspace:discussion",
     dependencies: ["hub:discussion:edit"],
-    assertions: [
-      {
-        property: "context:isAlphaOrg",
-        type: "eq",
-        value: false,
-        conditions: [
-          {
-            property: "context:environment",
-            type: "included-in",
-            value: ["devext", "qaext"],
-          },
-        ],
-      },
-    ],
   },
   {
     permission: "hub:discussion:workspace:metrics",

--- a/packages/common/src/discussions/_internal/DiscussionSchema.ts
+++ b/packages/common/src/discussions/_internal/DiscussionSchema.ts
@@ -6,6 +6,7 @@ export const DiscussionEditorTypes = [
   "hub:discussion:edit",
   "hub:discussion:create",
   "hub:discussion:settings",
+  "hub:discussion:settings:discussions",
 ] as const;
 
 /**
@@ -20,6 +21,24 @@ export const DiscussionSchema: IConfigurationSchema = {
       type: "string",
       default: "",
       maxLength: 150,
+    },
+    // TODO: externalize & spread onto HubItemEntitySchema rather than here
+    discussionSettings: {
+      type: "object",
+      properties: {
+        allowedChannelIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        allowedLocations: {
+          type: "array",
+          items: {
+            type: "object",
+          },
+        },
+      },
     },
   },
 } as IConfigurationSchema;

--- a/packages/common/src/discussions/_internal/DiscussionUiSchemaSettings.ts
+++ b/packages/common/src/discussions/_internal/DiscussionUiSchemaSettings.ts
@@ -18,29 +18,6 @@ export const buildUiSchema = async (
     elements: [
       {
         type: "Section",
-        labelKey: `${i18nScope}.sections.settings.label`,
-        elements: [
-          {
-            labelKey: `${i18nScope}.fields.discussable.label`,
-            scope: "/properties/isDiscussable",
-            type: "Control",
-            options: {
-              control: "hub-field-input-radio",
-              labels: [
-                `{{${i18nScope}.fields.discussable.enabled.label:translate}}`,
-                `{{${i18nScope}.fields.discussable.disabled.label:translate}}`,
-              ],
-              descriptions: [
-                `{{${i18nScope}.fields.discussable.enabled.description:translate}}`,
-                `{{${i18nScope}.fields.discussable.disabled.description:translate}}`,
-              ],
-              icons: ["speech-bubbles", "circle-disallowed"],
-            },
-          },
-        ],
-      },
-      {
-        type: "Section",
         labelKey: `shared.sections.mapSettings.label`,
         elements: [
           {

--- a/packages/common/src/discussions/edit.ts
+++ b/packages/common/src/discussions/edit.ts
@@ -60,18 +60,25 @@ export async function createDiscussion(
   // create the item
   model = await createModel(model, requestOptions as IUserRequestOptions);
   const defaultSettings = getDefaultEntitySettings("discussion");
+  const settings = {
+    ...defaultSettings.settings,
+    discussions: {
+      ...defaultSettings.settings.discussions,
+      ...discussion.discussionSettings,
+    },
+  };
+  if (!settings.discussions.allowedChannelIds?.length) {
+    settings.discussions.allowedChannelIds = null;
+  }
+  if (!settings.discussions.allowedLocations?.length) {
+    settings.discussions.allowedLocations = null;
+  }
   // create the entity settings
   model.entitySettings = await createSetting({
     data: {
       id: model.item.id,
       type: defaultSettings.type,
-      settings: {
-        ...defaultSettings.settings,
-        discussions: {
-          ...defaultSettings.settings.discussions,
-          ...discussion.discussionSettings,
-        },
-      },
+      settings,
     },
     ...requestOptions,
   });
@@ -141,6 +148,12 @@ export async function updateDiscussion(
       allowedLocations,
     },
   };
+  if (!settings.discussions.allowedChannelIds?.length) {
+    settings.discussions.allowedChannelIds = null;
+  }
+  if (!settings.discussions.allowedLocations?.length) {
+    settings.discussions.allowedLocations = null;
+  }
   const newOrUpdatedSettings = updatedDiscussion.entitySettingsId
     ? await updateSetting({
         id: updatedDiscussion.entitySettingsId,

--- a/packages/common/src/search/_internal/hubDiscussionsHelpers/channelResultsToSearchResults.ts
+++ b/packages/common/src/search/_internal/hubDiscussionsHelpers/channelResultsToSearchResults.ts
@@ -1,0 +1,65 @@
+import { IHubSearchOptions, IHubSearchResult } from "../../types";
+import {
+  channelToSearchResult,
+  getChannelGroupIds,
+} from "../../../discussions/utils";
+import { IGroup, ISearchResult, searchGroups } from "@esri/arcgis-rest-portal";
+import { batch } from "../../../utils/batch";
+import { splitArrayByLength } from "../../../utils/_array";
+import { IChannel } from "../../../discussions/api/types";
+
+/**
+ * @private
+ * Convert an array of Discussions API channel search results into an
+ * array of IHubSearchResult objects
+ * @param channels An array of IChannel objects
+ * @param options an IHubSearchOptions object
+ * @returns a promise that resolves an array of IHubSearchResult objects
+ */
+export async function channelResultsToSearchResults(
+  channels: IChannel[],
+  options: IHubSearchOptions
+): Promise<IHubSearchResult[]> {
+  let groupResults: IGroup[] = [];
+  if (options.include?.includes("groups")) {
+    // we can search for up to 100 channels at a time that can each
+    // have up to 100 groups...
+    const uniqueGroupIds = channels.reduce(
+      (acc, channel) =>
+        getChannelGroupIds(channel).reduce(
+          (memo, groupId) =>
+            memo.includes(groupId) ? memo : [...memo, groupId],
+          acc
+        ),
+      []
+    );
+    // conduct up to 5 concurrent searches that can request
+    // up to 100 ids per search. if less than 101 ids exist,
+    // it performs a single search
+    const batchResults: Array<ISearchResult<IGroup>> = await batch(
+      splitArrayByLength(uniqueGroupIds, 100),
+      (groupIds: string[]) =>
+        searchGroups({
+          q: groupIds.map((id) => `id:${id}`).join(" OR "),
+          num: groupIds.length,
+          ...options.requestOptions,
+        }),
+      5
+    );
+    // reassemble the batch results into a single array
+    groupResults = batchResults.reduce<IGroup[]>(
+      (acc, batchResult) => [...acc, ...batchResult.results],
+      []
+    );
+  }
+  return channels.map((channel) =>
+    channelToSearchResult(
+      channel,
+      options.include?.includes("groups")
+        ? getChannelGroupIds(channel).map(
+            (groupId) => groupResults.find(({ id }) => id === groupId) || null
+          )
+        : []
+    )
+  );
+}

--- a/packages/common/src/search/_internal/hubDiscussionsHelpers/processChannelFilters.ts
+++ b/packages/common/src/search/_internal/hubDiscussionsHelpers/processChannelFilters.ts
@@ -1,0 +1,76 @@
+import { ISearchChannels } from "../../../discussions/api/types";
+import { IFilter, IPredicate } from "../../types/IHubCatalog";
+
+function flattenFilters(filters: IFilter[]): Record<string, any[]> {
+  return filters.reduce<Record<string, any[]>>(
+    (acc1, filter) =>
+      filter.predicates.reduce<Record<string, any[]>>(
+        (acc2, predicate: IPredicate) =>
+          Object.keys(predicate).reduce<Record<string, any[]>>(
+            (acc3, predicateKey) => {
+              const values: any[] = acc3[predicateKey] || [];
+              values.push(
+                ...(Array.isArray(predicate[predicateKey])
+                  ? predicate[predicateKey]
+                  : [predicate[predicateKey]])
+              );
+              return {
+                ...acc3,
+                [predicateKey]: values,
+              };
+            },
+            acc2
+          ),
+        acc1
+      ),
+    {}
+  );
+}
+
+/**
+ * @private
+ * Converts an IFilter array into a partial ISearchChannels
+ * object of filter parameters
+ * @param filters An array of IFilter objects
+ * @returns a partial ISearchChannels object
+ */
+export function processChannelFilters(
+  filters: IFilter[]
+): Partial<ISearchChannels> {
+  const channelOptions: Partial<ISearchChannels> = {};
+  const flattenedFilters = flattenFilters(filters);
+  if (flattenedFilters.term?.length) {
+    channelOptions.name = flattenedFilters.term[0];
+  }
+  if (flattenedFilters.groups?.length) {
+    channelOptions.groups = flattenedFilters.groups;
+  }
+  if (flattenedFilters.access?.length) {
+    channelOptions.access = flattenedFilters.access;
+  }
+  if (flattenedFilters.id?.length) {
+    const { ids, notIds } = flattenedFilters.id.reduce(
+      (acc, id) =>
+        id.not
+          ? {
+              ...acc,
+              notIds: [
+                ...acc.notIds,
+                ...(Array.isArray(id.not) ? id.not : [id.not]),
+              ],
+            }
+          : {
+              ...acc,
+              ids: [...acc.ids, id],
+            },
+      { ids: [], notIds: [] }
+    );
+    if (ids.length) {
+      channelOptions.ids = ids;
+    }
+    if (notIds.length) {
+      channelOptions.notIds = notIds;
+    }
+  }
+  return channelOptions;
+}

--- a/packages/common/src/search/_internal/hubDiscussionsHelpers/processChannelOptions.ts
+++ b/packages/common/src/search/_internal/hubDiscussionsHelpers/processChannelOptions.ts
@@ -1,0 +1,44 @@
+import {
+  ChannelSort,
+  ISearchChannels,
+  SortOrder,
+} from "../../../discussions/api/types";
+import { IHubSearchOptions } from "../../types/IHubSearchOptions";
+
+const SORT_FIELD_MAP: Record<string, ChannelSort> = {
+  access: ChannelSort.ACCESS,
+  created: ChannelSort.CREATED_AT,
+  modified: ChannelSort.UPDATED_AT,
+  owner: ChannelSort.CREATOR,
+};
+
+const SORT_ORDER_MAP: Record<"desc" | "asc", SortOrder> = {
+  desc: SortOrder.DESC,
+  asc: SortOrder.ASC,
+};
+
+/**
+ * @private
+ * Converts an IHubSearchOptions object into a partial ISearchChannels
+ * object of paging & sort parameters
+ * @param options An IHubSearchOptions object
+ * @returns a partial ISearchChannels object
+ */
+export function processChannelOptions(
+  options: IHubSearchOptions
+): Partial<ISearchChannels> {
+  const channelOptions: Partial<ISearchChannels> = {};
+  if (options.num) {
+    channelOptions.num = options.num;
+  }
+  if (options.start) {
+    channelOptions.start = options.start;
+  }
+  if (options.sortField && SORT_FIELD_MAP[options.sortField]) {
+    channelOptions.sortBy = SORT_FIELD_MAP[options.sortField];
+  }
+  if (options.sortOrder && SORT_ORDER_MAP[options.sortOrder]) {
+    channelOptions.sortOrder = SORT_ORDER_MAP[options.sortOrder];
+  }
+  return channelOptions;
+}

--- a/packages/common/src/search/_internal/hubSearchChannels.ts
+++ b/packages/common/src/search/_internal/hubSearchChannels.ts
@@ -2,181 +2,49 @@ import {
   IHubSearchOptions,
   IHubSearchResponse,
   IHubSearchResult,
-  IPredicate,
   IQuery,
 } from "../types";
 import HubError from "../../HubError";
 import { searchChannels } from "../../discussions/api/channels";
-import {
-  ChannelRelation,
-  IChannel,
-  IPagedResponse,
-  ISearchChannels,
-  ISearchChannelsParams,
-  channelToSearchResult,
-} from "../../discussions";
-import { getChannelGroupIds } from "../../discussions/utils";
-import { getGroup } from "@esri/arcgis-rest-portal";
+import { processChannelFilters } from "./hubDiscussionsHelpers/processChannelFilters";
+import { processChannelOptions } from "./hubDiscussionsHelpers/processChannelOptions";
+import { channelResultsToSearchResults } from "./hubDiscussionsHelpers/channelResultsToSearchResults";
 
 /**
  * @private
- * Convert hubSearch IHubSearchOptions and IQuery interfaces to a
- * ISearchChannelsParams structure that is needed for the Discussions API
- * searchChannels(searchOptions: ISearchCHannelsParams) function
- * @param {IHubSearchOptions} options
- * @param {IQuery} query
- * @returns ISearchChannelParams
+ * Executes a Discussions API channel search and resolves an IHubSearchResponse<IHubSearchResult> for the channel results
+ * @param query an IQuery object
+ * @param options an IHubSearchOptions object
+ * @returns a promise that resolves an HubSearchResponse<IHubSearchResult> object
  */
-export const processSearchParams = (
-  options: IHubSearchOptions,
-  query: IQuery
-): ISearchChannelsParams => {
-  if (!options.requestOptions) {
+export const hubSearchChannels = async (
+  query: IQuery,
+  searchOptions: IHubSearchOptions
+): Promise<IHubSearchResponse<IHubSearchResult>> => {
+  if (!searchOptions.requestOptions) {
     throw new HubError(
       "hubSearchChannels",
       "options.requestOptions is required"
     );
   }
-  // Array of properties we want to copy over from IHubSeachOptions to ISearchChannels
-  const paginationProps: Partial<Record<keyof ISearchChannels, any>> = {};
-  const allowedPaginationProps: Array<keyof IHubSearchOptions> = [
-    "num",
-    "start",
-    "sortField",
-    "sortOrder",
-  ];
-  // Map ISearchOptions key to ISearchChannels key
-  const keyMappings: Record<
-    keyof IHubSearchOptions | keyof IPredicate,
-    keyof ISearchChannels
-  > = {
-    sortField: "sortBy",
-    term: "name",
-  };
-  // Map any values that originated from ISearchOptions
-  // into a correct ISearchChannels value
-  const mapValue = (key: keyof ISearchChannels, value: any): string => {
-    let _value = value;
-    if (key === "sortOrder") {
-      _value = value?.toUpperCase();
-    } else if (key === "sortBy") {
-      _value = {
-        created: "createdAt",
-        modified: "updatedAt",
-        title: null,
-      }[value as "created" | "modified" | "title"];
-    }
-    return _value;
-  };
-  allowedPaginationProps.forEach((prop) => {
-    if (options.hasOwnProperty(prop)) {
-      const { [prop]: key = prop as any } = keyMappings;
-      const _key = key as keyof ISearchChannels;
-      const value = mapValue(_key, options[prop]);
-      if (key && value) {
-        paginationProps[_key] = value;
-      }
-    }
-  });
-  // Acceptable fields to use as filters
-  const filterProps: Record<string, string[]> = {};
-  const allowedFilterProps: Array<keyof ISearchChannels> = [
-    "access",
-    "groups",
-    "name",
-  ];
-  // Find predicates that match acceptable filter fields
-  query.filters.forEach((filter) => {
-    filter.predicates.forEach((predicate) => {
-      Object.keys(predicate).forEach((key: any) => {
-        const { [key]: _key = key } = keyMappings;
-        if (allowedFilterProps.includes(_key)) {
-          filterProps[_key] = [...(filterProps[_key] || []), predicate[key]];
-        }
-      });
-    });
-  });
-  // Return as ISearchChannelsParams
-  return {
-    ...options.requestOptions,
+  const filters = processChannelFilters(query.filters);
+  const options = processChannelOptions(searchOptions);
+  const { total, nextStart, items } = await searchChannels({
     data: {
-      ...paginationProps,
-      ...filterProps,
-      relations: [ChannelRelation.CHANNEL_ACL],
+      ...filters,
+      ...options,
     },
-  };
-};
-
-/**
- * @private
- * Convert the Discussions API searchChannels response into an
- * IHubSearchResponse necessary for supporting hubSearch results
- * @param {IPagedResponse{IChannel}} channelsResponse
- * @param {IQuery} query
- * @param {IHubSearchOptions} options
- * @returns IHubSearchResponse<IHubSearchResult>
- */
-export const toHubSearchResults = async (
-  channelsResponse: IPagedResponse<IChannel>,
-  query: IQuery,
-  options: IHubSearchOptions
-): Promise<IHubSearchResponse<IHubSearchResult>> => {
-  const { total, items, nextStart } = channelsResponse;
-  // Convert IChannel to IHubSearchResult
-  const itemsAndGroups = await Promise.all(
-    items.map(async (channel) => {
-      const groupIds = getChannelGroupIds(channel);
-      const groups = options.include?.includes("groups")
-        ? await Promise.all(
-            groupIds.map(async (groupId) => {
-              let group;
-              try {
-                group = await getGroup(groupId, options.requestOptions);
-              } catch (e) {
-                group = null;
-                /* tslint:disable-next-line: no-console */
-                console.warn(
-                  `Cannot fetch group enhancement for id = ${groupId}`,
-                  e
-                );
-              }
-              return group;
-            })
-          )
-        : [];
-      return { channel, groups };
-    })
-  );
+    ...searchOptions.requestOptions,
+  });
+  const results = await channelResultsToSearchResults(items, searchOptions);
   return {
     total,
-    results: itemsAndGroups.map(({ channel, groups }) =>
-      channelToSearchResult(channel, groups)
-    ),
+    results,
     hasNext: nextStart > -1,
-    next: () => {
-      return hubSearchChannels(query, {
-        ...options,
+    next: () =>
+      hubSearchChannels(query, {
+        ...searchOptions,
         start: nextStart,
-      });
-    },
+      }),
   };
-};
-
-/**
- * @private
- * Execute channel search against the Discussions API
- * @param query
- * @param options
- * @returns
- */
-export const hubSearchChannels = async (
-  query: IQuery,
-  options: IHubSearchOptions
-): Promise<IHubSearchResponse<IHubSearchResult>> => {
-  // Pull useful info out of query
-  const searchOptions = processSearchParams(options, query);
-  // Call to searchChannels
-  const channelsResponse = await searchChannels(searchOptions);
-  // Parse into <IHubSearchResponse<IHubSearchResult>>
-  return toHubSearchResults(channelsResponse, query, options);
 };

--- a/packages/common/src/users/_internal/UserBusinessRules.ts
+++ b/packages/common/src/users/_internal/UserBusinessRules.ts
@@ -16,7 +16,6 @@ export const UserPermissions = [
   "hub:user:workspace:content",
   "hub:user:workspace:groups",
   "hub:user:workspace:events",
-  "hub:user:workspace:discussions",
   "hub:user:workspace:shared-with-me",
   "hub:user:manage",
 ] as const;
@@ -69,12 +68,6 @@ export const UserPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:user:workspace:events",
     services: ["events"],
-    dependencies: ["hub:user:workspace", "hub:user:owner"],
-  },
-  {
-    permission: "hub:user:workspace:discussions",
-    availability: ["alpha"],
-    services: ["discussions"],
     dependencies: ["hub:user:workspace", "hub:user:owner"],
   },
   {

--- a/packages/common/src/utils/_array.ts
+++ b/packages/common/src/utils/_array.ts
@@ -12,7 +12,7 @@ export const maybeConcat = (arrays: any[][]) => {
 };
 
 /**
- * Splits a single array into many arrays of max a given max length.
+ * Splits a single array into many arrays of a given max length.
  * E.g. splitArrayByLength(['a', 'b', 'c'], 2); // => [['a', 'b'], ['c']]
  * @param originalValues The original array of values
  * @param length The max length of the resulting arrays

--- a/packages/common/src/utils/_array.ts
+++ b/packages/common/src/utils/_array.ts
@@ -10,3 +10,25 @@ export const maybeConcat = (arrays: any[][]) => {
   const result = [].concat.apply([], arrays.filter(Array.isArray));
   return result.length ? result : undefined;
 };
+
+/**
+ * Splits a single array into many arrays of max a given max length.
+ * E.g. splitArrayByLength(['a', 'b', 'c'], 2); // => [['a', 'b'], ['c']]
+ * @param originalValues The original array of values
+ * @param length The max length of the resulting arrays
+ * @returns an array of arrays
+ */
+export function splitArrayByLength<T>(
+  originalValues: T[],
+  length: number
+): T[][] {
+  return originalValues.reduce((splits, originalValue) => {
+    let split = splits[splits.length - 1];
+    if (!split || split.length === length) {
+      split = [];
+      splits.push(split);
+    }
+    split.push(originalValue);
+    return splits;
+  }, []);
+}

--- a/packages/common/src/utils/batch.ts
+++ b/packages/common/src/utils/batch.ts
@@ -1,4 +1,5 @@
 import { IBatch, IBatchTransform } from "../hub-types";
+import { splitArrayByLength } from "./_array";
 
 /**
  * Helper to split a large number of calls into
@@ -13,16 +14,6 @@ export function batch(
   fn: IBatchTransform,
   batchSize: number = 5
 ): Promise<any> {
-  const toBatches = (_batches: IBatch[], value: any): IBatch[] => {
-    let _batch = _batches[_batches.length - 1];
-    if (!_batch || _batch.length === batchSize) {
-      _batch = [];
-      _batches.push(_batch);
-    }
-    _batch.push(value);
-    return _batches;
-  };
-
   const toSerialBatchChain = (
     promise: Promise<any>,
     batchOfValues: IBatch
@@ -37,7 +28,7 @@ export function batch(
   };
 
   // split values into batches of values
-  const batches = values.reduce(toBatches, []);
+  const batches = splitArrayByLength<IBatch>(values, batchSize);
 
   // batches are processed serially, however
   // all calls within a batch are concurrent

--- a/packages/common/test/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.test.ts
+++ b/packages/common/test/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.test.ts
@@ -1,0 +1,160 @@
+import { IArcGISContext } from "../../../../../src/types";
+import { IHubDiscussion } from "../../../../../src/core/types/IHubDiscussion";
+import { buildUiSchema } from "../../../../../src/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings";
+
+describe("EntityUiSchemaDiscussionsSettings", () => {
+  it("should support num", async () => {
+    const entity: IHubDiscussion = { id: "31c" } as unknown as IHubDiscussion;
+    const context: IArcGISContext = {
+      hubLicense: "hub-premium",
+      currentUser: {
+        groups: [
+          { id: "42b", title: "Group 1" },
+          { id: "53a", title: "Group 2" },
+        ],
+      },
+    } as unknown as IArcGISContext;
+    const results = await buildUiSchema("myI18nScope", entity, context);
+    expect(results).toEqual({
+      type: "Layout",
+      elements: [
+        {
+          type: "Section",
+          labelKey: "shared.sections.discussionSettings.moderation.label",
+          elements: [
+            {
+              labelKey: "shared.fields.discussable.label",
+              scope: "/properties/isDiscussable",
+              type: "Control",
+              options: {
+                control: "hub-field-input-tile-select",
+                labels: [
+                  "{{shared.fields.discussable.enabled.label:translate}}",
+                  "{{myI18nScope.fields.discussable.disabled.label:translate}}",
+                ],
+                descriptions: [
+                  "{{shared.fields.discussable.disabled.label:translate}}",
+                  "{{myI18nScope.fields.discussable.disabled.description:translate}}",
+                ],
+                icons: ["speech-bubbles", "circle-disallowed"],
+                layout: "horizontal",
+                styles: { "max-width": "45rem" },
+                type: "radio",
+              },
+            },
+            // {
+            //   labelKey: "shared.fields.allowedChannelIds.label",
+            //   scope:
+            //     "/properties/discussionSettings/properties/allowedChannelIds",
+            //   type: "Control",
+            //   options: {
+            //     control: "hub-field-input-gallery-picker",
+            //     targetEntity: "channel",
+            //     showSelection: false,
+            //     showAllCollectionFacet: false,
+            //     canReorder: false,
+            //     catalogs: [
+            //       {
+            //         schemaVersion: 1,
+            //         title:
+            //           "{{shared.fields.allowedChannelIds.catalog.title:translate}}",
+            //         scopes: {},
+            //         collections: [
+            //           {
+            //             label:
+            //               "{{shared.fields.allowedChannelIds.catalog.title:translate}}",
+            //             key: "channels",
+            //             targetEntity: "channel",
+            //             scope: {
+            //               targetEntity: "channel",
+            //               filters: [],
+            //               collection: "channel",
+            //             },
+            //             include: ["groups"],
+            //           },
+            //         ],
+            //       },
+            //     ],
+            //     facets: [
+            //       {
+            //         label:
+            //           "{{shared.fields.allowedChannelIds.facets.access.label:translate}}",
+            //         key: "access",
+            //         display: "multi-select",
+            //         operation: "OR",
+            //         options: [
+            //           {
+            //             label:
+            //               "{{shared.fields.allowedChannelIds.facets.access.options.public.label:translate}}",
+            //             key: "public",
+            //             selected: false,
+            //             predicates: [
+            //               {
+            //                 access: "public",
+            //               },
+            //             ],
+            //           },
+            //           {
+            //             label:
+            //               "{{shared.fields.allowedChannelIds.facets.access.options.org.label:translate}}",
+            //             key: "organization",
+            //             selected: false,
+            //             predicates: [
+            //               {
+            //                 access: "org",
+            //               },
+            //             ],
+            //           },
+            //           {
+            //             label:
+            //               "{{shared.fields.allowedChannelIds.facets.access.options.private.label:translate}}",
+            //             key: "private",
+            //             selected: false,
+            //             predicates: [
+            //               {
+            //                 access: "private",
+            //               },
+            //             ],
+            //           },
+            //         ],
+            //       },
+            //       {
+            //         label:
+            //           "{{shared.fields.allowedChannelIds.facets.groups.label:translate}}",
+            //         key: "groups",
+            //         display: "multi-select",
+            //         operation: "OR",
+            //         options: [
+            //           {
+            //             label: "Group 1",
+            //             key: "Group 1",
+            //             selected: false,
+            //             predicates: [
+            //               {
+            //                 groups: "42b",
+            //               },
+            //             ],
+            //           },
+            //           {
+            //             label: "Group 2",
+            //             key: "Group 2",
+            //             selected: false,
+            //             predicates: [
+            //               {
+            //                 groups: "53a",
+            //               },
+            //             ],
+            //           },
+            //         ],
+            //       },
+            //     ],
+            //     include: "groups",
+            //     reorderable: false,
+            //   },
+            // },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/common/test/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.test.ts
+++ b/packages/common/test/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.test.ts
@@ -149,7 +149,7 @@ describe("EntityUiSchemaDiscussionsSettings", () => {
             //       },
             //     ],
             //     include: "groups",
-            //     reorderable: false,
+            //     canReorder: false,
             //   },
             // },
           ],

--- a/packages/common/test/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.test.ts
+++ b/packages/common/test/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.test.ts
@@ -3,7 +3,7 @@ import { IHubDiscussion } from "../../../../../src/core/types/IHubDiscussion";
 import { buildUiSchema } from "../../../../../src/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings";
 
 describe("EntityUiSchemaDiscussionsSettings", () => {
-  it("should support num", async () => {
+  it("should build a ui schema for a premium user", async () => {
     const entity: IHubDiscussion = { id: "31c" } as unknown as IHubDiscussion;
     const context: IArcGISContext = {
       hubLicense: "hub-premium",

--- a/packages/common/test/core/schemas/internal/getEditorSchemas.test.ts
+++ b/packages/common/test/core/schemas/internal/getEditorSchemas.test.ts
@@ -33,6 +33,7 @@ import { DiscussionEditorTypes } from "../../../../src/discussions/_internal/Dis
 import * as DiscussionBuildEditUiSchema from "../../../../src/discussions/_internal/DiscussionUiSchemaEdit";
 import * as DiscussionBuildCreateUiSchema from "../../../../src/discussions/_internal/DiscussionUiSchemaCreate";
 import * as DiscussionBuildSettingsUiSchema from "../../../../src/discussions/_internal/DiscussionUiSchemaSettings";
+import * as EntityBuildDiscussionSettingsUiSchema from "../../../../src/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings";
 
 import { ChannelEditorTypes } from "../../../../src/channels/_internal/ChannelSchema";
 import * as ChannelBuildEditUiSchema from "../../../../src/channels/_internal/ChannelUiSchemaEdit";
@@ -113,6 +114,10 @@ describe("getEditorSchemas: ", () => {
     { type: DiscussionEditorTypes[0], module: DiscussionBuildEditUiSchema },
     { type: DiscussionEditorTypes[1], module: DiscussionBuildCreateUiSchema },
     { type: DiscussionEditorTypes[2], module: DiscussionBuildSettingsUiSchema },
+    {
+      type: DiscussionEditorTypes[3],
+      module: EntityBuildDiscussionSettingsUiSchema,
+    },
 
     { type: ContentEditorTypes[0], module: ContentBuildEditUiSchema },
     { type: ContentEditorTypes[1], module: ContentBuildSettingsUiSchema },

--- a/packages/common/test/discussions/HubDiscussion.test.ts
+++ b/packages/common/test/discussions/HubDiscussion.test.ts
@@ -344,27 +344,6 @@ describe("HubDiscussion Class:", () => {
         // other than via code-coverage
         expect(getProp(result, "_thumbnail")).not.toBeDefined();
       });
-      it("throws if creating", async () => {
-        const chk = HubDiscussion.fromJson(
-          {
-            name: "Test Entity",
-            thumbnailUrl: "https://myserver.com/thumbnail.png",
-          },
-          authdCtxMgr.context
-        );
-        // spy on the instance .save method and retrn void
-        const saveSpy = spyOn(chk, "save").and.returnValue(Promise.resolve());
-        // make changes to the editor
-        const editor = await chk.toEditor();
-        editor.name = "new name";
-        // call fromEditor
-        try {
-          await chk.fromEditor(editor);
-        } catch (ex) {
-          expect(ex.message).toContain("Cannot create");
-          expect(saveSpy).toHaveBeenCalledTimes(0);
-        }
-      });
     });
   });
 });

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaSettings.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaSettings.test.ts
@@ -9,29 +9,6 @@ describe("buildUiSchema: discussions settings", () => {
       elements: [
         {
           type: "Section",
-          labelKey: "some.scope.sections.settings.label",
-          elements: [
-            {
-              labelKey: "some.scope.fields.discussable.label",
-              scope: "/properties/isDiscussable",
-              type: "Control",
-              options: {
-                control: "hub-field-input-radio",
-                labels: [
-                  "{{some.scope.fields.discussable.enabled.label:translate}}",
-                  "{{some.scope.fields.discussable.disabled.label:translate}}",
-                ],
-                descriptions: [
-                  "{{some.scope.fields.discussable.enabled.description:translate}}",
-                  "{{some.scope.fields.discussable.disabled.description:translate}}",
-                ],
-                icons: ["speech-bubbles", "circle-disallowed"],
-              },
-            },
-          ],
-        },
-        {
-          type: "Section",
           labelKey: "shared.sections.mapSettings.label",
           elements: [
             {

--- a/packages/common/test/discussions/utils.test.ts
+++ b/packages/common/test/discussions/utils.test.ts
@@ -1,3 +1,4 @@
+import { IGroup } from "@esri/arcgis-rest-portal";
 import {
   CANNOT_DISCUSS,
   isDiscussable,
@@ -14,6 +15,7 @@ import {
   AclCategory,
   AclSubCategory,
   getPostCSVFileName,
+  channelToSearchResult,
 } from "../../src";
 
 describe("discussions utils", () => {
@@ -599,6 +601,41 @@ describe("discussions utils", () => {
       expect(result).toEqual(
         "some-really-really-really-really-long-title-with-non-alpha-numeric-characters-i-can-t-believe-how-long-this-title-is-it-exceeds-250-characters-yet-we-re-still-able-to-produce-a-reasonable-file-name-from-it-geesh-i-m-runni_2024-04-01T16-00-00-000Z.csv"
       );
+    });
+  });
+  describe("channelToSearchResult", () => {
+    it("should transform an IChannel and array of IGroup objects into an IHubSearchResult", () => {
+      const channel: IChannel = {
+        id: "c1",
+        access: "private",
+        name: "My channel",
+        createdAt: new Date("2021-09-23T15:16:27.166Z"),
+        updatedAt: new Date("2025-03-31T06:52:58.476Z"),
+        creator: "juliana",
+        blockWords: ["bad"],
+      } as unknown as IChannel;
+      const groups: IGroup[] = [];
+      const result = channelToSearchResult(channel, groups);
+      expect(result).toEqual({
+        ...channel,
+        id: channel.id,
+        name: channel.name,
+        createdDate: channel.createdAt,
+        createdDateSource: "channel",
+        updatedDate: channel.updatedAt,
+        updatedDateSource: "channel",
+        type: "channel",
+        access: "private",
+        family: "channel",
+        owner: channel.creator,
+        links: {
+          thumbnail: null,
+          self: null,
+          siteRelative: null,
+        },
+        includes: { groups },
+        rawResult: channel,
+      });
     });
   });
 });

--- a/packages/common/test/search/_internal/hubDiscussionsHelpers/channelResultsToSearchResults.test.ts
+++ b/packages/common/test/search/_internal/hubDiscussionsHelpers/channelResultsToSearchResults.test.ts
@@ -1,0 +1,162 @@
+import * as restPortal from "@esri/arcgis-rest-portal";
+import { IChannel } from "../../../../src/discussions/api/types";
+import { IHubSearchOptions } from "../../../../src/search/types/IHubSearchOptions";
+import { channelResultsToSearchResults } from "../../../../src/search/_internal/hubDiscussionsHelpers/channelResultsToSearchResults";
+import { IHubSearchResult } from "../../../../src/search/types/IHubSearchResult";
+import * as discussionUtilsModule from "../../../../src/discussions/utils";
+
+describe("channelResultsToSearchResults", () => {
+  it("should resolve an array of IHubSearchResult without group enrichments", async () => {
+    const channels: IChannel[] = [
+      {
+        id: "c1",
+        groups: ["g1"],
+      },
+      {
+        id: "c2",
+        groups: ["g1", "g2"],
+      },
+      {
+        id: "c3",
+        groups: ["g3", "g4"],
+      },
+    ] as unknown as IChannel[];
+    const hubSearchOptions: IHubSearchOptions = {
+      requestOptions: {
+        authentication: { token: "token-123" },
+      },
+    } as unknown as IHubSearchOptions;
+    const groupResults: restPortal.IGroup[] = [
+      {
+        id: "g1",
+      },
+      {
+        id: "g2",
+      },
+      {
+        id: "g4",
+      },
+    ] as any as restPortal.IGroup[];
+    const channelSearchResults: IHubSearchResult[] = [
+      {
+        id: "c1",
+        includes: { groups: [] },
+      },
+      {
+        id: "c2",
+        includes: { groups: [] },
+      },
+      {
+        id: "c3",
+        includes: { groups: [] },
+      },
+    ] as unknown as IHubSearchResult[];
+    const searchGroupsSpy = spyOn(restPortal, "searchGroups").and.returnValue(
+      Promise.resolve(groupResults)
+    );
+    const channelToSearchResultSpy = spyOn(
+      discussionUtilsModule,
+      "channelToSearchResult"
+    ).and.callFake(
+      (channel: IChannel) =>
+        ({
+          id: channel.id,
+          includes: { groups: [] },
+        } as unknown as IHubSearchResult)
+    );
+    const results = await channelResultsToSearchResults(
+      channels,
+      hubSearchOptions
+    );
+    expect(searchGroupsSpy).not.toHaveBeenCalled();
+    expect(channelToSearchResultSpy).toHaveBeenCalledTimes(3);
+    expect(channelToSearchResultSpy).toHaveBeenCalledWith(channels[0], []);
+    expect(channelToSearchResultSpy).toHaveBeenCalledWith(channels[1], []);
+    expect(channelToSearchResultSpy).toHaveBeenCalledWith(channels[2], []);
+    expect(results).toEqual(channelSearchResults);
+  });
+  it("should resolve an array of IHubSearchResult with group enrichments", async () => {
+    const channels: IChannel[] = [
+      {
+        id: "c1",
+        groups: ["g1"],
+      },
+      {
+        id: "c2",
+        groups: ["g1", "g2"],
+      },
+      {
+        id: "c3",
+        groups: ["g3", "g4"],
+      },
+    ] as unknown as IChannel[];
+    const hubSearchOptions: IHubSearchOptions = {
+      include: "groups",
+      requestOptions: {
+        authentication: { token: "token-123" },
+      },
+    } as unknown as IHubSearchOptions;
+    const groupResults: restPortal.IGroup[] = [
+      {
+        id: "g1",
+      },
+      {
+        id: "g2",
+      },
+      {
+        id: "g4",
+      },
+    ] as any as restPortal.IGroup[];
+    const channelSearchResults: IHubSearchResult[] = [
+      {
+        id: "c1",
+        includes: { groups: [groupResults[0]] },
+      },
+      {
+        id: "c2",
+        includes: { groups: [groupResults[0], groupResults[1]] },
+      },
+      {
+        id: "c3",
+        includes: { groups: [null, groupResults[2]] },
+      },
+    ] as unknown as IHubSearchResult[];
+    const searchGroupsSpy = spyOn(restPortal, "searchGroups").and.returnValue(
+      Promise.resolve({ results: groupResults })
+    );
+    const channelToSearchResultSpy = spyOn(
+      discussionUtilsModule,
+      "channelToSearchResult"
+    ).and.callFake((channel: IChannel) => ({
+      id: channel.id,
+      includes: {
+        groups: channel.groups.map(
+          (groupId) => groupResults.find(({ id }) => id === groupId) || null
+        ),
+      },
+    }));
+    const results = await channelResultsToSearchResults(
+      channels,
+      hubSearchOptions
+    );
+    expect(searchGroupsSpy).toHaveBeenCalledTimes(1);
+    expect(searchGroupsSpy).toHaveBeenCalledWith({
+      q: "id:g1 OR id:g2 OR id:g3 OR id:g4",
+      num: 4,
+      ...hubSearchOptions.requestOptions,
+    });
+    expect(channelToSearchResultSpy).toHaveBeenCalledTimes(3);
+    expect(channelToSearchResultSpy).toHaveBeenCalledWith(channels[0], [
+      groupResults[0],
+    ]);
+    expect(channelToSearchResultSpy).toHaveBeenCalledWith(channels[1], [
+      groupResults[0],
+      groupResults[1],
+    ]);
+    expect(channelToSearchResultSpy).toHaveBeenCalledWith(channels[2], [
+      null,
+      groupResults[2],
+    ]);
+    expect(results).toEqual(channelSearchResults);
+  });
+});

--- a/packages/common/test/search/_internal/hubDiscussionsHelpers/processChannelFilters.test.ts
+++ b/packages/common/test/search/_internal/hubDiscussionsHelpers/processChannelFilters.test.ts
@@ -1,0 +1,78 @@
+import {
+  ChannelSort,
+  SharingAccess,
+  SortOrder,
+} from "../../../../src/discussions/api/types";
+import { processChannelFilters } from "../../../../src/search/_internal/hubDiscussionsHelpers/processChannelFilters";
+
+describe("processChannelFilters", () => {
+  it("should support term", () => {
+    let results = processChannelFilters([]);
+    expect(results.name).toBeUndefined();
+    results = processChannelFilters([
+      {
+        predicates: [{ term: "term 1" }, { term: "term 2" }],
+      },
+      {
+        predicates: [{ term: "term 3" }],
+      },
+    ]);
+    expect(results.name).toEqual("term 1");
+  });
+  it("should support groups", () => {
+    let results = processChannelFilters([]);
+    expect(results.groups).toBeUndefined();
+    results = processChannelFilters([
+      {
+        predicates: [{ groups: "group-id-1" }, { groups: ["group-id-2"] }],
+      },
+      {
+        predicates: [{ groups: "group-id-3" }],
+      },
+    ]);
+    expect(results.groups).toEqual(["group-id-1", "group-id-2", "group-id-3"]);
+  });
+  it("should support access", () => {
+    let results = processChannelFilters([]);
+    expect(results.access).toBeUndefined();
+    results = processChannelFilters([
+      {
+        predicates: [{ access: "public" }, { access: ["org"] }],
+      },
+      {
+        predicates: [{ access: "private" }],
+      },
+    ]);
+    expect(results.access).toEqual([
+      SharingAccess.PUBLIC,
+      SharingAccess.ORG,
+      SharingAccess.PRIVATE,
+    ]);
+  });
+  it("should support ids", () => {
+    let results = processChannelFilters([]);
+    expect(results.ids).toBeUndefined();
+    results = processChannelFilters([
+      {
+        predicates: [{ id: "id-1" }, { id: ["id-2"] }],
+      },
+      {
+        predicates: [{ id: "id-3" }],
+      },
+    ]);
+    expect(results.ids).toEqual(["id-1", "id-2", "id-3"]);
+  });
+  it("should support ids using not syntax", () => {
+    let results = processChannelFilters([]);
+    expect(results.notIds).toBeUndefined();
+    results = processChannelFilters([
+      {
+        predicates: [{ id: { not: "id-1" } }, { id: { not: ["id-2"] } }],
+      },
+      {
+        predicates: [{ id: { not: "id-3" } }],
+      },
+    ]);
+    expect(results.notIds).toEqual(["id-1", "id-2", "id-3"]);
+  });
+});

--- a/packages/common/test/search/_internal/hubDiscussionsHelpers/processChannelOptions.test.ts
+++ b/packages/common/test/search/_internal/hubDiscussionsHelpers/processChannelOptions.test.ts
@@ -1,0 +1,37 @@
+import { ChannelSort, SortOrder } from "../../../../src/discussions/api/types";
+import { processChannelOptions } from "../../../../src/search/_internal/hubDiscussionsHelpers/processChannelOptions";
+
+describe("processChannelOptions", () => {
+  it("should support num", () => {
+    let results = processChannelOptions({});
+    expect(results.num).toBeUndefined();
+    results = processChannelOptions({ num: 5 });
+    expect(results.num).toEqual(5);
+  });
+  it("should support start", () => {
+    let results = processChannelOptions({});
+    expect(results.start).toBeUndefined();
+    results = processChannelOptions({ start: 11 });
+    expect(results.start).toEqual(11);
+  });
+  it("should support sortBy", () => {
+    let results = processChannelOptions({});
+    expect(results.sortBy).toBeUndefined();
+    results = processChannelOptions({ sortField: "access" });
+    expect(results.sortBy).toEqual(ChannelSort.ACCESS);
+    results = processChannelOptions({ sortField: "created" });
+    expect(results.sortBy).toEqual(ChannelSort.CREATED_AT);
+    results = processChannelOptions({ sortField: "modified" });
+    expect(results.sortBy).toEqual(ChannelSort.UPDATED_AT);
+    results = processChannelOptions({ sortField: "owner" });
+    expect(results.sortBy).toEqual(ChannelSort.CREATOR);
+  });
+  it("should support sortOrder", () => {
+    let results = processChannelOptions({});
+    expect(results.sortOrder).toBeUndefined();
+    results = processChannelOptions({ sortOrder: "asc" });
+    expect(results.sortOrder).toEqual(SortOrder.ASC);
+    results = processChannelOptions({ sortOrder: "desc" });
+    expect(results.sortOrder).toEqual(SortOrder.DESC);
+  });
+});

--- a/packages/common/test/search/_internal/hubSearchChannels.test.ts
+++ b/packages/common/test/search/_internal/hubSearchChannels.test.ts
@@ -1,262 +1,201 @@
-import * as hubSearchChannels from "../../../src/search/_internal/hubSearchChannels";
-import * as API from "../../../src/discussions/api/channels";
-import {
-  IQuery,
-  IHubSearchOptions,
-  IHubRequestOptions,
-  ISearchChannels,
-  ChannelRelation,
-} from "../../../src";
-import SEARCH_CHANNELS_RESPONSE from "./mocks/searchChannelsResponse";
-import * as arcgisRestPortal from "@esri/arcgis-rest-portal";
+import { IQuery } from "../../../src/search/types/IHubCatalog";
+import { hubSearchChannels } from "../../../src/search/_internal";
+import { IHubSearchOptions, IHubSearchResult } from "../../../src/search/types";
+import * as channelsModule from "../../../src/discussions/api/channels";
+import * as processChannelFiltersModule from "../../../src/search/_internal/hubDiscussionsHelpers/processChannelFilters";
+import * as processChannelOptionsModule from "../../../src/search/_internal/hubDiscussionsHelpers/processChannelOptions";
+import * as channelResultsToSearchResultsModule from "../../../src/search/_internal/hubDiscussionsHelpers/channelResultsToSearchResults";
+import { IChannel, IPagedResponse } from "../../../src/discussions/api/types";
 
-describe("discussionsSearchItems Module |", () => {
-  let processSearchParamsSpy: jasmine.Spy;
-  let toHubSearchResultsSpy: jasmine.Spy;
-  let searchChannelsSpy: jasmine.Spy;
-  let getGroupSpy: jasmine.Spy;
+describe("hubSearchChannels", () => {
+  const query: IQuery = {
+    targetEntity: "channel",
+    filters: [
+      {
+        predicates: [
+          {
+            id: ["c1", "c2", "c3"],
+          },
+        ],
+      },
+    ],
+  };
 
-  beforeEach(() => {
-    processSearchParamsSpy = spyOn(
-      hubSearchChannels,
-      "processSearchParams"
-    ).and.callThrough();
-    toHubSearchResultsSpy = spyOn(
-      hubSearchChannels,
-      "toHubSearchResults"
-    ).and.callThrough();
-    searchChannelsSpy = spyOn(API, "searchChannels").and.callFake(() => {
-      return Promise.resolve(SEARCH_CHANNELS_RESPONSE);
-    });
-    getGroupSpy = spyOn(arcgisRestPortal, "getGroup").and.callFake(() => {
-      return Promise.resolve({ title: "My Group Title" });
-    });
-    spyOn(console, "warn");
-  });
-
-  it("calls searchChannels", async () => {
-    const qry: IQuery = {
-      targetEntity: "channel",
-      filters: [
-        {
-          predicates: [
-            {
-              access: "private",
-              groups: ["cb0ddfc90f4f45b899c076c88d3fdc84"],
-              foo: "bar",
-            },
-          ],
-        },
-      ],
+  it("should reject when searchOptions.requestOptions is not provided", async () => {
+    const hubSearchOptions: IHubSearchOptions = {
+      num: 3,
+      start: 1,
     };
-    const opts: IHubSearchOptions = {
-      num: 10,
-      sortField: "createdAt",
-      sortOrder: "desc",
-      requestOptions: {
-        isPortal: false,
-        hubApiUrl: "https://hubqa.arcgis.com/api",
-        token: "my-secret-token",
-      } as IHubRequestOptions,
-    };
-    const result = await hubSearchChannels.hubSearchChannels(qry, opts);
-    expect(processSearchParamsSpy).toHaveBeenCalledTimes(1);
-    expect(toHubSearchResultsSpy).toHaveBeenCalledTimes(1);
-    expect(searchChannelsSpy).toHaveBeenCalledTimes(1);
-    expect(result).toBeTruthy();
-    const nextResult = await result.next();
-    expect(nextResult).toBeTruthy();
-  });
-  it("throws error if requestOptions not provided", async () => {
-    const qry: IQuery = {
-      targetEntity: "channel",
-      filters: [
-        {
-          predicates: [
-            {
-              access: "private",
-              groups: ["cb0ddfc90f4f45b899c076c88d3fdc84"],
-            },
-          ],
-        },
-      ],
-    };
-    const opts: IHubSearchOptions = {
-      num: 10,
-      sortField: "createdAt",
-      sortOrder: "desc",
-    };
+    const processChannelFiltersSpy = spyOn(
+      processChannelFiltersModule,
+      "processChannelFilters"
+    );
+    const processChannelOptionsSpy = spyOn(
+      processChannelOptionsModule,
+      "processChannelOptions"
+    );
+    const searchChannelsSpy = spyOn(channelsModule, "searchChannels");
+    const channelResultsToSearchResultsSpy = spyOn(
+      channelResultsToSearchResultsModule,
+      "channelResultsToSearchResults"
+    );
     try {
-      await hubSearchChannels.hubSearchChannels(qry, opts);
-    } catch (err) {
-      expect((err as any).name).toBe("HubError");
+      await hubSearchChannels(query, hubSearchOptions);
+      fail("did not reject");
+    } catch (e) {
+      expect(processChannelFiltersSpy).not.toHaveBeenCalled();
+      expect(processChannelOptionsSpy).not.toHaveBeenCalled();
+      expect(searchChannelsSpy).not.toHaveBeenCalled();
+      expect(channelResultsToSearchResultsSpy).not.toHaveBeenCalled();
+      expect((e as Error).message).toEqual(
+        "options.requestOptions is required"
+      );
     }
   });
-  it("handles undefined values", async () => {
-    const qry: IQuery = {
-      targetEntity: "channel",
-      filters: [
+  it("should search for channels and transform results to IHubSearchResult objects", async () => {
+    const hubSearchOptions: IHubSearchOptions = {
+      requestOptions: {
+        authentication: { token: "token" },
+      },
+      num: 3,
+      start: 1,
+    } as unknown as IHubSearchOptions;
+    const processedFilters = {
+      ids: ["c1", "c2", "c3"],
+    };
+    const channelResultsPage1: IPagedResponse<IChannel> = {
+      total: 3,
+      nextStart: 3,
+      start: 1,
+      num: 3,
+      items: [
         {
-          predicates: [
-            {
-              access: "private",
-              groups: ["cb0ddfc90f4f45b899c076c88d3fdc84"],
-            },
-          ],
+          id: "c1",
+        },
+        {
+          id: "c2",
         },
       ],
-    };
-    const opts: IHubSearchOptions = {
-      num: 10,
-      sortField: undefined,
-      sortOrder: undefined,
-      requestOptions: {
-        isPortal: false,
-        hubApiUrl: "https://hubqa.arcgis.com/api",
-        token: "my-secret-token",
-      } as IHubRequestOptions,
-    };
-    const result = await hubSearchChannels.hubSearchChannels(qry, opts);
-    expect(processSearchParamsSpy).toHaveBeenCalledTimes(1);
-    expect(toHubSearchResultsSpy).toHaveBeenCalledTimes(1);
-    expect(searchChannelsSpy).toHaveBeenCalledTimes(1);
-    expect(result).toBeTruthy();
-  });
-  it("processes an IQuery object", () => {
-    const qry: IQuery = {
-      targetEntity: "channel",
-      filters: [
+    } as unknown as IPagedResponse<IChannel>;
+    const channelResultsPage2: IPagedResponse<IChannel> = {
+      total: 3,
+      nextStart: -1,
+      start: 2,
+      num: 3,
+      items: [
         {
-          operation: "OR",
-          predicates: [
-            {
-              access: "private",
-            },
-            {
-              access: "org",
-            },
-          ],
-        },
-        {
-          predicates: [
-            {
-              term: "Foo",
-            },
-          ],
+          id: "c3",
         },
       ],
-    };
-    const opts: IHubSearchOptions = {
-      num: 10,
-      sortField: "createdAt",
-      sortOrder: "desc",
-      requestOptions: {
-        isPortal: false,
-        hubApiUrl: "https://hubqa.arcgis.com/api",
-        token: "my-secret-token",
-      } as IHubRequestOptions,
-    };
-    const result = hubSearchChannels.processSearchParams(opts, qry);
-    expect(result.data).toEqual({
-      num: 10,
-      sortOrder: "DESC",
-      access: ["private", "org"],
-      name: ["Foo"],
-      relations: [ChannelRelation.CHANNEL_ACL],
-    } as any as ISearchChannels);
-  });
-  it("excludes group enrichment when include groups not requested", async () => {
-    const qry: IQuery = {
-      targetEntity: "channel",
-      filters: [
-        {
-          predicates: [
-            {
-              access: "private",
-              groups: ["cb0ddfc90f4f45b899c076c88d3fdc84"],
-              foo: "bar",
-            },
-          ],
-        },
-      ],
-    };
-    const opts: IHubSearchOptions = {
-      num: 10,
-      sortField: "createdAt",
-      sortOrder: "desc",
-      requestOptions: {
-        isPortal: false,
-        hubApiUrl: "https://hubqa.arcgis.com/api",
-        token: "my-secret-token",
-      } as IHubRequestOptions,
-    };
-    const result = await hubSearchChannels.hubSearchChannels(qry, opts);
-    expect(getGroupSpy).not.toHaveBeenCalled();
-    expect(result.results[0].includes).toEqual({ groups: [] });
-  });
-  it("includes group enrichment when include groups requested", async () => {
-    const qry: IQuery = {
-      targetEntity: "channel",
-      filters: [
-        {
-          predicates: [
-            {
-              access: "private",
-              groups: ["cb0ddfc90f4f45b899c076c88d3fdc84"],
-              foo: "bar",
-            },
-          ],
-        },
-      ],
-    };
-    const opts: IHubSearchOptions = {
-      num: 10,
-      sortField: "createdAt",
-      sortOrder: "desc",
-      requestOptions: {
-        isPortal: false,
-        hubApiUrl: "https://hubqa.arcgis.com/api",
-        token: "my-secret-token",
-      } as IHubRequestOptions,
-      include: ["groups"],
-    };
-    const result = await hubSearchChannels.hubSearchChannels(qry, opts);
-    expect(getGroupSpy).toHaveBeenCalled();
-    expect(result.results[0].includes).toEqual({
-      groups: [{ title: "My Group Title" }],
+    } as unknown as IPagedResponse<IChannel>;
+    const searchResultsPage1: IHubSearchResult[] = [
+      {
+        id: "c1",
+        type: "channel",
+      },
+      {
+        id: "c2",
+        type: "channel",
+      },
+    ] as unknown as IHubSearchResult[];
+    const searchResultsPage2: IHubSearchResult[] = [
+      {
+        id: "c3",
+        type: "channel",
+      },
+    ] as unknown as IHubSearchResult[];
+    const processChannelFiltersSpy = spyOn(
+      processChannelFiltersModule,
+      "processChannelFilters"
+    ).and.returnValue(processedFilters);
+    const processChannelOptionsSpy = spyOn(
+      processChannelOptionsModule,
+      "processChannelOptions"
+    ).and.returnValues(
+      {
+        num: 3,
+        start: 1,
+      },
+      {
+        num: 3,
+        start: 3,
+      }
+    );
+    const searchChannelsSpy = spyOn(
+      channelsModule,
+      "searchChannels"
+    ).and.returnValues(
+      Promise.resolve(channelResultsPage1),
+      Promise.resolve(channelResultsPage2)
+    );
+    const channelResultsToSearchResultsSpy = spyOn(
+      channelResultsToSearchResultsModule,
+      "channelResultsToSearchResults"
+    ).and.returnValues(
+      Promise.resolve(searchResultsPage1),
+      Promise.resolve(searchResultsPage2)
+    );
+    let results = await hubSearchChannels(query, hubSearchOptions);
+    expect(results).toEqual({
+      total: 3,
+      results: searchResultsPage1,
+      hasNext: true,
+      next: jasmine.any(Function),
     });
-  });
-  it("handles error when group is inaccessible", async () => {
-    getGroupSpy.and.throwError("groups is inaccessible");
-    const qry: IQuery = {
-      targetEntity: "channel",
-      filters: [
-        {
-          predicates: [
-            {
-              access: "private",
-              groups: ["cb0ddfc90f4f45b899c076c88d3fdc84"],
-              foo: "bar",
-            },
-          ],
-        },
-      ],
-    };
-    const opts: IHubSearchOptions = {
-      num: 10,
-      sortField: "createdAt",
-      sortOrder: "desc",
-      requestOptions: {
-        isPortal: false,
-        hubApiUrl: "https://hubqa.arcgis.com/api",
-        token: "my-secret-token",
-      } as IHubRequestOptions,
-      include: ["groups"],
-    };
-    const result = await hubSearchChannels.hubSearchChannels(qry, opts);
-    expect(getGroupSpy).toHaveBeenCalled();
-    /* tslint:disable-next-line: no-console */
-    expect(console.warn).toHaveBeenCalled();
-    expect(result.results[0].includes).toEqual({ groups: [null] });
+    expect(searchChannelsSpy).toHaveBeenCalledTimes(1);
+    expect(searchChannelsSpy).toHaveBeenCalledWith({
+      data: {
+        ...processedFilters,
+        num: 3,
+        start: 1,
+      },
+      ...hubSearchOptions.requestOptions,
+    });
+    expect(processChannelFiltersSpy).toHaveBeenCalledTimes(1);
+    expect(processChannelFiltersSpy).toHaveBeenCalledWith(query.filters);
+    expect(processChannelOptionsSpy).toHaveBeenCalledTimes(1);
+    expect(processChannelOptionsSpy).toHaveBeenCalledWith(hubSearchOptions);
+    expect(channelResultsToSearchResultsSpy).toHaveBeenCalledTimes(1);
+    expect(channelResultsToSearchResultsSpy).toHaveBeenCalledWith(
+      channelResultsPage1.items,
+      hubSearchOptions
+    );
+
+    // next page
+    searchChannelsSpy.calls.reset();
+    processChannelFiltersSpy.calls.reset();
+    processChannelOptionsSpy.calls.reset();
+    channelResultsToSearchResultsSpy.calls.reset();
+    results = await results.next();
+    expect(results).toEqual({
+      total: 3,
+      results: searchResultsPage2,
+      hasNext: false,
+      next: jasmine.any(Function),
+    });
+    expect(searchChannelsSpy).toHaveBeenCalledTimes(1);
+    expect(searchChannelsSpy).toHaveBeenCalledWith({
+      data: {
+        ...processedFilters,
+        num: 3,
+        start: 3,
+      },
+      ...hubSearchOptions.requestOptions,
+    });
+    expect(processChannelFiltersSpy).toHaveBeenCalledTimes(1);
+    expect(processChannelFiltersSpy).toHaveBeenCalledWith(query.filters);
+    expect(processChannelOptionsSpy).toHaveBeenCalledTimes(1);
+    expect(processChannelOptionsSpy).toHaveBeenCalledWith({
+      ...hubSearchOptions,
+      start: 3,
+    });
+    expect(channelResultsToSearchResultsSpy).toHaveBeenCalledTimes(1);
+    expect(channelResultsToSearchResultsSpy).toHaveBeenCalledWith(
+      channelResultsPage2.items,
+      {
+        ...hubSearchOptions,
+        start: 3,
+      }
+    );
   });
 });

--- a/packages/common/test/utils/_array.test.ts
+++ b/packages/common/test/utils/_array.test.ts
@@ -1,4 +1,4 @@
-import { maybeConcat } from "../../src/utils/_array";
+import { maybeConcat, splitArrayByLength } from "../../src/utils/_array";
 
 describe("maybeConcat", () => {
   it("returns undefined when no arrays", () => {
@@ -15,5 +15,12 @@ describe("maybeConcat", () => {
       [3, 4],
     ]);
     expect(result).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe("splitArrayByLength", () => {
+  it("should convert a single array into multiple arrays of the given max length", () => {
+    const results = splitArrayByLength<string>(["a", "b", "c"], 2);
+    expect(results).toEqual([["a", "b"], ["c"]]);
   });
 });


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 12668

1. Description:
- Adds a reusable entity discussion settings schema
- Hooks up the reusable entity discussion settings schema for discussion boards
- Refactors the hub channel search logic to significantly reduce the number of XHRs needed to fetch the group enrichments
- Adds support for `id` and `notId` channel search API params, integrates into `hubSearch` using `id: string | string[] | { not: string | string[] }` syntax

1. Instructions for testing:

1. Closes Issues: #12668

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
