### PR TITLE
fix(hub-common): settings => discussions pane is not accessible in en…

### DIFF
--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -173,5 +173,6 @@ export const ContentPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:content:workspace:settings:discussions",
     dependencies: ["hub:content:workspace", "hub:content:edit"],
+    licenses: ["hub-basic", "hub-premium"],
   },
 ];

--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -53,12 +53,14 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:discussion:edit",
     authenticated: true,
     dependencies: ["hub:discussion"],
+    licenses: ["hub-basic", "hub-premium"],
     entityEdit: true,
   },
   {
     permission: "hub:discussion:delete",
     authenticated: true,
     dependencies: ["hub:discussion"],
+    licenses: ["hub-basic", "hub-premium"],
     entityDelete: true,
   },
   {

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -154,6 +154,7 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:site:workspace:settings:discussions",
     dependencies: ["hub:site:workspace", "hub:site:edit"],
+    licenses: ["hub-basic", "hub-premium"],
   },
   {
     permission: "hub:site:workspace:collaborators",


### PR DESCRIPTION
…terprise-sites

affects: @esri/hub-common

ISSUES CLOSED: 14010

1. Description:

- `Settings => Discussions` workspace pane is not accessible in enterprise sites

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
