### PR TITLE
[WIP] feat: opt-in/out of hub features and clean release permissions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
       files: ["**/*.test.ts"], // Files for tests
       rules: {
         // Rules specific for test files
+        "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/require-await": "off", // Disable require-await for tests
         "no-unused-vars": "off", // Disable no-unused-vars
         "no-console": "off", // Disable no-console

--- a/package-lock.json
+++ b/package-lock.json
@@ -54268,7 +54268,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "17.16.2",
+			"version": "17.16.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -88,6 +88,7 @@ export class ArcGISContext implements IArcGISContext {
 
   private _currentUser: IUser;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _properties: Record<string, any>;
 
   private _serviceStatus: HubServiceStatus;
@@ -714,13 +715,14 @@ export class ArcGISContext implements IArcGISContext {
         "Cannot update user hub settings without an authenticated user"
       );
     }
-    // update the user-app-resource
-    await updateUserHubSettings(settings, this);
+    // update the user-app-resource replacing it instead of extending
+    // changes onto it. This ensures that migrations are applied.
+    await updateUserHubSettings(settings, this, true);
     // update the context
     this._userHubSettings = settings;
     // iterate the props in the features object
     Object.keys(getWithDefault(settings, "features", {})).forEach((key) => {
-      const val = getProp(settings, `features.${key}`);
+      const val = getProp(settings, `features.${key}`) as boolean;
       this._featureFlags[`hub:feature:${key}`] = val;
     });
   }

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -718,14 +718,10 @@ export class ArcGISContext implements IArcGISContext {
     await updateUserHubSettings(settings, this);
     // update the context
     this._userHubSettings = settings;
-    // update the feature flags
-    Object.keys(getWithDefault(settings, "preview", {})).forEach((key) => {
-      // only set the flag if it's true, otherwise delete the flag so we revert to default behavior
-      if (getProp(settings, `preview.${key}`)) {
-        this._featureFlags[`hub:feature:${key}`] = true;
-      } else {
-        delete this._featureFlags[`hub:feature:${key}`];
-      }
+    // iterate the props in the features object
+    Object.keys(getWithDefault(settings, "features", {})).forEach((key) => {
+      const val = getProp(settings, `features.${key}`);
+      this._featureFlags[`hub:feature:${key}`] = val;
     });
   }
 }

--- a/packages/common/src/ArcGISContextManager.ts
+++ b/packages/common/src/ArcGISContextManager.ts
@@ -331,13 +331,9 @@ export class ArcGISContextManager {
     // update the context
     this._userHubSettings = settings;
     // update the feature flags
-    Object.keys(getWithDefault(settings, "preview", {})).forEach((key) => {
-      // only set the flag if it's true, otherwise delete the flag so we revert to default behavior
-      if (getProp(settings, `preview.${key}`)) {
-        this._featureFlags[`hub:feature:${key}`] = true;
-      } else {
-        delete this._featureFlags[`hub:feature:${key}`];
-      }
+    Object.keys(getWithDefault(settings, "features", {})).forEach((key) => {
+      const value = getProp(settings, `features.${key}`) as boolean;
+      this._featureFlags[`hub:feature:${key}`] = value;
     });
 
     this._context = new ArcGISContext(this.contextOpts);
@@ -444,6 +440,10 @@ export class ArcGISContextManager {
     // if we are auth'd and have a hubforarcgis token,
     // fetch the users IUserHubSettings extract out the
     // preview properties and cross-walk to permissions
+    // ======================================
+    // NOTE: We don't call `fetchUserHubSettings` here because the "context"
+    // is not created yet, so we cannot pass it in to that function.
+    // ======================================
     const hubAppToken = this._userResourceTokens.find(
       (e) => e.app === "hubforarcgis"
     );
@@ -453,11 +453,15 @@ export class ArcGISContextManager {
         this._portalUrl,
         hubAppToken.token
       );
+
       // Check for feature settings and walk the into feature flags
       Object.keys(
         getWithDefault(this._userHubSettings, "features", {})
       ).forEach((key) => {
-        const val = getProp(this._userHubSettings, `features.${key}`);
+        const val = getProp(
+          this._userHubSettings,
+          `features.${key}`
+        ) as boolean;
         this._featureFlags[`hub:feature:${key}`] = val;
       });
     }

--- a/packages/common/src/ArcGISContextManager.ts
+++ b/packages/common/src/ArcGISContextManager.ts
@@ -162,6 +162,10 @@ export class ArcGISContextManager {
     if (opts.resourceTokens) {
       this._userResourceTokens = cloneObject(opts.resourceTokens);
     }
+
+    if (opts.userHubSettings) {
+      this._userHubSettings = cloneObject(opts.userHubSettings);
+    }
   }
 
   /**
@@ -449,16 +453,13 @@ export class ArcGISContextManager {
         this._portalUrl,
         hubAppToken.token
       );
-      // Check for preview settings and walk the into feature flags
-      Object.keys(getWithDefault(this._userHubSettings, "preview", {})).forEach(
-        (key) => {
-          // only set the flag if it's true, otherwise we can override
-          // feature flag query params
-          if (getProp(this._userHubSettings, `preview.${key}`)) {
-            this._featureFlags[`hub:feature:${key}`] = true;
-          }
-        }
-      );
+      // Check for feature settings and walk the into feature flags
+      Object.keys(
+        getWithDefault(this._userHubSettings, "features", {})
+      ).forEach((key) => {
+        const val = getProp(this._userHubSettings, `features.${key}`);
+        this._featureFlags[`hub:feature:${key}`] = val;
+      });
     }
 
     Logger.debug(`ArcGISContextManager-${this.id}: updating context`);

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -70,11 +70,24 @@ import { UserPermissionPolicies } from "../users/_internal/UserBusinessRules";
 /**
  * Highlevel Permission definitions for the Hub System as a whole
  * Typically other permissions depend on these so a whole set of features
- * can be enabled / disabled by changing a single permission
+ * can be enabled / disabled by changing a single permission.
  * MAKE SURE to add the permission string to the SystemPermissions array
  * in Permissions.ts
  */
 const SystemPermissionPolicies: IPermissionPolicy[] = [
+  // GATING PERMISSIONS
+  // these are used for the final release of a Hub Feature
+  // and should be removed when the feature is released
+  {
+    // Feature that gates the workspace release
+    // when removed, the workspace feature will be available to all users
+    permission: "hub:gating:workspace:released",
+    availability: ["alpha"],
+    environments: ["devext", "qaext", "production"],
+  },
+  // FEATURE PERMISSIONS
+  // these are used to enable/disable features in the Hub
+  // and are expected to be long-lived
   {
     permission: "hub:feature:ai-assistant",
     availability: ["alpha"],
@@ -92,10 +105,14 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     environments: ["devext"],
   },
   {
+    // Feature we can override to opt in/out of workspace
     permission: "hub:feature:workspace",
-    availability: ["alpha"],
-    environments: ["devext", "qaext", "production"],
+    // To release the workspace feature, remove this dependency
+    dependencies: ["hub:gating:workspace:released"],
+    // availability: ["alpha"],
+    // environments: ["devext", "qaext", "production"],
   },
+
   {
     // Enables access to the user preferences section of the user profile
     // This will likely be removed when we swap the user profile to use workspace

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -83,8 +83,6 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     // when all the other condition props are removed,
     // the workspace feature will be available to all users
     permission: "hub:gating:workspace:released",
-    availability: ["alpha"], // REMOVE THIS WHEN WORKSPACE IS RELEASED
-    environments: ["devext", "qaext", "production"], // REMOVE THIS WHEN WORKSPACE IS RELEASED
   },
   // FEATURE PERMISSIONS
   // these are used to enable/disable features in the Hub
@@ -108,10 +106,7 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
   {
     // Feature we can override to opt in/out of workspace
     permission: "hub:feature:workspace",
-    // To release the workspace feature, remove this dependency
     dependencies: ["hub:gating:workspace:released"],
-    // availability: ["alpha"],
-    // environments: ["devext", "qaext", "production"],
   },
 
   {
@@ -154,10 +149,7 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
   {
     // When enabled, the manage links will take the user the org home site
     permission: "hub:feature:workspace:user",
-    // NOTE: qaext and devext might seem redundant, given that hub:feature:workspace is alpha
-    // but we allow users to "opt-in" which overrides that
-    environments: ["production", "qaext", "devext"],
-    dependencies: ["hub:feature:workspace"],
+    dependencies: ["hub:gating:workspace:released"],
   },
   {
     // When enabled, the manage links will take the user the org home site

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -80,10 +80,11 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
   // and should be removed when the feature is released
   {
     // Feature that gates the workspace release
-    // when removed, the workspace feature will be available to all users
+    // when all the other condition props are removed,
+    // the workspace feature will be available to all users
     permission: "hub:gating:workspace:released",
-    availability: ["alpha"],
-    environments: ["devext", "qaext", "production"],
+    availability: ["alpha"], // REMOVE THIS WHEN WORKSPACE IS RELEASED
+    environments: ["devext", "qaext", "production"], // REMOVE THIS WHEN WORKSPACE IS RELEASED
   },
   // FEATURE PERMISSIONS
   // these are used to enable/disable features in the Hub

--- a/packages/common/src/permissions/checkPermission.ts
+++ b/packages/common/src/permissions/checkPermission.ts
@@ -108,33 +108,9 @@ export function checkPermission(
     flagging.type = "uri-flag";
   }
 
-  // We also check the context.userHubSettings.preview array
-  // which can also be used to enable features.
-  // DEPRECATED: REMOVE WITH PR THAT ADDS THE FEATURES OBJECT
-  // if (context.userHubSettings?.preview) {
-  //   const preview = getWithDefault(
-  //     context,
-  //     "userHubSettings.preview",
-  //     {}
-  //   ) as IUserHubSettings["preview"];
-  //   Object.keys(preview).forEach((key) => {
-  //     // only set the flag if it's true, otherwise delete the flag so we revert to default behavior
-  //     if (
-  //       permission === `hub:feature:${key}` &&
-  //       getProp(preview, key) === true
-  //     ) {
-  //       flagging.hasFlag = true;
-  //       flagging.value = true;
-  //       flagging.type = "feature";
-  //     }
-  //   });
-  // }
-
   // Preview was too limiting as it could only be true, so we
   // added a features object to userHubSettings that can be
-  // used to enable/disable features
-  // This is a more general purpose flagging system that allows
-  // for more complex feature flags
+  // used to opt-in/out of features
   if (context.userHubSettings?.features) {
     const features = getWithDefault(
       context,

--- a/packages/common/src/users/_internal/UserSchema.ts
+++ b/packages/common/src/users/_internal/UserSchema.ts
@@ -17,7 +17,7 @@ export const UserSchema: IConfigurationSchema = {
           properties: {
             workspace: {
               type: "boolean",
-              default: false,
+              default: true,
             },
           },
         },

--- a/packages/common/src/users/_internal/UserSchema.ts
+++ b/packages/common/src/users/_internal/UserSchema.ts
@@ -12,7 +12,7 @@ export const UserSchema: IConfigurationSchema = {
     settings: {
       type: "object",
       properties: {
-        preview: {
+        features: {
           type: "object",
           properties: {
             workspace: {

--- a/packages/common/src/users/_internal/UserUiSchemaSettings.ts
+++ b/packages/common/src/users/_internal/UserUiSchemaSettings.ts
@@ -83,7 +83,7 @@ export const buildUiSchema = async (
           {
             type: "Control",
             scope:
-              "/properties/settings/properties/preview/properties/workspace",
+              "/properties/settings/properties/features/properties/workspace",
             labelKey: `${i18nScope}.fields.workspacePreview.label`,
             options: {
               type: "Control",

--- a/packages/common/src/utils/IUserHubSettings.ts
+++ b/packages/common/src/utils/IUserHubSettings.ts
@@ -28,6 +28,12 @@ export interface IUserHubSettings {
     workspace: boolean;
   };
   /**
+   * Allow features to be opted in or out of
+   */
+  features?: {
+    workspace: boolean;
+  };
+  /**
    * Optional history of sites/content the user has visited
    */
   history?: IHubHistory;

--- a/packages/common/src/utils/IUserHubSettings.ts
+++ b/packages/common/src/utils/IUserHubSettings.ts
@@ -18,20 +18,12 @@ export interface IUserHubSettings {
      */
     dismissed?: string[];
   };
-  /**
-   * Features that are enabled for the user in preview mode
-   */
-  preview?: {
-    /**
-     * Enable the workspace feature
-     */
-    workspace: boolean;
-  };
+
   /**
    * Allow features to be opted in or out of
    */
   features?: {
-    workspace: boolean;
+    workspace?: boolean;
   };
   /**
    * Optional history of sites/content the user has visited

--- a/packages/common/src/utils/hasOwnProperty.ts
+++ b/packages/common/src/utils/hasOwnProperty.ts
@@ -1,0 +1,13 @@
+/**
+ * Check if an object has a specific property in a type-safe manner
+ * that meets the eslint rule `@typescript-eslint/no-prototype-builtins`.
+ * @param obj
+ * @param prop
+ * @returns
+ */
+export function hasOwnProperty<
+  T extends Record<string, unknown>,
+  K extends PropertyKey
+>(obj: T, prop: K): obj is T & Record<K, unknown> {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+}

--- a/packages/common/src/utils/hubUserAppResources.ts
+++ b/packages/common/src/utils/hubUserAppResources.ts
@@ -27,7 +27,7 @@ import { IUserHubSettings } from "./IUserHubSettings";
 export async function updateUserSiteSettings(
   settings: IUserSiteSettings,
   context: IArcGISContext,
-  replace: boolean = false
+  replace = false
 ): Promise<void> {
   const token = context.tokenFor(USER_SITE_SETTINGS_APP);
 
@@ -71,10 +71,11 @@ export async function fetchUserSiteSettings(
       USER_SITE_SETTINGS_KEY,
       context.portalUrl,
       token
-    )) as Promise<IUserSiteSettings>;
+    )) as IUserSiteSettings;
     // run though schema upgrades
     return applySiteSettingsMigrations(settings);
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return Promise.resolve(null);
   }
 }
@@ -89,7 +90,7 @@ export async function fetchUserSiteSettings(
 export async function updateUserHubSettings(
   settings: IUserHubSettings,
   context: IArcGISContext,
-  replace: boolean = false
+  replace = false
 ): Promise<void> {
   const token = context.tokenFor(USER_HUB_SETTINGS_APP);
 
@@ -124,7 +125,7 @@ export async function updateUserHubSettings(
  */
 export async function fetchUserHubSettings(
   context: IArcGISContext
-): Promise<IUserHubSettings> {
+): Promise<IUserHubSettings | null> {
   const token = context.tokenFor(USER_HUB_SETTINGS_APP);
   if (token) {
     return await fetchAndMigrateUserHubSettings(
@@ -133,6 +134,7 @@ export async function fetchUserHubSettings(
       token
     );
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return Promise.resolve(null);
   }
 }

--- a/packages/common/src/utils/internal/fetchAndMigrateUserHubSettings.ts
+++ b/packages/common/src/utils/internal/fetchAndMigrateUserHubSettings.ts
@@ -50,7 +50,7 @@ function getDefaultUserHubSettings(username: string): IUserHubSettings {
     username,
     updated: new Date().getTime(),
     features: {
-      workspace: false,
+      workspace: true,
     },
   };
 }

--- a/packages/common/src/utils/internal/fetchAndMigrateUserHubSettings.ts
+++ b/packages/common/src/utils/internal/fetchAndMigrateUserHubSettings.ts
@@ -25,12 +25,12 @@ export async function fetchAndMigrateUserHubSettings(
     getDefaultUserHubSettings(username)
   );
   // fetch the user's Hub Settings
-  const settings = await fsGetResource(
+  const settings = (await fsGetResource(
     username,
     USER_HUB_SETTINGS_KEY,
     portalUrl,
     token
-  );
+  )) as IUserHubSettings;
   // apply any migrations and return the result
   return applyHubSettingsMigrations(settings);
 }
@@ -42,10 +42,9 @@ export async function fetchAndMigrateUserHubSettings(
  * @returns
  */
 function getDefaultUserHubSettings(username: string): IUserHubSettings {
-  // TODO: We may need to consider how we swap the features.workspace flag
-  // based on the release status of the workspace feature.
-  // For now, since we are in the opt-in phase, we will set it to false.
-  // If the workspace feature is released, this should be set to true.
+  // This is current for schemaVersion 1.1 but can be updated as needed
+  // but it is run through migrations after being returned
+  // so it doesn't need to be the latest version
   return {
     schemaVersion: 1.1,
     username,

--- a/packages/common/src/utils/internal/fetchAndMigrateUserHubSettings.ts
+++ b/packages/common/src/utils/internal/fetchAndMigrateUserHubSettings.ts
@@ -42,11 +42,15 @@ export async function fetchAndMigrateUserHubSettings(
  * @returns
  */
 function getDefaultUserHubSettings(username: string): IUserHubSettings {
+  // TODO: We may need to consider how we swap the features.workspace flag
+  // based on the release status of the workspace feature.
+  // For now, since we are in the opt-in phase, we will set it to false.
+  // If the workspace feature is released, this should be set to true.
   return {
-    schemaVersion: 1,
+    schemaVersion: 1.1,
     username,
     updated: new Date().getTime(),
-    preview: {
+    features: {
       workspace: false,
     },
   };

--- a/packages/common/src/utils/internal/siteSettingsMigrations.ts
+++ b/packages/common/src/utils/internal/siteSettingsMigrations.ts
@@ -23,7 +23,26 @@ export function applySiteSettingsMigrations(
 export function applyHubSettingsMigrations(
   settings: Record<string, any>
 ): IUserHubSettings {
-  // const currentSchema = 1;
+  let clone = cloneObject(settings) as IUserHubSettings;
+  clone = swapPreviewToFeatures(clone);
+  return clone;
+}
 
-  return cloneObject(settings) as IUserHubSettings;
+/**
+ * Migration to swap .preview to .features which allows for
+ * opting in and out of features
+ * @private
+ * @param settings
+ * @returns
+ */
+function swapPreviewToFeatures(settings: IUserHubSettings): IUserHubSettings {
+  if (settings.schemaVersion <= 1.1) {
+    settings.schemaVersion = 1.1;
+    if (settings.preview && !settings.features) {
+      settings.features = settings.preview;
+    }
+    // Ensure .preview is removed
+    delete settings.preview;
+  }
+  return settings;
 }

--- a/packages/common/src/utils/internal/siteSettingsMigrations.ts
+++ b/packages/common/src/utils/internal/siteSettingsMigrations.ts
@@ -1,5 +1,4 @@
 import { getProp } from "../../objects/get-prop";
-import { HubPermissionsPolicies } from "../../permissions";
 import { cloneObject } from "../../util";
 import { hasOwnProperty } from "../hasOwnProperty";
 import { IUserHubSettings } from "../IUserHubSettings";
@@ -31,7 +30,6 @@ export function applyHubSettingsMigrations(
   // so we can chain them together, and at the end we cast back to IUserHubSettings
   let clone = cloneObject(settings) as ILegacyUserHubSettings;
   clone = swapPreviewToFeatures(clone);
-  clone = clearWorkspaceFeatureForRelease(clone);
   return clone as IUserHubSettings;
 }
 
@@ -68,38 +66,6 @@ function swapPreviewToFeatures(
   return settings;
 }
 
-function clearWorkspaceFeatureForRelease(
-  settings: ILegacyUserHubSettings
-): ILegacyUserHubSettings {
-  // THIS IS AN ANTI-PATTERN
-  // But we can't use checkPermission here because
-  // it requires an IArcGISContext and this is a migration function
-  // that is run before the context is available. Chicken, meet egg.
-  // So we are just going to grab the permission object
-  // and assume that if it has no props other than `permission`
-  // then it is released.
-  const workspaceGatePermission = HubPermissionsPolicies.find((entry) => {
-    return entry.permission === "hub:gating:workspace:released";
-  });
-
-  // if the permission has only a single property
-  // then we consider it released.
-  // istanbul ignore next
-  const isWorkspacesReleased = workspaceGatePermission
-    ? Object.keys(workspaceGatePermission).length === 1
-    : false;
-  // istanbul ignore next
-  if (isWorkspacesReleased && settings.schemaVersion < 1.2) {
-    if (hasOwnProperty(settings, "features") && settings.features) {
-      // when workspace is released we remove the workspace feature
-      // if the user opts out, it will be re-added as false.
-      delete settings.features.workspace;
-    }
-    settings.schemaVersion = 1.2;
-  }
-
-  return settings;
-}
 // FUTURE: For when we end the opt-out period for workspaces
 // /**
 //  * Remove the workspace feature because the opt-out period has ended.

--- a/packages/common/src/utils/internal/userAppResources.ts
+++ b/packages/common/src/utils/internal/userAppResources.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 // These Types and Functions can land in rest-js
 // a friendly name for the scope of the resource
 // the API deals with clientIds, which are
@@ -121,7 +122,7 @@ export async function setUserResource(
   username: string,
   portalUrl: string,
   token: string,
-  replace: boolean = false
+  replace = false
 ): Promise<void> {
   // Ensure we are below 5MB max size
   if (getObjectSize(resource.data).megabytes > 4.95) {
@@ -133,6 +134,7 @@ export async function setUserResource(
   let payload = resource.data;
   if (!replace) {
     const fsGetResource = failSafe(getUserResource, {});
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const currentResource = await fsGetResource(
       username,
       resource.key,
@@ -140,6 +142,7 @@ export async function setUserResource(
       token
     );
     // extend current object witn updated object
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     payload = { ...currentResource, ...resource.data };
   }
   const ro: IRequestOptions = {
@@ -229,7 +232,7 @@ export function listUserResources(
   username: string,
   portalUrl: string,
   token: string,
-  returnAllApps: boolean = false
+  returnAllApps = false
 ): Promise<IUserResourceListResponse> {
   const ro: IRequestOptions = {
     portal: portalUrl,

--- a/packages/common/test/ArcGISContext.test.ts
+++ b/packages/common/test/ArcGISContext.test.ts
@@ -255,19 +255,19 @@ describe("ArcGISContext:", () => {
       const ctx = createMockContext();
       await ctx.updateUserHubSettings({
         schemaVersion: 1,
-        preview: {
+        features: {
           workspace: true,
         },
       } as unknown as IUserHubSettings);
       expect(uarSpy).toHaveBeenCalled();
-      expect(ctx.featureFlags["hub:feature:workspace"]).toBeDefined();
+      expect(ctx.featureFlags["hub:feature:workspace"]).toBeTruthy();
       await ctx.updateUserHubSettings({
         schemaVersion: 1,
-        preview: {
+        features: {
           workspace: false,
         },
       } as unknown as IUserHubSettings);
-      expect(ctx.featureFlags["hub:feature:workspace"]).not.toBeDefined();
+      expect(ctx.featureFlags["hub:feature:workspace"]).toBeFalsy();
     });
   });
 });

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -262,7 +262,7 @@ const featureFlags: IFeatureFlags = {
   "hub:site:create": false,
 };
 
-describe("ArcGISContext:", () => {
+describe("ArcGISContextManager:", () => {
   describe("AGO:", () => {
     it("verify props when passed nothing", async () => {
       const t = new Date().getTime();
@@ -576,8 +576,8 @@ describe("ArcGISContext:", () => {
         "getUserResource"
       ).and.callFake(() => {
         return Promise.resolve({
-          schemaVersion: 1,
-          preview: {
+          schemaVersion: 1.1,
+          features: {
             workspace: true,
           },
         });
@@ -606,15 +606,15 @@ describe("ArcGISContext:", () => {
       // verify userHubSettings
       expect(fetchSettingsSpy).toHaveBeenCalled();
       expect(mgr.context.userHubSettings).toEqual({
-        schemaVersion: 1,
-        preview: {
+        schemaVersion: 1.1,
+        features: {
           workspace: true,
         },
       });
 
       expect(mgr.context.featureFlags["hub:feature:workspace"]).toBe(true);
     });
-    it("verify flags not set if preview false when passed session", async () => {
+    it("verify flags not set if feature false when passed session", async () => {
       const t = new Date().getTime();
       spyOn(portalModule, "getSelf").and.callFake(() => {
         return Promise.resolve(cloneObject(onlinePortalSelfWithLimitsResponse));
@@ -631,7 +631,7 @@ describe("ArcGISContext:", () => {
       ).and.callFake(() => {
         return Promise.resolve({
           schemaVersion: 1,
-          preview: {
+          features: {
             workspace: false,
           },
         });
@@ -660,15 +660,13 @@ describe("ArcGISContext:", () => {
       // verify userHubSettings
       expect(fetchSettingsSpy).toHaveBeenCalled();
       expect(mgr.context.userHubSettings).toEqual({
-        schemaVersion: 1,
-        preview: {
+        schemaVersion: 1.1,
+        features: {
           workspace: false,
         },
       });
 
-      expect(
-        mgr.context.featureFlags["hub:feature:workspace"]
-      ).not.toBeDefined();
+      expect(mgr.context.featureFlags["hub:feature:workspace"]).toBeFalsy();
     });
     it("verify props when passed session, portalSelf, User, and serviceStatus", async () => {
       const selfSpy = spyOn(portalModule, "getSelf").and.callFake(() => {

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -600,12 +600,15 @@ describe("ArcGISContextManager:", () => {
       // verify userHubSettings
       expect(fetchSettingsSpy).toHaveBeenCalled();
       expect(mgr.context.userHubSettings).toEqual({
-        schemaVersion: 1.2,
-        features: {},
+        schemaVersion: 1.1,
+        features: {
+          workspace: true,
+        },
       });
 
-      expect(mgr.context.featureFlags["hub:feature:workspace"]).toBeUndefined();
+      expect(mgr.context.featureFlags["hub:feature:workspace"]).toBeTruthy();
     });
+
     it("verify flags not set if feature false when passed session", async () => {
       // const t = new Date().getTime();
       spyOn(portalModule, "getSelf").and.callFake(() => {
@@ -652,8 +655,10 @@ describe("ArcGISContextManager:", () => {
       // verify userHubSettings
       expect(fetchSettingsSpy).toHaveBeenCalled();
       expect(mgr.context.userHubSettings).toEqual({
-        schemaVersion: 1.2,
-        features: {},
+        schemaVersion: 1.1,
+        features: {
+          workspace: false,
+        },
       });
 
       expect(mgr.context.featureFlags["hub:feature:workspace"]).toBeFalsy();

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -600,13 +600,11 @@ describe("ArcGISContextManager:", () => {
       // verify userHubSettings
       expect(fetchSettingsSpy).toHaveBeenCalled();
       expect(mgr.context.userHubSettings).toEqual({
-        schemaVersion: 1.1,
-        features: {
-          workspace: true,
-        },
+        schemaVersion: 1.2,
+        features: {},
       });
 
-      expect(mgr.context.featureFlags["hub:feature:workspace"]).toBe(true);
+      expect(mgr.context.featureFlags["hub:feature:workspace"]).toBeUndefined();
     });
     it("verify flags not set if feature false when passed session", async () => {
       // const t = new Date().getTime();
@@ -654,10 +652,8 @@ describe("ArcGISContextManager:", () => {
       // verify userHubSettings
       expect(fetchSettingsSpy).toHaveBeenCalled();
       expect(mgr.context.userHubSettings).toEqual({
-        schemaVersion: 1.1,
-        features: {
-          workspace: false,
-        },
+        schemaVersion: 1.2,
+        features: {},
       });
 
       expect(mgr.context.featureFlags["hub:feature:workspace"]).toBeFalsy();

--- a/packages/common/test/mocks/mock-auth.ts
+++ b/packages/common/test/mocks/mock-auth.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { ArcGISContext, IHubRequestOptions } from "../../src";
 import type { IArcGISContext } from "../../src";
 

--- a/packages/common/test/permissions/checkPermission.test.ts
+++ b/packages/common/test/permissions/checkPermission.test.ts
@@ -138,18 +138,13 @@ describe("checkPermission:", () => {
   let gatingOptOutCtxMgr: ArcGISContextManager;
   let gatingOptInCtxMgr: ArcGISContextManager;
   let premiumCtxMgr: ArcGISContextManager;
-  let consoleInfoSpy: jasmine.Spy;
-  let consoleDirSpy: jasmine.Spy;
+
   beforeEach(async () => {
-    // tslint:disable-next-line: no-empty
-    consoleInfoSpy = spyOn(console, "info").and.callFake(() => {}); // suppress console output
-    // tslint:disable-next-line: no-empty
-    consoleDirSpy = spyOn(console, "dir").and.callFake(() => {}); // suppress console output
     spyOn(GetPolicyModule, "getPermissionPolicy").and.callFake(
       getPermissionPolicy
     );
     spyOn(IsPermissionModule, "isPermission").and.callFake(isPermission);
-    // unauthdCtxMgr = await ArcGISContextManager.create();
+
     // When we pass in all this information, the context
     // manager will not try to fetch anything, so no need
     // to mock those calls
@@ -280,11 +275,6 @@ describe("checkPermission:", () => {
     expect(chk.access).toBe(false);
     expect(chk.response).toBe("invalid-permission");
     expect(chk.checks.length).toBe(0);
-    // expect(consoleDirSpy).toHaveBeenCalled();
-    // expect(consoleInfoSpy).toHaveBeenCalled();
-    // expect(consoleInfoSpy.calls.argsFor(0)[0]).toContain(
-    //   "checkPermission: YAMMER"
-    // );
   });
   it("fails for missing policy", () => {
     const chk = checkPermission("hub:missing:policy", basicCtxMgr.context);
@@ -319,7 +309,7 @@ describe("checkPermission:", () => {
       "hub:feature:subscriptions",
       basicCtxMgr.context
     );
-    expect(chk.access).toBe(true);
+    expect(chk2.access).toBe(true);
   });
   it("user can opt out ungated feature", () => {
     const chk = checkPermission(

--- a/packages/common/test/users/HubUser.test.ts
+++ b/packages/common/test/users/HubUser.test.ts
@@ -112,7 +112,7 @@ describe("HubUser Class:", () => {
           {
             id: "123",
             name: "Paige",
-            settings: { schemaVersion: 1, preview: { workspace: false } },
+            settings: { schemaVersion: 1.1, features: { workspace: false } },
           },
           authdCtxMgr.context
         );
@@ -120,9 +120,9 @@ describe("HubUser Class:", () => {
         const result = await chk.fromEditor({
           id: "123",
           name: "Paige",
-          settings: { schemaVersion: 1, preview: { workspace: true } },
+          settings: { schemaVersion: 1.1, features: { workspace: true } },
         } as IHubUser);
-        expect(result.settings?.preview?.workspace).toEqual(true);
+        expect(result.settings?.features?.workspace).toEqual(true);
         expect(saveSpy).toHaveBeenCalledTimes(1);
       });
     });
@@ -133,7 +133,7 @@ describe("HubUser Class:", () => {
       const user = {
         id: "123",
         name: "Paige",
-        settings: { schemaVersion: 1, preview: { workspace: false } },
+        settings: { schemaVersion: 1.1, features: { workspace: false } },
       } as IHubUser;
 
       const updateUserHubSettingsSpy = spyOn(
@@ -468,7 +468,7 @@ describe("HubUser Class:", () => {
         await chk.save();
         fail("should have thrown");
       } catch (err) {
-        expect((err as any).message).toEqual("HubUser is already destroyed.");
+        expect(err.message).toEqual("HubUser is already destroyed.");
       }
     });
   });
@@ -491,7 +491,7 @@ describe("HubUser Class:", () => {
         await chk.delete();
         fail("should have thrown");
       } catch (err) {
-        expect((err as any).message).toEqual("HubUser is already destroyed.");
+        expect(err.message).toEqual("HubUser is already destroyed.");
       }
     });
   });

--- a/packages/common/test/users/_internal/UserUiSchemaSettings.test.ts
+++ b/packages/common/test/users/_internal/UserUiSchemaSettings.test.ts
@@ -61,7 +61,7 @@ describe("UserUiSchemaSettings:", () => {
             {
               type: "Control",
               scope:
-                "/properties/settings/properties/preview/properties/workspace",
+                "/properties/settings/properties/features/properties/workspace",
               labelKey: "some.scope.fields.workspacePreview.label",
               options: {
                 type: "Control",
@@ -300,7 +300,7 @@ describe("UserUiSchemaSettings:", () => {
             {
               type: "Control",
               scope:
-                "/properties/settings/properties/preview/properties/workspace",
+                "/properties/settings/properties/features/properties/workspace",
               labelKey: "some.scope.fields.workspacePreview.label",
               options: {
                 type: "Control",
@@ -540,7 +540,7 @@ describe("UserUiSchemaSettings:", () => {
             {
               type: "Control",
               scope:
-                "/properties/settings/properties/preview/properties/workspace",
+                "/properties/settings/properties/features/properties/workspace",
               labelKey: "some.scope.fields.workspacePreview.label",
               options: {
                 type: "Control",
@@ -767,7 +767,7 @@ describe("UserUiSchemaSettings:", () => {
             {
               type: "Control",
               scope:
-                "/properties/settings/properties/preview/properties/workspace",
+                "/properties/settings/properties/features/properties/workspace",
               labelKey: "some.scope.fields.workspacePreview.label",
               options: {
                 type: "Control",
@@ -1001,7 +1001,7 @@ describe("UserUiSchemaSettings:", () => {
             {
               type: "Control",
               scope:
-                "/properties/settings/properties/preview/properties/workspace",
+                "/properties/settings/properties/features/properties/workspace",
               labelKey: "some.scope.fields.workspacePreview.label",
               options: {
                 type: "Control",
@@ -1228,7 +1228,7 @@ describe("UserUiSchemaSettings:", () => {
             {
               type: "Control",
               scope:
-                "/properties/settings/properties/preview/properties/workspace",
+                "/properties/settings/properties/features/properties/workspace",
               labelKey: "some.scope.fields.workspacePreview.label",
               options: {
                 type: "Control",
@@ -1458,7 +1458,7 @@ describe("UserUiSchemaSettings:", () => {
             {
               type: "Control",
               scope:
-                "/properties/settings/properties/preview/properties/workspace",
+                "/properties/settings/properties/features/properties/workspace",
               labelKey: "some.scope.fields.workspacePreview.label",
               options: {
                 type: "Control",
@@ -1690,7 +1690,7 @@ describe("UserUiSchemaSettings:", () => {
             {
               type: "Control",
               scope:
-                "/properties/settings/properties/preview/properties/workspace",
+                "/properties/settings/properties/features/properties/workspace",
               labelKey: "some.scope.fields.workspacePreview.label",
               options: {
                 type: "Control",
@@ -1923,7 +1923,7 @@ describe("UserUiSchemaSettings:", () => {
             {
               type: "Control",
               scope:
-                "/properties/settings/properties/preview/properties/workspace",
+                "/properties/settings/properties/features/properties/workspace",
               labelKey: "some.scope.fields.workspacePreview.label",
               options: {
                 type: "Control",

--- a/packages/common/test/utils/hubUserAppResources.test.ts
+++ b/packages/common/test/utils/hubUserAppResources.test.ts
@@ -53,6 +53,7 @@ describe("hubUserAppResources:", () => {
       expect(username).toBe("jsmith");
       expect(url).toBe(ctx.portalUrl);
       expect(token).toBe("FAKESITETOKEN");
+      expect(replace).toBe(false);
       await updateUserSiteSettings(settings, ctx, true);
       expect(spy.calls.argsFor(1)[4]).toEqual(true);
     });
@@ -78,10 +79,9 @@ describe("hubUserAppResources:", () => {
       });
       try {
         await updateUserSiteSettings(settings, ctx);
-      } catch (ex) {
-        expect((ex as any).message).toContain(
-          "user-app-resource token available"
-        );
+      } catch (err) {
+        const ex = err as Error;
+        expect(ex.message).toContain("user-app-resource token available");
       }
     });
   });
@@ -170,7 +170,7 @@ describe("hubUserAppResources:", () => {
       await updateUserHubSettings(settings, ctx);
       expect(spy).toHaveBeenCalled();
       // inspect the arts
-      const [resource, username, url, token, replace] = spy.calls.argsFor(0);
+      let [resource, username, url, token, replace] = spy.calls.argsFor(0);
       expect(replace).toBe(false);
       expect(resource.key).toBe(USER_HUB_SETTINGS_KEY);
       expect(resource.data.username).toBe("jsmith");
@@ -180,7 +180,8 @@ describe("hubUserAppResources:", () => {
       expect(url).toBe(ctx.portalUrl);
       expect(token).toBe("FAKEHUBTOKEN");
       await updateUserHubSettings(settings, ctx, true);
-      expect(spy.calls.argsFor(1)[4]).toEqual(true);
+      [resource, username, url, token, replace] = spy.calls.argsFor(1);
+      expect(replace).toEqual(true, "replace should be true");
     });
     it("throws if token not found for ", async () => {
       const settings: IUserSiteSettings = {
@@ -204,10 +205,9 @@ describe("hubUserAppResources:", () => {
       });
       try {
         await updateUserHubSettings(settings, ctx);
-      } catch (ex) {
-        expect((ex as any).message).toContain(
-          "user-app-resource token available"
-        );
+      } catch (err) {
+        const ex = err as Error;
+        expect(ex.message).toContain("user-app-resource token available");
       }
     });
   });

--- a/packages/common/test/utils/internal/siteSettingsMigrations.test.ts
+++ b/packages/common/test/utils/internal/siteSettingsMigrations.test.ts
@@ -24,6 +24,20 @@ describe("siteSettingsMigrations", () => {
       const result = applyHubSettingsMigrations(settings);
       expect(result.schemaVersion).toBe(1.1);
       expect((result as any).preview).toBeUndefined();
+      expect((result as any).features).toBeDefined();
+      expect((result as any).features.workspace).not.toBeDefined();
+    });
+    it("should migrate preview to features if schemaVersion < 1.1 and preview exists", () => {
+      const settings = {
+        schemaVersion: 1.0,
+        preview: { workspace: false },
+      } as any;
+
+      const result = applyHubSettingsMigrations(settings);
+      expect(result.schemaVersion).toBe(1.1);
+      expect((result as any).preview).toBeUndefined();
+      expect((result as any).features).toBeDefined();
+      expect((result as any).features.workspace).not.toBeDefined();
     });
 
     it("should not overwrite features if already present", () => {
@@ -64,7 +78,7 @@ describe("siteSettingsMigrations", () => {
       } as any;
       const result = applyHubSettingsMigrations(settings);
       expect(result.schemaVersion).toBe(1.1);
-      expect(result.features).toBeUndefined();
+      expect(result.features).toBeDefined();
       expect((result as any).preview).toBeUndefined();
     });
   });

--- a/packages/common/test/utils/internal/siteSettingsMigrations.test.ts
+++ b/packages/common/test/utils/internal/siteSettingsMigrations.test.ts
@@ -22,8 +22,7 @@ describe("siteSettingsMigrations", () => {
       } as any;
 
       const result = applyHubSettingsMigrations(settings);
-      expect(result.schemaVersion).toBe(1.1);
-      expect(result.features).toEqual({ workspace: true });
+      expect(result.schemaVersion).toBe(1.2);
       expect((result as any).preview).toBeUndefined();
     });
 
@@ -34,8 +33,7 @@ describe("siteSettingsMigrations", () => {
         features: { workspace: true },
       } as any;
       const result = applyHubSettingsMigrations(settings);
-      expect(result.schemaVersion).toBe(1.1);
-      expect(result.features).toEqual({ workspace: true });
+      expect(result.schemaVersion).toBe(1.2);
       expect((result as any).preview).toBeUndefined();
     });
 
@@ -49,13 +47,17 @@ describe("siteSettingsMigrations", () => {
       expect((result as any).preview).toBeUndefined();
     });
 
-    it("should not change settings if schemaVersion >= 1.1", () => {
+    it("should clear workspaces for release", () => {
       const settings = {
         schemaVersion: 1.1,
         features: { workspace: true },
       } as any;
       const result = applyHubSettingsMigrations(settings);
-      expect(result).toEqual(settings);
+      const expected = {
+        schemaVersion: 1.2,
+        features: {},
+      };
+      expect(result).toEqual(expected);
     });
 
     it("should not set features.workspace if preview.workspace is undefined", () => {
@@ -64,7 +66,7 @@ describe("siteSettingsMigrations", () => {
         preview: {},
       } as any;
       const result = applyHubSettingsMigrations(settings);
-      expect(result.schemaVersion).toBe(1.1);
+      expect(result.schemaVersion).toBe(1.2);
       expect(result.features.workspace).not.toBeDefined();
       expect(getProp(result, "preview")).toBeUndefined();
     });
@@ -74,7 +76,7 @@ describe("siteSettingsMigrations", () => {
         schemaVersion: 1.0,
       } as any;
       const result = applyHubSettingsMigrations(settings);
-      expect(result.schemaVersion).toBe(1.1);
+      expect(result.schemaVersion).toBe(1.2);
       expect(result.features).toBeUndefined();
       expect((result as any).preview).toBeUndefined();
     });

--- a/packages/common/test/utils/internal/siteSettingsMigrations.test.ts
+++ b/packages/common/test/utils/internal/siteSettingsMigrations.test.ts
@@ -22,7 +22,7 @@ describe("siteSettingsMigrations", () => {
       } as any;
 
       const result = applyHubSettingsMigrations(settings);
-      expect(result.schemaVersion).toBe(1.2);
+      expect(result.schemaVersion).toBe(1.1);
       expect((result as any).preview).toBeUndefined();
     });
 
@@ -33,7 +33,7 @@ describe("siteSettingsMigrations", () => {
         features: { workspace: true },
       } as any;
       const result = applyHubSettingsMigrations(settings);
-      expect(result.schemaVersion).toBe(1.2);
+      expect(result.schemaVersion).toBe(1.1);
       expect((result as any).preview).toBeUndefined();
     });
 
@@ -47,26 +47,13 @@ describe("siteSettingsMigrations", () => {
       expect((result as any).preview).toBeUndefined();
     });
 
-    it("should clear workspaces for release", () => {
-      const settings = {
-        schemaVersion: 1.1,
-        features: { workspace: true },
-      } as any;
-      const result = applyHubSettingsMigrations(settings);
-      const expected = {
-        schemaVersion: 1.2,
-        features: {},
-      };
-      expect(result).toEqual(expected);
-    });
-
     it("should not set features.workspace if preview.workspace is undefined", () => {
       const settings = {
         schemaVersion: 1.0,
         preview: {},
       } as any;
       const result = applyHubSettingsMigrations(settings);
-      expect(result.schemaVersion).toBe(1.2);
+      expect(result.schemaVersion).toBe(1.1);
       expect(result.features.workspace).not.toBeDefined();
       expect(getProp(result, "preview")).toBeUndefined();
     });
@@ -76,7 +63,7 @@ describe("siteSettingsMigrations", () => {
         schemaVersion: 1.0,
       } as any;
       const result = applyHubSettingsMigrations(settings);
-      expect(result.schemaVersion).toBe(1.2);
+      expect(result.schemaVersion).toBe(1.1);
       expect(result.features).toBeUndefined();
       expect((result as any).preview).toBeUndefined();
     });

--- a/packages/common/test/utils/internal/siteSettingsMigrations.test.ts
+++ b/packages/common/test/utils/internal/siteSettingsMigrations.test.ts
@@ -1,0 +1,82 @@
+import { getProp } from "../../../src/objects/get-prop";
+import {
+  applySiteSettingsMigrations,
+  applyHubSettingsMigrations,
+} from "../../../src/utils/internal/siteSettingsMigrations";
+
+describe("siteSettingsMigrations", () => {
+  describe("applySiteSettingsMigrations", () => {
+    it("should clone the settings object", () => {
+      const settings = { schemaVersion: 1.0 };
+      const result = applySiteSettingsMigrations(settings);
+      expect(result).not.toBe(settings);
+      expect(result).toEqual(settings);
+    });
+  });
+
+  describe("applyHubSettingsMigrations", () => {
+    it("should migrate preview to features if schemaVersion < 1.1 and preview exists", () => {
+      const settings = {
+        schemaVersion: 1.0,
+        preview: { workspace: true },
+      } as any;
+
+      const result = applyHubSettingsMigrations(settings);
+      expect(result.schemaVersion).toBe(1.1);
+      expect(result.features).toEqual({ workspace: true });
+      expect((result as any).preview).toBeUndefined();
+    });
+
+    it("should not overwrite features if already present", () => {
+      const settings = {
+        schemaVersion: 1.0,
+        preview: { workspace: false },
+        features: { workspace: true },
+      } as any;
+      const result = applyHubSettingsMigrations(settings);
+      expect(result.schemaVersion).toBe(1.1);
+      expect(result.features).toEqual({ workspace: true });
+      expect((result as any).preview).toBeUndefined();
+    });
+
+    it("should remove preview even if features is present", () => {
+      const settings = {
+        schemaVersion: 1.0,
+        preview: { workspace: false },
+        features: { workspace: false },
+      } as any;
+      const result = applyHubSettingsMigrations(settings);
+      expect((result as any).preview).toBeUndefined();
+    });
+
+    it("should not change settings if schemaVersion >= 1.1", () => {
+      const settings = {
+        schemaVersion: 1.1,
+        features: { workspace: true },
+      } as any;
+      const result = applyHubSettingsMigrations(settings);
+      expect(result).toEqual(settings);
+    });
+
+    it("should not set features.workspace if preview.workspace is undefined", () => {
+      const settings = {
+        schemaVersion: 1.0,
+        preview: {},
+      } as any;
+      const result = applyHubSettingsMigrations(settings);
+      expect(result.schemaVersion).toBe(1.1);
+      expect(result.features.workspace).not.toBeDefined();
+      expect(getProp(result, "preview")).toBeUndefined();
+    });
+
+    it("should handle missing preview gracefully", () => {
+      const settings = {
+        schemaVersion: 1.0,
+      } as any;
+      const result = applyHubSettingsMigrations(settings);
+      expect(result.schemaVersion).toBe(1.1);
+      expect(result.features).toBeUndefined();
+      expect((result as any).preview).toBeUndefined();
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -72,7 +72,7 @@
   ],
   "include": [
     "./node_modules/@types",
-    "packages",
+    "packages/**/*.ts",
     "support"
   ]
 }


### PR DESCRIPTION
***NOTE*** This needs to be merged with related changes in `opendata-ui`.

1. Description:

- swap from `IUserHubSettings.preview` to `IUserHubSettings.features` to allow both opt-in and opt-out
- migrates existing hub user app resources to this structure, preserving existing settings
- add "gating" permissions to enable formal release of a feature
   - `hub:gating:workspace:released` which is a dependency of `hub:feature:workspace`
- update permissions guide
### TODO
- [ ] leverage the `hub:gating:workspace:released` permission to gate a second migration, which will clear out the `.features.workspace` property, thus re-setting everyone's preview status.

1. Instructions for testing: run tests

1. Part of Issues: [11970](https://devtopia.esri.com/dc/hub/issues/11970)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
