### PR TITLE
fix: support location for initiative template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54268,7 +54268,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "17.18.1",
+			"version": "17.19.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
+++ b/packages/common/src/initiative-templates/_internal/InitiativeTemplateUiSchemaEdit.ts
@@ -6,6 +6,8 @@ import { getEntityThumbnailUrl } from "../../core/getEntityThumbnailUrl";
 import { getTagItems } from "../../core/schemas/internal/getTagItems";
 import { fetchCategoriesUiSchemaElement } from "../../core/schemas/internal/fetchCategoriesUiSchemaElement";
 import { HubEntity, IHubInitiativeTemplate } from "../../core";
+import { getLocationExtent } from "../../core/schemas/internal/getLocationExtent";
+import { getLocationOptions } from "../../core/schemas/internal/getLocationOptions";
 
 /**
  * @private
@@ -197,31 +199,31 @@ export const buildUiSchema = async (
         ],
       },
       // NOTE: this does not work quite right...
-      // {
-      //   type: "Section",
-      //   labelKey: `${i18nScope}.sections.location.label`,
-      //   elements: [
-      //     {
-      //       scope: "/properties/location",
-      //       type: "Control",
-      //       options: {
-      //         control: "hub-field-input-location-picker",
-      //         extent: await getLocationExtent(
-      //           options.location,
-      //           context.hubRequestOptions
-      //         ),
-      //         options: await getLocationOptions(
-      //           options.id,
-      //           options.type,
-      //           options.location,
-      //           context.portal.name,
-      //           context.hubRequestOptions
-      //         ),
-      //         noticeTitleElementAriaLevel: 3,
-      //       },
-      //     },
-      //   ],
-      // },
+      {
+        type: "Section",
+        labelKey: `${i18nScope}.sections.location.label`,
+        elements: [
+          {
+            scope: "/properties/location",
+            type: "Control",
+            options: {
+              control: "hub-field-input-location-picker",
+              extent: await getLocationExtent(
+                options.location,
+                context.hubRequestOptions
+              ),
+              options: await getLocationOptions(
+                options.id,
+                options.type,
+                options.location,
+                context.portal.name,
+                context.hubRequestOptions
+              ),
+              noticeTitleElementAriaLevel: 3,
+            },
+          },
+        ],
+      },
     ],
   };
 };


### PR DESCRIPTION
affects: @esri/hub-common

ISSUES CLOSED: 13240

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
