### PR TITLE
fix: url key not present breaks enterprise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54211,7 +54211,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "19.1.2",
+			"version": "19.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -44,7 +44,13 @@ import { cloneObject } from "../util";
 import { PropertyMapper } from "../core/_internal/PropertyMapper";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 
-import { IHubSiteEditor, IModel, setProp, SettableAccessLevel } from "../index";
+import {
+  getWithDefault,
+  IHubSiteEditor,
+  IModel,
+  setProp,
+  SettableAccessLevel,
+} from "../index";
 import { isDiscussable } from "../discussions/utils";
 import { SiteEditorType } from "./_internal/SiteSchema";
 import { getEditorSlug } from "../core/_internal/getEditorSlug";
@@ -159,7 +165,12 @@ export class HubSite
   ): IHubSite {
     // ensure we have the orgUrlKey
     if (!partialSite.orgUrlKey) {
-      partialSite.orgUrlKey = context.portal.urlKey as string;
+      // if we're in enterprise, there is no portalUrlKey
+      partialSite.orgUrlKey = getWithDefault(
+        context,
+        "portal.urlKey",
+        ""
+      ) as string;
     }
     // ensure lower case
     partialSite.orgUrlKey = partialSite.orgUrlKey.toLowerCase();


### PR DESCRIPTION
1. Description:

1. Instructions for testing:
- copy this build of hub.js into opendata-ui
- run portal proxy
- run portaldev:local
- open any Hub site

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/13921

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
