### PR TITLE
fix: case insensitive subdomain comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65005,7 +65005,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "16.3.0",
+			"version": "16.5.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/sites/_internal/handleDomainChanges.ts
+++ b/packages/common/src/sites/_internal/handleDomainChanges.ts
@@ -32,7 +32,7 @@ export async function handleDomainChanges(
   ["customHostname", "defaultHostname"].forEach((key) => {
     const currentValue = getProp(currentModel, `data.values.${key}`) || "";
     const updatedValue = getProp(updatedModel, `data.values.${key}`) || "";
-    if (updatedValue !== currentValue) {
+    if (updatedValue?.toLowerCase() !== currentValue?.toLowerCase()) {
       domainChanges.remove.push(currentValue);
       domainChanges.add.push(updatedValue);
     }

--- a/packages/common/src/sites/_internal/handleDomainChanges.ts
+++ b/packages/common/src/sites/_internal/handleDomainChanges.ts
@@ -32,7 +32,7 @@ export async function handleDomainChanges(
   ["customHostname", "defaultHostname"].forEach((key) => {
     const currentValue = getProp(currentModel, `data.values.${key}`) || "";
     const updatedValue = getProp(updatedModel, `data.values.${key}`) || "";
-    if (updatedValue?.toLowerCase() !== currentValue?.toLowerCase()) {
+    if (updatedValue.toLowerCase() !== currentValue.toLowerCase()) {
       domainChanges.remove.push(currentValue);
       domainChanges.add.push(updatedValue);
     }

--- a/packages/common/test/sites/_internal/handleDomainChanges.test.ts
+++ b/packages/common/test/sites/_internal/handleDomainChanges.test.ts
@@ -12,7 +12,7 @@ const currentModel = {
   data: {
     values: {
       customHostname: "site.city.gov",
-      defaultHostname: "site-city.hub.arcgis.com",
+      defaultHostname: "site-CITY.hub.arcgis.com",
     },
   },
 } as unknown as IModel;
@@ -63,6 +63,30 @@ describe("handleDomainChanges", () => {
     (u as any).data.values = {
       customHostname: "site.city.gov",
       defaultHostname: "",
+    };
+
+    await handleDomainChanges(u, c, MOCK_HUB_REQOPTS);
+
+    expect(addSpy.calls.count()).toBe(0);
+    expect(removeSpy.calls.count()).toBe(0);
+  });
+
+  it("does not attempt to update domains that only have case changes", async () => {
+    const addSpy = spyOn(domainModule, "addDomain").and.returnValue(
+      Promise.resolve()
+    );
+    const removeSpy = spyOn(
+      domainModule,
+      "removeDomainByHostname"
+    ).and.returnValue(Promise.resolve());
+    const c = cloneObject(currentModel);
+    (c as any).data.values = {
+      defaultHostname: "luke-REBELS.hub.arcgis.com",
+    };
+    const u = cloneObject(updatedModel);
+    (u as any).data.values = {
+      defaultHostname: "luke-rebels.hub.arcgis.com",
+      customHostname: "",
     };
 
     await handleDomainChanges(u, c, MOCK_HUB_REQOPTS);


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Prevents inadvertant domain deletion when the org-short is uppercase (and thus the `defaultHostname` has uppercase characters.
2. 
1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
