### PR TITLE
feat(hub-common): added file too large errors to shapefiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54268,7 +54268,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "18.2.0",
+			"version": "18.5.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/downloads/_internal/file-url-fetchers/fetchHubApiDownloadFile.ts
+++ b/packages/common/src/downloads/_internal/file-url-fetchers/fetchHubApiDownloadFile.ts
@@ -9,6 +9,7 @@ import {
   IFetchDownloadFileResponse,
   ServiceDownloadFormat,
   downloadProgressCallback,
+  ArcgisHubDownloadFileTooLargeError,
 } from "../../types";
 
 /**
@@ -139,6 +140,17 @@ async function pollDownloadApi(
   if (!response.ok) {
     const errorBody = await response.json();
     // TODO: Add standarized messageId when available
+
+    // Checks the "file too large" error
+    if (
+      errorBody.message ==
+      "Error downloading Shapefile. File size is larger than the 2GB limit."
+    ) {
+      throw new ArcgisHubDownloadFileTooLargeError({
+        rawMessage: errorBody.message,
+      });
+    }
+    // throws a generic download error
     throw new ArcgisHubDownloadError({
       rawMessage: errorBody.message,
     });

--- a/packages/common/src/downloads/types.ts
+++ b/packages/common/src/downloads/types.ts
@@ -240,3 +240,13 @@ export class ArcgisHubDownloadError extends Error {
     this.operation = options.operation;
   }
 }
+
+/**
+ * Error class specifically for when download files exceed size limits.
+ */
+export class ArcgisHubDownloadFileTooLargeError extends ArcgisHubDownloadError {
+  constructor(options: IArcgisHubDownloadErrorOptions) {
+    super(options);
+    this.name = "ArcgisHubDownloadFileTooLargeError";
+  }
+}


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
