### PR TITLE
feat(hub-common): ungate events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54268,7 +54268,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "17.13.1",
+			"version": "17.16.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/events/_internal/EventBusinessRules.ts
+++ b/packages/common/src/events/_internal/EventBusinessRules.ts
@@ -33,8 +33,6 @@ export const EventPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:event",
     services: ["events"],
     licenses: ["hub-premium"],
-    // gating
-    environments: ["devext", "qaext"],
   },
   {
     permission: "hub:event:create",

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -166,8 +166,6 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:site:workspace:catalog:events",
     licenses: ["hub-premium"],
     dependencies: ["hub:site:workspace:catalog", "hub:event"],
-    environments: ["qaext"],
-    availability: ["alpha"],
   },
   {
     permission: "hub:site:workspace:pages",

--- a/packages/common/src/users/_internal/UserBusinessRules.ts
+++ b/packages/common/src/users/_internal/UserBusinessRules.ts
@@ -70,8 +70,6 @@ export const UserPermissionPolicies: IPermissionPolicy[] = [
     services: ["events"],
     dependencies: ["hub:user:workspace", "hub:user:owner"],
     licenses: ["hub-premium"],
-    // gating, remove when releasing events 3
-    environments: ["devext", "qaext"],
   },
   {
     permission: "hub:user:workspace:settings",


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #13197

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
