### PR TITLE
feat(hub-common): add permissions for ai assistant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38663,7 +38663,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "20.0.0",
+			"version": "20.3.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/assistants/IHubAssistant.ts
+++ b/packages/common/src/assistants/IHubAssistant.ts
@@ -13,6 +13,10 @@ export interface IHubAssistant {
    */
   access?: string;
   /**
+   * Assistant access groups when not public.
+   */
+  accessGroups?: string[];
+  /**
    * Personality for the assistant.
    */
   personality?: string;

--- a/packages/common/src/sites/HubSite.ts
+++ b/packages/common/src/sites/HubSite.ts
@@ -45,6 +45,7 @@ import { PropertyMapper } from "../core/_internal/PropertyMapper";
 import { getPropertyMap } from "./_internal/getPropertyMap";
 
 import {
+  IEntityPermissionPolicy,
   getWithDefault,
   IHubSiteEditor,
   IModel,
@@ -508,6 +509,22 @@ export class HubSite
     entity.url = url;
     entity.subdomain = subdomain;
     entity.defaultHostname = defaultHostname;
+
+    // assistant group permissions
+    // 1. Remove any existing 'hub:site:assistant:access' group permissions
+    entity.permissions = entity.permissions.filter(
+      (p) => p.permission !== "hub:site:assistant:access"
+    );
+    // 2. Add new group permissions from assistant.accessGroups if any exist
+    if (entity.assistant.accessGroups?.length > 0) {
+      const assistantPermissions: IEntityPermissionPolicy[] =
+        entity.assistant.accessGroups.map((groupId: string) => ({
+          permission: "hub:site:assistant:access",
+          collaborationType: "group",
+          collaborationId: groupId,
+        }));
+      entity.permissions = [...entity.permissions, ...assistantPermissions];
+    }
 
     // 3. create or update the in-memory entity and save
     this.entity = entity;

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -51,6 +51,7 @@ export const SitePermissions = [
   "hub:site:workspace:feeds",
   "hub:site:workspace:assistant",
   "hub:site:workspace:settings:discussions",
+  "hub:site:assistant:access",
 ] as const;
 
 /**
@@ -252,6 +253,10 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
     licenses: ["hub-premium"],
     dependencies: ["hub:site:workspace", "hub:site:edit"],
     environments: ["devext", "qaext", "production"],
+  },
+  {
+    permission: "hub:site:assistant:access",
+    licenses: ["hub-premium"],
   },
 ];
 


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
