### PR TITLE
fix: workspace permission update

### DIFF
--- a/packages/common/src/ArcGISContextManager.ts
+++ b/packages/common/src/ArcGISContextManager.ts
@@ -327,7 +327,7 @@ export class ArcGISContextManager {
       );
     }
     // update the user-app-resource
-    await updateUserHubSettings(settings, this.context);
+    await updateUserHubSettings(settings, this.context, true);
     // update the context
     this._userHubSettings = settings;
     // update the feature flags

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -149,7 +149,8 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
   {
     // When enabled, the manage links will take the user the org home site
     permission: "hub:feature:workspace:user",
-    dependencies: ["hub:gating:workspace:released"],
+    // depends on hub:feature:workspace so users can opt out
+    dependencies: ["hub:feature:workspace"],
   },
   {
     // When enabled, the manage links will take the user the org home site


### PR DESCRIPTION
1. Description:

Ensure workspace permissions cascade as expected
`hub:feature:workspace:user -> hub:feature:workspace -> hub:gating:workspace:released`
When a user opts-out of workspace, `hub:feature:workspace` will be `false` 

1. Instructions for testing: run tests

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
