### PR TITLE
fix(hub-common): fix issue where org home sites didn't have default group and user catalog scopes

### DIFF
--- a/packages/common/src/search/upgradeCatalogSchema.ts
+++ b/packages/common/src/search/upgradeCatalogSchema.ts
@@ -113,8 +113,16 @@ function applyCatalogSchema(original: any): IHubCatalog {
     // for org-level home sites (e.g., "my-org.hub.arcgis.com")
     const orgId = getProp(original, "orgId") as string;
     if (orgId) {
-      // Unlike other sites, org-level home sites also have default
-      // group and user scopes, so we add those here
+      // Org-level sites should ignore any configured groups.
+      // They also need 'group' and 'user' scopes within the catalog.
+      catalog.scopes.item = {
+        targetEntity: "item",
+        filters: [],
+      };
+      catalog.scopes.event = {
+        targetEntity: "event",
+        filters: [],
+      };
       catalog.scopes.group = {
         targetEntity: "group",
         filters: [],
@@ -134,7 +142,6 @@ function applyCatalogSchema(original: any): IHubCatalog {
             [entityType]: {
               ...query,
               filters: [
-                ...query.filters,
                 {
                   operation: "AND",
                   predicates:

--- a/packages/common/src/sites/_internal/applyCatalogStructureMigration.ts
+++ b/packages/common/src/sites/_internal/applyCatalogStructureMigration.ts
@@ -20,24 +20,26 @@ export function applyCatalogStructureMigration(model: IModel): IModel {
   if (!siteCatalog.schemaVersion) {
     const clonedModel = cloneObject(model);
     clonedModel.data.catalog = upgradeCatalogSchema(siteCatalog);
+    const upgradedCatalog = clonedModel.data.catalog as IHubCatalog;
 
     // The umbrella site needs a special predicate added to the catalog to ensure
     // that its item scope only includes results shared to open data groups.
     // We also don't want to include the groups from the site model
     if (getProp(clonedModel, "data.values.isUmbrella")) {
-      (clonedModel.data.catalog as IHubCatalog).scopes.item.filters = [
+      upgradedCatalog.scopes.item.filters = [
         {
           predicates: [{ openData: true }],
         },
       ];
-      // The umbrella site doesn't have an event scope
-      (clonedModel.data.catalog as IHubCatalog).scopes.event.filters = [];
+      // The umbrella site doesn't have any other scopes defined, so remove any
+      // others that might have been added by the migration
+      upgradedCatalog.scopes = { item: upgradedCatalog.scopes.item };
     }
 
     // applyCatalogSchema sets the catalog to `Default Catalog` but this fn previously
     // set it to `Default Site Catalog`. Overriding title to `Default Site Catalog` here
     // to prevent any potential regressions
-    (clonedModel.data.catalog as IHubCatalog).title = "Default Site Catalog";
+    upgradedCatalog.title = "Default Site Catalog";
     return clonedModel;
   }
   return model;

--- a/packages/common/test/search/upgradeCatalogSchema.test.ts
+++ b/packages/common/test/search/upgradeCatalogSchema.test.ts
@@ -55,16 +55,35 @@ describe("upgradeCatalogSchema", () => {
     const chk = upgradeCatalogSchema({ orgId: "a3g" });
     expect(chk.title).toBe("Default Catalog");
     expect(chk.scopes).toBeDefined();
-    expect(chk.scopes?.item?.filters.length).toBe(1);
-    expect(chk.scopes?.item?.filters[0].operation).toEqual("AND");
-    expect(chk.scopes?.item?.filters[0].predicates[0].orgid).toEqual(["a3g"]);
-    expect(chk.scopes?.item?.filters[0].predicates[1].type).toEqual({
+
+    const scopeKeys = Object.keys(chk.scopes).sort();
+    expect(scopeKeys).toEqual(["event", "group", "item", "user"]);
+
+    expect(chk.scopes.item).toBeDefined();
+    expect(chk.scopes.item.filters.length).toBe(1);
+    expect(chk.scopes.item.filters[0].operation).toEqual("AND");
+    expect(chk.scopes.item.filters[0].predicates[0].orgid).toEqual(["a3g"]);
+    expect(chk.scopes.item.filters[0].predicates[1].type).toEqual({
       not: ["Code Attachment"],
     });
-    expect(chk.scopes?.event?.filters.length).toBe(1);
-    expect(chk.scopes?.event?.filters[0].operation).toEqual("AND");
-    expect(chk.scopes?.event?.filters[0].predicates[0].orgId).toEqual("a3g");
-    expect(chk.scopes?.event?.filters[0].predicates[1]).toBeUndefined();
+
+    expect(chk.scopes.event).toBeDefined();
+    expect(chk.scopes.event.filters.length).toBe(1);
+    expect(chk.scopes.event.filters[0].operation).toEqual("AND");
+    expect(chk.scopes.event.filters[0].predicates[0].orgId).toEqual("a3g");
+    expect(chk.scopes.event.filters[0].predicates[1]).toBeUndefined();
+
+    expect(chk.scopes.group).toBeDefined();
+    expect(chk.scopes.group.filters.length).toBe(1);
+    expect(chk.scopes.group.filters[0].operation).toEqual("AND");
+    expect(chk.scopes.group.filters[0].predicates[0].orgid).toEqual("a3g");
+    expect(chk.scopes.group.filters[0].predicates[1]).toBeUndefined();
+
+    expect(chk.scopes.user).toBeDefined();
+    expect(chk.scopes.user.filters.length).toBe(1);
+    expect(chk.scopes.user.filters[0].operation).toEqual("AND");
+    expect(chk.scopes.user.filters[0].predicates[0].orgid).toEqual("a3g");
+    expect(chk.scopes.user.filters[0].predicates[1]).toBeUndefined();
   });
 
   it("skips upgrade if on the same version", () => {

--- a/packages/common/test/search/upgradeCatalogSchema.test.ts
+++ b/packages/common/test/search/upgradeCatalogSchema.test.ts
@@ -52,7 +52,10 @@ describe("upgradeCatalogSchema", () => {
   });
 
   it("handles org-level home site legacy catalogs", () => {
-    const chk = upgradeCatalogSchema({ orgId: "a3g" });
+    const chk = upgradeCatalogSchema({
+      orgId: "{{orgId}}", // org sites have this value interpolated in later on
+      groups: ["abc"], // groups should be ignored for org-level sites
+    });
     expect(chk.title).toBe("Default Catalog");
     expect(chk.scopes).toBeDefined();
 
@@ -62,7 +65,9 @@ describe("upgradeCatalogSchema", () => {
     expect(chk.scopes.item).toBeDefined();
     expect(chk.scopes.item.filters.length).toBe(1);
     expect(chk.scopes.item.filters[0].operation).toEqual("AND");
-    expect(chk.scopes.item.filters[0].predicates[0].orgid).toEqual(["a3g"]);
+    expect(chk.scopes.item.filters[0].predicates[0].orgid).toEqual([
+      "{{orgId}}",
+    ]);
     expect(chk.scopes.item.filters[0].predicates[1].type).toEqual({
       not: ["Code Attachment"],
     });
@@ -70,19 +75,23 @@ describe("upgradeCatalogSchema", () => {
     expect(chk.scopes.event).toBeDefined();
     expect(chk.scopes.event.filters.length).toBe(1);
     expect(chk.scopes.event.filters[0].operation).toEqual("AND");
-    expect(chk.scopes.event.filters[0].predicates[0].orgId).toEqual("a3g");
+    expect(chk.scopes.event.filters[0].predicates[0].orgId).toEqual(
+      "{{orgId}}"
+    );
     expect(chk.scopes.event.filters[0].predicates[1]).toBeUndefined();
 
     expect(chk.scopes.group).toBeDefined();
     expect(chk.scopes.group.filters.length).toBe(1);
     expect(chk.scopes.group.filters[0].operation).toEqual("AND");
-    expect(chk.scopes.group.filters[0].predicates[0].orgid).toEqual("a3g");
+    expect(chk.scopes.group.filters[0].predicates[0].orgid).toEqual(
+      "{{orgId}}"
+    );
     expect(chk.scopes.group.filters[0].predicates[1]).toBeUndefined();
 
     expect(chk.scopes.user).toBeDefined();
     expect(chk.scopes.user.filters.length).toBe(1);
     expect(chk.scopes.user.filters[0].operation).toEqual("AND");
-    expect(chk.scopes.user.filters[0].predicates[0].orgid).toEqual("a3g");
+    expect(chk.scopes.user.filters[0].predicates[0].orgid).toEqual("{{orgId}}");
     expect(chk.scopes.user.filters[0].predicates[1]).toBeUndefined();
   });
 

--- a/packages/common/test/sites/_internal/applyCatalogStructureMigration.test.ts
+++ b/packages/common/test/sites/_internal/applyCatalogStructureMigration.test.ts
@@ -73,11 +73,7 @@ describe("applyCatalogStructureMigration:", () => {
             },
           ],
         },
-        // There is no openData predicate for the event scope for now
-        event: {
-          targetEntity: "event",
-          filters: [],
-        },
+        // There is no openData predicate for the other scopes for now
       },
       collections: [],
     });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Discovered while working on https://devtopia.esri.com/dc/hub/issues/13501
Ports over a temp fix that lived in opendata-ui

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
