### PR TITLE
feat: add permission for catalog appearance

### DIFF
--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -177,8 +177,10 @@ export const InitiativePermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:initiative:workspace:metrics",
     dependencies: ["hub:initiative:workspace", "hub:initiative:edit"],
   },
+  // DEPRECATED PERMISSION - TODO: remove at next major version
+  // Leverage singular "hub:initiative:workspace:catalog" instead
   {
-    permission: "hub:initiative:workspace:catalogs", // TODO: remove plural permission
+    permission: "hub:initiative:workspace:catalogs", 
     dependencies: [
       "hub:initiative:workspace",
       "hub:feature:catalogs",

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -203,6 +203,13 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     environments: ["qaext"],
     availability: ["flag"],
   },
+  // DEPRECATED PERMISSION - TODO: remove at next major version
+  {
+    // Enables catalog configuration and viewing
+    permission: "hub:feature:catalogs",
+    environments: ["qaext"],
+    availability: ["alpha"],
+  },
   /**
    * Gates advanced editing (e.g. adding new collections, adding
    * additional scope filters, etc.) in the catalog configuration

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -203,16 +203,10 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     environments: ["qaext"],
     availability: ["flag"],
   },
-  {
-    // Enables catalog configuration and viewing
-    permission: "hub:feature:catalogs",
-    environments: ["qaext"],
-    availability: ["alpha"],
-  },
   /**
    * Gates advanced editing (e.g. adding new collections, adding
-   * additional scope filters, appearance settings, etc.) in
-   * the catalog configuration experince.
+   * additional scope filters, etc.) in the catalog configuration
+   * experince.
    *
    * TODO: Remove the site entity assertion once all catalog
    * configuration features are supported by sites
@@ -228,6 +222,22 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
         value: "Hub Site Application",
       },
     ],
+  },
+  /**
+   * Gates catalog & collection appearance editing
+   * in the catalog configuration experience.
+   *
+   * TODO: remove environment & availability gating once
+   * we are ready to release catalog appearance
+   * configuration. Alternatively, we can remove it entirely
+   * in favor of the "hub:feature:caatalogs:edit:advanced"
+   * permission
+   */
+  {
+    permission: "hub:feature:catalogs:edit:appearance",
+    dependencies: ["hub:feature:catalogs:edit:advanced"],
+    environments: ["qaext"],
+    availability: ["alpha"],
   },
   {
     // Enable inline-workspace for Entity Views

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -31,7 +31,7 @@ const SystemPermissions = [
   "hub:feature:keyboardshortcuts",
   "hub:feature:newentityview",
   "hub:feature:history",
-  "hub:feature:catalogs",
+  "hub:feature:catalogs", // DEPRECATED - TODO: remove at next major version
   /** remove once sites support all catalog configuration features */
   "hub:feature:catalogs:edit:advanced",
   "hub:feature:inline-workspace",

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -34,6 +34,7 @@ const SystemPermissions = [
   "hub:feature:catalogs", // DEPRECATED - TODO: remove at next major version
   /** remove once sites support all catalog configuration features */
   "hub:feature:catalogs:edit:advanced",
+  "hub:feature:catalogs:edit:appearance",
   "hub:feature:inline-workspace",
   "hub:feature:pagescatalog",
   "hub:license:hub-premium",
@@ -92,5 +93,5 @@ export type Permission =
  * @returns
  */
 export function isPermission(maybePermission: string): boolean {
-  return validPermissions.includes(maybePermission );
+  return validPermissions.includes(maybePermission);
 }


### PR DESCRIPTION
### Description
- Adds a new temporary permission (`"hub:feature:catalogs:edit:appearance"`) to gate catalog/collection appearance configuration to qa premium alpha organizations
- adds deprecation notice to unused `"hub:feature:catalogs"` permission

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)
1. [x] used semantic commit messages
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)
1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.