### PR TITLE
fix: item.data not saved in commitItemUpload, createItem, and updateItem

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -31,6 +31,7 @@ export * from "./permissions";
 export * from "./projects";
 export * from "./request";
 export * from "./resources";
+export * from "./rest";
 export * from "./search";
 export * from "./sites";
 export * from "./templates";

--- a/packages/common/src/items/create-item-from-file.ts
+++ b/packages/common/src/items/create-item-from-file.ts
@@ -2,11 +2,10 @@ import type { IUserRequestOptions } from "@esri/arcgis-rest-request";
 import {
   addItemPart,
   cancelItemUpload,
-  commitItemUpload,
-  createItem,
   ICreateItemResponse,
 } from "@esri/arcgis-rest-portal";
 import type { IItemAdd } from "@esri/arcgis-rest-portal";
+import { commitItemUpload, createItem } from "../rest/portal";
 import { isBBox, bboxToString } from "../extent";
 import { batch } from "../utils";
 import { _prepareUploadRequests } from "./_internal/_prepare-upload-requests";

--- a/packages/common/src/items/create-item-from-url.ts
+++ b/packages/common/src/items/create-item-from-url.ts
@@ -1,6 +1,7 @@
 import type { IUserRequestOptions } from "@esri/arcgis-rest-request";
-import { createItem, ICreateItemResponse } from "@esri/arcgis-rest-portal";
+import { ICreateItemResponse } from "@esri/arcgis-rest-portal";
 import type { IItemAdd } from "@esri/arcgis-rest-portal";
+import { createItem } from "../rest/portal";
 
 /**
  * Create AGO item from a URL

--- a/packages/common/src/items/fail-safe-update.ts
+++ b/packages/common/src/items/fail-safe-update.ts
@@ -1,8 +1,9 @@
 import { IModel } from "../hub-types";
-import { updateItem, IUpdateItemOptions } from "@esri/arcgis-rest-portal";
+import type { IUpdateItemOptions } from "@esri/arcgis-rest-portal";
 import { serializeModel } from "../models/serializeModel";
 import { failSafe } from "../utils";
 import type { IUserRequestOptions } from "@esri/arcgis-rest-request";
+import { updateItem } from "../rest/portal";
 
 /**
  * Update a model's item, wrapped in a failSafe so this will not blow up if

--- a/packages/common/src/items/setItemThumbnail.ts
+++ b/packages/common/src/items/setItemThumbnail.ts
@@ -1,5 +1,5 @@
 import type { IUserRequestOptions } from "@esri/arcgis-rest-request";
-import { updateItem } from "@esri/arcgis-rest-portal";
+import { updateItem } from "../rest/portal";
 import HubError from "../HubError";
 
 /**

--- a/packages/common/src/models/index.ts
+++ b/packages/common/src/models/index.ts
@@ -2,16 +2,15 @@ export * from "./serializeModel";
 
 import type { IUserRequestOptions } from "@esri/arcgis-rest-request";
 import {
-  createItem,
   FetchReadMethodName,
   getItem,
   getItemData,
   getItemResource,
   IItem,
   IUpdateItemOptions,
-  updateItem,
 } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { createItem, updateItem } from "../rest/portal";
 import { bboxToString } from "../extent";
 import { getItemBySlug } from "../items";
 import { upsertResource } from "../resources";

--- a/packages/common/src/resources/fetch-and-upload-thumbnail.ts
+++ b/packages/common/src/resources/fetch-and-upload-thumbnail.ts
@@ -1,5 +1,5 @@
 import { fetchImageAsBlob } from "./fetch-image-as-blob";
-import { updateItem } from "@esri/arcgis-rest-portal";
+import { updateItem } from "../rest/portal";
 import type { ArcGISIdentityManager } from "@esri/arcgis-rest-request";
 
 /**

--- a/packages/common/src/rest/index.ts
+++ b/packages/common/src/rest/index.ts
@@ -1,0 +1,1 @@
+export * from "./portal/wrappers";

--- a/packages/common/src/rest/portal/_internal/helpers.ts
+++ b/packages/common/src/rest/portal/_internal/helpers.ts
@@ -1,0 +1,38 @@
+import {
+  IItemAdd,
+  IItemUpdate,
+  IItem,
+  ICreateItemOptions,
+  IUpdateItemOptions,
+  ICommitItemOptions,
+} from "@esri/arcgis-rest-portal";
+
+// needed to preserve 3.x behavior for saving item data
+export function serializeItemParams<T>(
+  requestOptions: ICreateItemOptions | IUpdateItemOptions | ICommitItemOptions
+): T {
+  requestOptions.params = {
+    ...requestOptions.params,
+    ...serializeItem(requestOptions.item),
+  };
+  return requestOptions as unknown as T;
+}
+
+// istanbul ignore next - copied from
+// https://github.com/Esri/arcgis-rest-js/blob/8eccee45394850467194e53390df7df3e661f104/packages/arcgis-rest-portal/src/items/helpers.ts#L255
+function serializeItem(item: IItemAdd | IItemUpdate | IItem): any {
+  // create a clone so we're not messing with the original
+  const clone = JSON.parse(JSON.stringify(item));
+
+  // binary data needs POSTed as a `file`
+  // JSON object literals should be passed as `text`.
+  if (clone.data) {
+    (typeof Blob !== "undefined" && item.data instanceof Blob) ||
+    // Node.js doesn't implement Blob
+    item.data.constructor.name === "ReadStream"
+      ? (clone.file = item.data)
+      : (clone.text = item.data);
+    delete clone.data;
+  }
+  return clone;
+}

--- a/packages/common/src/rest/portal/index.ts
+++ b/packages/common/src/rest/portal/index.ts
@@ -1,0 +1,1 @@
+export * from "./wrappers";

--- a/packages/common/src/rest/portal/wrappers.ts
+++ b/packages/common/src/rest/portal/wrappers.ts
@@ -1,0 +1,45 @@
+/* istanbul ignore file - these are just wrappers around rest-js functions */
+// import functions that need to be wrapped and/or spied on
+import {
+  commitItemUpload as _commitItemUpload,
+  createItem as _createItem,
+  updateItem as _updateItem,
+} from "@esri/arcgis-rest-portal";
+import { serializeItemParams } from "./_internal/helpers";
+
+// implement wrappers
+/**
+ * wrapper around @esri/arcgis-rest-portal's createItem
+ * NOTE: this preserves 3.x behavior for saving item data
+ * @param args
+ * @returns
+ */
+export function createItem(
+  ...args: Parameters<typeof _createItem>
+): ReturnType<typeof _createItem> {
+  return _createItem(serializeItemParams(args[0]));
+}
+
+/**
+ * wrapper around @esri/arcgis-rest-portal's updateItem
+ * NOTE: this preserves 3.x behavior for saving item data
+ * @param args
+ * @returns
+ */
+export function updateItem(
+  ...args: Parameters<typeof _updateItem>
+): ReturnType<typeof _updateItem> {
+  return _updateItem(serializeItemParams(args[0]));
+}
+
+/**
+ * wrapper around @esri/arcgis-rest-portal's commitItemUpload
+ * NOTE: this preserves 3.x behavior for saving item data
+ * @param args
+ * @returns
+ */
+export function commitItemUpload(
+  ...args: Parameters<typeof _commitItemUpload>
+): ReturnType<typeof _commitItemUpload> {
+  return _commitItemUpload(serializeItemParams(args[0]));
+}

--- a/packages/common/test/items/create-item-from-file.test.ts
+++ b/packages/common/test/items/create-item-from-file.test.ts
@@ -3,6 +3,7 @@ import * as portal from "@esri/arcgis-rest-portal";
 import * as _prepareUploadRequestsModule from "../../src/items/_internal/_prepare-upload-requests";
 import type { IUserRequestOptions } from "@esri/arcgis-rest-request";
 import type { IItemAdd } from "@esri/arcgis-rest-portal";
+import * as restPortal from "../../src/rest/portal";
 
 describe("createItemFromFile", () => {
   if (typeof Blob !== "undefined") {
@@ -29,7 +30,7 @@ describe("createItemFromFile", () => {
         file: new Blob(["foo"], { type: "csv" }),
       } as IItemAdd;
       // spies
-      const createItemSpy = spyOn(portal, "createItem").and.returnValue(
+      const createItemSpy = spyOn(restPortal, "createItem").and.returnValue(
         Promise.resolve({ id: "123abc", success: true, folder: "test" })
       );
       const cancelItemSpy = spyOn(portal, "cancelItemUpload").and.returnValue(
@@ -77,7 +78,7 @@ describe("createItemFromFile", () => {
         file: new Blob(["foo"], { type: "csv" }),
       } as unknown as IItemAdd;
       // spies
-      const createItemSpy = spyOn(portal, "createItem").and.returnValue(
+      const createItemSpy = spyOn(restPortal, "createItem").and.returnValue(
         Promise.resolve({ id: "123abc", success: true, folder: "test" })
       );
       const cancelItemSpy = spyOn(portal, "cancelItemUpload").and.returnValue(
@@ -125,7 +126,7 @@ describe("createItemFromFile", () => {
         },
       } as IItemAdd;
       // spies
-      const createItemSpy = spyOn(portal, "createItem").and.returnValue(
+      const createItemSpy = spyOn(restPortal, "createItem").and.returnValue(
         Promise.resolve({ success: true, id: "123abc" })
       );
       const cancelItemSpy = spyOn(portal, "cancelItemUpload").and.returnValue(
@@ -172,7 +173,7 @@ describe("createItemFromFile", () => {
         },
       } as IItemAdd;
       // spies
-      const createItemSpy = spyOn(portal, "createItem").and.returnValue(
+      const createItemSpy = spyOn(restPortal, "createItem").and.returnValue(
         Promise.resolve({ success: true, id: "123abc" })
       );
       const cancelItemSpy = spyOn(portal, "cancelItemUpload").and.returnValue(

--- a/packages/common/test/items/create-item-from-url.test.ts
+++ b/packages/common/test/items/create-item-from-url.test.ts
@@ -1,5 +1,5 @@
 import { createItemFromUrl } from "../../src/items/create-item-from-url";
-import * as portal from "@esri/arcgis-rest-portal";
+import * as portal from "../../src/rest/portal";
 import type { IUserRequestOptions } from "@esri/arcgis-rest-request";
 
 describe("createContentWithUrl", () => {

--- a/packages/common/test/items/fail-safe-update.test.ts
+++ b/packages/common/test/items/fail-safe-update.test.ts
@@ -1,9 +1,9 @@
 import { failSafeUpdate, IModel } from "../../src";
 import { mockUserSession } from "../test-helpers/fake-user-session";
 
-import * as portal from "@esri/arcgis-rest-portal";
+import * as portal from "../../src/rest/portal";
 
-describe("failSafeUpdate", function() {
+describe("failSafeUpdate", function () {
   const model: IModel = {
     item: {
       id: "someId",
@@ -15,25 +15,25 @@ describe("failSafeUpdate", function() {
       numViews: 3,
       size: 3,
       title: "title",
-      type: "Hub Site Application"
+      type: "Hub Site Application",
     },
-    data: { foo: "bar", baz: { boop: "beep" } }
+    data: { foo: "bar", baz: { boop: "beep" } },
   };
 
-  it("updates item", async function() {
+  it("updates item", async function () {
     const updateItemSpy = spyOn(portal, "updateItem").and.returnValue(
       Promise.resolve({ id: model.item.id, success: true })
     );
 
     const res = await failSafeUpdate(model, {
-      authentication: mockUserSession
+      authentication: mockUserSession,
     });
 
     expect(res.success).toBeTruthy("returned success");
     expect(updateItemSpy.calls.count()).toBe(1, "updateItem called");
   });
 
-  it("never fails", async function() {
+  it("never fails", async function () {
     const updateItemSpy = spyOn(portal, "updateItem").and.returnValue(
       Promise.reject({ success: false })
     );
@@ -41,7 +41,7 @@ describe("failSafeUpdate", function() {
     let res;
     try {
       res = await failSafeUpdate(model, {
-        authentication: mockUserSession
+        authentication: mockUserSession,
       });
     } catch (_) {
       fail(Error("failSafeUpdate rejected"));

--- a/packages/common/test/items/setItemThumbnail.test.ts
+++ b/packages/common/test/items/setItemThumbnail.test.ts
@@ -1,5 +1,5 @@
 import { setItemThumbnail } from "../../src/items/setItemThumbnail";
-import * as portalModule from "@esri/arcgis-rest-portal";
+import * as portalModule from "../../src/rest/portal";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 
 describe("setItemThumbnail:", () => {

--- a/packages/common/test/models/models.test.ts
+++ b/packages/common/test/models/models.test.ts
@@ -1,6 +1,7 @@
 import * as portalModule from "@esri/arcgis-rest-portal";
 import * as itemsModule from "../../src/items";
 import * as resourcesModule from "../../src/resources";
+import * as restPortal from "../../src/rest/portal";
 
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import {
@@ -62,7 +63,7 @@ describe("model utils:", () => {
   });
   describe("createModel:", () => {
     it("creates item and stores it", async () => {
-      const createItemSpy = spyOn(portalModule, "createItem").and.returnValue(
+      const createItemSpy = spyOn(restPortal, "createItem").and.returnValue(
         Promise.resolve({ success: true, id: "bc3" })
       );
       const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
@@ -109,7 +110,7 @@ describe("model utils:", () => {
       expect(opts.item.extent).toBe("1, 2, 3, 4" as unknown as number[][]);
     });
     it("creates item and stores it w/ extent as string", async () => {
-      const createItemSpy = spyOn(portalModule, "createItem").and.returnValue(
+      const createItemSpy = spyOn(restPortal, "createItem").and.returnValue(
         Promise.resolve({ success: true, id: "bc3" })
       );
       const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
@@ -156,7 +157,7 @@ describe("model utils:", () => {
   // longterm TODO: change these to spy on getModel rather than the implementations of it
   describe("updateModel: ", () => {
     it("updates a model", async () => {
-      const updateItemSpy = spyOn(portalModule, "updateItem").and.returnValue(
+      const updateItemSpy = spyOn(restPortal, "updateItem").and.returnValue(
         Promise.resolve({ success: true, id: "00c" })
       );
       const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
@@ -223,7 +224,7 @@ describe("model utils:", () => {
       expect(opts.item.categories).toEqual([]);
     });
     it("updates a model without data", async () => {
-      const updateItemSpy = spyOn(portalModule, "updateItem").and.returnValue(
+      const updateItemSpy = spyOn(restPortal, "updateItem").and.returnValue(
         Promise.resolve({ success: true, id: "00c" })
       );
       const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(
@@ -283,7 +284,7 @@ describe("model utils:", () => {
       expect(opts.item.categories).toEqual([]);
     });
     it("updates a model w/ extent as string", async () => {
-      const updateItemSpy = spyOn(portalModule, "updateItem").and.returnValue(
+      const updateItemSpy = spyOn(restPortal, "updateItem").and.returnValue(
         Promise.resolve({ success: true, id: "00c" })
       );
       const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(

--- a/packages/common/test/resources/fetch-and-upload-thumbnail.test.ts
+++ b/packages/common/test/resources/fetch-and-upload-thumbnail.test.ts
@@ -1,20 +1,20 @@
 import * as fetchImageAsBlobModule from "../../src/resources/fetch-image-as-blob";
-import * as portalModule from "@esri/arcgis-rest-portal";
+import * as portalModule from "../../src/rest/portal";
 
 import { fetchAndUploadThumbnail } from "../../src";
 import { mockUserSession } from "../test-helpers/fake-user-session";
 
-describe("fetchAndUploadThumbnail", function() {
+describe("fetchAndUploadThumbnail", function () {
   // These tests create a blob
   if (typeof Blob !== "undefined") {
-    it("fetches and uploads a thumbnail", async function() {
+    it("fetches and uploads a thumbnail", async function () {
       const file = new Blob(["a"]);
       const opts = {
         id: "my-id",
         owner: "owner",
         fileName: "file",
         url: "some-url",
-        authentication: mockUserSession
+        authentication: mockUserSession,
       };
 
       spyOn(fetchImageAsBlobModule, "fetchImageAsBlob").and.returnValue(
@@ -32,14 +32,14 @@ describe("fetchAndUploadThumbnail", function() {
 
       expect(portalModule.updateItem).toHaveBeenCalled();
     });
-    it("is impervious to thumbnail upload failure", async function() {
+    it("is impervious to thumbnail upload failure", async function () {
       const file = new Blob(["a"]);
       const opts = {
         id: "my-id",
         owner: "owner",
         fileName: "file",
         url: "some-url",
-        authentication: mockUserSession
+        authentication: mockUserSession,
       };
 
       spyOn(fetchImageAsBlobModule, "fetchImageAsBlob").and.returnValue(
@@ -61,13 +61,13 @@ describe("fetchAndUploadThumbnail", function() {
     });
   }
 
-  it("is impervious to fetch-thumbnail failure", async function() {
+  it("is impervious to fetch-thumbnail failure", async function () {
     const opts = {
       id: "my-id",
       owner: "owner",
       fileName: "file",
       url: "some-url",
-      authentication: mockUserSession
+      authentication: mockUserSession,
     };
 
     spyOn(fetchImageAsBlobModule, "fetchImageAsBlob").and.returnValue(

--- a/packages/common/test/rest/portal/_internal/helpers.test.ts
+++ b/packages/common/test/rest/portal/_internal/helpers.test.ts
@@ -1,0 +1,23 @@
+import { serializeItemParams } from "../../../../src/rest/portal/_internal/helpers";
+
+describe("serializeItemParams", () => {
+  it("should serialize item params correctly", () => {
+    const requestOptions = {
+      params: { someParam: "someValue" },
+      item: {
+        id: "123",
+        title: "Test Item",
+        data: "test",
+      },
+    } as any;
+
+    const result = serializeItemParams(requestOptions);
+
+    expect((result as any).params).toEqual({
+      someParam: "someValue",
+      id: "123",
+      title: "Test Item",
+      text: requestOptions.item.data,
+    });
+  });
+});

--- a/packages/downloads/src/portal/portal-export-success-handler.ts
+++ b/packages/downloads/src/portal/portal-export-success-handler.ts
@@ -1,14 +1,10 @@
-import {
-  updateItem,
-  removeItem,
-  moveItem,
-  setItemAccess,
-} from "@esri/arcgis-rest-portal";
+import { removeItem, moveItem, setItemAccess } from "@esri/arcgis-rest-portal";
 import {
   getExportLayerTypeKeyword,
   getExportItemTypeKeyword,
   getSpatialRefTypeKeyword,
   parseDatasetId,
+  updateItem,
 } from "@esri/hub-common";
 import { urlBuilder } from "../utils";
 import { getExportsFolderId } from "./portal-get-exports-folder-id";

--- a/packages/downloads/test/portal/portal-export-success-handler.test.ts
+++ b/packages/downloads/test/portal/portal-export-success-handler.test.ts
@@ -2,6 +2,7 @@ import * as portal from "@esri/arcgis-rest-portal";
 import * as folderHelper from "../../src/portal/portal-get-exports-folder-id";
 import { exportSuccessHandler } from "../../src/portal/portal-export-success-handler";
 import * as EventEmitter from "eventemitter3";
+import * as common from "@esri/hub-common";
 
 function delay(milliseconds: number) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -30,7 +31,7 @@ describe("portalPollExportJobStatus", () => {
   describe("export-completed handling errors", () => {
     it("updateItem failure", async (done) => {
       try {
-        spyOn(portal, "updateItem").and.callFake(async () => {
+        spyOn(common, "updateItem").and.callFake(async () => {
           return Promise.reject(new Error("5xx"));
         });
 
@@ -50,8 +51,8 @@ describe("portalPollExportJobStatus", () => {
       } catch (err) {
         expect(err.message).toBe("5xx");
       } finally {
-        expect(portal.updateItem).toHaveBeenCalledTimes(1);
-        expect((portal.updateItem as any).calls.first().args).toEqual([
+        expect(common.updateItem).toHaveBeenCalledTimes(1);
+        expect((common.updateItem as any).calls.first().args).toEqual([
           {
             item: {
               id: "download-id",
@@ -73,7 +74,7 @@ describe("portalPollExportJobStatus", () => {
 
     it("setItemAccess failure", async (done) => {
       try {
-        spyOn(portal, "updateItem").and.callFake(async () => {
+        spyOn(common, "updateItem").and.callFake(async () => {
           return Promise.resolve();
         });
 
@@ -97,8 +98,8 @@ describe("portalPollExportJobStatus", () => {
         throw new Error("should have errored");
       } catch (err) {
         expect(err.message).toEqual("5xx");
-        expect(portal.updateItem).toHaveBeenCalledTimes(1);
-        expect((portal.updateItem as any).calls.first().args).toEqual([
+        expect(common.updateItem).toHaveBeenCalledTimes(1);
+        expect((common.updateItem as any).calls.first().args).toEqual([
           {
             item: {
               id: "download-id",
@@ -129,7 +130,7 @@ describe("portalPollExportJobStatus", () => {
 
     it("getExportsFolderId failure", async (done) => {
       try {
-        spyOn(portal, "updateItem").and.callFake(async () => {
+        spyOn(common, "updateItem").and.callFake(async () => {
           return Promise.resolve();
         });
 
@@ -157,8 +158,8 @@ describe("portalPollExportJobStatus", () => {
         throw new Error("should have errored");
       } catch (err) {
         expect(err.message).toEqual("5xx");
-        expect(portal.updateItem).toHaveBeenCalledTimes(1);
-        expect((portal.updateItem as any).calls.first().args).toEqual([
+        expect(common.updateItem).toHaveBeenCalledTimes(1);
+        expect((common.updateItem as any).calls.first().args).toEqual([
           {
             item: {
               id: "download-id",
@@ -193,7 +194,7 @@ describe("portalPollExportJobStatus", () => {
 
     it("moveItem failure", async (done) => {
       try {
-        spyOn(portal, "updateItem").and.callFake(async () => {
+        spyOn(common, "updateItem").and.callFake(async () => {
           return Promise.resolve();
         });
 
@@ -225,8 +226,8 @@ describe("portalPollExportJobStatus", () => {
         throw new Error("should have errored");
       } catch (err) {
         expect(err.message).toEqual("5xx");
-        expect(portal.updateItem).toHaveBeenCalledTimes(1);
-        expect((portal.updateItem as any).calls.first().args).toEqual([
+        expect(common.updateItem).toHaveBeenCalledTimes(1);
+        expect((common.updateItem as any).calls.first().args).toEqual([
           {
             item: {
               id: "download-id",
@@ -271,7 +272,7 @@ describe("portalPollExportJobStatus", () => {
   describe("exported-completed, successful handling", () => {
     it("succeeds without moving download", async (done) => {
       try {
-        spyOn(portal, "updateItem").and.callFake(async () => {
+        spyOn(common, "updateItem").and.callFake(async () => {
           return Promise.resolve();
         });
 
@@ -302,8 +303,8 @@ describe("portalPollExportJobStatus", () => {
         });
 
         await delay(100);
-        expect(portal.updateItem).toHaveBeenCalledTimes(1);
-        expect((portal.updateItem as any).calls.first().args).toEqual([
+        expect(common.updateItem).toHaveBeenCalledTimes(1);
+        expect((common.updateItem as any).calls.first().args).toEqual([
           {
             item: {
               id: "download-id",
@@ -374,7 +375,7 @@ describe("portalPollExportJobStatus", () => {
           })
         );
 
-        spyOn(portal, "updateItem").and.callFake(async () => {
+        spyOn(common, "updateItem").and.callFake(async () => {
           return Promise.resolve();
         });
 
@@ -406,8 +407,8 @@ describe("portalPollExportJobStatus", () => {
         });
 
         await delay(100);
-        expect(portal.updateItem).toHaveBeenCalledTimes(1);
-        expect((portal.updateItem as any).calls.first().args).toEqual([
+        expect(common.updateItem).toHaveBeenCalledTimes(1);
+        expect((common.updateItem as any).calls.first().args).toEqual([
           {
             item: {
               id: "download-id",
@@ -478,7 +479,7 @@ describe("portalPollExportJobStatus", () => {
           })
         );
 
-        spyOn(portal, "updateItem").and.callFake(async () => {
+        spyOn(common, "updateItem").and.callFake(async () => {
           return Promise.resolve();
         });
 
@@ -509,8 +510,8 @@ describe("portalPollExportJobStatus", () => {
         });
 
         await delay(100);
-        expect(portal.updateItem).toHaveBeenCalledTimes(1);
-        expect((portal.updateItem as any).calls.first().args).toEqual([
+        expect(common.updateItem).toHaveBeenCalledTimes(1);
+        expect((common.updateItem as any).calls.first().args).toEqual([
           {
             item: {
               id: "download-id",

--- a/packages/initiatives/src/detach-site.ts
+++ b/packages/initiatives/src/detach-site.ts
@@ -3,12 +3,13 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import {
   getItem,
-  updateItem,
   shareItemWithGroup,
   IItem,
   IUpdateItemOptions,
-  IGroupSharingOptions
+  IGroupSharingOptions,
 } from "@esri/arcgis-rest-portal";
+import { updateItem } from "@esri/hub-common";
+
 /**
  * Remove the linkage between a site and an Initiative
  * Share the site to the Org's default Collaboration Group
@@ -36,7 +37,7 @@ export function detachSiteFromInitiative(
       // update the site item
       const opts = {
         item: site,
-        ...requestOptions
+        ...requestOptions,
       } as any;
       return updateItem(opts as IUpdateItemOptions);
     })
@@ -46,7 +47,7 @@ export function detachSiteFromInitiative(
         const opts = {
           id: siteId,
           groupId: collaborationGroupId,
-          ...requestOptions
+          ...requestOptions,
         } as IGroupSharingOptions;
         return shareItemWithGroup(opts) as Promise<any>;
       } else {

--- a/packages/initiatives/src/model.ts
+++ b/packages/initiatives/src/model.ts
@@ -1,14 +1,12 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 import { IRequestOptions } from "@esri/arcgis-rest-request";
-import { IModel, cloneObject } from "@esri/hub-common";
+import { IModel, cloneObject, createItem, updateItem } from "@esri/hub-common";
 import geometryService from "./geometry";
 import {
-  createItem,
-  updateItem,
   IUpdateItemOptions,
   ICreateItemOptions,
-  ICreateItemResponse
+  ICreateItemResponse,
 } from "@esri/arcgis-rest-portal";
 
 /**
@@ -74,7 +72,7 @@ function createRequestOptions(
   // create the options...
   const opts = {
     item,
-    ...requestOptions
+    ...requestOptions,
   };
   return opts;
 }

--- a/packages/initiatives/src/update-initiative-site-id.ts
+++ b/packages/initiatives/src/update-initiative-site-id.ts
@@ -1,8 +1,14 @@
 /* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
-import { IItem } from "@esri/arcgis-rest-portal";
-import { IModel, IHubRequestOptions, getProp, isGuid } from "@esri/hub-common";
-import { updateItem, getItem } from "@esri/arcgis-rest-portal";
+import type { IItem } from "@esri/arcgis-rest-portal";
+import {
+  IModel,
+  IHubRequestOptions,
+  getProp,
+  isGuid,
+  updateItem,
+} from "@esri/hub-common";
+import { getItem } from "@esri/arcgis-rest-portal";
 
 /**
  * Update the Site associated with an Initiative by setting the
@@ -33,7 +39,7 @@ export function updateInitiativeSiteId(
       );
     } else {
       itemPromise = getItem(maybeModel, {
-        authentication: hubRequestOptions.authentication
+        authentication: hubRequestOptions.authentication,
       });
     }
   } else {
@@ -56,7 +62,7 @@ export function updateInitiativeSiteId(
     // and... update the item
     return updateItem({
       item,
-      authentication: hubRequestOptions.authentication
+      authentication: hubRequestOptions.authentication,
     });
   });
 }

--- a/packages/initiatives/test/detach-site.test.ts
+++ b/packages/initiatives/test/detach-site.test.ts
@@ -4,6 +4,7 @@ import { detachSiteFromInitiative } from "../src/detach-site";
 import { MOCK_REQUEST_OPTIONS } from "./mocks/fake-session";
 import { cloneObject } from "@esri/hub-common";
 import * as portal from "@esri/arcgis-rest-portal";
+import * as common from "@esri/hub-common";
 import { SiteItem } from "./mocks/site-item";
 
 describe("detaching a site from initiative", () => {
@@ -19,7 +20,7 @@ describe("detaching a site from initiative", () => {
         return Promise.resolve(clone.item);
       }
     );
-    updateItemSpy = spyOn(portal, "updateItem").and.callFake(
+    updateItemSpy = spyOn(common, "updateItem").and.callFake(
       (opts: any): Promise<any> => {
         return Promise.resolve({ success: true });
       }
@@ -31,24 +32,24 @@ describe("detaching a site from initiative", () => {
     );
   });
 
-  it("should get the site, reset props, save it and share to now group", done => {
+  it("should get the site, reset props, save it and share to now group", (done) => {
     return detachSiteFromInitiative(
       "FAKESITEID",
       "FAKEODGROUPID",
       MOCK_REQUEST_OPTIONS
-    ).then(result => {
+    ).then((result) => {
       expect(getItemSpy.calls.count()).toBe(1);
       expect(updateItemSpy.calls.count()).toBe(1);
       expect(sharingSpy.calls.count()).toBe(1);
       done();
     });
   });
-  it("should get the site, reset props, save it if new group undefined", done => {
+  it("should get the site, reset props, save it if new group undefined", (done) => {
     return detachSiteFromInitiative(
       "FAKESITEID",
       undefined,
       MOCK_REQUEST_OPTIONS
-    ).then(result => {
+    ).then((result) => {
       expect(getItemSpy.calls.count()).toBe(1);
       expect(updateItemSpy.calls.count()).toBe(1);
       expect(sharingSpy.calls.count()).toBe(0);

--- a/packages/sites/src/_update-pages.ts
+++ b/packages/sites/src/_update-pages.ts
@@ -3,9 +3,10 @@ import {
   IHubRequestOptions,
   failSafe,
   serializeModel,
-  IModelTemplate
+  IModelTemplate,
+  updateItem,
 } from "@esri/hub-common";
-import { updateItem, IUpdateItemResponse } from "@esri/arcgis-rest-portal";
+import { IUpdateItemResponse } from "@esri/arcgis-rest-portal";
 import { _secondPassAdlibPages } from "./_second-pass-adlib-pages";
 
 /**
@@ -21,7 +22,7 @@ export function _updatePages(
   hubRequestOptions: IHubRequestOptions
 ): Promise<IUpdateItemResponse[]> {
   // 2) for any page item, check if it has the site in it's pages array and if not add it
-  const pageModels = solutionModels.filter(m => {
+  const pageModels = solutionModels.filter((m) => {
     return m.item.type.indexOf("Page") > -1;
   });
   // Create Fail-safe version of update b/c this is not critical
@@ -30,17 +31,17 @@ export function _updatePages(
   // if not, add and update the item
   const siteEntry = {
     id: siteModel.item.id,
-    title: siteModel.item.title
+    title: siteModel.item.title,
   };
 
   // iterate the pages
   return Promise.all(
-    pageModels.map(m => {
+    pageModels.map((m) => {
       m.data.values.sites.push(siteEntry);
       m = _secondPassAdlibPages(siteModel, m);
       return failSafeUpdate({
-        item: serializeModel((m as unknown) as IModel),
-        authentication: hubRequestOptions.authentication
+        item: serializeModel(m as unknown as IModel),
+        authentication: hubRequestOptions.authentication,
       });
     })
   );

--- a/packages/sites/src/create-site.ts
+++ b/packages/sites/src/create-site.ts
@@ -3,18 +3,15 @@ import {
   IHubRequestOptions,
   serializeModel,
   cloneObject,
+  createItem,
   interpolateItemId,
   uploadResourcesFromUrl,
   getProp,
   addSiteDomains,
+  updateItem,
 } from "@esri/hub-common";
 import { ensureRequiredSiteProperties } from "./ensure-required-site-properties";
-import {
-  createItem,
-  protectItem,
-  updateItem,
-  shareItemWithGroup,
-} from "@esri/arcgis-rest-portal";
+import { protectItem, shareItemWithGroup } from "@esri/arcgis-rest-portal";
 
 import { updateInitiativeSiteId } from "@esri/hub-initiatives";
 

--- a/packages/sites/src/link-site-and-page.ts
+++ b/packages/sites/src/link-site-and-page.ts
@@ -11,8 +11,8 @@ import {
   failSafe,
   shareItemToGroups,
   deepSet,
+  updateItem,
 } from "@esri/hub-common";
-import { updateItem } from "@esri/arcgis-rest-portal";
 import type { ArcGISIdentityManager } from "@esri/arcgis-rest-request";
 import { isSite } from "./is-site";
 

--- a/packages/sites/src/pages/create-page.ts
+++ b/packages/sites/src/pages/create-page.ts
@@ -2,18 +2,18 @@ import {
   IHubRequestOptions,
   IModelTemplate,
   serializeModel,
+  createItem,
   uploadResourcesFromUrl,
   getWithDefault,
   IItemResource,
-  IModel
+  IModel,
 } from "@esri/hub-common";
 import { ensureRequiredPageProperties } from "./ensure-required-page-properties";
 import { linkSiteAndPage } from "../link-site-and-page";
 import {
-  createItem,
   protectItem,
   shareItemWithGroup,
-  ISharingResponse
+  ISharingResponse,
 } from "@esri/arcgis-rest-portal";
 
 /**
@@ -38,7 +38,7 @@ export function createPage(
 
   const newPage = ensureRequiredPageProperties(model, {
     username: hubRequestOptions.authentication.username,
-    isPortal: hubRequestOptions.isPortal
+    isPortal: hubRequestOptions.isPortal,
   });
   // convert to a flat object w. .data --> .text as a json string
   const serializedModel = serializeModel(newPage);
@@ -46,19 +46,19 @@ export function createPage(
   return createItem({
     item: serializedModel,
     owner: newPage.item.owner,
-    authentication: hubRequestOptions.authentication
+    authentication: hubRequestOptions.authentication,
   })
-    .then(createResponse => {
+    .then((createResponse) => {
       // hold onto the Id so we can return a complete model
       newPage.item.id = createResponse.id;
       // protect it
       return protectItem({
         id: newPage.item.id,
         owner: newPage.item.owner,
-        authentication: hubRequestOptions.authentication
+        authentication: hubRequestOptions.authentication,
       });
     })
-    .then(protectReponse => {
+    .then((protectReponse) => {
       // share to any groups
       let sharingPromises: Array<Promise<ISharingResponse>> = [];
       if (Array.isArray(options.shareTo) && options.shareTo.length) {
@@ -68,25 +68,25 @@ export function createPage(
             id: newPage.item.id,
             groupId: groupInfo.id,
             authentication: hubRequestOptions.authentication,
-            confirmItemControl: groupInfo.confirmItemControl || false
+            confirmItemControl: groupInfo.confirmItemControl || false,
           });
         });
         newPage.item.access = "shared";
       }
       return Promise.all(sharingPromises);
     })
-    .then(response => {
+    .then((response) => {
       // link page to sites
       const sites = getWithDefault(newPage, "data.values.sites", []);
       const requestOptions = {
-        authentication: hubRequestOptions.authentication
+        authentication: hubRequestOptions.authentication,
       };
       return Promise.all(
         sites.map((entry: any) => {
           const opts = Object.assign(
             {
               siteId: entry.id,
-              pageModel: newPage
+              pageModel: newPage,
             },
             requestOptions
           );
@@ -94,13 +94,13 @@ export function createPage(
         })
       );
     })
-    .then(siteLinkingResponse => {
+    .then((siteLinkingResponse) => {
       // upload resources
       const assets = getWithDefault(options, "assets", []) as IItemResource[];
       return uploadResourcesFromUrl(newPage, assets, hubRequestOptions);
     })
     .then(() => newPage)
-    .catch(err => {
+    .catch((err) => {
       throw Error(`createPage: Error creating page: ${err}`);
     });
 }

--- a/packages/sites/src/pages/update-page.ts
+++ b/packages/sites/src/pages/update-page.ts
@@ -4,9 +4,10 @@ import {
   serializeModel,
   getModel,
   getProp,
-  mergeObjects
+  mergeObjects,
+  updateItem,
 } from "@esri/hub-common";
-import { updateItem, IUpdateItemResponse } from "@esri/arcgis-rest-portal";
+import type { IUpdateItemResponse } from "@esri/arcgis-rest-portal";
 
 /**
  * Update a Page item
@@ -39,7 +40,7 @@ export function updatePage(
     prms = getModel(getProp(model, "item.id"), updateSiteOptions);
   }
 
-  return prms.then(modelFromAGO => {
+  return prms.then((modelFromAGO) => {
     if (patchList.length) {
       // "patch" operation
       model = mergeObjects(model, modelFromAGO, patchList);

--- a/packages/sites/src/update-site.ts
+++ b/packages/sites/src/update-site.ts
@@ -6,10 +6,11 @@ import {
   mergeObjects,
   serializeModel,
   getSiteById,
+  updateItem,
 } from "@esri/hub-common";
 import { SITE_UI_VERSION } from "./site-ui-version";
 import { _ensurePortalDomainKeyword } from "./_ensure-portal-domain-keyword";
-import { updateItem, IUpdateItemResponse } from "@esri/arcgis-rest-portal";
+import type { IUpdateItemResponse } from "@esri/arcgis-rest-portal";
 
 /**
  * Update an existing site item

--- a/packages/sites/test/create-site.test.ts
+++ b/packages/sites/test/create-site.test.ts
@@ -13,14 +13,14 @@ describe("create site :: ", function () {
   let uploadResourcesSpy: jasmine.Spy;
   let shareSpy: jasmine.Spy;
   beforeEach(function () {
-    createSpy = spyOn(portalModule, "createItem").and.returnValue(
+    createSpy = spyOn(commonModule, "createItem").and.returnValue(
       Promise.resolve({ success: true, id: "3ef" })
     );
     protectSpy = spyOn(portalModule, "protectItem").and.returnValue(
       Promise.resolve({ success: true, id: "3ef" })
     );
 
-    updateSpy = spyOn(portalModule, "updateItem").and.returnValue(
+    updateSpy = spyOn(commonModule, "updateItem").and.returnValue(
       Promise.resolve({ success: true, id: "3ef" })
     );
     domainsSpy = spyOn(commonModule, "addSiteDomains").and.returnValue(

--- a/packages/sites/test/link-site-and-page.test.ts
+++ b/packages/sites/test/link-site-and-page.test.ts
@@ -1,6 +1,5 @@
 import { linkSiteAndPage } from "../src";
 import * as commonModule from "@esri/hub-common";
-import * as portalModule from "@esri/arcgis-rest-portal";
 import * as fetchMock from "fetch-mock";
 import { cloneObject } from "@esri/hub-common";
 
@@ -46,7 +45,7 @@ describe("linkSiteAndPage", () => {
       Promise.resolve({})
     );
 
-    updateSpy = spyOn(portalModule, "updateItem").and.callFake((opts: any) =>
+    updateSpy = spyOn(commonModule, "updateItem").and.callFake((opts: any) =>
       Promise.resolve({ success: true, id: opts.item.id })
     );
   });

--- a/packages/sites/test/pages/create-page.test.ts
+++ b/packages/sites/test/pages/create-page.test.ts
@@ -3,7 +3,7 @@ import {
   IHubRequestOptions,
   IModelTemplate,
   IItemResource,
-  cloneObject
+  cloneObject,
 } from "@esri/hub-common";
 import * as commonModule from "@esri/hub-common";
 import * as portalModule from "@esri/arcgis-rest-portal";
@@ -11,27 +11,27 @@ import * as linkModule from "../../src/link-site-and-page";
 import { expectAllCalled } from "../test-helpers.test";
 
 describe("createPage", () => {
-  const ro = ({
+  const ro = {
     authentication: {
       username: "tate",
-      isPortal: false
-    }
-  } as unknown) as IHubRequestOptions;
+      isPortal: false,
+    },
+  } as unknown as IHubRequestOptions;
 
-  const pageModel = ({
+  const pageModel = {
     item: {
-      typeKeywords: []
+      typeKeywords: [],
     },
     data: {
       values: {
-        sites: [{ id: "site-1" }, { id: "site-2" }, { id: "site-3" }]
-      }
-    }
-  } as unknown) as IModelTemplate;
+        sites: [{ id: "site-1" }, { id: "site-2" }, { id: "site-3" }],
+      },
+    },
+  } as unknown as IModelTemplate;
 
   const opts = {
     shareTo: [{ id: "group-1", confirmItemControl: true }, { id: "group-2" }],
-    assets: [{ url: "foobar-asset" } as IItemResource]
+    assets: [{ url: "foobar-asset" } as IItemResource],
   };
 
   const itemId = "id-foo-bar";
@@ -42,7 +42,7 @@ describe("createPage", () => {
   let linkSpy: jasmine.Spy;
   let uploadResourcesSpy: jasmine.Spy;
   beforeEach(() => {
-    createSpy = spyOn(portalModule, "createItem").and.returnValue(
+    createSpy = spyOn(commonModule, "createItem").and.returnValue(
       Promise.resolve({ id: itemId })
     );
     protectSpy = spyOn(portalModule, "protectItem").and.returnValue(
@@ -90,14 +90,14 @@ describe("createPage", () => {
       id: itemId,
       groupId: "group-1",
       authentication: ro.authentication,
-      confirmItemControl: true
+      confirmItemControl: true,
     });
 
     expect(shareItemSpy).toHaveBeenCalledWith({
       id: itemId,
       groupId: "group-2",
       authentication: ro.authentication,
-      confirmItemControl: false
+      confirmItemControl: false,
     });
 
     expect(linkSpy.calls.count()).toBe(3);
@@ -105,7 +105,7 @@ describe("createPage", () => {
       Object.assign(
         {
           siteId: "site-1",
-          pageModel: created
+          pageModel: created,
         },
         ro
       )
@@ -114,7 +114,7 @@ describe("createPage", () => {
       Object.assign(
         {
           siteId: "site-2",
-          pageModel: created
+          pageModel: created,
         },
         ro
       )
@@ -123,7 +123,7 @@ describe("createPage", () => {
       Object.assign(
         {
           siteId: "site-3",
-          pageModel: created
+          pageModel: created,
         },
         ro
       )

--- a/packages/sites/test/pages/update-page.test.ts
+++ b/packages/sites/test/pages/update-page.test.ts
@@ -1,5 +1,4 @@
 import { updatePage } from "../../src";
-import * as portalModule from "@esri/arcgis-rest-portal";
 import * as commonModule from "@esri/hub-common";
 import { IModel, IHubUserRequestOptions, cloneObject } from "@esri/hub-common";
 
@@ -28,7 +27,7 @@ describe("updatePage", () => {
 
   let updateSpy: jasmine.Spy;
   beforeEach(() => {
-    updateSpy = spyOn(portalModule, "updateItem").and.returnValue(
+    updateSpy = spyOn(commonModule, "updateItem").and.returnValue(
       Promise.resolve({ success: true })
     );
   });

--- a/packages/sites/test/update-site.test.ts
+++ b/packages/sites/test/update-site.test.ts
@@ -1,6 +1,5 @@
 import { SITE_ITEM_RESPONSE, SITE_DATA_RESPONSE } from "./site-responses.test";
 import * as commonModule from "@esri/hub-common";
-import * as portalModule from "@esri/arcgis-rest-portal";
 import { updateSite } from "../src";
 
 describe("update site", function () {
@@ -16,7 +15,7 @@ describe("update site", function () {
       })
     );
 
-    updateSpy = spyOn(portalModule, "updateItem").and.returnValue(
+    updateSpy = spyOn(commonModule, "updateItem").and.returnValue(
       Promise.resolve({ success: true, id: "3ef" })
     );
 
@@ -54,15 +53,13 @@ describe("update site", function () {
     expect(result.success).toBeTruthy("should return sucess");
     expect(updateSpy).toHaveBeenCalled();
 
-    const updateItem = updateSpy.calls.argsFor(0)[0].item;
+    const item = updateSpy.calls.argsFor(0)[0].item;
     // title wasn't on allow list, so shouldn't update
-    expect(updateItem.title).not.toBe(localSite.item.title);
+    expect(item.title).not.toBe(localSite.item.title);
     // newprop was on allow list, so should update
-    expect(updateItem.properties.newProp).toBe(
-      localSite.item.properties.newProp
-    );
+    expect(item.properties.newProp).toBe(localSite.item.properties.newProp);
     // versions updated
-    expect(updateItem.properties.schemaVersion).toEqual(
+    expect(item.properties.schemaVersion).toEqual(
       localSite.item.properties.schemaVersion
     );
   });
@@ -92,15 +89,15 @@ describe("update site", function () {
     expect(result.success).toBeTruthy("should return sucess");
     expect(updateSpy).toHaveBeenCalled();
 
-    const updateItem = updateSpy.calls.argsFor(0)[0].item;
+    const updatedItem = updateSpy.calls.argsFor(0)[0].item;
     // title wasn't on allow list, so shouldn't update
-    expect(updateItem.title).not.toBe(localSite.item.title);
+    expect(updatedItem.title).not.toBe(localSite.item.title);
     // newprop was on allow list, so should update
-    expect(updateItem.properties.newProp).toBe(
+    expect(updatedItem.properties.newProp).toBe(
       localSite.item.properties.newProp
     );
     // versions not updated
-    expect(updateItem.properties.schemaVersion).toEqual(
+    expect(updatedItem.properties.schemaVersion).toEqual(
       SITE_ITEM_RESPONSE.properties.schemaVersion
     );
   });

--- a/packages/teams/src/remove-team-from-items.ts
+++ b/packages/teams/src/remove-team-from-items.ts
@@ -1,6 +1,6 @@
 import type { ArcGISIdentityManager } from "@esri/arcgis-rest-request";
-import { IUpdateItemResponse, updateItem } from "@esri/arcgis-rest-portal";
-import { cloneObject, IModel, without } from "@esri/hub-common";
+import type { IUpdateItemResponse } from "@esri/arcgis-rest-portal";
+import { cloneObject, IModel, without, updateItem } from "@esri/hub-common";
 
 /**
  * Removes a Team from N hub models.

--- a/packages/teams/test/remove-team-from-items.test.ts
+++ b/packages/teams/test/remove-team-from-items.test.ts
@@ -1,4 +1,4 @@
-import * as restPortalModule from "@esri/arcgis-rest-portal";
+import * as commonModule from "@esri/hub-common";
 import { IModel } from "@esri/hub-common";
 import { removeTeamFromItems } from "../src/remove-team-from-items";
 
@@ -75,7 +75,7 @@ describe("remove-team-from-items", function () {
   let updateItemSpy: jasmine.Spy;
 
   beforeEach(() => {
-    updateItemSpy = spyOn(restPortalModule, "updateItem");
+    updateItemSpy = spyOn(commonModule, "updateItem");
   });
   afterEach(() => {
     updateItemSpy.calls.reset();


### PR DESCRIPTION
affects: @esri/hub-common, @esri/hub-downloads, @esri/hub-initiatives, @esri/hub-sites, @esri/hub-teams

1. Description:

Adds wrappers for  ArcGIS REST JS's `commitItemUpload`, `createItem`, and `updateItem` that restore the 3.x behavior of those functions, updates all the packges to use those wrappers, and re-exports those wrappers for use in other Hub packages.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
