### PR TITLE
fix: add discussions subscription permission and gating

### DIFF
--- a/packages/common/src/permissions/HubPermissionPolicies.ts
+++ b/packages/common/src/permissions/HubPermissionPolicies.ts
@@ -288,6 +288,14 @@ const SystemPermissionPolicies: IPermissionPolicy[] = [
     permission: "hub:feature:gallery-card:enterprise",
     environments: ["enterprise", "enterprise-k8s"],
   },
+  // DISCUSSION SUBSCRIPTIONS
+  // TODO: remove the environments & availability gating before release
+  {
+    permission: "hub:feature:discussions:subscription",
+    environments: ["devext", "qaext"],
+    availability: ["alpha"],
+    licenses: ["hub-premium"], // TODO: waiting for product's confirmation on hub-basic
+  },
   // NOTE: only use this permission if necessary. Use the licenses check on a permission to check license when able instead of a separate permission.
   // checks if using hub-premium
   {

--- a/packages/common/src/permissions/_internal/constants.ts
+++ b/packages/common/src/permissions/_internal/constants.ts
@@ -41,6 +41,7 @@ export const SystemPermissions = [
   "hub:feature:gallery-card:enterprise",
   "hub:feature:inline-workspace",
   "hub:feature:pagescatalog",
+  "hub:feature:discussions:subscription",
   "hub:license:hub-premium",
   "hub:license:hub-basic",
   "hub:license:enterprise-sites",


### PR DESCRIPTION
affects: @esri/hub-common

1. Description:

Add discussions subscription permission and gating

1. Instructions for testing:

1. Closes Issues: #<number> (if appropriate)

1. [ ] Updated meaningful TSDoc to methods including Parameters and Returns, see [Documentation Guide](https://friendly-adventure-7w1eyl2.pages.github.io/storybook/?path=/story/guides-documentation--page)

1. [ ] used semantic commit messages
  
1. [ ] PR title follows semantic commit format (**CRITICAL** if the title is not in a semantic format, the release automation will not run!)

1. [ ] Updated `peerDependencies` as needed. **CRITICAL** our automated release system can **not** be counted on to update `peerDependencies` so we _must_ do it manually in our PRs when needed. See the [updating peerDependencies](/RELEASE.md#Updating-peerDependencies) section of the release instructions for more details.

1. [ ] These changes have been verified by QA using a `?uiVersion` that includes a PR-Preview of this branch and the `v_req` label has been applied to the issue.

1. [ ] OD-UI E2E tests pass against these changes using a `?uiVersion` that includes a PR-Preview of this branch
 
***CRITICAL** 
If you are making a breaking change, make sure to add the `BREAKING CHANGE` comment _in the merge commit message_. If this is not done, `semantic-release` will not do the right thing. 

If you find yourself in this position...
1) open a PR to master with a trivial change - fix a linting problem or something.
2) when you merge that, make sure you add the `BREAKING CHANGE` message in the merge commit.
3) then run `npm deprecate @esri/{package-name}@v{version-you-don't-want-out}`
