### PR TITLE
fix(hub-common)!: events don't set discussions settings on portal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38663,7 +38663,7 @@
 		},
 		"packages/common": {
 			"name": "@esri/hub-common",
-			"version": "20.4.5",
+			"version": "20.4.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@terraformer/arcgis": "^2.1.2",

--- a/packages/common/e2e/hub-groups.e2e.ts
+++ b/packages/common/e2e/hub-groups.e2e.ts
@@ -27,10 +27,7 @@ describe("Hub Groups", () => {
       expect(newGroup).toBeDefined();
       expect(newGroup.summary).toBe("New group summary");
       expect(newGroup.membershipAccess).toBe("organization");
-      const fetchedGroup = await fetchHubGroup(
-        newGroup.id,
-        ctxMgr.context.hubRequestOptions
-      );
+      const fetchedGroup = await fetchHubGroup(newGroup.id, ctxMgr.context);
       // verify can* flags
       expect(fetchedGroup.canDelete).toBe(true);
       expect(fetchedGroup.canEdit).toBe(true);
@@ -45,10 +42,10 @@ describe("Hub Groups", () => {
       expect(updatedGroup.membershipAccess).toBe("anyone");
       await deleteHubGroup(newGroup.id, ctxMgr.context.userRequestOptions);
       try {
-        await fetchHubGroup(newGroup.id, ctxMgr.context.hubRequestOptions);
+        await fetchHubGroup(newGroup.id, ctxMgr.context);
         fail("should have thrown error");
       } catch (e) {
-        expect((e ).message).toBe(
+        expect(e.message).toBe(
           "COM_0003: Group does not exist or is inaccessible."
         );
       }
@@ -115,7 +112,7 @@ describe("HubGroup Class", () => {
       try {
         await HubGroup.fetch(id, ctxMgr.context);
       } catch (e) {
-        expect((e ).message).toBe("Group not found.");
+        expect(e.message).toBe("Group not found.");
       }
     });
   });

--- a/packages/common/src/core/fetchHubEntity.ts
+++ b/packages/common/src/core/fetchHubEntity.ts
@@ -48,13 +48,13 @@ export async function fetchHubEntity(
       result = await fetchPage(identifier, context.hubRequestOptions);
       break;
     case "content":
-      result = await fetchHubContent(identifier, context.hubRequestOptions);
+      result = await fetchHubContent(identifier, context);
       break;
     case "template":
       result = await fetchTemplate(identifier, context.requestOptions);
       break;
     case "group":
-      result = await fetchHubGroup(identifier, context.hubRequestOptions);
+      result = await fetchHubGroup(identifier, context);
       break;
     case "event":
       result = await fetchEvent(identifier, context.hubRequestOptions);

--- a/packages/common/src/groups/HubGroup.ts
+++ b/packages/common/src/groups/HubGroup.ts
@@ -122,7 +122,7 @@ export class HubGroup
     context: IArcGISContext
   ): Promise<HubGroup> {
     try {
-      const group = await fetchHubGroup(identifier, context.hubRequestOptions);
+      const group = await fetchHubGroup(identifier, context);
       // create an instance of HubGroup from the group
       return HubGroup.fromJson(group, context);
     } catch (ex) {

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -148,7 +148,7 @@ export async function createHubGroup(
   );
 
   // create or update entity settings
-  if (checkPermission("hub:group:settings:discussions", context)) {
+  if (checkPermission("hub:group:settings:discussions", context).access) {
     const entitySetting = await createOrUpdateEntitySettings(
       { ...hubGroup, id: entity.id },
       context.hubRequestOptions
@@ -172,7 +172,7 @@ export async function fetchHubGroup(
 ): Promise<IHubGroup> {
   const group = await getGroup(identifier, context.hubRequestOptions);
   let entitySettings;
-  if (checkPermission("hub:group:settings:discussions", context)) {
+  if (checkPermission("hub:group:settings:discussions", context).access) {
     entitySettings = await fetchSettingV2({
       id: group.id,
       ...context.hubRequestOptions,
@@ -230,7 +230,7 @@ export async function updateHubGroup(
   await updateGroup(opts);
 
   // create or update entity settings
-  if (checkPermission("hub:group:settings:discussions", context)) {
+  if (checkPermission("hub:group:settings:discussions", context).access) {
     const entitySetting = await createOrUpdateEntitySettings(
       hubGroup,
       context.hubRequestOptions

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -17,12 +17,18 @@ import type { IUserRequestOptions } from "@esri/arcgis-rest-request";
 import { DEFAULT_GROUP } from "./defaults";
 import { convertHubGroupToGroup } from "./_internal/convertHubGroupToGroup";
 import { convertGroupToHubGroup } from "./_internal/convertGroupToHubGroup";
-import { fetchSettingV2, setDiscussableKeyword } from "../discussions";
+import {
+  fetchSettingV2,
+  getDefaultEntitySettings,
+  IEntitySetting,
+  setDiscussableKeyword,
+} from "../discussions";
 import { IHubSearchResult } from "../search/types/IHubSearchResult";
 import { computeLinks } from "./_internal/computeLinks";
 import { getUniqueGroupTitle } from "./_internal/getUniqueGroupTitle";
 import { createOrUpdateEntitySettings } from "../core/_internal/createOrUpdateEntitySettings";
 import { IArcGISContext } from "../types";
+import { checkPermission } from "../permissions/checkPermission";
 
 /**
  * Enrich a generic search result
@@ -142,7 +148,7 @@ export async function createHubGroup(
   );
 
   // create or update entity settings
-  if (!context.isPortal) {
+  if (checkPermission("hub:group:settings:discussions", context)) {
     const entitySetting = await createOrUpdateEntitySettings(
       { ...hubGroup, id: entity.id },
       context.hubRequestOptions
@@ -162,17 +168,31 @@ export async function createHubGroup(
  */
 export async function fetchHubGroup(
   identifier: string,
-  requestOptions: IHubRequestOptions
+  context: IArcGISContext
 ): Promise<IHubGroup> {
-  const group = await getGroup(identifier, requestOptions);
-  const entitySettings = await fetchSettingV2({
-    id: group.id,
-    ...requestOptions,
-  }).catch((): null => null);
+  const group = await getGroup(identifier, context.hubRequestOptions);
+  let entitySettings;
+  if (checkPermission("hub:group:settings:discussions", context)) {
+    entitySettings = await fetchSettingV2({
+      id: group.id,
+      ...context.hubRequestOptions,
+    }).catch(
+      () =>
+        ({
+          id: null,
+          ...getDefaultEntitySettings("group"),
+        } as IEntitySetting)
+    );
+  } else {
+    entitySettings = {
+      id: null,
+      ...getDefaultEntitySettings("group"),
+    } as IEntitySetting;
+  }
   const hubGroup = convertGroupToHubGroup(
     group,
     entitySettings,
-    requestOptions
+    context.hubRequestOptions
   );
   return hubGroup;
 }
@@ -210,7 +230,7 @@ export async function updateHubGroup(
   await updateGroup(opts);
 
   // create or update entity settings
-  if (!context.isPortal) {
+  if (checkPermission("hub:group:settings:discussions", context)) {
     const entitySetting = await createOrUpdateEntitySettings(
       hubGroup,
       context.hubRequestOptions

--- a/packages/common/src/groups/HubGroups.ts
+++ b/packages/common/src/groups/HubGroups.ts
@@ -142,12 +142,14 @@ export async function createHubGroup(
   );
 
   // create or update entity settings
-  const entitySetting = await createOrUpdateEntitySettings(
-    { ...hubGroup, id: entity.id },
-    context.hubRequestOptions
-  );
-  entity.entitySettingsId = entitySetting.id;
-  entity.discussionSettings = entitySetting.settings.discussions;
+  if (!context.isPortal) {
+    const entitySetting = await createOrUpdateEntitySettings(
+      { ...hubGroup, id: entity.id },
+      context.hubRequestOptions
+    );
+    entity.entitySettingsId = entitySetting.id;
+    entity.discussionSettings = entitySetting.settings.discussions;
+  }
 
   return entity;
 }
@@ -208,12 +210,14 @@ export async function updateHubGroup(
   await updateGroup(opts);
 
   // create or update entity settings
-  const entitySetting = await createOrUpdateEntitySettings(
-    hubGroup,
-    context.hubRequestOptions
-  );
-  hubGroup.entitySettingsId = entitySetting.id;
-  hubGroup.discussionSettings = entitySetting.settings.discussions;
+  if (!context.isPortal) {
+    const entitySetting = await createOrUpdateEntitySettings(
+      hubGroup,
+      context.hubRequestOptions
+    );
+    hubGroup.entitySettingsId = entitySetting.id;
+    hubGroup.discussionSettings = entitySetting.settings.discussions;
+  }
 
   return hubGroup;
 }

--- a/packages/common/test/content/fetchHubContent.test.ts
+++ b/packages/common/test/content/fetchHubContent.test.ts
@@ -64,7 +64,9 @@ describe("fetchHubContent", () => {
       portal: MOCK_AUTH.portal,
       authentication: MOCK_AUTH,
     } as IHubRequestOptions;
-    const context = { requestOptions } as any as IArcGISContext;
+    const context = {
+      hubRequestOptions: requestOptions,
+    } as any as IArcGISContext;
 
     const chk = await fetchHubContent(HOSTED_FEATURE_SERVICE_GUID, context);
     const extendedProps = chk.extendedProps as IServiceExtendedProps;
@@ -108,7 +110,9 @@ describe("fetchHubContent", () => {
     checkPermissionSpy.and.returnValue(true);
 
     const requestOptions = { authentication: MOCK_AUTH } as IHubRequestOptions;
-    const context = { requestOptions } as any as IArcGISContext;
+    const context = {
+      hubRequestOptions: requestOptions,
+    } as any as IArcGISContext;
     const chk = await fetchHubContent(PDF_GUID, context);
     expect(chk.id).toBe(PDF_GUID);
     expect(chk.owner).toBe(PDF_ITEM.owner);
@@ -151,7 +155,9 @@ describe("fetchHubContent", () => {
       portal: MOCK_AUTH.portal,
       authentication: MOCK_AUTH,
     } as IHubRequestOptions;
-    const context = { requestOptions } as any as IArcGISContext;
+    const context = {
+      hubRequestOptions: requestOptions,
+    } as any as IArcGISContext;
 
     const chk = await fetchHubContent(HOSTED_FEATURE_SERVICE_GUID, context, [
       "metadata",

--- a/packages/common/test/content/fetchHubContent.test.ts
+++ b/packages/common/test/content/fetchHubContent.test.ts
@@ -10,15 +10,21 @@ import {
 } from "./fixtures";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import { fetchHubContent } from "../../src/content/fetchHubContent";
-import { IHubRequestOptions, IServiceExtendedProps } from "../../src";
+import {
+  IArcGISContext,
+  IHubRequestOptions,
+  IServiceExtendedProps,
+} from "../../src";
 import * as modelsModule from "../../src/models";
 import * as fetchSettingsModule from "../../src/discussions/api/settings/settings";
+import * as checkPermissionModule from "../../src/permissions/checkPermission";
 
 describe("fetchHubContent", () => {
   let fetchContentSpy: jasmine.Spy;
   let fetchEditableContentEnrichmentsSpy: jasmine.Spy;
   let fetchModelFromItemSpy: jasmine.Spy;
   let fetchSettingsSpy: jasmine.Spy;
+  let checkPermissionSpy: jasmine.Spy;
 
   beforeEach(() => {
     fetchContentSpy = spyOn(fetchContentModule, "fetchContent");
@@ -28,6 +34,7 @@ describe("fetchHubContent", () => {
     );
     fetchModelFromItemSpy = spyOn(modelsModule, "fetchModelFromItem");
     fetchSettingsSpy = spyOn(fetchSettingsModule, "fetchSettingV2");
+    checkPermissionSpy = spyOn(checkPermissionModule, "checkPermission");
   });
 
   it("gets feature service content", async () => {
@@ -52,15 +59,14 @@ describe("fetchHubContent", () => {
         ...DISCUSSION_SETTINGS,
       })
     );
+    checkPermissionSpy.and.returnValue(true);
     const requestOptions = {
       portal: MOCK_AUTH.portal,
       authentication: MOCK_AUTH,
     } as IHubRequestOptions;
+    const context = { requestOptions } as any as IArcGISContext;
 
-    const chk = await fetchHubContent(
-      HOSTED_FEATURE_SERVICE_GUID,
-      requestOptions
-    );
+    const chk = await fetchHubContent(HOSTED_FEATURE_SERVICE_GUID, context);
     const extendedProps = chk.extendedProps as IServiceExtendedProps;
     expect(chk.id).toBe(HOSTED_FEATURE_SERVICE_GUID);
     expect(chk.owner).toBe(HOSTED_FEATURE_SERVICE_ITEM.owner);
@@ -99,9 +105,11 @@ describe("fetchHubContent", () => {
         ...DISCUSSION_SETTINGS,
       })
     );
+    checkPermissionSpy.and.returnValue(true);
 
     const requestOptions = { authentication: MOCK_AUTH } as IHubRequestOptions;
-    const chk = await fetchHubContent(PDF_GUID, requestOptions);
+    const context = { requestOptions } as any as IArcGISContext;
+    const chk = await fetchHubContent(PDF_GUID, context);
     expect(chk.id).toBe(PDF_GUID);
     expect(chk.owner).toBe(PDF_ITEM.owner);
 
@@ -137,17 +145,17 @@ describe("fetchHubContent", () => {
         ...DISCUSSION_SETTINGS,
       })
     );
+    checkPermissionSpy.and.returnValue(true);
 
     const requestOptions = {
       portal: MOCK_AUTH.portal,
       authentication: MOCK_AUTH,
     } as IHubRequestOptions;
+    const context = { requestOptions } as any as IArcGISContext;
 
-    const chk = await fetchHubContent(
-      HOSTED_FEATURE_SERVICE_GUID,
-      requestOptions,
-      ["metadata"]
-    );
+    const chk = await fetchHubContent(HOSTED_FEATURE_SERVICE_GUID, context, [
+      "metadata",
+    ]);
     expect(chk.id).toBe(HOSTED_FEATURE_SERVICE_GUID);
     expect(chk.owner).toBe(HOSTED_FEATURE_SERVICE_ITEM.owner);
     // NOTE: These are undefined since we didn't explicitly ask for the server to be fetched
@@ -196,10 +204,13 @@ describe("fetchHubContent", () => {
         ...DISCUSSION_SETTINGS,
       })
     );
+    checkPermissionSpy.and.returnValue(true);
 
     const chk = await fetchHubContent("ae3", {
-      authentication: MOCK_AUTH,
-    });
+      hubRequestOptions: {
+        authentication: MOCK_AUTH,
+      },
+    } as any as IArcGISContext);
 
     expect(chk.type).toBe("Hub Site Application");
   });
@@ -230,10 +241,13 @@ describe("fetchHubContent", () => {
     fetchSettingsSpy.and.returnValue(
       Promise.reject(new Error("Failed to fetch settings"))
     );
+    checkPermissionSpy.and.returnValue(true);
 
     const chk = await fetchHubContent("ae3", {
-      authentication: MOCK_AUTH,
-    });
+      hubRequestOptions: {
+        authentication: MOCK_AUTH,
+      },
+    } as any as IArcGISContext);
 
     expect(chk.type).toBe("Hub Site Application");
   });

--- a/packages/common/test/content/fetchHubContent.test.ts
+++ b/packages/common/test/content/fetchHubContent.test.ts
@@ -257,4 +257,38 @@ describe("fetchHubContent", () => {
 
     expect(chk.type).toBe("Hub Site Application");
   });
+
+  it("does not call fetchSettings if permissions invalid", async () => {
+    fetchContentSpy.and.returnValue(
+      Promise.resolve({
+        item: {
+          id: "ae3",
+          type: "Web Mapping Application",
+          typeKeywords: ["hubSite"],
+        },
+      })
+    );
+    fetchEditableContentEnrichmentsSpy.and.returnValue({ metadata: null });
+    fetchModelFromItemSpy.and.returnValue(
+      Promise.resolve(
+        Promise.resolve({
+          item: {
+            id: "ae3",
+            type: "Hub Site Application",
+            typeKeywords: ["hubSite"],
+          },
+          data: { values: {} },
+        })
+      )
+    );
+    checkPermissionSpy.and.returnValue(false);
+
+    const chk = await fetchHubContent("ae3", {
+      hubRequestOptions: {
+        authentication: MOCK_AUTH,
+      },
+    } as any as IArcGISContext);
+
+    expect(chk.type).toBe("Hub Site Application");
+  });
 });

--- a/packages/common/test/content/fetchHubContent.test.ts
+++ b/packages/common/test/content/fetchHubContent.test.ts
@@ -59,7 +59,7 @@ describe("fetchHubContent", () => {
         ...DISCUSSION_SETTINGS,
       })
     );
-    checkPermissionSpy.and.returnValue(true);
+    checkPermissionSpy.and.returnValue({ access: true });
     const requestOptions = {
       portal: MOCK_AUTH.portal,
       authentication: MOCK_AUTH,
@@ -107,7 +107,7 @@ describe("fetchHubContent", () => {
         ...DISCUSSION_SETTINGS,
       })
     );
-    checkPermissionSpy.and.returnValue(true);
+    checkPermissionSpy.and.returnValue({ access: true });
 
     const requestOptions = { authentication: MOCK_AUTH } as IHubRequestOptions;
     const context = {
@@ -149,7 +149,7 @@ describe("fetchHubContent", () => {
         ...DISCUSSION_SETTINGS,
       })
     );
-    checkPermissionSpy.and.returnValue(true);
+    checkPermissionSpy.and.returnValue({ access: true });
 
     const requestOptions = {
       portal: MOCK_AUTH.portal,
@@ -210,7 +210,7 @@ describe("fetchHubContent", () => {
         ...DISCUSSION_SETTINGS,
       })
     );
-    checkPermissionSpy.and.returnValue(true);
+    checkPermissionSpy.and.returnValue({ access: true });
 
     const chk = await fetchHubContent("ae3", {
       hubRequestOptions: {
@@ -247,7 +247,7 @@ describe("fetchHubContent", () => {
     fetchSettingsSpy.and.returnValue(
       Promise.reject(new Error("Failed to fetch settings"))
     );
-    checkPermissionSpy.and.returnValue(true);
+    checkPermissionSpy.and.returnValue({ access: true });
 
     const chk = await fetchHubContent("ae3", {
       hubRequestOptions: {
@@ -281,7 +281,7 @@ describe("fetchHubContent", () => {
         })
       )
     );
-    checkPermissionSpy.and.returnValue(false);
+    checkPermissionSpy.and.returnValue({ access: false });
 
     const chk = await fetchHubContent("ae3", {
       hubRequestOptions: {

--- a/packages/common/test/core/fetchHubEntity.test.ts
+++ b/packages/common/test/core/fetchHubEntity.test.ts
@@ -1,5 +1,19 @@
 import type { IArcGISContext, HubEntityType } from "../../src";
 import { fetchHubEntity } from "../../src/core/fetchHubEntity";
+import * as fetchProjectsModule from "../../src/projects/fetch";
+import * as sitesModule from "../../src/sites/HubSites";
+import * as fetchOrganizationModule from "../../src/org/fetch";
+import * as fetchChannelsModule from "../../src/channels/fetch";
+import * as initiativesModule from "../../src/initiatives/HubInitiatives";
+import * as fetchDiscussionsModule from "../../src/discussions/fetch";
+import * as fetchContentModule from "../../src/content/fetchHubContent";
+import * as fetchTemplatesModule from "../../src/templates/fetch";
+import * as pagesModule from "../../src/pages/HubPages";
+import * as groupsModule from "../../src/groups/HubGroups";
+import * as fetchInitiativeTemplateModule from "../../src/initiative-templates/fetch";
+import * as fetchEventsModule from "../../src/events/fetch";
+import * as fetchHubUserModule from "../../src/users";
+import * as userModule from "../../src/users/HubUsers";
 
 describe("fetchHubEntity:", () => {
   it("returns undefined for non-hub types", async () => {
@@ -11,10 +25,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       requestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/projects/fetch"),
-      "fetchProject"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(fetchProjectsModule, "fetchProject").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("project", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
@@ -22,10 +35,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/sites/HubSites"),
-      "fetchSite"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(sitesModule, "fetchSite").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("site", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
@@ -34,7 +46,7 @@ describe("fetchHubEntity:", () => {
       requestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
     const spy = spyOn(
-      require("../../src/org/fetch"),
+      fetchOrganizationModule,
       "fetchOrganization"
     ).and.returnValue(Promise.resolve({}));
     await fetchHubEntity("organization", "123", ctx);
@@ -44,10 +56,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       requestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/channels/fetch"),
-      "fetchHubChannel"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(fetchChannelsModule, "fetchHubChannel").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("channel", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", ctx);
   });
@@ -55,10 +66,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       requestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/initiatives/HubInitiatives"),
-      "fetchInitiative"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(initiativesModule, "fetchInitiative").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("initiative", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
@@ -67,7 +77,7 @@ describe("fetchHubEntity:", () => {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
     const spy = spyOn(
-      require("../../src/discussions/fetch"),
+      fetchDiscussionsModule,
       "fetchDiscussion"
     ).and.returnValue(Promise.resolve({}));
     await fetchHubEntity("discussion", "123", ctx);
@@ -77,21 +87,19 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/content/fetchHubContent"),
-      "fetchHubContent"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(fetchContentModule, "fetchHubContent").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("content", "123", ctx);
-    expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
+    expect(spy).toHaveBeenCalledWith("123", ctx);
   });
   it("fetches template", async () => {
     const ctx = {
       requestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/templates/fetch"),
-      "fetchTemplate"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(fetchTemplatesModule, "fetchTemplate").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("template", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
@@ -99,10 +107,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/pages/HubPages"),
-      "fetchPage"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(pagesModule, "fetchPage").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("page", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
@@ -110,19 +117,18 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/groups/HubGroups"),
-      "fetchHubGroup"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(groupsModule, "fetchHubGroup").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("group", "123", ctx);
-    expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
+    expect(spy).toHaveBeenCalledWith("123", ctx);
   });
   it("fetches initiative template", async () => {
     const ctx = {
       requestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
     const spy = spyOn(
-      require("../../src/initiative-templates/fetch"),
+      fetchInitiativeTemplateModule,
       "fetchInitiativeTemplate"
     ).and.returnValue(Promise.resolve({}));
     await fetchHubEntity("initiativeTemplate", "123", ctx);
@@ -132,10 +138,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/events/fetch"),
-      "fetchEvent"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(fetchEventsModule, "fetchEvent").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("event", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
@@ -143,10 +148,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/users"),
-      "fetchHubUser"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(fetchHubUserModule, "fetchHubUser").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("user", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", {
       hubRequestOptions: "fakeRequestOptions",
@@ -156,10 +160,7 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       currentUser: {},
     } as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/users/HubUsers"),
-      "convertUserToHubUser"
-    ).and.returnValue({});
+    const spy = spyOn(userModule, "convertUserToHubUser").and.returnValue({});
     await fetchHubEntity("user", "self", ctx);
     expect(spy).toHaveBeenCalledWith(ctx.currentUser);
   });

--- a/packages/common/test/groups/HubGroups.test.ts
+++ b/packages/common/test/groups/HubGroups.test.ts
@@ -188,7 +188,7 @@ describe("HubGroups Module:", () => {
         group.protected = false;
         return Promise.resolve(group);
       });
-      checkPermissionSpy.and.returnValue(true);
+      checkPermissionSpy.and.returnValue({ access: true });
       const chk = await HubGroupsModule.createHubGroup(
         { name: TEST_GROUP.title, protected: TEST_GROUP.protected },
         { userRequestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -228,7 +228,7 @@ describe("HubGroups Module:", () => {
         group.protected = false;
         return Promise.resolve(group);
       });
-      checkPermissionSpy.and.returnValue(true);
+      checkPermissionSpy.and.returnValue({ access: true });
       const chk = await HubGroupsModule.createHubGroup(
         { name: TEST_GROUP.title, protected: false },
         { userRequestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -268,7 +268,7 @@ describe("HubGroups Module:", () => {
         group.protected = false;
         return Promise.resolve(group);
       });
-      checkPermissionSpy.and.returnValue(true);
+      checkPermissionSpy.and.returnValue({ access: true });
       const chk = await HubGroupsModule.createHubGroup(
         { name: TEST_GROUP.title, protected: TEST_GROUP.protected },
         { userRequestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -302,7 +302,7 @@ describe("HubGroups Module:", () => {
         group.protected = false;
         return Promise.resolve(group);
       });
-      checkPermissionSpy.and.returnValue(false);
+      checkPermissionSpy.and.returnValue({ access: false });
       const chk = await HubGroupsModule.createHubGroup(
         { name: TEST_GROUP.title, protected: TEST_GROUP.protected },
         {
@@ -322,7 +322,7 @@ describe("HubGroups Module:", () => {
       const portalGetGroupSpy = spyOn(PortalModule, "getGroup").and.returnValue(
         Promise.resolve(TEST_GROUP)
       );
-      checkPermissionSpy.and.returnValue(true);
+      checkPermissionSpy.and.returnValue({ access: true });
       const chk = await HubGroupsModule.fetchHubGroup(GUID, {
         hubRequestOptions: {
           authentication: MOCK_AUTH,
@@ -337,7 +337,7 @@ describe("HubGroups Module:", () => {
       const portalGetGroupSpy = spyOn(PortalModule, "getGroup").and.returnValue(
         Promise.resolve(TEST_GROUP)
       );
-      checkPermissionSpy.and.returnValue(false);
+      checkPermissionSpy.and.returnValue({ access: false });
       const chk = await HubGroupsModule.fetchHubGroup(GUID, {
         hubRequestOptions: {
           authentication: MOCK_AUTH,
@@ -362,7 +362,7 @@ describe("HubGroups Module:", () => {
         PortalModule,
         "updateGroup"
       ).and.returnValue(Promise.resolve(TEST_HUB_GROUP));
-      checkPermissionSpy.and.returnValue(true);
+      checkPermissionSpy.and.returnValue({ access: true });
       const chk = await HubGroupsModule.updateHubGroup(
         TEST_HUB_GROUP as IHubGroup,
         { requestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -379,7 +379,7 @@ describe("HubGroups Module:", () => {
         Promise.resolve({ id: "abc", settings: { discussions: {} } })
       );
       const portalUpdateGroupSpy = spyOn(PortalModule, "updateGroup");
-      checkPermissionSpy.and.returnValue(true);
+      checkPermissionSpy.and.returnValue({ access: true });
       const chk = await HubGroupsModule.updateHubGroup(
         { ...TEST_HUB_GROUP, membershipAccess: "anyone" } as IHubGroup,
         { requestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -404,7 +404,7 @@ describe("HubGroups Module:", () => {
         Promise.resolve({ id: "abc", settings: { discussions: {} } })
       );
       const portalUpdateGroupSpy = spyOn(PortalModule, "updateGroup");
-      checkPermissionSpy.and.returnValue(true);
+      checkPermissionSpy.and.returnValue({ access: true });
       const chk = await HubGroupsModule.updateHubGroup(
         { ...TEST_HUB_GROUP, membershipAccess: "organization" } as IHubGroup,
         { requestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -423,7 +423,7 @@ describe("HubGroups Module:", () => {
         Promise.resolve({ id: "abc", settings: { discussions: {} } })
       );
       const portalUpdateGroupSpy = spyOn(PortalModule, "updateGroup");
-      checkPermissionSpy.and.returnValue(true);
+      checkPermissionSpy.and.returnValue({ access: true });
       const chk = await HubGroupsModule.updateHubGroup(
         { ...TEST_HUB_GROUP, membershipAccess: "collaborators" } as IHubGroup,
         { requestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -439,7 +439,7 @@ describe("HubGroups Module:", () => {
         PortalModule,
         "updateGroup"
       ).and.returnValue(Promise.resolve(TEST_HUB_GROUP));
-      checkPermissionSpy.and.returnValue(false);
+      checkPermissionSpy.and.returnValue({ access: false });
       const chk = await HubGroupsModule.updateHubGroup(
         TEST_HUB_GROUP as IHubGroup,
         {

--- a/packages/common/test/groups/HubGroups.test.ts
+++ b/packages/common/test/groups/HubGroups.test.ts
@@ -11,6 +11,7 @@ import * as HubGroupsModule from "../../src/groups/HubGroups";
 import * as FetchEnrichments from "../../src/groups/_internal/enrichments";
 import * as GetUniqueGroupTitleModule from "../../src/groups/_internal/getUniqueGroupTitle";
 import * as createOrUpdateEntitySettingsModule from "../../src/core/_internal/createOrUpdateEntitySettings";
+import * as checkPermissionModule from "../../src/permissions/checkPermission";
 import { IHubGroup } from "../../src/core/types/IHubGroup";
 
 const GUID = "9b77674e43cf4bbd9ecad5189b3f1fdc";
@@ -180,6 +181,7 @@ describe("HubGroups Module:", () => {
         group.protected = false;
         return Promise.resolve(group);
       });
+      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
       const chk = await HubGroupsModule.createHubGroup(
         { name: TEST_GROUP.title, protected: TEST_GROUP.protected },
         { userRequestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -219,6 +221,7 @@ describe("HubGroups Module:", () => {
         group.protected = false;
         return Promise.resolve(group);
       });
+      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
       const chk = await HubGroupsModule.createHubGroup(
         { name: TEST_GROUP.title, protected: false },
         { userRequestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -258,6 +261,7 @@ describe("HubGroups Module:", () => {
         group.protected = false;
         return Promise.resolve(group);
       });
+      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
       const chk = await HubGroupsModule.createHubGroup(
         { name: TEST_GROUP.title, protected: TEST_GROUP.protected },
         { userRequestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -291,11 +295,11 @@ describe("HubGroups Module:", () => {
         group.protected = false;
         return Promise.resolve(group);
       });
+      spyOn(checkPermissionModule, "checkPermission").and.returnValue(false);
       const chk = await HubGroupsModule.createHubGroup(
         { name: TEST_GROUP.title, protected: TEST_GROUP.protected },
         {
           userRequestOptions: { authentication: MOCK_AUTH },
-          isPortal: true,
         } as IArcGISContext
       );
       expect(chk.name).toBe("dev followers Content");
@@ -311,9 +315,12 @@ describe("HubGroups Module:", () => {
       const portalGetGroupSpy = spyOn(PortalModule, "getGroup").and.returnValue(
         Promise.resolve(TEST_GROUP)
       );
+      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
       const chk = await HubGroupsModule.fetchHubGroup(GUID, {
-        authentication: MOCK_AUTH,
-      });
+        hubRequestOptions: {
+          authentication: MOCK_AUTH,
+        },
+      } as any as IArcGISContext);
       expect(chk.name).toBe("dev followers Content");
       expect(chk.description).toBe("dev followers Content summary");
       expect(chk.orgId).toBe(TEST_GROUP.orgId);
@@ -333,6 +340,7 @@ describe("HubGroups Module:", () => {
         PortalModule,
         "updateGroup"
       ).and.returnValue(Promise.resolve(TEST_HUB_GROUP));
+      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
       const chk = await HubGroupsModule.updateHubGroup(
         TEST_HUB_GROUP as IHubGroup,
         { requestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -349,6 +357,7 @@ describe("HubGroups Module:", () => {
         Promise.resolve({ id: "abc", settings: { discussions: {} } })
       );
       const portalUpdateGroupSpy = spyOn(PortalModule, "updateGroup");
+      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
       const chk = await HubGroupsModule.updateHubGroup(
         { ...TEST_HUB_GROUP, membershipAccess: "anyone" } as IHubGroup,
         { requestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -373,6 +382,7 @@ describe("HubGroups Module:", () => {
         Promise.resolve({ id: "abc", settings: { discussions: {} } })
       );
       const portalUpdateGroupSpy = spyOn(PortalModule, "updateGroup");
+      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
       const chk = await HubGroupsModule.updateHubGroup(
         { ...TEST_HUB_GROUP, membershipAccess: "organization" } as IHubGroup,
         { requestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -391,6 +401,7 @@ describe("HubGroups Module:", () => {
         Promise.resolve({ id: "abc", settings: { discussions: {} } })
       );
       const portalUpdateGroupSpy = spyOn(PortalModule, "updateGroup");
+      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
       const chk = await HubGroupsModule.updateHubGroup(
         { ...TEST_HUB_GROUP, membershipAccess: "collaborators" } as IHubGroup,
         { requestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -406,11 +417,11 @@ describe("HubGroups Module:", () => {
         PortalModule,
         "updateGroup"
       ).and.returnValue(Promise.resolve(TEST_HUB_GROUP));
+      spyOn(checkPermissionModule, "checkPermission").and.returnValue(false);
       const chk = await HubGroupsModule.updateHubGroup(
         TEST_HUB_GROUP as IHubGroup,
         {
           requestOptions: { authentication: MOCK_AUTH },
-          isPortal: true,
         } as IArcGISContext
       );
       expect(chk.name).toBe("A new hub group");

--- a/packages/common/test/groups/HubGroups.test.ts
+++ b/packages/common/test/groups/HubGroups.test.ts
@@ -412,7 +412,7 @@ describe("HubGroups Module:", () => {
         portalUpdateGroupSpy.calls.argsFor(0)[0].group.membershipAccess
       ).toBe("collaboration");
     });
-    it("does not set discussion settings in enterprise", async () => {
+    it("does not fetch discussion settings in enterprise", async () => {
       const portalUpdateGroupSpy = spyOn(
         PortalModule,
         "updateGroup"

--- a/packages/common/test/groups/HubGroups.test.ts
+++ b/packages/common/test/groups/HubGroups.test.ts
@@ -65,9 +65,16 @@ const TEST_HUB_GROUP = {
 };
 
 describe("HubGroups Module:", () => {
+  let checkPermissionSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    checkPermissionSpy = spyOn(checkPermissionModule, "checkPermission");
+  });
+
   describe("enrichments:", () => {
     let enrichmentSpy: jasmine.Spy;
     let hubRo: IHubRequestOptions;
+
     beforeEach(() => {
       enrichmentSpy = spyOn(
         FetchEnrichments,
@@ -181,7 +188,7 @@ describe("HubGroups Module:", () => {
         group.protected = false;
         return Promise.resolve(group);
       });
-      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
+      checkPermissionSpy.and.returnValue(true);
       const chk = await HubGroupsModule.createHubGroup(
         { name: TEST_GROUP.title, protected: TEST_GROUP.protected },
         { userRequestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -221,7 +228,7 @@ describe("HubGroups Module:", () => {
         group.protected = false;
         return Promise.resolve(group);
       });
-      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
+      checkPermissionSpy.and.returnValue(true);
       const chk = await HubGroupsModule.createHubGroup(
         { name: TEST_GROUP.title, protected: false },
         { userRequestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -261,7 +268,7 @@ describe("HubGroups Module:", () => {
         group.protected = false;
         return Promise.resolve(group);
       });
-      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
+      checkPermissionSpy.and.returnValue(true);
       const chk = await HubGroupsModule.createHubGroup(
         { name: TEST_GROUP.title, protected: TEST_GROUP.protected },
         { userRequestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -295,7 +302,7 @@ describe("HubGroups Module:", () => {
         group.protected = false;
         return Promise.resolve(group);
       });
-      spyOn(checkPermissionModule, "checkPermission").and.returnValue(false);
+      checkPermissionSpy.and.returnValue(false);
       const chk = await HubGroupsModule.createHubGroup(
         { name: TEST_GROUP.title, protected: TEST_GROUP.protected },
         {
@@ -315,7 +322,22 @@ describe("HubGroups Module:", () => {
       const portalGetGroupSpy = spyOn(PortalModule, "getGroup").and.returnValue(
         Promise.resolve(TEST_GROUP)
       );
-      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
+      checkPermissionSpy.and.returnValue(true);
+      const chk = await HubGroupsModule.fetchHubGroup(GUID, {
+        hubRequestOptions: {
+          authentication: MOCK_AUTH,
+        },
+      } as any as IArcGISContext);
+      expect(chk.name).toBe("dev followers Content");
+      expect(chk.description).toBe("dev followers Content summary");
+      expect(chk.orgId).toBe(TEST_GROUP.orgId);
+      expect(portalGetGroupSpy).toHaveBeenCalledTimes(1);
+    });
+    it("does not fetch settings if permissions invalid", async () => {
+      const portalGetGroupSpy = spyOn(PortalModule, "getGroup").and.returnValue(
+        Promise.resolve(TEST_GROUP)
+      );
+      checkPermissionSpy.and.returnValue(false);
       const chk = await HubGroupsModule.fetchHubGroup(GUID, {
         hubRequestOptions: {
           authentication: MOCK_AUTH,
@@ -340,7 +362,7 @@ describe("HubGroups Module:", () => {
         PortalModule,
         "updateGroup"
       ).and.returnValue(Promise.resolve(TEST_HUB_GROUP));
-      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
+      checkPermissionSpy.and.returnValue(true);
       const chk = await HubGroupsModule.updateHubGroup(
         TEST_HUB_GROUP as IHubGroup,
         { requestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -357,7 +379,7 @@ describe("HubGroups Module:", () => {
         Promise.resolve({ id: "abc", settings: { discussions: {} } })
       );
       const portalUpdateGroupSpy = spyOn(PortalModule, "updateGroup");
-      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
+      checkPermissionSpy.and.returnValue(true);
       const chk = await HubGroupsModule.updateHubGroup(
         { ...TEST_HUB_GROUP, membershipAccess: "anyone" } as IHubGroup,
         { requestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -382,7 +404,7 @@ describe("HubGroups Module:", () => {
         Promise.resolve({ id: "abc", settings: { discussions: {} } })
       );
       const portalUpdateGroupSpy = spyOn(PortalModule, "updateGroup");
-      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
+      checkPermissionSpy.and.returnValue(true);
       const chk = await HubGroupsModule.updateHubGroup(
         { ...TEST_HUB_GROUP, membershipAccess: "organization" } as IHubGroup,
         { requestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -401,7 +423,7 @@ describe("HubGroups Module:", () => {
         Promise.resolve({ id: "abc", settings: { discussions: {} } })
       );
       const portalUpdateGroupSpy = spyOn(PortalModule, "updateGroup");
-      spyOn(checkPermissionModule, "checkPermission").and.returnValue(true);
+      checkPermissionSpy.and.returnValue(true);
       const chk = await HubGroupsModule.updateHubGroup(
         { ...TEST_HUB_GROUP, membershipAccess: "collaborators" } as IHubGroup,
         { requestOptions: { authentication: MOCK_AUTH } } as IArcGISContext
@@ -412,12 +434,12 @@ describe("HubGroups Module:", () => {
         portalUpdateGroupSpy.calls.argsFor(0)[0].group.membershipAccess
       ).toBe("collaboration");
     });
-    it("does not fetch discussion settings in enterprise", async () => {
+    it("does not set discussion settings if permissions invalid", async () => {
       const portalUpdateGroupSpy = spyOn(
         PortalModule,
         "updateGroup"
       ).and.returnValue(Promise.resolve(TEST_HUB_GROUP));
-      spyOn(checkPermissionModule, "checkPermission").and.returnValue(false);
+      checkPermissionSpy.and.returnValue(false);
       const chk = await HubGroupsModule.updateHubGroup(
         TEST_HUB_GROUP as IHubGroup,
         {


### PR DESCRIPTION
1. Description: Fixes errors in groups relating to Discussions API not implemented on Enterprise.

1. Instructions for testing:

1. Closes Issues: #14183

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] Updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.

1. [ ] These changes have been verified by QA using a `?uiVersion` that includes a PR-Preview of this branch and the `v_req` label has been applied to the issue.

1. [ ] OD-UI E2E tests pass against these changes using a `?uiVersion` that includes a PR-Preview of this branch
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
