### PR TITLE
fix: ensure all permissions are in HubPermissions array

### DIFF
--- a/packages/common/src/content/_internal/ContentBusinessRules.ts
+++ b/packages/common/src/content/_internal/ContentBusinessRules.ts
@@ -13,6 +13,7 @@ export const ContentDefaultFeatures: IFeatureFlags = {
  * @private
  */
 export const ContentPermissions = [
+  "hub:content",
   "hub:content:create",
   "hub:content:delete",
   "hub:content:edit",

--- a/packages/common/src/permissions/types/Permission.ts
+++ b/packages/common/src/permissions/types/Permission.ts
@@ -19,6 +19,7 @@ import { UserPermissions } from "../../users/_internal/UserBusinessRules";
  */
 
 const SystemPermissions = [
+  "hub:gating:workspace:released",
   "hub:feature:ai-assistant",
   "hub:platform:ai-assistant",
   "hub:feature:privacy",

--- a/packages/common/test/permissions/HubPermissionPolicies.test.ts
+++ b/packages/common/test/permissions/HubPermissionPolicies.test.ts
@@ -1,4 +1,9 @@
-import { getPermissionPolicy, Permission } from "../../src";
+import {
+  getPermissionPolicy,
+  HubPermissionsPolicies,
+  isPermission,
+  Permission,
+} from "../../src";
 
 describe("HubPermissionPolicies:", () => {
   it("returns true for valid permission policy", () => {
@@ -7,5 +12,14 @@ describe("HubPermissionPolicies:", () => {
 
   it("returns false for invalid permission policy", () => {
     expect(getPermissionPolicy("WAT" as Permission)).toBeFalsy();
+  });
+
+  // verify that all HubPermissionPolicies are valid permissions
+  it("verifies all HubPermissionPolicies are valid permissions", () => {
+    HubPermissionsPolicies.forEach((policy) => {
+      expect(isPermission(policy.permission)).toBeTruthy(
+        `Permission ${policy.permission} is not included in HubPermissionsPolicies`
+      );
+    });
   });
 });

--- a/packages/common/test/permissions/HubPermissionPolicies.test.ts
+++ b/packages/common/test/permissions/HubPermissionPolicies.test.ts
@@ -18,7 +18,7 @@ describe("HubPermissionPolicies:", () => {
   it("verifies all HubPermissionPolicies are valid permissions", () => {
     HubPermissionsPolicies.forEach((policy) => {
       expect(isPermission(policy.permission)).toBeTruthy(
-        `Permission ${policy.permission} is not included in HubPermissionsPolicies`
+        `Permission ${policy.permission} is not included in HubPermissions`
       );
     });
   });


### PR DESCRIPTION
1. Description:
`hub:gating:workspace:released` was not in the `HubPermissionPolicies` array and thus was returning `invalid-permission` when checked. Happily this was not impacting the UX because the code path was only hit by anon users, who don't have access to workspaces so it was ok that the permission check failed.

This PR does add a test which verifies that all defined permission policies have valid permission values in them, as a means of ensuring that this does not happen again


1. Instructions for testing: run tests

1. Closes Issues: #14102

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] Updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.

1. [ ] These changes have been verified by QA using a `?uiVersion` that includes a PR-Preview of this branch and the `v_req` label has been applied to the issue.

1. [ ] OD-UI E2E tests pass against these changes using a `?uiVersion` that includes a PR-Preview of this branch
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
