### PR TITLE
feat(hub-common): Prevent items list from being resorted on save event

### DIFF
--- a/packages/common/src/utils/_array.ts
+++ b/packages/common/src/utils/_array.ts
@@ -33,23 +33,3 @@ export function splitArrayByLength<T>(
     return splits;
   }, []);
 }
-
-/**
- * Determines if two arrays are shallowly equal.
- *
- * @param a - The first array to compare.
- * @param b - The second array to compare.
- * @returns True if both arrays are the same reference or contain identical elements in the same order; otherwise, false.
- */
-export function isArrayEqual(a: unknown[], b: unknown[]): boolean {
-  if (a === b) {
-    return true;
-  }
-  if (!Array.isArray(a) || !Array.isArray(b)) {
-    return false;
-  }
-  if (a.length !== b.length) {
-    return false;
-  }
-  return a.every((_, i) => a[i] === b[i]);
-}

--- a/packages/common/src/utils/array.ts
+++ b/packages/common/src/utils/array.ts
@@ -1,0 +1,19 @@
+/**
+ * Determines if two arrays are shallowly equal.
+ *
+ * @param a - The first array to compare.
+ * @param b - The second array to compare.
+ * @returns True if both arrays are the same reference or contain identical elements in the same order; otherwise, false.
+ */
+export function isArrayEqual(a: unknown[], b: unknown[]): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!Array.isArray(a) || !Array.isArray(b)) {
+    return false;
+  }
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((_, i) => a[i] === b[i]);
+}

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -32,4 +32,4 @@ export * from "./isComboboxItemSelected";
 export * from "./wait";
 export * from "./IUserHubSettings";
 export * from "./IUserSiteSettings";
-export * from "./_array";
+export * from "./array";

--- a/packages/common/test/utils/_array.test.ts
+++ b/packages/common/test/utils/_array.test.ts
@@ -1,8 +1,4 @@
-import {
-  maybeConcat,
-  splitArrayByLength,
-  isArrayEqual,
-} from "../../src/utils/_array";
+import { maybeConcat, splitArrayByLength } from "../../src/utils/_array";
 
 describe("maybeConcat", () => {
   it("returns undefined when no arrays", () => {
@@ -26,30 +22,5 @@ describe("splitArrayByLength", () => {
   it("should convert a single array into multiple arrays of the given max length", () => {
     const results = splitArrayByLength<string>(["a", "b", "c"], 2);
     expect(results).toEqual([["a", "b"], ["c"]]);
-  });
-});
-
-describe("isArrayEqual", () => {
-  it("returns true for the same reference", () => {
-    const arr = [1, 2, 3];
-    expect(isArrayEqual(arr, arr)).toBe(true);
-  });
-
-  it("returns true for arrays with the same elements in the same order", () => {
-    expect(isArrayEqual([1, 2, 3], [1, 2, 3])).toBe(true);
-  });
-
-  it("returns false for arrays with different elements", () => {
-    expect(isArrayEqual([1, 2, 3], [1, 2, 4])).toBe(false);
-  });
-
-  it("returns false for arrays with different lengths", () => {
-    expect(isArrayEqual([1, 2, 3], [1, 2])).toBe(false);
-  });
-
-  it("returns false if either argument is not an array", () => {
-    expect(isArrayEqual([1, 2, 3], null)).toBe(false);
-    expect(isArrayEqual(null, [1, 2, 3])).toBe(false);
-    expect(isArrayEqual("not-an-array" as any, [1, 2, 3])).toBe(false);
   });
 });

--- a/packages/common/test/utils/array.test.ts
+++ b/packages/common/test/utils/array.test.ts
@@ -1,0 +1,26 @@
+import { isArrayEqual } from "../../src/utils/array";
+
+describe("isArrayEqual", () => {
+  it("returns true for the same reference", () => {
+    const arr = [1, 2, 3];
+    expect(isArrayEqual(arr, arr)).toBe(true);
+  });
+
+  it("returns true for arrays with the same elements in the same order", () => {
+    expect(isArrayEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+  });
+
+  it("returns false for arrays with different elements", () => {
+    expect(isArrayEqual([1, 2, 3], [1, 2, 4])).toBe(false);
+  });
+
+  it("returns false for arrays with different lengths", () => {
+    expect(isArrayEqual([1, 2, 3], [1, 2])).toBe(false);
+  });
+
+  it("returns false if either argument is not an array", () => {
+    expect(isArrayEqual([1, 2, 3], null)).toBe(false);
+    expect(isArrayEqual(null, [1, 2, 3])).toBe(false);
+    expect(isArrayEqual("not-an-array" as any, [1, 2, 3])).toBe(false);
+  });
+});


### PR DESCRIPTION


1. Description:

Added `isArrayEqual` util for common use
affects: @esri/hub-common

2. Instructions for testing:

This PR is in relation to [ticket 13644](https://devtopia.esri.com/dc/hub/issues/13644)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
