### PR TITLE
Feat(hub-common): assistant configuration schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54268,7 +54268,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "18.0.0",
+			"version": "18.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -494,6 +494,9 @@ export class ArcGISContext implements IArcGISContext {
     return this._portalSelf;
   }
 
+  /**
+   * Returns the portal settings object as IPortalSettings
+   */
   public get portalSettings(): IPortalSettings {
     return this._portalSettings;
   }

--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -3,7 +3,12 @@ import {
   IUserRequestOptions,
   ArcGISIdentityManager,
 } from "@esri/arcgis-rest-request";
-import { IGetUserOptions, IPortal, getUser } from "@esri/arcgis-rest-portal";
+import {
+  IGetUserOptions,
+  IPortal,
+  IPortalSettings,
+  getUser,
+} from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import {
   IHubHistory,
@@ -89,6 +94,8 @@ export class ArcGISContext implements IArcGISContext {
 
   private _portalSelf: IPortal;
 
+  private _portalSettings: IPortalSettings;
+
   private _currentUser: IUser;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -122,6 +129,10 @@ export class ArcGISContext implements IArcGISContext {
 
     if (opts.portalSelf) {
       this._portalSelf = opts.portalSelf;
+    }
+
+    if (opts.portalSettings) {
+      this._portalSettings = opts.portalSettings;
     }
 
     if (opts.currentUser) {
@@ -481,6 +492,10 @@ export class ArcGISContext implements IArcGISContext {
    */
   public get portal(): IPortal {
     return this._portalSelf;
+  }
+
+  public get portalSettings(): IPortalSettings {
+    return this._portalSettings;
   }
 
   /**

--- a/packages/common/src/ArcGISContextManager.ts
+++ b/packages/common/src/ArcGISContextManager.ts
@@ -1,4 +1,10 @@
-import { getSelf, getUser, IPortal } from "@esri/arcgis-rest-portal";
+import {
+  getPortalSettings,
+  getSelf,
+  getUser,
+  IPortal,
+  IPortalSettings,
+} from "@esri/arcgis-rest-portal";
 import {
   exchangeToken,
   IUser,
@@ -47,7 +53,7 @@ const CONTEXT_SERIALIZABLE_PROPS: Array<keyof IArcGISContextManagerOptions> = [
  */
 const CONTEXT_AUTHD_SERIALIZABLE_PROPS: Array<
   keyof IArcGISContextManagerOptions
-> = ["resourceTokens", "portal", "currentUser"];
+> = ["resourceTokens", "portal", "currentUser", "portalSettings"];
 
 /**
  * The manager exposes context (`IArcGISContext`), which combines a `ArcGISIdentityManager` with
@@ -82,6 +88,8 @@ export class ArcGISContextManager {
   private _hubUrl: string;
 
   private _portal: IPortal;
+
+  private _portalSettings: IPortalSettings;
 
   private _currentUser: IUser;
 
@@ -137,6 +145,10 @@ export class ArcGISContextManager {
 
     if (opts.portal) {
       this._portal = cloneObject(opts.portal);
+    }
+
+    if (opts.portalSettings) {
+      this._portalSettings = cloneObject(opts.portalSettings);
     }
 
     if (opts.currentUser) {
@@ -369,6 +381,12 @@ export class ArcGISContextManager {
         promises.push(getSelfWithLimits(this._authentication));
         promiseKeys.push("portal");
       }
+      if (!this._portalSettings) {
+        promises.push(
+          getPortalSettings("self", { authentication: this._authentication })
+        );
+        promiseKeys.push("portalSettings");
+      }
       if (this._portal && !this._portal.limits) {
         promises.push(getPortalLimits(this._portal.id, this._authentication));
         promiseKeys.push("portalLimits");
@@ -421,6 +439,9 @@ export class ArcGISContextManager {
       switch (key) {
         case "portal":
           this._portal = result as IPortal;
+          break;
+        case "portalSettings":
+          this._portalSettings = result as IPortalSettings;
           break;
         case "portalLimits":
           this._portal.limits = result as Record<string, number>;
@@ -504,7 +525,12 @@ export class ArcGISContextManager {
     // up exactly with the prop names on the serialized context so we have to define
     // separate arrays here
     const anonProps = ["hubUrl", ...CONTEXT_SERIALIZABLE_PROPS];
-    const authdProps = ["currentUser", "userResourceTokens", "userHubSettings"];
+    const authdProps = [
+      "currentUser",
+      "userResourceTokens",
+      "userHubSettings",
+      ...CONTEXT_AUTHD_SERIALIZABLE_PROPS,
+    ];
 
     let contextOpts: IArcGISContextOptions = {
       id: this.id,

--- a/packages/common/src/ArcGISContextManager.ts
+++ b/packages/common/src/ArcGISContextManager.ts
@@ -382,8 +382,11 @@ export class ArcGISContextManager {
         promiseKeys.push("portal");
       }
       if (!this._portalSettings) {
+        const failSafeGetPortalSettings = failSafe(getPortalSettings, {});
         promises.push(
-          getPortalSettings("self", { authentication: this._authentication })
+          failSafeGetPortalSettings("self", {
+            authentication: this._authentication,
+          })
         );
         promiseKeys.push("portalSettings");
       }
@@ -529,7 +532,7 @@ export class ArcGISContextManager {
       "currentUser",
       "userResourceTokens",
       "userHubSettings",
-      ...CONTEXT_AUTHD_SERIALIZABLE_PROPS,
+      "portalSettings",
     ];
 
     let contextOpts: IArcGISContextOptions = {

--- a/packages/common/src/assistants/IHubAssistant.ts
+++ b/packages/common/src/assistants/IHubAssistant.ts
@@ -6,23 +6,28 @@ export interface IHubAssistant {
   /**
    * Enable this assistant.
    */
-  enabled: boolean;
+  enabled?: boolean;
+  /**
+   * Access level for the assistant.
+   * This can be public, org, or private.
+   */
+  access?: string;
   /**
    * Personality for the assistant.
    */
-  personality: string;
+  personality?: string;
   /**
    * Example prompts to display to the user.
    */
-  examplePrompts: string[];
+  examplePrompts?: string[];
   /**
    * Workflows for the assistant.
    */
-  workflows: IHubAssistantWorkflow[];
+  workflows?: IHubAssistantWorkflow[];
   /**
    * Test prompts for the assistant.
    */
-  testPrompts: string[];
+  testPrompts?: string[];
   /**
    * Schema version for the assistant.
    */
@@ -46,25 +51,16 @@ export interface IHubAssistantWorkflow {
    */
   description: string;
   /**
-   * Assistant response for the workflow.
+   * Action to be performed in the workflow.
+   * This can be "search", or "respond".
    */
-  response: IHubAssistantWorkflowResponse[];
-}
-
-/**
- * Interface representing a Hub Assistant Workflow response.
- */
-export interface IHubAssistantWorkflowResponse {
+  action: "search" | "respond";
   /**
    * Assistant response.
    */
-  text: string;
+  response: string;
   /**
-   * Optional actions to perform after the response.
+   * Data sources to be used in the workflow.
    */
-  actions?: Array<Record<string, string>>;
-  /**
-   * Optional sources to include in the response.
-   */
-  sources?: Array<Record<string, string>>;
+  sources: string[];
 }

--- a/packages/common/src/assistants/IHubAssistant.ts
+++ b/packages/common/src/assistants/IHubAssistant.ts
@@ -39,13 +39,14 @@ export interface IHubAssistant {
  */
 export interface IHubAssistantWorkflow {
   /**
-   * Unique identifier for the workflow.
+   * Unique key for the workflow.
+   * This is used to reference the workflow in the configuration list field.
    */
-  id: string;
+  key: string;
   /**
-   * Name of the workflow.
+   * Label of the workflow.
    */
-  name: string;
+  label: string;
   /**
    * Description of the workflow.
    */

--- a/packages/common/src/core/schemas/internal/getEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getEditorSchemas.ts
@@ -74,6 +74,8 @@ export async function getEditorSchemas(
           import("../../../sites/_internal/SiteUiSchemaDiscussions"),
         "hub:site:settings": () =>
           import("../../../sites/_internal/SiteUiSchemaSettings"),
+        "hub:site:assistant": () =>
+          import("../../../sites/_internal/SiteUiSchemaAssistant"),
       }[type as SiteEditorType]();
       uiSchema = await siteModule.buildUiSchema(
         i18nScope,

--- a/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
+++ b/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
@@ -82,5 +82,42 @@ export const HubItemEntitySchema: IAsyncConfigurationSchema = {
       },
     },
     _slug: SLUG_SCHEMA,
+    assistant: {
+      type: "object",
+      required: [
+        "access",
+        "personality",
+        "description",
+        "location",
+        "examplePrompts",
+      ],
+      properties: {
+        schemaVersion: { type: "number" },
+        enabled: {
+          type: "boolean",
+          default: false,
+        },
+        access: ENTITY_ACCESS_SCHEMA,
+        personality: { type: "string" },
+        description: { type: "string" },
+        location: { type: "string" },
+        examplePrompts: { type: "array", items: { type: "string" } },
+        workflows: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              name: { type: "string" },
+              description: { type: "string" },
+              action: { type: "string", enum: ["search", "respond"] },
+              response: { type: "string" },
+              sources: { type: "array", items: { type: "string" } },
+            },
+          },
+        },
+        testPrompts: { type: "array", items: { type: "string" } },
+      },
+    },
   },
 } as IAsyncConfigurationSchema;

--- a/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
+++ b/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
@@ -98,6 +98,7 @@ export const HubItemEntitySchema: IAsyncConfigurationSchema = {
           default: false,
         },
         access: ENTITY_ACCESS_SCHEMA,
+        accessGroups: { type: "array", items: { type: "string" } },
         personality: { type: "string" },
         description: { type: "string" },
         location: { type: "string" },

--- a/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
+++ b/packages/common/src/core/schemas/shared/HubItemEntitySchema.ts
@@ -108,8 +108,8 @@ export const HubItemEntitySchema: IAsyncConfigurationSchema = {
           items: {
             type: "object",
             properties: {
-              id: { type: "string" },
-              name: { type: "string" },
+              key: { type: "string" },
+              label: { type: "string" },
               description: { type: "string" },
               action: { type: "string", enum: ["search", "respond"] },
               response: { type: "string" },
@@ -117,7 +117,16 @@ export const HubItemEntitySchema: IAsyncConfigurationSchema = {
             },
           },
         },
-        testPrompts: { type: "array", items: { type: "string" } },
+        testPrompts: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              key: { type: "string" },
+              label: { type: "string" },
+            },
+          },
+        },
       },
     },
   },

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -84,6 +84,28 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     // the workspace feature will be available to all users
     permission: "hub:gating:workspace:released",
   },
+
+  // AI Assistant permissions
+  // this is used to enable the AI Assistant feature on an entity
+  // an org must have the AI Assistant feature enabled
+  // and the org bust turn off the beta apps block
+  // to allow the AI Assistant to be enabled on an entity
+  {
+    permission: "hub:platform:ai-assistant",
+    environments: ["devext", "qaext"],
+    assertions: [
+      {
+        property: "context:portalSettings.aiAssistantsEnabled",
+        type: "eq",
+        value: true,
+      },
+      {
+        property: "context:portalSettings.blockBetaApps",
+        type: "eq",
+        value: false,
+      },
+    ],
+  },
   // FEATURE PERMISSIONS
   // these are used to enable/disable features in the Hub
   // and are expected to be long-lived

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -21,6 +21,7 @@ import { UserPermissions } from "../../users/_internal/UserBusinessRules";
 
 const SystemPermissions = [
   "hub:feature:ai-assistant",
+  "hub:platform:ai-assistant",
   "hub:feature:privacy",
   "hub:feature:workspace",
   "hub:feature:user:preferences",
@@ -91,5 +92,5 @@ export type Permission =
  * @returns
  */
 export function isPermission(maybePermission: string): boolean {
-  return validPermissions.includes(maybePermission as Permission);
+  return validPermissions.includes(maybePermission );
 }

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -50,6 +50,7 @@ export const SitePermissions = [
   "hub:site:workspace:initiatives",
   "hub:site:manage",
   "hub:site:workspace:feeds",
+  "hub:site:workspace:assistant",
 ] as const;
 
 /**
@@ -242,6 +243,13 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:site:workspace:feeds",
+    dependencies: ["hub:site:workspace", "hub:site:edit"],
+    environments: ["devext", "qaext", "production"],
+  },
+  {
+    permission: "hub:site:workspace:assistant",
+    availability: ["alpha"],
+    licenses: ["hub-premium"],
     dependencies: ["hub:site:workspace", "hub:site:edit"],
     environments: ["devext", "qaext", "production"],
   },

--- a/packages/common/src/sites/_internal/SiteSchema.ts
+++ b/packages/common/src/sites/_internal/SiteSchema.ts
@@ -13,6 +13,7 @@ export const SiteEditorTypes = [
   "hub:site:followers",
   "hub:site:discussions",
   "hub:site:settings",
+  "hub:site:assistant",
 ] as const;
 
 /**

--- a/packages/common/src/sites/_internal/SiteUiSchemaAssistant.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaAssistant.ts
@@ -1,0 +1,139 @@
+import type { IArcGISContext } from "../../types/IArcGISContext";
+import { IHubSite } from "../../core";
+import { IUiSchema } from "../../core/schemas/types";
+
+/**
+ * @private
+ * constructs the edit uiSchema for assistants.
+ * This defines how the schema properties should
+ * be rendered in the assistant editing experience
+ */
+export const buildUiSchema = async (
+  i18nScope: string,
+  options: Partial<IHubSite>,
+  context: IArcGISContext
+  // eslint-disable-next-line @typescript-eslint/require-await
+): Promise<IUiSchema> => {
+  // NOTE: if this is not defined on the site then
+  // the component will use the authenticated user's org
+  // which may not be the same as the site's org
+  return {
+    type: "Layout",
+    elements: [
+      {
+        type: "Section",
+        label: `{{${i18nScope}.assistant.sections.availability.label:translate}}`,
+        elements: [
+          {
+            label: `{{${i18nScope}.assistant.fields.enabled.label:translate}}`,
+            scope: "/properties/assistant/properties/enabled",
+            type: "Control",
+            options: {
+              control: "hub-field-input-switch",
+              layout: "inline-space-between",
+            },
+          },
+          {
+            label: `{{${i18nScope}.assistant.fields.access.label:translate}}`,
+            scope: "/properties/assistant/properties/access",
+            type: "Control",
+            options: {
+              control: "arcgis-hub-access-level-controls",
+              itemType: "assistant",
+              orgName: context.portal.name,
+              accessOptions: {
+                canSetAccessToPublic: true,
+                canSetAccessToOrg: true,
+                canSetAccessToPrivate: true,
+              },
+            },
+          },
+        ],
+      },
+      {
+        type: "Section",
+        label: `{{${i18nScope}.assistant.sections.details.label:translate}}`,
+        options: {
+          helperText: {
+            label: `{{${i18nScope}.assistant.sections.details.helperText:translate}}`,
+          },
+        },
+        elements: [
+          {
+            label: `{{${i18nScope}.assistant.fields.description.label:translate}}`,
+            scope: "/properties/assistant/properties/description",
+            type: "Control",
+            options: {
+              control: "hub-field-input-input",
+              type: "textarea",
+              placeholder: `{{${i18nScope}.assistant.fields.description.placeholder:translate}}`,
+              helperText: {
+                label: `{{${i18nScope}.assistant.fields.description.helperText:translate}}`,
+              },
+            },
+          },
+          {
+            label: `{{${i18nScope}.assistant.fields.location.label:translate}}`,
+            scope: "/properties/assistant/properties/location",
+            type: "Control",
+            options: {
+              control: "hub-field-input-input",
+              placeholder: `{{${i18nScope}.assistant.fields.location.placeholder:translate}}`,
+              helperText: {
+                label: `{{${i18nScope}.assistant.fields.location.helperText:translate}}`,
+              },
+            },
+          },
+        ],
+      },
+      {
+        type: "Section",
+        label: `{{${i18nScope}.assistant.sections.personality.label:translate}}`,
+        options: {
+          helperText: {
+            label: `{{${i18nScope}.assistant.sections.personality.helperText:translate}}`,
+          },
+        },
+        elements: [
+          {
+            label: "Assistant Personality",
+            scope: "/properties/assistant/properties/personality",
+            type: "Control",
+            options: {
+              control: "hub-field-input-input",
+              type: "textarea",
+              placeholder: `{{${i18nScope}.assistant.fields.personality.placeholder:translate}}`,
+              helperText: {
+                label: `{{${i18nScope}.assistant.fields.personality.helperText:translate}}`,
+              },
+            },
+          },
+        ],
+      },
+      {
+        type: "Section",
+        label: `{{${i18nScope}.assistant.sections.prompts.label:translate}}`,
+        options: {
+          helperText: {
+            label: `{{${i18nScope}.assistant.sections.prompts.helperText:translate}}`,
+          },
+        },
+        elements: [
+          {
+            label: `{{${i18nScope}.assistant.fields.examplePrompts.label:translate}}`,
+            scope: "/properties/assistant/properties/examplePrompts",
+            type: "Control",
+            options: {
+              control: "hub-field-input-multiselect",
+              placeholder: `{{${i18nScope}.assistant.fields.examplePrompts.placeholder:translate}}`,
+              allowCustomValues: true,
+              helperText: {
+                label: `{{${i18nScope}.assistant.fields.examplePrompts.helperText:translate}}`,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
+};

--- a/packages/common/src/sites/_internal/SiteUiSchemaAssistant.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaAssistant.ts
@@ -211,6 +211,167 @@ export const buildUiSchema = async (
           },
         ],
       },
+      {
+        type: "Section",
+        label: `{{${i18nScope}.assistant.sections.workflows.label:translate}}`,
+        options: {
+          helperText: {
+            label: `{{${i18nScope}.assistant.sections.workflows.helperText:translate}}`,
+          },
+        },
+        elements: [
+          {
+            scope: "/properties/assistant/properties/workflows",
+            type: "Control",
+            options: {
+              control: "hub-field-input-list",
+              allowEdit: true,
+              allowAdd: true,
+              allowDelete: true,
+              addItemButtonWidth: "fit",
+              addItemLabel: `{{${i18nScope}.assistant.sections.workflows.addWorkflowLabel:translate}}`,
+              newItemModalTitle: `{{${i18nScope}.assistant.sections.workflows.modal.newWorkflowModalHeader:translate}}`,
+              editItemModalTitle: `{{${i18nScope}.assistant.sections.workflows.modal.editWorkflowModalHeader:translate}}`,
+              // use "action" as the description for the workflow
+              descriptionProp: "action",
+              descriptionPropPostfix: `{{${i18nScope}.assistant.sections.workflows.descriptionPropPostfix:translate}}`,
+              editSchema: {
+                type: "object",
+                required: ["label", "description", "action"],
+                properties: {
+                  label: {
+                    type: "string",
+                    maxLength: 120,
+                  },
+                  description: {
+                    type: "string",
+                  },
+                  action: {
+                    type: "string",
+                    enum: ["search", "respond"],
+                    default: "search",
+                  },
+                  response: {
+                    type: "string",
+                  },
+                },
+                allOf: [
+                  {
+                    if: {
+                      properties: { action: { const: "respond" } },
+                    },
+                    then: {
+                      required: ["response"],
+                    },
+                  },
+                ],
+              },
+              editUiSchema: {
+                type: "Layout",
+                elements: [
+                  {
+                    label: `{{${i18nScope}.assistant.sections.workflows.modal.title:translate}}`,
+                    scope: "/properties/label",
+                    type: "Control",
+                    options: {
+                      control: "hub-field-input-input",
+                    },
+                  },
+                  {
+                    label: `{{${i18nScope}.assistant.sections.workflows.modal.description:translate}}`,
+                    scope: "/properties/description",
+                    type: "Control",
+                    options: {
+                      control: "hub-field-input-input",
+                    },
+                  },
+                  {
+                    label: `{{${i18nScope}.assistant.sections.workflows.modal.action.title:translate}}`,
+                    scope: "/properties/action",
+                    type: "Control",
+                    options: {
+                      control: "hub-field-input-tile-select",
+                      layout: "horizontal",
+                      icons: ["search", "speech-bubble"],
+                      labels: [
+                        `{{${i18nScope}.assistant.sections.workflows.modal.action.search:translate}}`,
+                        `{{${i18nScope}.assistant.sections.workflows.modal.action.respond:translate}}`,
+                      ],
+                      descriptions: [
+                        `{{${i18nScope}.assistant.sections.workflows.modal.action.searchDescription:translate}}`,
+                        `{{${i18nScope}.assistant.sections.workflows.modal.action.respondDescription:translate}}`,
+                      ],
+                    },
+                  },
+                  {
+                    label: `{{${i18nScope}.assistant.sections.workflows.modal.action.response:translate}}`,
+                    scope: "/properties/response",
+                    type: "Control",
+                    options: {
+                      control: "hub-field-input-input",
+                    },
+                    rule: {
+                      effect: "HIDE",
+                      condition: {
+                        scope: "/properties/action",
+                        schema: { const: "search" },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      // {
+      //   type: "Section",
+      //   label: `{{${i18nScope}.assistant.sections.testPrompts.label:translate}}`,
+      //   options: {
+      //     helperText: {
+      //       label: `{{${i18nScope}.assistant.sections.testPrompts.helperText:translate}}`,
+      //     },
+      //   },
+      //   elements: [
+      //     {
+      //       scope: "/properties/assistant/properties/testPrompts",
+      //       type: "Control",
+      //       options: {
+      //         control: "hub-field-input-list",
+      //         allowEdit: true,
+      //         allowAdd: true,
+      //         allowDelete: true,
+      //         addItemButtonWidth: "fit",
+      //         addItemLabel: `{{${i18nScope}.assistant.sections.testPrompts.addTestPromptLabel:translate}}`,
+      //         newItemModalTitle: `{{${i18nScope}.assistant.sections.testPrompts.modal.newTestPromptModalHeader:translate}}`,
+      //         editItemModalTitle: `{{${i18nScope}.assistant.sections.testPrompts.modal.editTestPromptModalHeader:translate}}`,
+      //         editSchema: {
+      //           type: "object",
+      //           required: ["label"],
+      //           properties: {
+      //             label: {
+      //               type: "string",
+      //               maxLength: 120,
+      //             },
+      //           },
+      //         },
+      //         editUiSchema: {
+      //           type: "Layout",
+      //           elements: [
+      //             {
+      //               label: `{{${i18nScope}.assistant.sections.testPrompts.modal.title:translate}}`,
+      //               scope: "/properties/label",
+      //               type: "Control",
+      //               options: {
+      //                 control: "hub-field-input-input",
+      //               },
+      //             },
+      //           ],
+      //         },
+      //       },
+      //     },
+      //   ],
+      // },
     ],
   };
 };

--- a/packages/common/src/sites/_internal/SiteUiSchemaAssistant.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaAssistant.ts
@@ -48,6 +48,83 @@ export const buildUiSchema = async (
               },
             },
           },
+          {
+            label: `{{${i18nScope}.assistant.fields.accessGroups.label:translate}}`,
+            scope: "/properties/assistant/properties/accessGroups",
+            type: "Control",
+            options: {
+              control: "hub-field-input-gallery-picker",
+              targetEntity: "group",
+              helperText: {
+                label: `{{${i18nScope}.assistant.fields.accessGroups.helperText:translate}}`,
+              },
+              catalogs: [
+                {
+                  schemaVersion: 1,
+                  scopes: {
+                    group: {
+                      targetEntity: "group",
+                      filters: [
+                        {
+                          predicates: [
+                            {
+                              capabilities: {
+                                not: ["updateitemcontrol"],
+                              },
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                  collections: [
+                    {
+                      targetEntity: "group",
+                      scope: {
+                        targetEntity: "group",
+                        filters: [
+                          {
+                            predicates: [
+                              {
+                                q: "*",
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+              facets: [
+                {
+                  label: `{{${i18nScope}.assistant.fields.accessGroups.facets.label.from:translate}}`,
+                  display: "single-select",
+                  operation: "OR",
+                  options: [
+                    {
+                      label: `{{${i18nScope}.assistant.fields.accessGroups.facets.label.group:translate}}`,
+                      selected: true,
+                      predicates: [
+                        {
+                          owner: context.currentUser.username,
+                        },
+                      ],
+                    },
+                    {
+                      label: `{{${i18nScope}.assistant.fields.accessGroups.facets.label.org:translate}}`,
+                      selected: false,
+                      predicates: [
+                        {
+                          orgid: context.currentUser.orgId,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
         ],
       },
       {

--- a/packages/common/src/sites/defaults.ts
+++ b/packages/common/src/sites/defaults.ts
@@ -16,8 +16,8 @@ export const DEFAULT_SITE: Partial<IHubSite> = {
     schemaVersion: 0,
     workflows: [
       {
-        id: "search_workflow",
-        name: "Data search",
+        key: "search_workflow",
+        label: "Data search",
         description:
           "This workflow is for questions about geographic data that can be answered from open data.",
         action: "search",
@@ -25,8 +25,8 @@ export const DEFAULT_SITE: Partial<IHubSite> = {
         sources: [],
       },
       {
-        id: "crisis_workflow",
-        name: "Personal crisis topics",
+        key: "crisis_workflow",
+        label: "Personal crisis topics",
         description:
           "Relating to suicide, self harm, or other personal crisis.",
         action: "respond",
@@ -35,8 +35,8 @@ export const DEFAULT_SITE: Partial<IHubSite> = {
         sources: [],
       },
       {
-        id: "disaster_workflow",
-        name: "Disaster response",
+        key: "disaster_workflow",
+        label: "Disaster response",
         description: "Relating preparing for disaster, tornado, hurricanes.",
         action: "respond",
         response: "If this is an emergency, call 911.",

--- a/packages/common/src/sites/defaults.ts
+++ b/packages/common/src/sites/defaults.ts
@@ -12,6 +12,38 @@ export const DEFAULT_SITE: Partial<IHubSite> = {
   tags: [],
   typeKeywords: ["Hub Site", "hubSite"],
   catalog: { schemaVersion: 0 },
+  assistant: {
+    schemaVersion: 0,
+    workflows: [
+      {
+        id: "search_workflow",
+        name: "Data search",
+        description:
+          "This workflow is for questions about geographic data that can be answered from open data.",
+        action: "search",
+        response: "Query for the right dataset and filter.",
+        sources: [],
+      },
+      {
+        id: "crisis_workflow",
+        name: "Personal crisis topics",
+        description:
+          "Relating to suicide, self harm, or other personal crisis.",
+        action: "respond",
+        response:
+          "If you are in a crisis or feeling suicidal, please call 911 for emergency response or 988 for the Suicide and Crisis Lifeline.",
+        sources: [],
+      },
+      {
+        id: "disaster_workflow",
+        name: "Disaster response",
+        description: "Relating preparing for disaster, tornado, hurricanes.",
+        action: "respond",
+        response: "If this is an emergency, call 911.",
+        sources: [],
+      },
+    ],
+  },
   permissions: [],
   schemaVersion: 1,
   features: SiteDefaultFeatures,

--- a/packages/common/src/types/IArcGISContext.ts
+++ b/packages/common/src/types/IArcGISContext.ts
@@ -2,7 +2,7 @@ import {
   ArcGISIdentityManager,
   IUserRequestOptions,
 } from "@esri/arcgis-rest-request";
-import type { IPortal } from "@esri/arcgis-rest-portal";
+import type { IPortal, IPortalSettings } from "@esri/arcgis-rest-portal";
 import type { IRequestOptions } from "@esri/arcgis-rest-request";
 import type { IUser } from "@esri/arcgis-rest-portal";
 import { HubServiceStatus, HubEntity } from "../core";
@@ -160,6 +160,11 @@ export interface IArcGISContext {
    * Returns the portal object
    */
   portal: IPortal;
+
+  /**
+   * Returns the portal settings object
+   */
+  portalSettings: IPortalSettings;
 
   /**
    * What is the current user's hub license level?

--- a/packages/common/src/types/IArcGISContextManagerOptions.ts
+++ b/packages/common/src/types/IArcGISContextManagerOptions.ts
@@ -1,6 +1,6 @@
 import type { ArcGISIdentityManager } from "@esri/arcgis-rest-request";
 import { IPortal } from "@esri/arcgis-rest-portal";
-import type { IUser } from "@esri/arcgis-rest-portal";
+import type { IPortalSettings, IUser } from "@esri/arcgis-rest-portal";
 import { IUserResourceToken } from "./IUserResourceToken";
 import { IUserResourceConfig } from "./IUserResourceConfig";
 import { HubServiceStatus } from "../core/types/ISystemStatus";
@@ -36,6 +36,12 @@ export interface IArcGISContextManagerOptions {
    * with the ArcGISIdentityManager, it will be fetched
    */
   portal?: IPortal;
+
+  /**
+   * Portal settings for the authenticated user. If not passed into `.create`
+   * with the ArcGISIdentityManager, it will be fetched
+   */
+  portalSettings?: IPortalSettings;
 
   /**
    * Current user as `IUser`. If not passed into `.create` with the ArcGISIdentityManager

--- a/packages/common/src/types/IArcGISContextOptions.ts
+++ b/packages/common/src/types/IArcGISContextOptions.ts
@@ -1,5 +1,5 @@
 import type { ArcGISIdentityManager } from "@esri/arcgis-rest-request";
-import type { IPortal } from "@esri/arcgis-rest-portal";
+import type { IPortal, IPortalSettings } from "@esri/arcgis-rest-portal";
 import type { IUser } from "@esri/arcgis-rest-portal";
 import type { IUserResourceToken } from "./IUserResourceToken";
 import type { HubServiceStatus } from "../core/types/ISystemStatus";
@@ -40,6 +40,14 @@ export interface IArcGISContextOptions {
    * ArcGISContextManager handles this internally
    */
   portalSelf?: IPortal;
+
+  /**
+   * If the user is authenticated, the portal settings should be passed in
+   * so various getters can work as expected.
+   *
+   * ArcGISContextManager handles this internally
+   */
+  portalSettings?: IPortalSettings;
 
   /**
    * If the user is authenticated, the user should be passed in

--- a/packages/common/test/ArcGISContext.test.ts
+++ b/packages/common/test/ArcGISContext.test.ts
@@ -222,7 +222,7 @@ describe("ArcGISContext:", () => {
         await anonCtx.updateUserHubSettings({} as IUserHubSettings);
       } catch (ex) {
         // we expect this to throw
-        expect((ex as any).message).toEqual(
+        expect((ex ).message).toEqual(
           "Cannot update user hub settings without an authenticated user"
         );
       }
@@ -268,6 +268,12 @@ describe("ArcGISContext:", () => {
         },
       } as unknown as IUserHubSettings);
       expect(ctx.featureFlags["hub:feature:workspace"]).toBeFalsy();
+    });
+  });
+  describe("portalSettings:", () => {
+    it("returns the portalSettings object", () => {
+      const ctx = createMockContext();
+      expect(ctx.portalSettings).toBe(undefined);
     });
   });
 });

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -797,6 +797,12 @@ describe("ArcGISContextManager:", () => {
       const userSpy = spyOn(portalModule, "getUser").and.callFake(() => {
         return Promise.resolve(cloneObject(onlineUserResponse));
       });
+      const portalSettingsSpy = spyOn(
+        portalModule,
+        "getPortalSettings"
+      ).and.callFake(() => {
+        return Promise.resolve({} as portalModule.IPortalSettings);
+      });
       const trustedSpy = spyOn(requestModule, "request").and.callFake(() => {
         return Promise.resolve(cloneObject(onlinePartneredOrgResponse));
       });
@@ -815,6 +821,7 @@ describe("ArcGISContextManager:", () => {
         authentication: MOCK_AUTH,
         serviceStatus: {} as unknown as HubServiceStatus,
         portal: { fake: "portal", limits: {} } as unknown as IPortal,
+        portalSettings: {} as portalModule.IPortalSettings,
         currentUser: { username: "fakeuser" } as unknown as portalModule.IUser,
         trustedOrgs: cloneObject(onlinePartneredOrgResponse.trustedOrgs),
         resourceTokens: [{ app: "self", clientId: "bar", token: "FAKETOKEN" }],
@@ -826,6 +833,7 @@ describe("ArcGISContextManager:", () => {
       expect(trustedSpy).not.toHaveBeenCalled();
       expect(exchangeSpy).not.toHaveBeenCalled();
       expect(orgLimitSpy).not.toHaveBeenCalled();
+      expect(portalSettingsSpy).not.toHaveBeenCalled();
 
       expect(mgr.context.tokenFor("self")).toEqual("FAKETOKEN");
       expect(mgr.context.tokenFor("arcgisonline")).toBeUndefined();

--- a/packages/common/test/content/HubContent.test.ts
+++ b/packages/common/test/content/HubContent.test.ts
@@ -32,6 +32,7 @@ describe("HubContent class", () => {
         id: "BRXFAKE",
         urlKey: "fake-org",
       } as unknown as PortalModule.IPortal,
+      portalSettings: {} as PortalModule.IPortalSettings,
       portalUrl: "https://myserver.com",
     });
   });

--- a/packages/common/test/core/schemas/internal/getEditorSchemas.test.ts
+++ b/packages/common/test/core/schemas/internal/getEditorSchemas.test.ts
@@ -28,6 +28,7 @@ import * as SiteBuildCreateUiSchema from "../../../../src/sites/_internal/SiteUi
 import * as SiteBuildFollowersUiSchema from "../../../../src/sites/_internal/SiteUiSchemaFollowers";
 import * as SiteBuildDiscussionsUiSchema from "../../../../src/sites/_internal/SiteUiSchemaDiscussions";
 import * as SiteBuildTelemetryUiSchema from "../../../../src/sites/_internal/SiteUiSchemaSettings";
+import * as SiteBuildAssistantUiSchema from "../../../../src/sites/_internal/SiteUiSchemaAssistant";
 
 import { DiscussionEditorTypes } from "../../../../src/discussions/_internal/DiscussionSchema";
 import * as DiscussionBuildEditUiSchema from "../../../../src/discussions/_internal/DiscussionUiSchemaEdit";
@@ -110,6 +111,7 @@ describe("getEditorSchemas: ", () => {
     { type: SiteEditorTypes[2], module: SiteBuildFollowersUiSchema },
     { type: SiteEditorTypes[3], module: SiteBuildDiscussionsUiSchema },
     { type: SiteEditorTypes[4], module: SiteBuildTelemetryUiSchema },
+    { type: SiteEditorTypes[5], module: SiteBuildAssistantUiSchema },
 
     { type: DiscussionEditorTypes[0], module: DiscussionBuildEditUiSchema },
     { type: DiscussionEditorTypes[1], module: DiscussionBuildCreateUiSchema },

--- a/packages/common/test/sites/HubSite.test.ts
+++ b/packages/common/test/sites/HubSite.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as PortalModule from "@esri/arcgis-rest-portal";
 import { ArcGISContextManager } from "../../src/ArcGISContextManager";
 import { HubSite } from "../../src/sites/HubSite";
@@ -459,7 +460,7 @@ describe("HubSite Class:", () => {
       expect(createVersionSpy).toHaveBeenCalledTimes(1);
       const args = createVersionSpy.calls.argsFor(0);
       const modelArg = args[0];
-      expect(modelArg).toEqual(model);
+      expect(modelArg.item).toEqual(model.item);
       expect(args[1]).toEqual(authdCtxMgr.context.userRequestOptions);
       expect(args[2]).toEqual(createVersionOptions);
     });
@@ -496,7 +497,7 @@ describe("HubSite Class:", () => {
       expect(updateVersionSpy).toHaveBeenCalledTimes(1);
       const args = updateVersionSpy.calls.argsFor(0);
       const modelArg = args[0];
-      expect(modelArg).toEqual(model);
+      expect(modelArg.item).toEqual(model.item);
       expect(args[2]).toEqual(authdCtxMgr.context.userRequestOptions);
       expect(args[1]).toEqual(version);
     });

--- a/packages/common/test/sites/_internal/SiteUiSchemaAssistant.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaAssistant.test.ts
@@ -1,0 +1,204 @@
+import { buildUiSchema } from "../../../src/sites/_internal/SiteUiSchemaAssistant";
+import { MOCK_CONTEXT } from "../../mocks/mock-auth";
+
+describe("buildUiSchema: site assistant", () => {
+  it("returns the full site assistant uiSchema", async () => {
+    const uiSchema = await buildUiSchema("some.scope", {} as any, MOCK_CONTEXT);
+    expect(uiSchema).toEqual({
+      type: "Layout",
+      elements: [
+        {
+          type: "Section",
+          label: `{{some.scope.assistant.sections.availability.label:translate}}`,
+          elements: [
+            {
+              label: `{{some.scope.assistant.fields.enabled.label:translate}}`,
+              scope: "/properties/assistant/properties/enabled",
+              type: "Control",
+              options: {
+                control: "hub-field-input-switch",
+                layout: "inline-space-between",
+              },
+            },
+            {
+              label: `{{some.scope.assistant.fields.access.label:translate}}`,
+              scope: "/properties/assistant/properties/access",
+              type: "Control",
+              options: {
+                control: "arcgis-hub-access-level-controls",
+                itemType: "assistant",
+                orgName: MOCK_CONTEXT.portal.name,
+                accessOptions: {
+                  canSetAccessToPublic: true,
+                  canSetAccessToOrg: true,
+                  canSetAccessToPrivate: true,
+                },
+              },
+            },
+            {
+              label: `{{some.scope.assistant.fields.accessGroups.label:translate}}`,
+              scope: "/properties/assistant/properties/accessGroups",
+              type: "Control",
+              options: {
+                control: "hub-field-input-gallery-picker",
+                targetEntity: "group",
+                helperText: {
+                  label: `{{some.scope.assistant.fields.accessGroups.helperText:translate}}`,
+                },
+                catalogs: [
+                  {
+                    schemaVersion: 1,
+                    scopes: {
+                      group: {
+                        targetEntity: "group",
+                        filters: [
+                          {
+                            predicates: [
+                              {
+                                capabilities: {
+                                  not: ["updateitemcontrol"],
+                                },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                    collections: [
+                      {
+                        targetEntity: "group",
+                        scope: {
+                          targetEntity: "group",
+                          filters: [
+                            {
+                              predicates: [
+                                {
+                                  q: "*",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+                facets: [
+                  {
+                    label: `{{some.scope.assistant.fields.accessGroups.facets.label.from:translate}}`,
+                    display: "single-select",
+                    operation: "OR",
+                    options: [
+                      {
+                        label: `{{some.scope.assistant.fields.accessGroups.facets.label.group:translate}}`,
+                        selected: true,
+                        predicates: [
+                          {
+                            owner: MOCK_CONTEXT.currentUser.username,
+                          },
+                        ],
+                      },
+                      {
+                        label: `{{some.scope.assistant.fields.accessGroups.facets.label.org:translate}}`,
+                        selected: false,
+                        predicates: [
+                          {
+                            orgid: MOCK_CONTEXT.currentUser.orgId,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          type: "Section",
+          label: `{{some.scope.assistant.sections.details.label:translate}}`,
+          options: {
+            helperText: {
+              label: `{{some.scope.assistant.sections.details.helperText:translate}}`,
+            },
+          },
+          elements: [
+            {
+              label: `{{some.scope.assistant.fields.description.label:translate}}`,
+              scope: "/properties/assistant/properties/description",
+              type: "Control",
+              options: {
+                control: "hub-field-input-input",
+                type: "textarea",
+                placeholder: `{{some.scope.assistant.fields.description.placeholder:translate}}`,
+                helperText: {
+                  label: `{{some.scope.assistant.fields.description.helperText:translate}}`,
+                },
+              },
+            },
+            {
+              label: `{{some.scope.assistant.fields.location.label:translate}}`,
+              scope: "/properties/assistant/properties/location",
+              type: "Control",
+              options: {
+                control: "hub-field-input-input",
+                placeholder: `{{some.scope.assistant.fields.location.placeholder:translate}}`,
+                helperText: {
+                  label: `{{some.scope.assistant.fields.location.helperText:translate}}`,
+                },
+              },
+            },
+          ],
+        },
+        {
+          type: "Section",
+          label: `{{some.scope.assistant.sections.personality.label:translate}}`,
+          options: {
+            helperText: {
+              label: `{{some.scope.assistant.sections.personality.helperText:translate}}`,
+            },
+          },
+          elements: [
+            {
+              label: "Assistant Personality",
+              scope: "/properties/assistant/properties/personality",
+              type: "Control",
+              options: {
+                control: "hub-field-input-input",
+                type: "textarea",
+                placeholder: `{{some.scope.assistant.fields.personality.placeholder:translate}}`,
+                helperText: {
+                  label: `{{some.scope.assistant.fields.personality.helperText:translate}}`,
+                },
+              },
+            },
+          ],
+        },
+        {
+          type: "Section",
+          label: `{{some.scope.assistant.sections.prompts.label:translate}}`,
+          options: {
+            helperText: {
+              label: `{{some.scope.assistant.sections.prompts.helperText:translate}}`,
+            },
+          },
+          elements: [
+            {
+              label: `{{some.scope.assistant.fields.examplePrompts.label:translate}}`,
+              scope: "/properties/assistant/properties/examplePrompts",
+              type: "Control",
+              options: {
+                control: "hub-field-input-multiselect",
+                placeholder: `{{some.scope.assistant.fields.examplePrompts.placeholder:translate}}`,
+                allowCustomValues: true,
+                helperText: {
+                  label: `{{some.scope.assistant.fields.examplePrompts.helperText:translate}}`,
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/common/test/sites/_internal/SiteUiSchemaAssistant.test.ts
+++ b/packages/common/test/sites/_internal/SiteUiSchemaAssistant.test.ts
@@ -198,6 +198,119 @@ describe("buildUiSchema: site assistant", () => {
             },
           ],
         },
+        {
+          type: "Section",
+          label: `{{some.scope.assistant.sections.workflows.label:translate}}`,
+          options: {
+            helperText: {
+              label: `{{some.scope.assistant.sections.workflows.helperText:translate}}`,
+            },
+          },
+          elements: [
+            {
+              scope: "/properties/assistant/properties/workflows",
+              type: "Control",
+              options: {
+                control: "hub-field-input-list",
+                allowEdit: true,
+                allowAdd: true,
+                allowDelete: true,
+                addItemButtonWidth: "fit",
+                addItemLabel: `{{some.scope.assistant.sections.workflows.addWorkflowLabel:translate}}`,
+                newItemModalTitle: `{{some.scope.assistant.sections.workflows.modal.newWorkflowModalHeader:translate}}`,
+                editItemModalTitle: `{{some.scope.assistant.sections.workflows.modal.editWorkflowModalHeader:translate}}`,
+                // use "action" as the description for the workflow
+                descriptionProp: "action",
+                descriptionPropPostfix: `{{some.scope.assistant.sections.workflows.descriptionPropPostfix:translate}}`,
+                editSchema: {
+                  type: "object",
+                  required: ["label", "description", "action"],
+                  properties: {
+                    label: {
+                      type: "string",
+                      maxLength: 120,
+                    },
+                    description: {
+                      type: "string",
+                    },
+                    action: {
+                      type: "string",
+                      enum: ["search", "respond"],
+                      default: "search",
+                    },
+                    response: {
+                      type: "string",
+                    },
+                  },
+                  allOf: [
+                    {
+                      if: {
+                        properties: { action: { const: "respond" } },
+                      },
+                      then: {
+                        required: ["response"],
+                      },
+                    },
+                  ],
+                },
+                editUiSchema: {
+                  type: "Layout",
+                  elements: [
+                    {
+                      label: `{{some.scope.assistant.sections.workflows.modal.title:translate}}`,
+                      scope: "/properties/label",
+                      type: "Control",
+                      options: {
+                        control: "hub-field-input-input",
+                      },
+                    },
+                    {
+                      label: `{{some.scope.assistant.sections.workflows.modal.description:translate}}`,
+                      scope: "/properties/description",
+                      type: "Control",
+                      options: {
+                        control: "hub-field-input-input",
+                      },
+                    },
+                    {
+                      label: `{{some.scope.assistant.sections.workflows.modal.action.title:translate}}`,
+                      scope: "/properties/action",
+                      type: "Control",
+                      options: {
+                        control: "hub-field-input-tile-select",
+                        layout: "horizontal",
+                        icons: ["search", "speech-bubble"],
+                        labels: [
+                          `{{some.scope.assistant.sections.workflows.modal.action.search:translate}}`,
+                          `{{some.scope.assistant.sections.workflows.modal.action.respond:translate}}`,
+                        ],
+                        descriptions: [
+                          `{{some.scope.assistant.sections.workflows.modal.action.searchDescription:translate}}`,
+                          `{{some.scope.assistant.sections.workflows.modal.action.respondDescription:translate}}`,
+                        ],
+                      },
+                    },
+                    {
+                      label: `{{some.scope.assistant.sections.workflows.modal.action.response:translate}}`,
+                      scope: "/properties/response",
+                      type: "Control",
+                      options: {
+                        control: "hub-field-input-input",
+                      },
+                      rule: {
+                        effect: "HIDE",
+                        condition: {
+                          scope: "/properties/action",
+                          schema: { const: "search" },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
       ],
     });
   });


### PR DESCRIPTION
1. Description: This PR adds the JSON Schema and permissions needed to configure an AI assistant on a Hub Site. See issue [13265](https://devtopia.esri.com/dc/hub/issues/13265), [13264](https://devtopia.esri.com/dc/hub/issues/13264) and `opendata-ui` PR [here](https://github.com/ArcGIS/opendata-ui/pull/14972) 

1. Instructions for testing: The above PR is dependent on these changes and can be tested with the new UI it provides.

1. Closes Issues: # [13264](https://devtopia.esri.com/dc/hub/issues/13264)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
