### PR TITLE
tests: address catch typing for typescript upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54036,7 +54036,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "17.8.0",
+			"version": "17.13.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -54117,7 +54117,7 @@
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "17.1.0",
+			"version": "17.1.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/e2e/hub-project-class.e2e.ts
+++ b/packages/common/e2e/hub-project-class.e2e.ts
@@ -117,7 +117,8 @@ describe("HubProject Class", () => {
     try {
       await HubProject.fetch(id, ctxMgr.context);
     } catch (ex) {
-      expect(ex.message).toBe("Project not found.");
+      const err = ex as Error;
+      expect(err.message).toBe("Project not found.");
     }
   });
   it("add remove clear catalogs", async () => {
@@ -226,7 +227,8 @@ describe("HubProject Class", () => {
     try {
       await HubProject.fetch(id, ctxMgr.context);
     } catch (ex) {
-      expect(ex.message).toBe("Project not found.");
+      const err = ex as Error;
+      expect(err.message).toBe("Project not found.");
     }
   });
   it("ensure unique slug", async () => {
@@ -269,7 +271,8 @@ describe("HubProject Class", () => {
     try {
       await treesProject.save();
     } catch (ex) {
-      expect(ex.message).toBe("HubProject is already destroyed.");
+      const err = ex as Error;
+      expect(err.message).toBe("HubProject is already destroyed.");
     }
   });
   it("catalog manipulation", async () => {

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -872,7 +872,8 @@ describe("ArcGISContext:", () => {
       try {
         await ArcGISContextManager.create({ authentication: MOCK_AUTH });
       } catch (ex) {
-        expect(ex).toBeDefined();
+        const error = ex as { message?: string };
+        expect(error).toBeDefined();
       }
     });
     it("serializes anon manager to string", async () => {

--- a/packages/common/test/associations/internal/getAssociationHierarchy.test.ts
+++ b/packages/common/test/associations/internal/getAssociationHierarchy.test.ts
@@ -18,7 +18,7 @@ describe("getAssociationHierarchy:", () => {
     try {
       getAssociationHierarchy("unsupportedEntity" as HubEntityType);
     } catch (err) {
-      expect(err.message).toBe(
+      expect((err as Error).message).toBe(
         "getAssociationHierarchy: Invalid type for associations: unsupportedEntity."
       );
     }

--- a/packages/common/test/associations/wellKnownAssociationCatalogs.test.ts
+++ b/packages/common/test/associations/wellKnownAssociationCatalogs.test.ts
@@ -141,7 +141,7 @@ describe("getWellKnownAssociationsCatalog", () => {
         {} as ArcGISContext
       );
     } catch (err) {
-      expect(err.message).toBe(
+      expect((err as Error).message).toBe(
         "getWellKnownAssociationsCatalog: Association between initiative and group is not supported."
       );
     }
@@ -182,7 +182,7 @@ describe("getAvailableToRequestAssociationCatalogs", () => {
         {} as ArcGISContext
       );
     } catch (err) {
-      expect((err as any).message).toBe(
+      expect((err as Error).message).toBe(
         "getAvailableToRequestAssociationCatalogs: Association between initiative and group is not supported."
       );
     }

--- a/packages/common/test/channels/HubChannel.test.ts
+++ b/packages/common/test/channels/HubChannel.test.ts
@@ -59,9 +59,8 @@ describe("HubChannel", () => {
         instance.toJson();
         fail("did not reject");
       } catch (e) {
-        expect((e as Error).message).toEqual(
-          "HubChannel is already destroyed."
-        );
+        const error = e as { message?: string };
+        expect(error.message).toEqual("HubChannel is already destroyed.");
       }
     });
     it("should return a clone of the entity", () => {
@@ -190,9 +189,8 @@ describe("HubChannel", () => {
         await instance.delete();
         fail("did not reject");
       } catch (e) {
-        expect((e as Error).message).toEqual(
-          "HubChannel is already destroyed."
-        );
+        const error = e as { message?: string };
+        expect(error.message).toEqual("HubChannel is already destroyed.");
         expect(deleteHubChannelSpy).not.toHaveBeenCalled();
       }
     });
@@ -220,7 +218,8 @@ describe("HubChannel", () => {
         instance.convertToCardModel({});
         fail("should have thrown");
       } catch (e) {
-        expect((e as Error).message).toEqual("not implemented");
+        const error = e as { message?: string };
+        expect(error.message).toEqual("not implemented");
       }
     });
   });
@@ -417,10 +416,11 @@ describe("HubChannel", () => {
         await HubChannel.fetch("channelId1", context);
         fail("should have thrown");
       } catch (e) {
+        const error = e as { message?: string };
         expect(fetchHubChannelSpy).toHaveBeenCalledTimes(1);
         expect(fetchHubChannelSpy).toHaveBeenCalledWith("channelId1", context);
         expect(fromJsonSpy).not.toHaveBeenCalled();
-        expect((e as Error).message).toEqual("Channel not found.");
+        expect(error.message).toEqual("Channel not found.");
       }
     });
     it("call fetchHubChannel and resolve a HubChannel instance", async () => {

--- a/packages/common/test/content/HubContent.test.ts
+++ b/packages/common/test/content/HubContent.test.ts
@@ -111,13 +111,13 @@ describe("HubContent class", () => {
     try {
       await chk.delete();
     } catch (e) {
-      expect(e.message).toEqual("HubContent is already destroyed.");
+      expect((e as Error).message).toEqual("HubContent is already destroyed.");
     }
 
     try {
       await chk.save();
     } catch (e) {
-      expect(e.message).toEqual("HubContent is already destroyed.");
+      expect((e as Error).message).toEqual("HubContent is already destroyed.");
     }
   });
   describe("IWithEditorBehavior:", () => {
@@ -327,7 +327,7 @@ describe("HubContent class", () => {
         try {
           await chk.fromEditor(editor);
         } catch (ex) {
-          expect(ex.message).toContain("Cannot create");
+          expect((ex as Error).message).toContain("Cannot create");
           expect(saveSpy).toHaveBeenCalledTimes(0);
         }
       });

--- a/packages/common/test/content/fetchItemJobRecords.test.ts
+++ b/packages/common/test/content/fetchItemJobRecords.test.ts
@@ -26,7 +26,7 @@ describe("fetchItemJobRecords", () => {
       await fetchItemJobRecords(id, options);
       fail();
     } catch (e) {
-      expect(e.message).toEqual(
+      expect((e as Error).message).toEqual(
         "The following options are not yet implemented: types, statuses"
       );
       expect(fetchMock.calls().length).toBe(0);

--- a/packages/common/test/core/HubItemEntity.test.ts
+++ b/packages/common/test/core/HubItemEntity.test.ts
@@ -110,7 +110,8 @@ describe("HubItemEntity Class: ", () => {
           await instance.shareWithGroup("efUpdate");
           fail("should have thrown");
         } catch (err) {
-          expect(err.name).toBe("HubError");
+          const error = err as { name?: string; message?: string };
+          expect(error.name).toBe("HubError");
         }
       });
     });
@@ -213,7 +214,8 @@ describe("HubItemEntity Class: ", () => {
         try {
           const chk = instance.toJson();
         } catch (err) {
-          expect((err as any).message === "Entity is already destroyed.");
+          const error = err as { name?: string; message?: string };
+          expect(error.message === "Entity is already destroyed.");
         }
       });
 
@@ -489,7 +491,8 @@ describe("HubItemEntity Class: ", () => {
         await instance.clearFeaturedImage();
         fail("should have thrown error");
       } catch (err) {
-        expect(err.name).toBe("HubError");
+        const error = err as { name?: string; message?: string };
+        expect(error.name).toBe("HubError");
       }
       expect(clearImageSpy).toHaveBeenCalledTimes(1);
       const chk = instance.toJson();
@@ -516,7 +519,8 @@ describe("HubItemEntity Class: ", () => {
         await instance.clearFeaturedImage();
         fail("should have thrown error");
       } catch (err) {
-        expect(err.name).toBe("HubError");
+        const error = err as { name?: string; message?: string };
+        expect(error.name).toBe("HubError");
       }
       expect(clearImageSpy).toHaveBeenCalledTimes(1);
       const chk = instance.toJson();
@@ -543,7 +547,8 @@ describe("HubItemEntity Class: ", () => {
         await instance.clearFeaturedImage();
         fail("should have thrown error");
       } catch (err) {
-        expect(err.name).toBe("HubError");
+        const error = err as { name?: string; message?: string };
+        expect(error.name).toBe("HubError");
       }
       expect(clearImageSpy).toHaveBeenCalledTimes(1);
       const chk = instance.toJson();
@@ -676,6 +681,7 @@ describe("HubItemEntity Class: ", () => {
       await instance.setFeaturedImage("fake-file");
       fail("should have thrown error");
     } catch (err) {
+      const error = err as { name?: string; message?: string };
       expect(clearImageSpy).toHaveBeenCalledTimes(1);
       expect(setImageSpy).toHaveBeenCalledTimes(1);
       const chk = instance.toJson();

--- a/packages/common/test/discussions/HubDiscussion.test.ts
+++ b/packages/common/test/discussions/HubDiscussion.test.ts
@@ -76,7 +76,7 @@ describe("HubDiscussion Class:", () => {
         await HubDiscussion.fetch("3ef", authdCtxMgr.context);
       } catch (ex) {
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect(ex.message).toBe("Discussion not found.");
+        expect((ex as Error).message).toBe("Discussion not found.");
       }
     });
 
@@ -92,7 +92,7 @@ describe("HubDiscussion Class:", () => {
         await HubDiscussion.fetch("3ef", authdCtxMgr.context);
       } catch (ex) {
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect((ex as any).message).toBe("ZOMG!");
+        expect((ex as Error).message).toBe("ZOMG!");
       }
     });
   });
@@ -205,13 +205,17 @@ describe("HubDiscussion Class:", () => {
     try {
       await chk.delete();
     } catch (e) {
-      expect(e.message).toEqual("HubDiscussion is already destroyed.");
+      expect((e as Error).message).toEqual(
+        "HubDiscussion is already destroyed."
+      );
     }
 
     try {
       await chk.save();
     } catch (e) {
-      expect(e.message).toEqual("HubDiscussion is already destroyed.");
+      expect((e as Error).message).toEqual(
+        "HubDiscussion is already destroyed."
+      );
     }
   });
   describe("IWithEditorBehavior:", () => {

--- a/packages/common/test/discussions/api/settings.test.ts
+++ b/packages/common/test/discussions/api/settings.test.ts
@@ -209,7 +209,9 @@ describe("settings", () => {
       try {
         getDefaultEntitySettings("site");
       } catch (e) {
-        expect(e.message).toBe("no default entity settings defined for site");
+        expect((e as Error).message).toBe(
+          "no default entity settings defined for site"
+        );
       }
     });
   });

--- a/packages/common/test/downloads/_internal/file-url-fetchers/fetchExportImageDownloadFile.test.ts
+++ b/packages/common/test/downloads/_internal/file-url-fetchers/fetchExportImageDownloadFile.test.ts
@@ -142,7 +142,9 @@ describe("fetchExportImageDownloadFile", () => {
       await fetchExportImageDownloadFile(options);
       expect(true).toBe(false);
     } catch (error) {
-      expect(error.message).toBe("Extent required for this download operation");
+      expect((error as Error).message).toBe(
+        "Extent required for this download operation"
+      );
     }
   });
 
@@ -177,7 +179,7 @@ describe("fetchExportImageDownloadFile", () => {
       await fetchExportImageDownloadFile(options);
       expect(true).toBe(false);
     } catch (error) {
-      expect(error.message).toBe(
+      expect((error as Error).message).toBe(
         "Only extent geometric filters are supported for this type of download"
       );
     }

--- a/packages/common/test/downloads/_internal/file-url-fetchers/fetchHubApiDownloadFile.test.ts
+++ b/packages/common/test/downloads/_internal/file-url-fetchers/fetchHubApiDownloadFile.test.ts
@@ -22,7 +22,7 @@ describe("fetchHubApiDownloadFile", () => {
       });
       expect(true).toBe(false);
     } catch (error) {
-      expect(error.message).toBe("No layers provided for download");
+      expect((error as Error).message).toBe("No layers provided for download");
     }
   });
   it("throws an error if empty layers array is provided", async () => {
@@ -38,7 +38,7 @@ describe("fetchHubApiDownloadFile", () => {
       });
       expect(true).toBe(false);
     } catch (error) {
-      expect(error.message).toBe("No layers provided for download");
+      expect((error as Error).message).toBe("No layers provided for download");
     }
   });
   it("throws an error if multiple layers are provided", async () => {
@@ -54,7 +54,7 @@ describe("fetchHubApiDownloadFile", () => {
       });
       expect(true).toBe(false);
     } catch (error) {
-      expect(error.message).toBe(
+      expect((error as Error).message).toBe(
         "Multiple layer downloads are not yet supported"
       );
     }
@@ -81,7 +81,7 @@ describe("fetchHubApiDownloadFile", () => {
       expect(true).toBe(false);
     } catch (error) {
       expect(error instanceof ArcgisHubDownloadError).toBeTruthy();
-      expect(error.message).toBe("Special Server Error");
+      expect((error as Error).message).toBe("Special Server Error");
     }
   });
   it('throws an error when the api returns a status of "Failed"', async () => {
@@ -102,7 +102,9 @@ describe("fetchHubApiDownloadFile", () => {
       });
       expect(true).toBe(false);
     } catch (error) {
-      expect(error.message).toBe("Download operation failed with a 200");
+      expect((error as Error).message).toBe(
+        "Download operation failed with a 200"
+      );
     }
   });
   it("polls without a progress callback", async () => {

--- a/packages/common/test/downloads/fetchDownloadFile.test.ts
+++ b/packages/common/test/downloads/fetchDownloadFile.test.ts
@@ -51,7 +51,7 @@ describe("fetchDownloadFile", () => {
       });
       expect(true).toBe(false);
     } catch (err) {
-      expect(err.message).toBe(
+      expect((err as Error).message).toBe(
         `The following format is not enabled for the entity: ${ServiceDownloadFormat.CSV}`
       );
     }
@@ -76,7 +76,7 @@ describe("fetchDownloadFile", () => {
       });
       expect(true).toBe(false);
     } catch (err) {
-      expect(err.message).toBe(
+      expect((err as Error).message).toBe(
         "Downloads are not supported for this item in this environment"
       );
     }

--- a/packages/common/test/events/HubEvent.test.ts
+++ b/packages/common/test/events/HubEvent.test.ts
@@ -115,14 +115,16 @@ describe("HubEvent Class:", () => {
       await chk.delete();
       fail("delete did not reject");
     } catch (e) {
-      expect(e.message).toEqual("HubEvent is already destroyed.");
+      const error = e as { message?: string };
+      expect(error.message).toEqual("HubEvent is already destroyed.");
     }
 
     try {
       await chk.save();
       fail("save did not reject");
     } catch (e) {
-      expect(e.message).toEqual("HubEvent is already destroyed.");
+      const error = e as { message?: string };
+      expect(error.message).toEqual("HubEvent is already destroyed.");
     }
   });
 
@@ -266,7 +268,8 @@ describe("HubEvent Class:", () => {
         try {
           await chk.fromEditor(editor);
         } catch (ex) {
-          expect(ex.message).toContain("Cannot create");
+          const error = ex as { message?: string };
+          expect(error.message).toContain("Cannot create");
           expect(saveSpy).toHaveBeenCalledTimes(0);
         }
       });
@@ -295,7 +298,8 @@ describe("HubEvent Class:", () => {
         await chk.shareWithGroup("123");
         fail("not rejected");
       } catch (e) {
-        expect(e.message).toBe(
+        const error = e as { message?: string };
+        expect(error.message).toBe(
           "Cannot share event with group when no user is logged in."
         );
       }
@@ -468,7 +472,8 @@ describe("HubEvent Class:", () => {
         await HubEvent.fetch("31c", authdCtxMgr.context);
         fail("not rejected");
       } catch (e) {
-        expect(e.message).toBe("Event not found.");
+        const error = e as { message?: string };
+        expect(error.message).toBe("Event not found.");
       }
     });
   });

--- a/packages/common/test/events/_internal/shareEventWithGroups.test.ts
+++ b/packages/common/test/events/_internal/shareEventWithGroups.test.ts
@@ -105,7 +105,8 @@ describe("shareEventWithGroups", () => {
       await shareEventWithGroups(["abc", "def"], entity, context);
       fail("did not reject");
     } catch (e) {
-      expect(e.message).toEqual(
+      const error = e as { message?: string };
+      expect(error.message).toEqual(
         "Entity: 62p could not be shared with groups: abc, def"
       );
     }

--- a/packages/common/test/events/_internal/unshareEventWithGroups.test.ts
+++ b/packages/common/test/events/_internal/unshareEventWithGroups.test.ts
@@ -70,7 +70,7 @@ describe("unshareEventWithGroups", () => {
       await unshareEventWithGroups(["31c", "52n"], entity, context);
       fail("did not reject");
     } catch (e) {
-      expect(e.message).toEqual(
+      expect((e as Error).message).toEqual(
         "Entity: 62p could not be unshared with groups: 31c, 52n"
       );
     }

--- a/packages/common/test/events/fetch.test.ts
+++ b/packages/common/test/events/fetch.test.ts
@@ -154,7 +154,8 @@ describe("HubEvent fetch module:", () => {
         await fetchEvent("123", authdCtxMgr.context.hubRequestOptions);
         fail("did not reject");
       } catch (e) {
-        expect(e.message).toEqual("Failed to fetch event.");
+        const error = e as { message?: string };
+        expect(error.message).toEqual("Failed to fetch event.");
       }
     });
   });

--- a/packages/common/test/groups/setGroupThumbnail.test.ts
+++ b/packages/common/test/groups/setGroupThumbnail.test.ts
@@ -38,7 +38,7 @@ describe("setGroupThumbnail:", () => {
         "fakeOwner"
       );
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      expect((err as Error).name).toBe("HubError");
     }
   });
   it("throws hub error if update rejects with error", async () => {
@@ -56,7 +56,7 @@ describe("setGroupThumbnail:", () => {
         "fakeOwner"
       );
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      expect((err as Error).name).toBe("HubError");
     }
   });
   it("throws hub error if update rejects", async () => {
@@ -74,7 +74,7 @@ describe("setGroupThumbnail:", () => {
         "fakeOwner"
       );
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      expect((err as Error).name).toBe("HubError");
     }
   });
 });

--- a/packages/common/test/i18n/fetch-hub-translation.test.ts
+++ b/packages/common/test/i18n/fetch-hub-translation.test.ts
@@ -2,13 +2,13 @@ import { fetchHubTranslation } from "../../src/i18n/fetch-hub-translation";
 import { IPortal } from "@esri/arcgis-rest-portal";
 import * as fetchMock from "fetch-mock";
 
-describe("fetchHubTranslation", function() {
-  it("fetches a translation", async function() {
+describe("fetchHubTranslation", function () {
+  it("fetches a translation", async function () {
     const portal: IPortal = {
       name: "My Portal",
       id: "portal-id",
       isPortal: false,
-      portalHostname: "devext.foo.bar"
+      portalHostname: "devext.foo.bar",
     };
 
     const locale = "es";
@@ -26,12 +26,12 @@ describe("fetchHubTranslation", function() {
     );
   });
 
-  it("allows you to set mode", async function() {
+  it("allows you to set mode", async function () {
     const portal: IPortal = {
       name: "My Portal",
       id: "portal-id",
       isPortal: false,
-      portalHostname: "devext.foo.bar"
+      portalHostname: "devext.foo.bar",
     };
 
     const locale = "es";
@@ -47,12 +47,12 @@ describe("fetchHubTranslation", function() {
     );
   });
 
-  it("throws an error when it fails", async function() {
+  it("throws an error when it fails", async function () {
     const portal: IPortal = {
       name: "My Portal",
       id: "portal-id",
       isPortal: false,
-      portalHostname: "devext.foo.bar"
+      portalHostname: "devext.foo.bar",
     };
 
     const locale = "es";
@@ -63,8 +63,9 @@ describe("fetchHubTranslation", function() {
       await fetchHubTranslation("es", portal);
       fail(Error("translation fetch should not have succeeded"));
     } catch (err) {
-      expect(err).toBeDefined("threw error");
-      expect(err.message).toContain("Attempt to fetch locale");
+      const error = err as { message?: string };
+      expect(error).toBeDefined("threw error");
+      expect(error.message).toContain("Attempt to fetch locale");
     }
   });
 });

--- a/packages/common/test/initiative-templates/HubInitiativeTemplate.test.ts
+++ b/packages/common/test/initiative-templates/HubInitiativeTemplate.test.ts
@@ -81,8 +81,9 @@ describe("HubInitiativeTemplate Class: ", () => {
       try {
         await HubInitiativeTemplate.fetch("3ef", authdCtxMgr.context);
       } catch (ex) {
+        const error = ex as { message?: string };
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect((ex as any).message).toBe("Initiative Template not found.");
+        expect(error.message).toBe("Initiative Template not found.");
       }
     });
 
@@ -97,8 +98,9 @@ describe("HubInitiativeTemplate Class: ", () => {
       try {
         await HubInitiativeTemplate.fetch("3ef", authdCtxMgr.context);
       } catch (ex) {
+        const error = ex as { message?: string };
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect((ex as any).message).toBe("ZOMG!");
+        expect(error.message).toBe("ZOMG!");
       }
     });
 
@@ -254,7 +256,8 @@ describe("HubInitiativeTemplate Class: ", () => {
     try {
       await chk.delete();
     } catch (e) {
-      expect((e as any).message).toEqual(
+      const error = e as { message?: string };
+      expect(error.message).toEqual(
         "HubInitiativeTemplate is already destroyed."
       );
     }
@@ -262,7 +265,8 @@ describe("HubInitiativeTemplate Class: ", () => {
     try {
       await chk.save();
     } catch (e) {
-      expect((e as any).message).toEqual(
+      const error = e as { message?: string };
+      expect(error.message).toEqual(
         "HubInitiativeTemplate is already destroyed."
       );
     }

--- a/packages/common/test/initiatives/HubInitiative.test.ts
+++ b/packages/common/test/initiatives/HubInitiative.test.ts
@@ -85,8 +85,9 @@ describe("HubInitiative Class:", () => {
       try {
         await HubInitiative.fetch("3ef", authdCtxMgr.context);
       } catch (ex) {
+        const error = ex as { message?: string };
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect((ex as any).message).toBe("Initiative not found.");
+        expect(error.message).toBe("Initiative not found.");
       }
     });
 
@@ -101,8 +102,9 @@ describe("HubInitiative Class:", () => {
       try {
         await HubInitiative.fetch("3ef", authdCtxMgr.context);
       } catch (ex) {
+        const error = ex as { message?: string };
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect((ex as any).message).toBe("ZOMG!");
+        expect(error.message).toBe("ZOMG!");
       }
     });
   });
@@ -218,13 +220,15 @@ describe("HubInitiative Class:", () => {
     try {
       await chk.delete();
     } catch (e) {
-      expect((e as any).message).toEqual("HubInitiative is already destroyed.");
+      const error = e as { message?: string };
+      expect(error.message).toEqual("HubInitiative is already destroyed.");
     }
 
     try {
       await chk.save();
     } catch (e) {
-      expect((e as any).message).toEqual("HubInitiative is already destroyed.");
+      const error = e as { message?: string };
+      expect(error.message).toEqual("HubInitiative is already destroyed.");
     }
   });
 
@@ -270,9 +274,8 @@ describe("HubInitiative Class:", () => {
       try {
         await chk.resolveMetric("initiativeBudget_00c");
       } catch (e) {
-        expect((e as any).message).toEqual(
-          "Metric initiativeBudget_00c not found."
-        );
+        const error = e as { message?: string };
+        expect(error.message).toEqual("Metric initiativeBudget_00c not found.");
       }
     });
 

--- a/packages/common/test/items/_unprotect-and-remove-item.test.ts
+++ b/packages/common/test/items/_unprotect-and-remove-item.test.ts
@@ -2,8 +2,8 @@ import { _unprotectAndRemoveItem } from "../../src";
 import * as portal from "@esri/arcgis-rest-portal";
 import { mockUserSession } from "../test-helpers/fake-user-session";
 
-describe("_unprotectAndRemoveItem", function() {
-  it("unprotects and removes a group", async function() {
+describe("_unprotectAndRemoveItem", function () {
+  it("unprotects and removes a group", async function () {
     const unprotectItemSpy = spyOn(portal, "unprotectItem").and.returnValue(
       Promise.resolve({ success: true })
     );
@@ -13,7 +13,7 @@ describe("_unprotectAndRemoveItem", function() {
 
     const res = await _unprotectAndRemoveItem({
       id: "foo-baz",
-      authentication: mockUserSession
+      authentication: mockUserSession,
     });
 
     expect(res.success).toBeTruthy("resolves to success:true");
@@ -21,7 +21,7 @@ describe("_unprotectAndRemoveItem", function() {
     expect(removeItemSpy.calls.count()).toBe(1, "remove called");
   });
 
-  it("is impervious to failures", async function() {
+  it("is impervious to failures", async function () {
     spyOn(portal, "unprotectItem").and.returnValue(Promise.reject());
     spyOn(portal, "removeItem").and.returnValue(Promise.reject());
 
@@ -29,9 +29,10 @@ describe("_unprotectAndRemoveItem", function() {
     try {
       res = await _unprotectAndRemoveItem({
         id: "foo-baz",
-        authentication: mockUserSession
+        authentication: mockUserSession,
       });
     } catch (_) {
+      const error = _ as { message?: string };
       fail(Error("function rejected"));
     }
 

--- a/packages/common/test/items/_wait-for-item-ready.test.ts
+++ b/packages/common/test/items/_wait-for-item-ready.test.ts
@@ -19,7 +19,8 @@ describe("_waitForItemReady", () => {
       await _waitForItemReady("1234abc", ro, 10);
       expect(portal.getItemStatus).toHaveBeenCalledTimes(2);
     } catch (err) {
-      expect(err).toEqual(undefined);
+      const error = err as { message?: string };
+      expect(error).toEqual(undefined);
     }
   });
   it("throws an error when an error occurs", async () => {
@@ -42,7 +43,8 @@ describe("_waitForItemReady", () => {
       await _waitForItemReady("1234abc", ro, 10);
       expect(portal.getItemStatus).toHaveBeenCalledTimes(2);
     } catch (err) {
-      expect((err as Error).message).toEqual("Upload failed");
+      const error = err as { message?: string };
+      expect(error.message).toEqual("Upload failed");
     }
   });
 });

--- a/packages/common/test/items/create-item-from-file.test.ts
+++ b/packages/common/test/items/create-item-from-file.test.ts
@@ -150,6 +150,7 @@ describe("createItemFromFile", () => {
         expect(commitItemUploadSpy).not.toHaveBeenCalled();
         expect(_prepareUploadRequestsSpy).toHaveBeenCalledTimes(1);
       } catch (err) {
+        const error = err as { message?: string };
         expect(cancelItemSpy).toHaveBeenCalledTimes(1);
       }
     });
@@ -197,6 +198,7 @@ describe("createItemFromFile", () => {
         expect(commitItemUploadSpy).not.toHaveBeenCalled();
         expect(_prepareUploadRequestsSpy).toHaveBeenCalledTimes(1);
       } catch (err) {
+        const error = err as { message?: string };
         expect(cancelItemSpy).toHaveBeenCalledTimes(1);
       }
     });

--- a/packages/common/test/items/does-item-exist-with-title.test.ts
+++ b/packages/common/test/items/does-item-exist-with-title.test.ts
@@ -4,7 +4,7 @@ import { IAuthenticationManager } from "@esri/arcgis-rest-request";
 
 describe("doesItemExistWithTitle", () => {
   const options = {
-    typekeywords: "foo"
+    typekeywords: "foo",
   };
 
   const authMgr = {} as IAuthenticationManager;
@@ -12,11 +12,11 @@ describe("doesItemExistWithTitle", () => {
   it("should resolve true when item with same name exists", async () => {
     const opts = {
       q: `title:"exists"`,
-      authentication: authMgr
+      authentication: authMgr,
     };
     const spy = spyOn(portalModule, "searchItems").and.returnValue(
       Promise.resolve({
-        results: [{}]
+        results: [{}],
       })
     );
     const res = await doesItemExistWithTitle("exists", options, authMgr);
@@ -24,7 +24,7 @@ describe("doesItemExistWithTitle", () => {
 
     const expectedSearchOpts = {
       q: `title:"exists" AND typekeywords:"foo"`,
-      authentication: authMgr
+      authentication: authMgr,
     };
     expect(spy.calls.argsFor(0)[0]).toEqual(
       expectedSearchOpts,
@@ -35,11 +35,11 @@ describe("doesItemExistWithTitle", () => {
   it("should resolve false when item with same name DOES NOT exist", async () => {
     const opts = {
       q: `title:"not-exists"`,
-      authentication: authMgr
+      authentication: authMgr,
     };
     const spy = spyOn(portalModule, "searchItems").and.returnValue(
       Promise.resolve({
-        results: [] // empty
+        results: [], // empty
       })
     );
     const res = await doesItemExistWithTitle("not-exists", options, authMgr);
@@ -47,7 +47,7 @@ describe("doesItemExistWithTitle", () => {
 
     const expectedSearchOpts = {
       q: `title:"not-exists" AND typekeywords:"foo"`,
-      authentication: authMgr
+      authentication: authMgr,
     };
     expect(spy.calls.argsFor(0)[0]).toEqual(
       expectedSearchOpts,
@@ -62,7 +62,8 @@ describe("doesItemExistWithTitle", () => {
       await doesItemExistWithTitle("not-exists", options, authMgr);
       fail("should reject");
     } catch (err) {
-      expect(err).toBeDefined();
+      const error = err as { message?: string };
+      expect(error).toBeDefined();
     }
   });
 });

--- a/packages/common/test/items/fail-safe-update.test.ts
+++ b/packages/common/test/items/fail-safe-update.test.ts
@@ -44,6 +44,7 @@ describe("failSafeUpdate", function () {
         authentication: mockUserSession,
       });
     } catch (_) {
+      const error = _ as { message?: string };
       fail(Error("failSafeUpdate rejected"));
     }
 

--- a/packages/common/test/items/follow.test.ts
+++ b/packages/common/test/items/follow.test.ts
@@ -123,8 +123,8 @@ describe("follow", function () {
           hubRequestOptions: {},
         } as ArcGISContext);
       } catch (e) {
-        const error = e as { message?: string };
-        expect(error.message).toBe("User is already following this entity.");
+        const error = e as string;
+        expect(error).toBe("User is already following this entity.");
       }
     });
 
@@ -151,7 +151,7 @@ describe("follow", function () {
           hubRequestOptions: {},
         } as ArcGISContext);
       } catch (e) {
-        const error = e as { message?: string };
+        const error = e as Error;
         expect(error.message).toBe("Error joining group: error");
       }
     });
@@ -179,8 +179,8 @@ describe("follow", function () {
           hubRequestOptions: {},
         } as ArcGISContext);
       } catch (e) {
-        const error = e as { message?: string };
-        expect(error.message).toBe("User is not following this entity.");
+        const error = e as string;
+        expect(error).toBe("User is not following this entity.");
       }
     });
 
@@ -200,7 +200,7 @@ describe("follow", function () {
           hubRequestOptions: {},
         } as ArcGISContext);
       } catch (e) {
-        const error = e as { message?: string };
+        const error = e as Error;
         expect(error.message).toBe("Error leaving group: error");
       }
     });

--- a/packages/common/test/items/follow.test.ts
+++ b/packages/common/test/items/follow.test.ts
@@ -51,7 +51,8 @@ describe("follow", function () {
           hubRequestOptions: {},
         } as ArcGISContext);
       } catch (e) {
-        expect(e.message).toBe(
+        const error = e as { message?: string };
+        expect(error.message).toBe(
           "Error fetching entity followers group ID: error"
         );
       }
@@ -122,7 +123,8 @@ describe("follow", function () {
           hubRequestOptions: {},
         } as ArcGISContext);
       } catch (e) {
-        expect(e).toBe("User is already following this entity.");
+        const error = e as { message?: string };
+        expect(error.message).toBe("User is already following this entity.");
       }
     });
 
@@ -149,7 +151,8 @@ describe("follow", function () {
           hubRequestOptions: {},
         } as ArcGISContext);
       } catch (e) {
-        expect(e.message).toBe("Error joining group: error");
+        const error = e as { message?: string };
+        expect(error.message).toBe("Error joining group: error");
       }
     });
   });
@@ -176,7 +179,8 @@ describe("follow", function () {
           hubRequestOptions: {},
         } as ArcGISContext);
       } catch (e) {
-        expect(e).toBe("User is not following this entity.");
+        const error = e as { message?: string };
+        expect(error.message).toBe("User is not following this entity.");
       }
     });
 
@@ -196,7 +200,8 @@ describe("follow", function () {
           hubRequestOptions: {},
         } as ArcGISContext);
       } catch (e) {
-        expect(e.message).toBe("Error leaving group: error");
+        const error = e as { message?: string };
+        expect(error.message).toBe("Error leaving group: error");
       }
     });
   });

--- a/packages/common/test/items/get-unique-item-title.test.ts
+++ b/packages/common/test/items/get-unique-item-title.test.ts
@@ -4,12 +4,12 @@ import { IAuthenticationManager } from "@esri/arcgis-rest-request";
 
 describe("getUniqueItemTitle", () => {
   const opts = {
-    typekeywords: "typeX"
+    typekeywords: "typeX",
   };
-  it("generates a unique name", async function() {
+  it("generates a unique name", async function () {
     const initialTitle = "foobar";
     spyOn(doesItemExistWithTitleModule, "doesItemExistWithTitle").and.callFake(
-      function(candidate: string) {
+      function (candidate: string) {
         return Promise.resolve(
           [`${initialTitle}`, `${initialTitle} 1`].indexOf(candidate) !== -1
         );
@@ -25,7 +25,7 @@ describe("getUniqueItemTitle", () => {
     expect(uniqueTitle).toBe("foobar 2");
   });
 
-  it("rejects if error", async function() {
+  it("rejects if error", async function () {
     const initialTitle = "foobar";
     spyOn(
       doesItemExistWithTitleModule,
@@ -40,7 +40,8 @@ describe("getUniqueItemTitle", () => {
       );
       fail("should reject");
     } catch (err) {
-      expect(err).toBeDefined();
+      const error = err as { message?: string };
+      expect(error).toBeDefined();
     }
   });
 });

--- a/packages/common/test/items/setItemThumbnail.test.ts
+++ b/packages/common/test/items/setItemThumbnail.test.ts
@@ -38,7 +38,8 @@ describe("setItemThumbnail:", () => {
         "fakeOwner"
       );
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      const error = err as { name?: string; message?: string };
+      expect(error.name).toBe("HubError");
     }
   });
   it("throws hub error if update rejects with error", async () => {
@@ -56,7 +57,8 @@ describe("setItemThumbnail:", () => {
         "fakeOwner"
       );
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      const error = err as { name?: string; message?: string };
+      expect(error.name).toBe("HubError");
     }
   });
   it("throws hub error if update rejects", async () => {
@@ -74,7 +76,8 @@ describe("setItemThumbnail:", () => {
         "fakeOwner"
       );
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      const error = err as { name?: string; message?: string };
+      expect(error.name).toBe("HubError");
     }
   });
 });

--- a/packages/common/test/items/share-item-to-groups.test.ts
+++ b/packages/common/test/items/share-item-to-groups.test.ts
@@ -104,7 +104,8 @@ describe("shareItemToGroups", function () {
       await shareItemToGroups("abc", ["31c", "56n"], requestOptions, "jdoe");
       fail("not rejected");
     } catch (e) {
-      expect(e.message).toEqual(
+      const error = e as { message?: string };
+      expect(error.message).toEqual(
         "Error sharing item: abc with groups: 31c, 56n"
       );
     }
@@ -141,7 +142,8 @@ describe("shareItemToGroups", function () {
       await shareItemToGroups("abc", ["31c", "56n"], requestOptions, "jdoe");
       fail("not rejected");
     } catch (e) {
-      expect(e.message).toEqual("Error sharing item: abc with group: 56n");
+      const error = e as { message?: string };
+      expect(error.message).toEqual("Error sharing item: abc with group: 56n");
     }
     expect(pollSpy).toHaveBeenCalledTimes(1);
     expect(pollSpy).toHaveBeenCalledWith(

--- a/packages/common/test/items/slugs.test.ts
+++ b/packages/common/test/items/slugs.test.ts
@@ -14,7 +14,7 @@ describe("slug utils: ", () => {
       );
       expect(
         slugModule.constructSlug(
-          "A really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really long title",
+          "A really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really long title",
           "qa-bas-hub"
         )
       ).toBe(
@@ -142,8 +142,9 @@ describe("slug utils: ", () => {
           authentication: MOCK_AUTH,
         });
       } catch (ex) {
-        expect(ex).toBeDefined();
-        expect(ex.message).toBe("An error occurred");
+        const error = ex as { message?: string };
+        expect(error).toBeDefined();
+        expect(error.message).toBe("An error occurred");
         expect(searchSpy.calls.count()).toBe(1);
       }
     });
@@ -293,8 +294,9 @@ describe("slug utils: ", () => {
         // Never reach here
         expect(true).toBe(false);
       } catch (err) {
-        expect(err).toBeDefined();
-        expect(err.message).toBe("Error occurred");
+        const error = err as { message?: string };
+        expect(error).toBeDefined();
+        expect(error.message).toBe("Error occurred");
       }
     });
   });
@@ -390,7 +392,8 @@ describe("slug utils: ", () => {
           }
         );
       } catch (ex) {
-        expect(ex).toBeDefined();
+        const error = ex as { message?: string };
+        expect(error).toBeDefined();
         expect(searchSpy.calls.count()).toBe(1);
       }
     });

--- a/packages/common/test/items/unshare-item-from-groups.test.ts
+++ b/packages/common/test/items/unshare-item-from-groups.test.ts
@@ -56,8 +56,9 @@ describe("unshareItemFromGroups", function () {
         authentication: mockUserSession,
       });
     } catch (err) {
+      const error = err as { message?: string };
       expect(unshareItemSpy).toHaveBeenCalled();
-      expect(err.message).toBe(
+      expect(error.message).toBe(
         "Error unsharing item: item-id with group: grp1"
       );
     }

--- a/packages/common/test/items/uploadImageResource.test.ts
+++ b/packages/common/test/items/uploadImageResource.test.ts
@@ -64,7 +64,7 @@ describe("uploadImageResource:", () => {
         authentication: MOCK_AUTH,
       });
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      expect((err as Error).name).toBe("HubError");
     }
   });
 
@@ -77,7 +77,7 @@ describe("uploadImageResource:", () => {
         authentication: MOCK_AUTH,
       });
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      expect((err as Error).name).toBe("HubError");
     }
   });
 
@@ -90,7 +90,7 @@ describe("uploadImageResource:", () => {
         authentication: MOCK_AUTH,
       });
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      expect((err as Error).name).toBe("HubError");
     }
   });
 });

--- a/packages/common/test/metrics/resolveMetric.test.ts
+++ b/packages/common/test/metrics/resolveMetric.test.ts
@@ -48,7 +48,8 @@ describe("resolveMetric:", () => {
       try {
         await resolveMetric(metric, ctx);
       } catch (ex) {
-        expect((ex as any).message).toBe("Unknown metric type passed in.");
+        const error = ex as { message?: string };
+        expect(error.message).toBe("Unknown metric type passed in.");
       }
     });
   });

--- a/packages/common/test/pages/HubPage.test.ts
+++ b/packages/common/test/pages/HubPage.test.ts
@@ -82,8 +82,9 @@ describe("HubPage Class:", () => {
       try {
         await HubPage.fetch("3ef", authdCtxMgr.context);
       } catch (ex) {
+        const error = ex as { message?: string };
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect((ex as any).message).toBe("Page not found.");
+        expect(error.message).toBe("Page not found.");
       }
     });
 
@@ -97,8 +98,9 @@ describe("HubPage Class:", () => {
       try {
         await HubPage.fetch("3ef", authdCtxMgr.context);
       } catch (ex) {
+        const error = ex as { message?: string };
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect((ex as any).message).toBe("ZOMG!");
+        expect(error.message).toBe("ZOMG!");
       }
     });
   });
@@ -346,7 +348,8 @@ describe("HubPage Class:", () => {
         try {
           await chk.fromEditor(editor);
         } catch (ex) {
-          expect(ex.message).toContain("Cannot create");
+          const error = ex as { message?: string };
+          expect(error.message).toContain("Cannot create");
           expect(saveSpy).toHaveBeenCalledTimes(0);
         }
       });

--- a/packages/common/test/request.test.ts
+++ b/packages/common/test/request.test.ts
@@ -9,9 +9,10 @@ describe("hubApiRequest", () => {
       status,
     });
     hubApiRequest(route).catch((e) => {
-      expect(e.message).toBe("Forbidden");
-      expect(e.status).toBe(status);
-      expect(e.url).toBe(`https://hub.arcgis.com/api/v3/${route}`);
+      const error = e as { message?: string; status?: number; url?: string };
+      expect(error.message).toBe("Forbidden");
+      expect(error.status).toBe(status);
+      expect(error.url).toBe(`https://hub.arcgis.com/api/v3/${route}`);
       done();
     });
   });

--- a/packages/common/test/resources/_validate-url-helpers.test.ts
+++ b/packages/common/test/resources/_validate-url-helpers.test.ts
@@ -40,7 +40,9 @@ describe("_validate-url-helpers", () => {
     try {
       getFileName("test");
     } catch (e) {
-      expect(e.message).toBe("Error getting file name from data url");
+      expect((e as Error).message).toBe(
+        "Error getting file name from data url"
+      );
     }
   });
 

--- a/packages/common/test/resources/object-to-json-blob.test.ts
+++ b/packages/common/test/resources/object-to-json-blob.test.ts
@@ -3,7 +3,7 @@ import { objectToJsonBlob } from "../../src/resources";
 describe("objectToJsonBlob", () => {
   it("returns a blob given a string", () => {
     const obj = {
-      foo: "bar––"
+      foo: "bar––",
     };
 
     try {
@@ -13,7 +13,7 @@ describe("objectToJsonBlob", () => {
       expect(blob.type).toBe("application/json", "blob of type JSON");
     } catch (ex) {
       if (typeof Blob === "undefined") {
-        expect(ex.message).toEqual(
+        expect((ex as Error).message).toEqual(
           "objectToJsonBlob is not currently supported on Node"
         );
       }

--- a/packages/common/test/resources/removeResource.test.ts
+++ b/packages/common/test/resources/removeResource.test.ts
@@ -44,7 +44,7 @@ describe("removeResource:", () => {
         authentication: MOCK_AUTH,
       });
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      expect((err as Error).name).toBe("HubError");
     }
   });
 
@@ -57,7 +57,7 @@ describe("removeResource:", () => {
         authentication: MOCK_AUTH,
       });
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      expect((err as Error).name).toBe("HubError");
     }
   });
 
@@ -70,7 +70,7 @@ describe("removeResource:", () => {
         authentication: MOCK_AUTH,
       });
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      expect((err as Error).name).toBe("HubError");
     }
   });
 });

--- a/packages/common/test/resources/string-to-blob.test.ts
+++ b/packages/common/test/resources/string-to-blob.test.ts
@@ -19,7 +19,7 @@ describe("stringToBlob", () => {
       );
     } catch (ex) {
       if (typeof Blob === "undefined") {
-        expect(ex.message).toEqual(
+        expect((ex as Error).message).toEqual(
           "stringToBlob is not currently supported on Node"
         );
       }

--- a/packages/common/test/resources/upsertResource.test.ts
+++ b/packages/common/test/resources/upsertResource.test.ts
@@ -136,7 +136,7 @@ describe("createResource:", () => {
       expect(args.authentication).toEqual(MOCK_AUTH);
     } catch (ex) {
       if (typeof Blob === "undefined") {
-        expect(ex.message).toEqual(
+        expect((ex as Error).message).toEqual(
           "objectToJsonBlob is not currently supported on Node"
         );
       }
@@ -176,7 +176,7 @@ describe("createResource:", () => {
       expect(args.authentication).toEqual(MOCK_AUTH);
     } catch (ex) {
       if (typeof Blob === "undefined") {
-        expect(ex.message).toEqual(
+        expect((ex as Error).message).toEqual(
           "stringToBlob is not currently supported on Node"
         );
       }
@@ -196,7 +196,7 @@ describe("createResource:", () => {
         authentication: MOCK_AUTH,
       });
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      expect((err as Error).name).toBe("HubError");
     }
   });
 
@@ -213,7 +213,7 @@ describe("createResource:", () => {
         authentication: MOCK_AUTH,
       });
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      expect((err as Error).name).toBe("HubError");
     }
   });
 
@@ -230,7 +230,7 @@ describe("createResource:", () => {
         authentication: MOCK_AUTH,
       });
     } catch (err) {
-      expect(err.name).toBe("HubError");
+      expect((err as Error).name).toBe("HubError");
     }
   });
 });

--- a/packages/common/test/search/Catalog.test.ts
+++ b/packages/common/test/search/Catalog.test.ts
@@ -218,8 +218,9 @@ describe("Catalog Class:", () => {
       try {
         await Catalog.init("https://somesite.com", context);
       } catch (err) {
-        expect(getProp(err, "name")).toBe("HubError");
-        expect(getProp(err, "message")).toContain("No catalog found");
+        const error = err as { message?: string };
+        expect(getProp(error, "name")).toBe("HubError");
+        expect(getProp(error, "message")).toContain("No catalog found");
         // verify the context was used
         expect(fetchCatalogSpy.calls.argsFor(0)[1]).toBe(context);
       }
@@ -252,8 +253,9 @@ describe("Catalog Class:", () => {
       try {
         instance.getCollection("invalid");
       } catch (err) {
-        expect(getProp(err, "name")).toBe("HubError");
-        expect(getProp(err, "message")).toContain(
+        const error = err as { message?: string };
+        expect(getProp(error, "name")).toBe("HubError");
+        expect(getProp(error, "message")).toContain(
           'Collection "invalid" is not present in the Catalog'
         );
       }

--- a/packages/common/test/search/_internal/explainHelpers.test.ts
+++ b/packages/common/test/search/_internal/explainHelpers.test.ts
@@ -39,7 +39,8 @@ describe("explainQuery helpers:", () => {
       try {
         await explainDatePredicate(predicate, result, {} as IRequestOptions);
       } catch (err) {
-        expect(err.message).toBe("Not implemented");
+        const error = err as { message?: string };
+        expect(error.message).toBe("Not implemented");
       }
     });
   });
@@ -54,7 +55,8 @@ describe("explainQuery helpers:", () => {
       try {
         await explainPropPredicate(predicate, result, {} as IRequestOptions);
       } catch (err) {
-        expect(err.message).toBe("Not implemented");
+        const error = err as { message?: string };
+        expect(error.message).toBe("Not implemented");
       }
     });
   });

--- a/packages/common/test/search/_internal/getTopLevelPredicate.test.ts
+++ b/packages/common/test/search/_internal/getTopLevelPredicate.test.ts
@@ -28,7 +28,7 @@ describe("getTopLevelPredicate |", () => {
       getTopLevelPredicate("bbox", filters);
       expect(true).toBe(false);
     } catch (err) {
-      expect(err.message).toEqual(
+      expect((err as Error).message).toEqual(
         "Only 1 IFilter can have a 'bbox' predicate but 2 were detected"
       );
     }
@@ -45,7 +45,7 @@ describe("getTopLevelPredicate |", () => {
       getTopLevelPredicate("bbox", filters);
       expect(true).toBe(false);
     } catch (err) {
-      expect(err.message).toEqual(
+      expect((err as Error).message).toEqual(
         "Only 1 'bbox' predicate is allowed but 2 were detected"
       );
     }
@@ -63,7 +63,7 @@ describe("getTopLevelPredicate |", () => {
       getTopLevelPredicate("bbox", filters);
       expect(true).toBe(false);
     } catch (err) {
-      expect(err.message).toEqual(
+      expect((err as Error).message).toEqual(
         "'bbox' predicates cannot be OR'd to other predicates"
       );
     }
@@ -80,7 +80,7 @@ describe("getTopLevelPredicate |", () => {
       getTopLevelPredicate("bbox", filters);
       expect(true).toBe(false);
     } catch (err) {
-      expect(err.message).toEqual(
+      expect((err as Error).message).toEqual(
         "'bbox' predicate must be a string or boolean primitive. string[] and IMatchOptions are not allowed."
       );
     }
@@ -103,7 +103,7 @@ describe("getTopLevelPredicate |", () => {
       getTopLevelPredicate("bbox", filters);
       expect(true).toBe(false);
     } catch (err) {
-      expect(err.message).toEqual(
+      expect((err as Error).message).toEqual(
         "'bbox' predicate must be a string or boolean primitive. string[] and IMatchOptions are not allowed."
       );
     }

--- a/packages/common/test/search/_internal/hubSearchEventAttendees.test.ts
+++ b/packages/common/test/search/_internal/hubSearchEventAttendees.test.ts
@@ -225,7 +225,8 @@ describe("hubSearchEventAttendees", () => {
         await results2.next();
         fail("did not reject");
       } catch (e) {
-        expect((e as any).message).toEqual(
+        const error = e as { message?: string };
+        expect(error.message).toEqual(
           "No more hub events for the given query and options"
         );
       }

--- a/packages/common/test/search/_internal/hubSearchEvents.test.ts
+++ b/packages/common/test/search/_internal/hubSearchEvents.test.ts
@@ -322,7 +322,8 @@ describe("hubSearchEvents", () => {
       await results2.next();
       fail("did not reject");
     } catch (e) {
-      expect((e as Error).message).toEqual(
+      const error = e as { message?: string };
+      expect(error.message).toEqual(
         "No more hub events for the given query and options"
       );
     }

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -1209,7 +1209,8 @@ describe("hubSearchItems Module |", () => {
           await ogcApiRequest(hubApiUrl, queryParams, options);
           expect(true).toBe(false);
         } catch (err) {
-          expect((err as any).message).toEqual("404: Not Found");
+          const error = err as { message?: string };
+          expect(error.message).toEqual("404: Not Found");
         }
       });
     });

--- a/packages/common/test/search/_internal/portalFetchOrgs.test.ts
+++ b/packages/common/test/search/_internal/portalFetchOrgs.test.ts
@@ -38,7 +38,7 @@ describe("portalFetchOrgs:", () => {
     try {
       await portalFetchOrgs(query, options);
     } catch (e) {
-      expect(e.message).toBe(
+      expect((e as Error).message).toBe(
         "Organization query must contain an id predicate."
       );
     }

--- a/packages/common/test/search/_internal/portalSearchGroupMembers.test.ts
+++ b/packages/common/test/search/_internal/portalSearchGroupMembers.test.ts
@@ -26,7 +26,7 @@ describe("portalSearchGroupMembers:", () => {
       try {
         await portalSearchGroupMembers(qry, opts);
       } catch (err) {
-        expect(err.message).toEqual(
+        expect((err as Error).message).toEqual(
           "Group Id required. Please pass as a predicate in the query."
         );
       }
@@ -38,7 +38,7 @@ describe("portalSearchGroupMembers:", () => {
       try {
         await portalSearchGroupMembers(qry, opts);
       } catch (err) {
-        expect(err.message).toEqual(
+        expect((err as Error).message).toEqual(
           "Group Id required. Please pass as a predicate in the query."
         );
       }

--- a/packages/common/test/search/_internal/portalSearchGroups.test.ts
+++ b/packages/common/test/search/_internal/portalSearchGroups.test.ts
@@ -124,8 +124,10 @@ describe("portalSearchGroups module:", () => {
       try {
         await portalSearchGroups(qry, {});
       } catch (err) {
-        expect(err.name).toBe("HubError");
-        expect(err.message).toBe("options.requestOptions is required.");
+        expect((err as Error).name).toBe("HubError");
+        expect((err as Error).message).toBe(
+          "options.requestOptions is required."
+        );
       }
     });
   });

--- a/packages/common/test/search/_internal/portalSearchItems.test.ts
+++ b/packages/common/test/search/_internal/portalSearchItems.test.ts
@@ -40,8 +40,10 @@ describe("portalSearchItems Module:", () => {
       try {
         await portalSearchItems(qry, opts);
       } catch (err) {
-        expect(err.name).toBe("HubError");
-        expect(err.message).toBe("options.requestOptions is required.");
+        expect((err as Error).name).toBe("HubError");
+        expect((err as Error).message).toBe(
+          "options.requestOptions is required."
+        );
       }
     });
     it("simple search", async () => {

--- a/packages/common/test/search/_internal/portalSearchUsers.test.ts
+++ b/packages/common/test/search/_internal/portalSearchUsers.test.ts
@@ -29,8 +29,8 @@ describe("searchPortalUsersLegacy module:", () => {
       try {
         await searchPortalUsersLegacy(qry, opts);
       } catch (err) {
-        expect(err.name).toBe("HubError");
-        expect(err.message).toBe(
+        expect((err as Error).name).toBe("HubError");
+        expect((err as Error).message).toBe(
           "requestOptions: IHubRequestOptions is required."
         );
       }
@@ -57,8 +57,10 @@ describe("searchPortalUsersLegacy module:", () => {
       try {
         await searchPortalUsersLegacy(qry, opts);
       } catch (err) {
-        expect(err.name).toBe("HubError");
-        expect(err.message).toBe("requestOptions must pass authentication.");
+        expect((err as Error).name).toBe("HubError");
+        expect((err as Error).message).toBe(
+          "requestOptions must pass authentication."
+        );
       }
     });
     it("simple search", async () => {
@@ -124,8 +126,8 @@ describe("searchPortalUsersLegacy module:", () => {
       try {
         await searchPortalUsers(qry, opts);
       } catch (err) {
-        expect(err.name).toBe("HubError");
-        expect(err.message).toBe(
+        expect((err as Error).name).toBe("HubError");
+        expect((err as Error).message).toBe(
           "requestOptions: IHubRequestOptions is required."
         );
       }
@@ -152,8 +154,10 @@ describe("searchPortalUsersLegacy module:", () => {
       try {
         await searchPortalUsers(qry, opts);
       } catch (err) {
-        expect(err.name).toBe("HubError");
-        expect(err.message).toBe("requestOptions must pass authentication.");
+        expect((err as Error).name).toBe("HubError");
+        expect((err as Error).message).toBe(
+          "requestOptions must pass authentication."
+        );
       }
     });
     it("simple search", async () => {
@@ -219,8 +223,8 @@ describe("searchPortalUsersLegacy module:", () => {
       try {
         await searchCommunityUsers(qry, opts);
       } catch (err) {
-        expect(err.name).toBe("HubError");
-        expect(err.message).toBe(
+        expect((err as Error).name).toBe("HubError");
+        expect((err as Error).message).toBe(
           "requestOptions: IHubRequestOptions is required."
         );
       }
@@ -247,8 +251,10 @@ describe("searchPortalUsersLegacy module:", () => {
       try {
         await searchCommunityUsers(qry, opts);
       } catch (err) {
-        expect(err.name).toBe("HubError");
-        expect(err.message).toBe("requestOptions must pass authentication.");
+        expect((err as Error).name).toBe("HubError");
+        expect((err as Error).message).toBe(
+          "requestOptions must pass authentication."
+        );
       }
     });
     it("simple search", async () => {

--- a/packages/common/test/search/combineQueries.test.ts
+++ b/packages/common/test/search/combineQueries.test.ts
@@ -60,7 +60,8 @@ describe("combineQueries:", () => {
     try {
       combineQueries(qrys);
     } catch (err) {
-      expect((err as any).message).toEqual(
+      const error = err as { message?: string };
+      expect(error.message).toEqual(
         "Cannot combine queries for different entity types"
       );
     }

--- a/packages/common/test/search/explainQueryResult.test.ts
+++ b/packages/common/test/search/explainQueryResult.test.ts
@@ -13,7 +13,8 @@ describe("explainQueryResult:", () => {
     try {
       await explainQueryResult(result, query, requestOptions);
     } catch (err) {
-      expect(err.message).toContain(
+      const error = err as { message?: string };
+      expect(error.message).toContain(
         'Only queries with targetEntity: "item" are supported'
       );
     }

--- a/packages/common/test/search/fetchEntityCatalog.test.ts
+++ b/packages/common/test/search/fetchEntityCatalog.test.ts
@@ -30,8 +30,9 @@ describe("fetchEntityCatalog:", () => {
     try {
       await fetchEntityCatalog("not a valid identifier", context);
     } catch (err) {
-      expect(err.name).toBe("HubError");
-      expect(err.message).toBe("Identifier must be a url, item or event id");
+      const error = err as { name?: string; message?: string };
+      expect(error.name).toBe("HubError");
+      expect(error.message).toBe("Identifier must be a url, item or event id");
     }
   });
 

--- a/packages/common/test/search/hubSearch.test.ts
+++ b/packages/common/test/search/hubSearch.test.ts
@@ -11,8 +11,9 @@ describe("hubSearch Module:", () => {
             {} as unknown as IHubSearchOptions
           );
         } catch (err) {
-          expect(err.name).toBe("HubError");
-          expect(err.message).toBe("Query is required.");
+          const error = err as { name?: string; message?: string };
+          expect(error.name).toBe("HubError");
+          expect(error.message).toBe("Query is required.");
         }
       });
       it("throws if Query does not have filters", async () => {
@@ -22,8 +23,9 @@ describe("hubSearch Module:", () => {
             {} as unknown as IHubSearchOptions
           );
         } catch (err) {
-          expect(err.name).toBe("HubError");
-          expect(err.message).toBe("Query must have a filters array.");
+          const error = err as { name?: string; message?: string };
+          expect(error.name).toBe("HubError");
+          expect(error.message).toBe("Query must have a filters array.");
         }
       });
       it("throws if Query has an empty filters array and no collection prop", async () => {
@@ -33,8 +35,9 @@ describe("hubSearch Module:", () => {
             {} as unknown as IHubSearchOptions
           );
         } catch (err) {
-          expect(err.name).toBe("HubError");
-          expect(err.message).toBe(
+          const error = err as { name?: string; message?: string };
+          expect(error.name).toBe("HubError");
+          expect(error.message).toBe(
             "Query must contain at least one Filter or a collection."
           );
         }
@@ -52,8 +55,9 @@ describe("hubSearch Module:", () => {
         try {
           await hubSearch(qry, {} as unknown as IHubSearchOptions);
         } catch (err) {
-          expect(err.name).toBe("HubError");
-          expect(err.message).toBe(
+          const error = err as { name?: string; message?: string };
+          expect(error.name).toBe("HubError");
+          expect(error.message).toBe(
             "requestOptions: IHubRequestOptions is required."
           );
         }
@@ -77,8 +81,9 @@ describe("hubSearch Module:", () => {
         try {
           await hubSearch(qry, opts);
         } catch (err) {
-          expect(err.name).toBe("HubError");
-          expect(err.message).toBe(
+          const error = err as { name?: string; message?: string };
+          expect(error.name).toBe("HubError");
+          expect(error.message).toBe(
             `Search via "group" filter against "arcgis-hub" api is not implemented. Please ensure "targetEntity" is defined on the query.`
           );
         }

--- a/packages/common/test/search/searchAssociatedContent.test.ts
+++ b/packages/common/test/search/searchAssociatedContent.test.ts
@@ -35,11 +35,12 @@ describe("searchAssociatedContent", () => {
       await searchAssociatedContent(options);
       fail("Expected HubError to be thrown");
     } catch (error) {
+      const err = error as { message?: string };
       const expectedError = new HubError(
         "searchAssociatedContent",
         'associated content is not supported for entity type "event"'
       );
-      expect(error).toEqual(expectedError);
+      expect(err).toEqual(expectedError);
     }
   });
 
@@ -55,11 +56,12 @@ describe("searchAssociatedContent", () => {
       await searchAssociatedContent(options);
       fail("Expected HubError to be thrown");
     } catch (error) {
+      const err = error as { message?: string };
       const expectedError = new HubError(
         "searchAssociatedContent",
         'associated content scope does not support targetEntity "group"'
       );
-      expect(error).toEqual(expectedError);
+      expect(err).toEqual(expectedError);
     }
   });
 
@@ -74,11 +76,12 @@ describe("searchAssociatedContent", () => {
       await searchAssociatedContent(options);
       fail("Expected HubError to be thrown");
     } catch (error) {
+      const err = error as { message?: string };
       const expectedError = new HubError(
         "searchAssociatedContent",
         '"layerId" is required for searching "connected" content'
       );
-      expect(error).toEqual(expectedError);
+      expect(err).toEqual(expectedError);
     }
   });
 

--- a/packages/common/test/search/wellKnownCatalog.test.ts
+++ b/packages/common/test/search/wellKnownCatalog.test.ts
@@ -54,7 +54,8 @@ describe("WellKnownCatalog", () => {
           options
         );
       } catch (err) {
-        expect(err).toEqual(
+        const error = err as { message?: string };
+        expect(error).toEqual(
           new Error(
             "Requested catalogs must be of the same targetEntity type: item"
           )

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -95,7 +95,7 @@ describe("HubSite Class:", () => {
         await HubSite.fetch("3ef", authdCtxMgr.context);
       } catch (ex) {
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect(ex.message).toBe("Site not found.");
+        expect((ex as Error).message).toBe("Site not found.");
       }
     });
 
@@ -110,7 +110,7 @@ describe("HubSite Class:", () => {
         await HubSite.fetch("3ef", authdCtxMgr.context);
       } catch (ex) {
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect(ex.message).toBe("ZOMG!");
+        expect((ex as Error).message).toBe("ZOMG!");
       }
     });
   });
@@ -217,13 +217,13 @@ describe("HubSite Class:", () => {
     try {
       await chk.delete();
     } catch (e) {
-      expect(e.message).toEqual("HubSite is already destroyed.");
+      expect((e as Error).message).toEqual("HubSite is already destroyed.");
     }
 
     try {
       await chk.save();
     } catch (e) {
-      expect(e.message).toEqual("HubSite is already destroyed.");
+      expect((e as Error).message).toEqual("HubSite is already destroyed.");
     }
   });
 
@@ -824,7 +824,7 @@ describe("HubSite Class:", () => {
         try {
           await _chk.fromEditor(editor);
         } catch (ex) {
-          expect(ex.message).toContain("Cannot create");
+          expect((ex as Error).message).toContain("Cannot create");
           expect(saveSpy).toHaveBeenCalledTimes(0);
           expect(_getFollowersGroupSpy).toHaveBeenCalledTimes(1);
         }

--- a/packages/common/test/sites/domains/_check-status-and-parse-json.test.ts
+++ b/packages/common/test/sites/domains/_check-status-and-parse-json.test.ts
@@ -40,7 +40,7 @@ describe("_checkStatusAndParseJson", function () {
       await _checkStatusAndParseJson(res);
       fail("should reject");
     } catch (err) {
-      expect(err.message).toBe("title :: an error :: 404");
+      expect((err as Error).message).toBe("title :: an error :: 404");
     }
   });
 
@@ -59,7 +59,7 @@ describe("_checkStatusAndParseJson", function () {
       await _checkStatusAndParseJson(res);
       fail("should reject");
     } catch (err) {
-      expect(err).toBeDefined("threw generic error");
+      expect(err as Error).toBeDefined("threw generic error");
     }
   });
 });

--- a/packages/common/test/sites/feeds/previewFeed.test.ts
+++ b/packages/common/test/sites/feeds/previewFeed.test.ts
@@ -72,7 +72,7 @@ describe("previewFeed", () => {
       await previewFeed(options);
       fail("Expected an error to be thrown");
     } catch (error) {
-      expect(error.message).toBe(
+      expect((error as Error).message).toBe(
         "Failed to preview feed: Internal Server Error"
       );
     }

--- a/packages/common/test/surveys/HubSurvey.test.ts
+++ b/packages/common/test/surveys/HubSurvey.test.ts
@@ -108,13 +108,13 @@ describe("HubSurvey Class:", () => {
     try {
       await chk.delete();
     } catch (e) {
-      expect(e.message).toEqual("HubSurvey is already destroyed.");
+      expect((e as Error).message).toEqual("HubSurvey is already destroyed.");
     }
 
     try {
       await chk.save();
     } catch (e) {
-      expect(e.message).toEqual("HubSurvey is already destroyed.");
+      expect((e as Error).message).toEqual("HubSurvey is already destroyed.");
     }
   });
 
@@ -296,7 +296,7 @@ describe("HubSurvey Class:", () => {
         try {
           await chk.fromEditor(editor);
         } catch (ex) {
-          expect(ex.message).toContain("Cannot create");
+          expect((ex as Error).message).toContain("Cannot create");
           expect(saveSpy).toHaveBeenCalledTimes(0);
         }
       });
@@ -327,7 +327,7 @@ describe("HubSurvey Class:", () => {
         await HubSurvey.fetch("31c", authdCtxMgr.context);
         fail("not rejected");
       } catch (e) {
-        expect(e.message).toBe("Survey not found.");
+        expect((e as Error).message).toBe("Survey not found.");
       }
     });
     it("should reject with the caught error when an error occurs", async () => {
@@ -336,7 +336,7 @@ describe("HubSurvey Class:", () => {
         await HubSurvey.fetch("31c", authdCtxMgr.context);
         fail("not rejected");
       } catch (e) {
-        expect(e.message).toBe("fail");
+        expect((e as Error).message).toBe("fail");
       }
     });
   });

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -697,7 +697,7 @@ describe("util functions", () => {
       try {
         addDays("hello", 1);
       } catch (e) {
-        expect(e.message).toBe("Invalid Date");
+        expect((e as Error).message).toBe("Invalid Date");
       }
     });
   });

--- a/packages/common/test/utils/create-operation-pipeline.test.ts
+++ b/packages/common/test/utils/create-operation-pipeline.test.ts
@@ -3,8 +3,12 @@ import {
   IPipeable,
 } from "../../src/utils/create-operation-pipeline";
 import OperationStack from "../../src/OperationStack";
-import { IHubRequestOptions } from "../../src/hub-types";
+import {
+  IHubRequestOptions,
+  ISerializedOperationStack,
+} from "../../src/hub-types";
 import OperationError from "../../src/OperationError";
+import { getProp } from "../../src";
 // Test Fakes
 interface IFakeItem {
   id: string;
@@ -185,13 +189,15 @@ describe("createOperationPipeline:: ", () => {
       const error = err as {
         name?: string;
         message?: string;
-        operationStack?: OperationStack;
+        operationStack?: ISerializedOperationStack;
       };
       expect(error.name).toBe(
         "OperationError",
         "Should reject with an OperationError"
       );
-      expect(error.operationStack.getOperations().length).toBe(3);
+
+      const ops = getProp(error, "operationStack.operations") || [];
+      expect(ops.length).toBe(3);
       expect(error.message).toContain("Operation timeStampName");
       expect(error.message).toContain("Operation addCreatedAt");
       expect(error.message).toContain("Operation addOwnerThrows");

--- a/packages/common/test/utils/create-operation-pipeline.test.ts
+++ b/packages/common/test/utils/create-operation-pipeline.test.ts
@@ -154,7 +154,8 @@ describe("createOperationPipeline:: ", () => {
       fetchOwner,
     ]);
     return pipeline(input).catch((err) => {
-      expect(err.name).toBe(
+      const error = err as { name?: string };
+      expect(error.name).toBe(
         "OperationError",
         "Should reject with an OperationError"
       );
@@ -181,14 +182,19 @@ describe("createOperationPipeline:: ", () => {
       fetchOwner,
     ]);
     return pipeline(input).catch((err) => {
-      expect(err.name).toBe(
+      const error = err as {
+        name?: string;
+        message?: string;
+        operationStack?: OperationStack;
+      };
+      expect(error.name).toBe(
         "OperationError",
         "Should reject with an OperationError"
       );
-      expect(err.operationStack.operations.length).toBe(3);
-      expect(err.message).toContain("Operation timeStampName");
-      expect(err.message).toContain("Operation addCreatedAt");
-      expect(err.message).toContain("Operation addOwnerThrows");
+      expect(error.operationStack.getOperations().length).toBe(3);
+      expect(error.message).toContain("Operation timeStampName");
+      expect(error.message).toContain("Operation addCreatedAt");
+      expect(error.message).toContain("Operation addOwnerThrows");
     });
   });
 });

--- a/packages/common/test/utils/poll.test.ts
+++ b/packages/common/test/utils/poll.test.ts
@@ -83,7 +83,7 @@ describe("poll", () => {
       await promise;
       fail("did not reject");
     } catch (e) {
-      expect(e.message).toEqual("Polling failed after 7 attempts");
+      expect((e as Error).message).toEqual("Polling failed after 7 attempts");
     }
     expect(requestFnSpy).toHaveBeenCalledTimes(7);
   });
@@ -108,7 +108,7 @@ describe("poll", () => {
       await promise;
       fail("did not reject");
     } catch (e) {
-      expect(e.message).toEqual("Polling failed after 3 attempts");
+      expect((e as Error).message).toEqual("Polling failed after 3 attempts");
     }
     expect(requestFnSpy).toHaveBeenCalledTimes(3);
   });
@@ -145,7 +145,7 @@ describe("poll", () => {
       await promise;
       fail("did not reject");
     } catch (e) {
-      expect(e.message).toEqual("Polling failed after 7 attempts");
+      expect((e as Error).message).toEqual("Polling failed after 7 attempts");
     }
     expect(requestFnSpy).toHaveBeenCalledTimes(7);
   });
@@ -182,7 +182,7 @@ describe("poll", () => {
       await promise;
       fail("did not reject");
     } catch (e) {
-      expect(e.message).toEqual("Polling failed after 7 attempts");
+      expect((e as Error).message).toEqual("Polling failed after 7 attempts");
     }
     expect(requestFnSpy).toHaveBeenCalledTimes(7);
   });
@@ -219,7 +219,7 @@ describe("poll", () => {
       await promise;
       fail("did not reject");
     } catch (e) {
-      expect(e.message).toEqual("Polling failed after 7 attempts");
+      expect((e as Error).message).toEqual("Polling failed after 7 attempts");
     }
     expect(requestFnSpy).toHaveBeenCalledTimes(7);
   });
@@ -256,7 +256,7 @@ describe("poll", () => {
       await promise;
       fail("did not reject");
     } catch (e) {
-      expect(e.message).toEqual("Polling failed after 7 attempts");
+      expect((e as Error).message).toEqual("Polling failed after 7 attempts");
     }
     expect(requestFnSpy).toHaveBeenCalledTimes(7);
   });
@@ -293,7 +293,7 @@ describe("poll", () => {
       await promise;
       fail("did not reject");
     } catch (e) {
-      expect(e.message).toEqual("Polling failed after 7 attempts");
+      expect((e as Error).message).toEqual("Polling failed after 7 attempts");
     }
     expect(requestFnSpy).toHaveBeenCalledTimes(7);
   });

--- a/packages/common/test/versioning/updateVersion.test.ts
+++ b/packages/common/test/versioning/updateVersion.test.ts
@@ -120,7 +120,7 @@ describe("updateVersion", () => {
       await updateVersion(model, version, requestOpts);
       fail("should reject");
     } catch (err) {
-      expect(err.message).toBe(
+      expect((err as Error).message).toBe(
         "Version def456 is stale. Use force to overwrite."
       );
     }

--- a/packages/downloads/test/hub/hub-request-dataset-export.test.ts
+++ b/packages/downloads/test/hub/hub-request-dataset-export.test.ts
@@ -4,18 +4,18 @@ import { hubRequestDatasetExport } from "../../src/hub/hub-request-dataset-expor
 describe("hubRequestDatasetExport", () => {
   afterEach(() => fetchMock.restore());
 
-  it("handle remote server 502 error", async done => {
+  it("handle remote server 502 error", async (done) => {
     try {
       fetchMock.post(
         "http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads",
         {
-          status: 502
+          status: 502,
         },
         {
           body: {
             spatialRefId: "4326",
-            format: "csv"
-          }
+            format: "csv",
+          },
         }
       );
 
@@ -23,10 +23,11 @@ describe("hubRequestDatasetExport", () => {
         host: "http://hub.com",
         datasetId: "abcdef0123456789abcdef0123456789_0",
         spatialRefId: "4326",
-        format: "CSV"
+        format: "CSV",
       });
     } catch (err) {
-      const { message, status, url } = err;
+      const error = err as { message?: string; status?: number; url?: string };
+      const { message, status, url } = error;
       expect(message).toEqual("Bad Gateway");
       expect(status).toEqual(502);
       expect(url).toEqual(
@@ -37,19 +38,19 @@ describe("hubRequestDatasetExport", () => {
     }
   });
 
-  it("success", async done => {
+  it("success", async (done) => {
     try {
       fetchMock.post(
         "http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads",
         {
           status: 200,
-          body: {}
+          body: {},
         },
         {
           body: {
             spatialRefId: "4326",
-            format: "csv"
-          }
+            format: "csv",
+          },
         }
       );
 
@@ -57,31 +58,32 @@ describe("hubRequestDatasetExport", () => {
         host: "http://hub.com",
         datasetId: "abcdef0123456789abcdef0123456789_0",
         spatialRefId: "4326",
-        format: "CSV"
+        format: "CSV",
       });
       expect(json.downloadId).toEqual(
         "abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined"
       );
     } catch (err) {
-      expect(err).toBeUndefined();
+      const error = err as { message?: string; status?: number; url?: string };
+      expect(error).toBeUndefined();
     } finally {
       done();
     }
   });
 
-  it("success with a host that has trailing slash", async done => {
+  it("success with a host that has trailing slash", async (done) => {
     try {
       fetchMock.post(
         "http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads",
         {
           status: 200,
-          body: {}
+          body: {},
         },
         {
           body: {
             spatialRefId: "4326",
-            format: "csv"
-          }
+            format: "csv",
+          },
         }
       );
 
@@ -89,13 +91,14 @@ describe("hubRequestDatasetExport", () => {
         host: "http://hub.com/",
         datasetId: "abcdef0123456789abcdef0123456789_0",
         spatialRefId: "4326",
-        format: "CSV"
+        format: "CSV",
       });
       expect(json.downloadId).toEqual(
         "abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined"
       );
     } catch (err) {
-      expect(err).toBeUndefined();
+      const error = err as { message?: string; status?: number; url?: string };
+      expect(error).toBeUndefined();
     } finally {
       done();
     }

--- a/packages/downloads/test/hub/hub-request-download-metadata.test.ts
+++ b/packages/downloads/test/hub/hub-request-download-metadata.test.ts
@@ -17,30 +17,29 @@ const apiResponsefixture = {
         featureSet: "full",
         source: {
           type: "Feature Service",
-          url:
-            "https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json",
+          url: "https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0?f=json",
           supportsExtract: true,
           lastEditDate: "2020-06-18T01:17:31.492Z",
-          spatialRefId: "4326"
-        }
+          spatialRefId: "4326",
+        },
       },
       links: {
         content:
-          "https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv"
-      }
-    }
-  ]
+          "https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv",
+      },
+    },
+  ],
 };
 
 describe("hubRequestDownloadMetadata", () => {
   afterEach(() => fetchMock.restore());
 
-  it("handle remote server 502 error", async done => {
+  it("handle remote server 502 error", async (done) => {
     try {
       fetchMock.mock(
         "http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv",
         {
-          status: 502
+          status: 502,
         }
       );
 
@@ -48,10 +47,11 @@ describe("hubRequestDownloadMetadata", () => {
         host: "http://hub.com",
         datasetId: "abcdef0123456789abcdef0123456789_0",
         spatialRefId: "4326",
-        format: "CSV"
+        format: "CSV",
       });
     } catch (err) {
-      const { message, status, url } = err;
+      const error = err as { message?: string; status?: number; url?: string };
+      const { message, status, url } = error;
       expect(message).toEqual("Bad Gateway");
       expect(status).toEqual(502);
       expect(url).toEqual(
@@ -62,13 +62,13 @@ describe("hubRequestDownloadMetadata", () => {
     }
   });
 
-  it("handle missing data property", async done => {
+  it("handle missing data property", async (done) => {
     try {
       fetchMock.mock(
         "http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv",
         {
           status: 200,
-          body: {}
+          body: {},
         }
       );
 
@@ -76,12 +76,13 @@ describe("hubRequestDownloadMetadata", () => {
         host: "http://hub.com",
         datasetId: "abcdef0123456789abcdef0123456789_0",
         spatialRefId: "4326",
-        format: "CSV"
+        format: "CSV",
       });
 
       expect(result).toEqual(undefined);
     } catch (err) {
-      expect(err.message).toEqual(
+      const error = err as { message?: string; status?: number; url?: string };
+      expect(error.message).toEqual(
         'Unexpected API response; no "data" property.'
       );
     } finally {
@@ -89,13 +90,13 @@ describe("hubRequestDownloadMetadata", () => {
     }
   });
 
-  it("handle data is not array", async done => {
+  it("handle data is not array", async (done) => {
     try {
       fetchMock.mock(
         "http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv",
         {
           status: 200,
-          body: { data: {} }
+          body: { data: {} },
         }
       );
 
@@ -103,12 +104,13 @@ describe("hubRequestDownloadMetadata", () => {
         host: "http://hub.com",
         datasetId: "abcdef0123456789abcdef0123456789_0",
         spatialRefId: "4326",
-        format: "CSV"
+        format: "CSV",
       });
 
       expect(result).toEqual(undefined);
     } catch (err) {
-      expect(err.message).toEqual(
+      const error = err as { message?: string; status?: number; url?: string };
+      expect(error.message).toEqual(
         'Unexpected API response; "data" is not an array.'
       );
     } finally {
@@ -116,23 +118,24 @@ describe("hubRequestDownloadMetadata", () => {
     }
   });
 
-  it("handle data array with more than one element", async done => {
+  it("handle data array with more than one element", async (done) => {
     try {
       fetchMock.mock(
         "http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?formats=csv",
         {
           status: 200,
-          body: { data: [{}, {}] }
+          body: { data: [{}, {}] },
         }
       );
 
       await hubRequestDownloadMetadata({
         host: "http://hub.com",
         datasetId: "abcdef0123456789abcdef0123456789_0",
-        format: "CSV"
+        format: "CSV",
       });
     } catch (err) {
-      expect(err.message).toEqual(
+      const error = err as { message?: string; status?: number; url?: string };
+      expect(error.message).toEqual(
         'Unexpected API response; "data" contains more than one download.'
       );
     } finally {
@@ -140,15 +143,15 @@ describe("hubRequestDownloadMetadata", () => {
     }
   });
 
-  it("handle zero download results", async done => {
+  it("handle zero download results", async (done) => {
     try {
       fetchMock.mock(
         "http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv",
         {
           status: 200,
           body: {
-            data: []
-          }
+            data: [],
+          },
         }
       );
 
@@ -156,28 +159,29 @@ describe("hubRequestDownloadMetadata", () => {
         host: "http://hub.com",
         datasetId: "abcdef0123456789abcdef0123456789_0",
         spatialRefId: "4326",
-        format: "CSV"
+        format: "CSV",
       });
 
       expect(result).toEqual({
         downloadId:
           "abcdef0123456789abcdef0123456789_0:CSV:4326:undefined:undefined",
-        status: "not_ready"
+        status: "not_ready",
       });
     } catch (err) {
-      expect(err).toEqual(undefined);
+      const error = err as { message?: string; status?: number; url?: string };
+      expect(error).toEqual(undefined);
     } finally {
       done();
     }
   });
 
-  it("handle downloaded result", async done => {
+  it("handle downloaded result", async (done) => {
     try {
       fetchMock.mock(
         "http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv",
         {
           status: 200,
-          body: apiResponsefixture
+          body: apiResponsefixture,
         }
       );
 
@@ -185,7 +189,7 @@ describe("hubRequestDownloadMetadata", () => {
         host: "http://hub.com",
         datasetId: "abcdef0123456789abcdef0123456789_0",
         spatialRefId: "4326",
-        format: "CSV"
+        format: "CSV",
       });
 
       expect(result).toEqual({
@@ -199,22 +203,23 @@ describe("hubRequestDownloadMetadata", () => {
         downloadUrl:
           "https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv",
         contentLength: 1391454,
-        cacheTime: 13121
+        cacheTime: 13121,
       });
     } catch (err) {
-      expect(err).toEqual(undefined);
+      const error = err as { message?: string; status?: number; url?: string };
+      expect(error).toEqual(undefined);
     } finally {
       done();
     }
   });
 
-  it("handle downloaded result with host including trailing slash", async done => {
+  it("handle downloaded result with host including trailing slash", async (done) => {
     try {
       fetchMock.mock(
         "http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv",
         {
           status: 200,
-          body: apiResponsefixture
+          body: apiResponsefixture,
         }
       );
 
@@ -222,7 +227,7 @@ describe("hubRequestDownloadMetadata", () => {
         host: "http://hub.com/",
         datasetId: "abcdef0123456789abcdef0123456789_0",
         spatialRefId: "4326",
-        format: "CSV"
+        format: "CSV",
       });
 
       expect(result).toEqual({
@@ -236,22 +241,23 @@ describe("hubRequestDownloadMetadata", () => {
         downloadUrl:
           "https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv",
         contentLength: 1391454,
-        cacheTime: 13121
+        cacheTime: 13121,
       });
     } catch (err) {
-      expect(err).toEqual(undefined);
+      const error = err as { message?: string; status?: number; url?: string };
+      expect(error).toEqual(undefined);
     } finally {
       done();
     }
   });
 
-  it("handle downloaded result with geometry filter", async done => {
+  it("handle downloaded result with geometry filter", async (done) => {
     try {
       fetchMock.mock(
         "http://hub.com/api/v3/datasets/abcdef0123456789abcdef0123456789_0/downloads?spatialRefId=4326&formats=csv&geometry=%22%7B%5C%22xmin%5C%22%3A0%2C%5C%22xmax%5C%22%3A10%2C%5C%22ymin%5C%22%3A0%2C%5C%22ymax%5C%22%3A10%2C%5C%22spatialReference%5C%22%3A%7B%5C%22wkid%5C%22%3A4326%7D%7D%22",
         {
           status: 200,
-          body: apiResponsefixture
+          body: apiResponsefixture,
         }
       );
 
@@ -266,9 +272,9 @@ describe("hubRequestDownloadMetadata", () => {
           ymin: 0,
           ymax: 10,
           spatialReference: {
-            wkid: 4326
-          }
-        })
+            wkid: 4326,
+          },
+        }),
       });
 
       expect(result).toEqual({
@@ -282,10 +288,11 @@ describe("hubRequestDownloadMetadata", () => {
         downloadUrl:
           "https://dev-hub-indexer.s3.amazonaws.com/files/dd4580c810204019a7b8eb3e0b329dd6/0/full/4326/dd4580c810204019a7b8eb3e0b329dd6_0_full_4326.csv",
         contentLength: 1391454,
-        cacheTime: 13121
+        cacheTime: 13121,
       });
     } catch (err) {
-      expect(err).toEqual(undefined);
+      const error = err as { message?: string; status?: number; url?: string };
+      expect(error).toEqual(undefined);
     } finally {
       done();
     }

--- a/packages/downloads/test/poll-download-metadata.test.ts
+++ b/packages/downloads/test/poll-download-metadata.test.ts
@@ -11,7 +11,7 @@ describe("pollDownloadMetadata", () => {
 
       spyOn(hubPoller, "hubPollDownloadMetadata").and.returnValue(
         new Promise((resolve, _reject) => {
-          resolve();
+          resolve(undefined);
         })
       );
 
@@ -43,7 +43,8 @@ describe("pollDownloadMetadata", () => {
         },
       ]);
     } catch (err) {
-      expect(err).toBeUndefined();
+      const error = err as { message?: string };
+      expect(error).toBeUndefined();
     } finally {
       done();
     }
@@ -66,7 +67,7 @@ describe("pollDownloadMetadata", () => {
 
       spyOn(portalPoller, "portalPollExportJobStatus").and.returnValue(
         new Promise((resolve, reject) => {
-          resolve();
+          resolve(undefined);
         })
       );
 
@@ -104,7 +105,8 @@ describe("pollDownloadMetadata", () => {
         },
       ]);
     } catch (err) {
-      expect(err).toBeUndefined();
+      const error = err as { message?: string };
+      expect(error).toBeUndefined();
     } finally {
       done();
     }
@@ -127,7 +129,7 @@ describe("pollDownloadMetadata", () => {
 
       spyOn(portalPoller, "portalPollExportJobStatus").and.returnValue(
         new Promise((resolve, reject) => {
-          resolve();
+          resolve(undefined);
         })
       );
 
@@ -165,7 +167,8 @@ describe("pollDownloadMetadata", () => {
         },
       ]);
     } catch (err) {
-      expect(err).toBeUndefined();
+      const error = err as { message?: string };
+      expect(error).toBeUndefined();
     } finally {
       done();
     }

--- a/packages/downloads/test/portal/portal-export-success-handler.test.ts
+++ b/packages/downloads/test/portal/portal-export-success-handler.test.ts
@@ -49,7 +49,8 @@ describe("portalPollExportJobStatus", () => {
         });
         throw new Error("should have errored");
       } catch (err) {
-        expect(err.message).toBe("5xx");
+        const error = err as { message?: string };
+        expect(error.message).toBe("5xx");
       } finally {
         expect(common.updateItem).toHaveBeenCalledTimes(1);
         expect((common.updateItem as any).calls.first().args).toEqual([
@@ -97,7 +98,8 @@ describe("portalPollExportJobStatus", () => {
         });
         throw new Error("should have errored");
       } catch (err) {
-        expect(err.message).toEqual("5xx");
+        const error = err as { message?: string };
+        expect(error.message).toEqual("5xx");
         expect(common.updateItem).toHaveBeenCalledTimes(1);
         expect((common.updateItem as any).calls.first().args).toEqual([
           {
@@ -157,7 +159,8 @@ describe("portalPollExportJobStatus", () => {
         });
         throw new Error("should have errored");
       } catch (err) {
-        expect(err.message).toEqual("5xx");
+        const error = err as { message?: string };
+        expect(error.message).toEqual("5xx");
         expect(common.updateItem).toHaveBeenCalledTimes(1);
         expect((common.updateItem as any).calls.first().args).toEqual([
           {
@@ -225,7 +228,8 @@ describe("portalPollExportJobStatus", () => {
         });
         throw new Error("should have errored");
       } catch (err) {
-        expect(err.message).toEqual("5xx");
+        const error = err as { message?: string };
+        expect(error.message).toEqual("5xx");
         expect(common.updateItem).toHaveBeenCalledTimes(1);
         expect((common.updateItem as any).calls.first().args).toEqual([
           {
@@ -354,7 +358,8 @@ describe("portalPollExportJobStatus", () => {
           )
         ).toEqual(true);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -458,7 +463,8 @@ describe("portalPollExportJobStatus", () => {
           )
         ).toEqual(true);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -561,7 +567,8 @@ describe("portalPollExportJobStatus", () => {
           )
         ).toEqual(true);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }

--- a/packages/downloads/test/portal/portal-get-exports-folder-id.test.ts
+++ b/packages/downloads/test/portal/portal-get-exports-folder-id.test.ts
@@ -21,7 +21,8 @@ describe("portalPollExportJobStatus", () => {
       await getExportsFolderId(authentication);
       fail();
     } catch (err) {
-      expect(err.message).toEqual("5xx");
+      const error = err as { message?: string };
+      expect(error.message).toEqual("5xx");
       expect(portal.getUserContent).toHaveBeenCalledTimes(1);
       expect((portal.getUserContent as any).calls.first().args).toEqual([
         { authentication },
@@ -48,7 +49,8 @@ describe("portalPollExportJobStatus", () => {
       await getExportsFolderId(authentication);
       fail();
     } catch (err) {
-      expect(err.message).toEqual("5xx");
+      const error = err as { message?: string };
+      expect(error.message).toEqual("5xx");
       expect(portal.getUserContent).toHaveBeenCalledTimes(1);
       expect((portal.getUserContent as any).calls.first().args).toEqual([
         { authentication },
@@ -89,7 +91,8 @@ describe("portalPollExportJobStatus", () => {
         },
       ]);
     } catch (err) {
-      expect(err).toEqual(undefined);
+      const error = err as { message?: string };
+      expect(error).toEqual(undefined);
     } finally {
       done();
     }
@@ -121,7 +124,8 @@ describe("portalPollExportJobStatus", () => {
       ]);
       expect(portal.createFolder).toHaveBeenCalledTimes(0);
     } catch (err) {
-      expect(err).toEqual(undefined);
+      const error = err as { message?: string };
+      expect(error).toEqual(undefined);
     } finally {
       done();
     }

--- a/packages/downloads/test/portal/portal-request-dataset-export.test.ts
+++ b/packages/downloads/test/portal/portal-request-dataset-export.test.ts
@@ -28,7 +28,8 @@ describe("portalRequestDatasetExport", () => {
       });
       expect(result).toBeUndefined();
     } catch (err) {
-      expect(err.message).toEqual("5xx");
+      const error = err as { message?: string };
+      expect(error.message).toEqual("5xx");
       expect(portal.exportItem).toHaveBeenCalledTimes(1);
       expect((portal.exportItem as any).calls.first().args).toEqual([
         {
@@ -78,7 +79,8 @@ describe("portalRequestDatasetExport", () => {
       expect(result.size).toEqual(1000);
       expect(typeof result.exportCreated === "number").toEqual(true);
     } catch (err) {
-      expect(err).toBeUndefined();
+      const error = err as { message?: string };
+      expect(error).toBeUndefined();
     } finally {
       done();
     }
@@ -118,7 +120,8 @@ describe("portalRequestDatasetExport", () => {
       expect(result.size).toEqual(1000);
       expect(typeof result.exportCreated === "number").toEqual(true);
     } catch (err) {
-      expect(err).toBeUndefined();
+      const error = err as { message?: string };
+      expect(error).toBeUndefined();
     } finally {
       done();
     }
@@ -162,7 +165,8 @@ describe("portalRequestDatasetExport", () => {
       expect(result.size).toEqual(1000);
       expect(typeof result.exportCreated === "number").toEqual(true);
     } catch (err) {
-      expect(err).toBeUndefined();
+      const error = err as { message?: string };
+      expect(error).toBeUndefined();
     } finally {
       done();
     }
@@ -205,7 +209,8 @@ describe("portalRequestDatasetExport", () => {
       expect(result.size).toEqual(1000);
       expect(typeof result.exportCreated === "number").toEqual(true);
     } catch (err) {
-      expect(err).toBeUndefined();
+      const error = err as { message?: string };
+      expect(error).toBeUndefined();
     } finally {
       done();
     }
@@ -250,7 +255,8 @@ describe("portalRequestDatasetExport", () => {
       expect(result.size).toEqual(1000);
       expect(typeof result.exportCreated === "number").toEqual(true);
     } catch (err) {
-      expect(err).toBeUndefined();
+      const error = err as { message?: string };
+      expect(error).toBeUndefined();
     } finally {
       done();
     }

--- a/packages/downloads/test/portal/portal-request-download-metadata.test.ts
+++ b/packages/downloads/test/portal/portal-request-download-metadata.test.ts
@@ -3380,7 +3380,7 @@ describe("portalRequestDownloadMetadata", () => {
       }
     });
 
-    fit("has lastEditDate within last 10 minutes, cached, stale, targets enterprise", async (done) => {
+    it("has lastEditDate within last 10 minutes, cached, stale, targets enterprise", async (done) => {
       const nineMinutesAgo = new Date(new Date().getTime() - 9 * 60 * 1000);
       try {
         const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(

--- a/packages/downloads/test/portal/portal-request-download-metadata.test.ts
+++ b/packages/downloads/test/portal/portal-request-download-metadata.test.ts
@@ -3380,7 +3380,7 @@ describe("portalRequestDownloadMetadata", () => {
       }
     });
 
-    it("has lastEditDate within last 10 minutes, cached, stale, targets enterprise", async (done) => {
+    fit("has lastEditDate within last 10 minutes, cached, stale, targets enterprise", async (done) => {
       const nineMinutesAgo = new Date(new Date().getTime() - 9 * 60 * 1000);
       try {
         const getItemSpy = spyOn(portalModule, "getItem").and.returnValue(

--- a/packages/downloads/test/portal/portal-request-download-metadata.test.ts
+++ b/packages/downloads/test/portal/portal-request-download-metadata.test.ts
@@ -117,7 +117,8 @@ describe("portalRequestDownloadMetadata", () => {
 
         fail("should reject!");
       } catch (err) {
-        expect(err).toEqual(jasmine.any(NotAnAuthError));
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(jasmine.any(NotAnAuthError));
       }
     });
   });
@@ -138,7 +139,8 @@ describe("portalRequestDownloadMetadata", () => {
           authentication,
         });
       } catch (err) {
-        expect(err.code).toEqual("HTTP 502");
+        const error = err as { message?: string; code?: string };
+        expect(error.code).toEqual("HTTP 502");
       } finally {
         done();
       }
@@ -168,7 +170,8 @@ describe("portalRequestDownloadMetadata", () => {
 
         expect(result).toEqual(undefined);
       } catch (err) {
-        expect(err.message).toEqual("498: Invalid token.");
+        const error = err as { message?: string; code?: string };
+        expect(error.message).toEqual("498: Invalid token.");
       } finally {
         done();
       }
@@ -206,7 +209,8 @@ describe("portalRequestDownloadMetadata", () => {
           status: "not_ready",
         });
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -252,7 +256,8 @@ describe("portalRequestDownloadMetadata", () => {
             "http://portal.com/sharing/rest/content/items/abcdef/data?token=123",
         });
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -298,7 +303,8 @@ describe("portalRequestDownloadMetadata", () => {
             "http://portal.com/sharing/rest/content/items/abcdef/data?token=123",
         });
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -396,7 +402,8 @@ describe("portalRequestDownloadMetadata", () => {
           sortOrder: "DESC",
         });
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -447,7 +454,8 @@ describe("portalRequestDownloadMetadata", () => {
           sortOrder: "DESC",
         });
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -492,7 +500,8 @@ describe("portalRequestDownloadMetadata", () => {
           sortOrder: "DESC",
         });
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -542,7 +551,8 @@ describe("portalRequestDownloadMetadata", () => {
           sortOrder: "DESC",
         });
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -633,7 +643,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -723,7 +734,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -817,7 +829,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -911,7 +924,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -1006,7 +1020,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -1097,7 +1112,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -1196,7 +1212,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -1300,7 +1317,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -1381,7 +1399,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -1481,7 +1500,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -1581,7 +1601,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -1690,7 +1711,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -1794,7 +1816,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -1904,7 +1927,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -2010,7 +2034,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -2124,7 +2149,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -2242,7 +2268,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -2342,7 +2369,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -2451,7 +2479,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -2556,7 +2585,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -2668,7 +2698,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -2776,7 +2807,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -2892,7 +2924,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -3012,7 +3045,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -3122,7 +3156,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -3226,7 +3261,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -3337,7 +3373,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -3438,13 +3475,14 @@ describe("portalRequestDownloadMetadata", () => {
             portal: undefined,
             authentication,
             num: 1,
-            q: '(typekeywords:exportItem:abcdef0123456789abcdef0123456789 AND typekeywords:exportLayer:00) AND ( (type:"CSV" AND typekeywords:spatialRefId:4326))',
+            q: '(typekeywords:exportItem:abcdef0123456789abcdef0123456789 AND typekeywords:exportLayer:null) AND ( (type:"CSV" AND typekeywords:spatialRefId:4326))',
             sortField: "modified",
             sortOrder: "DESC",
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -3559,7 +3597,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -3678,7 +3717,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -3784,7 +3824,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -3890,7 +3931,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }
@@ -3960,7 +4002,8 @@ describe("portalRequestDownloadMetadata", () => {
           },
         ]);
       } catch (err) {
-        expect(err).toEqual(undefined);
+        const error = err as { message?: string; code?: string };
+        expect(error).toEqual(undefined);
       } finally {
         done();
       }

--- a/packages/downloads/test/portal/portal-request-download-metadata.test.ts
+++ b/packages/downloads/test/portal/portal-request-download-metadata.test.ts
@@ -3475,7 +3475,7 @@ describe("portalRequestDownloadMetadata", () => {
             portal: undefined,
             authentication,
             num: 1,
-            q: '(typekeywords:exportItem:abcdef0123456789abcdef0123456789 AND typekeywords:exportLayer:null) AND ( (type:"CSV" AND typekeywords:spatialRefId:4326))',
+            q: '(typekeywords:exportItem:abcdef0123456789abcdef0123456789 AND typekeywords:exportLayer:00) AND ( (type:"CSV" AND typekeywords:spatialRefId:4326))',
             sortField: "modified",
             sortOrder: "DESC",
           },

--- a/packages/search/test/util/merge-pagination/merge.test.ts
+++ b/packages/search/test/util/merge-pagination/merge.test.ts
@@ -40,7 +40,8 @@ describe("Merge Paginations Function", () => {
     try {
       mergePages(pagesOne);
     } catch (err) {
-      expect(err.message).toEqual(
+      const error = err as { message?: string };
+      expect(error.message).toEqual(
         "Invalid Input Error. Must be array of IDataPageNextStart, received: undefined"
       );
     }
@@ -48,7 +49,8 @@ describe("Merge Paginations Function", () => {
     try {
       mergePages(pagesTwo);
     } catch (err) {
-      expect(err.message).toEqual(
+      const error = err as { message?: string };
+      expect(error.message).toEqual(
         "Invalid Input Error. Must be array of IDataPageNextStart, received: object"
       );
     }
@@ -63,7 +65,8 @@ describe("Merge Paginations Function", () => {
     try {
       mergePages(pagesOne);
     } catch (err) {
-      expect(err.message).toEqual(
+      const error = err as { message?: string };
+      expect(error.message).toEqual(
         "Invalid Input Error. Must be array of IDataPageNextStart, received: function"
       );
     }
@@ -71,7 +74,8 @@ describe("Merge Paginations Function", () => {
     try {
       mergePages(pagesTwo);
     } catch (err) {
-      expect(err.message).toEqual(
+      const error = err as { message?: string };
+      expect(error.message).toEqual(
         "Invalid Input Error. Must be array of IDataPageNextStart, received: object"
       );
     }

--- a/packages/sites/test/link-site-and-page.test.ts
+++ b/packages/sites/test/link-site-and-page.test.ts
@@ -80,7 +80,9 @@ describe("linkSiteAndPage", () => {
     expect(shareSpy).toHaveBeenCalledWith(
       pageModel.item.id,
       ["collab-id", "content-id"],
-      { authentication: {} }
+      {
+        authentication: {},
+      }
     );
   });
 
@@ -119,7 +121,9 @@ describe("linkSiteAndPage", () => {
     expect(shareSpy).toHaveBeenCalledWith(
       pageModel.item.id,
       ["collab-id", "content-id"],
-      { authentication: {} }
+      {
+        authentication: {},
+      }
     );
   });
 
@@ -142,7 +146,9 @@ describe("linkSiteAndPage", () => {
     expect(shareSpy).toHaveBeenCalledWith(
       pageModel.item.id,
       ["collab-id", "content-id"],
-      { authentication: {} }
+      {
+        authentication: {},
+      }
     );
   });
 
@@ -162,7 +168,8 @@ describe("linkSiteAndPage", () => {
       });
       fail("should reject");
     } catch (err) {
-      expect(err.message).toContain("Site");
+      const error = err as { message?: string };
+      expect(error.message).toContain("Site");
     }
     expect(updateSpy).not.toHaveBeenCalled();
     expect(shareSpy).not.toHaveBeenCalled();
@@ -177,7 +184,8 @@ describe("linkSiteAndPage", () => {
       });
       fail("should reject");
     } catch (err) {
-      expect(err.message).toContain("Page");
+      const error = err as { message?: string };
+      expect(error.message).toContain("Page");
     }
     expect(updateSpy).not.toHaveBeenCalled();
     expect(shareSpy).not.toHaveBeenCalled();
@@ -192,7 +200,8 @@ describe("linkSiteAndPage", () => {
       });
       fail("should reject");
     } catch (err) {
-      expect(err.message).toContain("Both");
+      const error = err as { message?: string };
+      expect(error.message).toContain("Both");
     }
     expect(updateSpy).not.toHaveBeenCalled();
     expect(shareSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
1. Description:
In order to move to typescript 4+, all catch blocks need type assertions. This adds them to the tests.

1. Instructions for testing: urn tests

1. Closes Issues: n/a - part of experiments with CoPilot Agent mode

1. [ ] n/a Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
