### PR TITLE
fix: page slugify regex

### DIFF
--- a/packages/common/src/utils/slugify.ts
+++ b/packages/common/src/utils/slugify.ts
@@ -2,8 +2,9 @@
  * Perform the following operations on a string to make it slug-friendly:
  * 1. trim it
  * 2. convert to lowercase
- * 3. remove any character not a-z, 0-9, or _
+ * 3. remove any character not a-z or 0-9
  * 4. dasherize it
+ * 5. remove leading and trailing dashes
  * @param {String} value String to slugify
  */
 export function slugify<T>(value: T): T {
@@ -12,9 +13,9 @@ export function slugify<T>(value: T): T {
     return value
       .trim()
       .toLowerCase()
-      .replace(/ +/g, "-")
-      .replace(/[^\w-]/g, "")
-      .replace(/-+/g, "-");
+      .replace(/[^a-z0-9]+/g, "-") // replace runs of anything NOT a-z or 0-9 with "-"
+      .replace(/-+/g, "-") // collapse multiple "-" into one
+      .replace(/^-+|-+$/g, ""); // trim leading/trailing "-"
   } else {
     return value;
   }


### PR DESCRIPTION
1. Description: Slugs generated based off of a new page's provided title would incorrectly allow for leading hyphens and underscores

1. Instructions for testing: TBA

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/13433

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
