### PR TITLE
[PORTAL-11.5] fix: ensure fetchOrg works on enterprise

### DIFF
--- a/packages/common/src/org/fetch-org.ts
+++ b/packages/common/src/org/fetch-org.ts
@@ -11,10 +11,15 @@ import { getPortal } from "@esri/arcgis-rest-portal";
  * @returns
  */
 export function fetchOrg(orgId: string, options?: IRequestOptions) {
-  const orgPortalUrl =
+  let orgPortalUrl =
     getProp(options, "portal") ||
     getProp(options, "authentication.portal") ||
     "www.arcgis.com";
+
+  // if we got the value from authentication, we need to strip off the
+  // "/sharing/rest" part of the url to get the base portal url because
+  // getPortalBaseFromOrgUrl does not know how to handle enterprise urls.
+  orgPortalUrl = orgPortalUrl.split("/sharing/rest")[0];
 
   // In order to get the correct response, we must pass options.portal
   // as a base portal url (e.g., www.arcgis.com, qaext.arcgis.com, etc)

--- a/packages/common/src/urls/getPortalBaseFromOrgUrl.ts
+++ b/packages/common/src/urls/getPortalBaseFromOrgUrl.ts
@@ -7,7 +7,9 @@
  * @returns
  */
 export function getPortalBaseFromOrgUrl(orgUrl: string): string {
-  let result = orgUrl;
+  // strip off the /sharing/rest part of the url
+  // this will also handle enterprise urls
+  let result = orgUrl.split("/sharing/rest")[0];
 
   if (orgUrl.match(/(qaext|\.mapsqa)\.arcgis.com/)) {
     result = "https://qaext.arcgis.com";

--- a/packages/common/test/org/fetch-org.test.ts
+++ b/packages/common/test/org/fetch-org.test.ts
@@ -15,8 +15,12 @@ describe("fetchOrg", () => {
       Promise.resolve(mockPortal)
     );
   });
+  // TODO: Add tests that simulate Enterprise!
   it("Derives base portal from options.portal", async () => {
-    const mockAuth = { portal: "authentication-portal.mapsdevext.arcgis.com" };
+    const mockAuth = {
+      portal:
+        "https://authentication-portal.mapsdevext.arcgis.com/sharing/rest",
+    };
     const requestOptions = {
       portal: "top-level-portal.mapsqa.arcgis.com",
       authentication: mockAuth,
@@ -30,7 +34,10 @@ describe("fetchOrg", () => {
     expect(result).toBe(mockPortal);
   });
   it("Derives base portal from option.authentication.portal", async () => {
-    const mockAuth = { portal: "authentication-portal.mapsdevext.arcgis.com" };
+    const mockAuth = {
+      portal:
+        "https://authentication-portal.mapsdevext.arcgis.com/sharing/rest",
+    };
     const requestOptions = {
       authentication: mockAuth,
     } as unknown as IRequestOptions;
@@ -38,6 +45,20 @@ describe("fetchOrg", () => {
     await fetchOrg(orgId, requestOptions);
     expect(getPortalStub).toHaveBeenCalledWith(orgId, {
       portal: "https://devext.arcgis.com/sharing/rest",
+      authentication: mockAuth,
+    });
+  });
+  it("Derives base portal from option.authentication.portal for Enterprise", async () => {
+    const mockAuth = {
+      portal: "https://gis.fortcollins.com/portal/sharing/rest",
+    };
+    const requestOptions = {
+      authentication: mockAuth,
+    } as unknown as IRequestOptions;
+
+    await fetchOrg(orgId, requestOptions);
+    expect(getPortalStub).toHaveBeenCalledWith(orgId, {
+      portal: "https://gis.fortcollins.com/portal/sharing/rest",
       authentication: mockAuth,
     });
   });

--- a/packages/common/test/urls/getPortalBaseFromOrgUrl.test.ts
+++ b/packages/common/test/urls/getPortalBaseFromOrgUrl.test.ts
@@ -23,4 +23,10 @@ describe("getPortalBaseUrlFromOrgUrl:", () => {
     const chk2 = getPortalBaseFromOrgUrl("https://org.maps.arcgis.com");
     expect(chk2).toBe("https://www.arcgis.com");
   });
+  it("works for enterprise", () => {
+    const chk = getPortalBaseFromOrgUrl(
+      "https://gis.fortcollins.com/portal/sharing/rest"
+    );
+    expect(chk).toBe("https://gis.fortcollins.com/portal");
+  });
 });


### PR DESCRIPTION
1. Description:

Resolves a bug with `fetchOrg` and `getPortalBaseFromOrgUrl` functions, which did not quite work as expected in Enterprise.

1. Instructions for testing:
- run tests

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
