### PR TITLE
fix(hub-common): discussion settings aren't set on portal

### DIFF
--- a/packages/common/e2e/hub-groups.e2e.ts
+++ b/packages/common/e2e/hub-groups.e2e.ts
@@ -27,10 +27,7 @@ describe("Hub Groups", () => {
       expect(newGroup).toBeDefined();
       expect(newGroup.summary).toBe("New group summary");
       expect(newGroup.membershipAccess).toBe("organization");
-      const fetchedGroup = await fetchHubGroup(
-        newGroup.id,
-        ctxMgr.context.hubRequestOptions
-      );
+      const fetchedGroup = await fetchHubGroup(newGroup.id, ctxMgr.context);
       // verify can* flags
       expect(fetchedGroup.canDelete).toBe(true);
       expect(fetchedGroup.canEdit).toBe(true);
@@ -45,10 +42,10 @@ describe("Hub Groups", () => {
       expect(updatedGroup.membershipAccess).toBe("anyone");
       await deleteHubGroup(newGroup.id, ctxMgr.context.userRequestOptions);
       try {
-        await fetchHubGroup(newGroup.id, ctxMgr.context.hubRequestOptions);
+        await fetchHubGroup(newGroup.id, ctxMgr.context);
         fail("should have thrown error");
       } catch (e) {
-        expect((e ).message).toBe(
+        expect(e.message).toBe(
           "COM_0003: Group does not exist or is inaccessible."
         );
       }
@@ -115,7 +112,7 @@ describe("HubGroup Class", () => {
       try {
         await HubGroup.fetch(id, ctxMgr.context);
       } catch (e) {
-        expect((e ).message).toBe("Group not found.");
+        expect(e.message).toBe("Group not found.");
       }
     });
   });

--- a/packages/common/src/content/fetchHubContent.ts
+++ b/packages/common/src/content/fetchHubContent.ts
@@ -10,10 +10,11 @@ import { setProp } from "../objects/set-prop";
 import { modelToHubEditableContent } from "./modelToHubEditableContent";
 import { fetchSettingV2 } from "../discussions/api/settings/settings";
 import { getDefaultEntitySettings } from "../discussions/api/settings/getDefaultEntitySettings";
-import { IHubRequestOptions } from "../hub-types";
 import { fetchModelFromItem } from "../models";
 import { IItem } from "@esri/arcgis-rest-portal";
 import { IEntitySetting } from "../discussions/api/types";
+import { checkPermission } from "../permissions/checkPermission";
+import { IArcGISContext } from "../types/IArcGISContext";
 
 /**
  * fetch a content entity by identifier
@@ -23,21 +24,21 @@ import { IEntitySetting } from "../discussions/api/types";
  */
 export const fetchHubContent = async (
   identifier: string,
-  requestOptions: IHubRequestOptions,
+  context: IArcGISContext,
   enrichments?: EditableContentEnrichment[]
 ): Promise<IHubEditableContent> => {
   // NOTE: b/c we have to support slugs, we use fetchContent() to get the item
   // by telling it to not fetch any enrichments. We then can fetch enrichments
   // as needed after we have the item
   const options = {
-    ...requestOptions,
+    ...context.hubRequestOptions,
     enrichments: [],
   } as IFetchContentOptions;
   const { item } = await fetchContent(identifier, options);
 
   const editableContentEnrichments = await fetchEditableContentEnrichments(
     item,
-    requestOptions,
+    context.hubRequestOptions,
     enrichments
   );
 
@@ -47,7 +48,7 @@ export const fetchHubContent = async (
   const type = normalizeItemType(item);
   setProp("type", type, item);
 
-  return convertItemToContent(item, requestOptions, editableContentEnrichments);
+  return convertItemToContent(item, context, editableContentEnrichments);
 };
 
 /**
@@ -56,23 +57,29 @@ export const fetchHubContent = async (
  */
 export const convertItemToContent = async (
   item: IItem,
-  requestOptions: IHubRequestOptions,
+  context: IArcGISContext,
   enrichments?: IHubEditableContentEnrichments
 ): Promise<IHubEditableContent> => {
   const [model, entitySettings] = await Promise.all([
-    fetchModelFromItem(item, requestOptions),
-    fetchSettingV2({ id: item.id, ...requestOptions }).catch(
-      () =>
-        ({
-          id: null,
-          ...getDefaultEntitySettings("content"),
-        } as IEntitySetting)
-    ),
+    fetchModelFromItem(item, context.hubRequestOptions),
+    checkPermission("hub:content:workspace:settings:discussions", context)
+      .access
+      ? fetchSettingV2({
+          id: item.id,
+          ...context.hubRequestOptions,
+        }).catch(
+          () =>
+            ({
+              id: null,
+              ...getDefaultEntitySettings("content"),
+            } as IEntitySetting)
+        )
+      : null,
   ]);
   model.entitySettings = entitySettings;
   const content: Partial<IHubEditableContent> = modelToHubEditableContent(
     model,
-    requestOptions,
+    context.hubRequestOptions,
     enrichments
   );
 

--- a/packages/common/src/core/fetchHubEntity.ts
+++ b/packages/common/src/core/fetchHubEntity.ts
@@ -48,13 +48,13 @@ export async function fetchHubEntity(
       result = await fetchPage(identifier, context.hubRequestOptions);
       break;
     case "content":
-      result = await fetchHubContent(identifier, context.hubRequestOptions);
+      result = await fetchHubContent(identifier, context);
       break;
     case "template":
       result = await fetchTemplate(identifier, context.requestOptions);
       break;
     case "group":
-      result = await fetchHubGroup(identifier, context.hubRequestOptions);
+      result = await fetchHubGroup(identifier, context);
       break;
     case "event":
       result = await fetchEvent(identifier, context.hubRequestOptions);

--- a/packages/common/src/groups/HubGroup.ts
+++ b/packages/common/src/groups/HubGroup.ts
@@ -122,7 +122,7 @@ export class HubGroup
     context: IArcGISContext
   ): Promise<HubGroup> {
     try {
-      const group = await fetchHubGroup(identifier, context.hubRequestOptions);
+      const group = await fetchHubGroup(identifier, context);
       // create an instance of HubGroup from the group
       return HubGroup.fromJson(group, context);
     } catch (ex) {

--- a/packages/common/test/content/fetchHubContent.test.ts
+++ b/packages/common/test/content/fetchHubContent.test.ts
@@ -10,15 +10,21 @@ import {
 } from "./fixtures";
 import { MOCK_AUTH } from "../mocks/mock-auth";
 import { fetchHubContent } from "../../src/content/fetchHubContent";
-import { IHubRequestOptions, IServiceExtendedProps } from "../../src";
+import {
+  IArcGISContext,
+  IHubRequestOptions,
+  IServiceExtendedProps,
+} from "../../src";
 import * as modelsModule from "../../src/models";
 import * as fetchSettingsModule from "../../src/discussions/api/settings/settings";
+import * as checkPermissionModule from "../../src/permissions/checkPermission";
 
 describe("fetchHubContent", () => {
   let fetchContentSpy: jasmine.Spy;
   let fetchEditableContentEnrichmentsSpy: jasmine.Spy;
   let fetchModelFromItemSpy: jasmine.Spy;
   let fetchSettingsSpy: jasmine.Spy;
+  let checkPermissionSpy: jasmine.Spy;
 
   beforeEach(() => {
     fetchContentSpy = spyOn(fetchContentModule, "fetchContent");
@@ -28,6 +34,7 @@ describe("fetchHubContent", () => {
     );
     fetchModelFromItemSpy = spyOn(modelsModule, "fetchModelFromItem");
     fetchSettingsSpy = spyOn(fetchSettingsModule, "fetchSettingV2");
+    checkPermissionSpy = spyOn(checkPermissionModule, "checkPermission");
   });
 
   it("gets feature service content", async () => {
@@ -52,15 +59,16 @@ describe("fetchHubContent", () => {
         ...DISCUSSION_SETTINGS,
       })
     );
+    checkPermissionSpy.and.returnValue({ access: true });
     const requestOptions = {
       portal: MOCK_AUTH.portal,
       authentication: MOCK_AUTH,
     } as IHubRequestOptions;
+    const context = {
+      hubRequestOptions: requestOptions,
+    } as any as IArcGISContext;
 
-    const chk = await fetchHubContent(
-      HOSTED_FEATURE_SERVICE_GUID,
-      requestOptions
-    );
+    const chk = await fetchHubContent(HOSTED_FEATURE_SERVICE_GUID, context);
     const extendedProps = chk.extendedProps as IServiceExtendedProps;
     expect(chk.id).toBe(HOSTED_FEATURE_SERVICE_GUID);
     expect(chk.owner).toBe(HOSTED_FEATURE_SERVICE_ITEM.owner);
@@ -99,9 +107,13 @@ describe("fetchHubContent", () => {
         ...DISCUSSION_SETTINGS,
       })
     );
+    checkPermissionSpy.and.returnValue({ access: true });
 
     const requestOptions = { authentication: MOCK_AUTH } as IHubRequestOptions;
-    const chk = await fetchHubContent(PDF_GUID, requestOptions);
+    const context = {
+      hubRequestOptions: requestOptions,
+    } as any as IArcGISContext;
+    const chk = await fetchHubContent(PDF_GUID, context);
     expect(chk.id).toBe(PDF_GUID);
     expect(chk.owner).toBe(PDF_ITEM.owner);
 
@@ -137,17 +149,19 @@ describe("fetchHubContent", () => {
         ...DISCUSSION_SETTINGS,
       })
     );
+    checkPermissionSpy.and.returnValue({ access: true });
 
     const requestOptions = {
       portal: MOCK_AUTH.portal,
       authentication: MOCK_AUTH,
     } as IHubRequestOptions;
+    const context = {
+      hubRequestOptions: requestOptions,
+    } as any as IArcGISContext;
 
-    const chk = await fetchHubContent(
-      HOSTED_FEATURE_SERVICE_GUID,
-      requestOptions,
-      ["metadata"]
-    );
+    const chk = await fetchHubContent(HOSTED_FEATURE_SERVICE_GUID, context, [
+      "metadata",
+    ]);
     expect(chk.id).toBe(HOSTED_FEATURE_SERVICE_GUID);
     expect(chk.owner).toBe(HOSTED_FEATURE_SERVICE_ITEM.owner);
     // NOTE: These are undefined since we didn't explicitly ask for the server to be fetched
@@ -196,10 +210,13 @@ describe("fetchHubContent", () => {
         ...DISCUSSION_SETTINGS,
       })
     );
+    checkPermissionSpy.and.returnValue({ access: true });
 
     const chk = await fetchHubContent("ae3", {
-      authentication: MOCK_AUTH,
-    });
+      hubRequestOptions: {
+        authentication: MOCK_AUTH,
+      },
+    } as any as IArcGISContext);
 
     expect(chk.type).toBe("Hub Site Application");
   });
@@ -230,10 +247,47 @@ describe("fetchHubContent", () => {
     fetchSettingsSpy.and.returnValue(
       Promise.reject(new Error("Failed to fetch settings"))
     );
+    checkPermissionSpy.and.returnValue({ access: true });
 
     const chk = await fetchHubContent("ae3", {
-      authentication: MOCK_AUTH,
-    });
+      hubRequestOptions: {
+        authentication: MOCK_AUTH,
+      },
+    } as any as IArcGISContext);
+
+    expect(chk.type).toBe("Hub Site Application");
+  });
+
+  it("does not call fetchSettings if permissions invalid", async () => {
+    fetchContentSpy.and.returnValue(
+      Promise.resolve({
+        item: {
+          id: "ae3",
+          type: "Web Mapping Application",
+          typeKeywords: ["hubSite"],
+        },
+      })
+    );
+    fetchEditableContentEnrichmentsSpy.and.returnValue({ metadata: null });
+    fetchModelFromItemSpy.and.returnValue(
+      Promise.resolve(
+        Promise.resolve({
+          item: {
+            id: "ae3",
+            type: "Hub Site Application",
+            typeKeywords: ["hubSite"],
+          },
+          data: { values: {} },
+        })
+      )
+    );
+    checkPermissionSpy.and.returnValue({ access: false });
+
+    const chk = await fetchHubContent("ae3", {
+      hubRequestOptions: {
+        authentication: MOCK_AUTH,
+      },
+    } as any as IArcGISContext);
 
     expect(chk.type).toBe("Hub Site Application");
   });

--- a/packages/common/test/core/fetchHubEntity.test.ts
+++ b/packages/common/test/core/fetchHubEntity.test.ts
@@ -1,5 +1,19 @@
 import type { IArcGISContext, HubEntityType } from "../../src";
 import { fetchHubEntity } from "../../src/core/fetchHubEntity";
+import * as fetchProjectsModule from "../../src/projects/fetch";
+import * as sitesModule from "../../src/sites/HubSites";
+import * as fetchOrganizationModule from "../../src/org/fetch";
+import * as fetchChannelsModule from "../../src/channels/fetch";
+import * as initiativesModule from "../../src/initiatives/HubInitiatives";
+import * as fetchDiscussionsModule from "../../src/discussions/fetch";
+import * as fetchContentModule from "../../src/content/fetchHubContent";
+import * as fetchTemplatesModule from "../../src/templates/fetch";
+import * as pagesModule from "../../src/pages/HubPages";
+import * as groupsModule from "../../src/groups/HubGroups";
+import * as fetchInitiativeTemplateModule from "../../src/initiative-templates/fetch";
+import * as fetchEventsModule from "../../src/events/fetch";
+import * as fetchHubUserModule from "../../src/users";
+import * as userModule from "../../src/users/HubUsers";
 
 describe("fetchHubEntity:", () => {
   it("returns undefined for non-hub types", async () => {
@@ -11,10 +25,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       requestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/projects/fetch"),
-      "fetchProject"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(fetchProjectsModule, "fetchProject").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("project", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
@@ -22,10 +35,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/sites/HubSites"),
-      "fetchSite"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(sitesModule, "fetchSite").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("site", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
@@ -34,7 +46,7 @@ describe("fetchHubEntity:", () => {
       requestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
     const spy = spyOn(
-      require("../../src/org/fetch"),
+      fetchOrganizationModule,
       "fetchOrganization"
     ).and.returnValue(Promise.resolve({}));
     await fetchHubEntity("organization", "123", ctx);
@@ -44,10 +56,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       requestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/channels/fetch"),
-      "fetchHubChannel"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(fetchChannelsModule, "fetchHubChannel").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("channel", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", ctx);
   });
@@ -55,10 +66,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       requestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/initiatives/HubInitiatives"),
-      "fetchInitiative"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(initiativesModule, "fetchInitiative").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("initiative", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
@@ -67,7 +77,7 @@ describe("fetchHubEntity:", () => {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
     const spy = spyOn(
-      require("../../src/discussions/fetch"),
+      fetchDiscussionsModule,
       "fetchDiscussion"
     ).and.returnValue(Promise.resolve({}));
     await fetchHubEntity("discussion", "123", ctx);
@@ -77,21 +87,19 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/content/fetchHubContent"),
-      "fetchHubContent"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(fetchContentModule, "fetchHubContent").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("content", "123", ctx);
-    expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
+    expect(spy).toHaveBeenCalledWith("123", ctx);
   });
   it("fetches template", async () => {
     const ctx = {
       requestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/templates/fetch"),
-      "fetchTemplate"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(fetchTemplatesModule, "fetchTemplate").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("template", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
@@ -99,10 +107,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/pages/HubPages"),
-      "fetchPage"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(pagesModule, "fetchPage").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("page", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
@@ -110,19 +117,18 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/groups/HubGroups"),
-      "fetchHubGroup"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(groupsModule, "fetchHubGroup").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("group", "123", ctx);
-    expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
+    expect(spy).toHaveBeenCalledWith("123", ctx);
   });
   it("fetches initiative template", async () => {
     const ctx = {
       requestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
     const spy = spyOn(
-      require("../../src/initiative-templates/fetch"),
+      fetchInitiativeTemplateModule,
       "fetchInitiativeTemplate"
     ).and.returnValue(Promise.resolve({}));
     await fetchHubEntity("initiativeTemplate", "123", ctx);
@@ -132,10 +138,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/events/fetch"),
-      "fetchEvent"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(fetchEventsModule, "fetchEvent").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("event", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", "fakeRequestOptions");
   });
@@ -143,10 +148,9 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       hubRequestOptions: "fakeRequestOptions",
     } as unknown as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/users"),
-      "fetchHubUser"
-    ).and.returnValue(Promise.resolve({}));
+    const spy = spyOn(fetchHubUserModule, "fetchHubUser").and.returnValue(
+      Promise.resolve({})
+    );
     await fetchHubEntity("user", "123", ctx);
     expect(spy).toHaveBeenCalledWith("123", {
       hubRequestOptions: "fakeRequestOptions",
@@ -156,10 +160,7 @@ describe("fetchHubEntity:", () => {
     const ctx = {
       currentUser: {},
     } as IArcGISContext;
-    const spy = spyOn(
-      require("../../src/users/HubUsers"),
-      "convertUserToHubUser"
-    ).and.returnValue({});
+    const spy = spyOn(userModule, "convertUserToHubUser").and.returnValue({});
     await fetchHubEntity("user", "self", ctx);
     expect(spy).toHaveBeenCalledWith(ctx.currentUser);
   });


### PR DESCRIPTION
affects: @esri/hub-common

BREAKING CHANGE:
fetchHubContent and fecthHubGroup accept context instead of hubRequestOptions

ISSUES CLOSED: 14183

1. Description:

1. Instructions for testing:

1. Closes Issues: #14183

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] Updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.

1. [ ] These changes have been verified by QA using a `?uiVersion` that includes a PR-Preview of this branch and the `v_req` label has been applied to the issue.

1. [ ] OD-UI E2E tests pass against these changes using a `?uiVersion` that includes a PR-Preview of this branch
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
