### PR TITLE
feat(hub-common): added q and bbox to IOgcAggregationQueryParams

### DIFF
--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcAggregationQueryParams.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcAggregationQueryParams.ts
@@ -2,10 +2,14 @@ import { getProp } from "../../../objects/get-prop";
 import { IQuery } from "../../types/IHubCatalog";
 import { IHubSearchOptions } from "../../types/IHubSearchOptions";
 import { getFilterQueryParam } from "./getFilterQueryParam";
+import { getQQueryParam } from "./getQQueryParam";
+import { getBboxQueryParam } from "./getBboxQueryParam";
 
 export interface IOgcAggregationQueryParams {
   aggregations: string;
   filter?: string;
+  bbox?: string;
+  q?: string;
   token?: string;
 }
 
@@ -16,6 +20,8 @@ export function getOgcAggregationQueryParams(
   // TODO: use options.aggLimit once the OGC API supports it
   const aggregations = `terms(fields=(${options.aggFields.join()}))`;
   const filter = getFilterQueryParam(query);
+  const bbox = getBboxQueryParam(query);
+  const q = getQQueryParam(query);
   const token = getProp(
     options,
     "requestOptions.authentication.token"
@@ -23,7 +29,9 @@ export function getOgcAggregationQueryParams(
 
   return {
     aggregations,
+    bbox,
     filter,
+    q,
     token,
   };
 }

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcAggregationQueryParams.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getOgcAggregationQueryParams.ts
@@ -7,8 +7,8 @@ import { getBboxQueryParam } from "./getBboxQueryParam";
 
 export interface IOgcAggregationQueryParams {
   aggregations: string;
-  filter?: string;
   bbox?: string;
+  filter?: string;
   q?: string;
   token?: string;
 }

--- a/packages/common/src/search/_internal/hubSearchItemsHelpers/getQQueryParam.ts
+++ b/packages/common/src/search/_internal/hubSearchItemsHelpers/getQQueryParam.ts
@@ -6,7 +6,7 @@ import { getTopLevelPredicate } from "../commonHelpers/getTopLevelPredicate";
 // in the 'filter' string. Once that bug is resolved, rip this
 // logic out and let predicates with 'term' to be processed normally
 
-export function getQQueryParam(query: IQuery) {
+export function getQQueryParam(query: IQuery): string {
   const qPredicate = getTopLevelPredicate("term", query.filters);
   return qPredicate?.term;
 }

--- a/packages/common/test/search/_internal/hubSearchItems.test.ts
+++ b/packages/common/test/search/_internal/hubSearchItems.test.ts
@@ -625,9 +625,7 @@ describe("hubSearchItems Module |", () => {
         const options: IHubSearchOptions = {
           aggFields: ["type", "tags", "categories"],
           requestOptions: {
-            authentication: {
-              token: "abc",
-            } as any,
+            authentication: { token: "abc" } as any,
           },
         };
         const opendataQuery = cloneObject(baseQuery);
@@ -641,6 +639,51 @@ describe("hubSearchItems Module |", () => {
           )}&filter=${encodeURIComponent(
             "((type=typeA)) AND ((openData=true))"
           )}&token=abc`
+        );
+      });
+
+      it("handles aggregations, filter, q, and token", () => {
+        const options: IHubSearchOptions = {
+          aggFields: ["type", "tags", "categories"],
+          requestOptions: {
+            authentication: { token: "abc" } as any,
+          },
+        };
+        const termQuery: IQuery = cloneObject(baseQuery);
+        termQuery.filters.push({ predicates: [{ term: "dragonball" }] });
+
+        const result = getOgcAggregationQueryParams(termQuery, options);
+        const queryString = getQueryString(result);
+        expect(queryString).toEqual(
+          `?aggregations=${encodeURIComponent(
+            "terms(fields=(type,tags,categories))"
+          )}&filter=${encodeURIComponent(
+            "((type=typeA))"
+          )}&q=dragonball&token=abc`
+        );
+      });
+
+      it("handles aggregations, bbox, filter, q, and token", () => {
+        const options: IHubSearchOptions = {
+          aggFields: ["type", "tags", "categories"],
+          requestOptions: {
+            authentication: { token: "abc" } as any,
+          },
+        };
+        const bboxQuery: IQuery = cloneObject(baseQuery);
+        bboxQuery.filters.push({
+          operation: "AND",
+          predicates: [{ term: "dragonball" }, { bbox: "1,2,3,4" }],
+        });
+
+        const result = getOgcAggregationQueryParams(bboxQuery, options);
+        const queryString = getQueryString(result);
+        expect(queryString).toEqual(
+          `?aggregations=${encodeURIComponent(
+            "terms(fields=(type,tags,categories))"
+          )}&bbox=${encodeURIComponent("1,2,3,4")}&filter=${encodeURIComponent(
+            "((type=typeA))"
+          )}&q=dragonball&token=abc`
         );
       });
     });


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

added `q` and `bbox` to IOgcAggregationQueryParams to support dynamic aggregation of facets on map and search term filters

1. Instructions for testing:

1. Closes Issues: [12416](https://devtopia.esri.com/dc/hub/issues/12416)

1. [x] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [x] used semantic commit messages
  
1. [x] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [x] Updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.

1. [x] These changes have been verified by QA using a `?uiVersion` that includes a PR-Preview of this branch and the `v_req` label has been applied to the issue.

1. [x] OD-UI E2E tests pass against these changes using a `?uiVersion` that includes a PR-Preview of this branch
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
