### PR TITLE
feat(hub-common): updates the create and edit channel UISchemas to co…

### DIFF
--- a/packages/common/src/channels/_internal/ChannelUiSchemaCreate.ts
+++ b/packages/common/src/channels/_internal/ChannelUiSchemaCreate.ts
@@ -1,9 +1,12 @@
-import { IUiSchema } from "../../core/schemas/types";
+import { IUiSchema, UiSchemaRuleEffects } from "../../core/schemas/types";
 import { IArcGISContext } from "../../types";
 import { IHubChannel } from "../../core/types";
 import { getWellKnownCatalog } from "../../search/wellKnownCatalog";
 import { CANNOT_DISCUSS } from "../../discussions/constants";
 import { ChannelNonePermission } from "./ChannelBusinessRules";
+import { Role } from "../../discussions/api/types";
+import { deriveUserRoleV2 } from "../../discussions/api/utils/channels/derive-user-role-v2";
+import { CHANNEL_ACTION_PRIVS } from "../../discussions/api/utils/channel-permission";
 
 /**
  * @private
@@ -13,9 +16,12 @@ import { ChannelNonePermission } from "./ChannelBusinessRules";
  */
 export const buildUiSchema = async (
   i18nScope: string,
-  _options: Partial<IHubChannel>,
+  options: Partial<IHubChannel>,
   context: IArcGISContext
 ): Promise<IUiSchema> => {
+  const role = Boolean(options.id)
+    ? deriveUserRoleV2(options.channel, context.currentUser)
+    : Role.OWNER;
   const facet = {
     label: `{{${i18nScope}.sections.group.picker.facets.label:translate}}`,
     key: "groups",
@@ -77,6 +83,14 @@ export const buildUiSchema = async (
             labelKey: `${i18nScope}.fields.name.label`,
             type: "Control",
             scope: "/properties/name",
+            rules: [
+              {
+                effect: UiSchemaRuleEffects.DISABLE,
+                conditions: [
+                  !CHANNEL_ACTION_PRIVS.UPDATE_CHANNEL_NAME.includes(role),
+                ],
+              },
+            ],
             options: {
               control: "hub-field-input-input",
               messages: [
@@ -103,6 +117,14 @@ export const buildUiSchema = async (
             type: "Control",
             scope: "/properties/allowAsAnonymous",
             labelKey: `${i18nScope}.fields.allowAsAnonymous.label`,
+            rules: [
+              {
+                effect: UiSchemaRuleEffects.DISABLE,
+                conditions: [
+                  !CHANNEL_ACTION_PRIVS.UPDATE_POST_AS_ANONYMOUS.includes(role),
+                ],
+              },
+            ],
             options: {
               control: "hub-field-input-switch",
               helperText: {
@@ -115,6 +137,14 @@ export const buildUiSchema = async (
             scope: "/properties/blockWords",
             label: "Blocked words",
             labelKey: `${i18nScope}.fields.blockWords.label`,
+            rules: [
+              {
+                effect: UiSchemaRuleEffects.DISABLE,
+                conditions: [
+                  !CHANNEL_ACTION_PRIVS.UPDATE_BLOCKED_WORDS.includes(role),
+                ],
+              },
+            ],
             options: {
               control: "hub-field-input-input",
               type: "textarea",
@@ -156,6 +186,16 @@ export const buildUiSchema = async (
               {
                 type: "Control",
                 scope: "/properties/publicConfigs",
+                rules: [
+                  {
+                    effect: UiSchemaRuleEffects.DISABLE,
+                    conditions: [
+                      !CHANNEL_ACTION_PRIVS.UPDATE_ANONYMOUS_USERS.includes(
+                        role
+                      ),
+                    ],
+                  },
+                ],
                 options: {
                   control: "hub-field-permissions",
                   roles: [
@@ -195,6 +235,14 @@ export const buildUiSchema = async (
               {
                 type: "Control",
                 scope: "/properties/orgConfigs",
+                rules: [
+                  {
+                    effect: UiSchemaRuleEffects.DISABLE,
+                    conditions: [
+                      !CHANNEL_ACTION_PRIVS.UPDATE_ORGS.includes(role),
+                    ],
+                  },
+                ],
                 options: {
                   control: "hub-field-permissions",
                   roles: [
@@ -234,6 +282,14 @@ export const buildUiSchema = async (
               {
                 type: "Control",
                 scope: "/properties/groupConfigs",
+                rules: [
+                  {
+                    effect: UiSchemaRuleEffects.DISABLE,
+                    conditions: [
+                      !CHANNEL_ACTION_PRIVS.UPDATE_GROUPS.includes(role),
+                    ],
+                  },
+                ],
                 options: {
                   control: "hub-field-permissions",
                   actions: [

--- a/packages/common/src/discussions/api/utils/channel-permission.ts
+++ b/packages/common/src/discussions/api/utils/channel-permission.ts
@@ -27,8 +27,14 @@ enum ChannelAction {
   IS_OWNER = "isOwner",
 }
 
-// See confluence for privs documentation: https://confluencewikidev.esri.com/pages/viewpage.action?pageId=153747776#Roles&Privileges-ApplicationtoChannels
-const CHANNEL_ACTION_PRIVS: Record<string, Role[]> = {
+/**
+ * A map of update operations & ACL roles where the key is the update operation
+ * and the value is an array of roles that are permitted to perform the update operation.
+ * See confluence for privs documentation: https://confluencewikidev.esri.com/pages/viewpage.action?pageId=153747776#Roles&Privileges-ApplicationtoChannels
+ * @internal
+ * @hidden
+ */
+export const CHANNEL_ACTION_PRIVS: Record<string, Role[]> = {
   // permissions
   UPDATE_OWNERS: [Role.OWNER],
   UPDATE_MANAGERS: [Role.OWNER, Role.MANAGE],
@@ -74,6 +80,10 @@ export class ChannelPermission {
       this.permissionsByCategory[category]?.push(permission) ||
         (this.permissionsByCategory[category] = [permission]);
     });
+  }
+
+  deriveUserRole(user: IDiscussionsUser): Role {
+    return this.determineUserRole(user);
   }
 
   canPostToChannel(user: IDiscussionsUser): boolean {

--- a/packages/common/src/discussions/api/utils/channels/derive-user-role-v2.ts
+++ b/packages/common/src/discussions/api/utils/channels/derive-user-role-v2.ts
@@ -1,0 +1,17 @@
+import type { IUser } from "@esri/arcgis-rest-portal";
+import { IChannel, IDiscussionsUser, Role } from "../../types";
+import { ChannelPermission } from "../channel-permission";
+
+/**
+ * Derives the user role for the given channel and user
+ * @param channel an IChannel object
+ * @param user  An IUser or IDiscussionUser object
+ * @returns the appropriate Role for the given user relative to the given channel
+ */
+export function deriveUserRoleV2(
+  channel: IChannel,
+  user: IUser | IDiscussionsUser = {}
+): Role {
+  const channelPermission = new ChannelPermission(channel);
+  return channelPermission.deriveUserRole(user);
+}

--- a/packages/common/src/discussions/api/utils/channels/index.ts
+++ b/packages/common/src/discussions/api/utils/channels/index.ts
@@ -11,3 +11,4 @@ export { canCreateChannelV2 } from "./can-create-channel-v2";
 export { canDeleteChannelV2 } from "./can-delete-channel-v2";
 export { canEditChannelV2 } from "./can-edit-channel-v2";
 export { canReadChannelV2 } from "./can-read-channel-v2";
+export { deriveUserRoleV2 } from "./derive-user-role-v2";

--- a/packages/common/src/search/_internal/hubDiscussionsHelpers/processChannelOptions.ts
+++ b/packages/common/src/search/_internal/hubDiscussionsHelpers/processChannelOptions.ts
@@ -1,4 +1,5 @@
 import {
+  ChannelRelation,
   ChannelSort,
   ISearchChannels,
   SortOrder,
@@ -27,7 +28,9 @@ const SORT_ORDER_MAP: Record<"desc" | "asc", SortOrder> = {
 export function processChannelOptions(
   options: IHubSearchOptions
 ): Partial<ISearchChannels> {
-  const channelOptions: Partial<ISearchChannels> = {};
+  const channelOptions: Partial<ISearchChannels> = {
+    relations: [ChannelRelation.CHANNEL_ACL],
+  };
   if (options.num) {
     channelOptions.num = options.num;
   }

--- a/packages/common/test/channels/_internal/ChannelUiSchemaCreate.test.ts
+++ b/packages/common/test/channels/_internal/ChannelUiSchemaCreate.test.ts
@@ -1,35 +1,45 @@
 import { buildUiSchema } from "../../../src/channels/_internal/ChannelUiSchemaCreate";
-import { IChannel } from "../../../src/discussions/api/types";
+import { IChannel, Role } from "../../../src/discussions/api/types";
 import { IArcGISContext } from "../../../src/types/IArcGISContext";
-import { IUiSchema } from "../../../src/core/schemas/types";
+import {
+  IUiSchema,
+  UiSchemaRuleEffects,
+} from "../../../src/core/schemas/types";
 import * as getWellKnownCatalogModule from "../../../src/search/wellKnownCatalog";
 import { IHubCatalog } from "../../../src/search/types";
 import { CANNOT_DISCUSS } from "../../../src/discussions/constants";
 import { ChannelNonePermission } from "../../../src/channels/_internal/ChannelBusinessRules";
+import * as deriveUserRoleV2Module from "../../../src/discussions/api/utils/channels/derive-user-role-v2";
+import { IHubChannel } from "../../../src/core/types/IHubChannel";
 
 describe("ChannelUiSchemaCreate", () => {
-  const i18nScope = "myScope";
-  const options: Partial<IChannel> = {};
-  const catalog: IHubCatalog = { schemaVersion: 0 };
-  let getWellKnownCatalogSpy: jasmine.Spy;
   describe("buildUiSchema", () => {
+    const i18nScope = "myScope";
+    const catalog: IHubCatalog = { schemaVersion: 0 };
+    let partialChannel: Partial<IHubChannel>;
+    let getWellKnownCatalogSpy: jasmine.Spy;
+    let deriveUserRoleV2Spy: jasmine.Spy;
+
     beforeEach(() => {
+      partialChannel = {};
       getWellKnownCatalogSpy = spyOn(
         getWellKnownCatalogModule,
         "getWellKnownCatalog"
       ).and.returnValue(catalog);
+      deriveUserRoleV2Spy = spyOn(deriveUserRoleV2Module, "deriveUserRoleV2");
     });
+
     afterEach(() => {
       getWellKnownCatalogSpy.calls.reset();
+      deriveUserRoleV2Spy.calls.reset();
     });
-    it("should build a schema for an authenticated user", async () => {
-      const context = {
-        currentUser: {
-          orgId: "orgId123",
-          username: "user123",
-        },
-      } as unknown as IArcGISContext;
-      const expected: IUiSchema = {
+
+    const buildSchema = (
+      hasCommunityId: boolean,
+      disabledFields: string[],
+      context: IArcGISContext
+    ): IUiSchema => {
+      const schema: IUiSchema = {
         type: "Layout",
         elements: [
           {
@@ -43,6 +53,12 @@ describe("ChannelUiSchemaCreate", () => {
                 labelKey: `${i18nScope}.fields.name.label`,
                 type: "Control",
                 scope: "/properties/name",
+                rules: [
+                  {
+                    effect: UiSchemaRuleEffects.DISABLE,
+                    conditions: [disabledFields.includes("name")],
+                  },
+                ],
                 options: {
                   control: "hub-field-input-input",
                   messages: [
@@ -69,6 +85,12 @@ describe("ChannelUiSchemaCreate", () => {
                 type: "Control",
                 scope: "/properties/allowAsAnonymous",
                 labelKey: `${i18nScope}.fields.allowAsAnonymous.label`,
+                rules: [
+                  {
+                    effect: UiSchemaRuleEffects.DISABLE,
+                    conditions: [disabledFields.includes("allowAsAnonymous")],
+                  },
+                ],
                 options: {
                   control: "hub-field-input-switch",
                   helperText: {
@@ -81,6 +103,12 @@ describe("ChannelUiSchemaCreate", () => {
                 scope: "/properties/blockWords",
                 label: "Blocked words",
                 labelKey: `${i18nScope}.fields.blockWords.label`,
+                rules: [
+                  {
+                    effect: UiSchemaRuleEffects.DISABLE,
+                    conditions: [disabledFields.includes("blockWords")],
+                  },
+                ],
                 options: {
                   control: "hub-field-input-input",
                   type: "textarea",
@@ -122,6 +150,12 @@ describe("ChannelUiSchemaCreate", () => {
                   {
                     type: "Control",
                     scope: "/properties/publicConfigs",
+                    rules: [
+                      {
+                        effect: UiSchemaRuleEffects.DISABLE,
+                        conditions: [disabledFields.includes("publicConfigs")],
+                      },
+                    ],
                     options: {
                       control: "hub-field-permissions",
                       roles: [
@@ -161,6 +195,12 @@ describe("ChannelUiSchemaCreate", () => {
                   {
                     type: "Control",
                     scope: "/properties/orgConfigs",
+                    rules: [
+                      {
+                        effect: UiSchemaRuleEffects.DISABLE,
+                        conditions: [disabledFields.includes("orgConfigs")],
+                      },
+                    ],
                     options: {
                       control: "hub-field-permissions",
                       roles: [
@@ -200,6 +240,12 @@ describe("ChannelUiSchemaCreate", () => {
                   {
                     type: "Control",
                     scope: "/properties/groupConfigs",
+                    rules: [
+                      {
+                        effect: UiSchemaRuleEffects.DISABLE,
+                        conditions: [disabledFields.includes("groupConfigs")],
+                      },
+                    ],
                     options: {
                       control: "hub-field-permissions",
                       actions: [
@@ -297,315 +343,187 @@ describe("ChannelUiSchemaCreate", () => {
           },
         ],
       };
-      const result = await buildUiSchema(i18nScope, options, context);
-      expect(result).toEqual(expected);
-      expect(getWellKnownCatalogSpy).toHaveBeenCalledTimes(1);
-      expect(getWellKnownCatalogSpy).toHaveBeenCalledWith(
-        i18nScope,
-        "allGroups",
-        "group",
-        { user: context.currentUser }
-      );
+      if (hasCommunityId) {
+        schema.elements[2].elements[2].elements[0].options.actions[0].options.facets[0].options.push(
+          {
+            label: `{{${i18nScope}.sections.group.picker.facets.myCommunity.label:translate}}`,
+            key: "my-community",
+            selected: false,
+            predicates: [
+              {
+                orgid: context.communityOrgId,
+                searchUserAccess: "groupMember",
+                searchUserName: context.currentUser.username,
+                typekeywords: { not: CANNOT_DISCUSS },
+              },
+            ],
+          }
+        );
+      }
+      return schema;
+    };
+
+    describe("new channel", () => {
+      it("should build a schema for a user with no community org", async () => {
+        const context = {
+          currentUser: {
+            orgId: "orgId123",
+            username: "user123",
+          },
+        } as unknown as IArcGISContext;
+        const expected: IUiSchema = buildSchema(false, [], context);
+        const result = await buildUiSchema(i18nScope, partialChannel, context);
+        expect(result).toEqual(expected);
+        expect(getWellKnownCatalogSpy).toHaveBeenCalledTimes(1);
+        expect(getWellKnownCatalogSpy).toHaveBeenCalledWith(
+          i18nScope,
+          "allGroups",
+          "group",
+          { user: context.currentUser }
+        );
+        expect(deriveUserRoleV2Spy).not.toHaveBeenCalled();
+      });
+      it("should build a schema for a user with a community org", async () => {
+        const context = {
+          currentUser: {
+            orgId: "orgId123",
+            username: "user123",
+          },
+          communityOrgId: "communityId123",
+        } as unknown as IArcGISContext;
+        const expected: IUiSchema = buildSchema(true, [], context);
+        const result = await buildUiSchema(i18nScope, partialChannel, context);
+        expect(result).toEqual(expected);
+        expect(getWellKnownCatalogSpy).toHaveBeenCalledTimes(1);
+        expect(getWellKnownCatalogSpy).toHaveBeenCalledWith(
+          i18nScope,
+          "allGroups",
+          "group",
+          { user: context.currentUser }
+        );
+        expect(deriveUserRoleV2Spy).not.toHaveBeenCalled();
+      });
     });
-    it("should build a schema for a community user", async () => {
-      const context = {
-        currentUser: {
-          orgId: "orgId123",
-          username: "user123",
-        },
-        communityOrgId: "communityId123",
-      } as unknown as IArcGISContext;
-      const expected: IUiSchema = {
-        type: "Layout",
-        elements: [
-          {
-            type: "Section",
-            labelKey: `${i18nScope}.sections.basicInfo.label`,
-            options: {
-              headerTag: "h3",
-            },
-            elements: [
-              {
-                labelKey: `${i18nScope}.fields.name.label`,
-                type: "Control",
-                scope: "/properties/name",
-                options: {
-                  control: "hub-field-input-input",
-                  messages: [
-                    {
-                      type: "ERROR",
-                      keyword: "required",
-                      icon: true,
-                      labelKey: `${i18nScope}.fields.name.channelNameRequiredError`,
-                      allowShowBeforeInteract: true,
-                    },
-                  ],
-                },
-              },
-            ],
+    describe("existing channel", () => {
+      beforeEach(() => {
+        partialChannel.id = "channelId";
+        partialChannel.channel = { id: "channelId" } as IChannel;
+      });
+
+      it("should build a schema for a user with role Read", async () => {
+        const context = {
+          currentUser: {
+            orgId: "orgId123",
+            username: "user123",
           },
-          {
-            type: "Section",
-            labelKey: `${i18nScope}.sections.settings.label`,
-            options: {
-              headerTag: "h3",
-            },
-            elements: [
-              {
-                type: "Control",
-                scope: "/properties/allowAsAnonymous",
-                labelKey: `${i18nScope}.fields.allowAsAnonymous.label`,
-                options: {
-                  control: "hub-field-input-switch",
-                  helperText: {
-                    labelKey: `${i18nScope}.fields.allowAsAnonymous.helperText`,
-                  },
-                },
-              },
-              {
-                type: "Control",
-                scope: "/properties/blockWords",
-                label: "Blocked words",
-                labelKey: `${i18nScope}.fields.blockWords.label`,
-                options: {
-                  control: "hub-field-input-input",
-                  type: "textarea",
-                  helperText: {
-                    labelKey: `${i18nScope}.fields.blockWords.helperText`,
-                  },
-                  messages: [
-                    {
-                      type: "ERROR",
-                      keyword: "format",
-                      icon: true,
-                      labelKey: `${i18nScope}.fields.blockWords.formatError`,
-                    },
-                  ],
-                },
-              },
-            ],
+        } as unknown as IArcGISContext;
+        deriveUserRoleV2Spy.and.returnValue(Role.READ);
+        const expected: IUiSchema = buildSchema(
+          false,
+          [
+            "name",
+            "allowAsAnonymous",
+            "blockWords",
+            "publicConfigs",
+            "orgConfigs",
+            "groupConfigs",
+          ],
+          context
+        );
+        const result = await buildUiSchema(i18nScope, partialChannel, context);
+        expect(result).toEqual(expected);
+        expect(getWellKnownCatalogSpy).toHaveBeenCalledTimes(1);
+        expect(getWellKnownCatalogSpy).toHaveBeenCalledWith(
+          i18nScope,
+          "allGroups",
+          "group",
+          { user: context.currentUser }
+        );
+        expect(deriveUserRoleV2Spy).toHaveBeenCalledTimes(1);
+        expect(deriveUserRoleV2Spy).toHaveBeenCalledWith(
+          partialChannel.channel,
+          context.currentUser
+        );
+      });
+
+      it("should build a schema for a user with role Moderate", async () => {
+        const context = {
+          currentUser: {
+            orgId: "orgId123",
+            username: "user123",
           },
-          {
-            type: "Section",
-            labelKey: `${i18nScope}.sections.permissions.label`,
-            options: {
-              headerTag: "h3",
-            },
-            elements: [
-              // {
-              //   type: "Notice",
-              //   options: {
-              //     noticeId: "20250311-channel-permissions-info",
-              //   },
-              // },
-              {
-                type: "Section",
-                labelKey: `${i18nScope}.sections.public.label`,
-                options: {
-                  headerTag: "h4",
-                },
-                elements: [
-                  {
-                    type: "Control",
-                    scope: "/properties/publicConfigs",
-                    options: {
-                      control: "hub-field-permissions",
-                      roles: [
-                        {
-                          roleType: "anonymous",
-                          description: `{{${i18nScope}.fields.public.anonymous.description:translate}}`,
-                          label: `{{${i18nScope}.fields.public.anonymous.label:translate}}`,
-                          permissionLabels: [
-                            `{{${i18nScope}.sections.permissions.options.noAccess:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.view:translate}}`,
-                          ],
-                        },
-                        {
-                          roleType: "authenticated",
-                          description: `{{${i18nScope}.fields.public.authenticated.description:translate}}`,
-                          label: `{{${i18nScope}.fields.public.authenticated.label:translate}}`,
-                          permissionLabels: [
-                            `{{${i18nScope}.sections.permissions.options.noAccess:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.view:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.post:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.participate:translate}}`,
-                          ],
-                        },
-                      ],
-                    },
-                  },
-                ],
-              },
-              {
-                type: "Section",
-                labelKey: `${i18nScope}.sections.organization.label`,
-                options: {
-                  headerTag: "h4",
-                  variant: "variant-layout-editor",
-                },
-                elements: [
-                  {
-                    type: "Control",
-                    scope: "/properties/orgConfigs",
-                    options: {
-                      control: "hub-field-permissions",
-                      roles: [
-                        {
-                          roleType: "member",
-                          description: `{{${i18nScope}.fields.organization.member.description:translate}}`,
-                          label: `{{${i18nScope}.fields.organization.member.label:translate}}`,
-                          permissionLabels: [
-                            `{{${i18nScope}.sections.permissions.options.noAccess:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.view:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.post:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.participate:translate}}`,
-                          ],
-                        },
-                        {
-                          roleType: "admin",
-                          description: `{{${i18nScope}.fields.organization.admin.description:translate}}`,
-                          label: `{{${i18nScope}.fields.organization.admin.label:translate}}`,
-                          disabled: true,
-                          permissionLabels: [
-                            `{{${i18nScope}.sections.permissions.options.owner:translate}}`,
-                          ],
-                        },
-                      ],
-                    },
-                  },
-                ],
-              },
-              {
-                type: "Section",
-                labelKey: `${i18nScope}.sections.group.label`,
-                options: {
-                  headerTag: "h4",
-                  variant: "variant-layout-editor",
-                },
-                elements: [
-                  {
-                    type: "Control",
-                    scope: "/properties/groupConfigs",
-                    options: {
-                      control: "hub-field-permissions",
-                      actions: [
-                        {
-                          label: `{{${i18nScope}.sections.group.picker.button:translate}}`,
-                          type: "add",
-                          options: {
-                            label: `{{${i18nScope}.sections.group.picker.title:translate}}`,
-                            entityType: "group",
-                            catalogs: [catalog],
-                            facets: [
-                              {
-                                label: `{{${i18nScope}.sections.group.picker.facets.label:translate}}`,
-                                key: "groups",
-                                display: "single-select",
-                                operation: "OR",
-                                options: [
-                                  {
-                                    label: `{{${i18nScope}.sections.group.picker.facets.myGroups.label:translate}}`,
-                                    key: "my-group",
-                                    selected: true,
-                                    predicates: [
-                                      {
-                                        owner: context.currentUser.username,
-                                        typekeywords: { not: CANNOT_DISCUSS },
-                                      },
-                                    ],
-                                  },
-                                  {
-                                    label: `{{${i18nScope}.sections.group.picker.facets.myOrganization.label:translate}}`,
-                                    key: "my-organization",
-                                    selected: false,
-                                    predicates: [
-                                      {
-                                        orgid: context.currentUser.orgId,
-                                        searchUserAccess: "groupMember",
-                                        searchUserName:
-                                          context.currentUser.username,
-                                        typekeywords: { not: CANNOT_DISCUSS },
-                                      },
-                                    ],
-                                  },
-                                  {
-                                    label: `{{${i18nScope}.sections.group.picker.facets.myCommunity.label:translate}}`,
-                                    key: "my-community",
-                                    selected: false,
-                                    predicates: [
-                                      {
-                                        orgid: context.communityOrgId,
-                                        searchUserAccess: "groupMember",
-                                        searchUserName:
-                                          context.currentUser.username,
-                                        typekeywords: { not: CANNOT_DISCUSS },
-                                      },
-                                    ],
-                                  },
-                                ],
-                              },
-                            ],
-                            defaultValues: {
-                              member: ChannelNonePermission,
-                              admin: ChannelNonePermission,
-                            },
-                          },
-                        },
-                        {
-                          ariaLabel: `{{${i18nScope}.sections.group.remove.button:translate}}`,
-                          buttonStyle: "outline",
-                          buttonKind: "neutral",
-                          type: "remove",
-                          icon: "x",
-                        },
-                      ],
-                      roles: [
-                        {
-                          roleType: "member",
-                          description: `{{${i18nScope}.fields.group.member.description:translate}}`,
-                          label: `{{${i18nScope}.fields.group.member.label:translate}}`,
-                          permissionLabels: [
-                            `{{${i18nScope}.sections.permissions.options.noAccess:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.view:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.post:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.participate:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.moderate:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.manage:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.owner:translate}}`,
-                          ],
-                        },
-                        {
-                          roleType: "admin",
-                          description: `{{${i18nScope}.fields.group.admin.description:translate}}`,
-                          label: `{{${i18nScope}.fields.group.admin.label:translate}}`,
-                          permissionLabels: [
-                            `{{${i18nScope}.sections.permissions.options.noAccess:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.view:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.post:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.participate:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.moderate:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.manage:translate}}`,
-                            `{{${i18nScope}.sections.permissions.options.owner:translate}}`,
-                          ],
-                        },
-                      ],
-                    },
-                  },
-                ],
-              },
-            ],
+        } as unknown as IArcGISContext;
+        deriveUserRoleV2Spy.and.returnValue(Role.MODERATE);
+        const expected: IUiSchema = buildSchema(
+          false,
+          ["name", "publicConfigs", "orgConfigs", "groupConfigs"],
+          context
+        );
+        const result = await buildUiSchema(i18nScope, partialChannel, context);
+        expect(result).toEqual(expected);
+        expect(getWellKnownCatalogSpy).toHaveBeenCalledTimes(1);
+        expect(getWellKnownCatalogSpy).toHaveBeenCalledWith(
+          i18nScope,
+          "allGroups",
+          "group",
+          { user: context.currentUser }
+        );
+        expect(deriveUserRoleV2Spy).toHaveBeenCalledTimes(1);
+        expect(deriveUserRoleV2Spy).toHaveBeenCalledWith(
+          partialChannel.channel,
+          context.currentUser
+        );
+      });
+
+      it("should build a schema for a user with role Manage", async () => {
+        const context = {
+          currentUser: {
+            orgId: "orgId123",
+            username: "user123",
           },
-        ],
-      };
-      const result = await buildUiSchema(i18nScope, options, context);
-      expect(result).toEqual(expected);
-      expect(getWellKnownCatalogSpy).toHaveBeenCalledTimes(1);
-      expect(getWellKnownCatalogSpy).toHaveBeenCalledWith(
-        i18nScope,
-        "allGroups",
-        "group",
-        { user: context.currentUser }
-      );
+        } as unknown as IArcGISContext;
+        deriveUserRoleV2Spy.and.returnValue(Role.MANAGE);
+        const expected: IUiSchema = buildSchema(false, [], context);
+        const result = await buildUiSchema(i18nScope, partialChannel, context);
+        expect(result).toEqual(expected);
+        expect(getWellKnownCatalogSpy).toHaveBeenCalledTimes(1);
+        expect(getWellKnownCatalogSpy).toHaveBeenCalledWith(
+          i18nScope,
+          "allGroups",
+          "group",
+          { user: context.currentUser }
+        );
+        expect(deriveUserRoleV2Spy).toHaveBeenCalledTimes(1);
+        expect(deriveUserRoleV2Spy).toHaveBeenCalledWith(
+          partialChannel.channel,
+          context.currentUser
+        );
+      });
+
+      it("should build a schema for a user with role Owner", async () => {
+        const context = {
+          currentUser: {
+            orgId: "orgId123",
+            username: "user123",
+          },
+        } as unknown as IArcGISContext;
+        deriveUserRoleV2Spy.and.returnValue(Role.OWNER);
+        const expected: IUiSchema = buildSchema(false, [], context);
+        const result = await buildUiSchema(i18nScope, partialChannel, context);
+        expect(result).toEqual(expected);
+        expect(getWellKnownCatalogSpy).toHaveBeenCalledTimes(1);
+        expect(getWellKnownCatalogSpy).toHaveBeenCalledWith(
+          i18nScope,
+          "allGroups",
+          "group",
+          { user: context.currentUser }
+        );
+        expect(deriveUserRoleV2Spy).toHaveBeenCalledTimes(1);
+        expect(deriveUserRoleV2Spy).toHaveBeenCalledWith(
+          partialChannel.channel,
+          context.currentUser
+        );
+      });
     });
   });
 });

--- a/packages/common/test/discussions/api/utils/channel-permission.test.ts
+++ b/packages/common/test/discussions/api/utils/channel-permission.test.ts
@@ -110,6 +110,21 @@ describe("ChannelPermission class", () => {
     });
   });
 
+  describe("deriveUserRole", () => {
+    it("derives the user role for the channel", () => {
+      const user = buildUser();
+      const channelAcl = buildCompleteAcl();
+
+      const channel = {
+        allowReply: true,
+        channelAcl,
+      } as IChannel;
+      const channelPermission = new ChannelPermission(channel);
+
+      expect(channelPermission.deriveUserRole(user)).toBe(Role.READ);
+    });
+  });
+
   describe("canPostToChannel", () => {
     describe("all permission cases", () => {
       it("returns false if user logged in and channel permissions are empty", async () => {

--- a/packages/common/test/discussions/api/utils/channels/derive-user-role-v2.test.ts
+++ b/packages/common/test/discussions/api/utils/channels/derive-user-role-v2.test.ts
@@ -1,0 +1,33 @@
+import {
+  IChannel,
+  IDiscussionsUser,
+  Role,
+} from "../../../../../src/discussions/api/types";
+import { ChannelPermission } from "../../../../../src/discussions/api/utils/channel-permission";
+import { deriveUserRoleV2 } from "../../../../../src/discussions/api/utils/channels/derive-user-role-v2";
+
+describe("deriveUserRoleV2", () => {
+  it("derive the user role for an anonymous user", () => {
+    const channel = { orgId: "aaa", channelAcl: [] } as IChannel;
+    const deriveUserRoleSpy = spyOn(
+      ChannelPermission.prototype,
+      "deriveUserRole"
+    ).and.returnValue(Role.MANAGE);
+    const results = deriveUserRoleV2(channel);
+    expect(results).toEqual(Role.MANAGE);
+    expect(deriveUserRoleSpy).toHaveBeenCalledTimes(1);
+    expect(deriveUserRoleSpy).toHaveBeenCalledWith({});
+  });
+  it("derive the user role for an authenticated user", () => {
+    const user = {} as IDiscussionsUser;
+    const channel = { orgId: "aaa", channelAcl: [] } as IChannel;
+    const deriveUserRoleSpy = spyOn(
+      ChannelPermission.prototype,
+      "deriveUserRole"
+    ).and.returnValue(Role.MANAGE);
+    const results = deriveUserRoleV2(channel, user);
+    expect(results).toEqual(Role.MANAGE);
+    expect(deriveUserRoleSpy).toHaveBeenCalledTimes(1);
+    expect(deriveUserRoleSpy).toHaveBeenCalledWith(user);
+  });
+});

--- a/packages/common/test/discussions/index.test.ts
+++ b/packages/common/test/discussions/index.test.ts
@@ -125,6 +125,7 @@ describe("discussions index", () => {
     "isOrgAdminInOrg",
     "userHasPrivilege",
     "userHasPrivileges",
+    "deriveUserRoleV2",
   ];
   const exportedMembers = Object.keys(discussions);
 

--- a/packages/common/test/search/_internal/hubDiscussionsHelpers/processChannelOptions.test.ts
+++ b/packages/common/test/search/_internal/hubDiscussionsHelpers/processChannelOptions.test.ts
@@ -1,4 +1,8 @@
-import { ChannelSort, SortOrder } from "../../../../src/discussions/api/types";
+import {
+  ChannelRelation,
+  ChannelSort,
+  SortOrder,
+} from "../../../../src/discussions/api/types";
 import { processChannelOptions } from "../../../../src/search/_internal/hubDiscussionsHelpers/processChannelOptions";
 
 describe("processChannelOptions", () => {
@@ -33,5 +37,9 @@ describe("processChannelOptions", () => {
     expect(results.sortOrder).toEqual(SortOrder.ASC);
     results = processChannelOptions({ sortOrder: "desc" });
     expect(results.sortOrder).toEqual(SortOrder.DESC);
+  });
+  it("should add channel acl relation", () => {
+    const results = processChannelOptions({});
+    expect(results.relations).toEqual([ChannelRelation.CHANNEL_ACL]);
   });
 });


### PR DESCRIPTION
…nditionally disable fields base

affects: @esri/hub-common

ISSUES CLOSED: [12875](https://devtopia.esri.com/dc/hub/issues/12875)

1. Description:

* Updates the channel UISchemas to conditionally disable fields based on the authenticated user's role within that channel
* Refactors `hubSearchChannels` to always request the Channel ACL (needed for V2)

1. Instructions for testing:

1. Closes Issues: #[12875](https://devtopia.esri.com/dc/hub/issues/12875)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
