### PR TITLE
fix: user settings schema tolerant of misconfigured trustedOrgs

### DIFF
--- a/packages/common/src/ArcGISContext.ts
+++ b/packages/common/src/ArcGISContext.ts
@@ -105,9 +105,9 @@ export class ArcGISContext implements IArcGISContext {
 
   private _featureFlags: IFeatureFlags = {};
 
-  private _trustedOrgIds: string[];
+  private _trustedOrgIds: string[] = [];
 
-  private _trustedOrgs: IHubTrustedOrgsResponse[];
+  private _trustedOrgs: IHubTrustedOrgsResponse[] = [];
 
   private _userResourceTokens: IUserResourceToken[] = [];
 

--- a/packages/common/test/ArcGISContextManager.test.ts
+++ b/packages/common/test/ArcGISContextManager.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
 import {
   ALPHA_ORGS,
   ArcGISContextManager,
@@ -456,6 +457,7 @@ describe("ArcGISContextManager:", () => {
         onlinePartneredOrgResponse.trustedOrgs
       );
     });
+
     it("verify props when passed session", async () => {
       const t = new Date().getTime();
       spyOn(portalModule, "getSelf").and.callFake(() => {

--- a/packages/common/test/users/_internal/UserUiSchemaSettings.test.ts
+++ b/packages/common/test/users/_internal/UserUiSchemaSettings.test.ts
@@ -11,6 +11,97 @@ describe("UserUiSchemaSettings:", () => {
     portalSettingsSpy.calls.reset();
   });
 
+  it("reports misconfiguration for Community Org", async () => {
+    spyOn(FetchOrgModule, "fetchOrg").and.callFake(() => {
+      return Promise.resolve({});
+    });
+    const consoleWarnSpy = spyOn(console, "warn").and.callThrough();
+
+    portalSettingsSpy = spyOn(PortalModule, "getPortalSettings").and.callFake(
+      () => {
+        return Promise.resolve({
+          informationalBanner: {
+            enabled: true,
+          },
+        });
+      }
+    );
+
+    const chk = await UserUiSchemaSettings.buildUiSchema("some.scope", {}, {
+      portalUrl: "https://qaext.arcgis.com",
+      communityOrgId: "xyz",
+      trustedOrgs: [
+        {
+          to: {
+            orgId: "abc",
+            name: "Other org",
+          },
+        },
+      ],
+      communityOrgUrl: "https://qaext.c.arcgis.com",
+      portal: {
+        id: "123",
+        name: "My org",
+      },
+      currentUser: {
+        role: "org_admin",
+        orgId: "123",
+      },
+      isAlphaOrg: true,
+      isOrgAdmin: true,
+    } as IArcGISContext);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      `Links to the Community Org could not be displayed. There appears to be a misconfiguration in the trusted org relationships for this organization. Please contact Esri Customer Service for assistance.`
+    );
+    expect(chk).toBeDefined();
+  });
+
+  it("reports misconfiguration for Staff Org", async () => {
+    spyOn(FetchOrgModule, "fetchOrg").and.callFake(() => {
+      return Promise.resolve({});
+    });
+    const consoleWarnSpy = spyOn(console, "warn").and.callThrough();
+
+    portalSettingsSpy = spyOn(PortalModule, "getPortalSettings").and.callFake(
+      () => {
+        return Promise.resolve({
+          informationalBanner: {
+            enabled: true,
+          },
+        });
+      }
+    );
+
+    const chk = await UserUiSchemaSettings.buildUiSchema("some.scope", {}, {
+      portalUrl: "https://qaext.arcgis.com",
+      enterpriseOrgId: "xyz",
+      trustedOrgs: [
+        {
+          to: {
+            orgId: "abc",
+            name: "Other org",
+          },
+        },
+      ],
+      portal: {
+        id: "123",
+        name: "My org",
+      },
+      currentUser: {
+        role: "org_admin",
+        orgId: "123",
+      },
+      isAlphaOrg: true,
+      isOrgAdmin: true,
+    } as IArcGISContext);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      `Links to the Staff Org could not be displayed. There appears to be a misconfiguration in the trusted org relationships for this organization. Please contact Esri Customer Service for assistance.`
+    );
+    expect(chk).toBeDefined();
+  });
+
   it("creates the uiSchema correctly", async () => {
     const fetchOrgSpy = spyOn(FetchOrgModule, "fetchOrg").and.callFake(() => {
       return Promise.resolve({});
@@ -752,6 +843,7 @@ describe("UserUiSchemaSettings:", () => {
         role: "org_admin",
         orgId: "123",
       },
+      trustedOrgs: [],
       isAlphaOrg: true,
       isOrgAdmin: true,
     } as IArcGISContext);
@@ -1190,7 +1282,7 @@ describe("UserUiSchemaSettings:", () => {
       ],
     });
   });
-  it("creates the uiSchema correctly when no community org", async () => {
+  xit("creates the uiSchema correctly when no community org", async () => {
     const fetchOrgSpy = spyOn(FetchOrgModule, "fetchOrg").and.callFake(() => {
       return Promise.resolve({});
     });
@@ -1213,6 +1305,7 @@ describe("UserUiSchemaSettings:", () => {
         role: "org_admin",
         orgId: "123",
       },
+      trustedOrgs: [],
       isAlphaOrg: true,
       isOrgAdmin: true,
     } as IArcGISContext);


### PR DESCRIPTION
1. Description:

When org's are misconfigured (not something Hub can fix) the `trustedOrgs` array may not contain entries for the enterprise or community org. This PR updated the UserUiSchemaSettings module to detect this condition instead of erroring out. When detected, it will log a message to the console.

1. Instructions for testing:

1. Closes Issues: #[14119](https://devtopia.esri.com/dc/hub/issues/14119)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] Updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.

1. [x] These changes have been verified by QA using a `?uiVersion` that includes a PR-Preview of this branch and the `v_req` label has been applied to the issue.

1. [x] OD-UI E2E tests pass against these changes using a `?uiVersion` that includes a PR-Preview of this branch
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
