### PR TITLE
fix(hub-common): fix issue with hubSearch() where .next() functions would fail for portal-based searches

### DIFF
--- a/packages/common/src/search/_internal/commonHelpers/getNextPortalCallback.ts
+++ b/packages/common/src/search/_internal/commonHelpers/getNextPortalCallback.ts
@@ -5,8 +5,15 @@ import {
 import { cloneObject } from "../../../util";
 import { IHubSearchResponse } from "../../types/IHubSearchResponse";
 import { IPagingParams } from "@esri/arcgis-rest-portal";
+import { IHubRequestOptions } from "../../../hub-types";
+import { getProp } from "../../../objects/get-prop";
 
-type ICommonNextOptions = IRequestOptions & IPagingParams;
+type ICommonNextOptions = IRequestOptions &
+  IPagingParams & {
+    // The upstream `processSearchParams()` stabs this onto every request and many downstream
+    // functions seem to prefer it over the top-level `authentication` property.
+    requestOptions?: IHubRequestOptions;
+  };
 
 /**
  * @private
@@ -30,6 +37,14 @@ export function getNextPortalCallback<I extends ICommonNextOptions, O>(
     clonedRequest.authentication = ArcGISIdentityManager.deserialize(
       (request.authentication as ArcGISIdentityManager).serialize()
     );
+  }
+
+  // do the same workaround for requestOptions.authentication
+  if (getProp(request, "requestOptions.authentication")) {
+    clonedRequest.requestOptions.authentication =
+      ArcGISIdentityManager.deserialize(
+        request.requestOptions.authentication.serialize()
+      );
   }
 
   // figure out the start

--- a/packages/common/test/search/_internal/getNextPortalCallback.test.ts
+++ b/packages/common/test/search/_internal/getNextPortalCallback.test.ts
@@ -31,6 +31,9 @@ describe("getNextPortalCallback:", () => {
   it("uses auth on subsequent calls", async () => {
     const request = {
       authentication: MOCK_AUTH,
+      requestOptions: {
+        authentication: MOCK_AUTH,
+      },
     } as unknown as ISearchOptions;
 
     const Module = {
@@ -50,12 +53,12 @@ describe("getNextPortalCallback:", () => {
     expect(fnSpy).toHaveBeenCalled();
     // verify it's called with the MOCK_AUTH
     const opts = fnSpy.calls.mostRecent().args[0];
-    // once the tests using a mock authentication instead of an actual instance
+    // once the test started using a mock authentication instead of an actual instance
     // I had to add the .token to the check below b/c comparing the entire object failed
     expect(opts.authentication.token).toEqual(MOCK_AUTH.token);
+    expect(opts.requestOptions.authentication.token).toEqual(MOCK_AUTH.token);
     expect(opts.start).toBe(10);
   });
-  // I don't know why this condition is in the code, but it is. Adding for coverage.
   it("handles negative 'nextStart'", async () => {
     const request = {} as unknown as ISearchOptions;
 


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Part of https://devtopia.esri.com/dc/hub/issues/13715
 
