### PR TITLE
fix(hub-common): partial groups have group typing

### DIFF
--- a/packages/common/src/groups/getWellKnownGroup.ts
+++ b/packages/common/src/groups/getWellKnownGroup.ts
@@ -28,6 +28,7 @@ export function getWellKnownGroup(
     "org";
   const configs: Record<WellKnownGroup, Partial<IHubGroup>> = {
     hubGroup: {
+      type: "Group",
       access: "private",
       autoJoin: false,
       isSharedUpdate: false,
@@ -39,6 +40,7 @@ export function getWellKnownGroup(
       membershipAccess: "organization",
     },
     hubViewGroup: {
+      type: "Group",
       access: hasShareGroupToPublic || hasShareGroupToOrg || "private",
       autoJoin: false,
       isSharedUpdate: false,
@@ -55,6 +57,7 @@ export function getWellKnownGroup(
         : "organization",
     },
     hubEditGroup: {
+      type: "Group",
       access: "org",
       autoJoin: false,
       isSharedUpdate: true,
@@ -71,6 +74,7 @@ export function getWellKnownGroup(
         : "organization",
     },
     hubFollowersGroup: {
+      type: "Group",
       access: "public",
       autoJoin: true,
       isInvitationOnly: false,
@@ -78,6 +82,7 @@ export function getWellKnownGroup(
       leavingDisallowed: false,
     },
     hubAssociationsGroup: {
+      type: "Group",
       access: "public",
       autoJoin: false,
       isInvitationOnly: false,

--- a/packages/common/test/groups/_internal/GroupUiSchemaCreate.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaCreate.test.ts
@@ -7,6 +7,7 @@ import {
   MOCK_CONTEXT,
   getMockContextWithPrivilenges,
 } from "../../mocks/mock-auth";
+import * as permissionsModule from "../../../src/permissions";
 
 describe("GroupUiSchemaCreate", () => {
   describe("buildUiSchema: create group", () => {
@@ -434,10 +435,9 @@ describe("GroupUiSchemaCreate", () => {
       });
     });
     it("renders the Open data capability tooltip when group access is not public", async () => {
-      spyOn(
-        require("../../../src/permissions"),
-        "checkPermission"
-      ).and.returnValue({ access: true });
+      spyOn(permissionsModule, "checkPermission").and.returnValue({
+        access: true,
+      });
       const uiSchema = await buildUiSchema(
         "some.scope",
         { access: "private" } as IHubGroup,
@@ -448,10 +448,9 @@ describe("GroupUiSchemaCreate", () => {
       expect(isOpenDataTooltip).toEqual(`some.scope.fields.isOpenData.tooltip`);
     });
     it("renders the Open data capability tooltip when user does not have the permission to do so", async () => {
-      spyOn(
-        require("../../../src/permissions"),
-        "checkPermission"
-      ).and.returnValue({ access: false });
+      spyOn(permissionsModule, "checkPermission").and.returnValue({
+        access: false,
+      });
       const uiSchema = await buildUiSchema(
         "some.scope",
         { access: "public" } as IHubGroup,
@@ -472,6 +471,7 @@ describe("GroupUiSchemaCreate", () => {
       );
 
       expect(defaults).toEqual({
+        type: "Group",
         access: "private",
         autoJoin: false,
         isSharedUpdate: true,
@@ -491,6 +491,7 @@ describe("GroupUiSchemaCreate", () => {
         getMockContextWithPrivilenges(["portal:user:addExternalMembersToGroup"])
       );
       expect(defaults).toEqual({
+        type: "Group",
         access: "private",
         autoJoin: false,
         isSharedUpdate: true,

--- a/packages/common/test/groups/_internal/GroupUiSchemaCreateAssociation.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaCreateAssociation.test.ts
@@ -145,6 +145,7 @@ describe("GroupUiSchemaCreateAssociation", () => {
         MOCK_CONTEXT
       );
       expect(defaults).toEqual({
+        type: "Group",
         access: "public",
         autoJoin: false,
         isInvitationOnly: false,
@@ -164,6 +165,7 @@ describe("GroupUiSchemaCreateAssociation", () => {
         mockContext
       );
       expect(defaults).toEqual({
+        type: "Group",
         access: "public",
         autoJoin: false,
         isInvitationOnly: false,

--- a/packages/common/test/groups/_internal/GroupUiSchemaCreateEdit.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaCreateEdit.test.ts
@@ -134,6 +134,7 @@ describe("GroupUiSchemaCreateEdit", () => {
         MOCK_CONTEXT
       );
       expect(defaults).toEqual({
+        type: "Group",
         access: "org",
         autoJoin: false,
         isSharedUpdate: true,
@@ -152,6 +153,7 @@ describe("GroupUiSchemaCreateEdit", () => {
         getMockContextWithPrivilenges(["portal:user:addExternalMembersToGroup"])
       );
       expect(defaults).toEqual({
+        type: "Group",
         access: "org",
         autoJoin: false,
         isSharedUpdate: true,

--- a/packages/common/test/groups/_internal/GroupUiSchemaCreateFollowers.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaCreateFollowers.test.ts
@@ -141,6 +141,7 @@ describe("GroupUiSchemaCreateFollowers", () => {
         MOCK_CONTEXT
       );
       expect(defaults).toEqual({
+        type: "Group",
         access: "public",
         autoJoin: true,
         isInvitationOnly: false,

--- a/packages/common/test/groups/_internal/GroupUiSchemaCreateView.test.ts
+++ b/packages/common/test/groups/_internal/GroupUiSchemaCreateView.test.ts
@@ -146,6 +146,7 @@ describe("GroupUiSchemaCreateView", () => {
       );
 
       expect(defaults).toEqual({
+        type: "Group",
         access: "private",
         autoJoin: false,
         isSharedUpdate: false,
@@ -168,6 +169,7 @@ describe("GroupUiSchemaCreateView", () => {
         ])
       );
       expect(defaults).toEqual({
+        type: "Group",
         access: "org",
         autoJoin: false,
         isSharedUpdate: false,

--- a/packages/common/test/groups/_internal/computeProps.test.ts
+++ b/packages/common/test/groups/_internal/computeProps.test.ts
@@ -4,7 +4,7 @@ import { ArcGISContextManager } from "../../../src/ArcGISContextManager";
 import { computeProps } from "../../../src/groups/_internal/computeProps";
 import { IHubGroup } from "../../../src/core/types/IHubGroup";
 import * as computeLinksModule from "../../../src/groups/_internal/computeLinks";
-import { EntitySettingType } from "../../../dist/types";
+import { EntitySettingType } from "../../../src";
 
 describe("groups: computeProps:", () => {
   let group: IGroup;

--- a/packages/common/test/groups/_internal/convertGroupToHubGroup.test.ts
+++ b/packages/common/test/groups/_internal/convertGroupToHubGroup.test.ts
@@ -3,7 +3,7 @@ import { MOCK_AUTH } from "../../mocks/mock-auth";
 import { ArcGISContextManager } from "../../../src/ArcGISContextManager";
 import * as PortalModule from "@esri/arcgis-rest-portal";
 import { convertGroupToHubGroup } from "../../../src/groups/_internal/convertGroupToHubGroup";
-import { EntitySettingType, IEntitySetting } from "../../../dist/types";
+import { EntitySettingType, IEntitySetting } from "../../../src";
 
 describe("groups: convertGroupToHubGroup:", () => {
   it("converts an IGroup to a HubGroup", async () => {

--- a/packages/common/test/groups/getWellKnownGroup.test.ts
+++ b/packages/common/test/groups/getWellKnownGroup.test.ts
@@ -8,6 +8,7 @@ describe("getWellKnownGroup: ", () => {
   it("returns a followers group", () => {
     const resp = getWellKnownGroup("hubFollowersGroup", MOCK_CONTEXT);
     expect(resp).toEqual({
+      type: "Group",
       access: "public",
       autoJoin: true,
       isInvitationOnly: false,
@@ -18,6 +19,7 @@ describe("getWellKnownGroup: ", () => {
   it("returns a view group", () => {
     const resp = getWellKnownGroup("hubViewGroup", MOCK_CONTEXT);
     expect(resp).toEqual({
+      type: "Group",
       access: "private",
       autoJoin: false,
       isSharedUpdate: false,
@@ -35,6 +37,7 @@ describe("getWellKnownGroup: ", () => {
       getMockContextWithPrivilenges(["portal:user:addExternalMembersToGroup"])
     );
     expect(resp).toEqual({
+      type: "Group",
       access: "private",
       autoJoin: false,
       isSharedUpdate: false,
@@ -52,6 +55,7 @@ describe("getWellKnownGroup: ", () => {
       getMockContextWithPrivilenges(["portal:user:shareGroupToOrg"])
     );
     expect(resp).toEqual({
+      type: "Group",
       access: "org",
       autoJoin: false,
       isSharedUpdate: false,
@@ -69,6 +73,7 @@ describe("getWellKnownGroup: ", () => {
       getMockContextWithPrivilenges(["portal:user:shareGroupToPublic"])
     );
     expect(resp).toEqual({
+      type: "Group",
       access: "public",
       autoJoin: false,
       isSharedUpdate: false,
@@ -83,6 +88,7 @@ describe("getWellKnownGroup: ", () => {
   it("returns an edit group", () => {
     const resp = getWellKnownGroup("hubEditGroup", MOCK_CONTEXT);
     expect(resp).toEqual({
+      type: "Group",
       access: "org",
       autoJoin: false,
       isSharedUpdate: true,
@@ -100,6 +106,7 @@ describe("getWellKnownGroup: ", () => {
       getMockContextWithPrivilenges(["portal:user:addExternalMembersToGroup"])
     );
     expect(resp).toEqual({
+      type: "Group",
       access: "org",
       autoJoin: false,
       isSharedUpdate: true,
@@ -115,6 +122,7 @@ describe("getWellKnownGroup: ", () => {
   it("returns an associations group", () => {
     const resp = getWellKnownGroup("hubAssociationsGroup", MOCK_CONTEXT);
     expect(resp).toEqual({
+      type: "Group",
       access: "public",
       autoJoin: false,
       isInvitationOnly: false,
@@ -131,6 +139,7 @@ describe("getWellKnownGroup: ", () => {
       getMockContextWithPrivilenges(["portal:user:addExternalMembersToGroup"])
     );
     expect(resp).toEqual({
+      type: "Group",
       access: "public",
       autoJoin: false,
       isInvitationOnly: false,


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #14097

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] Updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.

1. [x] These changes have been verified by QA using a `?uiVersion` that includes a PR-Preview of this branch and the `v_req` label has been applied to the issue.

1. [x] OD-UI E2E tests pass against these changes using a `?uiVersion` that includes a PR-Preview of this branch
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
