### PR TITLE
test(hub-common): add missing fixture that was imported from initiatives

### DIFF
--- a/packages/common/test/content/content.test.ts
+++ b/packages/common/test/content/content.test.ts
@@ -49,7 +49,7 @@ import { cloneObject } from "../../src/util";
 import * as documentItem from "../mocks/items/document.json";
 import * as documentsJson from "../mocks/datasets/document.json";
 import * as featureLayerJson from "../mocks/datasets/feature-layer.json";
-import { MOCK_REQUEST_OPTIONS } from "../../../initiatives/test/mocks/fake-session";
+import { MOCK_REQUEST_OPTIONS } from "../mocks/fake-session";
 import * as fetchMock from "fetch-mock";
 import { IHubServiceBackedContentStatus } from "../../src/content/types";
 import { ArcGISRequestError } from "@esri/arcgis-rest-request";
@@ -1513,7 +1513,7 @@ describe("content: ", () => {
       };
 
       fetchMock.once(
-        entity.url as string,
+        entity.url,
         {
           status: 200,
           body: { message: "Success" },
@@ -1523,7 +1523,7 @@ describe("content: ", () => {
 
       const result = (await getServiceStatus(entity, {
         ...MOCK_REQUEST_OPTIONS,
-        url: entity.url as string,
+        url: entity.url,
       })) as IHubServiceBackedContentStatus;
       expect(result.service.availability).toEqual("available");
     });
@@ -1551,7 +1551,7 @@ describe("content: ", () => {
       };
 
       fetchMock.once(
-        entity.url as string,
+        entity.url,
         {
           status: 200,
           body: { message: "Success" },
@@ -1561,7 +1561,7 @@ describe("content: ", () => {
 
       const result = (await getServiceStatus(entity, {
         ...MOCK_REQUEST_OPTIONS,
-        url: entity.url as string,
+        url: entity.url,
       })) as IHubServiceBackedContentStatus;
       expect(result.service.availability).toEqual("slow");
     });
@@ -1606,7 +1606,7 @@ describe("content: ", () => {
       // Call `getServiceStatus` and expect the result to be "unavailable"
       await getServiceStatus(entity, {
         ...MOCK_REQUEST_OPTIONS,
-        url: entity.url as string,
+        url: entity.url,
       }).then((result) => {
         expect(
           (result as IHubServiceBackedContentStatus).service.availability
@@ -1644,7 +1644,7 @@ describe("content: ", () => {
       // Call `getServiceStatus` and expect the result to be "auth-required"
       await getServiceStatus(entity, {
         ...MOCK_REQUEST_OPTIONS,
-        url: entity.url as string,
+        url: entity.url,
       }).then((result) => {
         expect(
           (result as IHubServiceBackedContentStatus).service.availability
@@ -1682,7 +1682,7 @@ describe("content: ", () => {
       // Call `getServiceStatus` and expect the result to be "auth-required"
       await getServiceStatus(entity, {
         ...MOCK_REQUEST_OPTIONS,
-        url: entity.url as string,
+        url: entity.url,
       }).then((result) => {
         expect(
           (result as IHubServiceBackedContentStatus).service.availability

--- a/packages/common/test/mocks/fake-session.ts
+++ b/packages/common/test/mocks/fake-session.ts
@@ -1,0 +1,38 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { IHubRequestOptions } from "../../src/hub-types";
+// Fake Session for use in tests...
+
+export const TOMORROW = (function () {
+  const now = new Date();
+  now.setDate(now.getDate() + 1);
+  return now;
+})();
+
+const token = "fake-token";
+const username = "vader";
+export const MOCK_USER_SESSION = {
+  getToken: () => Promise.resolve(token),
+  getUsername: () => Promise.resolve(username),
+  portal: "https://www.arcgis.com/sharing/rest",
+  username,
+  password: "123456",
+  token,
+  tokenExpires: TOMORROW,
+} as any;
+
+export const MOCK_REQUEST_OPTIONS = {
+  authentication: MOCK_USER_SESSION,
+};
+
+export const MOCK_HUB_REQOPTS = {
+  authentication: MOCK_USER_SESSION,
+  portalSelf: {
+    id: "orgIdFromPortalSelf",
+    name: "my spiffy org",
+    urlKey: "org",
+  },
+  isPortal: false,
+  hubApiUrl: "https://hubqa.arcgis.com",
+} as unknown as IHubRequestOptions;


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
