### PR TITLE
feat(hub-common): deprecate GET /events

### DIFF
--- a/packages/common/src/events/api/events.ts
+++ b/packages/common/src/events/api/events.ts
@@ -3,7 +3,6 @@ import {
   IPagedEventResponse,
   ICreateEventParams,
   IGetEventParams,
-  IGetEventsParams,
   IUpdateEventParams,
   IDeleteEventParams,
   ISearchEventsParams,
@@ -11,7 +10,6 @@ import {
 import { authenticateRequest } from "./utils/authenticate-request";
 import {
   createEvent as _createEvent,
-  getEvents as _getEvents,
   searchEvents as _searchEvents,
   getEvent as _getEvent,
   updateEvent as _updateEvent,
@@ -29,20 +27,6 @@ export async function createEvent(
 ): Promise<IEvent> {
   options.token = await authenticateRequest(options);
   return _createEvent(options.data, options);
-}
-
-/**
- * get events
- * @deprecated use searchEvents instead
- *
- * @param {IGetEventsParams} options
- * @return {Promise<IPagedEventResponse>}
- */
-export async function getEvents(
-  options: IGetEventsParams
-): Promise<IPagedEventResponse> {
-  options.token = await authenticateRequest(options);
-  return _getEvents(options.data, options);
 }
 
 /**

--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -7,176 +7,6 @@
  */
 import { customClient } from "../custom-client";
 import { Awaited } from "../awaited-type";
-export type GetRegistrationsParams = {
-  /**
-   * Event id being registered for
-   */
-  eventId?: string;
-  /**
-   * ArcGIS Online id for a user
-   */
-  userId?: string;
-  /**
-   * comma separated string list of registration roles
-   */
-  role?: string;
-  /**
-   * comma separated string list of registration statuses
-   */
-  status?: string;
-  /**
-   * comma separated string list of registration types
-   */
-  type?: string;
-  /**
-   * latest ISO8601 updatedAt for the registrations
-   */
-  updatedAtBefore?: string;
-  /**
-   * earliest ISO8601 updatedAt for the registrations
-   */
-  updatedAtAfter?: string;
-  /**
-   * filter to be matched to firstName, lastName, or username
-   */
-  name?: string;
-  /**
-   * the max amount of registrations to return
-   */
-  num?: string;
-  /**
-   * the index to start at
-   */
-  start?: string;
-  /**
-   * property to sort results by
-   */
-  sortBy?: RegistrationSort;
-  /**
-   * sort order desc or asc
-   */
-  sortOrder?: EventSortOrder;
-};
-
-export type GetEventsParams = {
-  /**
-   * Comma separated string list of EventAccess. Example: PRIVATE,ORG,PUBLIC
-   */
-  access?: string;
-  /**
-   * Comma separated string list of AttendanceTypes. Example:  VIRTUAL,IN_PERSON
-   */
-  attendanceTypes?: string;
-  /**
-   * boolean to filter events that can be edited by the user
-   */
-  canEdit?: string;
-  /**
-   * Comma separated string list of categories
-   */
-  categories?: string;
-  /**
-   * Comma separated string list of createdByIds
-   */
-  createdByIds?: string;
-  /**
-   * Comma separated string list of edit groupIds
-   */
-  editGroups?: string;
-  /**
-   * earliest ISO8601 end date-time for the events
-   */
-  endDateTimeAfter?: string;
-  /**
-   * latest ISO8601 end date-time for the events
-   */
-  endDateTimeBefore?: string;
-  /**
-   * Comma separated string list of associated entityIds
-   */
-  entityIds?: string;
-  /**
-   * Comma separated string list of associated entity types. Example: Hub Site Application,Hub Initiative,Hub Project
-   */
-  entityTypes?: string;
-  /**
-   * Comma separated string list of event ids
-   */
-  eventIds?: string;
-  /**
-   * JSON stringified esri geometry object
-   */
-  geometry?: string;
-  /**
-   * Comma separated string list of relation fields to include in response. Example: associations,creator,location,onlineMeeting,registrations
-   */
-  include?: string;
-  /**
-   * orgId string
-   */
-  orgId?: string;
-  /**
-   * the max amount of events to return
-   */
-  num?: string;
-  /**
-   * Comma separated string list of read groupIds
-   */
-  readGroups?: string;
-  /**
-   * Comma separated string list of shared groupIds
-   */
-  sharedToGroups?: string;
-  /**
-   * Event property to sort results by
-   */
-  sortBy?: EventSort;
-  /**
-   * sort results order desc or asc
-   */
-  sortOrder?: EventSortOrder;
-  /**
-   * the index to start at
-   */
-  start?: string;
-  /**
-   * earliest ISO8601 start date-time for the events
-   */
-  startDateTimeAfter?: string;
-  /**
-   * latest ISO8601 start date-time for the events
-   */
-  startDateTimeBefore?: string;
-  /**
-   * comma separated string list of event statuses. Example: PLANNED,CANCELED,REMOVED
-   */
-  status?: string;
-  /**
-   * Comma separated string list of tags
-   */
-  tags?: string;
-  /**
-   * string to match within an event title
-   */
-  title?: string;
-  /**
-   * earliest ISO8601 updatedAt for the events
-   */
-  updatedAtAfter?: string;
-  /**
-   * latest ISO8601 updatedAt for the events
-   */
-  updatedAtBefore?: string;
-  /**
-   * Comma separated string list of edit groupIds that event is not shared to
-   */
-  withoutEditGroups?: string;
-  /**
-   * Comma separated string list of read groupIds that event is not shared to
-   */
-  withoutReadGroups?: string;
-};
-
 export interface IUpdateRegistration {
   /** Role of the user in the event */
   role?: RegistrationRole;
@@ -305,11 +135,78 @@ export interface IUpdateEvent {
   title?: string;
 }
 
+export interface IPagedEventResponse {
+  items: IEvent[];
+  nextStart: number;
+  total: number;
+}
+
 /**
  * esri geometry object
  */
 export type ISearchEventsGeometry = { [key: string]: unknown };
 
+export enum EventSortOrder {
+  asc = "asc",
+  desc = "desc",
+}
+export type GetRegistrationsParams = {
+  /**
+   * Event id being registered for
+   */
+  eventId?: string;
+  /**
+   * ArcGIS Online id for a user
+   */
+  userId?: string;
+  /**
+   * comma separated string list of registration roles
+   */
+  role?: string;
+  /**
+   * comma separated string list of registration statuses
+   */
+  status?: string;
+  /**
+   * comma separated string list of registration types
+   */
+  type?: string;
+  /**
+   * latest ISO8601 updatedAt for the registrations
+   */
+  updatedAtBefore?: string;
+  /**
+   * earliest ISO8601 updatedAt for the registrations
+   */
+  updatedAtAfter?: string;
+  /**
+   * filter to be matched to firstName, lastName, or username
+   */
+  name?: string;
+  /**
+   * the max amount of registrations to return
+   */
+  num?: string;
+  /**
+   * the index to start at
+   */
+  start?: string;
+  /**
+   * property to sort results by
+   */
+  sortBy?: RegistrationSort;
+  /**
+   * sort order desc or asc
+   */
+  sortOrder?: EventSortOrder;
+};
+
+export enum EventSort {
+  title = "title",
+  startDateTime = "startDateTime",
+  createdAt = "createdAt",
+  updatedAt = "updatedAt",
+}
 export enum GetEventsInclude {
   associations = "associations",
   creator = "creator",
@@ -320,22 +217,6 @@ export enum GetEventsInclude {
 export enum EventsSearchFormat {
   csv = "csv",
   json = "json",
-}
-export interface IPagedEventResponse {
-  items: IEvent[];
-  nextStart: number;
-  total: number;
-}
-
-export enum EventSortOrder {
-  asc = "asc",
-  desc = "desc",
-}
-export enum EventSort {
-  title = "title",
-  startDateTime = "startDateTime",
-  createdAt = "createdAt",
-  updatedAt = "updatedAt",
 }
 export interface ISearchEvents {
   /** Array of EventAccess. Example: PRIVATE,ORG,PUBLIC */
@@ -765,19 +646,6 @@ export const createEvent = (
 };
 
 /**
- * Get a list of events matching request criteria.
- */
-export const getEvents = (
-  params?: GetEventsParams,
-  options?: SecondParameter<typeof customClient>
-) => {
-  return customClient<IPagedEventResponse>(
-    { url: `/api/events/v1/events`, method: "GET", params },
-    options
-  );
-};
-
-/**
  * Search for events matching request criteria.
  */
 export const searchEvents = (
@@ -918,9 +786,6 @@ export const deleteRegistration = (
 
 export type CreateEventResult = NonNullable<
   Awaited<ReturnType<typeof createEvent>>
->;
-export type GetEventsResult = NonNullable<
-  Awaited<ReturnType<typeof getEvents>>
 >;
 export type SearchEventsResult = NonNullable<
   Awaited<ReturnType<typeof searchEvents>>

--- a/packages/common/src/events/api/types.ts
+++ b/packages/common/src/events/api/types.ts
@@ -3,7 +3,6 @@ export {
   EventAccess,
   EventAttendanceType,
   EventStatus,
-  GetEventsParams,
   ISearchEvents,
   IEventAssociation,
   ICreateEventAssociation,
@@ -40,7 +39,6 @@ import { IHubRequestOptions } from "../../hub-types";
 import {
   ICreateEvent,
   IUpdateEvent,
-  GetEventsParams,
   ISearchEvents,
   ICreateRegistration,
   IUpdateRegistration,
@@ -67,9 +65,6 @@ export interface IEventsRequestOptions
 
 export interface ICreateEventParams extends IEventsRequestOptions {
   data: ICreateEvent;
-}
-export interface IGetEventsParams extends IEventsRequestOptions {
-  data: GetEventsParams;
 }
 export interface ISearchEventsParams extends IEventsRequestOptions {
   data: ISearchEvents;

--- a/packages/common/src/search/_internal/commonHelpers/getApi.ts
+++ b/packages/common/src/search/_internal/commonHelpers/getApi.ts
@@ -35,7 +35,7 @@ export function getApi(
     result = getDiscussionsApiDefinition();
   } else if (shouldUseEventsApi(targetEntity, options)) {
     // Currently, url is null because this is handled internally by the
-    // events request method called by getEvents, which relies on
+    // events request method called by searchEvents, which relies on
     // the URL defined in the request options.hubApiUrl
     result = { type: "arcgis-hub", url: null };
   } else if (shouldUseOgcApi(targetEntity, options)) {

--- a/packages/common/test/events/api/events.test.ts
+++ b/packages/common/test/events/api/events.test.ts
@@ -2,12 +2,10 @@ import {
   ICreateEventParams,
   IDeleteEventParams,
   IGetEventParams,
-  IGetEventsParams,
   IUpdateEventParams,
   createEvent,
   deleteEvent,
   getEvent,
-  getEvents,
   searchEvents,
   updateEvent,
   IEvent,
@@ -109,35 +107,6 @@ describe("Events", () => {
 
       expect(authenticateRequestSpy).toHaveBeenCalledWith(options);
       expect(getEventSpy).toHaveBeenCalledWith(options.eventId, {
-        ...options,
-        token,
-      });
-    });
-  });
-
-  describe("getEvents", () => {
-    it("should get events", async () => {
-      const mockEvent = { burrito: "supreme" } as unknown as IEvent;
-      const pagedResponse = {
-        total: 1,
-        nextStart: 2,
-        items: [mockEvent],
-      };
-      const getEventsSpy = spyOn(orvalModule, "getEvents").and.callFake(
-        async () => pagedResponse
-      );
-
-      const options: IGetEventsParams = {
-        data: {
-          startDateTimeBefore: "2024-02-19T21:52:29.525Z",
-        },
-      };
-
-      const result = await getEvents(options);
-      expect(result).toEqual(pagedResponse);
-
-      expect(authenticateRequestSpy).toHaveBeenCalledWith(options);
-      expect(getEventsSpy).toHaveBeenCalledWith(options.data, {
         ...options,
         token,
       });

--- a/packages/common/test/search/_internal/hubSearchEventAttendees.test.ts
+++ b/packages/common/test/search/_internal/hubSearchEventAttendees.test.ts
@@ -225,10 +225,9 @@ describe("hubSearchEventAttendees", () => {
         await results2.next();
         fail("did not reject");
       } catch (e) {
-        expect(1).toEqual(2);
-        // expect(e.message).toEqual(
-        //  "No more hub events for the given query and options"
-        // );
+        expect((e as any).message).toEqual(
+          "No more hub events for the given query and options"
+        );
       }
     });
   });

--- a/packages/common/test/search/_internal/hubSearchEventAttendees.test.ts
+++ b/packages/common/test/search/_internal/hubSearchEventAttendees.test.ts
@@ -189,18 +189,15 @@ describe("hubSearchEventAttendees", () => {
         "processOptionsSpy.calls.argsFor(1)"
       );
       expect(getRegistrationsSpy).toHaveBeenCalledTimes(2);
-      expect(getRegistrationsSpy.calls.argsFor(1)).toEqual(
-        [
-          {
-            ...options2.requestOptions,
-            data: {
-              ...processedFilters,
-              ...processedOptions2,
-            },
+      expect(getRegistrationsSpy.calls.argsFor(1)).toEqual([
+        {
+          ...options2.requestOptions,
+          data: {
+            ...processedFilters,
+            ...processedOptions2,
           },
-        ],
-        "getEventsSpy.calls.argsFor(1)"
-      );
+        },
+      ]);
       expect(eventAttendeeToSearchResultSpy).toHaveBeenCalledTimes(4);
       expect(eventAttendeeToSearchResultSpy.calls.argsFor(2)).toEqual(
         [PAGE_2.items[0], options2],
@@ -228,9 +225,10 @@ describe("hubSearchEventAttendees", () => {
         await results2.next();
         fail("did not reject");
       } catch (e) {
-        expect(e.message).toEqual(
-          "No more hub events for the given query and options"
-        );
+        expect(1).toEqual(2);
+        // expect(e.message).toEqual(
+        //  "No more hub events for the given query and options"
+        // );
       }
     });
   });


### PR DESCRIPTION
1. Description: orval update for the deprecations of `GET /events` from the events api. An earlier ticket refactored hub search to use `searchEvents` instead

[Related hub-engagement pr](https://github.com/ArcGIS/hub-engagement/pull/214)
1. Issue: #12232 (https://zentopia.esri.com/workspaces/sprint-board-60340b9721bc3a4ab6367db5/issues/gh/dc/hub/12232)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
