### PR TITLE
fix(hub-common): fixed reference to hub page icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54268,7 +54268,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "17.13.1",
+			"version": "17.16.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/content/compose.ts
+++ b/packages/common/src/content/compose.ts
@@ -267,7 +267,7 @@ export const getContentTypeIcon = (contentType: string) => {
     group: "users",
     hubInitiative: "initiative",
     hubInitiativeTemplate: "initiative-template",
-    hubPage: "browser",
+    hubPage: "maximize",
     hubProject: "projects",
     hubSiteApplication: "browser",
     image: "file-image",
@@ -400,7 +400,7 @@ export const getProxyUrl = (
  */
 export const getLayerIdFromUrl = (url: string) => {
   const endsWithNumberSegmentRegEx = /\/\d+$/;
-  const matched = url && url.match(endsWithNumberSegmentRegEx);
+  const matched = url && endsWithNumberSegmentRegEx.exec(url);
   return matched && matched[0].slice(1);
 };
 


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
