### PR TITLE
fix(hub-common): events have migrated catalog

### DIFF
--- a/packages/common/src/events/_internal/PropertyMapper.ts
+++ b/packages/common/src/events/_internal/PropertyMapper.ts
@@ -5,6 +5,7 @@ import {
 } from "../../core/_internal/PropertyMapper";
 import { IHubEvent } from "../../core/types/IHubEvent";
 import { SettableAccessLevel } from "../../core/types/types";
+import { upgradeCatalogSchema } from "../../search/upgradeCatalogSchema";
 import { cloneObject } from "../../util";
 import {
   EventAccess,
@@ -105,6 +106,10 @@ export class EventPropertyMapper extends PropertyMapper<
     obj.createdDateSource = "createdAt";
     obj.updatedDate = new Date(store.updatedAt);
     obj.updatedDateSource = "updatedAt";
+
+    // Ensure we have a catalog and that its at the current schema
+    // Note: catalogs are not hooked up yet, so this will always be the default value.
+    obj.catalog = upgradeCatalogSchema(obj.catalog || {});
 
     obj.links = computeLinks(store as IEvent);
     obj.slug = getEventSlug(store as IEvent);

--- a/packages/common/test/events/_internal/PropertyMapper.test.ts
+++ b/packages/common/test/events/_internal/PropertyMapper.test.ts
@@ -136,6 +136,21 @@ describe("PropertyMapper", () => {
         canChangeAccessOrg: true,
         canChangeAccessPrivate: true,
         canChangeAccessPublic: true,
+        catalog: {
+          schemaVersion: 1,
+          title: "Default Catalog",
+          scopes: {
+            item: {
+              targetEntity: "item",
+              filters: [],
+            },
+            event: {
+              targetEntity: "event",
+              filters: [],
+            },
+          },
+          collections: [],
+        },
         orgId: "42b",
         description: "event description",
         id: "31c",


### PR DESCRIPTION
1. Description: Events run catalog schema migrations.

1. Instructions for testing:

1. Closes Issues: #13328

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
