### PR TITLE
Modify NPM auth injection in the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,8 @@ jobs:
 
       - name: Setup NPM auth
         run: |
-          npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_TOKEN }}
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
           npm whoami
 
       - name: Release


### PR DESCRIPTION
Attempting to resolve the consistent issue w/ the release: https://github.com/Esri/hub.js/actions/runs/15115549766/job/42492616445

```
Run npm run release

> @esri/hub.js@9.10.0 prerelease
> npm config set workspaces-update false


> @esri/hub.js@9.10.0 release
> multi-semantic-release --deps.prefix=^ --deps.bump=satisfy --deps.release=inherit --ignore-private-packages

multi-semantic-release version: 2.13.0
semantic-release version: 1[7](https://github.com/Esri/hub.js/actions/runs/15115549766/job/42492616445#step:7:8).4.7
flags: {
  "deps": {
    "prefix": "^",
    "bump": "satisfy",
    "release": "inherit"
  },
  "ignorePrivatePackages": true,
  "sequentialInit": false,
  "firstParent": false,
  "debug": false,
  "dryRun": false
}
package paths [
  '/home/runner/work/hub.js/hub.js/demos/ember-app/package.json',
  '/home/runner/work/hub.js/hub.js/demos/node/package.json',
  '/home/runner/work/hub.js/hub.js/demos/webpack/package.json',
  '/home/runner/work/hub.js/hub.js/packages/common/package.json',
  '/home/runner/work/hub.js/hub.js/packages/downloads/package.json',
  '/home/runner/work/hub.js/hub.js/packages/events/package.json',
  '/home/runner/work/hub.js/hub.js/packages/initiatives/package.json',
  '/home/runner/work/hub.js/hub.js/packages/search/package.json',
  '/home/runner/work/hub.js/hub.js/packages/sites/package.json',
  '/home/runner/work/hub.js/hub.js/packages/surveys/package.json',
  '/home/runner/work/hub.js/hub.js/packages/teams/package.json'
]
[4:03:59 PM] › 🎉  Started multirelease! Loading 11 packages...
[4:03:59 PM] › ⚠  [ember-app] is private, will be ignored
[4:03:59 PM] › ⚠  [node-demo] is private, will be ignored
[4:03:59 PM] › ⚠  [webpack-demo] is private, will be ignored
[4:03:59 PM] › ✔  Loaded package @esri/hub-common
[4:03:59 PM] › ✔  Loaded package @esri/hub-downloads
[4:03:59 PM] › ✔  Loaded package @esri/hub-events
[4:03:59 PM] › ✔  Loaded package @esri/hub-initiatives
[4:03:59 PM] › ✔  Loaded package @esri/hub-search
[4:03:59 PM] › ✔  Loaded package @esri/hub-sites
[4:03:59 PM] › ✔  Loaded package @esri/hub-surveys
[4:03:59 PM] › ✔  Loaded package @esri/hub-teams
[4:03:59 PM] › 🎉  Queued [8](https://github.com/Esri/hub.js/actions/runs/15115549766/job/42492616445#step:7:9) packages! Starting release...
[4:03:5[9](https://github.com/Esri/hub.js/actions/runs/15115549766/job/42492616445#step:7:10) PM] [@esri/hub-common] › ℹ  Running semantic-release version 17.4.7
[4:03:59 PM] [@esri/hub-downloads] › ℹ  Running semantic-release version 17.4.7
[4:03:59 PM] [@esri/hub-events] › ℹ  Running semantic-release version 17.4.7
[4:03:59 PM] [@esri/hub-initiatives] › ℹ  Running semantic-release version 17.4.7
[4:03:59 PM] [@esri/hub-search] › ℹ  Running semantic-release version 17.4.7
[4:03:59 PM] [@esri/hub-sites] › ℹ  Running semantic-release version 17.4.7
[4:03:59 PM] [@esri/hub-surveys] › ℹ  Running semantic-release version 17.4.7
[4:03:59 PM] [@esri/hub-teams] › ℹ  Running semantic-release version 17.4.7
[4:03:59 PM] [@esri/hub-downloads] › ✔  Loaded plugin "addChannel" from "@semantic-release/npm"
[4:03:59 PM] [@esri/hub-common] › ✔  Loaded plugin "addChannel" from "@semantic-release/npm"
[4:03:59 PM] [@esri/hub-search] › ✔  Loaded plugin "addChannel" from "@semantic-release/npm"
[4:03:59 PM] [@esri/hub-initiatives] › ✔  Loaded plugin "addChannel" from "@semantic-release/npm"
[4:03:59 PM] [@esri/hub-events] › ✔  Loaded plugin "addChannel" from "@semantic-release/npm"
[4:03:59 PM] [@esri/hub-sites] › ✔  Loaded plugin "addChannel" from "@semantic-release/npm"
[4:03:59 PM] [@esri/hub-surveys] › ✔  Loaded plugin "addChannel" from "@semantic-release/npm"
[4:03:59 PM] [@esri/hub-teams] › ✔  Loaded plugin "addChannel" from "@semantic-release/npm"
[4:05:02 PM] [@esri/hub-downloads] › ✔  Run automated release from branch master on repository https://x-access-token:[secure]@github.com/Esri/hub.js.git
[4:05:02 PM] [@esri/hub-downloads] › ✔  Allowed to push to the Git repository
[4:05:02 PM] [@esri/hub-downloads] › ℹ  Start step "verifyConditions" of plugin "Inline plugin"
dcdev-npm
[4:05:03 PM] [@esri/hub-downloads] › ✔  Completed step "verifyConditions" of plugin "Inline plugin"
[4:05:03 PM] [@esri/hub-downloads] › ℹ  Found git tag @esri/hub-downloads@17.1.0 associated with version 17.1.0 on branch master
[4:05:03 PM] [@esri/hub-downloads] › ℹ  Found 29 commits since last release
[4:05:03 PM] [@esri/hub-downloads] › ℹ  Start step "analyzeCommits" of plugin "Inline plugin"
[4:05:05 PM] [@esri/hub-search] › ✔  Run automated release from branch master on repository https://x-access-token:[secure]@github.com/Esri/hub.js.git
[4:05:05 PM] [@esri/hub-events] › ✔  Run automated release from branch master on repository https://x-access-token:[secure]@github.com/Esri/hub.js.git
[4:05:05 PM] [@esri/hub-search] › ✔  Allowed to push to the Git repository
[4:05:05 PM] [@esri/hub-search] › ℹ  Start step "verifyConditions" of plugin "Inline plugin"
[4:05:05 PM] [@esri/hub-events] › ✔  Allowed to push to the Git repository
[4:05:05 PM] [@esri/hub-events] › ℹ  Start step "verifyConditions" of plugin "Inline plugin"
[4:05:05 PM] [@esri/hub-surveys] › ✔  Run automated release from branch master on repository https://x-access-token:[secure]@github.com/Esri/hub.js.git
[4:05:05 PM] [@esri/hub-teams] › ✔  Run automated release from branch master on repository https://x-access-token:[secure]@github.com/Esri/hub.js.git
[4:05:05 PM] [@esri/hub-initiatives] › ✔  Run automated release from branch master on repository https://x-access-token:[secure]@github.com/Esri/hub.js.git
[4:05:05 PM] [@esri/hub-surveys] › ✔  Allowed to push to the Git repository
[4:05:05 PM] [@esri/hub-surveys] › ℹ  Start step "verifyConditions" of plugin "Inline plugin"
[4:05:06 PM] [@esri/hub-teams] › ✔  Allowed to push to the Git repository
[4:05:06 PM] [@esri/hub-teams] › ℹ  Start step "verifyConditions" of plugin "Inline plugin"
[4:05:06 PM] [@esri/hub-initiatives] › ✔  Allowed to push to the Git repository
[4:05:06 PM] [@esri/hub-initiatives] › ℹ  Start step "verifyConditions" of plugin "Inline plugin"
dcdev-npm
[4:05:06 PM] [@esri/hub-search] › ✔  Completed step "verifyConditions" of plugin "Inline plugin"
[4:05:06 PM] [@esri/hub-search] › ℹ  Found git tag @esri/hub-search@17.1.0 associated with version 17.1.0 on branch master
[4:05:06 PM] [@esri/hub-search] › ℹ  Found 27 commits since last release
[4:05:06 PM] [@esri/hub-search] › ℹ  Start step "analyzeCommits" of plugin "Inline plugin"
dcdev-npm
[4:05:06 PM] [@esri/hub-events] › ✔  Completed step "verifyConditions" of plugin "Inline plugin"
[4:05:06 PM] [@esri/hub-events] › ℹ  Found git tag @esri/hub-events@17.1.0 associated with version 17.1.0 on branch master
npm ERR! code ENEEDAUTH
npm ERR! need auth This command requires you to be logged in.
npm ERR! need auth You need to authorize this machine using `npm adduser`

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2025-05-19T16_05_06_426Z-debug.log
[4:05:06 PM] [@esri/hub-surveys] › ✖  Failed step "verifyConditions" of plugin "Inline plugin"
[4:05:06 PM] [@esri/hub-surveys] › ✖  EINVALIDNPMTOKEN Invalid npm token.
The npm token (https://github.com/semantic-release/npm/blob/master/README.md#npm-registry-authentication) configured in the NPM_TOKEN environment variable must be a valid token (https://docs.npmjs.com/getting-started/working_with_tokens) allowing to publish to the registry https://registry.npmjs.org/.

If you are using Two Factor Authentication for your account, set its level to "Authorization only" (https://docs.npmjs.com/getting-started/using-two-factor-authentication#levels-of-authentication) in your account settings. semantic-release cannot publish with the default "
Authorization and writes" level.

Please make sure to set the NPM_TOKEN environment variable in your CI with the exact value of the npm token.

[multi-semantic-release]: AggregateError: 
    SemanticReleaseError: Invalid npm token.
        at module.exports (/home/runner/work/hub.js/hub.js/node_modules/multi-semantic-release/node_modules/@semantic-release/npm/lib/get-error.js:6:[10](https://github.com/Esri/hub.js/actions/runs/15115549766/job/42492616445#step:7:11))
        at module.exports (/home/runner/work/hub.js/hub.js/node_modules/multi-semantic-release/node_modules/@semantic-release/npm/lib/verify-auth.js:26:33)
        at runMicrotasks (<anonymous>)
        at processTicksAndRejections (node:internal/process/task_queues:96:5)
        at async verifyConditions (/home/runner/work/hub.js/hub.js/node_modules/multi-semantic-release/node_modules/@semantic-release/npm/index.js:36:7)
        at async validator (/home/runner/work/hub.js/hub.js/node_modules/multi-semantic-release/node_modules/semantic-release/lib/plugins/normalize.js:34:24)
        at async /home/runner/work/hub.js/hub.js/node_modules/multi-semantic-release/node_modules/semantic-release/lib/plugins/pipeline.js:37:34
        at async Promise.all (index 0)
        at async next (/home/runner/work/hub.js/hub.js/node_modules/p-reduce/index.js:16:18)
    at /home/runner/work/hub.js/hub.js/node_modules/multi-semantic-release/node_modules/semantic-release/lib/plugins/pipeline.js:54:[11](https://github.com/Esri/hub.js/actions/runs/15115549766/job/42492616445#step:7:12)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Object.pluginsConf.<computed> [as verifyConditions] (/home/runner/work/hub.js/hub.js/node_modules/multi-semantic-release/node_modules/semantic-release/lib/plugins/index.js:80:11)
    at async run (/home/runner/work/hub.js/hub.js/node_modules/multi-semantic-release/node_modules/semantic-release/index.js:95:3)
    at async module.exports (/home/runner/work/hub.js/hub.js/node_modules/multi-semantic-release/node_modules/semantic-release/index.js:260:22)
    at async releasePackage (/home/runner/work/hub.js/hub.js/node_modules/multi-semantic-release/lib/multiSemanticRelease.js:201:[15](https://github.com/Esri/hub.js/actions/runs/15115549766/job/42492616445#step:7:16))
    at async Promise.all (index 6)
    at async multiSemanticRelease (/home/runner/work/hub.js/hub.js/node_modules/multi-semantic-release/lib/multiSemanticRelease.js:96:2)
Error: Process completed with exit code 1.
```