### PR TITLE
fix(hub-common): fix create group discussion settings

### DIFF
--- a/packages/common/src/core/_internal/createOrUpdateEntitySettings.ts
+++ b/packages/common/src/core/_internal/createOrUpdateEntitySettings.ts
@@ -19,7 +19,7 @@ import { IWithDiscussions } from "../traits/IWithDiscussions";
  * @returns a promise that resolves an IEntitySetting object
  */
 export async function createOrUpdateEntitySettings<
-  T extends IWithDiscussions & { id: string }
+  T extends IWithDiscussions & { id: string; type: string }
 >(
   entity: T,
   requestOptions: IHubRequestOptions,

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -17,7 +17,7 @@ import type { IUserRequestOptions } from "@esri/arcgis-rest-request";
 import { DEFAULT_GROUP } from "./defaults";
 import { convertHubGroupToGroup } from "./_internal/convertHubGroupToGroup";
 import { convertGroupToHubGroup } from "./_internal/convertGroupToHubGroup";
-import { setDiscussableKeyword } from "../discussions";
+import { fetchSettingV2, setDiscussableKeyword } from "../discussions";
 import { IHubSearchResult } from "../search/types/IHubSearchResult";
 import { computeLinks } from "./_internal/computeLinks";
 import { getUniqueGroupTitle } from "./_internal/getUniqueGroupTitle";
@@ -118,14 +118,6 @@ export async function createHubGroup(
     hubGroup.isDiscussable
   );
 
-  // create or update entity settings
-  const entitySetting = await createOrUpdateEntitySettings(
-    hubGroup,
-    context.hubRequestOptions
-  );
-  hubGroup.entitySettingsId = entitySetting.id;
-  hubGroup.discussionSettings = entitySetting.settings.discussions;
-
   const group = convertHubGroupToGroup(hubGroup);
   const opts = {
     group,
@@ -143,7 +135,21 @@ export async function createHubGroup(
     ).success;
   }
 
-  return await convertGroupToHubGroup(result.group, context.userRequestOptions);
+  const entity = convertGroupToHubGroup(
+    result.group,
+    null,
+    context.userRequestOptions
+  );
+
+  // create or update entity settings
+  const entitySetting = await createOrUpdateEntitySettings(
+    hubGroup,
+    context.hubRequestOptions
+  );
+  entity.entitySettingsId = entitySetting.id;
+  entity.discussionSettings = entitySetting.settings.discussions;
+
+  return entity;
 }
 
 /**
@@ -157,7 +163,16 @@ export async function fetchHubGroup(
   requestOptions: IHubRequestOptions
 ): Promise<IHubGroup> {
   const group = await getGroup(identifier, requestOptions);
-  return await convertGroupToHubGroup(group, requestOptions);
+  const entitySettings = await fetchSettingV2({
+    id: group.id,
+    ...requestOptions,
+  }).catch((): null => null);
+  const hubGroup = convertGroupToHubGroup(
+    group,
+    entitySettings,
+    requestOptions
+  );
+  return hubGroup;
 }
 
 /**
@@ -179,14 +194,6 @@ export async function updateHubGroup(
     hubGroup.isDiscussable
   );
 
-  // create or update entity settings
-  const entitySetting = await createOrUpdateEntitySettings(
-    hubGroup,
-    context.hubRequestOptions
-  );
-  hubGroup.entitySettingsId = entitySetting.id;
-  hubGroup.discussionSettings = entitySetting.settings.discussions;
-
   const group = convertHubGroupToGroup(hubGroup);
 
   const opts = {
@@ -199,6 +206,15 @@ export async function updateHubGroup(
     setProp("params.clearEmptyFields", true, opts);
   }
   await updateGroup(opts);
+
+  // create or update entity settings
+  const entitySetting = await createOrUpdateEntitySettings(
+    hubGroup,
+    context.hubRequestOptions
+  );
+  hubGroup.entitySettingsId = entitySetting.id;
+  hubGroup.discussionSettings = entitySetting.settings.discussions;
+
   return hubGroup;
 }
 

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -143,7 +143,7 @@ export async function createHubGroup(
 
   // create or update entity settings
   const entitySetting = await createOrUpdateEntitySettings(
-    hubGroup,
+    { ...hubGroup, id: entity.id },
     context.hubRequestOptions
   );
   entity.entitySettingsId = entitySetting.id;

--- a/packages/common/src/groups/_internal/computeProps.ts
+++ b/packages/common/src/groups/_internal/computeProps.ts
@@ -3,7 +3,11 @@ import type { ArcGISIdentityManager } from "@esri/arcgis-rest-request";
 
 import { IHubGroup } from "../../core/types/IHubGroup";
 import type { IGroup } from "@esri/arcgis-rest-portal";
-import { isDiscussable } from "../../discussions";
+import {
+  getDefaultEntitySettings,
+  IEntitySetting,
+  isDiscussable,
+} from "../../discussions";
 import { getGroupThumbnailUrl } from "../../search/utils";
 import { computeLinks } from "./computeLinks";
 
@@ -18,6 +22,7 @@ import { computeLinks } from "./computeLinks";
 export function computeProps(
   group: IGroup,
   hubGroup: Partial<IHubGroup>,
+  entitySettings: Partial<IEntitySetting>,
   requestOptions: IRequestOptions
 ): IHubGroup {
   let token: string;
@@ -65,6 +70,10 @@ export function computeProps(
   hubGroup.canDelete = hubGroup.canEdit;
 
   hubGroup.links = computeLinks(group, requestOptions);
+
+  const settings = entitySettings || getDefaultEntitySettings("group");
+  hubGroup.entitySettingsId = settings.id ?? null;
+  hubGroup.discussionSettings = settings.settings.discussions;
 
   // cast b/c this takes a partial but returns a full group
   return hubGroup as IHubGroup;

--- a/packages/common/src/groups/_internal/computeProps.ts
+++ b/packages/common/src/groups/_internal/computeProps.ts
@@ -1,6 +1,5 @@
 import { IRequestOptions } from "@esri/arcgis-rest-request";
 import type { ArcGISIdentityManager } from "@esri/arcgis-rest-request";
-
 import { IHubGroup } from "../../core/types/IHubGroup";
 import type { IGroup } from "@esri/arcgis-rest-portal";
 import {

--- a/packages/common/src/groups/_internal/convertGroupToHubGroup.ts
+++ b/packages/common/src/groups/_internal/convertGroupToHubGroup.ts
@@ -4,8 +4,6 @@ import { IHubGroup } from "../../core/types/IHubGroup";
 import { computeProps } from "./computeProps";
 import { getPropertyMap } from "./getPropertyMap";
 import { IHubRequestOptions } from "../../hub-types";
-import { getDefaultEntitySettings } from "../../discussions/api/settings/getDefaultEntitySettings";
-import { fetchSettingV2 } from "../../discussions/api/settings/settings";
 import { IEntitySetting } from "../../discussions/api/types";
 
 /**
@@ -14,25 +12,14 @@ import { IEntitySetting } from "../../discussions/api/types";
  * @param requestOptions
  */
 
-export async function convertGroupToHubGroup(
+export function convertGroupToHubGroup(
   group: IGroup,
+  entitySettings: IEntitySetting,
   requestOptions: IHubRequestOptions
-): Promise<IHubGroup> {
+): IHubGroup {
   const mapper = new PropertyMapper<Partial<IHubGroup>, IGroup>(
     getPropertyMap()
   );
   const hubGroup = mapper.storeToEntity(group, {}) as IHubGroup;
-  const entitySettings = await fetchSettingV2({
-    id: group.id,
-    ...requestOptions,
-  }).catch(
-    () =>
-      ({
-        id: null,
-        ...getDefaultEntitySettings("group"),
-      } as IEntitySetting)
-  );
-  hubGroup.entitySettingsId = entitySettings.id;
-  hubGroup.discussionSettings = entitySettings.settings.discussions;
-  return computeProps(group, hubGroup, requestOptions);
+  return computeProps(group, hubGroup, entitySettings, requestOptions);
 }

--- a/packages/common/src/initiatives/HubInitiative.ts
+++ b/packages/common/src/initiatives/HubInitiative.ts
@@ -296,8 +296,9 @@ export class HubInitiative
         this.context.requestOptions
       );
 
-      const hubAssociationGroup = await convertGroupToHubGroup(
+      const hubAssociationGroup = convertGroupToHubGroup(
         associationGroup,
+        null,
         this.context.userRequestOptions
       );
       const _associations = {

--- a/packages/common/test/groups/_internal/computeProps.test.ts
+++ b/packages/common/test/groups/_internal/computeProps.test.ts
@@ -4,6 +4,7 @@ import { ArcGISContextManager } from "../../../src/ArcGISContextManager";
 import { computeProps } from "../../../src/groups/_internal/computeProps";
 import { IHubGroup } from "../../../src/core/types/IHubGroup";
 import * as computeLinksModule from "../../../src/groups/_internal/computeLinks";
+import { EntitySettingType } from "../../../dist/types";
 
 describe("groups: computeProps:", () => {
   let group: IGroup;
@@ -50,9 +51,15 @@ describe("groups: computeProps:", () => {
   describe("computeProps:", () => {
     describe("computed props", () => {
       it("computes the correct props", async () => {
+        const settings = {
+          id: "abc",
+          type: "group" as EntitySettingType,
+          settings: {},
+        };
         let chk = computeProps(
           group,
           hubGroup,
+          settings,
           authdCtxMgr.context.requestOptions
         );
         expect(chk.createdDate).toBeDefined();
@@ -82,12 +89,22 @@ describe("groups: computeProps:", () => {
           } as unknown as IPortal,
           portalUrl: "https://org.maps.arcgis.com",
         });
-        chk = computeProps(group, hubGroup, authdCtxMgr.context.requestOptions);
+        chk = computeProps(
+          group,
+          hubGroup,
+          settings,
+          authdCtxMgr.context.requestOptions
+        );
         expect(chk.thumbnailUrl).toBe(
           "https://org.maps.arcgis.com/sharing/rest/community/groups/3ef/info/group.jpg"
         );
       });
       it("generates a links hash", () => {
+        const settings = {
+          id: "abc",
+          type: "group" as EntitySettingType,
+          settings: {},
+        };
         const computeLinksSpy = spyOn(
           computeLinksModule,
           "computeLinks"
@@ -95,6 +112,7 @@ describe("groups: computeProps:", () => {
         const chk = computeProps(
           group,
           hubGroup,
+          settings,
           authdCtxMgr.context.requestOptions
         );
         expect(computeLinksSpy).toHaveBeenCalledTimes(1);
@@ -105,9 +123,15 @@ describe("groups: computeProps:", () => {
           id: "3ef",
           name: "Test group",
         } as unknown as IGroup;
+        const settings = {
+          id: "abc",
+          type: "group" as EntitySettingType,
+          settings: {},
+        };
         const chk = computeProps(
           group,
           hubGroup,
+          settings,
           authdCtxMgr.context.requestOptions
         );
         expect(chk.memberType).toBeFalsy();

--- a/packages/common/test/groups/_internal/convertGroupToHubGroup.test.ts
+++ b/packages/common/test/groups/_internal/convertGroupToHubGroup.test.ts
@@ -3,6 +3,7 @@ import { MOCK_AUTH } from "../../mocks/mock-auth";
 import { ArcGISContextManager } from "../../../src/ArcGISContextManager";
 import * as PortalModule from "@esri/arcgis-rest-portal";
 import { convertGroupToHubGroup } from "../../../src/groups/_internal/convertGroupToHubGroup";
+import { EntitySettingType, IEntitySetting } from "../../../dist/types";
 
 describe("groups: convertGroupToHubGroup:", () => {
   it("converts an IGroup to a HubGroup", async () => {
@@ -18,6 +19,11 @@ describe("groups: convertGroupToHubGroup:", () => {
       },
       capabilities: ["updateitemcontrol"],
     } as unknown as IGroup;
+    const settings = {
+      id: "abc",
+      type: "group" as EntitySettingType,
+      settings: {},
+    } as IEntitySetting;
     // When we pass in all this information, the context
     // manager will not try to fetch anything, so no need
     // to mock those calls
@@ -33,8 +39,9 @@ describe("groups: convertGroupToHubGroup:", () => {
       } as unknown as PortalModule.IPortal,
       portalUrl: "https://myserver.com",
     });
-    const chk = await convertGroupToHubGroup(
+    const chk = convertGroupToHubGroup(
       group,
+      settings,
       authdCtxMgr.context.userRequestOptions
     );
     expect(chk.id).toBe("3ef");


### PR DESCRIPTION
1. Description: 

1. Instructions for testing:

1. Closes Issues: #15155

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
