### PR TITLE
feat(hub-common): context.hubHomeUrl works in enterprise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54268,7 +54268,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "17.16.5",
+			"version": "17.18.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -32,6 +32,9 @@ import { getOrgThumbnailUrl } from "./resources/get-org-thumbnail-url";
 import type { IArcGISContext } from "./types/IArcGISContext";
 import type { IArcGISContextOptions } from "./types/IArcGISContextOptions";
 
+export const ENTERPRISE_SITES_PATH = "/apps/sites";
+export const ENTERPRISE_HOME_SUBDOMAIN = "home";
+
 /**
  * Hash of Hub API end points so updates
  * are centralized
@@ -276,11 +279,11 @@ export class ArcGISContext implements IArcGISContext {
 
   /**
    * Returns the current user's hub-home url. If not authenticated,
-   * returns the Hub Url. If portal, returns undefined
+   * returns the Hub Url.
    */
   public get hubHomeUrl(): string {
     if (this.isPortal) {
-      return undefined;
+      return `${this.portalUrl}${ENTERPRISE_SITES_PATH}/#/${ENTERPRISE_HOME_SUBDOMAIN}`;
     } else {
       if (this.isAuthenticated) {
         const hubHostname = this._hubUrl.replace("https://", "");

--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -140,6 +140,8 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:content:workspace:discussion",
+    services: ["discussions"],
+    licenses: ["hub-premium"],
     dependencies: ["hub:content:workspace", "hub:content:edit"],
   },
   {

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -38,6 +38,7 @@ import { convertFeaturesToLegacyCapabilities } from "./_internal/capabilities/co
 import { computeLinks } from "./_internal/computeLinks";
 import { ensureUniqueEntitySlug } from "../items/_internal/ensureUniqueEntitySlug";
 import { IHubItemEntity } from "../core";
+import { ENTERPRISE_SITES_PATH } from "../ArcGISContext";
 export const HUB_SITE_ITEM_TYPE = "Hub Site Application";
 export const ENTERPRISE_SITE_ITEM_TYPE = "Site Application";
 
@@ -248,7 +249,7 @@ export async function createSite(
     site.typeKeywords.push(`hubsubdomain|${site.subdomain}`.toLowerCase());
     site.url = `${requestOptions.authentication.portal.replace(
       `/sharing/rest`,
-      `/apps/sites`
+      ENTERPRISE_SITES_PATH
     )}/#/${site.subdomain}`;
   }
 

--- a/packages/common/src/urls/get-cdn-asset-url.ts
+++ b/packages/common/src/urls/get-cdn-asset-url.ts
@@ -1,5 +1,6 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { getPortalUrl } from "./get-portal-url";
+import { ENTERPRISE_SITES_PATH } from "../ArcGISContext";
 
 /**
  * Returns an env-specific CDN asset URL for the given `assetPath` and `requestOptions`.
@@ -19,7 +20,7 @@ export function getCdnAssetUrl(
   } else if (/(www|maps)\.arcgis\.com/.test(portalUrl)) {
     baseUrl = "https://hubcdn.arcgis.com/opendata-ui/assets";
   } else {
-    baseUrl = `${portalUrl}/apps/sites`;
+    baseUrl = `${portalUrl}${ENTERPRISE_SITES_PATH}`;
   }
   const delimiter = assetPath.startsWith("/") ? "" : "/";
   return [baseUrl, assetPath].join(delimiter);

--- a/packages/common/src/urls/get-hub-locale-asset-url.ts
+++ b/packages/common/src/urls/get-hub-locale-asset-url.ts
@@ -1,6 +1,7 @@
 import { IPortal } from "@esri/arcgis-rest-portal";
 import { getPortalUrl } from "./get-portal-url";
 import { HUB_CDN_URLMAP } from "./hub-cdn-urlmap";
+import { ENTERPRISE_SITES_PATH } from "../ArcGISContext";
 
 // TODO: should this take IHubRequestOptions as well as a portal?
 // if so, address when we tackle https://github.com/Esri/hub.js/issues/321
@@ -13,12 +14,11 @@ export function getHubLocaleAssetUrl(portal: IPortal): string {
   if (portal.isPortal) {
     // Enterprise - use Site app as source for assets
     const baseUrl = getPortalUrl(portal);
-    return `${baseUrl}/apps/sites`;
+    return `${baseUrl}${ENTERPRISE_SITES_PATH}`;
   } else {
     // AGO - Convert portalHostname into CDN url
-    const index: "devext" | "qaext" | "www" = portal.portalHostname.split(
-      "."
-    )[0];
+    const index: "devext" | "qaext" | "www" =
+      portal.portalHostname.split(".")[0];
     const base = HUB_CDN_URLMAP[index] || HUB_CDN_URLMAP.www;
     return `${base}/opendata-ui/assets`;
   }

--- a/packages/common/src/users/_internal/UserBusinessRules.ts
+++ b/packages/common/src/users/_internal/UserBusinessRules.ts
@@ -48,7 +48,6 @@ export const UserPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:user:workspace",
-    environments: ["production", "qaext", "devext"],
     // seems like this should also depend on hub:user,
     // but other entities don't do that
     dependencies: ["hub:feature:workspace"],

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -1127,7 +1127,9 @@ describe("ArcGISContextManager:", () => {
       expect(mgr.context.isPortal).toBe(true);
       expect(mgr.context.hubUrl).toBeUndefined();
       expect(mgr.context.ogcApiUrl).toBeUndefined();
-      expect(mgr.context.hubHomeUrl).toBeUndefined();
+      expect(mgr.context.hubHomeUrl).toBe(
+        "https://myenterprise.com/gis/apps/sites/#/home"
+      );
       expect(mgr.context.discussionsServiceUrl).toBeUndefined();
       expect(mgr.context.hubSearchServiceUrl).toBeUndefined();
       expect(mgr.context.domainServiceUrl).toBeUndefined();


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
