### PR TITLE
fix: update site now uses fetch site model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22677,9 +22677,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._baseuniq": {
 			"version": "4.6.0",
@@ -22694,21 +22695,24 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash._getnative": "^3.0.0"
 			}
@@ -22722,9 +22726,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash._root": {
 			"version": "3.0.1",
@@ -22742,9 +22747,10 @@
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cz-lerna-changelog/node_modules/npm/node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -64999,7 +65005,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "16.0.1",
+			"version": "16.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -83436,7 +83442,8 @@
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
@@ -83451,17 +83458,20 @@
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"bundled": true,
-							"extraneous": true,
+							"dev": true,
+							"peer": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -83475,7 +83485,8 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash._root": {
 							"version": "3.0.1",
@@ -83492,7 +83503,8 @@
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"bundled": true,
-							"extraneous": true
+							"dev": true,
+							"peer": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -19,12 +19,7 @@ import { stripProtocol } from "../urls/strip-protocol";
 import { getHubApiUrl } from "../api";
 import { getOrgDefaultTheme } from "./themes";
 import { cloneObject, unique } from "../util";
-import {
-  createModel,
-  fetchModelFromItem,
-  getModel,
-  updateModel,
-} from "../models";
+import { createModel, fetchModelFromItem, updateModel } from "../models";
 import { addSiteDomains } from "./domains/addSiteDomains";
 import { IHubRequestOptions, IModel } from "../hub-types";
 import { removeDomainsBySiteId } from "./domains/remove-domains-by-site-id";
@@ -348,7 +343,7 @@ export async function updateSite(
     site.isDiscussable
   );
   // Fetch backing model from the portal
-  const currentModel = await getModel(site.id, requestOptions);
+  const currentModel = await fetchSiteModel(site.id, requestOptions);
   // Note: Although we are fetching the model, and applying changes onto it,
   // we are not attempting to handle "concurrent edit" conflict resolution
   // but this is where we would apply that sort of logic

--- a/packages/common/src/sites/_internal/_migrate-event-list-card-configs.ts
+++ b/packages/common/src/sites/_internal/_migrate-event-list-card-configs.ts
@@ -16,7 +16,7 @@ export function _migrateEventListCardConfigs<T extends IModel | IDraft>(
 
   // apply migration
   const clone = cloneObject(model);
-  clone.data.values.layout.sections.map((section: any) => ({
+  (clone.data.values.layout?.sections || []).map((section: any) => ({
     ...section,
     rows: (section.rows || []).map((row: any) => ({
       ...row,

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -17,7 +17,7 @@ import {
 import * as slugUtils from "../../src/items/slugs";
 import { SearchCategories } from "../../src/sites/_internal/types";
 
-const GUID = "00c77674e43cf4bbd9ecad5189b3f1fdc";
+const GUID = "042584cf391c428e995e97eccdebb8f8";
 const SITE_ITEM: portalModule.IItem = {
   id: GUID,
   title: "Fake Site",
@@ -63,7 +63,7 @@ const SITE: commonModule.IHubSite = {
   orgUrlKey: "dcdev",
   owner: "dcdev_dude",
   type: "Hub Site Application",
-  typeKeywords: [],
+  typeKeywords: ["cannotDiscuss"],
   createdDate: new Date(1595878748000),
   createdDateSource: "item.created",
   updatedDate: new Date(1595878750000),
@@ -252,7 +252,7 @@ describe("HubSites:", () => {
       expect(chk.id).toBe(GUID);
       expect(chk.owner).toBe("vader");
       expect(chk.thumbnailUrl).toBe(
-        "https://gis.myserver.com/portal/sharing/rest/content/items/00c77674e43cf4bbd9ecad5189b3f1fdc/info/vader.png"
+        `https://gis.myserver.com/portal/sharing/rest/content/items/${GUID}/info/vader.png`
       );
       expect(fetchSpy.calls.count()).toBe(1);
       expect(fetchSpy.calls.argsFor(0)[0]).toBe("mysite.com");
@@ -430,7 +430,15 @@ describe("HubSites:", () => {
 
       expect(domainChangeSpy.calls.count()).toBe(1);
 
-      expect(domainChangeSpy.calls.argsFor(0)[1]).toEqual(SITE_MODEL);
+      // I believe before we were confirming the hostnames remained unchanged, but
+      // now that we're using `fetchSiteModel`, we can't use the entire model to compare
+      const spyModel = domainChangeSpy.calls.argsFor(0)[1];
+      expect(spyModel.data.values.customHostname).toEqual(
+        SITE_MODEL.data.values.customHostname
+      );
+      expect(spyModel.data.values.defaultHostname).toEqual(
+        SITE_MODEL.data.values.defaultHostname
+      );
 
       expect(getModelSpy.calls.count()).toBe(1);
       expect(updateModelSpy.calls.count()).toBe(1);
@@ -454,7 +462,9 @@ describe("HubSites:", () => {
       expect(domainChangeArg0.data.values.customHostname).toEqual(
         updatedHostname
       );
-      expect(domainChangeArg1).toEqual(SITE_MODEL);
+      // now that we're using `fetchSiteModel`, this isn't necessarily true,
+      // BUT we should still be storing the customHostname in the same location
+      // expect(domainChangeArg1).toEqual(SITE_MODEL);
 
       expect(getModelSpy.calls.count()).toBe(1);
       expect(updateModelSpy.calls.count()).toBe(1);

--- a/packages/common/test/sites/_internal/capabilities/convertFeaturesToLegacyCapabilities.test.ts
+++ b/packages/common/test/sites/_internal/capabilities/convertFeaturesToLegacyCapabilities.test.ts
@@ -44,6 +44,44 @@ describe("convertFeaturesToLegacyCapabilities", () => {
     ]);
   });
 
+  it("missing capabilities and features", () => {
+    // this test is a simple duplicate of the one above, added for branch coverage when props are undefined
+    const modelToUpdate = {
+      item: {} as IItem,
+      data: {
+        settings: {
+          features: undefined,
+        },
+        values: {
+          capabilities: [],
+        },
+      },
+    } as IModel;
+    const currentModel = {
+      item: {} as IItem,
+      data: {
+        settings: {
+          features: {
+            "hub:site:content": true,
+          },
+        },
+        values: {
+          capabilities: undefined,
+        },
+      },
+    } as IModel;
+
+    const chk = convertFeaturesToLegacyCapabilities(
+      modelToUpdate,
+      currentModel
+    );
+
+    expect(chk.data?.values.capabilities).toEqual([
+      "hideFollow",
+      "disableDiscussions",
+    ]);
+  });
+
   it("removes relevant features from the site's legacy capabilities array", () => {
     const modelToUpdate = {
       item: {} as IItem,


### PR DESCRIPTION
1. Description: **this is a tech issue**, but I couldn't label it so in the title
- use `fetchSiteModel` in `updateSite`
- fix tests

1. Instructions for testing: 

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/12839

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
