### PR TITLE
feat(hub-common): add group events workspace permission policy

### DIFF
--- a/packages/common/src/groups/_internal/GroupBusinessRules.ts
+++ b/packages/common/src/groups/_internal/GroupBusinessRules.ts
@@ -25,6 +25,7 @@ export const GroupPermissions = [
   "hub:group:workspace:collaborators",
   "hub:group:workspace:content",
   "hub:group:workspace:members",
+  "hub:group:workspace:events",
   "hub:group:shareContent",
   "hub:group:manage",
 ] as const;
@@ -262,6 +263,12 @@ export const GroupPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:group:workspace:members",
     dependencies: ["hub:group:workspace"],
+  },
+  {
+    permission: "hub:group:workspace:events",
+    services: ["events"],
+    dependencies: ["hub:group:workspace"],
+    licenses: ["hub-premium"],
   },
   // permission to check if you can add/remove content from groups
   {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Added the permission policy for the group events workspace pane

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
