### PR TITLE
feat: hide privacy config in enterprise

### DIFF
--- a/packages/common/src/sites/_internal/SiteUiSchemaSettings.ts
+++ b/packages/common/src/sites/_internal/SiteUiSchemaSettings.ts
@@ -18,7 +18,7 @@ export const buildUiSchema = async (
   // the component will use the authenticated user's org
   // which may not be the same as the site's org
   const orgUrlKey = (options as IHubSite).orgUrlKey;
-  return {
+  const result: IUiSchema = {
     type: "Layout",
     elements: [
       {
@@ -49,19 +49,28 @@ export const buildUiSchema = async (
           },
         ],
       },
-      {
-        type: "Section",
-        labelKey: `${i18nScope}.sections.privacy.label`,
-        elements: [
-          {
-            scope: "/properties/telemetry/properties/consentNotice",
-            type: "Control",
-            options: {
-              control: "arcgis-privacy-config",
-            },
-          },
-        ],
-      },
     ],
   };
+
+  // Only Add this is it's not an enterprise environment
+  // This is better than using a condition, as that is applied after
+  // the UI renders, but and sometimes we get a flash of the privacy section
+  if (!context.isPortal) {
+    result.elements.push({
+      type: "Section",
+      labelKey: `${i18nScope}.sections.privacy.label`,
+
+      elements: [
+        {
+          scope: "/properties/telemetry/properties/consentNotice",
+          type: "Control",
+          options: {
+            control: "arcgis-privacy-config",
+          },
+        },
+      ],
+    });
+  }
+
+  return result;
 };

--- a/packages/common/test/mocks/mock-auth.ts
+++ b/packages/common/test/mocks/mock-auth.ts
@@ -164,6 +164,40 @@ export const MOCK_CONTEXT = new ArcGISContext({
   },
 }) as IArcGISContext;
 
+export const MOCK_ENTERPRISE_CONTEXT = new ArcGISContext({
+  id: 123,
+  currentUser: {
+    username: "mock_user",
+    favGroupId: "456abc",
+    orgId: "789def",
+    privileges: [],
+  },
+  portalUrl: "https://my.server.com/gis",
+  hubUrl: "",
+  authentication: MOCK_ENTERPRISE_AUTH,
+  portalSelf: {
+    id: "123",
+    name: "My org",
+    isPortal: true,
+    urlKey: "www",
+    portalHostname: "host",
+    customBaseUrl: "customUrl",
+  },
+  serviceStatus: {
+    portal: "online",
+    discussions: "not-available",
+    events: "not-available",
+    metrics: "not-available",
+    notifications: "not-available",
+    "hub-search": "not-available",
+    domains: "not-available",
+    "hub-downloads": "not-available",
+  },
+  userHubSettings: {
+    schemaVersion: 1,
+  },
+}) as IArcGISContext;
+
 export const MOCK_ANON_CONTEXT = new ArcGISContext({
   id: 123,
   currentUser: undefined,

--- a/packages/common/test/sites/_internal/SiteuUiSchemaSettings.test.ts
+++ b/packages/common/test/sites/_internal/SiteuUiSchemaSettings.test.ts
@@ -1,5 +1,5 @@
 import { buildUiSchema } from "../../../src/sites/_internal/SiteUiSchemaSettings";
-import { MOCK_CONTEXT } from "../../mocks/mock-auth";
+import { MOCK_CONTEXT, MOCK_ENTERPRISE_CONTEXT } from "../../mocks/mock-auth";
 
 describe("buildUiSchema: site settings", () => {
   it("returns the full site settings uiSchema", async () => {
@@ -50,6 +50,48 @@ describe("buildUiSchema: site settings", () => {
               type: "Control",
               options: {
                 control: "arcgis-privacy-config",
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+  it("does not return the Privacy section in enterprise", async () => {
+    const i18nScope = "some.scope";
+    const orgUrlKey = "my-org";
+    const uiSchema = await buildUiSchema(
+      i18nScope,
+      { orgUrlKey } as any,
+      MOCK_ENTERPRISE_CONTEXT
+    );
+    expect(uiSchema).toEqual({
+      type: "Layout",
+      elements: [
+        {
+          type: "Section",
+          labelKey: `${i18nScope}.sections.siteUrl.label`,
+          options: {
+            requiredHelperText: {
+              labelKey: `${i18nScope}.sections.defaultRequiredHelperText`,
+            },
+          },
+          elements: [
+            {
+              scope: "/properties/_urlInfo",
+              type: "Control",
+              options: {
+                type: "Control",
+                control: "hub-composite-input-site-url",
+                orgUrlKey,
+                messages: [
+                  {
+                    type: "ERROR",
+                    keyword: "isUniqueDomain",
+                    labelKey: `${i18nScope}.fields.siteUrl.isUniqueError`,
+                    icon: true,
+                  },
+                ],
               },
             },
           ],


### PR DESCRIPTION
1. Description:

Hide the Privacy Config section in the Site Settings UI Schema

1. Instructions for testing: run -tests

1. Closes Issues: #13699

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://esri.github.io/hub-components/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
