### PR TITLE
fix: update slug validation rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64999,7 +64999,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "16.0.1",
+			"version": "16.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/core/schemas/shared/subschemas.ts
+++ b/packages/common/src/core/schemas/shared/subschemas.ts
@@ -185,5 +185,7 @@ export const PRIVACY_CONFIG_SCHEMA = {
 export const SLUG_SCHEMA: JSONSchema = {
   type: "string",
   /** lower case alpha numeric characters and '-' only */
-  pattern: "^[a-z0-9]+(?:-[a-z0-9]+-*)*$",
+  // using the same regex as the slug formatter
+  // this will prevent trailing - or multiple - in a row
+  pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
 };


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Update slug validation rules.

1. Instructions for testing:

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/12417

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
