### PR TITLE
feat(hub-common): add interface IChannelAclUpdateDefinition

### DIFF
--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -776,6 +776,17 @@ export interface IChannelAclPermissionDefinition {
  * request option for updating a channel ACL permission
  *
  * @export
+ * @interface IChannelAclUpdateDefinition
+ */
+export interface IChannelAclUpdateDefinition
+  extends IChannelAclPermissionDefinition {
+  id?: string;
+}
+
+/**
+ * request option for updating a channel ACL permission
+ *
+ * @export
  * @interface IChannelAclPermissionUpdateDefinition
  * @extends {IChannelAclPermissionDefinition}
  */
@@ -896,7 +907,7 @@ export interface IUpdateChannelPermissions {
  * @interface IUpdateChannelPermissionsV2
  */
 export interface IUpdateChannelPermissionsV2 {
-  channelAclDefinition?: IChannelAclPermissionDefinition[];
+  channelAclDefinition?: IChannelAclUpdateDefinition[];
 }
 
 /**


### PR DESCRIPTION
affects: @esri/hub-common

Allow optional channel acl id to be passed in on channel update

1. Description: add interface `IChannelAclUpdateDefinition`, used on channel update. This interface allows an optional `id` property, if passing in existing channel acls

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
