### PR TITLE
feat: moving notice into image picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53922,7 +53922,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "17.0.2",
+			"version": "17.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
@@ -58,7 +58,7 @@ export function getThumbnailUiSchemaElement(
     };
   }
 
-  // We want the thumbnail to appear in the image picker rather than below it
+  // We want the notice to appear in the image picker rather than below it
   // this is a design requirement for proper element indexing
   const notice =
     !thumbnail || thumbnail === "thumbnail/ago_downloaded.png"
@@ -83,7 +83,8 @@ export function getThumbnailUiSchemaElement(
           // helper text varies between entity types
           labelKey: `${i18nScope}.fields._thumbnail.helperText`,
         },
-        // this notice will appear above the image picker but below the helper text
+        // Advise the user if the entity's thumbnail is either of the default values,
+        // and this notice will appear above the image picker but below the helper text
         notice,
         ...options,
       },

--- a/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
+++ b/packages/common/src/core/schemas/internal/getThumbnailUiSchemaElement.ts
@@ -1,7 +1,7 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { getCdnAssetUrl } from "../../../urls";
 import { HubEntityType } from "../../types/HubEntityType";
-import { IUiSchemaElement, UiSchemaRuleEffects } from "../types";
+import { IUiSchemaElement } from "../types";
 
 const DEFAULT_ENTITY_THUMBNAILS: Partial<Record<HubEntityType, string>> = {
   discussion:
@@ -58,6 +58,13 @@ export function getThumbnailUiSchemaElement(
     };
   }
 
+  // We want the thumbnail to appear in the image picker rather than below it
+  // this is a design requirement for proper element indexing
+  const notice =
+    !thumbnail || thumbnail === "thumbnail/ago_downloaded.png"
+      ? "20250425-image-picker-notice"
+      : null;
+
   return [
     {
       labelKey:
@@ -76,35 +83,10 @@ export function getThumbnailUiSchemaElement(
           // helper text varies between entity types
           labelKey: `${i18nScope}.fields._thumbnail.helperText`,
         },
+        // this notice will appear above the image picker but below the helper text
+        notice,
         ...options,
       },
-    },
-    // Advise the user if the entity's thumbnail is either of the default values
-    {
-      type: "Notice",
-      options: {
-        notice: {
-          configuration: {
-            id: "no-thumbnail-or-png-notice",
-            noticeType: "notice",
-            closable: false,
-            icon: "lightbulb",
-            kind: "info",
-            scale: "m",
-          },
-          message:
-            "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-          autoShow: true,
-        },
-      },
-      rules: [
-        {
-          effect: UiSchemaRuleEffects.SHOW,
-          conditions: [
-            !thumbnail || thumbnail === "thumbnail/ago_downloaded.png",
-          ],
-        },
-      ],
     },
   ];
 }

--- a/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
+++ b/packages/common/test/content/_internal/ContentUiSchemaEdit.test.ts
@@ -116,31 +116,8 @@ describe("buildUiSchema: content edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
+                notice: null,
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [false],
-                },
-              ],
             },
             {
               labelKey: "some.scope.fields.tags.label",

--- a/packages/common/test/core/schemas/internal/getThumbnailUiSchemaElement.test.ts
+++ b/packages/common/test/core/schemas/internal/getThumbnailUiSchemaElement.test.ts
@@ -31,13 +31,8 @@ describe("getThumbnailUiSchemaElement:", () => {
       entity.type as HubEntityType,
       requestOptions
     );
-    expect(uiSchema.length).toBe(2);
-    expect(uiSchema[1].rules).toEqual([
-      {
-        effect: UiSchemaRuleEffects.SHOW,
-        conditions: [false],
-      },
-    ]);
+    expect(uiSchema.length).toBe(1);
+    expect(uiSchema[0].options.notice).toBeNull();
   });
 
   it("includes the default thumbnail notice if the entity has no thumbnail", () => {
@@ -64,13 +59,8 @@ describe("getThumbnailUiSchemaElement:", () => {
       entity.type as HubEntityType,
       requestOptions
     );
-    expect(uiSchema.length).toBe(2);
-    expect(uiSchema[1].rules).toEqual([
-      {
-        effect: UiSchemaRuleEffects.SHOW,
-        conditions: [true],
-      },
-    ]);
+    expect(uiSchema.length).toBe(1);
+    expect(uiSchema[0].options.notice).not.toBeNull();
   });
 
   it("includes the default thumbnail notice if the entity has the default thumbnail", () => {
@@ -98,13 +88,8 @@ describe("getThumbnailUiSchemaElement:", () => {
       entity.type as HubEntityType,
       requestOptions
     );
-    expect(uiSchema.length).toBe(2);
-    expect(uiSchema[1].rules).toEqual([
-      {
-        effect: UiSchemaRuleEffects.SHOW,
-        conditions: [true],
-      },
-    ]);
+    expect(uiSchema.length).toBe(1);
+    expect(uiSchema[0].options.notice).not.toBeNull();
   });
 
   it("sets default thumbnail when available", () => {

--- a/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
+++ b/packages/common/test/discussions/_internal/DiscussionUiSchemaEdit.test.ts
@@ -113,31 +113,8 @@ describe("buildUiSchema: discussion edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
+                notice: null,
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [false],
-                },
-              ],
             },
           ],
         },
@@ -359,31 +336,8 @@ describe("buildUiSchema: discussion edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
+                notice: null,
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [false],
-                },
-              ],
             },
           ],
         },

--- a/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
+++ b/packages/common/test/events/_internal/EventUiSchemaEdit.test.ts
@@ -179,31 +179,8 @@ describe("EventUiSchemaEdit", () => {
                   sizeDescription: {
                     labelKey: "shared.fields._thumbnail.sizeDescription",
                   },
+                  notice: "20250425-image-picker-notice",
                 },
-              },
-              {
-                type: "Notice",
-                options: {
-                  notice: {
-                    configuration: {
-                      id: "no-thumbnail-or-png-notice",
-                      noticeType: "notice",
-                      closable: false,
-                      icon: "lightbulb",
-                      kind: "info",
-                      scale: "m",
-                    },
-                    message:
-                      "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                    autoShow: true,
-                  },
-                },
-                rules: [
-                  {
-                    effect: UiSchemaRuleEffects.SHOW,
-                    conditions: [true],
-                  },
-                ],
               },
             ],
           },

--- a/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaEdit.test.ts
@@ -88,31 +88,8 @@ describe("buildUiSchema: group edit", () => {
                 sizeDescription: {
                   labelKey: "some.scope.fields._thumbnail.sizeDescription",
                 },
+                notice: "20250425-image-picker-notice",
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [true],
-                },
-              ],
             },
           ],
         },

--- a/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.test.ts
@@ -139,31 +139,8 @@ describe("buildUiSchema: initiative template edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
+                notice: null,
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [false],
-                },
-              ],
             },
           ],
         },

--- a/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
+++ b/packages/common/test/initiatives/_internal/InitiativeUiSchemaEdit.test.ts
@@ -300,31 +300,8 @@ describe("buildUiSchema: initiative edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
+                notice: null,
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [false],
-                },
-              ],
             },
           ],
         },
@@ -650,31 +627,8 @@ describe("buildUiSchema: initiative edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
+                notice: null,
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [false],
-                },
-              ],
             },
           ],
         },

--- a/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
+++ b/packages/common/test/pages/_internal/PageUiSchemaEdit.test.ts
@@ -128,31 +128,8 @@ describe("buildUiSchema: page edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
+                notice: null,
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [false],
-                },
-              ],
             },
             mockSlugElement,
             {

--- a/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
+++ b/packages/common/test/projects/_internal/ProjectUiSchemaEdit.test.ts
@@ -266,31 +266,8 @@ describe("buildUiSchema: project edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
+                notice: null,
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [false],
-                },
-              ],
             },
           ],
         },
@@ -654,31 +631,8 @@ describe("buildUiSchema: project edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
+                notice: null,
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [false],
-                },
-              ],
             },
           ],
         },

--- a/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaEdit.test.ts
@@ -128,31 +128,8 @@ describe("buildUiSchema: site edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
+                notice: null,
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [false],
-                },
-              ],
             },
             {
               labelKey: "some.scope.fields.tags.label",
@@ -346,31 +323,8 @@ describe("buildUiSchema: site edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
+                notice: null,
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [false],
-                },
-              ],
             },
             mockSlugElement,
             {

--- a/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
+++ b/packages/common/test/surveys/_internal/SurveyUiSchemaEdit.test.ts
@@ -191,31 +191,8 @@ describe("buildUiSchema: survey edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
+                notice: null,
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [false],
-                },
-              ],
             },
           ],
         },

--- a/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
+++ b/packages/common/test/templates/_internal/TemplateUiSchemaEdit.test.ts
@@ -120,31 +120,8 @@ describe("buildUiSchema: template edit", () => {
                 sizeDescription: {
                   labelKey: "shared.fields._thumbnail.sizeDescription",
                 },
+                notice: null,
               },
-            },
-            {
-              type: "Notice",
-              options: {
-                notice: {
-                  configuration: {
-                    id: "no-thumbnail-or-png-notice",
-                    noticeType: "notice",
-                    closable: false,
-                    icon: "lightbulb",
-                    kind: "info",
-                    scale: "m",
-                  },
-                  message:
-                    "{{shared.fields._thumbnail.defaultThumbnailNotice:translate}}",
-                  autoShow: true,
-                },
-              },
-              rules: [
-                {
-                  effect: UiSchemaRuleEffects.SHOW,
-                  conditions: [false],
-                },
-              ],
             },
           ],
         },


### PR DESCRIPTION
1. Description: Minor style changes and element reordering in the image picker used in workspaces

1. Instructions for testing: 
- open the details page in workspaces for site or other entities that use it
- notice should now appear between the helper text and thumbnail in the image picker section
- spacing between helperText, thumbnail, and dropdown below thumbnail should all be 10px apart.

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/13051

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
