### PR TITLE
fix: site event catalog gating

### DIFF
--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -177,11 +177,8 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:site:workspace:catalog:events",
-    dependencies: [
-      "hub:site:workspace:catalog",
-      "hub:event",
-      "hub:feature:catalogs:edit:advanced",
-    ],
+    licenses: ["hub-premium"],
+    dependencies: ["hub:site:workspace:catalog", "hub:event"],
   },
   {
     permission: "hub:site:workspace:pages",


### PR DESCRIPTION
- [12770](https://devtopia.esri.com/dc/hub/issues/12770)

### Description
Gate the events catalog pane in the site workspace to premium users, but we can't use the `"hub:feature:catalogs:edit:advanced"` permission because it currently has an assertion for sites

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.