### PR TITLE
fix: make stage title required, migrate invalid stages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54211,7 +54211,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "19.1.0",
+			"version": "19.1.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/core/schemas/shared/subschemas.ts
+++ b/packages/common/src/core/schemas/shared/subschemas.ts
@@ -118,10 +118,11 @@ export const ENTITY_TIMELINE_SCHEMA = {
       type: "array",
       items: {
         type: "object",
+        required: ["title"],
         properties: {
           // we should make title required or add minLength: 1
           // once we know how to handle in the UI
-          title: { type: "string" },
+          title: { type: "string", minLength: 1 },
           timeframe: { type: "string" },
           stageDescription: { type: "string" },
           status: { type: "string" },

--- a/packages/common/src/initiatives/_internal/applyInitiativeMigrations.ts
+++ b/packages/common/src/initiatives/_internal/applyInitiativeMigrations.ts
@@ -1,8 +1,3 @@
-/**
- * Remove any timeline stages without a title
- * @param initiative
- * @returns initiative with cleaned timeline
- */
 import { migrateInvalidTimelineStages } from "./migrateInvalidTimelineStages";
 import { HUB_INITIATIVE_CURRENT_SCHEMA_VERSION } from "../defaults";
 import { IHubInitiative } from "../../core/types/IHubInitiative";

--- a/packages/common/src/initiatives/_internal/applyInitiativeMigrations.ts
+++ b/packages/common/src/initiatives/_internal/applyInitiativeMigrations.ts
@@ -1,3 +1,9 @@
+/**
+ * Remove any timeline stages without a title
+ * @param initiative
+ * @returns initiative with cleaned timeline
+ */
+import { migrateInvalidTimelineStages } from "./migrateInvalidTimelineStages";
 import { HUB_INITIATIVE_CURRENT_SCHEMA_VERSION } from "../defaults";
 import { IHubInitiative } from "../../core/types/IHubInitiative";
 import { migrateInitiativeSlugAndOrgUrlKey } from "./migrateInitiativeSlugAndOrgUrlKey";
@@ -18,6 +24,7 @@ export function applyInitiativeMigrations(
   // Apply the migrations
   let migrated = migrateInitiativeAddDefaultCatalog(initiative);
   migrated = migrateInitiativeSlugAndOrgUrlKey(migrated);
+  migrated = migrateInvalidTimelineStages(migrated);
   // add more migration here as needed
   // e.g. migrated = anotherMigration(migrated);
   return migrated;

--- a/packages/common/src/initiatives/_internal/migrateInvalidTimelineStages.ts
+++ b/packages/common/src/initiatives/_internal/migrateInvalidTimelineStages.ts
@@ -1,8 +1,3 @@
-/**
- * Remove any timeline stages without a title
- * @param initiative
- * @returns initiative with cleaned timeline
- */
 import { cloneObject } from "../..";
 import { IHubInitiative } from "../../core/types/IHubInitiative";
 

--- a/packages/common/src/initiatives/_internal/migrateInvalidTimelineStages.ts
+++ b/packages/common/src/initiatives/_internal/migrateInvalidTimelineStages.ts
@@ -1,0 +1,31 @@
+/**
+ * Remove any timeline stages without a title
+ * @param initiative
+ * @returns initiative with cleaned timeline
+ */
+import { cloneObject } from "../..";
+import { IHubInitiative } from "../../core/types/IHubInitiative";
+
+export function migrateInvalidTimelineStages(
+  initiative: IHubInitiative
+): IHubInitiative {
+  if (initiative.schemaVersion >= 2.2) {
+    return initiative;
+  }
+
+  const clone = cloneObject(initiative);
+  if (
+    clone.view &&
+    clone.view.timeline &&
+    clone.view.timeline.stages &&
+    Array.isArray(clone.view.timeline.stages)
+  ) {
+    clone.view.timeline.stages = clone.view.timeline.stages.filter(
+      (stage: any) => !!stage.title
+    );
+  }
+
+  clone.schemaVersion = 2.2; // Update schema version to reflect migration
+
+  return clone;
+}

--- a/packages/common/src/initiatives/defaults.ts
+++ b/packages/common/src/initiatives/defaults.ts
@@ -3,7 +3,7 @@ import { HubEntityHero, HubEntityStatus, IModel } from "../hub-types";
 import { InitiativeDefaultFeatures } from "./_internal/InitiativeBusinessRules";
 
 export const HUB_INITIATIVE_ITEM_TYPE = "Hub Initiative";
-export const HUB_INITIATIVE_CURRENT_SCHEMA_VERSION = 2.1;
+export const HUB_INITIATIVE_CURRENT_SCHEMA_VERSION = 2.2;
 
 /**
  * Default values of a IHubInitiative

--- a/packages/common/src/projects/_internal/applyProjectMigrations.ts
+++ b/packages/common/src/projects/_internal/applyProjectMigrations.ts
@@ -1,8 +1,3 @@
-/**
- * Remove any timeline stages without a title
- * @param project
- * @returns project with cleaned timeline
- */
 import { migrateInvalidTimelineStages } from "./migrateInvalidTimelineStages";
 import { IHubProject } from "../../core/types/IHubProject";
 import { HUB_PROJECT_CURRENT_SCHEMA_VERSION } from "../defaults";

--- a/packages/common/src/projects/_internal/applyProjectMigrations.ts
+++ b/packages/common/src/projects/_internal/applyProjectMigrations.ts
@@ -1,3 +1,9 @@
+/**
+ * Remove any timeline stages without a title
+ * @param project
+ * @returns project with cleaned timeline
+ */
+import { migrateInvalidTimelineStages } from "./migrateInvalidTimelineStages";
 import { IHubProject } from "../../core/types/IHubProject";
 import { HUB_PROJECT_CURRENT_SCHEMA_VERSION } from "../defaults";
 import { migrateProjectSlugAndOrgUrlKey } from "./migrateProjectSlugAndOrgUrlKey";
@@ -14,7 +20,8 @@ export function applyProjectMigrations(project: IHubProject): IHubProject {
     return project;
   }
   // Apply the migrations
-  const migrated = migrateProjectSlugAndOrgUrlKey(project);
+  let migrated = migrateProjectSlugAndOrgUrlKey(project);
+  migrated = migrateInvalidTimelineStages(migrated);
   // add more migration here as needed
   // e.g. migrated = anotherMigration(migrated);
   return migrated;

--- a/packages/common/src/projects/_internal/migrateInvalidTimelineStages.ts
+++ b/packages/common/src/projects/_internal/migrateInvalidTimelineStages.ts
@@ -1,8 +1,3 @@
-/**
- * Remove any timeline stages without a title
- * @param project
- * @returns project with cleaned timeline
- */
 import { IHubProject } from "../../core/types/IHubProject";
 import { cloneObject } from "../../util";
 

--- a/packages/common/src/projects/_internal/migrateInvalidTimelineStages.ts
+++ b/packages/common/src/projects/_internal/migrateInvalidTimelineStages.ts
@@ -1,0 +1,31 @@
+/**
+ * Remove any timeline stages without a title
+ * @param project
+ * @returns project with cleaned timeline
+ */
+import { IHubProject } from "../../core/types/IHubProject";
+import { cloneObject } from "../../util";
+
+export function migrateInvalidTimelineStages(
+  project: IHubProject
+): IHubProject {
+  if (project.schemaVersion >= 1.2) {
+    return project;
+  }
+
+  const clone = cloneObject(project);
+  if (
+    clone.view &&
+    clone.view.timeline &&
+    clone.view.timeline.stages &&
+    Array.isArray(clone.view.timeline.stages)
+  ) {
+    clone.view.timeline.stages = clone.view.timeline.stages.filter(
+      (stage: any) => !!stage.title
+    );
+  }
+
+  clone.schemaVersion = 1.2; // Update schema version to reflect migration
+
+  return clone;
+}

--- a/packages/common/src/projects/defaults.ts
+++ b/packages/common/src/projects/defaults.ts
@@ -3,7 +3,7 @@ import { InitiativeDefaultFeatures } from "../initiatives/_internal/InitiativeBu
 import { IModel, HubEntityStatus } from "../hub-types";
 
 export const HUB_PROJECT_ITEM_TYPE = "Hub Project";
-export const HUB_PROJECT_CURRENT_SCHEMA_VERSION = 1.1;
+export const HUB_PROJECT_CURRENT_SCHEMA_VERSION = 1.2;
 /**
  * Default values of a IHubProject
  */

--- a/packages/common/test/initiatives/_internal/migrateInvalidTimelineStages.test.ts
+++ b/packages/common/test/initiatives/_internal/migrateInvalidTimelineStages.test.ts
@@ -1,0 +1,36 @@
+import { migrateInvalidTimelineStages } from "../../../src/initiatives/_internal/migrateInvalidTimelineStages";
+import { IHubInitiative } from "../../../src/core/types/IHubInitiative";
+import { IHubStage } from "../../../src/core/types/IHubTimeline";
+
+describe("migrateInvalidTimelineStages", () => {
+  it("returns initiative unchanged if schemaVersion is >= 2.2", () => {
+    const initiative: IHubInitiative = {
+      schemaVersion: 2.2,
+    } as IHubInitiative;
+    const result = migrateInvalidTimelineStages(initiative);
+    expect(result).toBe(initiative);
+  });
+
+  it("removes stages without a title", () => {
+    const initiative: IHubInitiative = {
+      schemaVersion: 1.0,
+      view: {
+        timeline: {
+          stages: [
+            {},
+            { title: "Valid Stage" },
+            { title: "" },
+            { title: "Another Valid Stage" },
+            { foo: "bar" },
+          ],
+        },
+      },
+    } as IHubInitiative;
+    const result = migrateInvalidTimelineStages(initiative);
+    expect(result.view.timeline.stages).toEqual([
+      { title: "Valid Stage" },
+      { title: "Another Valid Stage" },
+    ] as IHubStage[]);
+    expect(result.schemaVersion).toBe(2.2);
+  });
+});

--- a/packages/common/test/projects/_internal/applyProjectMigrations.test.ts
+++ b/packages/common/test/projects/_internal/applyProjectMigrations.test.ts
@@ -1,8 +1,9 @@
 import { applyProjectMigrations } from "../../../src/projects/_internal/applyProjectMigrations";
 import { IHubProject } from "../../../src/core/types/IHubProject";
 import { HUB_PROJECT_CURRENT_SCHEMA_VERSION } from "../../../src/projects/defaults";
-
 import * as migrateProjectSlugAndOrgUrlKeyModule from "../../../src/projects/_internal/migrateProjectSlugAndOrgUrlKey";
+import * as timelineMigration from "../../../src/projects/_internal/migrateInvalidTimelineStages";
+import { IHubStage } from "../../../src/core/types/IHubTimeline";
 
 describe("applyProjectMigrations", () => {
   let project: IHubProject;
@@ -42,6 +43,38 @@ describe("applyProjectMigrations", () => {
       delete projectWithUndefinedTypeKeywords.typeKeywords;
       const result = applyProjectMigrations(projectWithUndefinedTypeKeywords);
       expect(result.typeKeywords).toEqual(["slug|orgkey|test-slug"]);
+    });
+
+    it("calls migrateInvalidTimelineStages and removes invalid stages", () => {
+      const timelineMigrationSpy = spyOn(
+        timelineMigration,
+        "migrateInvalidTimelineStages"
+      ).and.callThrough();
+
+      project.schemaVersion = 1.1;
+      project.view = {
+        timeline: {
+          schemaVersion: 1.0,
+          title: "Test Timeline",
+          description: "A test timeline",
+          canCollapse: true,
+          stages: [
+            {},
+            { title: "Valid Stage" },
+            { title: "" },
+            { title: "Another Valid Stage" },
+            { foo: "bar" },
+          ] as IHubStage[],
+        },
+      };
+
+      const result = applyProjectMigrations(project);
+
+      expect(timelineMigrationSpy).toHaveBeenCalledWith(project);
+      expect(result.view.timeline.stages).toEqual([
+        { title: "Valid Stage" },
+        { title: "Another Valid Stage" },
+      ] as IHubStage[]);
     });
   });
 });

--- a/packages/common/test/projects/_internal/migrateInvalidTimelineStages.test.ts
+++ b/packages/common/test/projects/_internal/migrateInvalidTimelineStages.test.ts
@@ -1,0 +1,36 @@
+import { migrateInvalidTimelineStages } from "../../../src/projects/_internal/migrateInvalidTimelineStages";
+import { IHubProject } from "../../../src/core/types/IHubProject";
+import { IHubStage } from "../../../src/core/types/IHubTimeline";
+
+describe("migrateInvalidTimelineStages", () => {
+  it("returns project unchanged if schemaVersion is >= 1.2", () => {
+    const project: IHubProject = {
+      schemaVersion: 1.2,
+    } as IHubProject;
+    const result = migrateInvalidTimelineStages(project);
+    expect(result).toBe(project);
+  });
+
+  it("removes stages without a title", () => {
+    const project: IHubProject = {
+      schemaVersion: 1.0,
+      view: {
+        timeline: {
+          stages: [
+            {},
+            { title: "Valid Stage" },
+            { title: "" },
+            { title: "Another Valid Stage" },
+            { foo: "bar" },
+          ],
+        },
+      },
+    } as IHubProject;
+    const result = migrateInvalidTimelineStages(project);
+    expect(result.view.timeline.stages).toEqual([
+      { title: "Valid Stage" },
+      { title: "Another Valid Stage" },
+    ] as IHubStage[]);
+    expect(result.schemaVersion).toBe(1.2);
+  });
+});


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Updates json schema for timelines.

1. Closes Issues: [13754](https://devtopia.esri.com/dc/hub/issues/13754)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
