### PR TITLE
feat(hub-common): ungate events pane in site workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54036,7 +54036,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "17.8.0",
+			"version": "17.10.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -54117,7 +54117,7 @@
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "17.1.0",
+			"version": "17.1.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -166,8 +166,6 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:site:workspace:catalog:events",
     licenses: ["hub-premium"],
     dependencies: ["hub:site:workspace:catalog", "hub:event"],
-    environments: ["qaext"],
-    availability: ["alpha"],
   },
   {
     permission: "hub:site:workspace:pages",


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 13197

1. Description:

1. Instructions for testing:

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/13197

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
