### PR TITLE
fix: getWellKnownGroup - hubViewGroup returns access level based on…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54211,7 +54211,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "18.12.2",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -54255,68 +54255,68 @@
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "18.0.1",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-feature-service": "^4.0.0",
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0"
+				"@esri/hub-common": "^19.0.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "18.0.1",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-feature-service": "^4.0.0",
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0"
+				"@esri/hub-common": "^19.0.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "18.0.1",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0"
+				"@esri/hub-common": "^19.0.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "18.0.1",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -54325,63 +54325,63 @@
 				"@esri/arcgis-rest-feature-service": "^4.0.0",
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0"
+				"@esri/hub-common": "^19.0.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "19.0.2",
+			"version": "20.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
-				"@esri/hub-initiatives": "^18.0.0",
-				"@esri/hub-teams": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-initiatives": "^19.0.0",
+				"@esri/hub-teams": "^19.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0",
-				"@esri/hub-initiatives": "^18.0.0",
-				"@esri/hub-teams": "^18.0.0"
+				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-initiatives": "^19.0.0",
+				"@esri/hub-teams": "^19.0.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "18.0.1",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-feature-service": "^4.0.0",
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0"
+				"@esri/hub-common": "^19.0.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "18.0.1",
+			"version": "19.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^18.0.0"
+				"@esri/hub-common": "^19.0.0"
 			}
 		}
 	},
@@ -57989,7 +57989,7 @@
 		"@esri/hub-downloads": {
 			"version": "file:packages/downloads",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -57998,7 +57998,7 @@
 		"@esri/hub-events": {
 			"version": "file:packages/events",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -58006,7 +58006,7 @@
 		"@esri/hub-initiatives": {
 			"version": "file:packages/initiatives",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -58015,7 +58015,7 @@
 		"@esri/hub-search": {
 			"version": "file:packages/search",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -58025,9 +58025,9 @@
 		"@esri/hub-sites": {
 			"version": "file:packages/sites",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
-				"@esri/hub-initiatives": "^18.0.0",
-				"@esri/hub-teams": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-initiatives": "^19.0.0",
+				"@esri/hub-teams": "^19.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -58035,7 +58035,7 @@
 		"@esri/hub-surveys": {
 			"version": "file:packages/surveys",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -58043,7 +58043,7 @@
 		"@esri/hub-teams": {
 			"version": "file:packages/teams",
 			"requires": {
-				"@esri/hub-common": "^18.0.0",
+				"@esri/hub-common": "^19.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/common/src/groups/getWellKnownGroup.ts
+++ b/packages/common/src/groups/getWellKnownGroup.ts
@@ -18,6 +18,14 @@ export function getWellKnownGroup(
   groupType: WellKnownGroup,
   context: IArcGISContext
 ): Partial<IHubGroup> {
+  // Check permissions for sharing view groups to public or org
+  // They are either the string OR false
+  const hasShareGroupToPublic =
+    checkPermission("platform:portal:user:shareGroupToPublic", context)
+      .access && "public";
+  const hasShareGroupToOrg =
+    checkPermission("platform:portal:user:shareGroupToOrg", context).access &&
+    "org";
   const configs: Record<WellKnownGroup, Partial<IHubGroup>> = {
     hubGroup: {
       access: "private",
@@ -31,7 +39,7 @@ export function getWellKnownGroup(
       membershipAccess: "organization",
     },
     hubViewGroup: {
-      access: "org",
+      access: hasShareGroupToPublic || hasShareGroupToOrg || "private",
       autoJoin: false,
       isSharedUpdate: false,
       isInvitationOnly: false,

--- a/packages/common/test/groups/_internal/GroupUiSchemaCreateView.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaCreateView.test.ts
@@ -146,7 +146,7 @@ describe("GroupUiSchemaCreateView", () => {
       );
 
       expect(defaults).toEqual({
-        access: "org",
+        access: "private",
         autoJoin: false,
         isSharedUpdate: false,
         isInvitationOnly: false,
@@ -162,7 +162,10 @@ describe("GroupUiSchemaCreateView", () => {
       const defaults = await buildDefaults(
         "some.scope",
         { isSharedUpdate: true } as IHubGroup,
-        getMockContextWithPrivilenges(["portal:user:addExternalMembersToGroup"])
+        getMockContextWithPrivilenges([
+          "portal:user:addExternalMembersToGroup",
+          "portal:user:shareGroupToOrg",
+        ])
       );
       expect(defaults).toEqual({
         access: "org",

--- a/packages/common/test/groups/getWellKnownGroup.test.ts
+++ b/packages/common/test/groups/getWellKnownGroup.test.ts
@@ -1,41 +1,10 @@
 import { getWellKnownGroup } from "../../src/groups/getWellKnownGroup";
-import { MOCK_CONTEXT, MOCK_AUTH } from "../mocks/mock-auth";
-import { ArcGISContext } from "../../src/ArcGISContext";
-import type { IArcGISContext } from "../../src";
+import {
+  MOCK_CONTEXT,
+  getMockContextWithPrivilenges,
+} from "../mocks/mock-auth";
 
 describe("getWellKnownGroup: ", () => {
-  const MOCK_CONTEXT_WITH_PRIVILEGES = new ArcGISContext({
-    id: 123,
-    currentUser: {
-      username: "mock_user",
-      favGroupId: "456abc",
-      orgId: "789def",
-      privileges: ["portal:user:addExternalMembersToGroup"],
-    },
-    portalUrl: "https://qaext.arcgis.com",
-    hubUrl: "https://hubqa.arcgis.com",
-    authentication: MOCK_AUTH,
-    portalSelf: {
-      id: "123",
-      name: "My org",
-      isPortal: false,
-      urlKey: "www",
-    },
-    serviceStatus: {
-      portal: "online",
-      discussions: "online",
-      events: "online",
-      metrics: "online",
-      notifications: "online",
-      "hub-search": "online",
-      domains: "online",
-      "hub-downloads": "online",
-      "hub-ai-assistant": "online",
-    },
-    userHubSettings: {
-      schemaVersion: 1,
-    },
-  }) as IArcGISContext;
   it("returns a followers group", () => {
     const resp = getWellKnownGroup("hubFollowersGroup", MOCK_CONTEXT);
     expect(resp).toEqual({
@@ -49,7 +18,7 @@ describe("getWellKnownGroup: ", () => {
   it("returns a view group", () => {
     const resp = getWellKnownGroup("hubViewGroup", MOCK_CONTEXT);
     expect(resp).toEqual({
-      access: "org",
+      access: "private",
       autoJoin: false,
       isSharedUpdate: false,
       isInvitationOnly: false,
@@ -63,7 +32,24 @@ describe("getWellKnownGroup: ", () => {
   it("returns a view group with membershipAccess set to anyone", () => {
     const resp = getWellKnownGroup(
       "hubViewGroup",
-      MOCK_CONTEXT_WITH_PRIVILEGES
+      getMockContextWithPrivilenges(["portal:user:addExternalMembersToGroup"])
+    );
+    expect(resp).toEqual({
+      access: "private",
+      autoJoin: false,
+      isSharedUpdate: false,
+      isInvitationOnly: false,
+      hiddenMembers: false,
+      isViewOnly: false,
+      leavingDisallowed: false,
+      tags: ["Hub Group"],
+      membershipAccess: "anyone",
+    });
+  });
+  it('returns a view group with access set to "org"', () => {
+    const resp = getWellKnownGroup(
+      "hubViewGroup",
+      getMockContextWithPrivilenges(["portal:user:shareGroupToOrg"])
     );
     expect(resp).toEqual({
       access: "org",
@@ -74,7 +60,24 @@ describe("getWellKnownGroup: ", () => {
       isViewOnly: false,
       leavingDisallowed: false,
       tags: ["Hub Group"],
-      membershipAccess: "anyone",
+      membershipAccess: "organization",
+    });
+  });
+  it('returns a view group with access set to "public"', () => {
+    const resp = getWellKnownGroup(
+      "hubViewGroup",
+      getMockContextWithPrivilenges(["portal:user:shareGroupToPublic"])
+    );
+    expect(resp).toEqual({
+      access: "public",
+      autoJoin: false,
+      isSharedUpdate: false,
+      isInvitationOnly: false,
+      hiddenMembers: false,
+      isViewOnly: false,
+      leavingDisallowed: false,
+      tags: ["Hub Group"],
+      membershipAccess: "organization",
     });
   });
   it("returns an edit group", () => {
@@ -94,7 +97,7 @@ describe("getWellKnownGroup: ", () => {
   it("returns an edit group with membershipAccess set to collaborators", () => {
     const resp = getWellKnownGroup(
       "hubEditGroup",
-      MOCK_CONTEXT_WITH_PRIVILEGES
+      getMockContextWithPrivilenges(["portal:user:addExternalMembersToGroup"])
     );
     expect(resp).toEqual({
       access: "org",
@@ -125,7 +128,7 @@ describe("getWellKnownGroup: ", () => {
   it("returns an associations group with membershipAccess set to anyone", () => {
     const resp = getWellKnownGroup(
       "hubAssociationsGroup",
-      MOCK_CONTEXT_WITH_PRIVILEGES
+      getMockContextWithPrivilenges(["portal:user:addExternalMembersToGroup"])
     );
     expect(resp).toEqual({
       access: "public",


### PR DESCRIPTION
… user privs

1. Description: After further discussion w/ @dbouwman we realized the permission linked to `access` was not `addExternalMembersToGroup`, but instead what I included below. Take a look at the `GroupUiSchemaCreate` for similar `access` permission logic

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
