### PR TITLE
fix: configuration editor now allows an empty value for the slug field

### DIFF
--- a/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
+++ b/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
@@ -26,13 +26,29 @@ export const addDynamicSlugValidation = (
   _slug.maxLength = getSlugMaxLength(orgUrlKey);
   // add conditional validation to ensure slug is unique
   const allOf = cloneObject(schema.allOf) || [];
+
   const { pattern } = _slug;
+  // remove pattern from base schema so the form doesn't always apply the pattern
+  // validation. We will add it back to the allOf conditionally
+  delete _slug.pattern;
+
   const { id } = options as HubEntity;
-  allOf.push({
-    // only do async isUniqueSlug check if the slug is valid
-    if: { properties: { _slug: { pattern } } },
-    then: { properties: { _slug: { isUniqueSlug: { id, orgUrlKey } } as any } },
-  });
+
+  allOf.push(
+    {
+      // only enforce the pattern if slug has been entered
+      if: { properties: { _slug: { minLength: 1 } } },
+      then: { properties: { _slug: { pattern } } },
+    },
+    {
+      // only do async isUniqueSlug check if the slug is valid
+      if: { properties: { _slug: { pattern } } },
+      then: {
+        properties: { _slug: { isUniqueSlug: { id, orgUrlKey } } as any },
+      },
+    }
+  );
+
   const clone = cloneObject(schema);
   clone.properties._slug = _slug;
   clone.allOf = allOf;

--- a/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
+++ b/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
@@ -28,26 +28,16 @@ export const addDynamicSlugValidation = (
   const allOf = cloneObject(schema.allOf) || [];
 
   const { pattern } = _slug;
-  // remove pattern from base schema so the form doesn't always apply the pattern
-  // validation. We will add it back to the allOf conditionally
-  delete _slug.pattern;
 
   const { id } = options as HubEntity;
 
-  allOf.push(
-    {
-      // only enforce the pattern if slug has been entered
-      if: { properties: { _slug: { minLength: 1 } } },
-      then: { properties: { _slug: { pattern } } },
+  allOf.push({
+    // only do async isUniqueSlug check if the slug is valid
+    if: { properties: { _slug: { pattern } } },
+    then: {
+      properties: { _slug: { isUniqueSlug: { id, orgUrlKey } } as any },
     },
-    {
-      // only do async isUniqueSlug check if the slug is valid
-      if: { properties: { _slug: { pattern } } },
-      then: {
-        properties: { _slug: { isUniqueSlug: { id, orgUrlKey } } as any },
-      },
-    }
-  );
+  });
 
   const clone = cloneObject(schema);
   clone.properties._slug = _slug;

--- a/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
+++ b/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
@@ -28,16 +28,26 @@ export const addDynamicSlugValidation = (
   const allOf = cloneObject(schema.allOf) || [];
 
   const { pattern } = _slug;
+  // remove pattern from base schema so the form doesn't always apply the pattern
+  // validation. We will add it back to the allOf conditionally
+  delete _slug.pattern;
 
   const { id } = options as HubEntity;
 
-  allOf.push({
-    // only do async isUniqueSlug check if the slug is valid
-    if: { properties: { _slug: { pattern } } },
-    then: {
-      properties: { _slug: { isUniqueSlug: { id, orgUrlKey } } as any },
+  allOf.push(
+    {
+      // only enforce the pattern if slug has been entered
+      if: { properties: { _slug: { minLength: 1 } } },
+      then: { properties: { _slug: { pattern } } },
     },
-  });
+    {
+      // only do async isUniqueSlug check if the slug is valid
+      if: { properties: { _slug: { pattern } } },
+      then: {
+        properties: { _slug: { isUniqueSlug: { id, orgUrlKey } } as any },
+      },
+    }
+  );
 
   const clone = cloneObject(schema);
   clone.properties._slug = _slug;

--- a/packages/common/src/core/schemas/internal/metrics/editorToEntity.ts
+++ b/packages/common/src/core/schemas/internal/metrics/editorToEntity.ts
@@ -30,6 +30,10 @@ export function editorToEntity(
   if (_slug) {
     // ensure the slug is truncated
     entity.slug = truncateSlug(_slug, entity.orgUrlKey);
+  } else {
+    // if no slug is passed in, save an empty string
+    // so that the slug is not truncated to the orgUrlKey
+    entity.slug = "";
   }
 
   return entity;

--- a/packages/common/src/core/schemas/internal/metrics/editorToEntity.ts
+++ b/packages/common/src/core/schemas/internal/metrics/editorToEntity.ts
@@ -31,8 +31,8 @@ export function editorToEntity(
     // ensure the slug is truncated
     entity.slug = truncateSlug(_slug, entity.orgUrlKey);
   } else {
-    // if no slug is passed in, save an empty string
-    // so that the slug is not truncated to the orgUrlKey
+    // if no slug is passed in, save an empty string as the slug, so that
+    // it is not saved as the orgUrlKey truncated with an empty string
     entity.slug = "";
   }
 

--- a/packages/common/src/core/schemas/shared/subschemas.ts
+++ b/packages/common/src/core/schemas/shared/subschemas.ts
@@ -184,8 +184,14 @@ export const PRIVACY_CONFIG_SCHEMA = {
 
 export const SLUG_SCHEMA: JSONSchema = {
   type: "string",
-  /** lower case alpha numeric characters and '-' only */
-  // using the same regex as the slug formatter
-  // this will prevent trailing - or multiple - in a row
-  pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+  allOf: [
+    {
+      // if a slug has been entered, ensure it is lower case
+      // alpha-numeric characters any '-' only
+      if: { properties: { _slug: { minLength: 1 } } },
+      then: {
+        properties: { _slug: { pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$" } },
+      },
+    },
+  ],
 };

--- a/packages/common/src/core/schemas/shared/subschemas.ts
+++ b/packages/common/src/core/schemas/shared/subschemas.ts
@@ -184,14 +184,8 @@ export const PRIVACY_CONFIG_SCHEMA = {
 
 export const SLUG_SCHEMA: JSONSchema = {
   type: "string",
-  allOf: [
-    {
-      // if a slug has been entered, ensure it is lower case
-      // alpha-numeric characters any '-' only
-      if: { properties: { _slug: { minLength: 1 } } },
-      then: {
-        properties: { _slug: { pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$" } },
-      },
-    },
-  ],
+  /** lower case alpha numeric characters and '-' only */
+  // using the same regex as the slug formatter
+  // this will prevent trailing - or multiple - in a row
+  pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
 };

--- a/packages/common/test/core/schemas/internal/addDynamicSlugValidation.test.ts
+++ b/packages/common/test/core/schemas/internal/addDynamicSlugValidation.test.ts
@@ -32,11 +32,26 @@ describe("addDynamicSlugValidation", () => {
     expect(result).toEqual({
       properties: {
         _slug: {
-          pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
           maxLength: 256 - ("slug".length + 1) - (options.orgUrlKey.length + 1),
         },
       },
       allOf: [
+        {
+          if: {
+            properties: {
+              _slug: {
+                minLength: 1,
+              },
+            },
+          },
+          then: {
+            properties: {
+              _slug: {
+                pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+              },
+            },
+          },
+        },
         {
           if: {
             properties: {

--- a/packages/common/test/core/schemas/internal/addDynamicSlugValidation.test.ts
+++ b/packages/common/test/core/schemas/internal/addDynamicSlugValidation.test.ts
@@ -32,26 +32,11 @@ describe("addDynamicSlugValidation", () => {
     expect(result).toEqual({
       properties: {
         _slug: {
+          pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
           maxLength: 256 - ("slug".length + 1) - (options.orgUrlKey.length + 1),
         },
       },
       allOf: [
-        {
-          if: {
-            properties: {
-              _slug: {
-                minLength: 1,
-              },
-            },
-          },
-          then: {
-            properties: {
-              _slug: {
-                pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
-              },
-            },
-          },
-        },
         {
           if: {
             properties: {


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 13184

1. Description:

Update slug validation logic so it allows an empty value for the slug field

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
