### PR TITLE
feat: log checkpermission failures with Logger

### DIFF
--- a/packages/common/src/permissions/checkPermission.ts
+++ b/packages/common/src/permissions/checkPermission.ts
@@ -21,6 +21,7 @@ import { PolicyResponse } from "./types/PolicyResponse";
 import { IPolicyCheck } from "./types/IPolicyCheck";
 import { IEntityPermissionPolicy } from "./types/IEntityPermissionPolicy";
 import { IUserHubSettings } from "../utils/IUserHubSettings";
+import { Logger } from "../utils";
 
 /**
  * Type to allow either an entity or and entity and label to be
@@ -47,6 +48,7 @@ export function checkPermission(
   context: IArcGISContext,
   entityOrOptions?: EntityOrOptions
 ): IPermissionAccessResponse {
+  const label = entityOrOptions?.label || "";
   const entity = entityOrOptions?.entity || entityOrOptions;
 
   // Is this even a valid permission?
@@ -58,7 +60,7 @@ export function checkPermission(
       code: getPolicyResponseCode("invalid-permission"),
       checks: [],
     } as IPermissionAccessResponse;
-    // logResponse(invalidPermissionResponse, label);
+    logResponse(invalidPermissionResponse, label);
     return invalidPermissionResponse;
   }
 
@@ -74,7 +76,7 @@ export function checkPermission(
       code: getPolicyResponseCode("no-policy-exists"),
       checks: [],
     } as IPermissionAccessResponse;
-    // logResponse(missingPolicyResponse, label);
+    logResponse(missingPolicyResponse, label);
     return missingPolicyResponse;
   }
 
@@ -144,7 +146,7 @@ export function checkPermission(
         },
       ],
     } as IPermissionAccessResponse;
-    // logResponse(disabledByFlagResponse, label);
+    logResponse(disabledByFlagResponse, label);
     return disabledByFlagResponse;
   }
 
@@ -240,20 +242,16 @@ export function checkPermission(
   }
 
   // log response
-  // logResponse(response, label);
+  logResponse(response, label);
 
   return response;
 }
 
-// function logResponse(response: IPermissionAccessResponse, label: string): void {
-//   if (!response.access && logPermissions) {
-//     // tslint:disable-next-line:no-console
-//     console.info(
-//       `checkPermission: ${label} ${response.policy} : ${response.response}`
-//     );
-//     // tslint:disable-next-line:no-console
-//     console.dir(response);
-//     // tslint:disable-next-line:no-console
-//     console.info(`-----------------------------------------`);
-//   }
-// }
+function logResponse(response: IPermissionAccessResponse, label: string): void {
+  if (!response.access) {
+    Logger.warn(
+      `checkPermission: ${label} ${response.policy} : ${response.response}`,
+      response
+    );
+  }
+}


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Reinstates logging of `checkPermission` failures via `Logger`.

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
