### PR TITLE
feat(hub-common): add notIds to interface ISearchEvents

### DIFF
--- a/jasmine.json
+++ b/jasmine.json
@@ -1,6 +1,6 @@
 {
   "spec_dir": "packages",
-  "spec_files": ["**/search/_internal/hubEventsHelpers/*.test.ts"],
+  "spec_files": ["*/test/**/*.test.ts"],
   "helpers": ["../support/test-helpers.js"],
   "stopSpecOnExpectationFailure": false,
   "random": false

--- a/jasmine.json
+++ b/jasmine.json
@@ -1,6 +1,6 @@
 {
   "spec_dir": "packages",
-  "spec_files": ["*/test/**/*.test.ts"],
+  "spec_files": ["**/search/_internal/hubEventsHelpers/*.test.ts"],
   "helpers": ["../support/test-helpers.js"],
   "stopSpecOnExpectationFailure": false,
   "random": false

--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -239,7 +239,7 @@ export interface ISearchEvents {
   entityIds?: string[];
   /** Array of associated entity types. Example: Hub Site Application,Hub Initiative,Hub Project */
   entityTypes?: EventAssociationEntityType[];
-  /** Array of event ids. Cannot be used with notIds. */
+  /** Array of event ids. Cannot be used with notEventIds. */
   eventIds?: string[];
   /** response data format. Example: csv,json */
   f?: EventsSearchFormat;
@@ -248,7 +248,7 @@ export interface ISearchEvents {
   /** Array of relation fields to include in response. Example: associations,creator,location,onlineMeeting,registrations */
   include?: GetEventsInclude[];
   /** Array of event ids to exclude. Cannot be used with eventIds */
-  notIds?: string[];
+  notEventIds?: string[];
   /** the max amount of events to return */
   num?: number;
   /** orgId string */

--- a/packages/common/src/events/api/orval/api/orval-events.ts
+++ b/packages/common/src/events/api/orval/api/orval-events.ts
@@ -239,7 +239,7 @@ export interface ISearchEvents {
   entityIds?: string[];
   /** Array of associated entity types. Example: Hub Site Application,Hub Initiative,Hub Project */
   entityTypes?: EventAssociationEntityType[];
-  /** Array of event ids */
+  /** Array of event ids. Cannot be used with notIds. */
   eventIds?: string[];
   /** response data format. Example: csv,json */
   f?: EventsSearchFormat;
@@ -247,6 +247,8 @@ export interface ISearchEvents {
   geometry?: ISearchEventsGeometry;
   /** Array of relation fields to include in response. Example: associations,creator,location,onlineMeeting,registrations */
   include?: GetEventsInclude[];
+  /** Array of event ids to exclude. Cannot be used with eventIds */
+  notIds?: string[];
   /** the max amount of events to return */
   num?: number;
   /** orgId string */

--- a/packages/common/src/search/_internal/hubEventsHelpers/processFilters.ts
+++ b/packages/common/src/search/_internal/hubEventsHelpers/processFilters.ts
@@ -44,7 +44,28 @@ export function processFilters(filters: IFilter[]): Partial<ISearchEvents> {
 
   // id
   if (flattenedFilters.id?.length) {
-    processedFilters.eventIds = flattenedFilters.id;
+    const { ids, notIds } = flattenedFilters.id.reduce(
+      (acc, id) =>
+        id.not
+          ? {
+              ...acc,
+              notIds: [
+                ...acc.notIds,
+                ...(Array.isArray(id.not) ? id.not : [id.not]),
+              ],
+            }
+          : {
+              ...acc,
+              ids: [...acc.ids, id],
+            },
+      { ids: [], notIds: [] }
+    );
+    if (ids.length) {
+      processedFilters.eventIds = ids.filter(unique);
+    }
+    if (notIds.length) {
+      processedFilters.notIds = notIds.filter(unique);
+    }
   }
 
   // term

--- a/packages/common/src/search/_internal/hubEventsHelpers/processFilters.ts
+++ b/packages/common/src/search/_internal/hubEventsHelpers/processFilters.ts
@@ -64,7 +64,7 @@ export function processFilters(filters: IFilter[]): Partial<ISearchEvents> {
       processedFilters.eventIds = ids.filter(unique);
     }
     if (notIds.length) {
-      processedFilters.notIds = notIds.filter(unique);
+      processedFilters.notEventIds = notIds.filter(unique);
     }
   }
 

--- a/packages/common/src/search/_internal/hubSearchEvents.ts
+++ b/packages/common/src/search/_internal/hubSearchEvents.ts
@@ -18,7 +18,7 @@ import { processFilters } from "./hubEventsHelpers/processFilters";
  *   - canEdit: boolean
  *   - entityId: string | string[];
  *   - entityType: string | string[];
- *   - id: string | string[];
+ *   - id: string | string[] | { not: string } | { not: string[] };
  *   - term: string;
  *   - categories: string | string[];
  *   - tags: string | string[];

--- a/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
+++ b/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
@@ -259,7 +259,7 @@ describe("processFilters", () => {
           ],
         },
       ]);
-      expect(result.notIds).toEqual(["abc", "def", "ghi"]);
+      expect(result.notEventIds).toEqual(["abc", "def", "ghi"]);
     });
   });
   describe("term", () => {

--- a/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
+++ b/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
@@ -235,6 +235,32 @@ describe("processFilters", () => {
       ]);
       expect(result.eventIds).toEqual(["abc", "def", "ghi"]);
     });
+
+    fit("should consolidate and unique values from multiple filters & predicates that contain objects with not property", () => {
+      const result = processFilters([
+        {
+          predicates: [
+            {
+              id: { not: "abc" },
+            },
+            {
+              id: { not: "def" },
+            },
+          ],
+        },
+        {
+          predicates: [
+            {
+              id: { not: "def" },
+            },
+            {
+              id: { not: ["ghi"] },
+            },
+          ],
+        },
+      ]);
+      expect(result.notIds).toEqual(["abc", "def", "ghi"]);
+    });
   });
   describe("term", () => {
     it("should return undefined", () => {

--- a/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
+++ b/packages/common/test/search/_internal/hubEventsHelpers/processFilters.test.ts
@@ -236,7 +236,7 @@ describe("processFilters", () => {
       expect(result.eventIds).toEqual(["abc", "def", "ghi"]);
     });
 
-    fit("should consolidate and unique values from multiple filters & predicates that contain objects with not property", () => {
+    it("should consolidate and unique values from multiple filters & predicates that contain objects with not property", () => {
       const result = processFilters([
         {
           predicates: [


### PR DESCRIPTION
1. Description: add optional `notEventIds` filter to `ISearchEvents` interface. Also update the events search filter processing logic for `id` property to handle object with not

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
