### PR TITLE
feat: add well-known group and event catalogs

### DIFF
--- a/packages/common/src/core/schemas/index.ts
+++ b/packages/common/src/core/schemas/index.ts
@@ -1,3 +1,8 @@
 export * from "./types";
 export * from "./getEditorConfig";
 export * from "./shared";
+/**
+ * we need to export this internal util to use in
+ * the catalog/query builder experience
+ */
+export * from "./internal/getTagItems";

--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -6,21 +6,42 @@ import { buildCatalog } from "./_internal/buildCatalog";
 import { getProp } from "../objects";
 import type { IArcGISContext } from "../types/IArcGISContext";
 
-/**
- * This is used to determine what IHubCatalog definition JSON object
- * can be created
- */
+/** well known item catalogs */
+export const WELL_KNOWN_ITEM_CATALOGS = [
+  "myContent",
+  "favorites",
+  "organization",
+  "world",
+  "partners",
+  "community",
+  "livingAtlas",
+] as const;
+export type WellKnownItemCatalog = (typeof WELL_KNOWN_ITEM_CATALOGS)[number];
+
+/** well known group catalogs */
+export const WELL_KNOWN_GROUP_CATALOGS = [
+  "editGroups",
+  "viewGroups",
+  "allGroups",
+  "myGroups",
+  "orgGroups",
+  "communityGroups",
+  "publicGroups",
+] as const;
+export type WellKnownGroupCatalog = (typeof WELL_KNOWN_GROUP_CATALOGS)[number];
+
+export const WELL_KNOWN_EVENT_CATALOGS = [
+  "myEvents",
+  "orgEvents",
+  "worldEvents",
+] as const;
+export type WellKnownEventCatalog = (typeof WELL_KNOWN_EVENT_CATALOGS)[number];
+
+/** well known catalogs */
 export type WellKnownCatalog =
-  | "myContent"
-  | "favorites"
-  | "organization"
-  | "world"
-  | "editGroups"
-  | "viewGroups"
-  | "allGroups"
-  | "partners"
-  | "community"
-  | "livingAtlas";
+  | WellKnownItemCatalog
+  | WellKnownGroupCatalog
+  | WellKnownEventCatalog;
 
 /**
  * This is used to determine what IHubCollection definition JSON object
@@ -62,6 +83,32 @@ export function dotifyString(i18nScope: string): string {
   return i18nScope && i18nScope.slice(-1) !== "." ? `${i18nScope}.` : i18nScope;
 }
 
+/**
+ * Helper function to build an array of well known Catalogs
+ *
+ * @param i18nScope Translation scope to be interpolated into the catalog
+ * @param targetEntity The type of entity to query for
+ * @param catalogNames Names of the catalog requested
+ * @param context contextual portal & auth information
+ * @param opts optional IGetWellKnownCatalogOptions args
+ */
+export function getWellKnownCatalogs(
+  i18nScope: string,
+  targetEntity: EntityType,
+  catalogNames: WellKnownCatalog[],
+  context: IArcGISContext,
+  opts?: Exclude<IGetWellKnownCatalogOptions, "context" | "user">
+): IHubCatalog[] {
+  return catalogNames.map((name: WellKnownCatalog) => {
+    const catalog = getWellKnownCatalog(i18nScope, name, targetEntity, {
+      ...(opts || {}),
+      user: context.currentUser,
+      context,
+    });
+    return catalog;
+  });
+}
+
 /** Get a single catalog based on the catalog name, entity type and optional requests
  * @param i18nScope Translation scope to be interpolated into the catalog
  * @param name Name of the catalog requested
@@ -80,7 +127,8 @@ export function getWellKnownCatalog(
       return getWellknownItemCatalog(i18nScope, catalogName, options);
     case "group":
       return getWellknownGroupCatalog(i18nScope, catalogName, options);
-    /* Add other entity handlers here, e.g. getWellknownEventCatalog */
+    case "event":
+      return getWellknownEventCatalog(i18nScope, catalogName, options);
     default:
       throw new Error(`Wellknown catalog not implemented for "${entityType}"`);
   }
@@ -281,9 +329,10 @@ function getWellknownGroupCatalog(
   catalogName: WellKnownCatalog,
   options?: IGetWellKnownCatalogOptions
 ): IHubCatalog {
-  i18nScope = dotifyString(i18nScope);
   let catalog;
-  const additionalFilters = getProp(options, "filters") || [];
+  const { context, filters: additionalFilters = [] } = options || {};
+  i18nScope = dotifyString(i18nScope);
+
   // because collections are needed in arcgis-hub-catalog and
   // "searchGroups" allows 'q: "*"', we use this as the collection
   const collections = [
@@ -301,6 +350,14 @@ function getWellknownGroupCatalog(
       },
     },
   ];
+
+  const idsOfUserAdminGroups = (context.currentUser.groups as any[]).reduce(
+    (acc, group) => {
+      group.userMembership.memberType === "admin" && acc.push(group.id);
+      return acc;
+    },
+    [] as string[]
+  );
 
   switch (catalogName) {
     case "editGroups":
@@ -339,7 +396,155 @@ function getWellknownGroupCatalog(
         "group"
       );
       break;
+    case "myGroups":
+      validateUserExistence(catalogName, options);
+      catalog = buildCatalog(
+        i18nScope,
+        catalogName,
+        [
+          { predicates: [{ owner: context?.currentUser?.username }] },
+          ...additionalFilters,
+        ],
+        collections,
+        "group"
+      );
+      break;
+    case "orgGroups":
+      validateUserExistence(catalogName, options);
+      catalog = buildCatalog(
+        i18nScope,
+        catalogName,
+        [
+          {
+            predicates: [
+              {
+                orgid: context?.currentUser?.orgId,
+                searchUserAccess: "groupMember",
+                searchUserName: context?.currentUser?.username,
+                isviewonly: false,
+              },
+              {
+                orgid: context?.currentUser?.orgId,
+                id: idsOfUserAdminGroups,
+              },
+            ],
+          },
+          ...additionalFilters,
+        ],
+        collections,
+        "group"
+      );
+      break;
+    case "communityGroups":
+      validateUserExistence(catalogName, options);
+      catalog = buildCatalog(
+        i18nScope,
+        catalogName,
+        [
+          {
+            predicates: [
+              {
+                orgid: context?.communityOrgId,
+                searchUserAccess: "groupMember",
+                searchUserName: context?.currentUser?.username,
+                isviewonly: false,
+              },
+              {
+                orgid: context?.communityOrgId,
+                id: idsOfUserAdminGroups,
+              },
+            ],
+          },
+          ...additionalFilters,
+        ],
+        collections,
+        "group"
+      );
+      break;
+    case "publicGroups":
+      validateUserExistence(catalogName, options);
+      catalog = buildCatalog(
+        i18nScope,
+        catalogName,
+        [{ predicates: [{ access: "public" }] }, ...additionalFilters],
+        collections,
+        "group"
+      );
+      break;
   }
+  return catalog;
+}
+
+/**
+ * Build a well-known event catalog
+ *
+ * @param i18nScope Translation scope to be interpolated into the catalog
+ * @param catalogName Name of the well-known catalog
+ * @param options opitional IGetWellKnownCatalogOptions args
+ */
+function getWellknownEventCatalog(
+  i18nScope: string,
+  catalogName: WellKnownCatalog,
+  options?: IGetWellKnownCatalogOptions
+): IHubCatalog {
+  let catalog;
+  const { context, filters: additionalFilters = [] } = options || {};
+  i18nScope = dotifyString(i18nScope);
+
+  const collections = [
+    {
+      key: catalogName,
+      label: catalogName,
+      targetEntity: "event",
+      include: [],
+      scope: {
+        targetEntity: "event",
+        filters: [{ predicates: [] }],
+      },
+    },
+  ] as IHubCollection[];
+  switch (catalogName) {
+    case "myEvents":
+      validateUserExistence(catalogName, options);
+      catalog = buildCatalog(
+        i18nScope,
+        catalogName,
+        [
+          { predicates: [{ owner: getProp(context, "currentUser.id") }] },
+          ...additionalFilters,
+        ],
+        collections,
+        "event"
+      );
+      break;
+    case "orgEvents":
+      validateUserExistence(catalogName, options);
+      catalog = buildCatalog(
+        i18nScope,
+        catalogName,
+        [
+          { predicates: [{ orgid: context?.currentUser?.orgId }] },
+          ...additionalFilters,
+        ],
+        collections,
+        "event"
+      );
+      break;
+    case "worldEvents":
+      validateUserExistence(catalogName, options);
+      catalog = buildCatalog(
+        i18nScope,
+        catalogName,
+        [
+          { predicates: [{ access: ["public", "private", "org"] }] },
+          ...additionalFilters,
+        ],
+        collections,
+        "event"
+      );
+      break;
+  }
+
   return catalog;
 }
 

--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -108,11 +108,7 @@ export function getWellKnownCatalogs(
     group: [...WELL_KNOWN_GROUP_CATALOGS] as WellKnownCatalog[],
     event: [...WELL_KNOWN_EVENT_CATALOGS] as WellKnownCatalog[],
   }[targetEntity as "item" | "group" | "event"];
-  if (
-    !catalogNames.every((name: WellKnownCatalog) =>
-      validCatalogNames.includes(name)
-    )
-  ) {
+  if (catalogNames.some(name => !validCatalogNames.includes(name))) {
     throw new Error(
       `Requested catalogs must be of the same targetEntity type: ${targetEntity}`
     );

--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -351,7 +351,7 @@ function getWellknownGroupCatalog(
     },
   ];
 
-  const idsOfUserAdminGroups = (context.currentUser.groups as any[]).reduce(
+  const idsOfUserAdminGroups = (context?.currentUser?.groups || []).reduce(
     (acc, group) => {
       group.userMembership.memberType === "admin" && acc.push(group.id);
       return acc;
@@ -491,6 +491,8 @@ function getWellknownEventCatalog(
   const { context, filters: additionalFilters = [] } = options || {};
   i18nScope = dotifyString(i18nScope);
 
+  // because collections are needed in arcgis-hub-catalog,
+  // we add an "empty" collection
   const collections = [
     {
       key: catalogName,

--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -6,7 +6,7 @@ import { buildCatalog } from "./_internal/buildCatalog";
 import { getProp, getWithDefault } from "../objects";
 import type { IArcGISContext } from "../types/IArcGISContext";
 
-/** well known item catalogs */
+/** well-known item catalogs */
 export const WELL_KNOWN_ITEM_CATALOGS = [
   "myContent",
   "favorites",
@@ -18,7 +18,7 @@ export const WELL_KNOWN_ITEM_CATALOGS = [
 ] as const;
 export type WellKnownItemCatalog = (typeof WELL_KNOWN_ITEM_CATALOGS)[number];
 
-/** well known group catalogs */
+/** well-known group catalogs */
 export const WELL_KNOWN_GROUP_CATALOGS = [
   "editGroups",
   "viewGroups",
@@ -30,6 +30,7 @@ export const WELL_KNOWN_GROUP_CATALOGS = [
 ] as const;
 export type WellKnownGroupCatalog = (typeof WELL_KNOWN_GROUP_CATALOGS)[number];
 
+/** well-known event catalogs */
 export const WELL_KNOWN_EVENT_CATALOGS = [
   "myEvents",
   "orgEvents",
@@ -84,13 +85,13 @@ export function dotifyString(i18nScope: string): string {
 }
 
 /**
- * Helper function to build an array of well known Catalogs
- * note: requested well known Catalogs must be for the same
+ * Helper function to build an array of well-known Catalogs
+ * note: requested well-known Catalogs must be for the same
  * targetEntity type
  *
  * @param i18nScope Translation scope to be interpolated into the catalog
  * @param targetEntity The type of entity to query for
- * @param catalogNames Names of the catalog requested
+ * @param catalogNames Names of the catalogs requested
  * @param context contextual portal & auth information
  * @param opts optional IGetWellKnownCatalogOptions args
  */
@@ -117,7 +118,7 @@ export function getWellKnownCatalogs(
     );
   }
 
-  // 2. build/return the well known Catalogs
+  // 2. build/return the well-known Catalogs
   return catalogNames.map((name: WellKnownCatalog) => {
     const catalog = getWellKnownCatalog(i18nScope, name, targetEntity, {
       ...(opts || {}),

--- a/packages/common/src/search/wellKnownCatalog.ts
+++ b/packages/common/src/search/wellKnownCatalog.ts
@@ -85,6 +85,8 @@ export function dotifyString(i18nScope: string): string {
 
 /**
  * Helper function to build an array of well known Catalogs
+ * note: requested well known Catalogs must be for the same
+ * targetEntity type
  *
  * @param i18nScope Translation scope to be interpolated into the catalog
  * @param targetEntity The type of entity to query for
@@ -99,6 +101,23 @@ export function getWellKnownCatalogs(
   context: IArcGISContext,
   opts?: Exclude<IGetWellKnownCatalogOptions, "context" | "user">
 ): IHubCatalog[] {
+  // 1. ensure the requested Catalogs are for the same targetEntity
+  const validCatalogNames = {
+    item: [...WELL_KNOWN_ITEM_CATALOGS] as WellKnownCatalog[],
+    group: [...WELL_KNOWN_GROUP_CATALOGS] as WellKnownCatalog[],
+    event: [...WELL_KNOWN_EVENT_CATALOGS] as WellKnownCatalog[],
+  }[targetEntity as "item" | "group" | "event"];
+  if (
+    !catalogNames.every((name: WellKnownCatalog) =>
+      validCatalogNames.includes(name)
+    )
+  ) {
+    throw new Error(
+      `Requested catalogs must be of the same targetEntity type: ${targetEntity}`
+    );
+  }
+
+  // 2. build/return the well known Catalogs
   return catalogNames.map((name: WellKnownCatalog) => {
     const catalog = getWellKnownCatalog(i18nScope, name, targetEntity, {
       ...(opts || {}),

--- a/packages/common/test/search/wellKnownCatalog.test.ts
+++ b/packages/common/test/search/wellKnownCatalog.test.ts
@@ -66,8 +66,7 @@ describe("WellKnownCatalog", () => {
         "mockI18nScope",
         "item",
         ["myContent", "organization"],
-        options.context,
-        options
+        options.context
       );
       expect(chk.length).toEqual(2);
       expect(chk[0].title).toEqual(
@@ -76,6 +75,17 @@ describe("WellKnownCatalog", () => {
       expect(chk[1].title).toEqual(
         "{{mockI18nScope.catalog.organization:translate}}"
       );
+    });
+    it("returns the requested catalogs with custom collection names", () => {
+      chk = getWellKnownCatalogs(
+        "mockI18nScope",
+        "item",
+        ["myContent", "organization"],
+        options.context,
+        { collectionNames: ["dataset"] }
+      );
+      expect(chk.length).toEqual(2);
+      expect(chk[0].collections.length).toEqual(1);
     });
   });
   describe("getWellKnownCatalog", () => {
@@ -484,6 +494,12 @@ describe("WellKnownCatalog", () => {
       expect(() =>
         getWellKnownCatalog("mockI18nScope", "myContent", "item")
       ).toThrowError('User needed to get "myContent" catalog');
+      expect(() =>
+        getWellKnownCatalog("mockI18nScope", "myGroups", "group")
+      ).toThrowError('User needed to get "myGroups" catalog');
+      expect(() =>
+        getWellKnownCatalog("mockI18nScope", "myEvents", "event")
+      ).toThrowError('User needed to get "myEvents" catalog');
       expect(() =>
         getWellKnownCatalog("mockI18nScope", "favorites", "item")
       ).toThrowError('User needed to get "favorites" catalog');

--- a/packages/common/test/search/wellKnownCatalog.test.ts
+++ b/packages/common/test/search/wellKnownCatalog.test.ts
@@ -7,41 +7,78 @@ import {
   IGetWellKnownCatalogOptions,
   WellKnownCollection,
   dotifyString,
+  getWellKnownCatalogs,
 } from "../../src/search/wellKnownCatalog";
 import { mockUser } from "../test-helpers/fake-user";
 
 describe("WellKnownCatalog", () => {
-  describe("getWellKnownCatalog", () => {
-    let options: IGetWellKnownCatalogOptions;
-    beforeEach(() => {
-      options = {
-        user: mockUser,
-        collectionNames: [],
-        context: {
-          currentUser: {
-            id: "userid",
-            orgId: "abc123",
-            username: "some-username",
-            groups: [
-              { id: "abc", userMembership: { memberType: "admin" } },
-              { id: "def", userMembership: { memberType: "member" } },
-              { id: "ghi", userMembership: { memberType: "member" } },
-              { id: "jkl", userMembership: { memberType: "admin" } },
-              { id: "mno", userMembership: { memberType: "member" } },
-            ],
-          } as unknown as IUser,
-          isCommunityOrg: false,
-          communityOrgId: "def456",
-          trustedOrgIds: ["abc123", "def456", "ghi789", "kjl012", "mno345"],
-          trustedOrgs: [
-            {
-              from: { orgId: "abc123" },
-              to: { orgId: "def456", name: "c-org name" },
-            },
+  let options: IGetWellKnownCatalogOptions;
+  beforeEach(() => {
+    options = {
+      user: mockUser,
+      collectionNames: [],
+      context: {
+        currentUser: {
+          id: "userid",
+          orgId: "abc123",
+          username: "some-username",
+          groups: [
+            { id: "abc", userMembership: { memberType: "admin" } },
+            { id: "def", userMembership: { memberType: "member" } },
+            { id: "ghi", userMembership: { memberType: "member" } },
+            { id: "jkl", userMembership: { memberType: "admin" } },
+            { id: "mno", userMembership: { memberType: "member" } },
           ],
-        } as ArcGISContext,
-      };
+        } as unknown as IUser,
+        isCommunityOrg: false,
+        communityOrgId: "def456",
+        trustedOrgIds: ["abc123", "def456", "ghi789", "kjl012", "mno345"],
+        trustedOrgs: [
+          {
+            from: { orgId: "abc123" },
+            to: { orgId: "def456", name: "c-org name" },
+          },
+        ],
+      } as ArcGISContext,
+    };
+  });
+  describe("getWellKnownCatalogs", () => {
+    let chk: any;
+    it("throws an error if the requested Catalogs are not for the same targetEntity", () => {
+      try {
+        chk = getWellKnownCatalogs(
+          "mockI18nScope",
+          "item",
+          ["myContent", "myGroups"],
+          options.context,
+          options
+        );
+      } catch (err) {
+        expect(err).toEqual(
+          new Error(
+            "Requested catalogs must be of the same targetEntity type: item"
+          )
+        );
+      }
     });
+    it("returns the requested catalogs", () => {
+      chk = getWellKnownCatalogs(
+        "mockI18nScope",
+        "item",
+        ["myContent", "organization"],
+        options.context,
+        options
+      );
+      expect(chk.length).toEqual(2);
+      expect(chk[0].title).toEqual(
+        "{{mockI18nScope.catalog.myContent:translate}}"
+      );
+      expect(chk[1].title).toEqual(
+        "{{mockI18nScope.catalog.organization:translate}}"
+      );
+    });
+  });
+  describe("getWellKnownCatalog", () => {
     it("returns the expected catalog for items", () => {
       let chk = getWellKnownCatalog(
         "mockI18nScope",


### PR DESCRIPTION
- [12732](https://devtopia.esri.com/dc/hub/issues/12732)

### Description
- adds new well-known group & event catalogs
  - groups: "myGroups", "orgGroups", "communityGroups", "publicGroups"
  - events: "myEvents", "orgEvents", "worldEvents"
- adds a new `getWellKnownCatalogs` util which returns an array of requested well-known catalogs
- exports internal `getTagItems` util

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.