### PR TITLE
fix: limit maxLength of site name to 240 characters in enterprise

### DIFF
--- a/packages/common/src/core/schemas/internal/getEditorSchemas.ts
+++ b/packages/common/src/core/schemas/internal/getEditorSchemas.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-case-declarations */
 import { cloneObject } from "../../../util";
 import { HubEntity } from "../../types/HubEntity";
 import {
@@ -54,13 +55,14 @@ export async function getEditorSchemas(
   let schema: IConfigurationSchema;
   let uiSchema: IUiSchema;
   let defaults: IConfigurationValues;
+
   switch (editorType) {
     case "site":
       const { getSiteSchema } = await import(
         "../../../sites/_internal/SiteSchema"
       );
       // site id is needed for validation of site url
-      schema = getSiteSchema((options as HubEntity).id);
+      schema = getSiteSchema((options as HubEntity).id, context);
 
       const siteModule: IEntityEditorModuleType = await {
         "hub:site:edit": () =>

--- a/packages/common/src/core/schemas/shared/subschemas.ts
+++ b/packages/common/src/core/schemas/shared/subschemas.ts
@@ -20,6 +20,13 @@ export const SITE_ENTITY_NAME_SCHEMA = {
   format: "siteEntityTitleValidator",
 };
 
+export const ENTERPRISE_SITE_ENTITY_NAME_SCHEMA = {
+  type: "string",
+  minLength: 1,
+  maxLength: 240, // 256 - 'hubsubdomain|' minus an extra 3 characters for a round number
+  format: "siteEntityTitleValidator",
+};
+
 export const ENTITY_SUMMARY_SCHEMA = {
   type: "string",
   maxLength: 2048,

--- a/packages/common/test/core/schemas/getEditorConfig.test.ts
+++ b/packages/common/test/core/schemas/getEditorConfig.test.ts
@@ -2,6 +2,8 @@ import { getEditorConfig } from "../../../src/core/schemas";
 import type { IArcGISContext } from "../../../src";
 import { EntityEditorOptions } from "../../../src/core/schemas/internal/EditorOptions";
 import * as GetEntitySchemasModule from "../../../src/core/schemas/internal/getEditorSchemas";
+import * as SiteSchemaModule from "../../../src/sites/_internal/SiteSchema";
+import { MOCK_CONTEXT } from "../../mocks/mock-auth";
 
 describe("getEditorConfig:", () => {
   it("delegates to getEditorSchemas with entity", async () => {
@@ -29,6 +31,38 @@ describe("getEditorConfig:", () => {
     );
     expect(chk).toBeDefined();
     expect(chk.schema).toBeDefined();
+  });
+
+  it("gets site schemas", async () => {
+    const getEditorSchemas = spyOn(
+      GetEntitySchemasModule,
+      "getEditorSchemas"
+    ).and.callThrough();
+
+    const getSiteSchema = spyOn(
+      SiteSchemaModule,
+      "getSiteSchema"
+    ).and.callThrough();
+
+    const chk = await getEditorConfig(
+      "someScope",
+      "hub:site:create",
+      {} as EntityEditorOptions,
+      MOCK_CONTEXT
+    );
+
+    expect(getEditorSchemas).toHaveBeenCalled();
+    // verify that the options are passed to the schemas
+    expect(getEditorSchemas).toHaveBeenCalledWith(
+      "someScope",
+      "hub:site:create",
+      {},
+      MOCK_CONTEXT
+    );
+    expect(getSiteSchema).toHaveBeenCalled();
+    expect(chk).toBeDefined();
+    expect(chk.schema).toBeDefined();
+    expect((chk.schema.properties.name as any).maxLength).toEqual(250);
   });
 
   it("delegates to getEditorSchemas with card", async () => {


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: Limit maxLength of site name to 240 characters in enterprise. In enterprise we look up the domain by the site name on a typekeyword prefixed with `hubsubdomain|` which is 13 characters long. So that 13 characters plus the length of the title if it _was_ 250 (and remains 250 in online) would give you a typekeword of 263 characters which is longer than the max length of a typekeyword (256).

1. Closes Issues: [13863](https://devtopia.esri.com/dc/hub/issues/13863)

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
