### PR TITLE
feat(hub-common): users can create channels from the discussion setti…

### DIFF
--- a/packages/common/src/channels/_internal/ChannelBusinessRules.ts
+++ b/packages/common/src/channels/_internal/ChannelBusinessRules.ts
@@ -1,3 +1,5 @@
+import { IPermissionPolicy } from "../../permissions/types/IPermissionPolicy";
+
 /**
  * @private
  * An array of all supported channel permissions
@@ -57,3 +59,13 @@ export const CHANNEL_PERMISSIONS: Record<
   channelReadWrite: "hub:channel:readWrite",
   channelModerate: "hub:channel:moderate",
 };
+
+export const ChannelPermissionPolicies: IPermissionPolicy[] = [
+  {
+    permission: CHANNEL_PERMISSIONS.channelCreate,
+    dependencies: ["hub:discussion"],
+    authenticated: true,
+    privileges: ["portal:user:createItem"],
+    licenses: ["hub-premium"],
+  },
+];

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -236,6 +236,7 @@ export const getContentTypeIcon = (contentType: string) => {
     applicationConfiguration: "app-gear",
     arcgisProMap: "desktop",
     cadDrawing: "file-cad",
+    channel: "channels",
     cityEngineWebScene: "urban-model",
     codeAttachment: "file-code",
     codeSample: "file-code",

--- a/packages/common/src/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.ts
+++ b/packages/common/src/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.ts
@@ -53,6 +53,8 @@ export const buildUiSchema = async (
       options: {
         control: "hub-field-input-gallery-picker",
         targetEntity: "channel",
+        showAddContent: true,
+        allowGroupSelection: false,
         showSelection: false,
         showAllCollectionFacet: false,
         canReorder: false,

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -2,6 +2,7 @@ import { InitiativePermissionPolicies } from "../initiatives/_internal/Initiativ
 import { ProjectPermissionPolicies } from "../projects/_internal/ProjectBusinessRules";
 import { SitesPermissionPolicies } from "../sites/_internal/SiteBusinessRules";
 import { DiscussionPermissionPolicies } from "../discussions/_internal/DiscussionBusinessRules";
+import { ChannelPermissionPolicies } from "../channels/_internal/ChannelBusinessRules";
 import { ContentPermissionPolicies } from "../content/_internal/ContentBusinessRules";
 
 import { IPermissionPolicy, Permission } from "./types";
@@ -253,6 +254,7 @@ export const HubPermissionsPolicies: IPermissionPolicy[] = [
   ...ProjectPermissionPolicies,
   ...InitiativePermissionPolicies,
   ...DiscussionPermissionPolicies,
+  ...ChannelPermissionPolicies,
   ...ContentPermissionPolicies,
   ...GroupPermissionPolicies,
   ...PagePermissionPolicies,

--- a/packages/common/test/channels/_internal/ChannelUiSchemaEdit.test.ts
+++ b/packages/common/test/channels/_internal/ChannelUiSchemaEdit.test.ts
@@ -1,13 +1,13 @@
 import { buildUiSchema } from "../../../src/channels/_internal/ChannelUiSchemaEdit";
 import * as ChannelUiSchemaCreateModule from "../../../src/channels/_internal/ChannelUiSchemaCreate";
-import { IChannel } from "../../../src/discussions/api/types";
 import { IArcGISContext } from "../../../src/types/IArcGISContext";
 import { IUiSchema } from "../../../src/core/schemas/types";
+import { IHubChannel } from "../../../src/core/types/IHubChannel";
 
 describe("ChannelUiSchemaEdit", () => {
   describe("buildUiSchema", () => {
     const i18nScope = "myScope";
-    const options: Partial<IChannel> = {};
+    const options: Partial<IHubChannel> = {};
     const context = {
       currentUser: {
         orgId: "orgId123",

--- a/packages/common/test/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.test.ts
+++ b/packages/common/test/core/schemas/internal/discussions/EntityUiSchemaDiscussionsSettings.test.ts
@@ -51,6 +51,8 @@ describe("EntityUiSchemaDiscussionsSettings", () => {
                 control: "hub-field-input-gallery-picker",
                 targetEntity: "channel",
                 showSelection: false,
+                showAddContent: true,
+                allowGroupSelection: false,
                 showAllCollectionFacet: false,
                 canReorder: false,
                 linkTarget: "event",


### PR DESCRIPTION
…ngs schema

affects: @esri/hub-common

ISSUES CLOSED: 12669

1. Description:

1. Instructions for testing:

1. Closes Issues: #[12669](https://devtopia.esri.com/dc/hub/issues/12669)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
