### PR TITLE
feat: add hub-premium gating to hub:feature:catalogs:edit:advanced permission

### DIFF
--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -40,6 +40,8 @@ export const InitiativePermissions = [
   "hub:initiative:workspace:metrics",
   "hub:initiative:workspace:catalogs", // deprecated -- should be removed
   "hub:initiative:workspace:catalog",
+  "hub:initiative:workspace:catalog:content",
+  "hub:initiative:workspace:catalog:events",
   "hub:initiative:workspace:associationGroup:create",
   "hub:initiative:manage",
 ] as const;
@@ -198,6 +200,18 @@ export const InitiativePermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:initiative:workspace:catalog",
     dependencies: ["hub:initiative:workspace", "hub:initiative:edit"],
+  },
+  {
+    permission: "hub:initiative:workspace:catalog:content",
+    dependencies: ["hub:initiative:workspace:catalog"],
+  },
+  {
+    permission: "hub:initiative:workspace:catalog:events",
+    dependencies: [
+      "hub:initiative:workspace:catalog",
+      "hub:event",
+      "hub:feature:catalogs:edit:advanced",
+    ],
   },
   {
     permission: "hub:initiative:manage",

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -173,12 +173,18 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     environments: ["qaext"],
     availability: ["alpha"],
   },
-  // gates advanced editing (e.g. adding new collections, adding
-  // additional scope filters, etc.) for site entities
-  // TODO: Remove this permission once all catalog configuration features are supported by sites
+  /**
+   * Gates advanced editing (e.g. adding new collections, adding
+   * additional scope filters, appearance settings, etc.) in
+   * the catalog configuration experince.
+   *
+   * TODO: Remove the site entity assertion once all catalog
+   * configuration features are supported by sites
+   */
   {
     permission: "hub:feature:catalogs:edit:advanced",
     entityEdit: true,
+    licenses: ["hub-premium"],
     assertions: [
       {
         property: "entity:type",

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -178,7 +178,11 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:project:workspace:catalog:events",
-    dependencies: ["hub:project:workspace:catalog", "hub:event"],
+    dependencies: [
+      "hub:project:workspace:catalog",
+      "hub:event",
+      "hub:feature:catalogs:edit:advanced",
+    ],
   },
   {
     permission: "hub:project:manage",

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -37,6 +37,8 @@ export const ProjectPermissions = [
   "hub:project:workspace:events",
   "hub:project:workspace:metrics",
   "hub:project:workspace:catalog",
+  "hub:project:workspace:catalog:content",
+  "hub:project:workspace:catalog:events",
   "hub:project:manage",
 ] as const;
 
@@ -169,6 +171,14 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:project:workspace:catalog",
     dependencies: ["hub:project:workspace", "hub:project:edit"],
+  },
+  {
+    permission: "hub:project:workspace:catalog:content",
+    dependencies: ["hub:project:workspace:catalog"],
+  },
+  {
+    permission: "hub:project:workspace:catalog:events",
+    dependencies: ["hub:project:workspace:catalog", "hub:event"],
   },
   {
     permission: "hub:project:manage",

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -177,7 +177,11 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:site:workspace:catalog:events",
-    dependencies: ["hub:site:workspace:catalog", "hub:event"],
+    dependencies: [
+      "hub:site:workspace:catalog",
+      "hub:event",
+      "hub:feature:catalogs:edit:advanced",
+    ],
   },
   {
     permission: "hub:site:workspace:pages",


### PR DESCRIPTION
[12770](https://devtopia.esri.com/dc/hub/issues/12770)

### Description:
adds premium gating to the "hub:feature:catalogs:edit:advanced" permission

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.