### PR TITLE
fix: temporarily remove feeds config before interpolating new site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54211,7 +54211,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "18.12.1",
+			"version": "18.12.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/sites/test/create-site.test.ts
+++ b/packages/sites/test/create-site.test.ts
@@ -210,6 +210,9 @@ describe("create site :: ", function () {
             foo: "{{some.undefined.thing}}",
           },
         },
+        feeds: {
+          foo: "{{some.other.undefined.thing}}",
+        },
       },
     } as unknown as commonModule.IModel;
 
@@ -218,6 +221,11 @@ describe("create site :: ", function () {
     expect(result.data?.values.dcatConfig.foo).toBe(
       "{{some.undefined.thing}}",
       "dcatConfig not interpolated"
+    );
+
+    expect(result.data?.feeds.foo).toBe(
+      "{{some.other.undefined.thing}}",
+      "feeds not interpolated"
     );
   });
 


### PR DESCRIPTION
affects: @esri/hub-sites

1. Description: Temporarily remove feeds config before interpolating new or cloned site

1. Instructions for testing:

1. Closes Issues: [13680](https://devtopia.esri.com/dc/hub/issues/13680)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
