### PR TITLE
feat(hub-common): add service to platform AI permission check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54268,7 +54268,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "18.6.1",
+			"version": "18.7.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54268,7 +54268,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "18.5.1",
+			"version": "18.6.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/ArcGISContextManager.ts
+++ b/packages/common/src/ArcGISContextManager.ts
@@ -718,6 +718,7 @@ export const HUB_SERVICE_STATUS: HubServiceStatus = {
   "hub-search": "online",
   domains: "online",
   "hub-downloads": "online",
+  "hub-ai-assistant": "online",
 };
 
 export const ENTERPRISE_SITES_SERVICE_STATUS: HubServiceStatus = {
@@ -729,6 +730,7 @@ export const ENTERPRISE_SITES_SERVICE_STATUS: HubServiceStatus = {
   "hub-search": "not-available",
   domains: "not-available",
   "hub-downloads": "not-available",
+  "hub-ai-assistant": "not-available",
 };
 
 const DEV_ALPHA_ORGS = [

--- a/packages/common/src/core/types/ISystemStatus.ts
+++ b/packages/common/src/core/types/ISystemStatus.ts
@@ -23,6 +23,7 @@ const validServices = [
   "hub-search",
   "domains",
   "hub-downloads",
+  "hub-ai-assistant",
 ] as const;
 
 export type HubService = (typeof validServices)[number];

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -94,6 +94,7 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:platform:ai-assistant",
     licenses: ["hub-premium"],
+    services: ["hub-ai-assistant"],
     assertions: [
       {
         property: "context:portalSettings.aiAssistantsEnabled",

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -92,7 +92,6 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
   // to allow the AI Assistant to be enabled on an entity
   {
     permission: "hub:platform:ai-assistant",
-    environments: ["devext", "qaext"],
     assertions: [
       {
         property: "context:portalSettings.aiAssistantsEnabled",

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -85,13 +85,15 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:gating:workspace:released",
   },
 
-  // AI Assistant permissions
-  // this is used to enable the AI Assistant feature on an entity
+  // AI Assistant org permissions
+  // this is used to allow AI Assistant features from the org level
   // an org must have the AI Assistant feature enabled
   // and the org bust turn off the beta apps block
+  // and be a premium org
   // to allow the AI Assistant to be enabled on an entity
   {
     permission: "hub:platform:ai-assistant",
+    licenses: ["hub-premium"],
     assertions: [
       {
         property: "context:portalSettings.aiAssistantsEnabled",

--- a/packages/common/test/groups/getWellKnownGroup.test.ts
+++ b/packages/common/test/groups/getWellKnownGroup.test.ts
@@ -30,6 +30,7 @@ describe("getWellKnownGroup: ", () => {
       "hub-search": "online",
       domains: "online",
       "hub-downloads": "online",
+      "hub-ai-assistant": "online",
     },
     userHubSettings: {
       schemaVersion: 1,

--- a/packages/common/test/mocks/mock-auth.ts
+++ b/packages/common/test/mocks/mock-auth.ts
@@ -194,6 +194,7 @@ export const MOCK_ENTERPRISE_CONTEXT = new ArcGISContext({
     "hub-search": "not-available",
     domains: "not-available",
     "hub-downloads": "not-available",
+    "hub-ai-assistant": "not-available",
   },
   userHubSettings: {
     schemaVersion: 1,

--- a/packages/common/test/mocks/mock-auth.ts
+++ b/packages/common/test/mocks/mock-auth.ts
@@ -123,6 +123,7 @@ export function getMockContextWithPrivilenges(
       "hub-search": "online",
       domains: "online",
       "hub-downloads": "online",
+      "hub-ai-assistant": "online",
     },
     userHubSettings: {
       schemaVersion: 1,
@@ -158,6 +159,7 @@ export const MOCK_CONTEXT = new ArcGISContext({
     "hub-search": "online",
     domains: "online",
     "hub-downloads": "online",
+    "hub-ai-assistant": "online",
   },
   userHubSettings: {
     schemaVersion: 1,
@@ -219,6 +221,7 @@ export const MOCK_ANON_CONTEXT = new ArcGISContext({
     "hub-search": "online",
     domains: "online",
     "hub-downloads": "online",
+    "hub-ai-assistant": "online",
   },
   userHubSettings: {
     schemaVersion: 1,
@@ -251,6 +254,7 @@ export function createMockContext(): ArcGISContext {
       "hub-search": "online",
       domains: "online",
       "hub-downloads": "online",
+      "hub-ai-assistant": "online",
     },
     userHubSettings: {
       schemaVersion: 1,
@@ -280,6 +284,7 @@ export function createMockAnonContext(): ArcGISContext {
       "hub-search": "online",
       domains: "online",
       "hub-downloads": "online",
+      "hub-ai-assistant": "online",
     },
     userHubSettings: {
       schemaVersion: 1,


### PR DESCRIPTION
1. Description: This allows checkPermission() to return true on production if the two assertions are met.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
