### PR TITLE
fix(hub-common): site subdomain not kept in sync w slug in enterprise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54211,7 +54211,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "18.11.0",
+			"version": "18.12.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -54255,7 +54255,7 @@
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "18.0.0",
+			"version": "18.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
@@ -54274,7 +54274,7 @@
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "18.0.0",
+			"version": "18.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -54292,7 +54292,7 @@
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "18.0.0",
+			"version": "18.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -54310,7 +54310,7 @@
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "18.0.0",
+			"version": "18.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -54330,7 +54330,7 @@
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "19.0.0",
+			"version": "19.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -54351,7 +54351,7 @@
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "18.0.0",
+			"version": "18.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -54369,7 +54369,7 @@
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "18.0.0",
+			"version": "18.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"

--- a/packages/common/src/sites/_internal/subdomains.ts
+++ b/packages/common/src/sites/_internal/subdomains.ts
@@ -1,0 +1,57 @@
+import { IHubRequestOptions } from "../../hub-types";
+import { IHubSite } from "../../core/types/IHubSite";
+import { ENTERPRISE_SITES_PATH } from "../../ArcGISContext";
+
+const TYPEKEYWORD_SUBDOMAIN_PREFIX = "hubsubdomain";
+
+/**
+ * Get the subdomain type keyword
+ * @param subdomain The subdomain to get the keyword for
+ * @returns The subdomain type keyword
+ */
+export function getSubdomainKeyword(subdomain: string): string {
+  return `${TYPEKEYWORD_SUBDOMAIN_PREFIX}|${subdomain.toLowerCase()}`;
+}
+
+/**
+ * Adds/Updates the subdomain typekeyword
+ * Returns a new array of keywords
+ *
+ * @param typeKeywords A collection of typekeywords
+ * @param subdomain The subdomain to add/update
+ * @returns An updated collection of typekeywords
+ */
+export function setSubdomainKeyword(
+  typeKeywords: string[],
+  subdomain: string
+): string[] {
+  // remove subdomain entry from array
+  const updatedTypekeywords = typeKeywords.filter(
+    (entry: string) => !entry.startsWith(`${TYPEKEYWORD_SUBDOMAIN_PREFIX}|`)
+  );
+
+  // now add it
+  updatedTypekeywords.push(
+    [TYPEKEYWORD_SUBDOMAIN_PREFIX, subdomain.toLowerCase()].join("|")
+  );
+  return updatedTypekeywords;
+}
+
+/**
+ * Update the site properties related to subdomain
+ * after the subdomain has been changed.
+ * @param site The site to update
+ * @param requestOptions
+ */
+export const handleSubdomainChange = (
+  site: Partial<IHubSite>,
+  requestOptions: IHubRequestOptions
+): void => {
+  // update the type keyword
+  site.typeKeywords = setSubdomainKeyword(site.typeKeywords, site.subdomain);
+  // update the URL
+  site.url = `${requestOptions.authentication.portal.replace(
+    `/sharing/rest`,
+    ENTERPRISE_SITES_PATH
+  )}/#/${site.subdomain}`;
+};

--- a/packages/common/src/sites/domains/_lookup-portal.ts
+++ b/packages/common/src/sites/domains/_lookup-portal.ts
@@ -1,6 +1,7 @@
 import { searchItems } from "@esri/arcgis-rest-portal";
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { includes } from "../../utils";
+import { getSubdomainKeyword } from "../_internal/subdomains";
 
 /**
  * Lookup a domain in Portal
@@ -19,7 +20,7 @@ export function _lookupPortal(
     subdomain = hostname.split("#/")[1];
   }
 
-  const queryTerm = `hubsubdomain|${subdomain}`;
+  const queryTerm = getSubdomainKeyword(subdomain);
   const opts = Object.assign(
     {
       q: `typekeywords: ${queryTerm}`,

--- a/packages/common/test/sites/HubSites.test.ts
+++ b/packages/common/test/sites/HubSites.test.ts
@@ -434,6 +434,26 @@ describe("HubSites:", () => {
       expect(modelToUpdate.item.title).toBe(updatedSite.name);
     });
 
+    it("handles change to slug in enterprise", async () => {
+      const updatedSite = commonModule.cloneObject(SITE);
+      updatedSite.slug = "updated-slug";
+      const ro = { ...MOCK_HUB_REQOPTS, isPortal: true };
+      const chk = await commonModule.updateSite(updatedSite, ro);
+
+      expect(chk.id).toBe(GUID);
+      expect(chk.subdomain).toBe("updated-slug");
+
+      // should not have made add/remove domain calls
+      expect(domainChangeSpy.calls.count()).toBe(0);
+
+      expect(fetchSiteModelSpy.calls.count()).toBe(1);
+      expect(updateModelSpy.calls.count()).toBe(1);
+      const modelToUpdate = updateModelSpy.calls.argsFor(0)[0];
+      expect(modelToUpdate.item.typeKeywords).toContain(
+        `hubsubdomain|${updatedSite.subdomain}`.toLowerCase()
+      );
+    });
+
     it("updates domain configurations", async () => {
       const updatedHostname = "my-cool-hostname.dev";
       const updatedSite = commonModule.cloneObject(SITE);


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

After updating a site slug in enterprise, the URL, subdomain and related type keyword were not being updated. This caused the "View Site" button to have the incorrect URL.

1. Instructions for testing:

Only wa to test is via portal-proxy

1. Closes Issues: [13723](https://devtopia.esri.com/dc/hub/issues/13723)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
