### PR TITLE
fix: image entities in search will display image as default thumbnail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38663,7 +38663,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "20.4.5",
+			"version": "20.4.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/src/content/search.ts
+++ b/packages/common/src/content/search.ts
@@ -5,7 +5,7 @@ import { getItemThumbnailUrl } from "../resources";
 import { IHubSearchResult } from "../search";
 import { parseInclude } from "../search/_internal/parseInclude";
 import { IHubRequestOptions } from "../hub-types";
-import { getItemHomeUrl } from "../urls";
+import { getItemDataUrl, getItemHomeUrl } from "../urls";
 import { unique } from "../util";
 import { mapBy } from "../utils";
 import { getFamily } from "./get-family";
@@ -95,5 +95,28 @@ export async function enrichContentSearchResult(
     result.id
   );
 
+  return result;
+}
+
+/**
+ * Enrich a search result for an Image item
+ * @param item
+ * @param include
+ * @param requestOptions
+ * @returns
+ */
+export async function enrichImageSearchResult(
+  item: IItem,
+  include: string[],
+  requestOptions: IHubRequestOptions
+): Promise<IHubSearchResult> {
+  // use all of the same enrichments as content
+  const result = await enrichContentSearchResult(item, include, requestOptions);
+
+  // but if we're missing a thumbnail, use the data url as a fallback for search results
+  const dataUrl = getItemDataUrl(item, requestOptions);
+  if (!result.links.thumbnail) {
+    result.links.thumbnail = dataUrl;
+  }
   return result;
 }

--- a/packages/common/src/search/_internal/portalSearchItems.ts
+++ b/packages/common/src/search/_internal/portalSearchItems.ts
@@ -26,7 +26,10 @@ import { getNextPortalCallback } from "./commonHelpers/getNextPortalCallback";
 import { convertPortalAggregations } from "./portalSearchUtils";
 import { expandPredicate } from "./expandPredicate";
 import HubError from "../../HubError";
-import { enrichContentSearchResult } from "../../content/search";
+import {
+  enrichContentSearchResult,
+  enrichImageSearchResult,
+} from "../../content/search";
 import { cloneObject } from "../../util";
 import { getFamilyTypes } from "../../content/get-family";
 
@@ -240,6 +243,10 @@ export async function itemToSearchResult(
       if (item.typeKeywords.includes("hubSite")) {
         fn = enrichSiteSearchResult;
       }
+      break;
+    case "Image":
+      // same as content but includes fallback for thumbnail
+      fn = enrichImageSearchResult;
       break;
   }
   return fn(item, includes, requestOptions);


### PR DESCRIPTION
1. Description: https://github.com/ArcGIS/opendata-ui/pull/15211

1. Instructions for testing: see opendata-ui PR

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/9891

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] Updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.

1. [ ] These changes have been verified by QA using a `?uiVersion` that includes a PR-Preview of this branch and the `v_req` label has been applied to the issue.

1. [ ] OD-UI E2E tests pass against these changes using a `?uiVersion` that includes a PR-Preview of this branch

