### PR TITLE
feat(hub-common): ungate the hub:site:workspace:catalog permission, remove deprecated hub:site:workspace:content permission

### DIFF
--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -166,6 +166,8 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:site:workspace:catalog:events",
     licenses: ["hub-premium"],
     dependencies: ["hub:site:workspace:catalog", "hub:event"],
+    environments: ["qaext"],
+    availability: ["alpha"],
   },
   {
     permission: "hub:site:workspace:pages",

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -35,8 +35,6 @@ export const SitePermissions = [
   "hub:site:workspace:details",
   "hub:site:workspace:settings",
   "hub:site:workspace:collaborators",
-  // DEPRECATED - use hub:site:workspace:catalog instead
-  "hub:site:workspace:content",
   "hub:site:workspace:catalog",
   "hub:site:workspace:catalog:content",
   "hub:site:workspace:catalog:events",
@@ -156,20 +154,9 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:site:workspace:collaborators",
     dependencies: ["hub:site:workspace", "hub:site:edit"],
   },
-  // DEPRECATED - use hub:site:workspace:catalog instead
-  // NOTE: this is still used in opendata-ui as of 03/26/2025
-  // TODO: remove in next breaking change
-  {
-    permission: "hub:site:workspace:content",
-    dependencies: ["hub:site:workspace", "hub:site:edit"],
-  },
   {
     permission: "hub:site:workspace:catalog",
-    dependencies: [
-      "hub:site:workspace",
-      "hub:feature:catalogs",
-      "hub:site:edit",
-    ],
+    dependencies: ["hub:site:workspace", "hub:site:edit"],
   },
   {
     permission: "hub:site:workspace:catalog:content",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
part of [12251](https://devtopia.esri.com/dc/hub/issues/12251)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
