### PR TITLE
fix: properly prefix slug with orgUrlKey; fallback to looking for ite…

### DIFF
--- a/packages/common/src/items/_internal/ensureUniqueEntitySlug.ts
+++ b/packages/common/src/items/_internal/ensureUniqueEntitySlug.ts
@@ -1,12 +1,19 @@
 import { IHubItemEntity } from "../../core";
 import { IHubRequestOptions } from "../../hub-types";
 import { getUniqueSlug, setSlugKeyword } from "../slugs";
+import { truncateSlug } from "./slugs";
 
 // NOTE: this mutates the entity that is passed in
 export const ensureUniqueEntitySlug = async (
   entity: IHubItemEntity,
   requestOptions: IHubRequestOptions
 ): Promise<IHubItemEntity> => {
+  // if we got the entity from the entity editor, the slug will already have the orgUrlKey prefix
+  // but it might not have been edited with the entity editor...
+  // ie a dev might have just set the slug to "my-slug" and not "org|my-slug" (like i did)
+  if (entity.slug && !entity.slug.startsWith(`${entity.orgUrlKey}|`)) {
+    entity.slug = truncateSlug(entity.slug, entity.orgUrlKey);
+  }
   // verify that the slug is unique
   const { id: existingId, slug } = entity;
   const slugInfo = existingId ? { slug, existingId } : { slug };

--- a/packages/common/src/items/fetch.ts
+++ b/packages/common/src/items/fetch.ts
@@ -24,19 +24,33 @@ export function fetchItem(
   requestOptions: IFetchItemOptions
 ): Promise<IItem> {
   const { id, slug, orgKey } = parseIdentifier(identifier);
+
   if (id) {
     // use the id to fetch the item
     return getItem(id, requestOptions);
   }
+
   // we'll have to look up by slug
   // first, ensure the slug has the org key
   const fullyQualifiedSlug = addContextToSlug(
     slug,
     orgKey || requestOptions.siteOrgKey
   );
+
   const slugKeyword = uriSlugToKeywordSlug(fullyQualifiedSlug);
-  return findItemsBySlug({ slug: slugKeyword }, requestOptions).then(
-    (results) => {
+
+  return findItemsBySlug({ slug: slugKeyword }, requestOptions)
+    .then((results) => {
+      if (results.length) {
+        return results;
+      } else {
+        // we had a bug where page slugs could have been stored without the org url key prefix
+        // we decided to fall back to looking for them without the prefix
+        const slugWithoutOrgKey = slugKeyword.split("|").slice(1).join("|");
+        return findItemsBySlug({ slug: slugWithoutOrgKey }, requestOptions);
+      }
+    })
+    .then((results) => {
       if (results.length) {
         // search results only include a subset of properties of the item, so
         // issue a subsequent call to getItem to get the full item details
@@ -44,6 +58,5 @@ export function fetchItem(
       } else {
         return null;
       }
-    }
-  );
+    });
 }

--- a/packages/common/test/discussions/edit.test.ts
+++ b/packages/common/test/discussions/edit.test.ts
@@ -289,7 +289,7 @@ describe("discussions edit:", () => {
   describe("updateDiscussion: ", () => {
     it("updates backing model and creates settings if none exist", async () => {
       const slugSpy = spyOn(slugUtils, "getUniqueSlug").and.returnValue(
-        Promise.resolve("dcdev-wat-blarg-1")
+        Promise.resolve("dcdev|dcdev-wat-blarg-1")
       );
       const getModelSpy = spyOn(modelUtils, "getModel").and.returnValue(
         Promise.resolve(DISCUSSION_MODEL)
@@ -343,7 +343,7 @@ describe("discussions edit:", () => {
       // should ensure unique slug
       expect(slugSpy.calls.count()).toBe(1);
       expect(slugSpy.calls.argsFor(0)[0]).toEqual(
-        { slug: "dcdev-wat-blarg", existingId: GUID },
+        { slug: "dcdev|dcdev-wat-blarg", existingId: GUID },
         "should receive slug"
       );
       expect(getModelSpy.calls.count()).toBe(1);
@@ -364,11 +364,13 @@ describe("discussions edit:", () => {
         ...requestOptions,
       });
       expect(modelToUpdate.item.description).toBe(disc.description);
-      expect(modelToUpdate.item.properties.slug).toBe("dcdev-wat-blarg-1");
+      expect(modelToUpdate.item.properties.slug).toBe(
+        "dcdev|dcdev-wat-blarg-1"
+      );
     });
     it("updates backing model and updates settings when settings id exists", async () => {
       const slugSpy = spyOn(slugUtils, "getUniqueSlug").and.returnValue(
-        Promise.resolve("dcdev-wat-blarg-1")
+        Promise.resolve("dcdev|dcdev-wat-blarg-1")
       );
       const getModelSpy = spyOn(modelUtils, "getModel").and.returnValue(
         Promise.resolve(DISCUSSION_MODEL)
@@ -434,7 +436,7 @@ describe("discussions edit:", () => {
       // should ensure unique slug
       expect(slugSpy.calls.count()).toBe(1);
       expect(slugSpy.calls.argsFor(0)[0]).toEqual(
-        { slug: "dcdev-wat-blarg", existingId: GUID },
+        { slug: "dcdev|dcdev-wat-blarg", existingId: GUID },
         "should receive slug"
       );
       expect(getModelSpy.calls.count()).toBe(1);
@@ -454,12 +456,14 @@ describe("discussions edit:", () => {
       });
       const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
       expect(modelToUpdate.item.description).toBe(disc.description);
-      expect(modelToUpdate.item.properties.slug).toBe("dcdev-wat-blarg-1");
+      expect(modelToUpdate.item.properties.slug).toBe(
+        "dcdev|dcdev-wat-blarg-1"
+      );
     });
     describe("allowedLocations", () => {
       it("processes locations and persists them to settings", async () => {
         const slugSpy = spyOn(slugUtils, "getUniqueSlug").and.returnValue(
-          Promise.resolve("dcdev-wat-blarg-1")
+          Promise.resolve("dcdev|dcdev-wat-blarg-1")
         );
         const getModelSpy = spyOn(modelUtils, "getModel").and.returnValue(
           Promise.resolve(DISCUSSION_MODEL)
@@ -522,7 +526,7 @@ describe("discussions edit:", () => {
         // should ensure unique slug
         expect(slugSpy.calls.count()).toBe(1);
         expect(slugSpy.calls.argsFor(0)[0]).toEqual(
-          { slug: "dcdev-wat-blarg", existingId: GUID },
+          { slug: "dcdev|dcdev-wat-blarg", existingId: GUID },
           "should receive slug"
         );
         expect(getModelSpy.calls.count()).toBe(1);
@@ -530,7 +534,9 @@ describe("discussions edit:", () => {
         expect(updateSettingsSpy.calls.count()).toBe(1);
         const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
         expect(modelToUpdate.item.description).toBe(disc.description);
-        expect(modelToUpdate.item.properties.slug).toBe("dcdev-wat-blarg-1");
+        expect(modelToUpdate.item.properties.slug).toBe(
+          "dcdev|dcdev-wat-blarg-1"
+        );
         // should transform location and persist to settings
         expect(arcgisToGeoJSONSpy.calls.count()).toBe(1);
         const settingsToUpdate = updateSettingsSpy.calls.argsFor(0)[0];
@@ -540,7 +546,7 @@ describe("discussions edit:", () => {
       });
       it("processes locations of type = 'none' and persists them to settings", async () => {
         const slugSpy = spyOn(slugUtils, "getUniqueSlug").and.returnValue(
-          Promise.resolve("dcdev-wat-blarg-1")
+          Promise.resolve("dcdev|dcdev-wat-blarg-1")
         );
         const getModelSpy = spyOn(modelUtils, "getModel").and.returnValue(
           Promise.resolve(DISCUSSION_MODEL)
@@ -602,7 +608,7 @@ describe("discussions edit:", () => {
         // should ensure unique slug
         expect(slugSpy.calls.count()).toBe(1);
         expect(slugSpy.calls.argsFor(0)[0]).toEqual(
-          { slug: "dcdev-wat-blarg", existingId: GUID },
+          { slug: "dcdev|dcdev-wat-blarg", existingId: GUID },
           "should receive slug"
         );
         expect(getModelSpy.calls.count()).toBe(1);
@@ -610,7 +616,9 @@ describe("discussions edit:", () => {
         expect(updateSettingsSpy.calls.count()).toBe(1);
         const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
         expect(modelToUpdate.item.description).toBe(disc.description);
-        expect(modelToUpdate.item.properties.slug).toBe("dcdev-wat-blarg-1");
+        expect(modelToUpdate.item.properties.slug).toBe(
+          "dcdev|dcdev-wat-blarg-1"
+        );
         // should transform location and persist to settings
         expect(arcgisToGeoJSONSpy.calls.count()).toBe(0);
         const settingsToUpdate = updateSettingsSpy.calls.argsFor(0)[0];
@@ -620,7 +628,7 @@ describe("discussions edit:", () => {
       });
       it("processes locations and handles error if thrown", async () => {
         const slugSpy = spyOn(slugUtils, "getUniqueSlug").and.returnValue(
-          Promise.resolve("dcdev-wat-blarg-1")
+          Promise.resolve("dcdev|dcdev-wat-blarg-1")
         );
         const getModelSpy = spyOn(modelUtils, "getModel").and.returnValue(
           Promise.resolve(DISCUSSION_MODEL)
@@ -686,7 +694,7 @@ describe("discussions edit:", () => {
         // should ensure unique slug
         expect(slugSpy.calls.count()).toBe(1);
         expect(slugSpy.calls.argsFor(0)[0]).toEqual(
-          { slug: "dcdev-wat-blarg", existingId: GUID },
+          { slug: "dcdev|dcdev-wat-blarg", existingId: GUID },
           "should receive slug"
         );
         expect(getModelSpy.calls.count()).toBe(1);
@@ -694,7 +702,9 @@ describe("discussions edit:", () => {
         expect(updateSettingsSpy.calls.count()).toBe(1);
         const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
         expect(modelToUpdate.item.description).toBe(disc.description);
-        expect(modelToUpdate.item.properties.slug).toBe("dcdev-wat-blarg-1");
+        expect(modelToUpdate.item.properties.slug).toBe(
+          "dcdev|dcdev-wat-blarg-1"
+        );
         // should transform location and persist to settings
         expect(arcgisToGeoJSONSpy.calls.count()).toBe(1);
         const settingsToUpdate = updateSettingsSpy.calls.argsFor(0)[0];

--- a/packages/common/test/initiative-templates/edit.test.ts
+++ b/packages/common/test/initiative-templates/edit.test.ts
@@ -120,7 +120,7 @@ describe("initiative template edit module:", () => {
   describe("updateInitiativeTemplate: ", () => {
     it("updates backing model", async () => {
       const slugSpy = spyOn(slugUtils, "getUniqueSlug").and.returnValue(
-        Promise.resolve("dcdev-wat-blarg-1")
+        Promise.resolve("dcdev|dcdev-wat-blarg-1")
       );
       const getModelSpy = spyOn(modelUtils, "getModel").and.returnValue(
         Promise.resolve(INITIATIVE_TEMPLATE_MODEL)
@@ -169,7 +169,7 @@ describe("initiative template edit module:", () => {
       expect(chk.description).toBe("Some longer description");
       expect(chk.typeKeywords).toEqual([
         "Hub Initiative Template",
-        "slug|dcdev-wat-blarg-1",
+        "slug|dcdev|dcdev-wat-blarg-1",
         "cannotDiscuss",
       ]);
       expect(chk.location).toEqual({
@@ -183,14 +183,16 @@ describe("initiative template edit module:", () => {
       // should ensure unique slug
       expect(slugSpy.calls.count()).toBe(1);
       expect(slugSpy.calls.argsFor(0)[0]).toEqual(
-        { slug: "dcdev-wat-blarg", existingId: GUID },
+        { slug: "dcdev|dcdev-wat-blarg", existingId: GUID },
         "should recieve slug"
       );
       expect(getModelSpy.calls.count()).toBe(1);
       expect(updateModelSpy.calls.count()).toBe(1);
       const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
       expect(modelToUpdate.item.description).toBe(it.description);
-      expect(modelToUpdate.item.properties.slug).toBe("dcdev-wat-blarg-1");
+      expect(modelToUpdate.item.properties.slug).toBe(
+        "dcdev|dcdev-wat-blarg-1"
+      );
     });
   });
 });

--- a/packages/common/test/initiatives/HubInitiatives.test.ts
+++ b/packages/common/test/initiatives/HubInitiatives.test.ts
@@ -295,7 +295,7 @@ describe("HubInitiatives:", () => {
   describe("updateInitiative: ", () => {
     it("updates backing model", async () => {
       const slugSpy = spyOn(slugUtils, "getUniqueSlug").and.returnValue(
-        Promise.resolve("dcdev-wat-blarg-1")
+        Promise.resolve("dcdev|dcdev-wat-blarg-1")
       );
       const getModelSpy = spyOn(modelUtils, "getModel").and.returnValue(
         Promise.resolve(INITIATIVE_MODEL)
@@ -338,14 +338,16 @@ describe("HubInitiatives:", () => {
       // should ensure unique slug
       expect(slugSpy.calls.count()).toBe(1);
       expect(slugSpy.calls.argsFor(0)[0]).toEqual(
-        { slug: "dcdev-wat-blarg", existingId: GUID },
+        { slug: "dcdev|dcdev-wat-blarg", existingId: GUID },
         "should recieve slug"
       );
       expect(getModelSpy.calls.count()).toBe(1);
       expect(updateModelSpy.calls.count()).toBe(1);
       const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
       expect(modelToUpdate.item.description).toBe(prj.description);
-      expect(modelToUpdate.item.properties.slug).toBe("dcdev-wat-blarg-1");
+      expect(modelToUpdate.item.properties.slug).toBe(
+        "dcdev|dcdev-wat-blarg-1"
+      );
     });
   });
 

--- a/packages/common/test/items/fetch.test.ts
+++ b/packages/common/test/items/fetch.test.ts
@@ -124,8 +124,9 @@ describe("fetchItem", () => {
       expect(result).toBeNull();
       expect(parseIdentifierSpy.calls.count()).toBe(1);
       expect(parseIdentifierSpy).toHaveBeenCalledWith(identifier);
-      expect(findItemsBySlugSpy.calls.count()).toBe(1);
+      expect(findItemsBySlugSpy.calls.count()).toBe(2);
       expect(findItemsBySlugSpy).toHaveBeenCalledWith(slugInfo, requestOptions);
+      expect(findItemsBySlugSpy).toHaveBeenCalledWith({ slug }, requestOptions);
       expect(getItemSpy.calls.count()).toBe(0);
     });
   });

--- a/packages/common/test/pages/HubPages.test.ts
+++ b/packages/common/test/pages/HubPages.test.ts
@@ -159,7 +159,7 @@ describe("HubPages Module", () => {
   describe("updatePage: ", () => {
     it("updates backing model", async () => {
       const slugSpy = spyOn(slugUtils, "getUniqueSlug").and.returnValue(
-        Promise.resolve("dcdev-wat-blarg-1")
+        Promise.resolve("dcdev|dcdev-wat-blarg-1")
       );
       const getModelSpy = spyOn(modelUtils, "getModel").and.returnValue(
         Promise.resolve(PAGE_MODEL)
@@ -197,14 +197,16 @@ describe("HubPages Module", () => {
       // should ensure unique slug
       expect(slugSpy.calls.count()).toBe(1);
       expect(slugSpy.calls.argsFor(0)[0]).toEqual(
-        { slug: "dcdev-wat-blarg", existingId: GUID },
+        { slug: "dcdev|dcdev-wat-blarg", existingId: GUID },
         "should recieve slug"
       );
       expect(getModelSpy.calls.count()).toBe(1);
       expect(updateModelSpy.calls.count()).toBe(1);
       const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
       expect(modelToUpdate.item.description).toBe(page.description);
-      expect(modelToUpdate.item.properties.slug).toBe("dcdev-wat-blarg-1");
+      expect(modelToUpdate.item.properties.slug).toBe(
+        "dcdev|dcdev-wat-blarg-1"
+      );
     });
   });
 

--- a/packages/common/test/projects/edit.test.ts
+++ b/packages/common/test/projects/edit.test.ts
@@ -128,7 +128,7 @@ describe("project edit module:", () => {
   describe("updateProject: ", () => {
     it("updates backing model", async () => {
       const slugSpy = spyOn(slugUtils, "getUniqueSlug").and.returnValue(
-        Promise.resolve("dcdev-wat-blarg-1")
+        Promise.resolve("dcdev|dcdev-wat-blarg-1")
       );
       const getModelSpy = spyOn(modelUtils, "getModel").and.returnValue(
         Promise.resolve(PROJECT_MODEL)
@@ -178,7 +178,7 @@ describe("project edit module:", () => {
       expect(chk.description).toBe("Some longer description");
       expect(chk.typeKeywords).toEqual([
         "Hub Project",
-        "slug|dcdev-wat-blarg-1",
+        "slug|dcdev|dcdev-wat-blarg-1",
         "status|inProgress",
         "cannotDiscuss",
       ]);
@@ -188,14 +188,16 @@ describe("project edit module:", () => {
       // should ensure unique slug
       expect(slugSpy.calls.count()).toBe(1);
       expect(slugSpy.calls.argsFor(0)[0]).toEqual(
-        { slug: "dcdev-wat-blarg", existingId: GUID },
+        { slug: "dcdev|dcdev-wat-blarg", existingId: GUID },
         "should recieve slug"
       );
       expect(getModelSpy.calls.count()).toBe(1);
       expect(updateModelSpy.calls.count()).toBe(1);
       const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
       expect(modelToUpdate.item.description).toBe(prj.description);
-      expect(modelToUpdate.item.properties.slug).toBe("dcdev-wat-blarg-1");
+      expect(modelToUpdate.item.properties.slug).toBe(
+        "dcdev|dcdev-wat-blarg-1"
+      );
     });
   });
   describe("editor to project", () => {

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -469,7 +469,7 @@ describe("HubSites:", () => {
 
       expect(chk.id).toBe(GUID);
       const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
-      expect(modelToUpdate.item.properties.slug).toBe("some-new-slug");
+      expect(modelToUpdate.item.properties.slug).toBe("dcdev|some-new-slug");
     });
     it("reflects collection changes to searchCategories", async () => {
       const updatedSite = commonModule.cloneObject(SITE);


### PR DESCRIPTION
…ms with slug typeKeyword lackin

affects: @esri/hub-common

This is for a hotfix release.

https://devtopia.esri.com/dc/hub/issues/13117
 
