### PR TITLE
F/13504 allow site migration

### DIFF
--- a/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
+++ b/packages/common/src/discussions/_internal/DiscussionBusinessRules.ts
@@ -106,10 +106,6 @@ export const DiscussionPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:discussion:workspace:catalog:events",
-    dependencies: [
-      "hub:discussion:workspace:catalog",
-      "hub:event",
-      "hub:feature:catalogs:edit:advanced",
-    ],
+    dependencies: ["hub:discussion:workspace:catalog", "hub:event"],
   },
 ];

--- a/packages/common/src/events/_internal/EventBusinessRules.ts
+++ b/packages/common/src/events/_internal/EventBusinessRules.ts
@@ -105,11 +105,7 @@ export const EventPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:event:workspace:catalog:events",
-    dependencies: [
-      "hub:event:workspace:catalog",
-      "hub:event",
-      "hub:feature:catalogs:edit:advanced",
-    ],
+    dependencies: ["hub:event:workspace:catalog", "hub:event"],
   },
   {
     permission: "hub:event:manage",

--- a/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
+++ b/packages/common/src/initiatives/_internal/InitiativeBusinessRules.ts
@@ -162,11 +162,7 @@ export const InitiativePermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:initiative:workspace:catalog:events",
-    dependencies: [
-      "hub:initiative:workspace:catalog",
-      "hub:event",
-      "hub:feature:catalogs:edit:advanced",
-    ],
+    dependencies: ["hub:initiative:workspace:catalog", "hub:event"],
   },
   {
     permission: "hub:initiative:manage",

--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -210,38 +210,17 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     availability: ["alpha"],
   },
   /**
-   * Gates advanced editing (e.g. adding new collections, adding
-   * additional scope filters, etc.) in the catalog configuration
-   * experince.
-   *
-   * TODO: Remove the site entity assertion once all catalog
-   * configuration features are supported by sites
-   */
-  {
-    permission: "hub:feature:catalogs:edit:advanced",
-    entityEdit: true,
-    licenses: ["hub-premium"],
-    assertions: [
-      {
-        property: "entity:type",
-        type: "neq",
-        value: "Hub Site Application",
-      },
-    ],
-  },
-  /**
    * Gates catalog & collection appearance editing
    * in the catalog configuration experience.
    *
    * TODO: remove environment & availability gating once
    * we are ready to release catalog appearance
-   * configuration. Alternatively, we can remove it entirely
-   * in favor of the "hub:feature:caatalogs:edit:advanced"
-   * permission
+   * configuration.
    */
   {
     permission: "hub:feature:catalogs:edit:appearance",
-    dependencies: ["hub:feature:catalogs:edit:advanced"],
+    entityEdit: true,
+    licenses: ["hub-premium"],
     environments: ["qaext"],
     availability: ["alpha"],
   },

--- a/packages/common/src/permissions/_internal/constants.ts
+++ b/packages/common/src/permissions/_internal/constants.ts
@@ -31,8 +31,6 @@ export const SystemPermissions = [
   "hub:feature:newentityview",
   "hub:feature:history",
   "hub:feature:catalogs", // DEPRECATED - TODO: remove at next major version
-  /** remove once sites support all catalog configuration features */
-  "hub:feature:catalogs:edit:advanced",
   "hub:feature:catalogs:edit:appearance",
   "hub:feature:gallery-card:enterprise",
   "hub:feature:inline-workspace",

--- a/packages/common/src/projects/_internal/ProjectBusinessRules.ts
+++ b/packages/common/src/projects/_internal/ProjectBusinessRules.ts
@@ -133,11 +133,7 @@ export const ProjectPermissionPolicies: IPermissionPolicy[] = [
   },
   {
     permission: "hub:project:workspace:catalog:events",
-    dependencies: [
-      "hub:project:workspace:catalog",
-      "hub:event",
-      "hub:feature:catalogs:edit:advanced",
-    ],
+    dependencies: ["hub:project:workspace:catalog", "hub:event"],
   },
   {
     permission: "hub:project:manage",

--- a/packages/common/src/sites/HubSites.ts
+++ b/packages/common/src/sites/HubSites.ts
@@ -29,10 +29,7 @@ import { mapBy } from "../utils";
 import { getProp, setProp } from "../objects";
 import { setDiscussableKeyword } from "../discussions";
 import { reflectCollectionsToSearchCategories } from "./_internal/reflectCollectionsToSearchCategories";
-import {
-  catalogToLegacy,
-  convertCatalogToLegacyFormat,
-} from "./_internal/convertCatalogToLegacyFormat";
+import { convertCatalogToLegacyFormat } from "./_internal/convertCatalogToLegacyFormat";
 import { convertFeaturesToLegacyCapabilities } from "./_internal/capabilities/convertFeaturesToLegacyCapabilities";
 import { computeLinks } from "./_internal/computeLinks";
 import { handleSubdomainChange } from "./_internal/subdomains";
@@ -123,9 +120,7 @@ const DEFAULT_SITE_MODEL: IModel = {
     url: "",
   } as IItem,
   data: {
-    catalog: {
-      groups: [],
-    },
+    catalogV2: { schemaVersion: 0 },
     feeds: {},
     values: {
       title: "",
@@ -278,15 +273,12 @@ export async function createSite(
   );
   let model = mapper.entityToStore(site, cloneObject(DEFAULT_SITE_MODEL));
 
-  // At this point `data.catalog` may have become a full IHubCatalog object due to an in-memory
-  // migration. However, we can't persist an IHubCatalog in `data.catalog` without breaking
-  // the application, since most of the app relies on the old catalog structure. As such,
-  // we convert any changes made to the catalog scope into the old format and merge the changes
-  // with the existing structure on the most current model.
-  // TODO: Remove once the application is plumbed to work off an IHubCatalog
-  if (getProp(model, "data.catalog.scopes")) {
-    model.data.catalog = catalogToLegacy(model.data.catalog);
-  }
+  // Remove default collections and set the v2 catalog
+  const catalogV2 = cloneObject(site.catalog);
+  catalogV2.collections = [];
+  model.data.catalogV2 = catalogV2;
+  // TODO: Remove once all sites are fully on catalogV2
+  model.data.useCatalogV2 = true;
 
   // create the backing item
   model = await createModel(
@@ -310,7 +302,7 @@ export async function createSite(
   );
 
   // convert the model into a IHubSite and return
-  return mapper.storeToEntity(updatedModel, {}) as IHubSite;
+  return convertModelToSite(updatedModel, requestOptions);
 }
 
 /**
@@ -373,20 +365,30 @@ export async function updateSite(
     await handleDomainChanges(modelToUpdate, currentModel, requestOptions);
   }
 
-  // Persist the new catalog to new property until the app is fully migrated
+  // Persist the v2 catalog
   modelToUpdate.data.catalogV2 = site.catalog;
-  // Because some old (but critical) application code still uses `data.values.searchCategories`
-  // as the source of truth for collection display configuration, we port all display changes
-  // in `data.catalog.collections` to the search category format.
-  // TODO: Remove once the app no longer relies on `data.values.searchCategories`
-  modelToUpdate = reflectCollectionsToSearchCategories(modelToUpdate);
-  // At this point `data.catalog` has become a full IHubCatalog object due to an in-memory
-  // migration. However, we can't persist an IHubCatalog in `data.catalog` without breaking
-  // the application, since most of the app relies on the old catalog structure. As such,
-  // we convert any changes made to the catalog scope into the old format and merge the changes
-  // with the existing structure on the most current model.
-  // TODO: Remove once the application is plumbed to work off an IHubCatalog
-  modelToUpdate = convertCatalogToLegacyFormat(modelToUpdate, currentModel);
+
+  // Perform backwards compatibility steps if the site is still using the v1 catalog
+  if (site.isCatalogV1Enabled) {
+    // Because some old (but critical) application code still uses `data.values.searchCategories`
+    // as the source of truth for collection display configuration, we port all display changes
+    // in `data.catalog.collections` to the search category format.
+    // TODO: Remove once the app no longer relies on `data.values.searchCategories`
+    modelToUpdate = reflectCollectionsToSearchCategories(modelToUpdate);
+    // We can't persist an IHubCatalog in `data.catalog` without breaking
+    // the application, since most of the app relies on the old catalog structure. As such,
+    // we convert any changes made to the catalog scope into the old format and merge the changes
+    // with the existing structure on the most current model.
+    // TODO: Remove once the application is fully migrated to always use IHubCatalog
+    modelToUpdate = convertCatalogToLegacyFormat(modelToUpdate, currentModel);
+  } else {
+    // ensure the old catalog is removed if the site is not using v1
+    delete modelToUpdate.data.catalog;
+    delete (modelToUpdate.data.values as Record<string, unknown>)
+      .searchCategories;
+    // set the temporary property to indicate the site is fully upgraded to catalogV2
+    modelToUpdate.data.useCatalogV2 = true;
+  }
   /**
    * Site capabilities are currently saved as an array on the
    * site.data.values.capabilities. We want to migragte these

--- a/packages/common/src/sites/_internal/SiteBusinessRules.ts
+++ b/packages/common/src/sites/_internal/SiteBusinessRules.ts
@@ -136,7 +136,13 @@ export const SitesPermissionPolicies: IPermissionPolicy[] = [
   {
     permission: "hub:site:workspace:catalog:upgrade",
     dependencies: ["hub:site:workspace:catalog"],
-    availability: ["flag"],
+    assertions: [
+      {
+        property: "entity:isCatalogV1Enabled",
+        type: "eq",
+        value: true,
+      },
+    ],
   },
   {
     permission: "hub:site:workspace:pages",

--- a/packages/common/src/sites/_internal/getPropertyMap.ts
+++ b/packages/common/src/sites/_internal/getPropertyMap.ts
@@ -64,7 +64,6 @@ export function getPropertyMap(): IPropertyMap[] {
     entityKey: "isHubHome",
     storeKey: "item.properties.isHubHome",
   });
-  map.push({ entityKey: "catalog", storeKey: "data.catalog" });
 
   map.push({
     entityKey: "features",

--- a/packages/common/src/sites/_internal/removeCatalogV1FromUpgradedSite.ts
+++ b/packages/common/src/sites/_internal/removeCatalogV1FromUpgradedSite.ts
@@ -1,0 +1,23 @@
+import { IModel } from "../../hub-types";
+import { cloneObject } from "../../util";
+
+/**
+ * Removes the `catalog` property from upgraded site models. We use site.data.useCatalogV2
+ * (a temporary property) to determine if the upgrade has been completed.
+ *
+ * We need this temporary migration because earlier versions of the site schema upgrade
+ * force data.catalog to be present, even if the site is using catalogV2.
+ *
+ * TODO: Remove this function once we force all sites to use catalogV2.
+ * @param model
+ * @returns
+ */
+export function removeCatalogV1FromUpgradedSite(model: IModel): IModel {
+  const clone = cloneObject(model);
+
+  if (clone.data.useCatalogV2) {
+    delete clone.data.catalog;
+  }
+
+  return clone;
+}

--- a/packages/common/src/sites/defaults.ts
+++ b/packages/common/src/sites/defaults.ts
@@ -66,7 +66,7 @@ export const DEFAULT_SITE_MODEL: IModel = {
     },
   },
   data: {
-    catalog: { schemaVersion: 0 },
+    catalogV2: { schemaVersion: 0 },
     layout: {},
   },
 } as unknown as IModel;

--- a/packages/common/src/sites/upgrade-site-schema.ts
+++ b/packages/common/src/sites/upgrade-site-schema.ts
@@ -16,6 +16,7 @@ import { migrateWebMappingApplicationSites } from "./_internal/migrateWebMapping
 import { _migrateLinkUnderlinesCapability } from "./_internal/_migrate-link-underlines-capability";
 import { _migrateToV2Catalog } from "./_internal/_migrate-to-v2-catalog";
 import { ensureLowercaseOrgUrlKeySlugAndKeyword } from "./_internal/ensureLowercaseOrgUrlKeySlugAndKeyword";
+import { removeCatalogV1FromUpgradedSite } from "./_internal/removeCatalogV1FromUpgradedSite";
 
 /**
  * Upgrades the schema upgrades
@@ -47,6 +48,8 @@ export function upgradeSiteSchema(model: IModel): IModel {
   model = migrateWebMappingApplicationSites(model);
   model = _migrateLinkUnderlinesCapability(model);
   model = ensureLowercaseOrgUrlKeySlugAndKeyword(model);
+  // TODO: Remove this once all sites are fully on catalogV2
+  model = removeCatalogV1FromUpgradedSite(model);
 
   return model;
 }


### PR DESCRIPTION
1. Description:

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] Updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.

1. [ ] These changes have been verified by QA using a `?uiVersion` that includes a PR-Preview of this branch and the `v_req` label has been applied to the issue.

1. [ ] OD-UI E2E tests pass against these changes using a `?uiVersion` that includes a PR-Preview of this branch
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
