### PR TITLE
feat: update permissions and slugs

### DIFF
--- a/packages/common/src/ArcGISContextManager.ts
+++ b/packages/common/src/ArcGISContextManager.ts
@@ -656,7 +656,7 @@ async function getUserResourceTokens(
   return results.filter((e) => !!e);
 }
 
-const HUB_SERVICE_STATUS: HubServiceStatus = {
+export const HUB_SERVICE_STATUS: HubServiceStatus = {
   portal: "online",
   discussions: "online",
   events: "online",
@@ -667,7 +667,7 @@ const HUB_SERVICE_STATUS: HubServiceStatus = {
   "hub-downloads": "online",
 };
 
-const ENTERPRISE_SITES_SERVICE_STATUS: HubServiceStatus = {
+export const ENTERPRISE_SITES_SERVICE_STATUS: HubServiceStatus = {
   portal: "online",
   discussions: "not-available",
   events: "not-available",

--- a/packages/common/src/core/_internal/getEditorSlug.ts
+++ b/packages/common/src/core/_internal/getEditorSlug.ts
@@ -5,7 +5,11 @@ import { IWithSlug } from "../traits/IWithSlug";
  * @param entity
  * @returns
  */
-export const getEditorSlug = (entity: IWithSlug) => {
+export const getEditorSlug = (entity: IWithSlug): string => {
   const { slug = "", orgUrlKey } = entity;
-  return slug.replace(`${orgUrlKey}|`, "");
+  if (orgUrlKey) {
+    return slug.replace(`${orgUrlKey}|`, "");
+  } else {
+    return slug;
+  }
 };

--- a/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
+++ b/packages/common/src/core/schemas/internal/addDynamicSlugValidation.ts
@@ -22,7 +22,11 @@ export const addDynamicSlugValidation = (
     return schema;
   }
   // add max length to slug
-  const { orgUrlKey } = options as IWithSlug;
+  let { orgUrlKey } = options as IWithSlug;
+  // orgUrlKey is undefined in Enterprise
+  if (!orgUrlKey) {
+    orgUrlKey = "";
+  }
   _slug.maxLength = getSlugMaxLength(orgUrlKey);
   // add conditional validation to ensure slug is unique
   const allOf = cloneObject(schema.allOf) || [];
@@ -44,7 +48,8 @@ export const addDynamicSlugValidation = (
       // only do async isUniqueSlug check if the slug is valid
       if: { properties: { _slug: { pattern } } },
       then: {
-        properties: { _slug: { isUniqueSlug: { id, orgUrlKey } } as any },
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        properties: { _slug: { isUniqueSlug: { id, orgUrlKey } } as unknown },
       },
     }
   );

--- a/packages/common/src/core/schemas/internal/metrics/editorToEntity.ts
+++ b/packages/common/src/core/schemas/internal/metrics/editorToEntity.ts
@@ -1,6 +1,10 @@
 import { IPortal } from "@esri/arcgis-rest-portal";
 import { cloneObject } from "../../../../util";
-import { IHubItemEntity, IHubItemEntityEditor } from "../../../../core/types";
+import {
+  IHubItemEntity,
+  IHubItemEntityEditor,
+  IHubLocation,
+} from "../../../../core/types";
 import { truncateSlug } from "../../../../items/_internal/slugs";
 
 // NOTE: this is covered by pre-existing tests for project to entity
@@ -22,10 +26,14 @@ export function editorToEntity(
   // convert back to an entity. Apply any reverse transforms used in
   // of the toEditor method
   const entity = cloneObject(editor) as IHubItemEntity;
-  entity.orgUrlKey = editor.orgUrlKey ? editor.orgUrlKey : portal.urlKey;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  entity.orgUrlKey = editor.orgUrlKey
+    ? editor.orgUrlKey
+    : portal.urlKey || ("" as string);
 
   // copy the location extent up one level
-  entity.extent = editor.location?.extent;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  entity.extent = (editor.location as IHubLocation)?.extent;
 
   if (_slug) {
     // ensure the slug is truncated

--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -115,6 +115,7 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
   {
     // TODO: remove this IPermissionPolicy when we deprecate the discussion board participation workspace pane
     permission: "hub:discussion:workspace:discussion",
+    services: ["discussions"],
     dependencies: ["hub:discussion:edit"],
   },
   {

--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -248,6 +248,7 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:group:workspace:discussion",
+    services: ["discussions"],
     dependencies: ["hub:group:workspace"],
   },
   {

--- a/packages/common/src/items/_internal/slugs.ts
+++ b/packages/common/src/items/_internal/slugs.ts
@@ -18,23 +18,29 @@ export const TYPEKEYWORD_SLUG_PREFIX = "slug";
  * @param orgKey
  * @returns
  */
-export function truncateSlug(slug: string, orgKey: string, paddingEnd = 0) {
+export function truncateSlug(
+  slug: string,
+  orgKey = "",
+  paddingEnd = 0
+): string {
   // typekeywords have a max length of 256 characters, so we use the slug
   // format that gets persisted in typekeywords as our basis
+  // Although it's removed later, we start with the typekeyword slug prefix
+  // to do the length check.
+  const parts = [TYPEKEYWORD_SLUG_PREFIX];
+  // if orgKey is provided, add it as a segment and ensure it is lowercased
+  if (orgKey) {
+    parts.push(orgKey.toLowerCase());
+  }
+  // add the slug
+  parts.push(slug);
   return (
-    [
-      // add the typekeyword slug prefix
-      TYPEKEYWORD_SLUG_PREFIX,
-      // add the orgKey segment
-      orgKey.toLowerCase(),
-      // add the slugified title segment
-      slug,
-    ]
+    parts
       .join("|")
       .substring(0, TYPEKEYWORD_MAX_LENGTH - paddingEnd)
       // removing tailing hyphens
       .replace(/-+$/, "")
-      // remove typekeyword slug prefix, it's re-added in setSlugKeyword
+      // remove slug prefix, it's re-added in setSlugKeyword
       .replace(new RegExp(`^${TYPEKEYWORD_SLUG_PREFIX}\\|`), "")
   );
 }
@@ -44,7 +50,7 @@ export function truncateSlug(slug: string, orgKey: string, paddingEnd = 0) {
  * @param orgKey
  * @returns
  */
-export function getSlugMaxLength(orgKey: string) {
+export function getSlugMaxLength(orgKey: string): number {
   const prefix = `${TYPEKEYWORD_SLUG_PREFIX}|${orgKey}|`;
   return TYPEKEYWORD_MAX_LENGTH - prefix.length;
 }
@@ -72,8 +78,8 @@ export const parseIdentifier = (identifier: string): IParsedIdentifier => {
     // otherwise try parsing id, slug, and org key from the identifier
     let slugParts;
     [slugParts, id] = identifier.split(SLUG_ID_SEPARATOR);
-    const match = slugParts.match(
-      new RegExp(`^((.*)${SLUG_ORG_SEPARATOR_URI})?(.*)$`)
+    const match = new RegExp(`^((.*)${SLUG_ORG_SEPARATOR_URI})?(.*)$`).exec(
+      slugParts
     );
     // istanbul ignore next - I think that regex will always match at least the slug
     if (match) {

--- a/packages/common/src/items/slugs.ts
+++ b/packages/common/src/items/slugs.ts
@@ -13,7 +13,7 @@ import { uriSlugToKeywordSlug } from "./_internal/slugConverters";
  * @param orgKey
  * @returns
  */
-export function constructSlug(title: string, orgKey: string) {
+export function constructSlug(title: string, orgKey = ""): string {
   // allow some padding at the end for incrementing so we don't wind up w/ weird, inconsistent slugs
   // when the increment goes from single to multiple digits,
   // avoid producing the following when deduping:
@@ -117,12 +117,9 @@ export async function findItemsBySlug(
   if (slugInfo.exclude) {
     opts.q = `NOT id:${slugInfo.exclude}`;
   }
-  try {
-    const response = await searchItems(opts);
-    return response.results;
-  } catch (e) {
-    throw e;
-  }
+
+  const response = await searchItems(opts);
+  return response.results;
 }
 
 /**
@@ -143,7 +140,7 @@ export function getUniqueSlug(
     existingId?: string;
   },
   requestOptions: IRequestOptions,
-  step: number = 0
+  step = 0
 ): Promise<string> {
   const combinedSlug = step ? [slugInfo.slug, step].join("-") : slugInfo.slug;
   return findItemsBySlug(

--- a/packages/common/src/pages/HubPage.ts
+++ b/packages/common/src/pages/HubPage.ts
@@ -120,7 +120,7 @@ export class HubPage
   ): IHubPage {
     // ensure we have the orgUrlKey
     if (!partialPage.orgUrlKey) {
-      partialPage.orgUrlKey = context.portal.urlKey as string;
+      partialPage.orgUrlKey = (context.portal.urlKey || "") as string;
     }
     // extend the partial over the defaults
     const pojo = { ...DEFAULT_PAGE, ...partialPage } as IHubPage;

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -246,6 +246,7 @@ export async function createSite(
     }`;
   } else {
     // Portal Sites use subdomain in hash based router
+    // Also in Enterprise orgUrlKey is undefined.
     site.typeKeywords.push(`hubsubdomain|${site.subdomain}`.toLowerCase());
     site.url = `${requestOptions.authentication.portal.replace(
       `/sharing/rest`,
@@ -258,7 +259,7 @@ export async function createSite(
   // to a property defined as `IExtent` without using `as unknown as ...`
   // which basically removes typechecking
 
-  site.orgUrlKey = portal.urlKey;
+  site.orgUrlKey = (portal.urlKey || "") as string;
 
   // override only if not set...
   if (!site.theme) {
@@ -315,7 +316,7 @@ export async function createSite(
   // Register domain and at the same time register the site as an application
   // for portal, this will return a single entry with just the clientKey
   const domainResponses = await addSiteDomains(model, requestOptions);
-  model.data.values.clientId = domainResponses[0].clientKey;
+  model.data.values.clientId = domainResponses[0].clientKey as string;
 
   // update the model
   const updatedModel = await updateModel(

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -223,6 +223,7 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:site:workspace:discussion",
+    services: ["discussions"],
     dependencies: ["hub:site:workspace", "hub:site:edit"],
   },
   {

--- a/packages/common/src/users/_internal/UserBusinessRules.ts
+++ b/packages/common/src/users/_internal/UserBusinessRules.ts
@@ -72,6 +72,7 @@ export const UserPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:user:workspace:settings",
+    environments: ["devext", "qaext", "production"], // Enterprise intentionally omitted for v12
     dependencies: ["hub:user:workspace", "hub:user:owner"],
   },
   {

--- a/packages/common/test/core/schemas/internal/addDynamicSlugValidation.test.ts
+++ b/packages/common/test/core/schemas/internal/addDynamicSlugValidation.test.ts
@@ -73,5 +73,55 @@ describe("addDynamicSlugValidation", () => {
         },
       ],
     });
+
+    // orgUrlKey can be undefined in Enterprise
+    const options2 = {
+      id: "id",
+    } as any;
+    const result2 = addDynamicSlugValidation(schema, options2);
+    expect(result2).toEqual({
+      properties: {
+        _slug: {
+          maxLength: 256 - ("slug".length + 1) - ("".length + 1),
+        },
+      },
+      allOf: [
+        {
+          if: {
+            properties: {
+              _slug: {
+                minLength: 1,
+              },
+            },
+          },
+          then: {
+            properties: {
+              _slug: {
+                pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+              },
+            },
+          },
+        },
+        {
+          if: {
+            properties: {
+              _slug: {
+                pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+              },
+            },
+          },
+          then: {
+            properties: {
+              _slug: {
+                isUniqueSlug: {
+                  id: "id",
+                  orgUrlKey: "",
+                },
+              } as any,
+            },
+          },
+        },
+      ],
+    });
   });
 });

--- a/packages/common/test/items/_internal/slug.test.ts
+++ b/packages/common/test/items/_internal/slug.test.ts
@@ -1,7 +1,31 @@
-import { parseIdentifier } from "../../../src/items/_internal/slugs";
+import {
+  parseIdentifier,
+  truncateSlug,
+} from "../../../src/items/_internal/slugs";
 
 describe("item _internal slug", () => {
   const guidId = "67be0486253a423891042361843d1b0a";
+
+  describe("truncateSlug:", () => {
+    it("truncates a slug to 251 characters", () => {
+      const longSlug = "a".repeat(300);
+
+      expect(truncateSlug(longSlug).length).toEqual(251);
+    });
+
+    it("does not truncate a slug that is less than 251 characters", () => {
+      expect(truncateSlug("hello-world")).toEqual("hello-world");
+    });
+
+    it("returns an empty string when given an empty string", () => {
+      expect(truncateSlug("")).toEqual("");
+    });
+    it("handles orgKey passed as undefined", () => {
+      const result = truncateSlug("hello-world", undefined);
+      expect(result).toEqual("hello-world");
+    });
+  });
+
   describe("parseIdentifier", () => {
     it("only returns an id when identifier is a guid", () => {
       const identifier = guidId;

--- a/packages/common/test/items/slugs.test.ts
+++ b/packages/common/test/items/slugs.test.ts
@@ -12,6 +12,9 @@ describe("slug utils: ", () => {
       expect(slugModule.constructSlug("E2E Test Project", "qa-bas-hub")).toBe(
         "qa-bas-hub|e2e-test-project"
       );
+      expect(slugModule.constructSlug("E2E Test Project", undefined)).toBe(
+        "e2e-test-project"
+      );
       expect(
         slugModule.constructSlug(
           "A really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really long title",
@@ -280,9 +283,7 @@ describe("slug utils: ", () => {
     });
 
     it("can re-throw original error", async () => {
-      const searchSpy = spyOn(portalModule, "searchItems").and.throwError(
-        "Error occurred"
-      );
+      spyOn(portalModule, "searchItems").and.throwError("Error occurred");
 
       try {
         await slugModule.findItemsBySlug(

--- a/packages/common/test/mocks/mock-auth.ts
+++ b/packages/common/test/mocks/mock-auth.ts
@@ -87,7 +87,7 @@ export const MOCK_ENTERPRISE_REQOPTS = {
   portalSelf: {
     id: "orgIdFromPortalSelf",
     name: "my spiffy org",
-    urlKey: "org",
+    // urlKey: "org", // urlKey is undefined in Enterprise
     culture: "en-us",
     defaultBasemap: { fake: "basemap" },
   },

--- a/packages/common/test/projects/edit.test.ts
+++ b/packages/common/test/projects/edit.test.ts
@@ -213,6 +213,7 @@ describe("project edit module:", () => {
           id: "123",
           cardTitle: "foo",
         },
+        title: "My Project",
         _slug: "new-slug",
       } as unknown as IHubProjectEditor;
 
@@ -231,6 +232,20 @@ describe("project edit module:", () => {
       const res = editorToProject(editor, portal);
 
       expect(res.orgUrlKey).toEqual("bar");
+    });
+    it("handles undefined orgUrlKey", () => {
+      const editor: IHubProjectEditor = {
+        orgUrlKey: undefined,
+        _slug: "my-project",
+      } as unknown as IHubProjectEditor;
+
+      const entPortal = cloneObject(portal);
+      delete entPortal.urlKey;
+
+      const res = editorToProject(editor, entPortal);
+      // should swap to ""
+      expect(res.orgUrlKey).toEqual("");
+      expect(res.slug).toEqual("my-project");
     });
     it("copies the location extent up one level", () => {
       const editor: IHubProjectEditor = {

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 import * as commonModule from "../../src";
 import * as portalModule from "@esri/arcgis-rest-portal";
 import * as FetchEnrichments from "../../src/items/_enrichments";
@@ -221,7 +222,7 @@ describe("HubSites:", () => {
         { key: "components.search.category_tabs.documents" },
         { key: "components.search.category_tabs.apps_and_maps" },
       ];
-      const borkedSite = cloneObject(SITE_MODEL) as commonModule.IModel;
+      const borkedSite = cloneObject(SITE_MODEL);
       borkedSite.data.values.searchCategories = borkedSearchCategories;
       spyOn(
         require("../../src/sites/fetchSiteModel"),
@@ -324,12 +325,11 @@ describe("HubSites:", () => {
     });
   });
   describe("updateSite removes properties:", () => {
-    let domainChangeSpy: jasmine.Spy;
     let updateModelSpy: jasmine.Spy;
     let fetchSiteModelSpy: jasmine.Spy;
-    let getUniqueSlugSpy: jasmine.Spy;
+
     beforeEach(() => {
-      domainChangeSpy = spyOn(
+      spyOn(
         require("../../src/sites/_internal"),
         "handleDomainChanges"
       ).and.returnValue(Promise.resolve());
@@ -370,11 +370,9 @@ describe("HubSites:", () => {
         "fetchSiteModel"
       ).and.returnValue(Promise.resolve(SiteModelWithExtraProps));
 
-      getUniqueSlugSpy = spyOn(slugUtils, "getUniqueSlug").and.callFake(
-        ({ slug }: any) => {
-          return Promise.resolve(slug as string);
-        }
-      );
+      spyOn(slugUtils, "getUniqueSlug").and.callFake(({ slug }: any) => {
+        return Promise.resolve(slug as string);
+      });
     });
     it("removes props", async () => {
       const updatedSite = commonModule.cloneObject(SITE);
@@ -394,7 +392,7 @@ describe("HubSites:", () => {
     let domainChangeSpy: jasmine.Spy;
     let updateModelSpy: jasmine.Spy;
     let fetchSiteModelSpy: jasmine.Spy;
-    let getUniqueSlugSpy: jasmine.Spy;
+
     beforeEach(() => {
       domainChangeSpy = spyOn(
         require("../../src/sites/_internal"),
@@ -413,11 +411,9 @@ describe("HubSites:", () => {
         "fetchSiteModel"
       ).and.returnValue(Promise.resolve(SITE_MODEL));
 
-      getUniqueSlugSpy = spyOn(slugUtils, "getUniqueSlug").and.callFake(
-        ({ slug }: any) => {
-          return Promise.resolve(slug as string);
-        }
-      );
+      spyOn(slugUtils, "getUniqueSlug").and.callFake(({ slug }: any) => {
+        return Promise.resolve(slug as string);
+      });
     });
     it("updates the backing model", async () => {
       const updatedSite = commonModule.cloneObject(SITE);
@@ -683,7 +679,7 @@ describe("HubSites:", () => {
       it("works in portal", async () => {
         const sparseSite: Partial<commonModule.IHubSite> = {
           name: "my site",
-          orgUrlKey: "dcdev",
+          // orgUrlKey: "dcdev", this is undefined in Enterpris
         };
 
         const chk = await commonModule.createSite(
@@ -699,8 +695,8 @@ describe("HubSites:", () => {
         const modelToCreate = createModelSpy.calls.argsFor(0)[0];
         expect(modelToCreate.item.title).toBe("my site");
         expect(modelToCreate.item.type).toBe("Site Application");
-        expect(modelToCreate.item.properties.slug).toBe("dcdev|my-site");
-        expect(modelToCreate.item.properties.orgUrlKey).toBe("org");
+        expect(modelToCreate.item.properties.slug).toBe("my-site");
+        expect(modelToCreate.item.properties.orgUrlKey).toEqual("");
         const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
         expect(modelToUpdate.data.values.clientId).toBe("arcgisonline");
         expect(chk.url).toBe(

--- a/packages/sites/test/create-site.test.ts
+++ b/packages/sites/test/create-site.test.ts
@@ -81,6 +81,32 @@ describe("create site :: ", function () {
       expect
     );
   });
+  it("handles urlKey undefined in Enterprise", async () => {
+    const entRo = {
+      authentication: {},
+      portalSelf: {
+        isPortal: true,
+        //urlKey is undefined in Enterprise
+      } as portalModule.IPortal,
+    } as commonModule.IHubRequestOptions;
+
+    const site = {
+      item: {
+        owner: "luke",
+        title: "Death Star Plans",
+      },
+      data: {
+        values: {
+          defaultHostname: "name-org.hub.arcgis.com",
+          verifySecondPass: "this should be {{appid}} interpolated",
+        },
+      },
+    } as unknown as commonModule.IModel;
+
+    const result = await createSite(site, {}, entRo);
+
+    expect(result.item.id).toBe("3ef", "should attach id into returned model");
+  });
 
   it("updates initiative if created", async () => {
     const site = {


### PR DESCRIPTION
1. Description:
- export the service status const's for use in -ui
- update workspace:discussion permissions to depend on the discussion service
- gate user:workspace:settings to not enterprise b/c there's only Hub settings present
- fix issues with slug handling in enterprise where `portal.urlKey` is `undefined`; tldr; we handle that by defaulting to `""` for that value

1. Instructions for testing: run tests

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
