### PR TITLE
fix: make stage.title required in timeline json schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54211,7 +54211,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "19.0.0",
+			"version": "19.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/core/schemas/shared/subschemas.ts
+++ b/packages/common/src/core/schemas/shared/subschemas.ts
@@ -118,10 +118,9 @@ export const ENTITY_TIMELINE_SCHEMA = {
       type: "array",
       items: {
         type: "object",
+        required: ["title"],
         properties: {
-          // we should make title required or add minLength: 1
-          // once we know how to handle in the UI
-          title: { type: "string" },
+          title: { type: "string", minLength: 1 },
           timeframe: { type: "string" },
           stageDescription: { type: "string" },
           status: { type: "string" },

--- a/packages/common/src/initiatives/_internal/applyInitiativeMigrations.ts
+++ b/packages/common/src/initiatives/_internal/applyInitiativeMigrations.ts
@@ -3,8 +3,9 @@ import { getProp } from "../../objects/get-prop";
 import { IHubCatalog } from "../../search/types/IHubCatalog";
 import { IModel } from "../../hub-types";
 import { cloneObject } from "../../util";
+import { migrateInvalidTimeline } from "../../utils/internal/migrateInvalidTimeline";
 
-export const INITIATIVE_SCHEMA_VERSION = 2;
+export const INITIATIVE_SCHEMA_VERSION = 2.1;
 
 /**
  * Apply all Initiative model migrations
@@ -13,7 +14,7 @@ export const INITIATIVE_SCHEMA_VERSION = 2;
  */
 export function applyInitiativeMigrations(
   model: IModel,
-  requestOptions: IRequestOptions
+  _requestOptions: IRequestOptions
 ): Promise<IModel> {
   if (
     getProp(model, "item.properties.schemaVersion") ===
@@ -23,6 +24,7 @@ export function applyInitiativeMigrations(
   } else {
     // apply upgrade functions in order...
     model = addDefaultCatalog(model);
+    model = migrateInvalidTimeline(model, INITIATIVE_SCHEMA_VERSION);
 
     return Promise.resolve(model);
   }
@@ -74,3 +76,5 @@ function addDefaultCatalog(model: IModel): IModel {
     return clone;
   }
 }
+
+// migrateInvalidTimeline is now imported from util

--- a/packages/common/src/projects/_internal/applyProjectMigrations.ts
+++ b/packages/common/src/projects/_internal/applyProjectMigrations.ts
@@ -1,0 +1,27 @@
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { IModel } from "../../hub-types";
+import { migrateInvalidTimeline } from "../../utils/internal/migrateInvalidTimeline";
+import { getProp } from "../../objects";
+
+export const PROJECT_SCHEMA_VERSION = 1.1;
+
+/**
+ * Apply all Project model migrations
+ * @param model
+ * @param requestOptions
+ * @returns
+ */
+export function applyProjectMigrations(
+  model: IModel,
+  _requestOptions: IRequestOptions
+): Promise<IModel> {
+  if (
+    getProp(model, "item.properties.schemaVersion") === PROJECT_SCHEMA_VERSION
+  ) {
+    return Promise.resolve(model);
+  } else {
+    // Only apply the migrateInvalidTimeline migration for now
+    model = migrateInvalidTimeline(model, PROJECT_SCHEMA_VERSION);
+    return Promise.resolve(model);
+  }
+}

--- a/packages/common/src/projects/fetch.ts
+++ b/packages/common/src/projects/fetch.ts
@@ -19,6 +19,7 @@ import { getProp } from "../objects/get-prop";
 
 import { computeLinks } from "./_internal/computeLinks";
 import { deriveLocationFromItem } from "../content/_internal/internalContentUtils";
+import { applyProjectMigrations } from "./_internal/applyProjectMigrations";
 
 /**
  * @private
@@ -55,7 +56,9 @@ export async function convertItemToProject(
   item: IItem,
   requestOptions: IRequestOptions
 ): Promise<IHubProject> {
-  const model = await fetchModelFromItem(item, requestOptions);
+  let model = await fetchModelFromItem(item, requestOptions);
+  // apply migrations
+  model = await applyProjectMigrations(model, requestOptions);
   // TODO: In the future we will handle the boundary fetching from resource
   const mapper = new PropertyMapper<Partial<IHubProject>, IModel>(
     getPropertyMap()

--- a/packages/common/src/utils/internal/migrateInvalidTimeline.ts
+++ b/packages/common/src/utils/internal/migrateInvalidTimeline.ts
@@ -1,0 +1,39 @@
+import { IModel } from "../../hub-types";
+import { getProp } from "../../objects/get-prop";
+import { cloneObject } from "../../util";
+
+/**
+ * Fix invalid timelines in the model
+ * @param model
+ * @param targetSchemaVersion - the schema version to set after migration
+ * @returns migrated model
+ */
+export function migrateInvalidTimeline(
+  model: IModel,
+  targetSchemaVersion: number
+): IModel {
+  if (getProp(model, "item.properties.schemaVersion") >= targetSchemaVersion) {
+    return model;
+  } else {
+    const clone = cloneObject(model);
+
+    const stages = getProp(clone, "data.view.timeline.stages") || [];
+    if (stages.length === 1) {
+      // if there is only one stage
+      if (!stages[0].title) {
+        // and it has no title, then we can just remove that stage
+        // this is because we had a json schema validation issue
+        // that allowed a single stage with no title
+        clone.data.view.timeline.stages = [];
+      }
+    }
+
+    // set the schema version
+    if (!clone.item.properties) {
+      clone.item.properties = {};
+    }
+    clone.item.properties.schemaVersion = targetSchemaVersion;
+
+    return clone;
+  }
+}

--- a/packages/common/src/utils/internal/migrateInvalidTimeline.ts
+++ b/packages/common/src/utils/internal/migrateInvalidTimeline.ts
@@ -18,14 +18,14 @@ export function migrateInvalidTimeline(
     const clone = cloneObject(model);
 
     const stages = getProp(clone, "data.view.timeline.stages") || [];
-    if (stages.length === 1) {
-      // if there is only one stage
-      if (!stages[0].title) {
-        // and it has no title, then we can just remove that stage
-        // this is because we had a json schema validation issue
-        // that allowed a single stage with no title
-        clone.data.view.timeline.stages = [];
-      }
+    if (
+      clone.data &&
+      clone.data.view &&
+      clone.data.view.timeline &&
+      Array.isArray(stages)
+    ) {
+      // Remove any stage without a title
+      clone.data.view.timeline.stages = stages.filter((stage) => !!stage.title);
     }
 
     // set the schema version

--- a/packages/common/test/projects/_internal/applyProjectMigrations.test.ts
+++ b/packages/common/test/projects/_internal/applyProjectMigrations.test.ts
@@ -1,0 +1,73 @@
+import { IItem } from "@esri/arcgis-rest-portal";
+import { IModel } from "../../../src";
+import {
+  applyProjectMigrations,
+  PROJECT_SCHEMA_VERSION,
+} from "../../../src/projects/_internal/applyProjectMigrations";
+
+describe("project migrations:", () => {
+  it("skips if on current version", async () => {
+    const m: IModel = {
+      item: {
+        id: "00c",
+        type: "Hub Project",
+        owner: "Alice",
+        created: 456,
+        properties: {
+          schemaVersion: PROJECT_SCHEMA_VERSION,
+        },
+      } as unknown as IItem,
+      data: {},
+    };
+    const c = await applyProjectMigrations(m, {});
+    expect(c).toBe(m);
+  });
+
+  it("skip on schema version >= 1.1", async () => {
+    const m: IModel = {
+      item: {
+        id: "00c",
+        type: "Hub Project",
+        owner: "Alice",
+        created: 456,
+        properties: {
+          schemaVersion: 1.1,
+        },
+      } as unknown as IItem,
+      data: {},
+    };
+    const c = await applyProjectMigrations(m, {});
+    expect(c).toBe(m);
+  });
+
+  describe("invalid timeline migration:", () => {
+    it("removes single stage with no title and updates schemaVersion to 1.1", async () => {
+      const m: IModel = {
+        item: {
+          id: "00c",
+          type: "Hub Project",
+          owner: "Alice",
+          created: 456,
+          properties: {
+            schemaVersion: 1.0,
+          },
+        } as unknown as IItem,
+        data: {
+          view: {
+            timeline: {
+              stages: [
+                {
+                  // an invalid stage - no title
+                },
+              ],
+            },
+          },
+        },
+      };
+      const c = await applyProjectMigrations(m, {});
+      expect(c).not.toBe(m);
+      expect(c.data?.view?.timeline?.stages).toEqual([]);
+      expect(c.item.properties.schemaVersion).toBe(1.1);
+    });
+  });
+});

--- a/packages/common/test/utils/internal/migrateInvalidTimeline.test.ts
+++ b/packages/common/test/utils/internal/migrateInvalidTimeline.test.ts
@@ -48,4 +48,37 @@ describe("migrateInvalidTimeline", () => {
     expect(result.item.properties).toBeDefined();
     expect(result.item.properties.schemaVersion).toBe(1.1);
   });
+
+  it("removes all stages without a title", () => {
+    const m: IModel = {
+      item: {
+        id: "3",
+        type: "Hub Project",
+        owner: "Alice",
+        created: 123,
+        properties: {
+          schemaVersion: 1.0,
+        },
+      } as unknown as IItem,
+      data: {
+        view: {
+          timeline: {
+            stages: [
+              {},
+              { title: "Valid Stage" },
+              { title: "" },
+              { title: "Another Valid Stage" },
+              { foo: "bar" },
+            ],
+          },
+        },
+      },
+    };
+    const result = migrateInvalidTimeline(m, 1.1);
+    expect(result.data.view.timeline.stages).toEqual([
+      { title: "Valid Stage" },
+      { title: "Another Valid Stage" },
+    ]);
+    expect(result.item.properties.schemaVersion).toBe(1.1);
+  });
 });

--- a/packages/common/test/utils/internal/migrateInvalidTimeline.test.ts
+++ b/packages/common/test/utils/internal/migrateInvalidTimeline.test.ts
@@ -1,0 +1,51 @@
+import { IItem } from "@esri/arcgis-rest-portal";
+import { IModel } from "../../../src/hub-types";
+import { migrateInvalidTimeline } from "../../../src/utils/internal/migrateInvalidTimeline";
+
+describe("migrateInvalidTimeline", () => {
+  it("returns model unchanged if schemaVersion >= target", () => {
+    const m: IModel = {
+      item: {
+        id: "1",
+        type: "Hub Project",
+        owner: "Alice",
+        created: 123,
+        properties: {
+          schemaVersion: 2.1,
+        },
+      } as unknown as IItem,
+      data: {
+        view: {
+          timeline: {
+            stages: [{ title: "Stage 1" }],
+          },
+        },
+      },
+    };
+    const result = migrateInvalidTimeline(m, 2.1);
+    expect(result).toBe(m);
+  });
+
+  it("sets schemaVersion if properties is missing", () => {
+    const m: IModel = {
+      item: {
+        id: "2",
+        type: "Hub Project",
+        owner: "Alice",
+        created: 123,
+        // properties missing
+      } as unknown as IItem,
+      data: {
+        view: {
+          timeline: {
+            stages: [{ title: "Stage 1" }],
+          },
+        },
+      },
+    };
+    const result = migrateInvalidTimeline(m, 1.1);
+    expect(result).not.toBe(m);
+    expect(result.item.properties).toBeDefined();
+    expect(result.item.properties.schemaVersion).toBe(1.1);
+  });
+});


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Updates json schema for timelines.

1. Closes Issues: [13754](https://devtopia.esri.com/dc/hub/issues/13754)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
