### PR TITLE
feat(hub-common): 2746 new relation replyCount discussion post query

### DIFF
--- a/packages/common/src/discussions/api/types.ts
+++ b/packages/common/src/discussions/api/types.ts
@@ -143,6 +143,7 @@ export interface IDiscussionParams {
  */
 export enum PostRelation {
   REPLIES = "replies",
+  REPLY_COUNT = "replyCount",
   REACTIONS = "reactions",
   PARENT = "parent",
   CHANNEL = "channel",


### PR DESCRIPTION
Description: new relation `replyCount` for discussion api
Related Issue: [2746](https://zentopia.esri.com/workspaces/sprint-board-60340b9721bc3a4ab6367db5/issues/gh/dc/hub/2746)

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
