### PR TITLE
feat(hub-common): re-export @esri/arcgis-rest-feature-service functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
 				"@commitlint/config-conventional": "^11.0.0",
 				"@commitlint/config-lerna-scopes": "^11.0.0",
 				"@commitlint/prompt": "^11.0.0",
-				"@esri/arcgis-rest-feature-service": "~4.0.5",
 				"@esri/arcgis-rest-portal": "~4.4.0",
 				"@esri/arcgis-rest-request": "~4.2.3",
 				"@semantic-release/changelog": "^6.0.1",
@@ -4891,6 +4890,7 @@
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-4.0.6.tgz",
 			"integrity": "sha512-M1iqrI5dq1PZOgIafqHvnkBtVpLWafAl7+w+TXVZ+P68FiDf44FGoX4cyEWi7E83ejFeIfSuM6sU61eI9K3hNg==",
+			"dev": true,
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
@@ -4905,7 +4905,8 @@
 		"node_modules/@esri/arcgis-rest-feature-service/node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
 		},
 		"node_modules/@esri/arcgis-rest-fetch": {
 			"version": "4.0.0",
@@ -53935,6 +53936,7 @@
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
+				"@esri/arcgis-rest-feature-service": "~4.0.5",
 				"@types/adlib": "^3.0.1",
 				"@types/geojson": "^7946.0.13",
 				"@types/terraformer__arcgis": "^2.0.5",
@@ -53977,10 +53979,9 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/arcgis-rest-feature-service": "~4.0.5",
 				"@esri/arcgis-rest-portal": "~4.4.0",
 				"@esri/arcgis-rest-request": "~4.2.3",
-				"@esri/hub-common": "^17.0.0"
+				"@esri/hub-common": "^17.1.0"
 			}
 		},
 		"packages/events": {
@@ -53995,10 +53996,9 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/arcgis-rest-feature-service": "~4.0.5",
 				"@esri/arcgis-rest-portal": "~4.4.0",
 				"@esri/arcgis-rest-request": "~4.2.3",
-				"@esri/hub-common": "^17.0.0"
+				"@esri/hub-common": "^17.1.0"
 			}
 		},
 		"packages/initiatives": {
@@ -54033,10 +54033,9 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/arcgis-rest-feature-service": "~4.0.5",
 				"@esri/arcgis-rest-portal": "~4.4.0",
 				"@esri/arcgis-rest-request": "~4.2.3",
-				"@esri/hub-common": "^17.0.0"
+				"@esri/hub-common": "^17.1.0"
 			}
 		},
 		"packages/sites": {
@@ -54072,10 +54071,9 @@
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
-				"@esri/arcgis-rest-feature-service": "~4.0.5",
 				"@esri/arcgis-rest-portal": "~4.4.0",
 				"@esri/arcgis-rest-request": "~4.2.3",
-				"@esri/hub-common": "^17.0.0"
+				"@esri/hub-common": "^17.1.0"
 			}
 		},
 		"packages/teams": {
@@ -57603,6 +57601,7 @@
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-4.0.6.tgz",
 			"integrity": "sha512-M1iqrI5dq1PZOgIafqHvnkBtVpLWafAl7+w+TXVZ+P68FiDf44FGoX4cyEWi7E83ejFeIfSuM6sU61eI9K3hNg==",
+			"dev": true,
 			"requires": {
 				"tslib": "^2.3.0"
 			},
@@ -57610,7 +57609,8 @@
 				"tslib": {
 					"version": "2.8.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-					"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+					"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+					"dev": true
 				}
 			}
 		},
@@ -57683,6 +57683,7 @@
 		"@esri/hub-common": {
 			"version": "file:packages/common",
 			"requires": {
+				"@esri/arcgis-rest-feature-service": "~4.0.5",
 				"@terraformer/arcgis": "^2.1.2",
 				"@types/adlib": "^3.0.1",
 				"@types/geojson": "^7946.0.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53922,7 +53922,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "17.0.0",
+			"version": "17.0.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -53966,7 +53966,7 @@
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "17.0.0",
+			"version": "17.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -54003,7 +54003,7 @@
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "17.0.0",
+			"version": "17.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -54041,7 +54041,7 @@
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "18.0.0",
+			"version": "18.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -54080,7 +54080,7 @@
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "17.0.0",
+			"version": "17.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 		"@commitlint/config-conventional": "^11.0.0",
 		"@commitlint/config-lerna-scopes": "^11.0.0",
 		"@commitlint/prompt": "^11.0.0",
-    "@esri/arcgis-rest-feature-service": "~4.0.5",
     "@esri/arcgis-rest-portal": "~4.4.0",
     "@esri/arcgis-rest-request": "~4.2.3",
 		"@semantic-release/changelog": "^6.0.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -27,6 +27,7 @@
     "@esri/arcgis-rest-request": "~4.2.3"
   },
   "devDependencies": {
+    "@esri/arcgis-rest-feature-service": "~4.0.5",
     "@types/adlib": "^3.0.1",
     "@types/geojson": "^7946.0.13",
     "@types/terraformer__arcgis": "^2.0.5",

--- a/packages/common/src/content/_internal/internalContentUtils.ts
+++ b/packages/common/src/content/_internal/internalContentUtils.ts
@@ -8,13 +8,13 @@
  * It's probably a good pattern to add functions here first and then
  * move them to index.ts only when they are needed by a consumer.
  */
-import { parseServiceUrl } from "@esri/arcgis-rest-feature-service";
+import { parseServiceUrl } from "../../rest/feature-service";
 import type { IItem, IPortal, IUser } from "@esri/arcgis-rest-portal";
 import type {
   IExtent,
   ILayerDefinition,
   ISpatialReference,
-} from "@esri/arcgis-rest-feature-service";
+} from "../../rest/feature-service";
 import {
   IGeometryInstance,
   IHubContent,

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -1,9 +1,9 @@
 import { IItem } from "@esri/arcgis-rest-portal";
-import {
+import type {
   ILayerDefinition,
   IFeatureServiceDefinition,
-  parseServiceUrl,
-} from "@esri/arcgis-rest-feature-service";
+} from "../rest/feature-service";
+import { parseServiceUrl } from "../rest/feature-service";
 import { BBox, IHubRequestOptions } from "../hub-types";
 import { getHubApiUrl } from "../api";
 import { isDownloadable } from "../categories";

--- a/packages/common/src/content/contentUtils.ts
+++ b/packages/common/src/content/contentUtils.ts
@@ -25,10 +25,7 @@ import {
   IHubContentStatus,
   IHubServiceBackedContentStatus,
 } from "./types";
-import {
-  getService,
-  IGetLayerOptions,
-} from "@esri/arcgis-rest-feature-service";
+import { getService, IGetLayerOptions } from "../rest/feature-service";
 import { isService } from "../resources/is-service";
 
 // TODO: remove this at next breaking version

--- a/packages/common/src/content/edit.ts
+++ b/packages/common/src/content/edit.ts
@@ -28,8 +28,8 @@ import {
   getService,
   IFeatureServiceDefinition,
   parseServiceUrl,
-} from "@esri/arcgis-rest-feature-service";
-import { updateServiceDefinition } from "@esri/arcgis-rest-feature-service";
+} from "../rest/feature-service";
+import { updateServiceDefinition } from "../rest/feature-service";
 import {
   hasServiceCapability,
   isHostedFeatureServiceMainEntity,

--- a/packages/common/src/content/fetchContent.ts
+++ b/packages/common/src/content/fetchContent.ts
@@ -2,7 +2,7 @@ import {
   getLayer,
   parseServiceUrl,
   queryFeatures,
-} from "@esri/arcgis-rest-feature-service";
+} from "../rest/feature-service";
 import { getItem } from "@esri/arcgis-rest-portal";
 import { IHubContent } from "../core";
 import {

--- a/packages/common/src/content/hostedServiceUtils.ts
+++ b/packages/common/src/content/hostedServiceUtils.ts
@@ -1,4 +1,4 @@
-import { IFeatureServiceDefinition } from "@esri/arcgis-rest-feature-service";
+import { IFeatureServiceDefinition } from "../rest/feature-service";
 import { IItem } from "@esri/arcgis-rest-portal";
 import { IHubEditableContent } from "../core/types/IHubEditableContent";
 

--- a/packages/common/src/core/schemas/internal/getLocationOptions.ts
+++ b/packages/common/src/core/schemas/internal/getLocationOptions.ts
@@ -2,7 +2,7 @@ import { extentToBBox, orgExtent as orgExtent } from "../../../extent";
 import { IHubRequestOptions } from "../../../hub-types";
 import { getTypeFromEntity } from "../../getTypeFromEntity";
 import { IHubLocation, IHubLocationOption } from "../../types/IHubLocation";
-import type { IExtent } from "@esri/arcgis-rest-feature-service";
+import type { IExtent } from "../../../rest/feature-service";
 
 /**
  * Construct the dynamic location picker options with the entity's

--- a/packages/common/src/core/types/IHubContent.ts
+++ b/packages/common/src/core/types/IHubContent.ts
@@ -1,5 +1,5 @@
 import { IItem, IGroup } from "@esri/arcgis-rest-portal";
-import { ILayerDefinition } from "@esri/arcgis-rest-feature-service";
+import { ILayerDefinition } from "../../rest/feature-service";
 import {
   AccessControl,
   HubFamily,

--- a/packages/common/src/core/types/IHubEditableContent.ts
+++ b/packages/common/src/core/types/IHubEditableContent.ts
@@ -1,4 +1,4 @@
-import type { IFeatureServiceDefinition } from "@esri/arcgis-rest-feature-service";
+import type { IFeatureServiceDefinition } from "../../rest/feature-service";
 import { IWithPermissions, IWithSlug } from "../traits/index";
 import { IHubAdditionalResource } from "./IHubAdditionalResource";
 import { IHubItemEntity, IHubItemEntityEditor } from "./IHubItemEntity";

--- a/packages/common/src/core/types/IHubLocation.ts
+++ b/packages/common/src/core/types/IHubLocation.ts
@@ -1,4 +1,4 @@
-import type { ISpatialReference } from "@esri/arcgis-rest-feature-service";
+import type { ISpatialReference } from "../../rest/feature-service";
 import { IHubLocationType } from "./types";
 import { HubEntityType } from "./HubEntityType";
 import { IGeometryInstance } from "../..";

--- a/packages/common/src/core/types/IHubSite.ts
+++ b/packages/common/src/core/types/IHubSite.ts
@@ -1,4 +1,4 @@
-import { IExtent } from "@esri/arcgis-rest-feature-service";
+import { IExtent } from "../../rest/feature-service";
 import { IWithVersioningBehavior } from "../behaviors";
 
 import { IHubItemEntity, IHubItemEntityEditor } from "./IHubItemEntity";

--- a/packages/common/src/core/types/IServerEnrichments.ts
+++ b/packages/common/src/core/types/IServerEnrichments.ts
@@ -1,7 +1,7 @@
 import {
   IFeatureServiceDefinition,
   ILayerDefinition,
-} from "@esri/arcgis-rest-feature-service";
+} from "../../rest/feature-service";
 
 export interface IServerEnrichments {
   /** Information about the service referenced by this content (currentVersion, capabilities, maxRecordCount etc) */

--- a/packages/common/src/core/types/Metrics.ts
+++ b/packages/common/src/core/types/Metrics.ts
@@ -1,5 +1,5 @@
 import { IQuery } from "../../search/types/IHubCatalog";
-import type { IField } from "@esri/arcgis-rest-feature-service";
+import type { IField } from "../../rest/feature-service";
 import type { FieldType } from "@esri/arcgis-rest-request";
 import { IReference } from "./IReference";
 import { IGeometryInstance, ServiceAggregation } from "../../core/types";

--- a/packages/common/src/downloads/_internal/file-url-fetchers/fetchExportImageDownloadFile.ts
+++ b/packages/common/src/downloads/_internal/file-url-fetchers/fetchExportImageDownloadFile.ts
@@ -1,4 +1,4 @@
-import type { IExtent } from "@esri/arcgis-rest-feature-service";
+import type { IExtent } from "../../../rest/feature-service";
 import { request } from "@esri/arcgis-rest-request";
 import {
   DownloadOperationStatus,

--- a/packages/common/src/downloads/build-existing-exports-portal-query.ts
+++ b/packages/common/src/downloads/build-existing-exports-portal-query.ts
@@ -1,5 +1,5 @@
 import { SearchQueryBuilder } from "@esri/arcgis-rest-portal";
-import type { ISpatialReference } from "@esri/arcgis-rest-feature-service";
+import type { ISpatialReference } from "../rest/feature-service";
 import { btoa } from "abab";
 import { flattenArray } from "../util";
 import { PORTAL_EXPORT_TYPES } from "./types";

--- a/packages/common/src/extent.ts
+++ b/packages/common/src/extent.ts
@@ -1,4 +1,4 @@
-import type { IExtent } from "@esri/arcgis-rest-feature-service";
+import type { IExtent } from "./rest/feature-service";
 import type {
   IPoint,
   IPolygon,

--- a/packages/common/src/items/_enrichments.ts
+++ b/packages/common/src/items/_enrichments.ts
@@ -10,7 +10,7 @@ import {
   getAllLayersAndTables,
   getService,
   parseServiceUrl,
-} from "@esri/arcgis-rest-feature-service";
+} from "../rest/feature-service";
 import { IItemEnrichments, IServerEnrichments } from "../core";
 import { IEnrichmentErrorInfo, IHubRequestOptions } from "../hub-types";
 import { IPipeable, createOperationPipeline } from "../utils";

--- a/packages/common/src/items/is-services-directory-disabled.ts
+++ b/packages/common/src/items/is-services-directory-disabled.ts
@@ -1,6 +1,6 @@
 import type { IUserRequestOptions } from "@esri/arcgis-rest-request";
 import type { IItem } from "@esri/arcgis-rest-portal";
-import { parseServiceUrl } from "@esri/arcgis-rest-feature-service";
+import { parseServiceUrl } from "../rest/feature-service";
 import { getItem } from "@esri/arcgis-rest-portal";
 
 /**

--- a/packages/common/src/metrics/resolveMetric.ts
+++ b/packages/common/src/metrics/resolveMetric.ts
@@ -8,9 +8,9 @@ import {
   IStaticValueMetricSource,
   MetricSource,
 } from "../core/types/Metrics";
-import { queryFeatures } from "@esri/arcgis-rest-feature-service";
+import { queryFeatures } from "../rest/feature-service";
 import type { IItem } from "@esri/arcgis-rest-portal";
-import type { IStatisticDefinition } from "@esri/arcgis-rest-feature-service";
+import type { IStatisticDefinition } from "../rest/feature-service";
 import { getProp } from "../objects/get-prop";
 import { IPredicate, IQuery } from "../search/types/IHubCatalog";
 import { combineQueries } from "../search/_internal/combineQueries";

--- a/packages/common/src/resources/_internal/_validate-url-helpers.ts
+++ b/packages/common/src/resources/_internal/_validate-url-helpers.ts
@@ -2,7 +2,7 @@ import type {
   IExtent,
   IFeatureServiceDefinition,
   ILayerDefinition,
-} from "@esri/arcgis-rest-feature-service";
+} from "../../rest/feature-service";
 import { ItemType } from "../../hub-types";
 import { Logger } from "../../utils";
 

--- a/packages/common/src/rest/feature-service/index.ts
+++ b/packages/common/src/rest/feature-service/index.ts
@@ -4,8 +4,10 @@
 // add type re-exports here as needed
 export type {
   IExtent,
-  IGetLayerOptions,
+  IFeature,
   IFeatureServiceDefinition,
+  IGeometry,
+  IGetLayerOptions,
   ISpatialReference,
   ILayerDefinition,
   IField,

--- a/packages/common/src/rest/feature-service/index.ts
+++ b/packages/common/src/rest/feature-service/index.ts
@@ -1,6 +1,4 @@
-// TODO: make @esri/arcgis-rest-feature-service a restricted import
-// see https://palantir.github.io/tslint/rules/import-blacklist/
-
+/* tslint:disable:import-blacklist */
 // add type re-exports here as needed
 export type {
   IExtent,

--- a/packages/common/src/rest/feature-service/index.ts
+++ b/packages/common/src/rest/feature-service/index.ts
@@ -17,8 +17,16 @@ export type {
 
 // add re-exports for functions that are not spied on here as needed
 export {
+  addAttachment,
+  addFeatures,
+  deleteAttachments,
+  deleteFeatures,
   getAllLayersAndTables,
+  getAttachments,
+  getFeature,
   parseServiceUrl,
+  updateAttachment,
+  updateFeatures,
 } from "@esri/arcgis-rest-feature-service";
 
 // re-export wrappers

--- a/packages/common/src/rest/feature-service/index.ts
+++ b/packages/common/src/rest/feature-service/index.ts
@@ -1,0 +1,25 @@
+// TODO: make @esri/arcgis-rest-feature-service a restricted import
+// see https://palantir.github.io/tslint/rules/import-blacklist/
+
+// add type re-exports here as needed
+export type {
+  IExtent,
+  IGetLayerOptions,
+  IFeatureServiceDefinition,
+  ISpatialReference,
+  ILayerDefinition,
+  IField,
+  IStatisticDefinition,
+  IQueryFeaturesOptions,
+  IQueryFeaturesResponse,
+  IQueryResponse,
+} from "@esri/arcgis-rest-feature-service";
+
+// add re-exports for functions that are not spied on here as needed
+export {
+  getAllLayersAndTables,
+  parseServiceUrl,
+} from "@esri/arcgis-rest-feature-service";
+
+// re-export wrappers
+export * from "./wrappers";

--- a/packages/common/src/rest/feature-service/wrappers.ts
+++ b/packages/common/src/rest/feature-service/wrappers.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:import-blacklist */
 /* istanbul ignore file */
 // in addition to it being a good practice to isolate dependencies
 // this is needed so that we can spy on the functions below in tests :(

--- a/packages/common/src/rest/feature-service/wrappers.ts
+++ b/packages/common/src/rest/feature-service/wrappers.ts
@@ -1,0 +1,49 @@
+/* istanbul ignore file */
+// in addition to it being a good practice to isolate dependencies
+// this is needed so that we can spy on the functions below in tests :(
+
+// add functions that need to be spied on here
+// and then add wrapper functions below
+import {
+  getLayer as _getLayer,
+  getService as _getService,
+  queryFeatures as _queryFeatures,
+  updateServiceDefinition as _updateServiceDefinition,
+} from "@esri/arcgis-rest-feature-service";
+
+// wrap functions that need to be spied on
+/**
+ * wrapper around @esri/arcgis-rest-feature-service's getLayer
+ */
+export function getLayer(
+  ...args: Parameters<typeof _getLayer>
+): ReturnType<typeof _getLayer> {
+  return _getLayer(...args);
+}
+
+/**
+ * wrapper around @esri/arcgis-rest-feature-service's getService
+ */
+export function getService(
+  ...args: Parameters<typeof _getService>
+): ReturnType<typeof _getService> {
+  return _getService(...args);
+}
+
+/**
+ * wrapper around @esri/arcgis-rest-feature-service's queryFeatures
+ */
+export function queryFeatures(
+  ...args: Parameters<typeof _queryFeatures>
+): ReturnType<typeof _queryFeatures> {
+  return _queryFeatures(...args);
+}
+
+/**
+ * wrapper around @esri/arcgis-rest-feature-service's updateServiceDefinition
+ */
+export function updateServiceDefinition(
+  ...args: Parameters<typeof _updateServiceDefinition>
+): ReturnType<typeof _updateServiceDefinition> {
+  return _updateServiceDefinition(...args);
+}

--- a/packages/common/src/rest/index.ts
+++ b/packages/common/src/rest/index.ts
@@ -1,1 +1,2 @@
-export * from "./portal/wrappers";
+export * from "./portal";
+export * from "./feature-service";

--- a/packages/common/src/utils/internal/resolveServiceQueryValues.ts
+++ b/packages/common/src/utils/internal/resolveServiceQueryValues.ts
@@ -1,5 +1,5 @@
-import { queryFeatures } from "@esri/arcgis-rest-feature-service";
-import type { IStatisticDefinition } from "@esri/arcgis-rest-feature-service";
+import { queryFeatures } from "../../rest/feature-service";
+import type { IStatisticDefinition } from "../../rest/feature-service";
 import type { IArcGISContext } from "../../types/IArcGISContext";
 import {
   DynamicValues,

--- a/packages/common/test/content/compose.test.ts
+++ b/packages/common/test/content/compose.test.ts
@@ -1,4 +1,4 @@
-import { ILayerDefinition } from "@esri/arcgis-rest-feature-service";
+import { ILayerDefinition } from "../../src/rest/feature-service";
 import { IItem } from "@esri/arcgis-rest-portal";
 import {
   cloneObject,

--- a/packages/common/test/content/content.test.ts
+++ b/packages/common/test/content/content.test.ts
@@ -1,6 +1,6 @@
 import type { IItem } from "@esri/arcgis-rest-portal";
-import type { ILayerDefinition } from "@esri/arcgis-rest-feature-service";
-import * as featureLayerModule from "@esri/arcgis-rest-feature-service";
+import type { ILayerDefinition } from "../../src/rest/feature-service";
+import * as featureLayerModule from "../../src/rest/feature-service";
 import {
   DatasetResource,
   datasetToContent,

--- a/packages/common/test/content/edit.test.ts
+++ b/packages/common/test/content/edit.test.ts
@@ -1,6 +1,6 @@
 import * as portalModule from "@esri/arcgis-rest-portal";
-import * as featureLayerModule from "@esri/arcgis-rest-feature-service";
-import * as adminModule from "@esri/arcgis-rest-feature-service";
+import * as featureLayerModule from "../../src/rest/feature-service";
+import * as adminModule from "../../src/rest/feature-service";
 import { MOCK_AUTH, MOCK_HUB_REQOPTS, TOMORROW } from "../mocks/mock-auth";
 import * as modelUtils from "../../src/models";
 import { IModel } from "../../src/hub-types";

--- a/packages/common/test/content/fetchContent.test.ts
+++ b/packages/common/test/content/fetchContent.test.ts
@@ -1,5 +1,5 @@
 import * as portalModule from "@esri/arcgis-rest-portal";
-import * as featureLayerModule from "@esri/arcgis-rest-feature-service";
+import * as featureLayerModule from "../../src/rest/feature-service";
 import {
   IHubRequestOptions,
   fetchContent,

--- a/packages/common/test/content/fixtures.ts
+++ b/packages/common/test/content/fixtures.ts
@@ -1,5 +1,5 @@
 import type { IItem } from "@esri/arcgis-rest-portal";
-import type { IFeatureServiceDefinition } from "@esri/arcgis-rest-feature-service";
+import type { IFeatureServiceDefinition } from "../../src/rest/feature-service";
 
 export const HOSTED_FEATURE_SERVICE_GUID = "A1295DEF67814571B99EDDEA65748143";
 export const HOSTED_FEATURE_SERVICE_URL =

--- a/packages/common/test/content/hostedServiceUtils.test.ts
+++ b/packages/common/test/content/hostedServiceUtils.test.ts
@@ -1,5 +1,5 @@
 import type { IItem } from "@esri/arcgis-rest-portal";
-import type { IFeatureServiceDefinition } from "@esri/arcgis-rest-feature-service";
+import type { IFeatureServiceDefinition } from "../../src/rest/feature-service";
 import { IHubEditableContent } from "../../src";
 import {
   hasServiceCapability,

--- a/packages/common/test/core/schemas/internal/metrics/fixtures.ts
+++ b/packages/common/test/core/schemas/internal/metrics/fixtures.ts
@@ -1,4 +1,4 @@
-import type { IField } from "@esri/arcgis-rest-feature-service";
+import type { IField } from "../../../../../src/rest/feature-service";
 
 export const MOCK_STRING_FIELD: IField = {
   name: "category",

--- a/packages/common/test/extent/create-extent.test.ts
+++ b/packages/common/test/extent/create-extent.test.ts
@@ -1,5 +1,5 @@
 import { createExtent } from "../../src";
-import type { IExtent } from "@esri/arcgis-rest-feature-service";
+import type { IExtent } from "../../src/rest/feature-service";
 
 describe("createExtent", function () {
   it("creates an extent with default spatial reference", function () {

--- a/packages/common/test/extent/extent-to-bbox.test.ts
+++ b/packages/common/test/extent/extent-to-bbox.test.ts
@@ -1,5 +1,5 @@
 import { extentToBBox } from "../../src";
-import type { IExtent } from "@esri/arcgis-rest-feature-service";
+import type { IExtent } from "../../src/rest/feature-service";
 
 describe("extentToBBox", function () {
   it("converts extent to bbox", function () {

--- a/packages/common/test/extent/extent.test.ts
+++ b/packages/common/test/extent/extent.test.ts
@@ -3,7 +3,7 @@ import {
   allCoordinatesPossiblyWGS84,
   GeoJSONPolygonToBBox,
 } from "../../src/extent";
-import type { IExtent } from "@esri/arcgis-rest-feature-service";
+import type { IExtent } from "../../src/rest/feature-service";
 
 describe("isValidExtent", function () {
   it("identifies valid extent coordinate array", function () {

--- a/packages/common/test/items/_enrichments.test.ts
+++ b/packages/common/test/items/_enrichments.test.ts
@@ -5,7 +5,7 @@ import { fetchItemEnrichments } from "../../src/items/_enrichments";
 import * as featureServiceItem from "../mocks/items/feature-service-item.json";
 import * as datasetWithMetadata from "../mocks/datasets/feature-layer-with-metadata.json";
 import * as servicesDirectory from "../../src/items/is-services-directory-disabled";
-import type { IFeatureServiceDefinition } from "@esri/arcgis-rest-feature-service";
+import type { IFeatureServiceDefinition } from "../../src/rest/feature-service";
 
 describe("_enrichments", () => {
   describe("fetchItemEnrichments", () => {

--- a/packages/common/test/metrics/resolveMetric.test.ts
+++ b/packages/common/test/metrics/resolveMetric.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../src";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import * as PortalModule from "@esri/arcgis-rest-portal";
-import * as FLModule from "@esri/arcgis-rest-feature-service";
+import * as FLModule from "../../src/rest/feature-service";
 import * as PSModule from "../../src/search/_internal/portalSearchItems";
 
 describe("resolveMetric:", () => {

--- a/packages/common/test/resources/_validate-url-helpers.test.ts
+++ b/packages/common/test/resources/_validate-url-helpers.test.ts
@@ -2,7 +2,7 @@ import type {
   IExtent,
   IFeatureServiceDefinition,
   ILayerDefinition,
-} from "@esri/arcgis-rest-feature-service";
+} from "../../src/rest/feature-service";
 import * as fetchMock from "fetch-mock";
 import { ItemType } from "../../src";
 import {

--- a/packages/common/test/resources/validate-url.test.ts
+++ b/packages/common/test/resources/validate-url.test.ts
@@ -1,4 +1,4 @@
-import type { IExtent } from "@esri/arcgis-rest-feature-service";
+import type { IExtent } from "../../src/rest/feature-service";
 import * as fetchMock from "fetch-mock";
 import { validateUrl } from "../../src";
 

--- a/packages/common/test/utils/internal/resolveServiceQueryValues.test.ts
+++ b/packages/common/test/utils/internal/resolveServiceQueryValues.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../src";
 import { resolveServiceQueryValues } from "../../../src/utils/internal/resolveServiceQueryValues";
 import { MOCK_AUTH } from "../../mocks/mock-auth";
-import * as featureLayer from "@esri/arcgis-rest-feature-service";
+import * as featureLayer from "../../../src/rest/feature-service";
 
 describe("resolveServiceQueryValues:", () => {
   let context: IArcGISContext;

--- a/packages/downloads/package.json
+++ b/packages/downloads/package.json
@@ -12,10 +12,9 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-feature-service": "~4.0.5",
     "@esri/arcgis-rest-portal": "~4.4.0",
     "@esri/arcgis-rest-request": "~4.2.3",
-    "@esri/hub-common": "^17.0.0"
+    "@esri/hub-common": "^17.1.0"
   },
   "devDependencies": {
     "@esri/hub-common": "^17.0.0",

--- a/packages/downloads/src/portal/portal-request-download-metadata.ts
+++ b/packages/downloads/src/portal/portal-request-download-metadata.ts
@@ -5,7 +5,7 @@ import {
   getLayer,
   IFeatureServiceDefinition,
   ILayerDefinition,
-} from "@esri/arcgis-rest-feature-service";
+} from "@esri/hub-common";
 import { DownloadFormat, DownloadFormats } from "../download-format";
 import { urlBuilder, composeDownloadId } from "../utils";
 import { DownloadTarget } from "../download-target";

--- a/packages/downloads/test/portal/portal-request-download-metadata.test.ts
+++ b/packages/downloads/test/portal/portal-request-download-metadata.test.ts
@@ -1,6 +1,6 @@
 import * as fetchMock from "fetch-mock";
 import * as portalModule from "@esri/arcgis-rest-portal";
-import * as featureLayer from "@esri/arcgis-rest-feature-service";
+import * as featureLayer from "@esri/hub-common";
 import { portalRequestDownloadMetadata } from "../../src/portal/portal-request-download-metadata";
 import { ArcGISAuthError } from "@esri/arcgis-rest-request";
 

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -11,10 +11,9 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-feature-service": "~4.0.5",
     "@esri/arcgis-rest-portal": "~4.4.0",
     "@esri/arcgis-rest-request": "~4.2.3",
-    "@esri/hub-common": "^17.0.0"
+    "@esri/hub-common": "^17.1.0"
   },
   "devDependencies": {
     "@esri/hub-common": "^17.0.0",

--- a/packages/events/src/search.ts
+++ b/packages/events/src/search.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { queryFeatures } from "@esri/arcgis-rest-feature-service";
+import { queryFeatures } from "@esri/hub-common";
 
 import { ISearchOptions, searchItems } from "@esri/arcgis-rest-portal";
 import type {
@@ -9,7 +9,7 @@ import type {
   IFeature,
   IQueryFeaturesOptions,
   IQueryFeaturesResponse,
-} from "@esri/arcgis-rest-feature-service";
+} from "@esri/hub-common";
 import type {
   ArcGISIdentityManager,
   IRequestOptions,

--- a/packages/events/src/util.ts
+++ b/packages/events/src/util.ts
@@ -3,7 +3,7 @@
 
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { searchItems, ISearchResult, IItem } from "@esri/arcgis-rest-portal";
-import { IQueryFeaturesOptions } from "@esri/arcgis-rest-feature-service";
+import { IQueryFeaturesOptions } from "@esri/hub-common";
 import type { ArcGISIdentityManager } from "@esri/arcgis-rest-request";
 import { getHubApiUrl } from "@esri/hub-common";
 

--- a/packages/events/test/mocks/event_search.ts
+++ b/packages/events/test/mocks/event_search.ts
@@ -3,7 +3,7 @@
 
 import type { IEventResourceObject } from "../../src/search";
 import type { IPoint, IField } from "@esri/arcgis-rest-request";
-import type { IQueryFeaturesResponse } from "@esri/arcgis-rest-feature-service";
+import type { IQueryFeaturesResponse } from "@esri/hub-common";
 import type { IItem, ISearchResult } from "@esri/arcgis-rest-portal";
 
 export const eventQueryResponseEmpty = {

--- a/packages/events/test/search.test.ts
+++ b/packages/events/test/search.test.ts
@@ -12,9 +12,9 @@ import {
   eventResponseWithoutSiteId,
 } from "./mocks/event_search";
 
-import * as featureService from "@esri/arcgis-rest-feature-service";
+import * as featureService from "@esri/hub-common";
 import * as portal from "@esri/arcgis-rest-portal";
-import { IQueryFeaturesOptions } from "@esri/arcgis-rest-feature-service";
+import { IQueryFeaturesOptions } from "@esri/hub-common";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { ISearchOptions } from "@esri/arcgis-rest-portal";
 

--- a/packages/events/test/util.test.ts
+++ b/packages/events/test/util.test.ts
@@ -12,7 +12,7 @@ import {
 import * as portal from "@esri/arcgis-rest-portal";
 
 import { ISearchOptions } from "@esri/arcgis-rest-portal";
-import { IQueryFeaturesOptions } from "@esri/arcgis-rest-feature-service";
+import { IQueryFeaturesOptions } from "@esri/hub-common";
 
 describe("getEventServiceUrl", () => {
   it("should return admin event service url", (done) => {

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -11,10 +11,9 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-feature-service": "~4.0.5",
     "@esri/arcgis-rest-portal": "~4.4.0",
     "@esri/arcgis-rest-request": "~4.2.3",
-    "@esri/hub-common": "^17.0.0"
+    "@esri/hub-common": "^17.1.0"
   },
   "devDependencies": {
     "@esri/hub-common": "^17.0.0",

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -11,10 +11,9 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-feature-service": "~4.0.5",
     "@esri/arcgis-rest-portal": "~4.4.0",
     "@esri/arcgis-rest-request": "~4.2.3",
-    "@esri/hub-common": "^17.0.0"
+    "@esri/hub-common": "^17.1.0"
   },
   "devDependencies": {
     "@esri/hub-common": "^17.0.0",

--- a/packages/surveys/src/utils/results-availability/has-user-responded.ts
+++ b/packages/surveys/src/utils/results-availability/has-user-responded.ts
@@ -1,7 +1,4 @@
-import {
-  queryFeatures,
-  IQueryResponse,
-} from "@esri/arcgis-rest-feature-service";
+import { queryFeatures, IQueryResponse } from "@esri/hub-common";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 
 /**

--- a/packages/surveys/test/utils/results-availability.test.ts
+++ b/packages/surveys/test/utils/results-availability.test.ts
@@ -16,7 +16,7 @@ import * as FeatureServiceItem from "../../../common/test/mocks/items/feature-se
 import * as FieldworkerItem from "../../../common/test/mocks/items/fieldworker-item.json";
 import * as StakeholderItem from "../../../common/test/mocks/items/stakeholder-item.json";
 import { cloneObject, IModel } from "@esri/hub-common";
-import * as featureLayerUtils from "@esri/arcgis-rest-feature-service";
+import * as featureLayerUtils from "@esri/hub-common";
 
 const getFormItem = (
   isDraft: boolean,

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     "tslint-config-prettier"
   ],
   "rules": {
+    "import-blacklist": [true, "@esri/arcgis-rest-feature-service"],
     "strict-type-predicates": false,
     "no-use-before-declare": false,
     "ordered-imports": ["any"],


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

re-export @esri/arcgis-rest-feature-service functions
get a few more node tests to pass by using wrapped functions

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
