### PR TITLE
fix: collection schema label maxLength

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2247,9 +2247,9 @@
 			}
 		},
 		"node_modules/@esri/arcgis-rest-feature-service": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-4.1.0.tgz",
-			"integrity": "sha512-XmgySXuoCTQVkBrlKiwn+vPFlp748xJv2/DLSSgTgtHPOTiSLW+tnqeQiZdl6DOHpFiI44aY2aCWFrh/PUm+tA==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-4.4.0.tgz",
+			"integrity": "sha512-aCUpWt2ZtSHLOylA9VXPWO9C8BFQHVk3sn1lnUQm5SWInMPE0cVrtaA4eAi9lzYz4m7oam7KqjqI7u/6FxW/ig==",
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
@@ -38663,7 +38663,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "19.4.1",
+			"version": "20.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",
@@ -38707,68 +38707,68 @@
 		},
 		"packages/downloads": {
 			"name": "@esri/hub-downloads",
-			"version": "19.0.0",
+			"version": "20.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-feature-service": "^4.0.0",
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^19.0.0"
+				"@esri/hub-common": "^20.0.0"
 			}
 		},
 		"packages/events": {
 			"name": "@esri/hub-events",
-			"version": "19.0.1",
+			"version": "20.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-feature-service": "^4.0.0",
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^19.0.0"
+				"@esri/hub-common": "^20.0.0"
 			}
 		},
 		"packages/initiatives": {
 			"name": "@esri/hub-initiatives",
-			"version": "19.0.1",
+			"version": "20.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
 				"blob": "0.0.4",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^19.0.0"
+				"@esri/hub-common": "^20.0.0"
 			}
 		},
 		"packages/search": {
 			"name": "@esri/hub-search",
-			"version": "19.0.0",
+			"version": "20.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"typescript": "^3.8.1"
@@ -38777,63 +38777,63 @@
 				"@esri/arcgis-rest-feature-service": "^4.0.0",
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^19.0.0"
+				"@esri/hub-common": "^20.0.0"
 			}
 		},
 		"packages/sites": {
 			"name": "@esri/hub-sites",
-			"version": "20.0.1",
+			"version": "21.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^19.0.0",
-				"@esri/hub-initiatives": "^19.0.0",
-				"@esri/hub-teams": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
+				"@esri/hub-initiatives": "^20.0.0",
+				"@esri/hub-teams": "^20.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^19.0.0",
-				"@esri/hub-initiatives": "^19.0.0",
-				"@esri/hub-teams": "^19.0.0"
+				"@esri/hub-common": "^20.0.0",
+				"@esri/hub-initiatives": "^20.0.0",
+				"@esri/hub-teams": "^20.0.0"
 			}
 		},
 		"packages/surveys": {
 			"name": "@esri/hub-surveys",
-			"version": "19.0.1",
+			"version": "20.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-feature-service": "^4.0.0",
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^19.0.0"
+				"@esri/hub-common": "^20.0.0"
 			}
 		},
 		"packages/teams": {
 			"name": "@esri/hub-teams",
-			"version": "19.0.1",
+			"version": "20.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^1.13.0"
 			},
 			"devDependencies": {
-				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
 				"typescript": "^3.8.1"
 			},
 			"peerDependencies": {
 				"@esri/arcgis-rest-portal": "^4.0.0",
 				"@esri/arcgis-rest-request": "^4.7.1",
-				"@esri/hub-common": "^19.0.0"
+				"@esri/hub-common": "^20.0.0"
 			}
 		}
 	},
@@ -40322,9 +40322,9 @@
 			}
 		},
 		"@esri/arcgis-rest-feature-service": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-4.1.0.tgz",
-			"integrity": "sha512-XmgySXuoCTQVkBrlKiwn+vPFlp748xJv2/DLSSgTgtHPOTiSLW+tnqeQiZdl6DOHpFiI44aY2aCWFrh/PUm+tA==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-4.4.0.tgz",
+			"integrity": "sha512-aCUpWt2ZtSHLOylA9VXPWO9C8BFQHVk3sn1lnUQm5SWInMPE0cVrtaA4eAi9lzYz4m7oam7KqjqI7u/6FxW/ig==",
 			"requires": {
 				"tslib": "^2.3.0"
 			},
@@ -40422,7 +40422,7 @@
 		"@esri/hub-downloads": {
 			"version": "file:packages/downloads",
 			"requires": {
-				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
 				"eventemitter3": "^4.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -40431,7 +40431,7 @@
 		"@esri/hub-events": {
 			"version": "file:packages/events",
 			"requires": {
-				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -40439,7 +40439,7 @@
 		"@esri/hub-initiatives": {
 			"version": "file:packages/initiatives",
 			"requires": {
-				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
 				"blob": "0.0.4",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
@@ -40448,7 +40448,7 @@
 		"@esri/hub-search": {
 			"version": "file:packages/search",
 			"requires": {
-				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
 				"@types/faker": "^5.1.5",
 				"faker": "^5.1.0",
 				"tslib": "^1.13.0",
@@ -40458,9 +40458,9 @@
 		"@esri/hub-sites": {
 			"version": "file:packages/sites",
 			"requires": {
-				"@esri/hub-common": "^19.0.0",
-				"@esri/hub-initiatives": "^19.0.0",
-				"@esri/hub-teams": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
+				"@esri/hub-initiatives": "^20.0.0",
+				"@esri/hub-teams": "^20.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -40468,7 +40468,7 @@
 		"@esri/hub-surveys": {
 			"version": "file:packages/surveys",
 			"requires": {
-				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}
@@ -40476,7 +40476,7 @@
 		"@esri/hub-teams": {
 			"version": "file:packages/teams",
 			"requires": {
-				"@esri/hub-common": "^19.0.0",
+				"@esri/hub-common": "^20.0.0",
 				"tslib": "^1.13.0",
 				"typescript": "^3.8.1"
 			}

--- a/packages/common/src/core/schemas/shared/CatalogSchema.ts
+++ b/packages/common/src/core/schemas/shared/CatalogSchema.ts
@@ -12,16 +12,16 @@ export const GalleryDisplayConfigSchema: IConfigurationSchema = {
     hidden: { type: "boolean", default: false },
     layout: {
       type: "string",
-      enum: [ 'grid', 'list', 'map', 'compact', 'table', 'calendar' ],
+      enum: ["grid", "list", "map", "compact", "table", "calendar"],
       default: "list",
     },
     layouts: {
       type: "array",
       items: {
         type: "string",
-        enum: [ 'grid', 'list', 'map', 'compact', 'table', 'calendar' ]
+        enum: ["grid", "list", "map", "compact", "table", "calendar"],
       },
-      default: []
+      default: [],
     },
     cardTitleTag: {
       type: "string",
@@ -144,6 +144,7 @@ export const CollectionSchema: IConfigurationSchema = {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       format: "isNotWhitespace",
+      maxLength: 64,
     },
     scope: QuerySchema,
     displayConfig: GalleryDisplayConfigSchema,


### PR DESCRIPTION
1. Description: Adds a maxLength to a collection label.

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
