### PR TITLE
fix: community org AGO url

### DIFF
--- a/packages/common/src/users/_internal/UserUiSchemaSettings.ts
+++ b/packages/common/src/users/_internal/UserUiSchemaSettings.ts
@@ -266,16 +266,22 @@ export const buildUiSchema = async (
 async function _getCommunityOrEnterpriseAGOUrl(
   context: IArcGISContext
 ): Promise<string> {
-  let orgUrl = `${context.communityOrgUrl}/home/organization.html`;
+  let orgUrl = `${context.communityOrgUrl}/home/index.html`;
   // if there's an enterprise org, we need to fetch it to get the url
   if (context.enterpriseOrgId) {
     // Fail safe fetch the e-org
     const fsGetOrg = failSafe(fetchOrg, {});
-    const org = await fsGetOrg(context.enterpriseOrgId, context.requestOptions);
+    const org = (await fsGetOrg(
+      context.enterpriseOrgId,
+      context.requestOptions
+    )) as {
+      urlKey?: string;
+      customBaseUrl?: string;
+    };
     // If the org response has a urlKey it is a real response. If the urlKey is missing the org is private
     if (org.urlKey) {
       // construct the url
-      orgUrl = `https://${org.urlKey}.${org.customBaseUrl}/home/organization.html`;
+      orgUrl = `https://${org.urlKey}.${org.customBaseUrl}/home/index.html`;
     } else {
       // If the org is private, we can't link to it
       orgUrl = undefined;

--- a/packages/common/test/users/_internal/UserUiSchemaSettings.test.ts
+++ b/packages/common/test/users/_internal/UserUiSchemaSettings.test.ts
@@ -113,7 +113,7 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToCommunityOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToCommunityOrg:translate}}`,
-                      href: `https://qaext.c.arcgis.com/home/organization.html`,
+                      href: `https://qaext.c.arcgis.com/home/index.html`,
                       target: "_blank",
                     },
                   ],
@@ -352,7 +352,7 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToStaffOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToStaffOrg:translate}}`,
-                      href: `https://qaext.arcgis.com/home/organization.html`,
+                      href: `https://qaext.arcgis.com/home/index.html`,
                       target: "_blank",
                     },
                   ],
@@ -592,7 +592,7 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToStaffOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToStaffOrg:translate}}`,
-                      href: `https://qaext.arcgis.com/home/organization.html`,
+                      href: `https://qaext.arcgis.com/home/index.html`,
                       target: "_blank",
                     },
                   ],
@@ -1053,7 +1053,7 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToStaffOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToStaffOrg:translate}}`,
-                      href: `https://qaext.arcgis.com/home/organization.html`,
+                      href: `https://qaext.arcgis.com/home/index.html`,
                       target: "_blank",
                     },
                   ],
@@ -1742,7 +1742,7 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToCommunityOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToCommunityOrg:translate}}`,
-                      href: `https://qaext.c.arcgis.com/home/organization.html`,
+                      href: `https://qaext.c.arcgis.com/home/index.html`,
                       target: "_blank",
                     },
                   ],
@@ -1975,7 +1975,7 @@ describe("UserUiSchemaSettings:", () => {
                     {
                       ariaLabel: `{{some.scope.notice.actions.goToCommunityOrg:translate}}`,
                       label: `{{some.scope.notice.actions.goToCommunityOrg:translate}}`,
-                      href: `https://qaext.c.arcgis.com/home/organization.html`,
+                      href: `https://qaext.c.arcgis.com/home/index.html`,
                       target: "_blank",
                     },
                   ],


### PR DESCRIPTION
[13587](https://devtopia.esri.com/dc/hub/issues/13587)

### Description
Remove `/organization` from the href construction - this route is only accessible to admins of the corresponding organization which is causing a redirect

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.