### PR TITLE
chore: generate pr previews for all prs

### DIFF
--- a/.github/workflows/publish-pr-preview.yaml
+++ b/.github/workflows/publish-pr-preview.yaml
@@ -4,10 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review, synchronize]
     branches:
-      - master
-      - next
-      - alpha
-      - beta
+      - "**"
     paths-ignore:
       - "**.md"
       - "docs/**"


### PR DESCRIPTION
ISSUES CLOSED: 11743

1. Description:

Updates CI to generate PR-Previews for PRs configured to merge to branches that _are not_ `master`.

1. Instructions for testing:

1. Closes Issues: #[11743](https://devtopia.esri.com/dc/hub/issues/11743)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
