### PR TITLE
feat(hub-common): added file too large error for hub download system workflow

### DIFF
--- a/packages/common/src/downloads/_internal/file-url-fetchers/fetchHubApiDownloadFile.ts
+++ b/packages/common/src/downloads/_internal/file-url-fetchers/fetchHubApiDownloadFile.ts
@@ -139,7 +139,7 @@ async function pollDownloadApi(
 
   if (!response.ok) {
     const errorBody = await response.json();
-    const errorMessage = errorBody.message || errorBody?.errors?.message;
+    const errorMessage = errorBody.message || errorBody.errors?.message;
     // TODO: Add standarized messageId when available
 
     // Checks for "file too large" errors from different workflows:


### PR DESCRIPTION
1. Description:

Per issue [#12798](https://devtopia.esri.com/dc/hub/issues/12798),

In addition to the create replica workflow in [1942](https://github.com/Esri/hub.js/pull/1942), this PR adds the error message for the hub download system workflow

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
