### PR TITLE
feat(hub-common): add updatedAtAfter and updatedAtBefore to interface…

### DIFF
--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -160,6 +160,14 @@ export type GetEventsParams = {
    */
   title?: string;
   /**
+   * earliest ISO8601 updatedAt for the events
+   */
+  updatedAtAfter?: string;
+  /**
+   * latest ISO8601 updatedAt for the events
+   */
+  updatedAtBefore?: string;
+  /**
    * Comma separated string list of edit groupIds that event is not shared to
    */
   withoutEditGroups?: string;
@@ -361,6 +369,10 @@ export interface ISearchEvents {
   tags?: string[];
   /** string to match within an event title */
   title?: string;
+  /** earliest ISO8601 updatedAt for the events */
+  updatedAtAfter?: string;
+  /** latest ISO8601 updatedAt for the events */
+  updatedAtBefore?: string;
   /** Array of edit groupIds that event is not shared to */
   withoutEditGroups?: string[];
   /** Array of read groupIds that event is not shared to */


### PR DESCRIPTION
… ISearchEvents

affects: @esri/hub-common

Issue https://devtopia.esri.com/dc/hub/issues/12925

1. Description: Add `updatedAtAfter` and `updateAtBefore` to interface `ISearchEvents`

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
