### PR TITLE
fix(): updates getWellKnownGroup to do a permission check for access …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54211,7 +54211,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "18.12.2",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -54255,68 +54255,68 @@
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "18.0.1",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-feature-service": "^4.0.0",
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0"
+				"@esri/hub-common": "^19.0.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "18.0.1",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-feature-service": "^4.0.0",
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0"
+				"@esri/hub-common": "^19.0.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "18.0.1",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0"
+				"@esri/hub-common": "^19.0.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "18.0.1",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -54325,63 +54325,63 @@
 				"@esri/arcgis-rest-feature-service": "^4.0.0",
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0"
+				"@esri/hub-common": "^19.0.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "19.0.2",
+			"version": "20.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
-				"@esri/hub-initiatives": "^18.0.0",
-				"@esri/hub-teams": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-initiatives": "^19.0.0",
+				"@esri/hub-teams": "^19.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0",
-				"@esri/hub-initiatives": "^18.0.0",
-				"@esri/hub-teams": "^18.0.0"
+				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-initiatives": "^19.0.0",
+				"@esri/hub-teams": "^19.0.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "18.0.1",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-feature-service": "^4.0.0",
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0"
+				"@esri/hub-common": "^19.0.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "18.0.1",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0"
+				"@esri/hub-common": "^19.0.0"
 			}
 		}
 	},
@@ -57989,7 +57989,7 @@
 		"@esri/hub-downloads": {
 			"version": "file:packages/downloads",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -57998,7 +57998,7 @@
 		"@esri/hub-events": {
 			"version": "file:packages/events",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -58006,7 +58006,7 @@
 		"@esri/hub-initiatives": {
 			"version": "file:packages/initiatives",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -58015,7 +58015,7 @@
 		"@esri/hub-search": {
 			"version": "file:packages/search",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -58025,9 +58025,9 @@
 		"@esri/hub-sites": {
 			"version": "file:packages/sites",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
-				"@esri/hub-initiatives": "^18.0.0",
-				"@esri/hub-teams": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-initiatives": "^19.0.0",
+				"@esri/hub-teams": "^19.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -58035,7 +58035,7 @@
 		"@esri/hub-surveys": {
 			"version": "file:packages/surveys",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -58043,7 +58043,7 @@
 		"@esri/hub-teams": {
 			"version": "file:packages/teams",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/common/src/groups/getWellKnownGroup.ts
+++ b/packages/common/src/groups/getWellKnownGroup.ts
@@ -31,7 +31,12 @@ export function getWellKnownGroup(
       membershipAccess: "organization",
     },
     hubViewGroup: {
-      access: "org",
+      access: checkPermission(
+        "platform:portal:user:addExternalMembersToGroup",
+        context
+      ).access
+        ? "public"
+        : "org",
       autoJoin: false,
       isSharedUpdate: false,
       isInvitationOnly: false,


### PR DESCRIPTION
…level

1. Description:
   -  updates getWellKnownGroup to do a permission check when determining access level

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
