### PR TITLE
fix: removeContextFromSlug when computing page slug

### DIFF
--- a/packages/common/src/content/contentUtils.ts
+++ b/packages/common/src/content/contentUtils.ts
@@ -31,7 +31,6 @@ import {
 } from "@esri/arcgis-rest-feature-service";
 import { isService } from "../resources/is-service";
 import { getItemIdentifier } from "../items";
-import { SLUG_ORG_SEPARATOR_URI } from "../items/_internal/slugConverters";
 
 // TODO: remove this at next breaking version
 /**
@@ -150,7 +149,8 @@ export function getContentIdentifier(
 
     // if not, use the slug if configured (per brolly, without org prefix; and per AT without the id suffix) and if not, the id
     const pageIdentifier = getItemIdentifier(content.item);
-    return pageIdentifier.split(SLUG_ORG_SEPARATOR_URI).pop();
+    const orgKey = getProp(site, "domainInfo.orgKey") as string;
+    return removeContextFromSlug(pageIdentifier, orgKey);
   }
 
   // If a slug is present, always return it

--- a/packages/common/test/content/content.test.ts
+++ b/packages/common/test/content/content.test.ts
@@ -267,7 +267,10 @@ describe("content: ", () => {
           },
         },
       } as IHubContent;
-      const site: any = { data: { values: {} } };
+      const site: any = {
+        domainInfo: { orgKey: "orgkey" },
+        data: { values: {} },
+      };
 
       const result = getContentIdentifier(page, site);
       expect(result).toBe("page_slug");


### PR DESCRIPTION
affects: @esri/hub-common

1. Description: page slug urls use bare slug unless they are cross org

1. Closes Issues: https://devtopia.esri.com/dc/hub/issues/14194

1. [X] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [X] used semantic commit messages
  
1. [X] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [X] Updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.

1. [ ] These changes have been verified by QA using a `?uiVersion` that includes a PR-Preview of this branch and the `v_req` label has been applied to the issue.

1. [ ] OD-UI E2E tests pass against these changes using a `?uiVersion` that includes a PR-Preview of this branch
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
