### PR TITLE
chore: update all workflows to use node 18

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: 18
 
       - name: NPM Install
         run: npm install

--- a/.github/workflows/publish-pr-preview.yaml
+++ b/.github/workflows/publish-pr-preview.yaml
@@ -20,10 +20,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
-      - name: Setup npm v7
-        run: npm i -g npm@7 --registry=https://registry.npmjs.org
+      # - name: Setup npm v7
+      #   run: npm i -g npm@7 --registry=https://registry.npmjs.org
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/publish-pr-preview.yaml
+++ b/.github/workflows/publish-pr-preview.yaml
@@ -22,8 +22,6 @@ jobs:
         with:
           node-version: 18
           cache: npm
-      # - name: Setup npm v7
-      #   run: npm i -g npm@7 --registry=https://registry.npmjs.org
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -33,11 +33,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      # Npm 7 is needed for workspaces, and it shipped w/ Node 16
-      # But we want to test on downlevel versions of node so we
-      # install npm7 directly
-      - name: Npm 7
-        run: npm i -g npm@7 --registry=https://registry.npmjs.org
+          cache: npm
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,6 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
 
-      # npm ci was failing b/c package-lock.json was not in sync with package.json
-      # copied this from publish-pr-preview.yaml
-      - name: Setup npm v7
-        run: npm i -g npm@7 --registry=https://registry.npmjs.org
-
       - name: Install
         run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Build, Test, Release
 
 # On pushes to master (i.e. merging a PR)
-# run all tests, on win, macos, linux, on node 12 & 14
+# run all tests, on win, macos, linux, on node versions
 on:
   push:
     branches:
@@ -23,8 +23,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    # PRs will run tests on node 14,16 on ubuntu, macos and windows
-    # so for the release, we're just running node 16@ubuntu
+    # PRs will run tests on the following os/node combos
+    # so for the release, we're just running node 18@ubuntu
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -73,7 +73,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.13
+          node-version: 18
 
       - name: Install
         run: npm ci


### PR DESCRIPTION
1. Description:

Stuff I missed from #2014 

This PR updates all GitHub workflow files to standardize on Node.js version 18, removing older version configurations and npm 7 setup steps that are no longer necessary.

- Updates Node.js versions across all workflows from various versions (12, 14, 16) to 18
- Removes npm 7 installation steps since npm workspaces are natively supported in Node 18
- Simplifies workflow configurations by removing outdated version compatibility code

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] Updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.

1. [ ] These changes have been verified by QA using a `?uiVersion` that includes a PR-Preview of this branch and the `v_req` label has been applied to the issue.

1. [ ] OD-UI E2E tests pass against these changes using a `?uiVersion` that includes a PR-Preview of this branch
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
