### PR TITLE
feat(hub-common): add / populate IHubSite.isCatalogV1Enabled while fetching

### DIFF
--- a/packages/common/src/core/types/IHubSite.ts
+++ b/packages/common/src/core/types/IHubSite.ts
@@ -100,6 +100,11 @@ export interface IHubSite
    * True when the site is the "Umbrella" site for an environment (i.e. hub.arcgis.com)
    */
   isUmbrella: boolean;
+
+  /**
+   * True if the site is still using the legacy v1 catalog
+   */
+  isCatalogV1Enabled?: boolean;
 }
 
 export type IHubSiteEditor = IHubItemEntityEditor<IHubSite> & {

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -132,6 +132,12 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
     licenses: ["hub-premium"],
     dependencies: ["hub:site:workspace:catalog", "hub:event"],
   },
+  // Temporary permission to support catalog upgrade process
+  {
+    permission: "hub:site:workspace:catalog:upgrade",
+    dependencies: ["hub:site:workspace:catalog"],
+    availability: ["flag"],
+  },
   {
     permission: "hub:site:workspace:pages",
     dependencies: ["hub:site:workspace", "hub:site:edit"],

--- a/packages/common/src/sites/_internal/SitePermissions.ts
+++ b/packages/common/src/sites/_internal/SitePermissions.ts
@@ -24,6 +24,7 @@ export const SitePermissions = [
   "hub:site:workspace:catalog",
   "hub:site:workspace:catalog:content",
   "hub:site:workspace:catalog:events",
+  "hub:site:workspace:catalog:upgrade",
   "hub:site:workspace:metrics",
   "hub:site:workspace:followers",
   "hub:site:workspace:followers:member",

--- a/packages/common/src/sites/_internal/computeProps.ts
+++ b/packages/common/src/sites/_internal/computeProps.ts
@@ -51,6 +51,9 @@ export function computeProps(
   // Perform schema upgrades on the new catalog structure
   site.catalog = upgradeCatalogSchema(site.catalog);
 
+  // Determine if the site is still using the legacy v1 catalog
+  site.isCatalogV1Enabled = !!model.data.catalog;
+
   // cast b/c this takes a partial but returns a full site
   return site as IHubSite;
 }

--- a/packages/common/test/sites/_internal/computeProps.test.ts
+++ b/packages/common/test/sites/_internal/computeProps.test.ts
@@ -104,4 +104,38 @@ describe("sites: computeProps:", () => {
     expect(computeLinksSpy).toHaveBeenCalledTimes(1);
     expect(chk.links).toEqual({ self: "some-link" });
   });
+  it("sets isCatalogV1Enabled to true when legacy catalog is present", () => {
+    const model: IModel = {
+      item: {
+        id: "9001",
+        created: new Date().getTime(),
+        modified: new Date().getTime(),
+      },
+      data: {
+        catalog: {
+          groups: ["1", "2"],
+        },
+      },
+    } as unknown as IModel;
+    const init: Partial<IHubSite> = { id: "9001" };
+    const chk = computeProps(model, init, requestOptions);
+    expect(chk.isCatalogV1Enabled).toBe(true);
+  });
+  it("sets isCatalogV1Enabled to false when legacy catalog is absent", () => {
+    const model: IModel = {
+      item: {
+        id: "9001",
+        created: new Date().getTime(),
+        modified: new Date().getTime(),
+      },
+      data: {
+        catalogV2: {
+          collections: [],
+        },
+      },
+    } as unknown as IModel;
+    const init: Partial<IHubSite> = { id: "9001" };
+    const chk = computeProps(model, init, requestOptions);
+    expect(chk.isCatalogV1Enabled).toBe(false);
+  });
 });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:
Part of https://devtopia.esri.com/dc/hub/issues/13505.
adds and populates isCatalogV1Enabled field on IHubSite interface. Only applies for fetching the site, no update logic is currently available.

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] These changes have been verified by QA using a `?uiVersion` that includes a PR-Preview of this branch and the `v_req` label has been applied to the issue.

1. [x] OD-UI E2E tests pass against these changes using a `?uiVersion` that includes a PR-Preview of this branch
