### PR TITLE
feat: additions to gallery display config interface & schema

### DIFF
--- a/packages/common/src/associations/getAvailableToRequestEntitiesQuery.ts
+++ b/packages/common/src/associations/getAvailableToRequestEntitiesQuery.ts
@@ -9,7 +9,7 @@ import { getIdsFromKeywords } from "./internal/getIdsFromKeywords";
 import { getTypeByNotIdsQuery } from "./internal/getTypeByNotIdsQuery";
 import { negateGroupPredicates } from "../search/negateGroupPredicates";
 import { getTypeByIdsQuery } from "./internal/getTypeByIdsQuery";
-import { combineQueries } from "../search/_internal/combineQueries";
+import { combineQueries } from "../search/combineQueries";
 
 /**
  * An entity can send an "outgoing" request to associate

--- a/packages/common/src/associations/internal/getIncludesAndReferencesQuery.ts
+++ b/packages/common/src/associations/internal/getIncludesAndReferencesQuery.ts
@@ -3,7 +3,7 @@ import { HubEntity, HubEntityType } from "../../core/types";
 import { getTypesFromEntityType } from "../../core/getTypesFromEntityType";
 import { getProp } from "../../objects/get-prop";
 import { IQuery } from "../../search/types";
-import { combineQueries } from "../../search/_internal/combineQueries";
+import { combineQueries } from "../../search/combineQueries";
 import { getTypeWithKeywordQuery } from "./getTypeWithKeywordQuery";
 import type { IArcGISContext } from "../../types/IArcGISContext";
 import { getTypeByIdsQuery } from "./getTypeByIdsQuery";

--- a/packages/common/src/associations/internal/getIncludesDoesNotReferenceQuery.ts
+++ b/packages/common/src/associations/internal/getIncludesDoesNotReferenceQuery.ts
@@ -3,7 +3,7 @@ import { HubEntity, HubEntityType } from "../../core/types";
 import { getTypesFromEntityType } from "../../core/getTypesFromEntityType";
 import { getProp } from "../../objects/get-prop";
 import { IQuery } from "../../search/types";
-import { combineQueries } from "../../search/_internal/combineQueries";
+import { combineQueries } from "../../search/combineQueries";
 import { getTypeWithoutKeywordQuery } from "./getTypeWithoutKeywordQuery";
 import type { IArcGISContext } from "../../types/IArcGISContext";
 import { getTypeByIdsQuery } from "./getTypeByIdsQuery";

--- a/packages/common/src/associations/internal/getReferencesDoesNotIncludeQuery.ts
+++ b/packages/common/src/associations/internal/getReferencesDoesNotIncludeQuery.ts
@@ -3,7 +3,7 @@ import { HubEntity, HubEntityType } from "../../core/types";
 import { getTypesFromEntityType } from "../../core/getTypesFromEntityType";
 import { getProp } from "../../objects/get-prop";
 import { IQuery } from "../../search/types";
-import { combineQueries } from "../../search/_internal/combineQueries";
+import { combineQueries } from "../../search/combineQueries";
 import { getTypeWithKeywordQuery } from "./getTypeWithKeywordQuery";
 import { negateGroupPredicates } from "../../search/negateGroupPredicates";
 import type { IArcGISContext } from "../../types/IArcGISContext";

--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -12,23 +12,16 @@ export const GalleryDisplayConfigSchema: IConfigurationSchema = {
     hidden: { type: "boolean", default: false },
     layout: {
       type: "string",
-      enum: ["list", "grid", "map", "table", "compact", "calendar"], // removed grid-filled and compact
+      enum: [ 'grid', 'list', 'map', 'compact', 'table', 'calendar' ],
       default: "list",
     },
     layouts: {
       type: "array",
       items: {
-        type: "object",
-        properties: {
-          key: {
-            type: "string",
-            enum: ["list", "grid", "map", "table", "calendar", "compact"],
-          },
-          label: { type: "string" },
-          description: { type: "string" },
-          hidden: { type: "boolean" },
-        },
+        type: "string",
+        enum: [ 'grid', 'list', 'map', 'compact', 'table', 'calendar' ]
       },
+      default: []
     },
     cardTitleTag: {
       type: "string",

--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -12,13 +12,33 @@ export const GalleryDisplayConfigSchema: IConfigurationSchema = {
     hidden: { type: "boolean", default: false },
     layout: {
       type: "string",
-      enum: ["list", "grid", "table", "map", "compact"], // removed grid-filled and compact
+      enum: ["list", "grid", "map", "table", "compact", "calendar"], // removed grid-filled and compact
       default: "list",
+    },
+    layouts: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          key: {
+            type: "string",
+            enum: ["list", "grid", "map", "table", "calendar", "compact"],
+          },
+          label: { type: "string" },
+          description: { type: "string" },
+          hidden: { type: "boolean" },
+        },
+      },
     },
     cardTitleTag: {
       type: "string",
       enum: Object.keys(CARD_TITLE_TAGS),
       default: CARD_TITLE_TAGS.h3,
+    },
+    imageType: {
+      type: "string",
+      enum: ["thumbnail", "icon"],
+      default: "thumbnail",
     },
     showThumbnail: {
       type: "string",

--- a/packages/common/src/initiatives/HubInitiatives.ts
+++ b/packages/common/src/initiatives/HubInitiatives.ts
@@ -42,7 +42,7 @@ import { DEFAULT_INITIATIVE, DEFAULT_INITIATIVE_MODEL } from "./defaults";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 import { computeProps } from "./_internal/computeProps";
 import { applyInitiativeMigrations } from "./_internal/applyInitiativeMigrations";
-import { combineQueries } from "../search/_internal/combineQueries";
+import { combineQueries } from "../search/combineQueries";
 import { getTypeWithKeywordQuery } from "../associations/internal/getTypeWithKeywordQuery";
 import { negateGroupPredicates } from "../search/negateGroupPredicates";
 import { computeLinks } from "./_internal/computeLinks";

--- a/packages/common/src/metrics/resolveMetric.ts
+++ b/packages/common/src/metrics/resolveMetric.ts
@@ -13,7 +13,7 @@ import type { IItem } from "@esri/arcgis-rest-portal";
 import type { IStatisticDefinition } from "@esri/arcgis-rest-feature-service";
 import { getProp } from "../objects/get-prop";
 import { IPredicate, IQuery } from "../search/types/IHubCatalog";
-import { combineQueries } from "../search/_internal/combineQueries";
+import { combineQueries } from "../search/combineQueries";
 import { IHubSearchOptions } from "../search/types/IHubSearchOptions";
 import { portalSearchItemsAsItems } from "../search/_internal/portalSearchItems";
 

--- a/packages/common/src/search/combineQueries.ts
+++ b/packages/common/src/search/combineQueries.ts
@@ -1,4 +1,4 @@
-import { IQuery } from "../types/IHubCatalog";
+import { IQuery } from "./types/IHubCatalog";
 
 /**
  * @internal

--- a/packages/common/src/search/index.ts
+++ b/packages/common/src/search/index.ts
@@ -7,3 +7,4 @@ export * from "./upgradeCatalogSchema";
 export * from "./utils";
 export * from "./wellKnownCatalog";
 export * from "./searchAssociatedContent";
+export * from "./combineQueries";

--- a/packages/common/src/search/types/IHubCatalog.ts
+++ b/packages/common/src/search/types/IHubCatalog.ts
@@ -197,19 +197,15 @@ export interface IGalleryDisplayConfig {
     | "compact"
     | "grid-filled";
   /**  Gallery layout options to expose in the layout switcher */
-  layouts?: Array<{
-    key:
-      | "list"
-      | "grid"
-      | "map"
-      | "table"
-      | "calendar"
-      | "compact"
-      | "grid-filled";
-    label?: string;
-    description?: string;
-    hidden?: boolean;
-  }>;
+  layouts?: Array<
+    | "list"
+    | "grid"
+    | "map"
+    | "table"
+    | "calendar"
+    | "compact"
+    | "grid-filled"
+  >;
   /** header tag for the gallery card titles - needed for a11y */
   cardTitleTag?: CARD_TITLE_TAGS;
   /** Type of media to render in the layout card */

--- a/packages/common/src/search/types/IHubCatalog.ts
+++ b/packages/common/src/search/types/IHubCatalog.ts
@@ -187,6 +187,7 @@ export interface IGalleryDisplayConfig {
    * If this is true on a collection's display config, that collection will not be shown in the gallery.
    */
   hidden?: boolean;
+  /** default layout */
   layout?:
     | "list"
     | "grid"
@@ -195,12 +196,43 @@ export interface IGalleryDisplayConfig {
     | "calendar"
     | "compact"
     | "grid-filled";
+  /**  Gallery layout options to expose in the layout switcher */
+  layouts?: Array<{
+    key:
+      | "list"
+      | "grid"
+      | "map"
+      | "table"
+      | "calendar"
+      | "compact"
+      | "grid-filled";
+    label?: string;
+    description?: string;
+    hidden?: boolean;
+  }>;
+  /** header tag for the gallery card titles - needed for a11y */
   cardTitleTag?: CARD_TITLE_TAGS;
+  /** Type of media to render in the layout card */
+  imageType?: "thumbnail" | "icon";
+  /**
+   * Indicates whether the card render show a thumbnail.
+   * "grid" means the card will only render a thumbnail
+   * if the layout is set to "grid"
+   */
   showThumbnail?: "show" | "hide" | "grid";
+  /** card corner appearance */
   corners?: CORNERS;
+  /** card drop shadow */
   shadow?: DROP_SHADOWS;
+  /**
+   * whether to show a button on the gallery card linking
+   * out to the content - redundant with the title link,
+   * but it's currently supported/desired
+   */
   showLinkButton?: boolean;
+  /** button style if showLinkButton = true */
   linkButtonStyle?: "solid" | "outline" | "outline-fill" | "transparent";
+  /** button text rendered if showLinkButton = true */
   linkButtonText?: string;
   sort?: "relevance" | "title" | "created" | "modified";
   filters?: Array<{

--- a/packages/common/src/utils/internal/resolveItemQueryValues.ts
+++ b/packages/common/src/utils/internal/resolveItemQueryValues.ts
@@ -8,7 +8,7 @@ import { getProp } from "../../objects/get-prop";
 import { IQuery } from "../../search/types/IHubCatalog";
 import { IHubSearchOptions } from "../../search/types/IHubSearchOptions";
 
-import { combineQueries } from "../../search/_internal/combineQueries";
+import { combineQueries } from "../../search/combineQueries";
 import { portalSearchItemsAsItems } from "../../search/_internal/portalSearchItems";
 import { aggregateValues } from "./aggregateValues";
 import { memoize } from "../memoize";

--- a/packages/common/test/search/combineQueries.test.ts
+++ b/packages/common/test/search/combineQueries.test.ts
@@ -1,5 +1,5 @@
-import { combineQueries } from "../../../src/search/_internal/combineQueries";
-import { cloneObject, IQuery } from "../../../src";
+import { combineQueries } from "../../src/search/combineQueries";
+import { cloneObject, IQuery } from "../../src";
 const harnessQueries: IQuery[] = [
   {
     targetEntity: "item",
@@ -60,7 +60,7 @@ describe("combineQueries:", () => {
     try {
       combineQueries(qrys);
     } catch (err) {
-      expect(err.message).toEqual(
+      expect((err as any).message).toEqual(
         "Cannot combine queries for different entity types"
       );
     }


### PR DESCRIPTION
- [12732](https://devtopia.esri.com/dc/hub/issues/12732)

### Description
- expose and export the `combineQueries` util for consumption in `opendata-ui`
- additions to `IGalleryDisplayConfig` and `GalleryDisplayConfigSchema` for `layouts` and `imageType` 

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.